### PR TITLE
fix: sm wait false timeout on Claude idle after sm send

### DIFF
--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -1197,7 +1197,15 @@ class MessageQueueManager:
                 # Guard: session disappeared mid-loop (killed/cleaned up)
                 if not session:
                     logger.warning(f"Watch {watch_id}: session {target_session_id} no longer exists")
-                    break
+                    notification = (
+                        f"[sm wait] {target_session_id} no longer exists (waited {int(elapsed)}s)"
+                    )
+                    self.queue_message(
+                        target_session_id=watcher_session_id,
+                        text=notification,
+                        delivery_mode="important",
+                    )
+                    return
 
                 # Phase 1: Check in-memory idle state
                 state = self.delivery_states.get(target_session_id)

--- a/tests/unit/test_message_queue.py
+++ b/tests/unit/test_message_queue.py
@@ -906,10 +906,11 @@ class TestWatchForIdlePhases:
 
         await mq._watch_for_idle("watch-gone", "target_gone", "watcher_gone", timeout_seconds=5)
 
-        # Should have exited to timeout path (session gone → break → timeout notification)
+        # Should emit distinct "no longer exists" notification, not a generic timeout
         pending = mq.get_pending_messages("watcher_gone")
         assert len(pending) == 1
-        assert "Timeout" in pending[0].text or "still active" in pending[0].text
+        assert "no longer exists" in pending[0].text
+        assert "Timeout" not in pending[0].text
 
     @pytest.mark.asyncio
     async def test_counters_reset_between_iterations(self, mock_session_manager, temp_db_path):


### PR DESCRIPTION
## Summary

- Extends tmux prompt idle detection from Codex-only to both Claude and Codex sessions, fixing the primary cause of false timeouts when Stop hook fails to reach the server
- Adds tmux tiebreaker to the pending-message validation so stuck (undeliverable) messages no longer suppress idle indefinitely
- Adds Session.status fallback for in-memory state corruption edge cases
- Renames `_check_codex_prompt` → `_check_idle_prompt` (both CLIs use `>` prompt)
- Guards against `get_session()` returning None mid-loop

## Test plan

- [x] 9 new unit tests covering all 4 phases, tiebreaker edge cases, session-gone guard, counter resets, and #153 regression
- [x] All 53 tests pass (unit + regression)
- [ ] Manual verification: dispatch agent, agent completes + sm sends back, sm wait detects idle promptly

Fixes #180