### PR TITLE
Implement sm send command

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ The `sm` CLI tool enables Claude sessions to coordinate with each other. It's au
 | `sm task "<description>"` | Register what you're working on |
 | `sm status` | Full status: you + others + lock file |
 | `sm subagents <session-id>` | List subagents spawned by a session |
+| `sm send <session-id> "<text>"` | Send input to any session |
 
 ### Subagent Tracking
 
@@ -186,6 +187,10 @@ engineer-db (a1b2c3d4) | running | ~/projects/myapp
 
 # Register your task to avoid conflicts
 $ sm task "Implementing user authentication API"
+
+# Send input to another agent
+$ sm send a1b2c3d4 "Database migration complete, you can proceed"
+Input sent to engineer-db (a1b2c3d4)
 ```
 
 **Tracking subagents:**

--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -148,3 +148,21 @@ class SessionManagerClient:
         if success and data:
             return data.get("subagents", [])
         return None
+
+    def send_input(self, session_id: str, text: str) -> tuple[bool, bool]:
+        """
+        Send text input to a session.
+
+        Args:
+            session_id: Target session ID
+            text: Text to send to the session's Claude input
+
+        Returns:
+            Tuple of (success, unavailable)
+        """
+        data, success, unavailable = self._request(
+            "POST",
+            f"/sessions/{session_id}/input",
+            {"text": text}
+        )
+        return success, unavailable

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -523,3 +523,45 @@ def cmd_subagents(client: SessionManagerClient, target_session_id: str) -> int:
             print(f"     {sa['summary']}")
 
     return 0
+
+
+def cmd_send(client: SessionManagerClient, session_id: str, text: str) -> int:
+    """
+    Send input text to a session.
+
+    Args:
+        client: API client
+        session_id: Target session ID
+        text: Text to send
+
+    Exit codes:
+        0: Success
+        1: Session not found or send failed
+        2: Session manager unavailable
+    """
+    # Check if session exists
+    session = client.get_session(session_id)
+    if session is None:
+        sessions = client.list_sessions()
+        if sessions is None:
+            print("Error: Session manager unavailable", file=sys.stderr)
+            return 2
+        else:
+            print(f"Error: Session {session_id} not found", file=sys.stderr)
+            return 1
+
+    # Send input
+    success, unavailable = client.send_input(session_id, text)
+
+    if unavailable:
+        print("Error: Session manager unavailable", file=sys.stderr)
+        return 2
+
+    if not success:
+        print(f"Error: Failed to send input to session {session_id}", file=sys.stderr)
+        return 1
+
+    # Success
+    name = session.get("friendly_name") or session.get("name") or session_id
+    print(f"Input sent to {name} ({session_id})")
+    return 0

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -68,11 +68,18 @@ def main():
     subagents_parser = subparsers.add_parser("subagents", help="List subagents spawned by a session")
     subagents_parser.add_argument("session_id", help="Session ID")
 
+    # sm send <session-id> "<text>"
+    send_parser = subparsers.add_parser("send", help="Send input to a session")
+    send_parser.add_argument("session_id", help="Target session ID")
+    send_parser.add_argument("text", help="Text to send to the session")
+
     args = parser.parse_args()
 
     # Check for CLAUDE_SESSION_MANAGER_ID
     session_id = os.environ.get("CLAUDE_SESSION_MANAGER_ID")
-    if not session_id and args.command not in ["lock", "unlock", "subagent-start", "subagent-stop", "all", None]:
+    # Commands that don't need session_id: lock, unlock, hooks, all, send, what, subagents
+    no_session_needed = ["lock", "unlock", "subagent-start", "subagent-stop", "all", "send", "what", "subagents", None]
+    if not session_id and args.command not in no_session_needed:
         print("Error: CLAUDE_SESSION_MANAGER_ID environment variable not set", file=sys.stderr)
         print("This tool must be run inside a Claude Code session managed by Session Manager", file=sys.stderr)
         sys.exit(2)
@@ -109,6 +116,8 @@ def main():
         sys.exit(commands.cmd_subagent_stop(client, session_id))
     elif args.command == "subagents":
         sys.exit(commands.cmd_subagents(client, args.session_id))
+    elif args.command == "send":
+        sys.exit(commands.cmd_send(client, args.session_id, args.text))
     else:
         parser.print_help()
         sys.exit(0)


### PR DESCRIPTION
Fixes #8

## Changes
- Add `send_input()` method to SessionManagerClient
- Add `cmd_send()` command handler with error handling
- Add `sm send <session-id> "<text>"` to CLI parser
- Update README with command documentation and example workflow
- Make `sm send` work without CLAUDE_SESSION_MANAGER_ID (can be used from anywhere)

## Testing
✅ Successfully sends input to target session
✅ Proper error handling for non-existent sessions
✅ Works from any terminal (doesn't require being in a managed session)

## Use Cases
- Agent-to-agent communication
- Parent answering child's questions  
- Peer coordination between parallel agents
- Quick manual intervention from any terminal

## Example
```bash
$ sm send fc7d7dbc "Database migration complete, you can proceed"
Input sent to office-automate (fc7d7dbc)
```