### PR TITLE
Add sm all command for system-wide session listing

### DIFF
--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -205,6 +205,38 @@ def cmd_others(client: SessionManagerClient, session_id: str, include_repo: bool
     return 0
 
 
+def cmd_all(client: SessionManagerClient, include_summaries: bool) -> int:
+    """
+    List all sessions system-wide across all workspaces.
+
+    Exit codes:
+        0: Sessions found
+        1: No sessions
+        2: Session manager unavailable
+    """
+    # List all sessions
+    sessions = client.list_sessions()
+    if sessions is None:
+        print("Error: Session manager unavailable", file=sys.stderr)
+        return 2
+
+    if not sessions:
+        print("No active sessions")
+        return 1
+
+    # Show sessions with optional summaries
+    if include_summaries:
+        for session in sessions:
+            summary = client.get_summary(session["id"], lines=100)
+            print(format_session_line(session, show_summary=True, summary=summary))
+            print()  # Blank line between sessions
+    else:
+        for session in sessions:
+            print(format_session_line(session, show_working_dir=True))
+
+    return 0
+
+
 def cmd_alone(client: SessionManagerClient, session_id: str) -> int:
     """
     Check if you're the only active agent (silent, for scripting).

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -37,6 +37,10 @@ def main():
     others_parser = subparsers.add_parser("others", help="List others + what they're doing")
     others_parser.add_argument("--repo", action="store_true", help="Include sessions in other worktrees of same repo")
 
+    # sm all
+    all_parser = subparsers.add_parser("all", help="List all sessions system-wide")
+    all_parser.add_argument("--summaries", action="store_true", help="Include AI-generated summaries")
+
     # sm alone
     subparsers.add_parser("alone", help="Check if you're the only active agent (for scripting)")
 
@@ -68,7 +72,7 @@ def main():
 
     # Check for CLAUDE_SESSION_MANAGER_ID
     session_id = os.environ.get("CLAUDE_SESSION_MANAGER_ID")
-    if not session_id and args.command not in ["lock", "unlock", "subagent-start", "subagent-stop", None]:
+    if not session_id and args.command not in ["lock", "unlock", "subagent-start", "subagent-stop", "all", None]:
         print("Error: CLAUDE_SESSION_MANAGER_ID environment variable not set", file=sys.stderr)
         print("This tool must be run inside a Claude Code session managed by Session Manager", file=sys.stderr)
         sys.exit(2)
@@ -87,6 +91,8 @@ def main():
         sys.exit(commands.cmd_what(client, args.session_id, args.lines, args.deep))
     elif args.command == "others":
         sys.exit(commands.cmd_others(client, session_id, args.repo))
+    elif args.command == "all":
+        sys.exit(commands.cmd_all(client, args.summaries))
     elif args.command == "alone":
         sys.exit(commands.cmd_alone(client, session_id))
     elif args.command == "task":


### PR DESCRIPTION
## Summary

Adds `sm all` command to list all active sessions across all directories/workspaces.

## Motivation

Currently, `sm who` and `sm others` only show sessions in the same workspace. When working across multiple projects (e.g., `office-automate` and `fractal-market-simulator`), there's no easy way to see all sessions system-wide without using `curl` to hit the API directly.

## Changes

### New Command: `sm all`

Lists all active Claude Code sessions across all directories:

```bash
$ sm all
office-automate (fc7d7dbc) | idle | ~/Desktop/automation/office-automate
architect1 (a55ff908)      | error | ~/Desktop/fractal-market-simulator
sessionmgr (a4af4272)      | error | ~/Desktop/fractal-market-simulator
```

### Optional `--summaries` Flag

Include AI-generated summaries for each session:

```bash
$ sm all --summaries
office-automate (fc7d7dbc) | idle | 2hr ago
  → Waiting for next task in office automation project

sessionmgr (a4af4272) | error | 1min ago
  → Implementing the sm all command to list all sessions system-wide
```

## Implementation

- **CLI (`main.py`)**: Added argument parser and command dispatch
- **Commands (`commands.py`)**: Added `cmd_all()` that queries `/sessions` API
- **No session ID required**: Works without `CLAUDE_SESSION_MANAGER_ID` env var

## Command Comparison

| Command | Scope | Filter |
|---------|-------|--------|
| `sm who` | Current workspace | Same `working_dir` |
| `sm others` | Current workspace/repo | Same `working_dir` or `--repo` |
| **`sm all`** | **System-wide** | **None (shows all)** |

## Use Cases

- Find sessions running in other directories
- Get system overview of all Claude agents
- Quickly locate session IDs for `sm what` or `sm subagents`
- Multi-project coordination

## Testing

✅ Basic list shows all sessions with directories  
✅ `--summaries` flag generates AI summaries  
✅ Works across different workspaces  
✅ No errors when session manager unavailable  

🤖 Generated with [Claude Code](https://claude.com/claude-code)