### PR TITLE
feat: remove idle gate from sequential/important delivery (sm#244)

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -447,4 +447,5 @@ class SessionDeliveryState:
     last_outgoing_sm_send_target: Optional[str] = None  # Target of last outgoing sm send (#182)
     last_outgoing_sm_send_at: Optional[datetime] = None  # When last outgoing sm send was recorded (#182)
     pending_handoff_path: Optional[str] = None  # File path for pending handoff (#196)
-    _stuck_delivery_count: int = 0  # Consecutive prompt detections with pending msgs but is_idle=False (#229)
+    paste_buffered_notify_sender_id: Optional[str] = None  # Staged stop-notify for mid-turn paste; promoted on first idle (sm#244)
+    paste_buffered_notify_sender_name: Optional[str] = None  # Sender name for the above (sm#244)

--- a/tests/regression/test_issue_183_pretooluse_mark_active.py
+++ b/tests/regression/test_issue_183_pretooluse_mark_active.py
@@ -50,10 +50,10 @@ def _make_session(session_id="target183", provider="claude"):
 
 
 class TestPreToolUseClearsStaleIdle:
-    """Core fix: PreToolUse fires mark_session_active to clear stale is_idle."""
+    """mark_session_active sets is_idle=False; with sm#244 this no longer defers sequential/important."""
 
     def test_mark_session_active_clears_idle(self, mq):
-        """mark_session_active sets is_idle=False, preventing stale delivery."""
+        """mark_session_active sets is_idle=False (used by urgent path and _watch_for_idle Phase 3)."""
         # Simulate: Stop hook fired → is_idle=True
         state = mq._get_or_create_state("target183")
         state.is_idle = True
@@ -64,47 +64,42 @@ class TestPreToolUseClearsStaleIdle:
         assert state.is_idle is False
 
     @pytest.mark.asyncio
-    async def test_important_deferred_after_mark_active(self, mq, mock_session_manager):
-        """Important message deferred when is_idle cleared by mark_session_active."""
+    async def test_important_delivers_regardless_of_is_idle(self, mq, mock_session_manager):
+        """sm#244: Important delivery proceeds even when is_idle=False (no idle gate)."""
         session = _make_session()
         mock_session_manager.get_session.return_value = session
 
-        # Simulate stale idle
+        # Simulate stale idle cleared by PreToolUse
         state = mq._get_or_create_state("target183")
         state.is_idle = True
-
-        # PreToolUse fires → clears idle
         mq.mark_session_active("target183")
 
-        # Queue important message
         mq.queue_message("target183", "Hello", delivery_mode="important")
-
-        # Mock user input check to return None
         mq._get_pending_user_input_async = AsyncMock(return_value=None)
 
-        # Try delivery — should be deferred (is_idle=False)
+        # No idle gate — delivery proceeds (message buffers in tty if mid-turn)
         await mq._try_deliver_messages("target183", important_only=True)
 
-        mock_session_manager._deliver_direct.assert_not_called()
-        assert mq.get_queue_length("target183") == 1
+        mock_session_manager._deliver_direct.assert_called_once()
+        assert mq.get_queue_length("target183") == 0
 
     @pytest.mark.asyncio
-    async def test_sequential_deferred_after_mark_active(self, mq, mock_session_manager):
-        """Sequential message deferred when is_idle cleared by mark_session_active."""
+    async def test_sequential_delivers_regardless_of_is_idle(self, mq, mock_session_manager):
+        """sm#244: Sequential delivery proceeds even when is_idle=False (no idle gate)."""
         session = _make_session()
         mock_session_manager.get_session.return_value = session
 
         state = mq._get_or_create_state("target183")
         state.is_idle = True
-
         mq.mark_session_active("target183")
+
         mq.queue_message("target183", "Hello", delivery_mode="sequential")
         mq._get_pending_user_input_async = AsyncMock(return_value=None)
 
         await mq._try_deliver_messages("target183")
 
-        mock_session_manager._deliver_direct.assert_not_called()
-        assert mq.get_queue_length("target183") == 1
+        mock_session_manager._deliver_direct.assert_called_once()
+        assert mq.get_queue_length("target183") == 0
 
 
 class TestIdleDeliveryUnaffected:
@@ -147,29 +142,25 @@ class TestIdleDeliveryUnaffected:
 
 
 class TestStopHookResetsIdle:
-    """Stop hook → mark_session_idle delivers deferred messages."""
+    """Stop hook → mark_session_idle sets is_idle and schedules delivery."""
 
     @pytest.mark.asyncio
-    async def test_deferred_message_delivered_on_stop_hook(self, mq, mock_session_manager):
-        """Message deferred by mark_session_active is delivered when Stop hook fires."""
+    async def test_direct_delivery_and_stop_hook_marks_idle(self, mq, mock_session_manager):
+        """sm#244: Sequential message delivers immediately; stop hook marks idle."""
         session = _make_session()
         mock_session_manager.get_session.return_value = session
 
-        # Queue message
-        mq.queue_message("target183", "Deferred msg", delivery_mode="sequential")
-
-        # Agent is active (PreToolUse cleared idle)
+        mq.queue_message("target183", "Direct msg", delivery_mode="sequential")
         mq.mark_session_active("target183")
         mq._get_pending_user_input_async = AsyncMock(return_value=None)
 
-        # Delivery attempt fails (is_idle=False)
+        # Direct delivery: no idle gate — proceeds immediately
         await mq._try_deliver_messages("target183")
-        mock_session_manager._deliver_direct.assert_not_called()
+        mock_session_manager._deliver_direct.assert_called_once()
 
-        # Stop hook fires → mark_session_idle → triggers delivery
+        # Stop hook fires → mark_session_idle → is_idle=True, schedules delivery check
         with patch("asyncio.create_task") as mock_task:
             mq.mark_session_idle("target183")
 
         assert mq.is_session_idle("target183") is True
-        # mark_session_idle creates a task to deliver
         assert mock_task.called

--- a/tests/regression/test_issue_76_message_delivery.py
+++ b/tests/regression/test_issue_76_message_delivery.py
@@ -98,10 +98,9 @@ async def test_delivery_to_idle_status_session(queue_manager, mock_session_manag
     # Give async tasks time to execute
     await asyncio.sleep(0.2)
 
-    # Verify session was marked idle at some point (last_idle_at should be set)
+    # Verify delivery state exists
     state = queue_manager.delivery_states.get(session_id)
     assert state is not None
-    assert state.last_idle_at is not None, "Session should have been marked idle"
 
     # Verify message was delivered (queue should be empty)
     pending = queue_manager.get_pending_messages(session_id)

--- a/tests/unit/test_remind.py
+++ b/tests/unit/test_remind.py
@@ -108,10 +108,11 @@ class TestDeliveryTriggeredStart:
 
     def test_queue_message_without_remind_has_none_thresholds(self, mq):
         """Messages without --remind have None remind thresholds."""
-        msg = mq.queue_message(
-            target_session_id="agent2",
-            text="Normal message",
-        )
+        with patch("asyncio.create_task", noop_create_task):
+            msg = mq.queue_message(
+                target_session_id="agent2",
+                text="Normal message",
+            )
         pending = mq.get_pending_messages("agent2")
         assert len(pending) == 1
         assert pending[0].remind_soft_threshold is None


### PR DESCRIPTION
Spec: docs/working/244_sm_send_direct_delivery.md

## Summary

- Removes the idle gate (`is_idle` check) from `_try_deliver_messages` for sequential and important delivery modes. Messages now paste directly into the tty buffer and are consumed by Claude after the current turn completes — no idle detection needed.
- Removes `_check_stuck_delivery` entirely (it was a workaround for unreliable idle detection; now obsolete).
- Adds two-phase stop-notify promotion: mid-turn paste stages sender in `paste_buffered_notify_sender_id` (promoted to `stop_notify_sender_id` on first idle transition); idle paste arms `stop_notify_sender_id` directly. Prevents false notification on Task X's Stop hook.
- Removes `is_idle` guard from `_check_stale_input` (Issue 3 fix: user-typing + hook-fail corner).
- Updates regression tests that assumed deferral behavior (now correctly document direct delivery).

## Test plan

- [ ] All 824 tests pass (1 pre-existing flaky failure: `test_monitor_loop_gives_up_after_max_retries`)
- [ ] `TestDirectDelivery244`: 9 new tests covering direct delivery, paste_buffered two-phase notify, stale input without idle guard, and delivery lock
- [ ] Regression tests updated: test_issue_153, test_issue_183, test_issue_39, test_issue_76

Fixes #244