### PR TITLE
Add pytest-timeout guard (30s per-test)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dev = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.0",
+    "pytest-timeout>=2.0",
     "httpx>=0.25.0",
 ]
 
@@ -51,3 +52,4 @@ include = ["src*"]
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+timeout = 30


### PR DESCRIPTION
## Summary
- Adds `pytest-timeout>=2.0` to dev dependencies
- Sets `timeout = 30` in `[tool.pytest.ini_options]`
- Any individual test exceeding 30s is killed as hanging
- Tests needing more time can override with `@pytest.mark.timeout(120)`

## Spec Reference
`docs/working/186_agent_test_timeout.md` — Layer 2 only

## Test Plan
- [x] `pytest-timeout` installed and active (`timeout: 30.0s` shown in header)
- [x] Targeted test run passes with timeout configured

Fixes rajeshgoli/session-manager#186