### PR TITLE
Fix session name/tmux_session mismatch (fixes #32)

### DIFF
--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -131,7 +131,6 @@ class SessionManager:
 
         if name:
             session.name = name
-            session.tmux_session = name
 
         # Set up log file path
         session.log_file = str(self.log_dir / f"{session.name}.log")


### PR DESCRIPTION
## Summary

Fixes #32 by removing the line that incorrectly set `tmux_session` to the user-provided name.

## The Bug

`create_session()` was violating the data model invariant:

```python
if name:
    session.name = name
    session.tmux_session = name  # BUG: Violates invariant
```

The `Session` model expects `tmux_session` to always be `claude-{id}`, not the custom name.

## Impact

Without this fix:
- Session recovery after server restart fails
- `_load_state()` checks `tmux.session_exists(session.tmux_session)` which fails when tmux_session doesn't match the actual tmux session name
- Restarting with the same name but different ID breaks tmux lookup

## The Fix

Remove line 134 in `session_manager.py`. Keep `tmux_session` as the auto-generated `claude-{id}` value set in the `Session` constructor.

## Testing

- [ ] Verify session recovery after server restart works
- [ ] Verify restarting with same name but different ID works
- [ ] Verify custom names still work for display purposes