### PR TITLE
Add sender metadata to sm send

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ The `sm` CLI tool enables Claude sessions to coordinate with each other. It's au
 | `sm task "<description>"` | Register what you're working on |
 | `sm status` | Full status: you + others + lock file |
 | `sm subagents <session-id>` | List subagents spawned by a session |
-| `sm send <session-id> "<text>"` | Send input to any session |
+| `sm send <session-id> "<text>"` | Send input to any session (includes sender metadata) |
 
 ### Subagent Tracking
 
@@ -192,9 +192,13 @@ $ sm task "Implementing user authentication API"
 $ sm send engineer-db "Database migration complete, you can proceed"
 Input sent to engineer-db (a1b2c3d4)
 
-$ sm send a1b2c3d4 "Additional context..."
-Input sent to engineer-db (a1b2c3d4)
+# When sent from a managed session, includes sender metadata:
+# The receiving agent sees:
+# [Input from: architect-pr1032 (08bc57cf) via sm send]
+# Database migration complete, you can proceed
 ```
+
+**Note:** When `sm send` is called from within a managed session, it automatically includes sender metadata so the receiving agent knows who sent the message. When called from a terminal outside a session, the message is sent without metadata.
 
 **Tracking subagents:**
 ```bash

--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -149,20 +149,25 @@ class SessionManagerClient:
             return data.get("subagents", [])
         return None
 
-    def send_input(self, session_id: str, text: str) -> tuple[bool, bool]:
+    def send_input(self, session_id: str, text: str, sender_session_id: Optional[str] = None) -> tuple[bool, bool]:
         """
         Send text input to a session.
 
         Args:
             session_id: Target session ID
             text: Text to send to the session's Claude input
+            sender_session_id: Optional sender session ID (for metadata)
 
         Returns:
             Tuple of (success, unavailable)
         """
+        payload = {"text": text}
+        if sender_session_id:
+            payload["sender_session_id"] = sender_session_id
+
         data, success, unavailable = self._request(
             "POST",
             f"/sessions/{session_id}/input",
-            {"text": text}
+            payload
         )
         return success, unavailable

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -580,8 +580,11 @@ def cmd_send(client: SessionManagerClient, identifier: str, text: str) -> int:
             print(f"Error: Session '{identifier}' not found", file=sys.stderr)
             return 1
 
-    # Send input
-    success, unavailable = client.send_input(session_id, text)
+    # Get sender session ID from environment (if available)
+    sender_session_id = client.session_id  # Set from CLAUDE_SESSION_MANAGER_ID in __init__
+
+    # Send input with sender metadata
+    success, unavailable = client.send_input(session_id, text, sender_session_id=sender_session_id)
 
     if unavailable:
         print("Error: Session manager unavailable", file=sys.stderr)

--- a/src/server.py
+++ b/src/server.py
@@ -33,6 +33,7 @@ class SessionResponse(BaseModel):
 class SendInputRequest(BaseModel):
     """Request to send input to a session."""
     text: str
+    sender_session_id: Optional[str] = None  # Optional sender identification
 
 
 class NotifyRequest(BaseModel):
@@ -252,7 +253,11 @@ def create_app(
         if not session:
             raise HTTPException(status_code=404, detail="Session not found")
 
-        success = app.state.session_manager.send_input(session_id, request.text)
+        success = app.state.session_manager.send_input(
+            session_id,
+            request.text,
+            sender_session_id=request.sender_session_id
+        )
 
         if not success:
             raise HTTPException(status_code=500, detail="Failed to send input")


### PR DESCRIPTION
Fixes #12

## Problem
When agents receive input via `sm send`, they couldn't distinguish:
- Human typing directly
- Another agent sending via `sm send`
- Session manager sending notifications

## Solution
Automatically wrap messages with sender metadata when sent from a managed session.

## Changes
- Add optional `sender_session_id` field to SendInputRequest API model
- Update `session_manager.send_input()` to wrap text with sender metadata
- CLI automatically includes sender ID when run from managed session (CLAUDE_SESSION_MANAGER_ID)
- Falls back to plain text when no sender ID available

## Message Format
```
[Input from: architect-pr1032 (08bc57cf) via sm send]
Please review this change
```

## Benefits
- Agents understand the chain of command
- Can respond appropriately based on sender
- Helps with debugging (know where input came from)
- Supports multi-agent coordination patterns
- Backward compatible

## Testing
✅ Sends with metadata when run from managed session
✅ Sends without metadata when run from terminal
✅ Backward compatible with existing API calls

## Example
```bash
# From within a managed session
$ sm send engineer-db "Migration complete"

# Receiving agent sees:
# [Input from: architect-pr1032 (08bc57cf) via sm send]
# Migration complete
```