### PR TITLE
Fix: Remove incorrect idle check from --wait notification (#75)

### DIFF
--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -679,21 +679,20 @@ class MessageQueueManager:
 
         async def send_followup():
             await asyncio.sleep(msg.notify_after_seconds)
-            # Only notify if recipient is idle
-            if self.is_session_idle(msg.target_session_id):
-                truncated = msg.text[:100] + "..." if len(msg.text) > 100 else msg.text
-                notification = (
-                    f'[sm] Reminder: {msg.notify_after_seconds}s since your message to '
-                    f'{msg.target_session_id} was delivered\n'
-                    f'Original: "{truncated}"\n'
-                    f'You can check status with: sm output {msg.target_session_id}'
-                )
-                self.queue_message(
-                    target_session_id=msg.sender_session_id,
-                    text=notification,
-                    delivery_mode="sequential",
-                )
-                logger.info(f"Sent follow-up notification to {msg.sender_session_id}")
+            # Send notification after N seconds regardless of recipient state
+            truncated = msg.text[:100] + "..." if len(msg.text) > 100 else msg.text
+            notification = (
+                f'[sm] Reminder: {msg.notify_after_seconds}s since your message to '
+                f'{msg.target_session_id} was delivered\n'
+                f'Original: "{truncated}"\n'
+                f'You can check status with: sm output {msg.target_session_id}'
+            )
+            self.queue_message(
+                target_session_id=msg.sender_session_id,
+                text=notification,
+                delivery_mode="sequential",
+            )
+            logger.info(f"Sent follow-up notification to {msg.sender_session_id}")
 
         asyncio.create_task(send_followup())
 

--- a/tests/regression/test_wait_features.py
+++ b/tests/regression/test_wait_features.py
@@ -215,8 +215,8 @@ class TestFollowupNotificationIdleCheck:
     """Test idle check in follow-up notifications (issue #72 fix)."""
 
     @pytest.mark.asyncio
-    async def test_followup_notification_only_sent_if_idle(self):
-        """Test that follow-up notification is only sent if recipient is still idle."""
+    async def test_followup_notification_sent_regardless_of_idle(self):
+        """Test that follow-up notification is sent after N seconds regardless of recipient state."""
         from src.message_queue import MessageQueueManager
         from src.models import QueuedMessage
         from datetime import datetime
@@ -239,7 +239,7 @@ class TestFollowupNotificationIdleCheck:
         )
         queue_mgr._init_db()
 
-        # Mock is_session_idle to return False (recipient became active)
+        # Mock is_session_idle to return False (recipient is active)
         queue_mgr.is_session_idle = MagicMock(return_value=False)
 
         # Create a message with notify_after_seconds
@@ -261,12 +261,12 @@ class TestFollowupNotificationIdleCheck:
         # Wait for the notification to fire
         await asyncio.sleep(1.5)
 
-        # Verify no notification was queued (recipient is not idle)
-        queue_mgr.queue_message.assert_not_called()
+        # Verify notification WAS queued even though recipient is not idle
+        queue_mgr.queue_message.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_followup_notification_sent_when_idle(self):
-        """Test that follow-up notification IS sent if recipient is idle."""
+    async def test_followup_notification_sent_after_timeout(self):
+        """Test that follow-up notification is sent after timeout with correct format."""
         from src.message_queue import MessageQueueManager
         from src.models import QueuedMessage
         from datetime import datetime


### PR DESCRIPTION
Fixes #75

## Summary
- Removed the incorrect idle state check from --wait notification
- Notifications are now sent after N seconds regardless of recipient state
- Updated tests to reflect correct behavior

## Problem
The --wait N notification was only sent if the recipient was still idle after N seconds. This defeated the purpose:
- User sends message with `sm send target "do X" --wait 300`
- Expects notification after 5 minutes to check on progress
- But notification only arrives IF target is still idle
- If target is working, sender never gets notified

This made --wait unreliable and confusing.

## Root Cause
In PR #74, an idle check was added to "reduce notification noise":
```python
if self.is_session_idle(msg.target_session_id):
    # Send notification
```

While well-intentioned, this was incorrect. The --wait flag should be a simple timeout notification, not conditional on recipient state.

## Solution
Removed the idle check from `_schedule_followup_notification()`. Now notifications are sent unconditionally after N seconds.

Users can:
- Use `sm output <session>` to check current output
- Use `sm wait <session> N` to poll until idle
- Make their own decision about what to do next

## Changes

### src/message_queue.py
- `_schedule_followup_notification()`: Removed `if self.is_session_idle()` check
- Updated comment: "Send notification after N seconds regardless of recipient state"

### tests/regression/test_wait_features.py
- `test_followup_notification_sent_regardless_of_idle`: Updated to expect notification even when recipient is NOT idle
- `test_followup_notification_sent_after_timeout`: Renamed (was `test_followup_notification_sent_when_idle`)

## Test Results
All 23 tests passing.

## Impact
Users can now reliably use --wait N for timeout-based notifications and make their own decisions about next steps.

Generated with Claude Code