### PR TITLE
feat: default dispatch templates + sm setup command (sm#225-D)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -50,6 +50,12 @@ fi
 # Create log directory
 mkdir -p /tmp/claude-sessions
 
+# Install default dispatch templates (only if not already present)
+if [ ! -f "$HOME/.sm/dispatch_templates.yaml" ]; then
+    echo "Installing default dispatch templates..."
+    sm setup 2>/dev/null || python -m src.cli.main setup 2>/dev/null || true
+fi
+
 echo ""
 echo "Setup complete!"
 echo ""

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -2339,3 +2339,37 @@ def cmd_context_monitor(
 
     print(f"Error: Unknown action '{action}'. Use: enable, disable, status", file=sys.stderr)
     return 1
+
+
+def cmd_setup(overwrite: bool = False) -> int:
+    """Copy default dispatch templates to ~/.sm/dispatch_templates.yaml.
+
+    Installs the bundled default_dispatch_templates.yaml to the user's global
+    ~/.sm/dispatch_templates.yaml. Never overwrites an existing file unless
+    overwrite=True.
+
+    Args:
+        overwrite: If True, replace an existing file. Default False.
+
+    Returns:
+        0 on success, 1 on error.
+    """
+    import shutil
+    from pathlib import Path
+
+    src = Path(__file__).parent / "default_dispatch_templates.yaml"
+    dest = Path.home() / ".sm" / "dispatch_templates.yaml"
+
+    if not src.is_file():
+        print(f"Error: Default template file not found: {src}", file=sys.stderr)
+        return 1
+
+    if dest.exists() and not overwrite:
+        print(f"Templates already installed at {dest}")
+        print("Use --overwrite to replace.")
+        return 0
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dest)
+    print(f"Installed dispatch templates to {dest}")
+    return 0

--- a/src/cli/default_dispatch_templates.yaml
+++ b/src/cli/default_dispatch_templates.yaml
@@ -1,0 +1,51 @@
+# Default dispatch templates for sm dispatch.
+# Install to ~/.sm/dispatch_templates.yaml with: sm setup
+# Edit to customize for your project.
+
+repo:
+  path: /path/to/your/repo  # Override this
+  pr_target: dev
+  test_command: "echo 'Configure test_command in .sm/dispatch_templates.yaml'"
+
+roles:
+  engineer:
+    template: |
+      As engineer, implement GitHub issue #{issue} in {repo.path}.
+      Read the spec at {spec}.
+      Read personas/engineer.md from ~/.agent-os/personas/.
+      Work on a feature branch off {repo.pr_target}, create a PR to {repo.pr_target} when done.
+      Run tests when done: {repo.test_command}
+      Report the PR number back to me ({em_id}) via sm send.
+    required: [issue, spec]
+    optional: [extra]
+
+  architect:
+    template: |
+      As architect, review PR #{pr} in {repo.path}.
+      Read personas/architect.md from ~/.agent-os/personas/.
+      Read the spec at {spec} for context.
+      Report all feedback as blocking.
+      Do NOT write code.
+      sm send your verdict to me ({em_id}).
+    required: [pr, spec]
+    optional: [extra]
+
+  scout:
+    template: |
+      As scout, investigate GitHub issue #{issue} in {repo.path}.
+      Read personas/scout.md from ~/.agent-os/personas/.
+      Write spec to {spec}.
+      Send the spec to codex reviewer ({reviewer_id}) for review via sm send. Iterate with reviewer directly.
+      When converged, commit and push, then report completion back to me ({em_id}) via sm send.
+    required: [issue, spec, reviewer_id]
+    optional: [extra]
+
+  reviewer:
+    template: |
+      You are a spec reviewer. Working directory: {repo.path}.
+      Review protocol is in ~/.agent-os/personas/em.md.
+      You will receive a spec from scout agent ({scout_id}) via sm send.
+      Classify feedback by severity. Send review to spec owner ({scout_id}) via sm send.
+      Stand by.
+    required: [scout_id]
+    optional: [extra]

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -319,6 +319,17 @@ def main():
         help="Session ID to register/deregister; defaults to self",
     )
 
+    # sm setup [--overwrite]
+    setup_parser = subparsers.add_parser(
+        "setup",
+        help="Install default dispatch templates to ~/.sm/dispatch_templates.yaml",
+    )
+    setup_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        help="Replace existing templates file",
+    )
+
     # sm review [session] --base|--uncommitted|--commit|--custom [options]
     review_parser = subparsers.add_parser("review", help="Start a Codex code review")
     review_parser.add_argument("session", nargs="?", help="Session ID or name to review on")
@@ -343,7 +354,7 @@ def main():
     no_session_needed = [
         "lock", "unlock", "subagent-start", "subagent-stop", "all", "send", "wait", "what",
         "subagents", "children", "kill", "new", "claude", "codex", "codex-app", "codex-server",
-        "attach", "output", "tail", "clear", "review", "context-monitor", "remind", None
+        "attach", "output", "tail", "clear", "review", "context-monitor", "remind", "setup", None
     ]
     # Commands that require session_id: spawn (needs to set parent_session_id)
     requires_session_id = ["spawn"]
@@ -461,6 +472,8 @@ def main():
         sys.exit(commands.cmd_handoff(client, session_id, args.file_path))
     elif args.command == "context-monitor":
         sys.exit(commands.cmd_context_monitor(client, session_id, args.action, args.target))
+    elif args.command == "setup":
+        sys.exit(commands.cmd_setup(overwrite=args.overwrite))
     elif args.command == "review":
         sys.exit(commands.cmd_review(
             client,


### PR DESCRIPTION
## Summary

- Ships `src/cli/default_dispatch_templates.yaml` with four role templates: engineer, architect, scout, reviewer
- Adds `sm setup [--overwrite]` command that installs the bundled templates to `~/.sm/dispatch_templates.yaml`
- Never overwrites existing config unless `--overwrite` is passed
- Updates `setup.sh` to call `sm setup` after installation

## Spec Reference

`docs/working/225_sm_dispatch_enhancements.md` — Section D / Sub-ticket 4

## Test Plan

- [x] `sm setup` → creates `~/.sm/dispatch_templates.yaml` with engineer, architect, scout, reviewer roles
- [x] `sm setup` when file exists → prints message, exits 0, no overwrite
- [x] `sm setup --overwrite` → overwrites existing file
- [x] `sm dispatch` with default templates → successful expansion (all 4 roles)
- [x] Missing required param raises `DispatchError` (engineer without `spec`)
- [x] 857 tests pass (1 pre-existing failure: `test_monitor_loop_gives_up_after_max_retries`)

Fixes #238