### PR TITLE
Support friendly names in sm send

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,8 +188,11 @@ engineer-db (a1b2c3d4) | running | ~/projects/myapp
 # Register your task to avoid conflicts
 $ sm task "Implementing user authentication API"
 
-# Send input to another agent
-$ sm send a1b2c3d4 "Database migration complete, you can proceed"
+# Send input to another agent (using friendly name or session ID)
+$ sm send engineer-db "Database migration complete, you can proceed"
+Input sent to engineer-db (a1b2c3d4)
+
+$ sm send a1b2c3d4 "Additional context..."
 Input sent to engineer-db (a1b2c3d4)
 ```
 


### PR DESCRIPTION
Fixes #10

## Changes
- Add `resolve_session_id()` helper function that resolves session ID or friendly name
- Update `cmd_send()` to accept both session IDs and friendly names
- Returns tuple (session_id, session_dict) to avoid redundant API calls
- Update README examples to show both usage patterns

## Benefits
- More user-friendly - can use names shown in `sm all` output
- Consistent with user expectations (if it's displayed, it should work)
- Reduced API calls (2 max instead of 3)
- Better performance and reliability

## Testing
✅ Works with friendly name: `sm send sessionmgr "text"`
✅ Works with session ID: `sm send a4af4272 "text"`  
✅ Proper error for non-existent identifier

## Example
```bash
$ sm all
sessionmgr (a4af4272) | running | ...

$ sm send sessionmgr "Update complete"
Input sent to sessionmgr (a4af4272)
```