### PR TITLE
Parse resume UUID from terminal output during crash recovery

### DIFF
--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -1061,9 +1061,15 @@ class SessionManager:
             stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
             if proc.returncode == 0:
                 import re
-                matches = re.findall(r'--resume\s+([0-9a-f-]{36})', stdout.decode())
-                if matches:
-                    resume_uuid = matches[-1]  # Last match is the most recent exit
+                # Match Claude's specific exit block:
+                #   "To resume this conversation, run:\n  claude --resume <uuid>"
+                match = re.search(
+                    r'To resume this conversation.*?--resume\s+([0-9a-f-]{36})',
+                    stdout.decode(),
+                    re.DOTALL,
+                )
+                if match:
+                    resume_uuid = match.group(1)
                     logger.info(f"Parsed resume UUID from terminal output: {resume_uuid}")
 
             if not resume_uuid:


### PR DESCRIPTION
## Summary
- `session.transcript_path` is set once from the first Stop hook and never updated — after `/clear` or a previous recovery it points at the wrong conversation UUID
- After Ctrl-C, Claude prints `To resume this conversation, run: claude --resume <uuid>` in the terminal
- Now captures the tmux pane output and parses the actual resume UUID from it
- Falls back to `transcript_path` only if parsing fails

## Test plan
- [ ] Trigger a crash recovery and verify the parsed UUID matches what Claude printed
- [ ] Verify session resumes with the correct conversation context
- [ ] Test fallback path when UUID can't be parsed from output

🤖 Generated with [Claude Code](https://claude.com/claude-code)