### PR TITLE
fix(context-monitor): compaction message says 'compacted — agent is still running'

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -2396,7 +2396,7 @@ Or continue working if not done yet."""
             if notify_target and queue_mgr:
                 msg = (
                     f"[sm context] Compaction fired for {session.friendly_name or session_id}. "
-                    "Context was lost."
+                    "Context was compacted — agent is still running."
                 )
                 queue_mgr.queue_message(
                     target_session_id=notify_target,

--- a/tests/unit/test_context_monitor.py
+++ b/tests/unit/test_context_monitor.py
@@ -204,6 +204,16 @@ class TestCompactionEvent:
         assert call_kwargs["target_session_id"] == "parent999"
         assert "Compaction fired" in call_kwargs["text"] or "compaction" in call_kwargs["text"].lower()
 
+    def test_compaction_notification_wording(self, client, mock_session_manager, session):
+        """Compaction notification says 'compacted — agent is still running', not 'Context was lost'."""
+        session.context_monitor_notify = "parent999"
+        _post_event(client, session.id, event="compaction", trigger="auto")
+
+        queue_mgr = mock_session_manager.message_queue_manager
+        text = queue_mgr.queue_message.call_args[1]["text"]
+        assert "Context was compacted — agent is still running." in text
+        assert "Context was lost" not in text
+
     def test_compaction_no_notify_no_notification(self, client, mock_session_manager, session):
         """Without context_monitor_notify, no notification is sent."""
         session.context_monitor_notify = None


### PR DESCRIPTION
## Summary

Changes the compaction notification message from the misleading "Context was lost." to "Context was compacted — agent is still running." so recipients understand the agent continues after compaction.

## Spec Reference

N/A — small focused wording fix per sm#226.

## Test Plan

- [x] `test_compaction_notification_wording` — asserts new wording present, old wording absent
- [x] All 790 existing tests pass

Fixes #226