### PR TITLE
sm review: core implementation (Phase 1)

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -142,6 +142,12 @@ codex:
   sandbox: "workspace-write"
   # Request timeout for JSON-RPC calls
   request_timeout_seconds: 60
+  # Review-specific timing (for sm review command)
+  review:
+    default_wait: 600                # Default --wait seconds for reviews
+    menu_settle_seconds: 1.0         # Wait for /review menu to appear
+    branch_settle_seconds: 1.0       # Wait for branch picker to appear
+    steer_delay_seconds: 5.0         # Wait before injecting steer text
 
 child_agents:
   # Auto-completion detection

--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -378,6 +378,97 @@ class SessionManagerClient:
             return None
         return data if success else None
 
+    def start_review(
+        self,
+        session_id: str,
+        mode: str,
+        base_branch: Optional[str] = None,
+        commit_sha: Optional[str] = None,
+        custom_prompt: Optional[str] = None,
+        steer: Optional[str] = None,
+        wait: Optional[int] = None,
+        watcher_session_id: Optional[str] = None,
+    ) -> Optional[dict]:
+        """
+        Start a review on an existing session.
+
+        Returns:
+            Dict with review info or None if unavailable
+        """
+        payload = {"mode": mode}
+        if base_branch:
+            payload["base_branch"] = base_branch
+        if commit_sha:
+            payload["commit_sha"] = commit_sha
+        if custom_prompt:
+            payload["custom_prompt"] = custom_prompt
+        if steer:
+            payload["steer"] = steer
+        if wait is not None:
+            payload["wait"] = wait
+        if watcher_session_id:
+            payload["watcher_session_id"] = watcher_session_id
+
+        data, success, unavailable = self._request(
+            "POST",
+            f"/sessions/{session_id}/review",
+            payload,
+            timeout=10,
+        )
+        if unavailable:
+            return None
+        return data
+
+    def spawn_review(
+        self,
+        parent_session_id: str,
+        mode: str,
+        base_branch: Optional[str] = None,
+        commit_sha: Optional[str] = None,
+        custom_prompt: Optional[str] = None,
+        steer: Optional[str] = None,
+        name: Optional[str] = None,
+        wait: Optional[int] = None,
+        model: Optional[str] = None,
+        working_dir: Optional[str] = None,
+    ) -> Optional[dict]:
+        """
+        Spawn a new session and start a review.
+
+        Returns:
+            Dict with session/review info or None if unavailable
+        """
+        payload = {
+            "parent_session_id": parent_session_id,
+            "mode": mode,
+        }
+        if base_branch:
+            payload["base_branch"] = base_branch
+        if commit_sha:
+            payload["commit_sha"] = commit_sha
+        if custom_prompt:
+            payload["custom_prompt"] = custom_prompt
+        if steer:
+            payload["steer"] = steer
+        if name:
+            payload["name"] = name
+        if wait is not None:
+            payload["wait"] = wait
+        if model:
+            payload["model"] = model
+        if working_dir:
+            payload["working_dir"] = working_dir
+
+        data, success, unavailable = self._request(
+            "POST",
+            "/sessions/review",
+            payload,
+            timeout=15,
+        )
+        if unavailable:
+            return None
+        return data
+
     def clear_session(self, session_id: str, prompt: Optional[str] = None) -> tuple[bool, bool]:
         """
         Clear/reset a session's context.


### PR DESCRIPTION
## Summary

Implements `sm review` command for native Codex `/review` support via TUI menu automation, plus `sm send --steer` for mid-turn steering.

Fixes #138

**Phase 1 scope (Steps 1-7 + 5b, 9 files):**

- **`src/models.py`** — `ReviewConfig` dataclass, `STEER` delivery mode, `review_config` on Session
- **`src/tmux_controller.py`** — `send_review_sequence()` (menu navigation for all 4 modes) and `send_steer_text()` (Enter-based injection)
- **`src/session_manager.py`** — `start_review()`, `spawn_review_session()`, steer branch in `send_input()`
- **`src/server.py`** — `StartReviewRequest`, `SpawnReviewRequest` models + two endpoints + steer delivery mode
- **`src/cli/commands.py`** — `cmd_review()` with mode validation and `--wait` defaulting
- **`src/cli/main.py`** — `review` subparser, `--steer` flag on `send`, `--pr`/`--repo` stubs
- **`src/cli/client.py`** — `start_review()` and `spawn_review()` API client methods
- **`config.yaml.example`** — `codex.review` section (4 timing settings)

## Key design decisions

- Reuse existing Codex tmux sessions (primary path); spawn-and-review as secondary (`--new`)
- TUI menu automation via tmux send-keys (not non-interactive `codex review`)
- `mark_session_active()` called before `watch_session()` to prevent premature idle detection
- `last_tool_call` set at review start to fix ChildMonitor idle baseline
- Steer bypasses message queue — injects directly via Enter key into active turn
- Commit mode explicitly errors (SHA navigation deferred); `--custom` is the workaround

## Test plan

- [x] 391 existing tests pass (no regressions)
- [ ] Manual: `sm review <session> --base main` on a live Codex session
- [ ] Manual: `sm review <session> --uncommitted`
- [ ] Manual: `sm review <session> --custom "Focus on security"`
- [ ] Manual: `sm send <session> "refine focus" --steer` during active review
- [ ] Manual: `sm review --new --base main --wait 600`