### PR TITLE
Fix spawning Claude Code sessions after CLI update

### DIFF
--- a/src/tmux_controller.py
+++ b/src/tmux_controller.py
@@ -263,6 +263,7 @@ class TmuxController:
             # it via send-keys after startup. This avoids timing issues where
             # Claude Code hasn't finished initializing when the prompt arrives.
             if initial_prompt:
+                cmd_parts.append("--")
                 cmd_parts.append(shlex.quote(initial_prompt))
 
             # Start Claude Code in the session
@@ -274,12 +275,14 @@ class TmuxController:
             )
 
             if initial_prompt:
-                logger.info(f"Created session with CLI prompt for {session_name}: {initial_prompt[:50]}...")
+                logger.info(f"Created session with CLI prompt for {session_name} (prompt_len={len(initial_prompt)})")
             else:
                 import time
                 time.sleep(self.claude_init_no_prompt_seconds)
 
-            logger.info(f"Created child session {session_name} (id={session_id}) with command {' '.join(cmd_parts)}")
+            # Log command without prompt payload to avoid leaking sensitive content
+            log_parts = [p for p in cmd_parts if p != "--" and p != shlex.quote(initial_prompt)] if initial_prompt else cmd_parts
+            logger.info(f"Created child session {session_name} (id={session_id}) with command {' '.join(log_parts)}")
             return True
 
         except subprocess.CalledProcessError as e:


### PR DESCRIPTION
## Summary
- **Unset CLAUDECODE env var**: Claude Code now sets `CLAUDECODE` to detect nested sessions and refuses to start if it's set. Spawned tmux sessions inherit this from the parent, so `claude` fails with "cannot be launched inside another Claude Code session." Fix: `unset CLAUDECODE` before launching claude in new tmux sessions.
- **Pass initial prompt as CLI argument**: The old approach waited 3 seconds then typed the prompt via `tmux send-keys`. The latest Claude Code takes longer to initialize, so the prompt arrives before Claude is ready and gets lost. Fix: pass the prompt as a positional argument on the command line (`claude --dangerously-skip-permissions 'prompt'`), which Claude Code natively supports.

## Test plan
- [ ] `sm spawn claude "say hello and exit" --name test-agent` — agent should start and receive the prompt
- [ ] Verify no "nested session" error on spawn
- [ ] Verify sessions without initial prompts still work