### PR TITLE
Simplify SessionStatus to RUNNING, IDLE, STOPPED

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -376,7 +376,7 @@ class SessionManagerApp:
 
         # Restore monitoring for existing sessions
         for session in self.session_manager.list_sessions():
-            if session.status not in (SessionStatus.STOPPED, SessionStatus.ERROR):
+            if session.status != SessionStatus.STOPPED:
                 if session.provider != "codex-app":
                     await self.output_monitor.start_monitoring(session, is_restored=True)
                     logger.info(f"Restored monitoring for session {session.name}")

--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -382,12 +382,12 @@ class MessageQueueManager:
                 logger.info(f"Session {target_session_id} already idle (in-memory), triggering immediate delivery")
                 asyncio.create_task(self._try_deliver_messages(target_session_id))
             else:
-                # Check actual session status - sessions with ERROR or IDLE status should receive messages
+                # Check actual session status - IDLE sessions should receive messages
                 session = self.session_manager.get_session(target_session_id)
                 if session:
                     from .models import SessionStatus
-                    if session.status in (SessionStatus.ERROR, SessionStatus.IDLE):
-                        logger.info(f"Session {target_session_id} has status={session.status.value}, marking idle for delivery")
+                    if session.status == SessionStatus.IDLE:
+                        logger.info(f"Session {target_session_id} is idle, marking for delivery")
                         self.mark_session_idle(target_session_id)
 
         return msg

--- a/src/models.py
+++ b/src/models.py
@@ -9,13 +9,9 @@ import uuid
 
 class SessionStatus(Enum):
     """Session lifecycle status."""
-    STARTING = "starting"
-    RUNNING = "running"
-    WAITING_INPUT = "waiting_input"
-    WAITING_PERMISSION = "waiting_permission"
-    IDLE = "idle"
-    STOPPED = "stopped"
-    ERROR = "error"
+    RUNNING = "running"  # Actively working
+    IDLE = "idle"        # Waiting for input
+    STOPPED = "stopped"  # Terminated
 
 
 class DeliveryMode(Enum):
@@ -102,7 +98,7 @@ class Session:
     tmux_session: str = ""
     provider: str = "claude"  # "claude", "codex" (tmux), or "codex-app" (app-server)
     log_file: str = ""
-    status: SessionStatus = SessionStatus.STARTING
+    status: SessionStatus = SessionStatus.RUNNING
     created_at: datetime = field(default_factory=datetime.now)
     last_activity: datetime = field(default_factory=datetime.now)
     telegram_chat_id: Optional[int] = None

--- a/tests/regression/test_issue_88_urgent_completed.py
+++ b/tests/regression/test_issue_88_urgent_completed.py
@@ -23,6 +23,7 @@ def mock_session_manager():
     manager.tmux = Mock()
     manager.tmux.send_input_async = AsyncMock(return_value=True)
     manager._save_state = Mock()
+    manager._deliver_direct = AsyncMock(return_value=True)
     return manager
 
 

--- a/tests/regression/test_issue_89_async_wait.py
+++ b/tests/regression/test_issue_89_async_wait.py
@@ -24,6 +24,7 @@ def mock_session_manager():
     manager.tmux = Mock()
     manager.tmux.send_input_async = AsyncMock(return_value=True)
     manager._save_state = Mock()
+    manager._deliver_direct = AsyncMock(return_value=True)
     return manager
 
 

--- a/tests/unit/test_message_queue.py
+++ b/tests/unit/test_message_queue.py
@@ -28,6 +28,7 @@ def mock_session_manager():
     mock.tmux = MagicMock()
     mock.tmux.send_input_async = AsyncMock(return_value=True)
     mock._save_state = MagicMock()
+    mock._deliver_direct = AsyncMock(return_value=True)
     return mock
 
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -93,7 +93,7 @@ class TestSession:
         assert session.working_dir == ""
         assert session.tmux_session == f"claude-{session.id}"
         assert session.log_file == ""
-        assert session.status == SessionStatus.STARTING
+        assert session.status == SessionStatus.RUNNING
         assert isinstance(session.created_at, datetime)
         assert isinstance(session.last_activity, datetime)
         assert session.telegram_chat_id is None
@@ -330,15 +330,7 @@ class TestEnums:
 
     def test_session_status_values(self):
         """SessionStatus has all expected values."""
-        expected = [
-            "starting",
-            "running",
-            "waiting_input",
-            "waiting_permission",
-            "idle",
-            "stopped",
-            "error",
-        ]
+        expected = ["running", "idle", "stopped"]
         actual = [s.value for s in SessionStatus]
         assert set(actual) == set(expected)
 


### PR DESCRIPTION
## Summary

Sessions were showing `error` status even when they completed successfully. The status detection was too noisy:

- Pattern matching for "Error:", "Failed to", etc. was setting ERROR status
- Completion detection ("Done.", "Task complete") never updated the status
- So if any error-like text appeared anywhere in output, status got stuck at ERROR

### Changes

**Simplified enum to 3 states:**
- `RUNNING` - actively working  
- `IDLE` - waiting for input
- `STOPPED` - terminated

**Removed statuses:**
- `STARTING` - now starts as RUNNING
- `WAITING_INPUT` - collapsed into IDLE
- `WAITING_PERMISSION` - collapsed into IDLE  
- `ERROR` - removed entirely (error patterns in output don't mean session failed)

**Fixed status transitions:**
- Completion detection now sets IDLE (clears any previous state)
- Permission prompts set IDLE (waiting for user)
- Error pattern matching no longer changes status

## Test plan
- [x] Run existing tests (384 pass, 4 pre-existing failures)
- [x] `sm all` now shows clean status for completed sessions

## Pre-existing test issues
These failures predate this PR:
- `test_issue_40`: Flaky timing-based test (retry delays)
- `test_issue_88/89`: Mock subprocess but not `_deliver_direct`