### PR TITLE
Fix dead sessions never cleaned up (fixes #49)

### DIFF
--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -532,17 +532,4 @@ class SessionManager:
 
         return self.tmux.capture_pane(session.tmux_session, lines)
 
-    def cleanup_dead_sessions(self):
-        """Remove sessions that no longer exist in tmux."""
-        dead_sessions = []
-        for session_id, session in self.sessions.items():
-            if not self.tmux.session_exists(session.tmux_session):
-                dead_sessions.append(session_id)
-
-        for session_id in dead_sessions:
-            session = self.sessions[session_id]
-            session.status = SessionStatus.STOPPED
-            logger.info(f"Marked dead session as stopped: {session.name}")
-
-        if dead_sessions:
-            self._save_state()
+    # cleanup_dead_sessions() removed - OutputMonitor now handles detection and cleanup automatically

--- a/tests/regression/test_issue_49_dead_session_cleanup.py
+++ b/tests/regression/test_issue_49_dead_session_cleanup.py
@@ -1,0 +1,262 @@
+"""
+Regression tests for issue #49: Dead sessions never cleaned up
+
+Tests verify that:
+1. OutputMonitor detects tmux death and cleans up
+2. Telegram topics are deleted when sessions die
+3. In-memory mappings are cleaned up
+4. kill_session() performs full cleanup
+"""
+
+import pytest
+import asyncio
+from pathlib import Path
+from unittest.mock import Mock, AsyncMock, patch, MagicMock
+from datetime import datetime
+
+from src.output_monitor import OutputMonitor
+from src.models import Session, SessionStatus
+
+
+@pytest.fixture
+def mock_session():
+    """Create a mock session."""
+    session = Session(
+        id="test-123",
+        name="test-session",
+        working_dir="/tmp/test",
+        tmux_session="claude-test-123",
+        log_file="/tmp/test.log",
+        status=SessionStatus.RUNNING,
+        telegram_chat_id=12345,
+        telegram_topic_id=67890,
+    )
+    return session
+
+
+@pytest.fixture
+def mock_session_manager():
+    """Create a mock SessionManager."""
+    manager = Mock()
+    manager.sessions = {}
+    manager.tmux = Mock()
+    manager.tmux.session_exists = Mock(return_value=True)
+    manager._save_state = Mock()
+    manager.app = Mock()
+    manager.app.state = Mock()
+    manager.app.state.last_claude_output = {}
+
+    # Mock notifier with telegram_bot
+    manager.notifier = Mock()
+    manager.notifier.telegram_bot = Mock()
+    manager.notifier.telegram_bot.bot = AsyncMock()
+    manager.notifier.telegram_bot._topic_sessions = {}
+    manager.notifier.telegram_bot._session_threads = {}
+
+    return manager
+
+
+@pytest.fixture
+def output_monitor(mock_session_manager):
+    """Create OutputMonitor with mocked session manager."""
+    monitor = OutputMonitor(poll_interval=0.1)  # Fast polling for tests
+    monitor.set_session_manager(mock_session_manager)
+    monitor.set_save_state_callback(mock_session_manager._save_state)
+    return monitor
+
+
+@pytest.mark.asyncio
+async def test_monitor_detects_tmux_death(output_monitor, mock_session, mock_session_manager, tmp_path):
+    """Test that monitor detects when tmux session dies and cleans up."""
+    # Setup: Create log file
+    log_file = tmp_path / "test.log"
+    log_file.touch()
+    mock_session.log_file = str(log_file)
+
+    # Add session to manager
+    mock_session_manager.sessions[mock_session.id] = mock_session
+
+    # Simulate tmux existing initially
+    mock_session_manager.tmux.session_exists = Mock(return_value=True)
+
+    # Start monitoring
+    await output_monitor.start_monitoring(mock_session)
+
+    # Wait for a few polls
+    await asyncio.sleep(0.3)
+
+    # Simulate tmux death after ~30 polls
+    # We need to wait for check_counter to hit 30
+    # With 0.1s poll interval, 30 polls = 3 seconds
+    # Let's make tmux die and wait
+    mock_session_manager.tmux.session_exists = Mock(return_value=False)
+
+    # Wait for detection (30 polls * 0.1s = 3s, add buffer)
+    await asyncio.sleep(3.5)
+
+    # Verify cleanup happened
+    # Session should be removed from sessions dict
+    assert mock_session.id not in mock_session_manager.sessions
+
+    # Status should be STOPPED
+    assert mock_session.status == SessionStatus.STOPPED
+
+    # State should be saved
+    mock_session_manager._save_state.assert_called()
+
+    # Telegram topic should be deleted
+    mock_session_manager.notifier.telegram_bot.bot.delete_forum_topic.assert_called_once_with(
+        chat_id=12345,
+        message_thread_id=67890,
+    )
+
+    # Monitoring should have stopped
+    assert mock_session.id not in output_monitor._tasks
+
+
+@pytest.mark.asyncio
+async def test_cleanup_session_full_workflow(output_monitor, mock_session, mock_session_manager):
+    """Test that cleanup_session performs all cleanup steps."""
+    # Add session to manager
+    mock_session_manager.sessions[mock_session.id] = mock_session
+
+    # Add to telegram mappings
+    mock_session_manager.notifier.telegram_bot._topic_sessions[(12345, 67890)] = mock_session.id
+    mock_session_manager.notifier.telegram_bot._session_threads[mock_session.id] = (12345, 99999)
+
+    # Add to hook output cache
+    mock_session_manager.app.state.last_claude_output[mock_session.id] = "some output"
+
+    # Add to monitoring state
+    output_monitor._file_positions[mock_session.id] = 1000
+    output_monitor._last_activity[mock_session.id] = datetime.now()
+    output_monitor._notified_permissions[mock_session.id] = datetime.now()
+
+    # Call cleanup
+    await output_monitor.cleanup_session(mock_session)
+
+    # Verify all cleanup happened
+    assert mock_session.status == SessionStatus.STOPPED
+    assert mock_session.id not in mock_session_manager.sessions
+    assert mock_session_manager._save_state.called
+
+    # Telegram cleanup
+    assert (12345, 67890) not in mock_session_manager.notifier.telegram_bot._topic_sessions
+    assert mock_session.id not in mock_session_manager.notifier.telegram_bot._session_threads
+    mock_session_manager.notifier.telegram_bot.bot.delete_forum_topic.assert_called_once()
+
+    # Hook output cache cleanup
+    assert mock_session.id not in mock_session_manager.app.state.last_claude_output
+
+    # Monitoring state cleanup
+    assert mock_session.id not in output_monitor._file_positions
+    assert mock_session.id not in output_monitor._last_activity
+    assert mock_session.id not in output_monitor._notified_permissions
+
+
+@pytest.mark.asyncio
+async def test_cleanup_handles_telegram_delete_failure(output_monitor, mock_session, mock_session_manager):
+    """Test that cleanup continues even if Telegram deletion fails."""
+    # Add session to manager
+    mock_session_manager.sessions[mock_session.id] = mock_session
+
+    # Make Telegram deletion fail
+    mock_session_manager.notifier.telegram_bot.bot.delete_forum_topic.side_effect = Exception("Permission denied")
+
+    # Call cleanup - should not raise
+    await output_monitor.cleanup_session(mock_session)
+
+    # Verify cleanup still happened for other things
+    assert mock_session.status == SessionStatus.STOPPED
+    assert mock_session.id not in mock_session_manager.sessions
+    assert mock_session_manager._save_state.called
+
+
+@pytest.mark.asyncio
+async def test_cleanup_without_telegram(output_monitor, mock_session, mock_session_manager):
+    """Test that cleanup works when session has no Telegram integration."""
+    # Create session without Telegram
+    mock_session.telegram_chat_id = None
+    mock_session.telegram_topic_id = None
+
+    # Add session to manager
+    mock_session_manager.sessions[mock_session.id] = mock_session
+
+    # Call cleanup
+    await output_monitor.cleanup_session(mock_session)
+
+    # Verify cleanup happened (without Telegram calls)
+    assert mock_session.status == SessionStatus.STOPPED
+    assert mock_session.id not in mock_session_manager.sessions
+
+    # Telegram delete should not be called
+    mock_session_manager.notifier.telegram_bot.bot.delete_forum_topic.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_without_notifier(output_monitor, mock_session, mock_session_manager):
+    """Test that cleanup works when notifier is not available."""
+    # Remove notifier
+    mock_session_manager.notifier = None
+
+    # Add session to manager
+    mock_session_manager.sessions[mock_session.id] = mock_session
+
+    # Call cleanup - should not crash
+    await output_monitor.cleanup_session(mock_session)
+
+    # Verify basic cleanup happened
+    assert mock_session.status == SessionStatus.STOPPED
+    assert mock_session.id not in mock_session_manager.sessions
+
+
+@pytest.mark.asyncio
+async def test_monitor_checks_tmux_every_30_polls(output_monitor, mock_session, mock_session_manager, tmp_path):
+    """Test that tmux existence is checked every 30 polls, not every poll."""
+    # Setup: Create log file
+    log_file = tmp_path / "test.log"
+    log_file.touch()
+    mock_session.log_file = str(log_file)
+
+    # Add session to manager
+    mock_session_manager.sessions[mock_session.id] = mock_session
+
+    # Track session_exists calls
+    call_count = 0
+    def mock_session_exists(tmux_session):
+        nonlocal call_count
+        call_count += 1
+        return True
+
+    mock_session_manager.tmux.session_exists = Mock(side_effect=mock_session_exists)
+
+    # Start monitoring
+    await output_monitor.start_monitoring(mock_session)
+
+    # Wait for ~35 polls (3.5 seconds with 0.1s interval)
+    await asyncio.sleep(3.5)
+
+    # Stop monitoring
+    await output_monitor.stop_monitoring(mock_session.id)
+
+    # Should have checked tmux existence ~1 time (at poll 30)
+    # With some timing variance, accept 1-2 calls
+    assert 1 <= call_count <= 2
+
+
+@pytest.mark.asyncio
+async def test_cleanup_removes_from_all_telegram_mappings(output_monitor, mock_session, mock_session_manager):
+    """Test that cleanup removes session from both topic and thread mappings."""
+    # Add session to manager
+    mock_session_manager.sessions[mock_session.id] = mock_session
+
+    # Add to both topic and thread mappings
+    mock_session_manager.notifier.telegram_bot._topic_sessions[(12345, 67890)] = mock_session.id
+    mock_session_manager.notifier.telegram_bot._session_threads[mock_session.id] = (12345, 11111)
+
+    # Call cleanup
+    await output_monitor.cleanup_session(mock_session)
+
+    # Verify both removed
+    assert (12345, 67890) not in mock_session_manager.notifier.telegram_bot._topic_sessions
+    assert mock_session.id not in mock_session_manager.notifier.telegram_bot._session_threads


### PR DESCRIPTION
## Summary

Fixes issue #49 where dead tmux sessions were never cleaned up, and Telegram forum topics were never deleted.

## Problem

When tmux sessions are killed externally (not via `/kill`), the session manager still lists them because:
1. OutputMonitor doesn't detect tmux death
2. Telegram cleanup never happens
3. In-memory mappings accumulate

## Solution

### Part 1: Auto-detect tmux death in monitor loop

OutputMonitor now checks if tmux session exists every ~30 polls (~30 seconds):
```python
async def _monitor_loop(self, session: Session):
    check_counter = 0
    while True:
        check_counter += 1
        
        # Every ~30 polls, verify tmux still exists
        if check_counter % 30 == 0:
            if not self._session_manager.tmux.session_exists(session.tmux_session):
                await self.cleanup_session(session)
                break
```

### Part 2: Comprehensive cleanup

Created `cleanup_session()` method that:
- Sets session.status = STOPPED
- Deletes Telegram forum topic (requires bot admin rights)
- Cleans up in-memory Telegram mappings (_topic_sessions, _session_threads)
- Removes from sessions dict
- Cleans up hook output cache
- Saves state

### Part 3: Explicit kills also cleanup

Updated both kill_session endpoints in server.py to call cleanup_session():
```python
async def kill_session(session_id: str):
    success = app.state.session_manager.kill_session(session_id)
    if app.state.output_monitor:
        await app.state.output_monitor.cleanup_session(session)
```

### Removed dead code

The `cleanup_dead_sessions()` method in SessionManager was never called. Removed it since the monitor now handles this automatically.

## Testing

**tests/regression/test_issue_49_dead_session_cleanup.py:**
- 7 comprehensive tests
- Test tmux death detection and cleanup
- Test Telegram topic deletion
- Test cleanup without Telegram
- Test cleanup handles failures gracefully
- Test check interval (every 30 polls)

All 51 tests passing.

## Bot Permissions

For Telegram topic deletion to work, the bot needs `can_delete_messages` admin rights in the forum group.

## Verification

Before fix:
```bash
$ sm attach
# Lists dead sessions that no longer exist in tmux
# Selecting them fails: "error failed to attach to tmux session claude-xxx"
```

After fix:
- Dead sessions automatically cleaned up after ~30 seconds
- Telegram topics deleted
- No orphaned entries