### PR TITLE
Fix crash recovery failing to parse resume UUID

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -1285,6 +1285,13 @@ Provide ONLY the summary, no preamble or questions."""
                 import asyncio
                 asyncio.create_task(queue_mgr._restore_user_input_after_response(session_manager_id))
 
+            # Always keep transcript_path up to date (needed for crash recovery)
+            if transcript_path and app.state.session_manager:
+                target = app.state.session_manager.get_session(session_manager_id)
+                if target and target.transcript_path != transcript_path:
+                    target.transcript_path = transcript_path
+                    app.state.session_manager._save_state()
+
             # Auto-release locks and check for cleanup
             if app.state.session_manager:
                 session = app.state.session_manager.get_session(session_manager_id)

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -1047,14 +1047,14 @@ class SessionManager:
                 await asyncio.wait_for(proc.communicate(), timeout=5)
                 await asyncio.sleep(0.5)
 
-            # 3. Wait for shell to be ready and capture output
-            await asyncio.sleep(1.0)
+            # 3. Wait for Claude to print exit message (crash dump is large)
+            await asyncio.sleep(3.0)
 
             # 4. Parse resume ID from Claude's exit output
             #    Claude prints: "To resume this conversation, run:\n  claude --resume <uuid>"
             resume_uuid = None
             proc = await asyncio.create_subprocess_exec(
-                "tmux", "capture-pane", "-p", "-t", session.tmux_session, "-S", "-50",
+                "tmux", "capture-pane", "-p", "-t", session.tmux_session, "-S", "-200",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )


### PR DESCRIPTION
## Summary
- Recovery was sending Ctrl-C but then failing to find the resume UUID, leaving sessions at a bare shell prompt
- **Root cause 1**: 1s wait after Ctrl-C too short — Claude's JS stack dump is massive and the resume hint hadn't been printed yet. Increased to 3s. Also increased capture window from 50 to 200 lines.
- **Root cause 2**: `transcript_path` fallback was always `None` because it was only stored inside a Telegram-conditional block and only on first Stop hook. Now always update `transcript_path` on every Stop hook.

## Test plan
- [ ] Trigger a crash in a session without Telegram configured — verify recovery completes
- [ ] Verify `transcript_path` updates after `/clear` + new conversation
- [ ] Verify sessions with large crash dumps still parse the resume UUID

🤖 Generated with [Claude Code](https://claude.com/claude-code)