### PR TITLE
Fix: Implement wait parameter in spawn_child_session (#36)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -179,6 +179,8 @@ class SessionManagerApp:
 
         # Child monitor for --wait functionality
         self.child_monitor = ChildMonitor(self.session_manager)
+        # Pass child monitor to session manager
+        self.session_manager.child_monitor = self.child_monitor
 
         # Message queue manager for reliable inter-agent messaging (sm-send-v2)
         sm_send_config = config.get("sm_send", {})

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -35,6 +35,9 @@ class SessionManager:
         # Message queue manager (set by main app)
         self.message_queue_manager = None
 
+        # Child monitor (set by main app)
+        self.child_monitor = None
+
         # Load existing sessions from state file
         self._load_state()
 
@@ -261,8 +264,13 @@ class SessionManager:
 
         logger.info(f"Spawned child session {session.name} (id={session.id}, parent={parent_session_id})")
 
-        # TODO: Register background monitoring if wait is specified
-        # This will be implemented in Task #5
+        # Register background monitoring if wait is specified
+        if wait and self.child_monitor:
+            self.child_monitor.register_child(
+                child_session_id=session.id,
+                parent_session_id=parent_session_id,
+                wait_seconds=wait,
+            )
 
         return session
 

--- a/tests/regression/test_issue_36_spawn_wait_param.py
+++ b/tests/regression/test_issue_36_spawn_wait_param.py
@@ -1,0 +1,200 @@
+"""
+Regression tests for issue #36: spawn_child_session wait parameter accepted but not implemented
+
+Tests verify that when wait parameter is provided to spawn_child_session,
+the child_monitor.register_child is called properly.
+"""
+
+import pytest
+from pathlib import Path
+from unittest.mock import Mock, MagicMock
+from datetime import datetime
+
+from src.session_manager import SessionManager
+from src.models import Session, SessionStatus
+
+
+@pytest.fixture
+def temp_state_file(tmp_path):
+    """Create a temporary state file."""
+    state_file = tmp_path / "sessions.json"
+    import json
+    with open(state_file, "w") as f:
+        json.dump({"sessions": []}, f)
+    return str(state_file)
+
+
+@pytest.fixture
+def mock_child_monitor():
+    """Create a mock ChildMonitor."""
+    monitor = Mock()
+    monitor.register_child = Mock()
+    return monitor
+
+
+@pytest.fixture
+def session_manager(temp_state_file, tmp_path, mock_child_monitor):
+    """Create a SessionManager for testing."""
+    manager = SessionManager(
+        log_dir=str(tmp_path),
+        state_file=temp_state_file,
+    )
+
+    # Replace tmux controller with mock
+    mock_tmux = Mock()
+    mock_tmux.session_exists = Mock(return_value=True)
+    mock_tmux.create_session_with_command = Mock(return_value=True)
+    manager.tmux = mock_tmux
+
+    # Set child monitor
+    manager.child_monitor = mock_child_monitor
+
+    return manager
+
+
+def test_spawn_child_with_wait_registers_monitor(session_manager, mock_child_monitor):
+    """Test that spawn_child_session with wait parameter calls child_monitor.register_child."""
+    # Create a parent session first
+    parent_session = Session(
+        id="parent-123",
+        name="parent-session",
+        working_dir="/tmp/test",
+        tmux_session="tmux-parent",
+        status=SessionStatus.RUNNING,
+    )
+    session_manager.sessions[parent_session.id] = parent_session
+
+    # Spawn a child session with wait parameter
+    child_session = session_manager.spawn_child_session(
+        parent_session_id=parent_session.id,
+        prompt="Test prompt",
+        name="test-child",
+        wait=300,  # Wait 300 seconds
+    )
+
+    # Verify child session was created
+    assert child_session is not None
+    assert child_session.parent_session_id == parent_session.id
+
+    # Verify child_monitor.register_child was called
+    mock_child_monitor.register_child.assert_called_once()
+
+    # Verify the call had correct parameters
+    call_args = mock_child_monitor.register_child.call_args
+    assert call_args[1]["child_session_id"] == child_session.id
+    assert call_args[1]["parent_session_id"] == parent_session.id
+    assert call_args[1]["wait_seconds"] == 300
+
+
+def test_spawn_child_without_wait_skips_monitor(session_manager, mock_child_monitor):
+    """Test that spawn_child_session without wait parameter doesn't call child_monitor.register_child."""
+    # Create a parent session
+    parent_session = Session(
+        id="parent-456",
+        name="parent-session-2",
+        working_dir="/tmp/test2",
+        tmux_session="tmux-parent-2",
+        status=SessionStatus.RUNNING,
+    )
+    session_manager.sessions[parent_session.id] = parent_session
+
+    # Spawn a child session WITHOUT wait parameter
+    child_session = session_manager.spawn_child_session(
+        parent_session_id=parent_session.id,
+        prompt="Test prompt",
+        name="test-child-2",
+        wait=None,  # No wait
+    )
+
+    # Verify child session was created
+    assert child_session is not None
+    assert child_session.parent_session_id == parent_session.id
+
+    # Verify child_monitor.register_child was NOT called
+    mock_child_monitor.register_child.assert_not_called()
+
+
+def test_spawn_child_with_wait_zero_skips_monitor(session_manager, mock_child_monitor):
+    """Test that spawn_child_session with wait=0 doesn't call child_monitor.register_child."""
+    # Create a parent session
+    parent_session = Session(
+        id="parent-789",
+        name="parent-session-3",
+        working_dir="/tmp/test3",
+        tmux_session="tmux-parent-3",
+        status=SessionStatus.RUNNING,
+    )
+    session_manager.sessions[parent_session.id] = parent_session
+
+    # Spawn a child session with wait=0 (falsy value)
+    child_session = session_manager.spawn_child_session(
+        parent_session_id=parent_session.id,
+        prompt="Test prompt",
+        name="test-child-3",
+        wait=0,  # Falsy value
+    )
+
+    # Verify child session was created
+    assert child_session is not None
+
+    # Verify child_monitor.register_child was NOT called (0 is falsy)
+    mock_child_monitor.register_child.assert_not_called()
+
+
+def test_spawn_child_without_child_monitor_succeeds(session_manager):
+    """Test that spawn_child_session works even when child_monitor is not set."""
+    # Remove child monitor
+    session_manager.child_monitor = None
+
+    # Create a parent session
+    parent_session = Session(
+        id="parent-abc",
+        name="parent-session-4",
+        working_dir="/tmp/test4",
+        tmux_session="tmux-parent-4",
+        status=SessionStatus.RUNNING,
+    )
+    session_manager.sessions[parent_session.id] = parent_session
+
+    # Spawn a child session with wait parameter (but no child_monitor)
+    child_session = session_manager.spawn_child_session(
+        parent_session_id=parent_session.id,
+        prompt="Test prompt",
+        name="test-child-4",
+        wait=300,
+    )
+
+    # Verify child session was created (doesn't crash)
+    assert child_session is not None
+    assert child_session.parent_session_id == parent_session.id
+
+
+def test_spawn_child_with_wait_positive_values(session_manager, mock_child_monitor):
+    """Test various positive wait values."""
+    parent_session = Session(
+        id="parent-def",
+        name="parent-session-5",
+        working_dir="/tmp/test5",
+        tmux_session="tmux-parent-5",
+        status=SessionStatus.RUNNING,
+    )
+    session_manager.sessions[parent_session.id] = parent_session
+
+    test_wait_values = [1, 60, 300, 600, 3600]
+
+    for wait_val in test_wait_values:
+        # Reset the mock
+        mock_child_monitor.reset_mock()
+
+        # Spawn child with specific wait value
+        child_session = session_manager.spawn_child_session(
+            parent_session_id=parent_session.id,
+            prompt="Test prompt",
+            name=f"test-child-wait-{wait_val}",
+            wait=wait_val,
+        )
+
+        # Verify register_child was called with correct wait_seconds
+        mock_child_monitor.register_child.assert_called_once()
+        call_args = mock_child_monitor.register_child.call_args
+        assert call_args[1]["wait_seconds"] == wait_val


### PR DESCRIPTION
Fixes #36

## Summary
- Implemented the wait parameter in spawn_child_session() by calling child_monitor.register_child()
- Added 5 comprehensive regression tests
- All 38 tests passing

## Problem
The `wait` parameter in `spawn_child_session()` was accepted and documented but completely ignored:

```python
def spawn_child_session(
    ...
    wait: Optional[int] = None,  # Accepted parameter
    ...
):
    ...
    # TODO: Register background monitoring if wait is specified
    # This will be implemented in Task #5
    
    return session  # Parameter ignored!
```

**Impact:**
- Callers using `wait=300` expected notification when child completed or was idle for 300s
- No notification was ever sent
- Silent failure - caller didn't know it wasn't working
- The infrastructure existed (ChildMonitor) but wasn't being used

**Note:** The API endpoint in `server.py:901-906` already implemented this correctly, but the core `spawn_child_session()` method itself did not.

## Solution
Implemented the wait parameter by calling `child_monitor.register_child()` when wait is provided, following the same pattern as the API endpoint:

```python
# Register background monitoring if wait is specified
if wait and self.child_monitor:
    self.child_monitor.register_child(
        child_session_id=session.id,
        parent_session_id=parent_session_id,
        wait_seconds=wait,
    )
```

## Changes

### src/session_manager.py
1. Added `self.child_monitor = None` to `__init__` (set by main app, follows same pattern as `message_queue_manager`)
2. Replaced TODO comment with actual implementation
3. Check if `wait` is provided and `child_monitor` exists before calling `register_child()`

### src/main.py
- Added `self.session_manager.child_monitor = self.child_monitor`
- This passes the child monitor instance to session manager
- Follows the same pattern as `message_queue_manager` assignment

### tests/regression/test_issue_36_spawn_wait_param.py
5 new regression tests:
1. **test_spawn_child_with_wait_registers_monitor**: Verify `register_child` is called with wait=300
2. **test_spawn_child_without_wait_skips_monitor**: Verify not called when wait=None
3. **test_spawn_child_with_wait_zero_skips_monitor**: Verify not called when wait=0 (falsy)
4. **test_spawn_child_without_child_monitor_succeeds**: Verify doesn't crash if monitor not set
5. **test_spawn_child_with_wait_positive_values**: Test various wait values (1, 60, 300, 600, 3600)

## Test Results
All 38 tests passing (5 new regression tests).

## Verification
When `wait=300` is provided:
- ✅ `child_monitor.register_child()` is called
- ✅ Correct parameters passed: child_session_id, parent_session_id, wait_seconds=300
- ✅ When wait is None or 0, register_child is not called
- ✅ Works even if child_monitor is not set (graceful degradation)

## Behavior
Now when you call:
```python
session_manager.spawn_child_session(
    parent_session_id="parent123",
    prompt="Do task X",
    wait=300
)
```

The child monitor will:
1. Monitor the child session
2. Detect when it completes or is idle for 300 seconds
3. Send notification to the parent session

Previously, the wait parameter was silently ignored.

Generated with Claude Code