### PR TITLE
sm review --pr: GitHub-integrated reviews (Phase 1b)

### DIFF
--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -469,6 +469,40 @@ class SessionManagerClient:
             return None
         return data
 
+    def start_pr_review(
+        self,
+        pr_number: int,
+        repo: Optional[str] = None,
+        steer: Optional[str] = None,
+        wait: Optional[int] = None,
+        caller_session_id: Optional[str] = None,
+    ) -> Optional[dict]:
+        """
+        Trigger @codex review on a GitHub PR.
+
+        Returns:
+            Dict with review info or None if unavailable
+        """
+        payload = {"pr_number": pr_number}
+        if repo:
+            payload["repo"] = repo
+        if steer:
+            payload["steer"] = steer
+        if wait is not None:
+            payload["wait"] = wait
+        if caller_session_id:
+            payload["caller_session_id"] = caller_session_id
+
+        data, success, unavailable = self._request(
+            "POST",
+            "/reviews/pr",
+            payload,
+            timeout=30,
+        )
+        if unavailable:
+            return None
+        return data
+
     def clear_session(self, session_id: str, prompt: Optional[str] = None) -> tuple[bool, bool]:
         """
         Clear/reset a session's context.

--- a/src/github_reviews.py
+++ b/src/github_reviews.py
@@ -1,0 +1,159 @@
+"""GitHub PR review integration via gh CLI.
+
+All functions are synchronous (subprocess.run). The server wraps them
+with asyncio.to_thread() where needed for non-blocking execution.
+"""
+
+import json
+import logging
+import subprocess
+import time
+from datetime import datetime
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def post_pr_review_comment(
+    repo: str,
+    pr_number: int,
+    steer: Optional[str] = None,
+) -> dict:
+    """Post @codex review comment on a PR.
+
+    Args:
+        repo: GitHub repo in owner/repo format
+        pr_number: PR number
+        steer: Optional focus instructions appended to the comment
+
+    Returns:
+        {"comment_id": int, "body": str, "posted_at": str (ISO)}
+
+    Raises:
+        RuntimeError: If gh CLI fails
+    """
+    if steer:
+        body = f"@codex review for {steer}"
+    else:
+        body = "@codex review"
+
+    result = subprocess.run(
+        ["gh", "pr", "comment", str(pr_number), "--repo", repo, "--body", body],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+    if result.returncode != 0:
+        raise RuntimeError(f"gh pr comment failed: {result.stderr.strip()}")
+
+    posted_at = datetime.now().isoformat()
+
+    # gh pr comment prints the comment URL on success; parse comment ID from it
+    # URL format: https://github.com/owner/repo/pull/N#issuecomment-NNNNN
+    comment_id = 0
+    output = result.stdout.strip()
+    if "#issuecomment-" in output:
+        try:
+            comment_id = int(output.split("#issuecomment-")[-1])
+        except (ValueError, IndexError):
+            pass
+
+    return {
+        "comment_id": comment_id,
+        "body": body,
+        "posted_at": posted_at,
+    }
+
+
+def poll_for_codex_review(
+    repo: str,
+    pr_number: int,
+    since: datetime,
+    timeout: int = 600,
+    poll_interval: int = 30,
+) -> Optional[dict]:
+    """Poll for a Codex review on a PR.
+
+    Synchronous function using subprocess.run in a loop with time.sleep.
+    Callable from sync CLI code or wrapped with asyncio.to_thread() on the server.
+
+    Args:
+        repo: GitHub repo in owner/repo format
+        pr_number: PR number
+        since: Only consider reviews submitted after this time
+        timeout: Maximum seconds to poll (default 600)
+        poll_interval: Seconds between polls (default 30)
+
+    Returns:
+        Review data dict or None on timeout
+    """
+    since_iso = since.isoformat()
+    deadline = time.monotonic() + timeout
+
+    owner, repo_name = repo.split("/", 1)
+
+    while time.monotonic() < deadline:
+        try:
+            result = subprocess.run(
+                [
+                    "gh", "api",
+                    f"repos/{owner}/{repo_name}/pulls/{pr_number}/reviews",
+                    "--jq", ".",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+
+            if result.returncode == 0 and result.stdout.strip():
+                reviews = json.loads(result.stdout)
+                for review in reviews:
+                    user_login = review.get("user", {}).get("login", "")
+                    submitted_at = review.get("submitted_at", "")
+
+                    # Match codex[bot] reviews submitted after our comment
+                    if "codex" in user_login.lower() and submitted_at > since_iso:
+                        logger.info(
+                            f"Found Codex review on PR #{pr_number}: "
+                            f"user={user_login}, submitted_at={submitted_at}"
+                        )
+                        return review
+
+        except subprocess.TimeoutExpired:
+            logger.warning(f"gh api call timed out while polling PR #{pr_number}")
+        except (json.JSONDecodeError, Exception) as e:
+            logger.warning(f"Error polling for Codex review on PR #{pr_number}: {e}")
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        time.sleep(min(poll_interval, remaining))
+
+    logger.info(f"Timeout polling for Codex review on PR #{pr_number} after {timeout}s")
+    return None
+
+
+def get_pr_repo_from_git(working_dir: str) -> Optional[str]:
+    """Infer owner/repo from the git remote in working_dir.
+
+    Args:
+        working_dir: Directory to check
+
+    Returns:
+        owner/repo string or None if not a git repo or gh fails
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "repo", "view", "--json", "nameWithOwner", "--jq", ".nameWithOwner"],
+            cwd=working_dir,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+        return None
+    except Exception as e:
+        logger.debug(f"Failed to get repo from git in {working_dir}: {e}")
+        return None

