### PR TITLE
Fix #89: Make sm wait notify asynchronously instead of blocking

### DIFF
--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -328,3 +328,34 @@ class SessionManagerClient:
             f"/sessions/{session_id}/send-queue"
         )
         return data if success else None
+
+    def watch_session(
+        self,
+        target_session_id: str,
+        watcher_session_id: str,
+        timeout_seconds: int,
+    ) -> Optional[dict]:
+        """
+        Watch a session and get notified when it goes idle or timeout.
+
+        Args:
+            target_session_id: Session to watch
+            watcher_session_id: Session to notify when target is idle
+            timeout_seconds: Maximum seconds to wait
+
+        Returns:
+            Dict with watch info or None if unavailable
+        """
+        payload = {
+            "watcher_session_id": watcher_session_id,
+            "timeout_seconds": timeout_seconds,
+        }
+        data, success, unavailable = self._request(
+            "POST",
+            f"/sessions/{target_session_id}/watch",
+            payload,
+            timeout=5,
+        )
+        if unavailable:
+            return None
+        return data if success else None

--- a/tests/regression/test_issue_89_async_wait.py
+++ b/tests/regression/test_issue_89_async_wait.py
@@ -1,0 +1,298 @@
+"""
+Regression tests for issue #89: sm wait blocks synchronously instead of notifying asynchronously
+
+Tests verify that sm wait returns immediately and notifies asynchronously when
+the target session goes idle or reaches timeout.
+"""
+
+import pytest
+import asyncio
+from unittest.mock import Mock, AsyncMock, MagicMock, patch
+from datetime import datetime
+
+from src.models import Session, SessionStatus
+from src.message_queue import MessageQueueManager
+from src.cli.commands import cmd_wait
+from src.cli.client import SessionManagerClient
+
+
+@pytest.fixture
+def mock_session_manager():
+    """Create a mock SessionManager."""
+    manager = Mock()
+    manager.get_session = Mock()
+    manager.tmux = Mock()
+    manager.tmux.send_input_async = AsyncMock(return_value=True)
+    manager._save_state = Mock()
+    return manager
+
+
+@pytest.fixture
+def temp_db(tmp_path):
+    """Create a temporary database path."""
+    return str(tmp_path / "test_queue.db")
+
+
+@pytest.fixture
+def message_queue(mock_session_manager, temp_db):
+    """Create a MessageQueueManager instance for testing."""
+    config = {
+        "urgent_delay_ms": 100,
+    }
+    queue_mgr = MessageQueueManager(
+        session_manager=mock_session_manager,
+        db_path=temp_db,
+        config=config,
+    )
+    return queue_mgr
+
+
+@pytest.mark.asyncio
+async def test_watch_session_notifies_when_target_goes_idle(
+    message_queue, mock_session_manager
+):
+    """Test that watch_session notifies when target goes idle."""
+    # Setup sessions
+    target_session = Session(
+        id="target-123",
+        name="target-session",
+        working_dir="/tmp/target",
+        tmux_session="claude-target-123",
+        friendly_name="target-agent",
+    )
+    watcher_session = Session(
+        id="watcher-456",
+        name="watcher-session",
+        working_dir="/tmp/watcher",
+        tmux_session="claude-watcher-456",
+        friendly_name="watcher-agent",
+    )
+
+    mock_session_manager.get_session.side_effect = lambda sid: {
+        "target-123": target_session,
+        "watcher-456": watcher_session,
+    }.get(sid)
+
+    # Track message queuing
+    queued_messages = []
+    original_queue = message_queue.queue_message
+
+    def track_queue(*args, **kwargs):
+        msg = original_queue(*args, **kwargs)
+        queued_messages.append((args, kwargs))
+        return msg
+
+    message_queue.queue_message = track_queue
+
+    # Start watch
+    watch_id = await message_queue.watch_session("target-123", "watcher-456", 30)
+    assert watch_id is not None
+
+    # Mark target as idle immediately
+    message_queue.mark_session_idle("target-123")
+
+    # Wait for watch task to check and queue notification (poll interval is 2s)
+    await asyncio.sleep(2.5)
+
+    # Verify notification was queued for watcher
+    assert len(queued_messages) > 0
+
+    # Check that watcher-456 received a notification
+    watcher_messages = [m for m in queued_messages if m[1].get("target_session_id") == "watcher-456"]
+    assert len(watcher_messages) > 0
+
+    # Check notification content
+    text = watcher_messages[0][1]["text"]
+    assert "target-agent" in text or "target-123" in text
+    assert "idle" in text.lower()
+    assert watcher_messages[0][1]["delivery_mode"] == "urgent"
+
+
+@pytest.mark.asyncio
+async def test_watch_session_notifies_on_timeout(
+    message_queue, mock_session_manager
+):
+    """Test that watch_session notifies when timeout is reached."""
+    # Setup sessions
+    target_session = Session(
+        id="target-789",
+        name="target-session",
+        working_dir="/tmp/target",
+        tmux_session="claude-target-789",
+        friendly_name="busy-agent",
+    )
+    watcher_session = Session(
+        id="watcher-abc",
+        name="watcher-session",
+        working_dir="/tmp/watcher",
+        tmux_session="claude-watcher-abc",
+        friendly_name="watcher-agent",
+    )
+
+    mock_session_manager.get_session.side_effect = lambda sid: {
+        "target-789": target_session,
+        "watcher-abc": watcher_session,
+    }.get(sid)
+
+    # Track message queuing
+    queued_messages = []
+    original_queue = message_queue.queue_message
+
+    def track_queue(*args, **kwargs):
+        msg = original_queue(*args, **kwargs)
+        queued_messages.append((args, kwargs))
+        return msg
+
+    message_queue.queue_message = track_queue
+
+    # Start watch with short timeout
+    watch_id = await message_queue.watch_session("target-789", "watcher-abc", 2)
+    assert watch_id is not None
+
+    # Target never goes idle - wait for timeout
+    await asyncio.sleep(2.5)
+
+    # Verify timeout notification was queued for watcher
+    assert len(queued_messages) > 0
+
+    # Check that watcher-abc received a notification
+    watcher_messages = [m for m in queued_messages if m[1].get("target_session_id") == "watcher-abc"]
+    assert len(watcher_messages) > 0
+
+    # Check notification content
+    text = watcher_messages[0][1]["text"]
+    assert "busy-agent" in text or "target-789" in text
+    assert "timeout" in text.lower() or "still active" in text.lower()
+    assert watcher_messages[0][1]["delivery_mode"] == "urgent"
+
+
+@pytest.mark.asyncio
+async def test_watch_creates_scheduled_task(message_queue, mock_session_manager):
+    """Test that watch creates a scheduled task that can be tracked."""
+    # Setup sessions
+    target_session = Session(
+        id="target-999",
+        name="target-session",
+        working_dir="/tmp/target",
+        tmux_session="claude-target-999",
+    )
+    watcher_session = Session(
+        id="watcher-111",
+        name="watcher-session",
+        working_dir="/tmp/watcher",
+        tmux_session="claude-watcher-111",
+    )
+
+    mock_session_manager.get_session.side_effect = lambda sid: {
+        "target-999": target_session,
+        "watcher-111": watcher_session,
+    }.get(sid)
+
+    # Start watch
+    watch_id = await message_queue.watch_session("target-999", "watcher-111", 30)
+
+    # Verify task was created and added to scheduled tasks
+    task = message_queue._scheduled_tasks.get(watch_id)
+    assert task is not None
+    assert not task.done()
+
+    # Cancel the task to clean up
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+def test_cmd_wait_returns_immediately():
+    """Test that cmd_wait returns immediately instead of blocking."""
+    import time
+
+    # Mock client
+    mock_client = MagicMock(spec=SessionManagerClient)
+    mock_client.session_id = "watcher-123"
+
+    # Mock resolve_session_id
+    with patch('src.cli.commands.resolve_session_id') as mock_resolve:
+        mock_resolve.return_value = ("target-456", {
+            "id": "target-456",
+            "friendly_name": "target-session",
+            "name": "target-session"
+        })
+
+        # Mock watch_session to return success
+        mock_client.watch_session.return_value = {
+            "status": "watching",
+            "watch_id": "watch-789",
+            "target_name": "target-session",
+            "timeout_seconds": 300,
+        }
+
+        # Time the execution
+        start = time.time()
+        exit_code = cmd_wait(mock_client, "target-456", 300)
+        elapsed = time.time() - start
+
+        # Should return immediately (< 1 second, not 300 seconds)
+        assert elapsed < 1.0
+        assert exit_code == 0
+
+        # Verify watch_session was called
+        mock_client.watch_session.assert_called_once_with(
+            "target-456",
+            "watcher-123",
+            300
+        )
+
+
+def test_cmd_wait_without_session_context():
+    """Test that cmd_wait fails gracefully without session context."""
+    # Mock client without session_id
+    mock_client = MagicMock(spec=SessionManagerClient)
+    mock_client.session_id = None  # No session context
+
+    with patch('src.cli.commands.resolve_session_id') as mock_resolve:
+        mock_resolve.return_value = ("target-456", {
+            "id": "target-456",
+            "friendly_name": "target-session"
+        })
+
+        exit_code = cmd_wait(mock_client, "target-456", 300)
+
+        # Should fail with exit code 1
+        assert exit_code == 1
+
+
+def test_cmd_wait_target_not_found():
+    """Test that cmd_wait handles target not found."""
+    mock_client = MagicMock(spec=SessionManagerClient)
+    mock_client.session_id = "watcher-123"
+    mock_client.list_sessions.return_value = []  # No sessions
+
+    with patch('src.cli.commands.resolve_session_id') as mock_resolve:
+        mock_resolve.return_value = (None, None)  # Session not found
+
+        exit_code = cmd_wait(mock_client, "nonexistent", 300)
+
+        # Should fail with exit code 2
+        assert exit_code == 2
+
+
+def test_cmd_wait_session_manager_unavailable():
+    """Test that cmd_wait handles session manager unavailable."""
+    mock_client = MagicMock(spec=SessionManagerClient)
+    mock_client.session_id = "watcher-123"
+
+    with patch('src.cli.commands.resolve_session_id') as mock_resolve:
+        mock_resolve.return_value = ("target-456", {
+            "id": "target-456",
+            "friendly_name": "target-session"
+        })
+
+        # watch_session returns None (unavailable)
+        mock_client.watch_session.return_value = None
+
+        exit_code = cmd_wait(mock_client, "target-456", 300)
+
+        # Should fail with exit code 2
+        assert exit_code == 2


