### PR TITLE
Defer important deliveries until idle

### DIFF
--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -653,6 +653,10 @@ class MessageQueueManager:
                 messages = [m for m in messages if m.delivery_mode == "important"]
                 if not messages:
                     return
+                # Important should not interrupt active work; wait until idle
+                if not state.is_idle:
+                    logger.debug(f"Session {session_id} not idle, deferring important delivery")
+                    return
             else:
                 # For sequential, only deliver if session is idle
                 if not state.is_idle:


### PR DESCRIPTION
## Summary
- ensure important deliveries only inject when the target session is idle

## Context
This prevents [sm wait] and Stop hook notifications (now important) from interrupting active work.

## Testing
- not run (logic-only change)