### PR TITLE
Add Telegram notifications for sm send messages

### DIFF
--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -149,7 +149,14 @@ class SessionManagerClient:
             return data.get("subagents", [])
         return None
 
-    def send_input(self, session_id: str, text: str, sender_session_id: Optional[str] = None, delivery_mode: str = "sequential") -> tuple[bool, bool]:
+    def send_input(
+        self,
+        session_id: str,
+        text: str,
+        sender_session_id: Optional[str] = None,
+        delivery_mode: str = "sequential",
+        from_sm_send: bool = False,
+    ) -> tuple[bool, bool]:
         """
         Send text input to a session.
 
@@ -158,11 +165,12 @@ class SessionManagerClient:
             text: Text to send to the session's Claude input
             sender_session_id: Optional sender session ID (for metadata)
             delivery_mode: Delivery mode (sequential, important, urgent)
+            from_sm_send: True if called from sm send command (triggers notification)
 
         Returns:
             Tuple of (success, unavailable)
         """
-        payload = {"text": text, "delivery_mode": delivery_mode}
+        payload = {"text": text, "delivery_mode": delivery_mode, "from_sm_send": from_sm_send}
         if sender_session_id:
             payload["sender_session_id"] = sender_session_id
 

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -584,8 +584,14 @@ def cmd_send(client: SessionManagerClient, identifier: str, text: str, delivery_
     # Get sender session ID from environment (if available)
     sender_session_id = client.session_id  # Set from CLAUDE_SESSION_MANAGER_ID in __init__
 
-    # Send input with sender metadata and delivery mode
-    success, unavailable = client.send_input(session_id, text, sender_session_id=sender_session_id, delivery_mode=delivery_mode)
+    # Send input with sender metadata, delivery mode, and sm send flag
+    success, unavailable = client.send_input(
+        session_id,
+        text,
+        sender_session_id=sender_session_id,
+        delivery_mode=delivery_mode,
+        from_sm_send=True,  # This is from sm send command
+    )
 
     if unavailable:
         print("Error: Session manager unavailable", file=sys.stderr)

--- a/src/models.py
+++ b/src/models.py
@@ -18,6 +18,13 @@ class SessionStatus(Enum):
     ERROR = "error"
 
 
+class DeliveryMode(Enum):
+    """Message delivery modes for sm send."""
+    SEQUENTIAL = "sequential"
+    IMPORTANT = "important"
+    URGENT = "urgent"
+
+
 class NotificationChannel(Enum):
     """Available notification channels."""
     TELEGRAM = "telegram"

--- a/src/server.py
+++ b/src/server.py
@@ -35,6 +35,7 @@ class SendInputRequest(BaseModel):
     text: str
     sender_session_id: Optional[str] = None  # Optional sender identification
     delivery_mode: str = "sequential"  # sequential, important, urgent
+    from_sm_send: bool = False  # True if called from sm send command
 
 
 class NotifyRequest(BaseModel):
@@ -276,6 +277,7 @@ def create_app(
             request.text,
             sender_session_id=request.sender_session_id,
             delivery_mode=request.delivery_mode,
+            from_sm_send=request.from_sm_send,
         )
 
         if not success:


### PR DESCRIPTION
## Summary

Adds Telegram notifications when agents send messages via `sm send`, providing visibility into multi-agent coordination.

Fixes #16

## Changes

1. **Added DeliveryMode enum** for type safety
2. **Extended send_input() chain** with `from_sm_send` flag:
   - CLI → Client → API → SessionManager
   - Only set to `true` when called from `sm send` command
3. **Added notification logic** in SessionManager:
   - Shows sender's friendly name
   - Indicates delivery mode with icons (📨/❗/⚡)
   - Displays full message text (no truncation)
   - Only notifies recipient's thread (lightweight)

## Behavior

**Triggers notification:**
- ✅ `sm send agent-b "message"` → Notification in agent-b's thread

**Silent (no notification):**
- ✅ Programmatic `send_input()` calls (internal coordination)
- ✅ ChildMonitor completion notifications (automatic)

**Notification format:**
```
📨 From [engineer-1042] (sequential): Please review PR #1234
⚡ From [architect] (urgent): STOP - wrong branch!
❗ From [reviewer] (important): Consider using async/await
```

## Testing

- [x] All imports successful
- [x] Client signature updated correctly
- [ ] Integration test: Send messages with all delivery modes
- [ ] Verify notifications appear in Telegram

## Files Changed

- `src/models.py`: Added DeliveryMode enum
- `src/session_manager.py`: Added from_sm_send param + notification logic
- `src/server.py`: Updated SendInputRequest + endpoint
- `src/cli/client.py`: Updated send_input() signature
- `src/cli/commands.py`: Set from_sm_send=True in cmd_send()

## Notes

Session manager restart required to load changes after merge.

cc @rajeshgoli