### PR TITLE
fix(context-monitor): disambiguate child-forwarded notifications

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -2433,11 +2433,19 @@ Or continue working if not done yet."""
             if not session._context_critical_sent:
                 session._context_critical_sent = True
                 if queue_mgr:
-                    msg = (
-                        f"[sm context] Context at {used_pct}% — critically high. "
-                        "Write your handoff doc NOW and run `sm handoff <path>`. "
-                        "Compaction is imminent."
-                    )
+                    is_self_alert = (session.context_monitor_notify == session.id)
+                    if is_self_alert:
+                        msg = (
+                            f"[sm context] Context at {used_pct}% — critically high. "
+                            "Write your handoff doc NOW and run `sm handoff <path>`. "
+                            "Compaction is imminent."
+                        )
+                    else:
+                        child_label = session.friendly_name or session.id
+                        msg = (
+                            f"[sm context] Child {child_label} ({session.id}) context at {used_pct}% — critically high. "
+                            "Compaction is imminent."
+                        )
                     queue_mgr.queue_message(
                         target_session_id=session.context_monitor_notify,
                         text=msg,
@@ -2447,11 +2455,16 @@ Or continue working if not done yet."""
             if not session._context_warning_sent:
                 session._context_warning_sent = True
                 if queue_mgr:
-                    total = data.get("total_input_tokens", 0)
-                    msg = (
-                        f"[sm context] Context at {used_pct}% ({total:,} tokens). "
-                        "Consider writing a handoff doc and running `sm handoff <path>`."
-                    )
+                    is_self_alert = (session.context_monitor_notify == session.id)
+                    if is_self_alert:
+                        total = data.get("total_input_tokens", 0)
+                        msg = (
+                            f"[sm context] Context at {used_pct}% ({total:,} tokens). "
+                            "Consider writing a handoff doc and running `sm handoff <path>`."
+                        )
+                    else:
+                        child_label = session.friendly_name or session.id
+                        msg = f"[sm context] Child {child_label} ({session.id}) context at {used_pct}%."
                     queue_mgr.queue_message(
                         target_session_id=session.context_monitor_notify,
                         text=msg,


### PR DESCRIPTION
## Summary

When a parent EM registers to monitor a child's context (`sm context-monitor enable <child-id>`), threshold alerts used the same generic text as self-alerts — making them indistinguishable and directing the handoff instruction at the wrong recipient.

This PR makes child-forwarded alerts clearly identify the child and omit instructions the EM cannot act on:

- **Critical (child):** `[sm context] Child <name> (<id>) context at X% — critically high. Compaction is imminent.`
- **Warning (child):** `[sm context] Child <name> (<id>) context at X%.`
- **Critical (self):** unchanged — includes handoff instruction
- **Warning (self):** unchanged — includes handoff suggestion

The `is_self_alert` check (`session.context_monitor_notify == session.id`) is computed inside each threshold branch, keeping the change localized. The compaction notification already used this format and is untouched.

## Spec Reference

`docs/working/212_context_monitor_child_notifications.md`

## Test Plan

- [x] Added `TestChildForwardedNotifications` class (7 new tests) covering:
  - Child critical contains friendly name when set
  - Child critical falls back to session id when friendly_name is None
  - Child critical omits handoff instruction
  - Child warning contains session label
  - Child warning omits handoff suggestion
  - Self critical includes handoff instruction, no "Child" prefix
  - Self warning includes handoff suggestion, no "Child" prefix
- [x] All 61 tests in `test_context_monitor.py` pass
- [x] 789/790 tests in full suite pass (1 pre-existing failure in `test_issue_40_error_swallowing.py::test_monitor_loop_gives_up_after_max_retries` — timeout unrelated to this change, predates this PR)

Fixes #212