### PR TITLE
Fix: Update Telegram topic name when session name changes via sm name

### DIFF
--- a/src/notifier.py
+++ b/src/notifier.py
@@ -214,6 +214,36 @@ class Notifier:
 
         return "\n".join(lines)
 
+    async def rename_session_topic(
+        self,
+        session: Session,
+        new_name: str,
+    ) -> bool:
+        """
+        Rename the Telegram topic for a session.
+
+        Args:
+            session: Session with telegram_chat_id and telegram_topic_id
+            new_name: New friendly name for the topic
+
+        Returns:
+            True if renamed successfully
+        """
+        if not self.telegram:
+            return False
+
+        if not session.telegram_chat_id or not session.telegram_topic_id:
+            return False
+
+        # Format topic name same way as when created
+        topic_name = f"{new_name} [{session.id}]"
+
+        return await self.telegram.rename_forum_topic(
+            chat_id=session.telegram_chat_id,
+            topic_id=session.telegram_topic_id,
+            name=topic_name,
+        )
+
     async def request_email_notification(
         self,
         session_id: str,

--- a/src/server.py
+++ b/src/server.py
@@ -299,6 +299,9 @@ def create_app(
             app.state.session_manager._save_state()
             # Update tmux status bar
             app.state.session_manager.tmux.set_status_bar(session.tmux_session, friendly_name)
+            # Update Telegram topic name if applicable
+            if session.telegram_topic_id and app.state.notifier:
+                await app.state.notifier.rename_session_topic(session, friendly_name)
 
         return SessionResponse(
             id=session.id,


### PR DESCRIPTION
## Summary
- Adds `rename_session_topic()` method to `Notifier` class
- Updates `PATCH /sessions/{session_id}` endpoint to rename Telegram topic when `friendly_name` is updated

## Test plan
- [ ] Run `sm name <new-name>` on a session with a Telegram topic
- [ ] Verify the Telegram topic name updates to `<new-name> [session_id]`

Fixes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)