--- a/tests/unit/test_github_reviews.py
+++ b/tests/unit/test_github_reviews.py
@@ -1,0 +1,175 @@
+"""Unit tests for github_reviews module — #141."""
+
+import json
+import time
+from datetime import datetime
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from src.github_reviews import (
+    post_pr_review_comment,
+    poll_for_codex_review,
+    get_pr_repo_from_git,
+)
+
+
+class TestPostPrReviewComment:
+    """Tests for post_pr_review_comment()."""
+
+    @patch("src.github_reviews.subprocess.run")
+    def test_posts_plain_review(self, mock_run):
+        """Posts @codex review without steer."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="https://github.com/owner/repo/pull/42#issuecomment-12345\n",
+        )
+
+        result = post_pr_review_comment("owner/repo", 42)
+
+        assert result["body"] == "@codex review"
+        assert result["comment_id"] == 12345
+        assert "posted_at" in result
+
+        mock_run.assert_called_once()
+        call_args = mock_run.call_args[0][0]
+        assert "gh" in call_args
+        assert "--body" in call_args
+        body_idx = call_args.index("--body")
+        assert call_args[body_idx + 1] == "@codex review"
+
+    @patch("src.github_reviews.subprocess.run")
+    def test_posts_steered_review(self, mock_run):
+        """Posts @codex review for <steer> with steer text."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="https://github.com/owner/repo/pull/42#issuecomment-99999\n",
+        )
+
+        result = post_pr_review_comment("owner/repo", 42, steer="security focus")
+
+        assert result["body"] == "@codex review for security focus"
+        assert result["comment_id"] == 99999
+
+    @patch("src.github_reviews.subprocess.run")
+    def test_raises_on_failure(self, mock_run):
+        """Raises RuntimeError when gh CLI fails."""
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stderr="not found",
+        )
+
+        with pytest.raises(RuntimeError, match="gh pr comment failed"):
+            post_pr_review_comment("owner/repo", 42)
+
+    @patch("src.github_reviews.subprocess.run")
+    def test_handles_missing_comment_id(self, mock_run):
+        """Returns comment_id=0 when URL doesn't contain issuecomment."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="https://github.com/owner/repo/pull/42\n",
+        )
+
+        result = post_pr_review_comment("owner/repo", 42)
+        assert result["comment_id"] == 0
+
+
+class TestPollForCodexReview:
+    """Tests for poll_for_codex_review()."""
+
+    @patch("src.github_reviews.time.sleep")
+    @patch("src.github_reviews.subprocess.run")
+    def test_finds_codex_review(self, mock_run, mock_sleep):
+        """Returns review when codex[bot] review is found after since."""
+        since = datetime(2026, 2, 14, 10, 0, 0)
+        review_data = [
+            {
+                "user": {"login": "codex[bot]"},
+                "submitted_at": "2026-02-14T10:05:00Z",
+                "state": "COMMENTED",
+            }
+        ]
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps(review_data),
+        )
+
+        result = poll_for_codex_review("owner/repo", 42, since, timeout=60)
+
+        assert result is not None
+        assert result["user"]["login"] == "codex[bot]"
+        mock_sleep.assert_not_called()  # Found on first poll
+
+    @patch("src.github_reviews.time.sleep")
+    @patch("src.github_reviews.time.monotonic")
+    @patch("src.github_reviews.subprocess.run")
+    def test_returns_none_on_timeout(self, mock_run, mock_monotonic, mock_sleep):
+        """Returns None when no review found within timeout."""
+        since = datetime(2026, 2, 14, 10, 0, 0)
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="[]",
+        )
+        # Simulate time passing: start, check, after sleep, check (past deadline)
+        mock_monotonic.side_effect = [0, 0, 0, 31, 31]
+
+        result = poll_for_codex_review("owner/repo", 42, since, timeout=30, poll_interval=30)
+
+        assert result is None
+
+    @patch("src.github_reviews.time.sleep")
+    @patch("src.github_reviews.subprocess.run")
+    def test_ignores_old_reviews(self, mock_run, mock_sleep):
+        """Ignores reviews submitted before since timestamp."""
+        since = datetime(2026, 2, 14, 10, 0, 0)
+        review_data = [
+            {
+                "user": {"login": "codex[bot]"},
+                "submitted_at": "2026-02-14T09:00:00Z",  # Before since
+                "state": "COMMENTED",
+            }
+        ]
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps(review_data),
+        )
+
+        # Make it timeout after one iteration
+        with patch("src.github_reviews.time.monotonic", side_effect=[0, 0, 0, 100]):
+            result = poll_for_codex_review("owner/repo", 42, since, timeout=1)
+
+        assert result is None
+
+
+class TestGetPrRepoFromGit:
+    """Tests for get_pr_repo_from_git()."""
+
+    @patch("src.github_reviews.subprocess.run")
+    def test_returns_repo(self, mock_run):
+        """Returns owner/repo from gh repo view."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="owner/repo\n",
+        )
+
+        result = get_pr_repo_from_git("/tmp/workspace")
+        assert result == "owner/repo"
+
+    @patch("src.github_reviews.subprocess.run")
+    def test_returns_none_on_failure(self, mock_run):
+        """Returns None when gh fails."""
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout="",
+        )
+
+        result = get_pr_repo_from_git("/tmp/workspace")
+        assert result is None
+
+    @patch("src.github_reviews.subprocess.run")
+    def test_returns_none_on_exception(self, mock_run):
+        """Returns None when subprocess raises."""
+        mock_run.side_effect = Exception("not a git repo")
+
+        result = get_pr_repo_from_git("/tmp/workspace")
+        assert result is None

