### PR TITLE
feat: remove --remind from sm send; dispatch is sole remind path (sm#225-B)

### DIFF
--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -862,7 +862,6 @@ def cmd_send(
     notify_after_seconds: Optional[int] = None,
     wait_seconds: Optional[int] = None,
     notify_on_stop: bool = True,
-    remind_seconds: Optional[int] = None,
     remind_soft_threshold: Optional[int] = None,
     remind_hard_threshold: Optional[int] = None,
 ) -> int:
@@ -879,22 +878,14 @@ def cmd_send(
         notify_after_seconds: Notify sender N seconds after delivery
         wait_seconds: Notify sender N seconds after delivery if recipient is idle (alias for notify_after_seconds)
         notify_on_stop: Notify sender when receiver's Stop hook fires (default True)
-        remind_seconds: Start periodic remind registration with this soft threshold (#188)
-        remind_soft_threshold: Explicit soft threshold in seconds; overrides remind_seconds (#225-A)
-        remind_hard_threshold: Explicit hard threshold in seconds (#225-A)
+        remind_soft_threshold: Soft remind threshold in seconds; only set by sm dispatch (#225-A)
+        remind_hard_threshold: Hard remind threshold in seconds; only set by sm dispatch (#225-A)
 
     Exit codes:
         0: Success
         1: Session not found or send failed
         2: Session manager unavailable
     """
-    # Resolve remind thresholds.
-    # Explicit remind_soft_threshold/remind_hard_threshold (from sm dispatch) take
-    # precedence over the legacy remind_seconds (from sm send --remind).
-    if remind_soft_threshold is None and remind_seconds is not None:
-        remind_soft_threshold = remind_seconds
-        # remind_hard_threshold stays None: server computes from config.remind.hard_gap_seconds
-
     # Resolve identifier to session ID and get session details
     session_id, session = resolve_session_id(client, identifier)
     if session_id is None:

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -131,7 +131,6 @@ def main():
     send_parser.add_argument("--wait", type=int, metavar="SECONDS", help="Notify sender N seconds after delivery if recipient is idle")
     send_parser.add_argument("--steer", action="store_true", help="Inject via Enter-based mid-turn steering (for Codex reviews)")
     send_parser.add_argument("--no-notify-on-stop", action="store_true", help="Don't notify sender when receiver's Stop hook fires")
-    send_parser.add_argument("--remind", type=int, metavar="SECONDS", help="Start periodic status reminders with this soft threshold (seconds)")
 
     # sm remind <delay> <message>  (one-shot self-reminder)
     # sm remind <session-id> --stop  (cancel periodic remind)
@@ -409,12 +408,9 @@ def main():
         wait_seconds = args.wait if hasattr(args, 'wait') else None
         # notify_on_stop defaults to True unless --no-notify-on-stop is passed
         notify_on_stop = not getattr(args, 'no_notify_on_stop', False)
-        # --remind: periodic status reminders (#188)
-        remind_seconds = getattr(args, 'remind', None)
         sys.exit(commands.cmd_send(
             client, args.session_id, args.text, delivery_mode,
             wait_seconds=wait_seconds, notify_on_stop=notify_on_stop,
-            remind_seconds=remind_seconds,
         ))
     elif args.command == "remind":
         if args.stop:


### PR DESCRIPTION
## Summary

- Removes `--remind SECONDS` flag from `sm send` (sm#225-B, fixes #236)
- `sm dispatch` (via `get_auto_remind_config`) is now the sole path to arm periodic reminders
- Deletes legacy `remind_seconds` compatibility shim from `cmd_send`

## Changes

- `src/cli/main.py`: remove `--remind` from `send_parser`; remove `remind_seconds` extraction and passthrough
- `src/cli/commands.py`: remove `remind_seconds` parameter and legacy conversion block from `cmd_send`
- `tests/unit/test_dispatch.py`: remove 2 obsolete tests; add `test_send_remind_flag_rejected` to verify flag is rejected with exit code 2

## Test plan

- [x] `test_send_remind_flag_rejected` — asserts `sm send --remind 180 target msg` exits with code 2
- [x] All 845 tests pass (1 pre-existing failure: `test_monitor_loop_gives_up_after_max_retries`)

Fixes #236