### PR DESCRIPTION
## Summary

Fixes #89 by making `sm wait` return immediately and notify asynchronously instead of blocking synchronously until the target session goes idle.

## Changes

### Core Implementation

1. **Message Queue (`src/message_queue.py`)**
   - Added `watch_session()` method to register async watches
   - Added `_watch_for_idle()` background task that polls target session every 2s
   - Sends urgent notification to watcher when target goes idle or timeout is reached

2. **Server API (`src/server.py`)**
   - Added `/sessions/{target_session_id}/watch` POST endpoint
   - Accepts `watcher_session_id` and `timeout_seconds` parameters
   - Returns immediately after registering watch task

3. **CLI Client (`src/cli/client.py`)**
   - Added `watch_session()` client method to call watch API
   - Returns watch info dict or None if unavailable

4. **CLI Commands (`src/cli/commands.py`)**
   - Completely rewrote `cmd_wait()` to use async notification pattern
   - Returns immediately after watch registration (exit 0)
   - User gets notification via message queue when target is idle or times out

### Testing

- **New tests**: `tests/regression/test_issue_89_async_wait.py` (7 tests)
  - Test async watch creation and notification
  - Test timeout handling
  - Test edge cases (session not found, unavailable, no context)
  
- **Updated tests**: `tests/regression/test_wait_features.py`
  - Updated old blocking/polling tests to match new async behavior
  - All tests verify watch registration instead of blocking waits

- **Test coverage**: All 128 tests passing (121 existing + 7 new)

## Behavior

**Before:**
```bash
$ sm wait my-session 300
# Blocks for up to 300 seconds, polling every 2s
# Returns 0 when idle, 1 on timeout
```

**After:**
```bash
$ sm wait my-session 300
Watch registered for my-session (timeout: 300s)
# Returns immediately

# Later, when target is idle or timeout:
[sm wait] my-session is now idle (waited 45s)
# Or: [sm wait] my-session still active after timeout (waited 300s)
```

## Exit Codes

- **0**: Watch registered successfully
- **1**: Watch registration failed
- **2**: Session not found or session manager unavailable

## Testing Performed

```bash
$ python -m pytest tests/ -v
========================== 128 passed in 98.16s ==========================
```

All tests passing including:
- 7 new async wait tests
- 11 updated wait feature tests  
- 110 existing tests (no regressions)

🤖 Generated with Claude Code