### PR TITLE
Mirror all agent-to-agent communications to Telegram

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -189,6 +189,7 @@ class SessionManagerApp:
             self.session_manager,
             db_path=sm_send_config.get("db_path", "~/.local/share/claude-sessions/message_queue.db"),
             config=config,  # Pass full config for timeout settings
+            notifier=self.notifier,  # Pass notifier for Telegram mirroring
         )
         # Pass message queue to session manager
         self.session_manager.message_queue_manager = self.message_queue


### PR DESCRIPTION
## Summary

Extends Telegram mirroring from just `sm send` to all agent-to-agent communications, providing full visibility into agent swarm coordination.

## Changes

### Core Implementation
- **MessageQueueManager**: Added `notifier` parameter and `_mirror_to_telegram()` helper
- **Message Delivery**: Mirror with 📨 emoji when messages are delivered
- **Delivery Confirmations**: Mirror with ✅ emoji when sender is notified of delivery  
- **Stop Notifications**: Mirror with 🛑 emoji when recipient completes (Stop hook)
- **Idle Notifications**: Mirror with 💤 emoji from `sm wait` (idle and timeout)
- **main.py**: Wire up notifier when creating MessageQueueManager

### Error Handling
Telegram mirroring is **fire-and-forget**: failures are logged as warnings but never block core message delivery. This ensures reliability.

### Test Coverage
- Added 6 new tests for Telegram mirroring functionality
- Updated existing test fixtures to handle new `notifier` parameter
- All message queue tests pass (27/27)
- 385 total tests pass

## Scope

- [x] `sm send` (already worked via `_notify_sm_send`)
- [x] Queued message delivery
- [x] `notify_on_delivery` confirmations
- [x] `notify_on_stop` notifications  
- [x] `sm wait` idle/timeout notifications

## Pre-existing Test Failures

Documented two pre-existing test failures found during testing (not related to this PR):
- Issue #115: `test_monitor_loop_resets_retry_count_on_success`
- Issue #116: `test_urgent_delivery_marks_message_as_delivered`

## Benefit

Full visibility into agent swarm coordination from your phone. Users can now see all inter-agent messages, not just explicit `sm send` commands.

Fixes #103