### PR TITLE
Add /subagents command and enhance /status with subagent info

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -189,6 +189,22 @@ class SessionManagerApp:
                 return False
             return self.session_manager.send_key(session_id, "Escape")
 
+        async def on_get_subagents(session_id: str) -> Optional[list]:
+            """Get subagents for a session."""
+            import httpx
+            try:
+                async with httpx.AsyncClient() as client:
+                    response = await client.get(
+                        f"http://127.0.0.1:{self.config['server']['port']}/sessions/{session_id}/subagents",
+                        timeout=5.0
+                    )
+                    if response.status_code == 200:
+                        data = response.json()
+                        return data.get("subagents", [])
+            except Exception as e:
+                logger.error(f"Error getting subagents: {e}")
+            return None
+
         self.telegram_bot.set_new_session_handler(on_new_session)
         self.telegram_bot.set_list_sessions_handler(on_list_sessions)
         self.telegram_bot.set_kill_session_handler(on_kill_session)
@@ -202,6 +218,7 @@ class SessionManagerApp:
         self.telegram_bot.set_get_last_message_handler(on_get_last_message)
         self.telegram_bot.set_get_tmux_output_handler(on_get_tmux_output)
         self.telegram_bot.set_interrupt_handler(on_interrupt_session)
+        self.telegram_bot.set_get_subagents_handler(on_get_subagents)
 
     async def _handle_monitor_event(self, event: NotificationEvent):
         """Handle events from the output monitor."""


### PR DESCRIPTION
## Summary

Implements issue #4 - Add subagent visibility to Telegram bot to match CLI functionality.

Users can now view spawned subagents via Telegram, providing the same visibility as the `sm subagents` and `sm what --deep` CLI commands.

## Key Features

### New `/subagents` Command
Lists all subagents spawned by a session when used in a session topic or replying to a session message:

```
/subagents

em-epic987 [1749a2fe] subagents:
  → engineer (abc123) | running | 3min ago
  ✓ architect (def456) | completed | 10min ago
     Designed pivot detection architecture
```

### Enhanced `/status` Command
Automatically includes subagent information when subagents exist:

```
/status

scout [1749a2fe]
Status: Working (idle 2m)
Dir: ~/projects/myapp

Subagents:
  → engineer (abc123) | running | 3min ago
```

## Changes

### Telegram Bot (`telegram_bot.py`)
- Added `_on_get_subagents` callback handler
- Added `set_get_subagents_handler()` for registering callback
- Added `_format_subagents()` helper for consistent formatting
- Implemented `/subagents` command handler
- Enhanced `/status` to automatically show subagents
- Updated help text to include new command
- Registered command handler in application

### Main Application (`main.py`)
- Added `on_get_subagents()` callback that fetches from API
- Wired up subagent handler to Telegram bot

## Implementation Details

- **Emoji indicators**: → (running), ✓ (completed), ✗ (error)
- **Relative timestamps**: "3min ago", "2h ago"
- **Summaries**: Displays subagent summaries when available
- **Context-aware**: Works in both forum topics and reply chains
- **API integration**: Uses `GET /sessions/{id}/subagents` endpoint

## Example Usage

**In a session topic:**
```
/subagents
→ Shows subagents for that session

/status
→ Shows status + subagents
```

**Replying to a session message:**
```
(Reply) /subagents
→ Shows subagents for that session
```

## Testing

- [ ] Test `/subagents` in forum topic
- [ ] Test `/subagents` in reply chain
- [ ] Test `/status` shows subagents automatically
- [ ] Test with 0 subagents
- [ ] Test with multiple subagents (running + completed)
- [ ] Test error handling when API unavailable

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)