--- a/tests/unit/test_pr_review.py
+++ b/tests/unit/test_pr_review.py
@@ -1,0 +1,420 @@
+"""Unit tests for PR review feature — #141.
+
+Tests the server endpoint, CLI command dispatch, client method,
+and Codex review bug fixes.
+"""
+
+import json
+from datetime import datetime
+from unittest.mock import MagicMock, AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.server import create_app
+from src.models import Session, SessionStatus, ReviewConfig
+
+
+@pytest.fixture
+def mock_session_manager():
+    """Create a mock SessionManager for PR review tests."""
+    mock = MagicMock()
+    mock.sessions = {}
+    mock.tmux = MagicMock()
+    mock.tmux.list_sessions = MagicMock(return_value=[])
+    mock.message_queue_manager = None
+    mock._save_state = MagicMock()
+    return mock
+
+
+@pytest.fixture
+def mock_output_monitor():
+    mock = MagicMock()
+    mock.start_monitoring = AsyncMock()
+    mock.cleanup_session = AsyncMock()
+    mock.update_activity = MagicMock()
+    mock._tasks = {}
+    return mock
+
+
+@pytest.fixture
+def test_client(mock_session_manager, mock_output_monitor):
+    app = create_app(
+        session_manager=mock_session_manager,
+        notifier=None,
+        output_monitor=mock_output_monitor,
+        config={},
+    )
+    return TestClient(app)
+
+
+@pytest.fixture
+def sample_session():
+    return Session(
+        id="test123",
+        name="test-session",
+        working_dir="/tmp/test",
+        tmux_session="codex-test123",
+        provider="codex",
+        log_file="/tmp/test.log",
+        status=SessionStatus.RUNNING,
+        created_at=datetime(2024, 1, 15, 10, 0, 0),
+        last_activity=datetime(2024, 1, 15, 11, 0, 0),
+    )
+
+
+class TestPRReviewEndpoint:
+    """Tests for POST /reviews/pr endpoint."""
+
+    def test_pr_review_success(self, test_client, mock_session_manager):
+        """POST /reviews/pr returns success result."""
+        mock_session_manager.start_pr_review = AsyncMock(return_value={
+            "repo": "owner/repo",
+            "pr_number": 42,
+            "posted_at": "2026-02-14T10:00:00",
+            "comment_id": 12345,
+            "comment_body": "@codex review",
+            "status": "posted",
+            "server_polling": False,
+        })
+
+        response = test_client.post(
+            "/reviews/pr",
+            json={"pr_number": 42, "repo": "owner/repo"},
+        )
+        assert response.status_code == 200
+
+        data = response.json()
+        assert data["status"] == "posted"
+        assert data["pr_number"] == 42
+        assert data["repo"] == "owner/repo"
+
+    def test_pr_review_returns_error_as_200(self, test_client, mock_session_manager):
+        """POST /reviews/pr returns 200 with error payload (not HTTP 400)."""
+        mock_session_manager.start_pr_review = AsyncMock(return_value={
+            "error": "PR #999 not found in owner/repo",
+        })
+
+        response = test_client.post(
+            "/reviews/pr",
+            json={"pr_number": 999, "repo": "owner/repo"},
+        )
+        # Key fix: should be 200, not 400
+        assert response.status_code == 200
+        data = response.json()
+        assert "error" in data
+
+    def test_pr_review_with_steer(self, test_client, mock_session_manager):
+        """POST /reviews/pr passes steer to session manager."""
+        mock_session_manager.start_pr_review = AsyncMock(return_value={
+            "repo": "owner/repo",
+            "pr_number": 42,
+            "posted_at": "2026-02-14T10:00:00",
+            "comment_id": 12345,
+            "comment_body": "@codex review for security",
+            "status": "posted",
+            "server_polling": False,
+        })
+
+        response = test_client.post(
+            "/reviews/pr",
+            json={
+                "pr_number": 42,
+                "repo": "owner/repo",
+                "steer": "security",
+            },
+        )
+        assert response.status_code == 200
+
+        mock_session_manager.start_pr_review.assert_called_once()
+        call_kwargs = mock_session_manager.start_pr_review.call_args
+        assert call_kwargs.kwargs["steer"] == "security"
+
+    def test_pr_review_with_wait_and_caller(self, test_client, mock_session_manager):
+        """POST /reviews/pr with wait and caller_session_id triggers server polling."""
+        mock_session_manager.start_pr_review = AsyncMock(return_value={
+            "repo": "owner/repo",
+            "pr_number": 42,
+            "posted_at": "2026-02-14T10:00:00",
+            "comment_id": 12345,
+            "comment_body": "@codex review",
+            "status": "posted",
+            "server_polling": True,
+        })
+
+        response = test_client.post(
+            "/reviews/pr",
+            json={
+                "pr_number": 42,
+                "repo": "owner/repo",
+                "wait": 600,
+                "caller_session_id": "parent123",
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["server_polling"] is True
+
+    def test_pr_review_unavailable(self):
+        """POST /reviews/pr returns 503 when session manager not configured."""
+        app = create_app(session_manager=None)
+        client = TestClient(app)
+
+        response = client.post("/reviews/pr", json={"pr_number": 42})
+        assert response.status_code == 503
+
+
+class TestReviewEndpointErrorFix:
+    """Tests for Codex P2 fix: review endpoints return 200 with error payload."""
+
+    def test_start_review_error_returns_200(self, test_client, mock_session_manager, sample_session):
+        """POST /sessions/{id}/review returns 200 with error, not HTTP 400."""
+        mock_session_manager.get_session.return_value = sample_session
+        mock_session_manager.start_review = AsyncMock(return_value={
+            "error": "Session is busy",
+        })
+
+        response = test_client.post(
+            "/sessions/test123/review",
+            json={"mode": "branch", "base_branch": "main"},
+        )
+        # Codex P2 fix: was 400, should now be 200 with error payload
+        assert response.status_code == 200
+        data = response.json()
+        assert "error" in data
+
+    def test_spawn_review_failure_returns_200(self, test_client, mock_session_manager, sample_session):
+        """POST /sessions/review returns 200 with error, not HTTP 500."""
+        mock_session_manager.get_session.return_value = sample_session
+        mock_session_manager.spawn_review_session = AsyncMock(return_value=None)
+
+        response = test_client.post(
+            "/sessions/review",
+            json={
+                "parent_session_id": "test123",
+                "mode": "branch",
+                "base_branch": "main",
+            },
+        )
+        # Codex P2 fix: was 500, should now be 200 with error payload
+        assert response.status_code == 200
+        data = response.json()
+        assert "error" in data
+
+
+class TestCmdReviewPR:
+    """Tests for cmd_review --pr dispatch path."""
+
+    def test_pr_mode_calls_start_pr_review(self):
+        """cmd_review with pr dispatches to client.start_pr_review."""
+        from src.cli.commands import cmd_review
+
+        mock_client = MagicMock()
+        mock_client.start_pr_review.return_value = {
+            "repo": "owner/repo",
+            "pr_number": 42,
+            "posted_at": "2026-02-14T10:00:00",
+            "comment_id": 12345,
+            "status": "posted",
+            "server_polling": True,
+        }
+
+        exit_code = cmd_review(
+            client=mock_client,
+            parent_session_id="parent123",
+            pr=42,
+            repo="owner/repo",
+            wait=600,
+        )
+
+        assert exit_code == 0
+        mock_client.start_pr_review.assert_called_once_with(
+            pr_number=42,
+            repo="owner/repo",
+            steer=None,
+            wait=600,
+            caller_session_id="parent123",
+        )
+
+    def test_pr_mode_mutually_exclusive_with_session(self):
+        """--pr rejects session argument."""
+        from src.cli.commands import cmd_review
+
+        mock_client = MagicMock()
+        exit_code = cmd_review(
+            client=mock_client,
+            parent_session_id=None,
+            session="some-session",
+            pr=42,
+        )
+        assert exit_code == 1
+
+    def test_pr_mode_mutually_exclusive_with_new(self):
+        """--pr rejects --new."""
+        from src.cli.commands import cmd_review
+
+        mock_client = MagicMock()
+        exit_code = cmd_review(
+            client=mock_client,
+            parent_session_id=None,
+            new=True,
+            pr=42,
+        )
+        assert exit_code == 1
+
+    def test_pr_mode_mutually_exclusive_with_base(self):
+        """--pr rejects --base."""
+        from src.cli.commands import cmd_review
+
+        mock_client = MagicMock()
+        exit_code = cmd_review(
+            client=mock_client,
+            parent_session_id=None,
+            base="main",
+            pr=42,
+        )
+        assert exit_code == 1
+
+    def test_pr_mode_error_from_api(self):
+        """cmd_review returns 1 when API returns error."""
+        from src.cli.commands import cmd_review
+
+        mock_client = MagicMock()
+        mock_client.start_pr_review.return_value = {
+            "error": "PR not found",
+        }
+
+        exit_code = cmd_review(
+            client=mock_client,
+            parent_session_id=None,
+            pr=42,
+            repo="owner/repo",
+        )
+        assert exit_code == 1
+
+    def test_pr_mode_unavailable(self):
+        """cmd_review returns 2 when session manager unavailable."""
+        from src.cli.commands import cmd_review
+
+        mock_client = MagicMock()
+        mock_client.start_pr_review.return_value = None
+
+        exit_code = cmd_review(
+            client=mock_client,
+            parent_session_id=None,
+            pr=42,
+            repo="owner/repo",
+        )
+        assert exit_code == 2
+
+    def test_pr_mode_defaults_wait_with_session_context(self):
+        """--wait defaults to 600 when caller has session context."""
+        from src.cli.commands import cmd_review
+
+        mock_client = MagicMock()
+        mock_client.start_pr_review.return_value = {
+            "repo": "owner/repo",
+            "pr_number": 42,
+            "posted_at": "2026-02-14T10:00:00",
+            "comment_id": 12345,
+            "status": "posted",
+            "server_polling": True,
+        }
+
+        cmd_review(
+            client=mock_client,
+            parent_session_id="parent123",
+            pr=42,
+            repo="owner/repo",
+            # wait not provided
+        )
+
+        call_kwargs = mock_client.start_pr_review.call_args
+        assert call_kwargs.kwargs["wait"] == 600
+
+
+class TestClientStartPrReview:
+    """Tests for SessionManagerClient.start_pr_review."""
+
+    def test_sends_correct_payload(self):
+        """start_pr_review sends correct POST to /reviews/pr."""
+        from src.cli.client import SessionManagerClient
+
+        client = SessionManagerClient()
+
+        with patch.object(client, "_request") as mock_request:
+            mock_request.return_value = (
+                {"status": "posted", "repo": "owner/repo"},
+                True,
+                False,
+            )
+
+            result = client.start_pr_review(
+                pr_number=42,
+                repo="owner/repo",
+                steer="security",
+                wait=600,
+                caller_session_id="parent123",
+            )
+
+            mock_request.assert_called_once_with(
+                "POST",
+                "/reviews/pr",
+                {
+                    "pr_number": 42,
+                    "repo": "owner/repo",
+                    "steer": "security",
+                    "wait": 600,
+                    "caller_session_id": "parent123",
+                },
+                timeout=30,
+            )
+            assert result["status"] == "posted"
+
+    def test_returns_none_when_unavailable(self):
+        """start_pr_review returns None when server is unavailable."""
+        from src.cli.client import SessionManagerClient
+
+        client = SessionManagerClient()
+
+        with patch.object(client, "_request") as mock_request:
+            mock_request.return_value = (None, False, True)
+
+            result = client.start_pr_review(pr_number=42, repo="owner/repo")
+            assert result is None
+
+
+class TestReviewConfigPRFields:
+    """Tests for ReviewConfig PR mode fields."""
+
+    def test_pr_mode_config(self):
+        """ReviewConfig supports PR mode fields."""
+        config = ReviewConfig(
+            mode="pr",
+            pr_number=42,
+            pr_repo="owner/repo",
+            pr_comment_id=12345,
+            steer_text="focus on security",
+        )
+
+        assert config.mode == "pr"
+        assert config.pr_number == 42
+        assert config.pr_repo == "owner/repo"
+        assert config.pr_comment_id == 12345
+
+    def test_pr_config_roundtrip(self):
+        """ReviewConfig with PR fields serializes correctly."""
+        config = ReviewConfig(
+            mode="pr",
+            pr_number=42,
+            pr_repo="owner/repo",
+            pr_comment_id=12345,
+        )
+
+        as_dict = config.to_dict()
+        restored = ReviewConfig.from_dict(as_dict)
+
+        assert restored.mode == "pr"
+        assert restored.pr_number == 42
+        assert restored.pr_repo == "owner/repo"
+        assert restored.pr_comment_id == 12345


### PR DESCRIPTION
## Summary

Adds `--pr` mode to `sm review` for triggering `@codex review` on GitHub PRs, plus fixes 3 Codex review findings from #138.

Fixes #141

**Phase 1b scope (Steps 9-12):**

- **`src/github_reviews.py`** (new) — `post_pr_review_comment()`, `poll_for_codex_review()`, `get_pr_repo_from_git()`. All sync via `subprocess.run`.
- **`src/session_manager.py`** — `start_pr_review()` with repo resolution, PR validation, comment posting, background polling via `asyncio.to_thread()`
- **`src/server.py`** — `PRReviewRequest` model + `POST /reviews/pr` endpoint
- **`src/cli/commands.py`** — `--pr` dispatch path in `cmd_review()` with CLI-side polling for standalone
- **`src/cli/client.py`** — `start_pr_review()` API client method

**Also fixes Codex review findings from #138:**
- P1: Orphan session cleanup on `spawn_review_session()` failure
- P1: Active state rollback when `send_review_sequence()` fails
- P2: Review endpoints return 200 + error body instead of HTTP 400

**Tests:** 2 new test files (595 lines), 419 total tests passing.

## Test plan

- [x] 419 tests pass (28 new tests for PR review + github_reviews)
- [ ] Manual: `sm review --pr <number> --repo rajeshgoli/claude-sessions --wait 600`
- [ ] Manual: `sm review --pr <number> --steer "focus on security"`
- [ ] Manual: standalone (no session context) `sm review --pr <number> --wait 300`