### PR TITLE
Fix: Add missing timeout and notification parameters to send_input() (fixes #56)

### DIFF
--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -156,6 +156,9 @@ class SessionManagerClient:
         sender_session_id: Optional[str] = None,
         delivery_mode: str = "sequential",
         from_sm_send: bool = False,
+        timeout_seconds: Optional[int] = None,
+        notify_on_delivery: bool = False,
+        notify_after_seconds: Optional[int] = None,
     ) -> tuple[bool, bool]:
         """
         Send text input to a session.
@@ -166,6 +169,9 @@ class SessionManagerClient:
             sender_session_id: Optional sender session ID (for metadata)
             delivery_mode: Delivery mode (sequential, important, urgent)
             from_sm_send: True if called from sm send command (triggers notification)
+            timeout_seconds: Drop message if not delivered in this time
+            notify_on_delivery: Notify sender when delivered
+            notify_after_seconds: Notify sender N seconds after delivery
 
         Returns:
             Tuple of (success, unavailable)
@@ -173,6 +179,12 @@ class SessionManagerClient:
         payload = {"text": text, "delivery_mode": delivery_mode, "from_sm_send": from_sm_send}
         if sender_session_id:
             payload["sender_session_id"] = sender_session_id
+        if timeout_seconds is not None:
+            payload["timeout_seconds"] = timeout_seconds
+        if notify_on_delivery:
+            payload["notify_on_delivery"] = notify_on_delivery
+        if notify_after_seconds is not None:
+            payload["notify_after_seconds"] = notify_after_seconds
 
         data, success, unavailable = self._request(
             "POST",


### PR DESCRIPTION
## Summary

Fixes #56 - `sm send` command fails with TypeError because `send_input()` was missing three parameters that `cmd_send()` was trying to pass.

## Changes

- Added `timeout_seconds: Optional[int] = None` parameter to `SessionManagerClient.send_input()`
- Added `notify_on_delivery: bool = False` parameter to `SessionManagerClient.send_input()`
- Added `notify_after_seconds: Optional[int] = None` parameter to `SessionManagerClient.send_input()`
- Updated method to include these parameters in the API payload when provided

## Root Cause

`commands.py:cmd_send()` was calling `client.send_input()` with parameters that didn't exist in the method signature, causing a TypeError.

## Testing

The fix ensures that when `cmd_send()` calls `send_input()` with timeout and notification options, the parameters are properly accepted and passed to the API endpoint.

## Impact

- Unblocks EM workflow
- Enables multi-agent coordination via `sm send` with timeout and notification features
- No breaking changes - all new parameters are optional with sensible defaults

🤖 Generated with Claude Code