### PR TITLE
Add codex bypass flag to config (sm#185 Part 1)

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -129,7 +129,8 @@ codex:
   # Command to launch Codex (CLI + app-server)
   command: "codex"
   # Extra args passed to interactive Codex CLI
-  args: []
+  args:
+    - "--dangerously-bypass-approvals-and-sandbox"
   # Extra args passed to `codex app-server` (override via codex_app_server.* if needed)
   app_server_args: []
   # Default model for Codex turns (optional)

--- a/tests/unit/test_codex_bypass_config.py
+++ b/tests/unit/test_codex_bypass_config.py
@@ -1,0 +1,71 @@
+"""Tests for codex bypass flag config (sm#185).
+
+Verifies that:
+1. codex.args with bypass flag is loaded into codex_cli_args
+2. app_server_args: [] prevents bypass flag from leaking into codex-app sessions
+"""
+
+import tempfile
+
+from src.session_manager import SessionManager
+
+
+class TestCodexBypassConfig:
+    """Test codex bypass flag isolation between CLI and app-server."""
+
+    def test_bypass_flag_in_codex_cli_args(self):
+        """Verify bypass flag is passed to codex CLI sessions."""
+        config = {
+            "codex": {
+                "command": "codex",
+                "args": ["--dangerously-bypass-approvals-and-sandbox"],
+                "app_server_args": [],
+            }
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sm = SessionManager(log_dir=tmpdir, state_file=f"{tmpdir}/state.json", config=config)
+            assert "--dangerously-bypass-approvals-and-sandbox" in sm.codex_cli_args
+
+    def test_app_server_args_empty_prevents_leak(self):
+        """Verify app_server_args: [] prevents bypass flag from leaking to codex app-server."""
+        config = {
+            "codex": {
+                "command": "codex",
+                "args": ["--dangerously-bypass-approvals-and-sandbox"],
+                "app_server_args": [],
+            }
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sm = SessionManager(log_dir=tmpdir, state_file=f"{tmpdir}/state.json", config=config)
+            assert sm.codex_config.args == []
+
+    def test_without_app_server_args_bypass_leaks(self):
+        """Verify that WITHOUT app_server_args, bypass flag leaks to app-server (the bug)."""
+        config = {
+            "codex": {
+                "command": "codex",
+                "args": ["--dangerously-bypass-approvals-and-sandbox"],
+                # No app_server_args key — fallback chain picks up args
+            }
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sm = SessionManager(log_dir=tmpdir, state_file=f"{tmpdir}/state.json", config=config)
+            # Without app_server_args, the fallback chain leaks bypass flag
+            assert "--dangerously-bypass-approvals-and-sandbox" in sm.codex_config.args
+
+    def test_separate_codex_app_server_section_overrides(self):
+        """Verify codex_app_server section overrides codex section for app-server."""
+        config = {
+            "codex": {
+                "command": "codex",
+                "args": ["--dangerously-bypass-approvals-and-sandbox"],
+            },
+            "codex_app_server": {
+                "command": "codex",
+                "app_server_args": ["--custom-flag"],
+            }
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            sm = SessionManager(log_dir=tmpdir, state_file=f"{tmpdir}/state.json", config=config)
+            assert sm.codex_cli_args == ["--dangerously-bypass-approvals-and-sandbox"]
+            assert sm.codex_config.args == ["--custom-flag"]


### PR DESCRIPTION
## Summary

- Add `--dangerously-bypass-approvals-and-sandbox` to `codex.args` in `config.yaml.example` so codex CLI sessions can execute shell commands (e.g., `sm send`) without approval prompts
- The existing `app_server_args: []` in the example prevents the bypass flag from leaking into codex app-server sessions via the fallback chain at `session_manager.py:55`
- Add 4 unit tests verifying the config isolation between CLI and app-server args

## Spec Reference

`docs/working/185_codex_spawn_bypass.md` — Part 1 only (config change)

## Test Plan

- [x] 4 new unit tests pass (bypass flag loaded, app-server isolation, leak detection, section override)
- [x] Full suite: 588 passed, 1 pre-existing failure (unrelated `test_monitor_loop_gives_up_after_max_retries`)

**Note:** `config.yaml` (live, gitignored) was also updated locally with the same change.

Fixes #185