### PR TITLE
Extract magic numbers to config with documentation (fixes #43)

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -21,6 +21,80 @@ monitor:
     completion: false          # Notify when task appears complete
     idle: true                 # Notify when session is idle
 
+# Timeout and delay configuration (all values in seconds unless specified)
+timeouts:
+  # Tmux session creation and interaction timeouts
+  tmux:
+    # Time to wait for shell exports to complete before starting Claude
+    # Must be long enough for bashrc/zshrc to finish setting env vars
+    shell_export_settle_seconds: 0.1
+
+    # Time for Claude Code to initialize and show first prompt
+    # Based on observed startup time of 2-3 seconds on typical hardware
+    claude_init_seconds: 3
+
+    # Shorter wait when no initial prompt is provided
+    # Claude starts faster without processing a prompt
+    claude_init_no_prompt_seconds: 1
+
+    # Maximum time to wait for tmux send-keys to complete
+    # Allows for shell processing and Claude response time
+    send_keys_timeout_seconds: 5
+
+    # Small delay after sending keys to ensure they're processed
+    # Prevents race conditions with rapid consecutive commands
+    send_keys_settle_seconds: 0.3
+
+  # Output monitor timing configuration
+  output_monitor:
+    # Don't send idle notifications within this time after Claude responds
+    # Prevents "idle" notification immediately after completion
+    # Set to 5 minutes to avoid noise
+    idle_cooldown_seconds: 300
+
+    # Debounce permission prompts - don't notify twice within this window
+    # Prevents duplicate notifications for the same permission request
+    permission_debounce_seconds: 30
+
+  # Message queue processing timeouts
+  message_queue:
+    # Timeout for subprocess calls (tmux send-keys, etc)
+    # Must be long enough for command to execute but not hang forever
+    subprocess_timeout_seconds: 2
+
+    # Longer timeout for async send operations
+    # Allows for Claude to process and respond
+    async_send_timeout_seconds: 5
+
+    # Initial retry delay for failed deliveries (seconds)
+    # Doubles on each retry up to max_retry_delay_seconds
+    initial_retry_delay_seconds: 1.0
+
+    # Maximum retry delay (exponential backoff cap)
+    max_retry_delay_seconds: 30
+
+    # Poll interval for watch_session idle detection
+    # Checks target session status every N seconds
+    watch_poll_interval_seconds: 2
+
+  # Server logging and request handling
+  server:
+    # Log requests that take longer than this (seconds)
+    # Helps identify slow endpoints
+    slow_request_threshold_seconds: 1.0
+
+    # Log detailed timing for requests faster than slow threshold
+    # but slower than this value (seconds)
+    request_timing_threshold_seconds: 0.1
+
+    # Log warning if PreToolUse hook takes longer than this
+    # Indicates lock contention or slow file operations
+    hook_timing_threshold_seconds: 0.05
+
+    # Maximum time to wait for AI summary generation
+    # Summary uses Claude API which can be slow
+    summary_generation_timeout_seconds: 60
+
 telegram:
   # Bot token from @BotFather (required for Telegram integration)
   token: "YOUR_BOT_TOKEN_HERE"
@@ -79,6 +153,19 @@ child_agents:
     enable_token_tracking: true     # Approximate from transcript length
     enable_tool_tracking: true      # Count tool calls in transcript
     snapshot_interval: 30           # Seconds between checks
+
+# sm send v2: Reliable inter-agent messaging
+sm_send:
+  # Path to SQLite database for message queue persistence
+  db_path: "~/.local/share/claude-sessions/message_queue.db"
+  # Polling interval when waiting for user input to become stale (seconds)
+  input_poll_interval: 5
+  # How long unchanged user input must be before we consider it stale (seconds)
+  input_stale_timeout: 120
+  # Maximum messages to batch in single delivery
+  max_batch_size: 10
+  # Delay after Escape in urgent mode (milliseconds)
+  urgent_delay_ms: 500
 
 # Session defaults
 sessions:

--- a/src/main.py
+++ b/src/main.py
@@ -139,6 +139,7 @@ class SessionManagerApp:
             notify_permission_prompts=notify_config.get("permission_prompts", True),
             notify_completion=notify_config.get("completion", False),
             notify_idle=notify_config.get("idle", True),
+            config=config,  # Pass full config for timeout settings
         )
 
         # Email handler (uses existing harness)
