### PR TITLE
Fix Telegram topic duplication on server restart

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -220,6 +220,7 @@ def create_app(
     output_monitor=None,
     child_monitor=None,
     config: Optional[dict] = None,
+    lifespan=None,
 ) -> FastAPI:
     """
     Create the FastAPI application.
@@ -230,6 +231,7 @@ def create_app(
         output_monitor: OutputMonitor instance
         child_monitor: ChildMonitor instance
         config: Configuration dictionary
+        lifespan: Optional ASGI lifespan context manager
 
     Returns:
         Configured FastAPI app
@@ -238,6 +240,7 @@ def create_app(
         title="Claude Session Manager",
         description="Manage Claude Code sessions with Telegram/Email notifications",
         version="0.1.0",
+        lifespan=lifespan,
     )
 
     # Store config first so middleware can access it

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -432,7 +432,8 @@ class SessionManager:
                 )
                 if thread_id:
                     session.telegram_thread_id = thread_id
-                    changed = True
+                    self._save_state()  # Persist IMMEDIATELY — minimize race window
+                    changed = False     # Already saved; prevent redundant outer save
                     logger.info(
                         f"Auto-created topic for session {session.id}: "
                         f"chat={session.telegram_chat_id}, thread={thread_id}"


### PR DESCRIPTION
## Summary

Fixes #147

- **Defer side effects to ASGI lifespan** (`src/main.py`): Move `_reconcile_telegram_topics()` and monitoring restoration into a post-bind lifespan hook. Doomed instances (port already in use) now exit before any Telegram API calls fire, preventing the crash-loop from creating hundreds of duplicate forum topics.
- **Persist `thread_id` immediately** (`src/session_manager.py`): Call `_save_state()` right after successful topic creation instead of at the end of `_ensure_telegram_topic()`. Minimizes the race window where a concurrent instance can overwrite the thread ID with `null`.
- **Accept `lifespan` parameter** (`src/server.py`): Thread the ASGI lifespan context manager through to `FastAPI()`.

## Test plan

- [ ] Start server normally — verify Telegram topic reconciliation and monitoring restoration still work (check logs for "Restored monitoring" messages)
- [ ] Simulate crash-loop: start server, then start a second instance — verify the second instance exits without creating any Telegram topics
- [ ] Verify `sessions.json` retains `telegram_thread_id` after topic creation (not overwritten to `null`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)