### PR TITLE
Unset CLAUDECODE env var before resume in crash recovery

### DIFF
--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -1668,7 +1668,18 @@ class SessionManager:
                 await asyncio.wait_for(proc.communicate(), timeout=5)
                 await asyncio.sleep(0.5)
 
-            # 6. Build resume command with config args
+            # 6. Unset CLAUDECODE to prevent nested-session detection
+            #    (Claude Code exports this; it persists in the shell after the process dies)
+            proc = await asyncio.create_subprocess_exec(
+                "tmux", "send-keys", "-t", session.tmux_session,
+                "unset CLAUDECODE", "Enter",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            await asyncio.wait_for(proc.communicate(), timeout=5)
+            await asyncio.sleep(0.3)
+
+            # 7. Build resume command with config args
             claude_config = self.config.get("claude", {})
             command = claude_config.get("command", "claude")
             args = claude_config.get("args", [])


### PR DESCRIPTION
## Summary
- `recover_session()` now runs `unset CLAUDECODE` before sending the `--resume` command
- Matches what `create_session()` and `create_session_with_command()` already do
- Without this, the resume fails with "cannot be launched inside another Claude Code session"

## Spec
`specs/172_crash_recovery_claudecode_env.md`

## Test plan
- [ ] Spawn a session, kill the Claude process, verify crash recovery resumes successfully
- [ ] Confirm `unset CLAUDECODE` appears in tmux send-keys before the resume command in logs

Fixes #172