@@ -187,7 +188,7 @@ class SessionManagerApp:
         self.message_queue = MessageQueueManager(
             self.session_manager,
             db_path=sm_send_config.get("db_path", "~/.local/share/claude-sessions/message_queue.db"),
-            config=sm_send_config,
+            config=config,  # Pass full config for timeout settings
         )
         # Pass message queue to session manager
         self.session_manager.message_queue_manager = self.message_queue
@@ -203,6 +204,7 @@ class SessionManagerApp:
             notifier=self.notifier,
             output_monitor=self.output_monitor,
             child_monitor=self.child_monitor,
+            config=config,  # Pass config for server timeout settings
         )
 
         # Attach tool logger to app state

--- a/tests/unit/test_config_loading.py
+++ b/tests/unit/test_config_loading.py
@@ -1,0 +1,218 @@
+"""Tests for config loading in various components.
+
+Verifies that timeout and delay values are correctly loaded from config.yaml
+and that fallback defaults work when config is not provided.
+"""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, AsyncMock
+
+import pytest
+
+from src.tmux_controller import TmuxController
+from src.output_monitor import OutputMonitor
+from src.message_queue import MessageQueueManager
+
+
+class TestTmuxControllerConfig:
+    """Test TmuxController loads config values correctly."""
+
+    def test_default_values_without_config(self):
+        """Verify default fallback values when no config provided."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            controller = TmuxController(log_dir=temp_dir)
+
+            assert controller.shell_export_settle_seconds == 0.1
+            assert controller.claude_init_seconds == 3
+            assert controller.claude_init_no_prompt_seconds == 1
+            assert controller.send_keys_timeout_seconds == 5
+            assert controller.send_keys_settle_seconds == 0.3
+
+    def test_config_values_loaded(self):
+        """Verify config values override defaults."""
+        config = {
+            "timeouts": {
+                "tmux": {
+                    "shell_export_settle_seconds": 0.5,
+                    "claude_init_seconds": 5,
+                    "claude_init_no_prompt_seconds": 2,
+                    "send_keys_timeout_seconds": 10,
+                    "send_keys_settle_seconds": 0.5,
+                }
+            }
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            controller = TmuxController(log_dir=temp_dir, config=config)
+
+            assert controller.shell_export_settle_seconds == 0.5
+            assert controller.claude_init_seconds == 5
+            assert controller.claude_init_no_prompt_seconds == 2
+            assert controller.send_keys_timeout_seconds == 10
+            assert controller.send_keys_settle_seconds == 0.5
+
+    def test_partial_config_uses_defaults(self):
+        """Verify missing config values fall back to defaults."""
+        config = {
+            "timeouts": {
+                "tmux": {
+                    "shell_export_settle_seconds": 0.2,
+                    # Other values not specified
+                }
+            }
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            controller = TmuxController(log_dir=temp_dir, config=config)
+
+            assert controller.shell_export_settle_seconds == 0.2  # From config
+            assert controller.claude_init_seconds == 3  # Default
+            assert controller.send_keys_timeout_seconds == 5  # Default
+
+
+class TestOutputMonitorConfig:
+    """Test OutputMonitor loads config values correctly."""
+
+    def test_default_values_without_config(self):
+        """Verify default fallback values when no config provided."""
+        monitor = OutputMonitor()
+
+        assert monitor._idle_cooldown == 300
+        assert monitor._permission_debounce == 30
+
+    def test_config_values_loaded(self):
+        """Verify config values override defaults."""
+        config = {
+            "timeouts": {
+                "output_monitor": {
+                    "idle_cooldown_seconds": 600,
+                    "permission_debounce_seconds": 60,
+                }
+            }
+        }
+
+        monitor = OutputMonitor(config=config)
+
+        assert monitor._idle_cooldown == 600
+        assert monitor._permission_debounce == 60
+
+    def test_partial_config_uses_defaults(self):
+        """Verify missing config values fall back to defaults."""
+        config = {
+            "timeouts": {
+                "output_monitor": {
+                    "idle_cooldown_seconds": 180,
+                    # permission_debounce_seconds not specified
+                }
+            }
+        }
+
+        monitor = OutputMonitor(config=config)
+
+        assert monitor._idle_cooldown == 180  # From config
+        assert monitor._permission_debounce == 30  # Default
+
+
+class TestMessageQueueManagerConfig:
+    """Test MessageQueueManager loads config values correctly."""
+
+    @pytest.fixture
+    def mock_session_manager(self):
+        """Create a mock session manager."""
+        mock = MagicMock()
+        mock.tmux = MagicMock()
+        mock.tmux.send_input_async = AsyncMock(return_value=True)
+        return mock
+
+    def test_default_values_without_config(self, mock_session_manager):
+        """Verify default fallback values when no config provided."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "test.db"
+            manager = MessageQueueManager(
+                mock_session_manager,
+                db_path=str(db_path),
+            )
+
+            # sm_send defaults
+            assert manager.input_poll_interval == 5
+            assert manager.input_stale_timeout == 120
+            assert manager.max_batch_size == 10
+            assert manager.urgent_delay_ms == 500
+
+            # timeout defaults
+            assert manager.subprocess_timeout == 2
+            assert manager.async_send_timeout == 5
+            assert manager.initial_retry_delay == 1.0
+            assert manager.max_retry_delay == 30
+            assert manager.watch_poll_interval == 2
+
+    def test_config_values_loaded(self, mock_session_manager):
+        """Verify config values override defaults."""
+        config = {
+            "sm_send": {
+                "input_poll_interval": 10,
+                "input_stale_timeout": 240,
+                "max_batch_size": 20,
+                "urgent_delay_ms": 1000,
+            },
+            "timeouts": {
+                "message_queue": {
+                    "subprocess_timeout_seconds": 5,
+                    "async_send_timeout_seconds": 10,
+                    "initial_retry_delay_seconds": 2.0,
+                    "max_retry_delay_seconds": 60,
+                    "watch_poll_interval_seconds": 5,
+                }
+            }
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "test.db"
+            manager = MessageQueueManager(
+                mock_session_manager,
+                db_path=str(db_path),
+                config=config,
+            )
+
+            # sm_send values
+            assert manager.input_poll_interval == 10
+            assert manager.input_stale_timeout == 240
+            assert manager.max_batch_size == 20
+            assert manager.urgent_delay_ms == 1000
+
+            # timeout values
+            assert manager.subprocess_timeout == 5
+            assert manager.async_send_timeout == 10
+            assert manager.initial_retry_delay == 2.0
+            assert manager.max_retry_delay == 60
+            assert manager.watch_poll_interval == 5
+
+    def test_partial_config_uses_defaults(self, mock_session_manager):
+        """Verify missing config values fall back to defaults."""
+        config = {
+            "sm_send": {
+                "input_poll_interval": 15,
+                # Other sm_send values not specified
+            },
+            "timeouts": {
+                "message_queue": {
+                    "subprocess_timeout_seconds": 3,
+                    # Other timeout values not specified
+                }
+            }
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            db_path = Path(temp_dir) / "test.db"
+            manager = MessageQueueManager(
+                mock_session_manager,
+                db_path=str(db_path),
+                config=config,
+            )
+
+            # Mixed config and defaults
+            assert manager.input_poll_interval == 15  # From config
+            assert manager.input_stale_timeout == 120  # Default
+            assert manager.subprocess_timeout == 3  # From config
+            assert manager.async_send_timeout == 5  # Default


### PR DESCRIPTION
## Summary
- Adds comprehensive `timeouts` section to config.yaml with documented default values
- Updates tmux_controller.py, output_monitor.py, message_queue.py, and server.py to load timeouts from config
- Adds unit tests verifying config loading with fallback defaults
- Updates config.yaml.example with new sections and detailed comments

## Changes

### Config Structure
Added new `timeouts` section with 4 subsections:
- **tmux**: shell_export_settle, claude_init, send_keys_timeout, send_keys_settle
- **output_monitor**: idle_cooldown, permission_debounce
- **message_queue**: subprocess_timeout, async_send_timeout, retry delays, watch_poll_interval
- **server**: slow_request_threshold, request_timing_threshold, hook_timing_threshold, summary_timeout

### Code Changes
- `tmux_controller.py`: Accept config in `__init__`, use configurable timeouts for all timing-sensitive operations
- `output_monitor.py`: Accept config in `__init__`, use configurable debounce/cooldown values
- `message_queue.py`: Load from both `sm_send` and `timeouts` sections with fallbacks
- `server.py`: Update `RequestTimingMiddleware` and hook endpoints to use config
- `main.py`: Pass full config to all updated components

### Tests
- 9 new unit tests in `tests/unit/test_config_loading.py`
- Tests verify default fallbacks, config overrides, and partial config handling

## Test plan
- [x] Run `python -m pytest tests/unit/test_config_loading.py -v` - 9 tests pass
- [x] Run full test suite - 172 passed, 2 pre-existing failures unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)