### PR TITLE
feat: default clear-before-dispatch + --no-clear opt-out (sm#234)

### DIFF
--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -726,6 +726,7 @@ def cmd_dispatch(
     params: dict,
     em_id: Optional[str],
     dry_run: bool = False,
+    no_clear: bool = False,
     delivery_mode: str = "sequential",
     notify_on_stop: bool = True,
 ) -> int:
@@ -738,6 +739,7 @@ def cmd_dispatch(
         params: Dynamic parameters (--issue, --spec, etc.)
         em_id: Sender's session ID
         dry_run: Print expanded template instead of sending
+        no_clear: Skip clearing target session before dispatch
         delivery_mode: Delivery mode for sm send
         notify_on_stop: Notify on stop flag for sm send
 
@@ -776,6 +778,12 @@ def cmd_dispatch(
     if dry_run:
         print(expanded)
         return 0
+
+    # Clear target before dispatch unless opted out (#234).
+    if not no_clear:
+        rc = cmd_clear(client, em_id, agent_id)
+        if rc != 0:
+            return rc
 
     # Auto-arm periodic remind and parent wake on every dispatch (#225-A, #225-C).
     soft_threshold, hard_threshold = get_auto_remind_config(os.getcwd())

--- a/src/cli/dispatch.py
+++ b/src/cli/dispatch.py
@@ -261,7 +261,7 @@ def parse_dispatch_args(argv: list[str]) -> tuple:
         argv: sys.argv[2:] (everything after 'dispatch')
 
     Returns:
-        Tuple of (agent_id, role, dry_run, delivery_mode, notify_on_stop, dynamic_params)
+        Tuple of (agent_id, role, dry_run, no_clear, delivery_mode, notify_on_stop, dynamic_params)
 
     Raises:
         SystemExit: On parse errors (via argparse).
@@ -283,6 +283,8 @@ def parse_dispatch_args(argv: list[str]) -> tuple:
     static_parser.add_argument("--important", action="store_true", help="Pass through to sm send --important")
     static_parser.add_argument("--steer", action="store_true", help="Pass through to sm send --steer")
     static_parser.add_argument("--no-notify-on-stop", action="store_true", help="Pass through to sm send --no-notify-on-stop")
+    static_parser.add_argument("--no-clear", action="store_true",
+        help="Skip clearing target session before dispatch (use for follow-up dispatches on same task)")
 
     known, remaining = static_parser.parse_known_args(argv)
 
@@ -318,6 +320,7 @@ def parse_dispatch_args(argv: list[str]) -> tuple:
         known.agent_id,
         known.role,
         known.dry_run,
+        known.no_clear,
         delivery_mode,
         notify_on_stop,
         dynamic_params,

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -18,7 +18,7 @@ def _handle_dispatch(session_id: Optional[str]) -> int:
     """
     from .dispatch import parse_dispatch_args
 
-    agent_id, role, dry_run, delivery_mode, notify_on_stop, dynamic_params = \
+    agent_id, role, dry_run, no_clear, delivery_mode, notify_on_stop, dynamic_params = \
         parse_dispatch_args(sys.argv[2:])
 
     # em_id check: required for send mode, placeholder for dry-run
@@ -34,8 +34,8 @@ def _handle_dispatch(session_id: Optional[str]) -> int:
     client = SessionManagerClient()
     return commands.cmd_dispatch(
         client, agent_id, role, dynamic_params, em_id,
-        dry_run=dry_run, delivery_mode=delivery_mode,
-        notify_on_stop=notify_on_stop,
+        dry_run=dry_run, no_clear=no_clear,
+        delivery_mode=delivery_mode, notify_on_stop=notify_on_stop,
     )
 
 

--- a/tests/unit/test_parent_wake.py
+++ b/tests/unit/test_parent_wake.py
@@ -549,6 +549,7 @@ class TestCmdDispatchPassesParentSessionId:
 
         with patch("src.cli.dispatch.load_template", return_value=SAMPLE_CONFIG), \
              patch("src.cli.dispatch.get_auto_remind_config", return_value=(210, 420)), \
+             patch("src.cli.commands.cmd_clear", return_value=0), \
              patch("os.getcwd", return_value="/tmp"):
             cmd_dispatch(
                 mock_client,


### PR DESCRIPTION
Fixes #234

Read spec: `docs/working/234_sm_dispatch_clear.md`

## Summary

- `sm dispatch` now calls `cmd_clear` before sending by default, matching the EM persona rule: *"Always sm clear before every dispatch"*
- `--no-clear` flag opts out for follow-up dispatches on the same task (re-dispatch pattern in em.md)
- `--dry-run` is unaffected — no side effects in dry-run mode

## Changes

- **`src/cli/dispatch.py`**: Added `--no-clear` flag to `parse_dispatch_args`; return tuple extended to 7 elements `(agent_id, role, dry_run, no_clear, delivery_mode, notify_on_stop, dynamic_params)`
- **`src/cli/main.py`**: Unpacks `no_clear` from `parse_dispatch_args`, passes to `cmd_dispatch`
- **`src/cli/commands.py`**: `cmd_dispatch` accepts `no_clear=False`; calls `cmd_clear(client, em_id, agent_id)` before send unless opted out

## Error handling

| Condition | Behavior |
|-----------|----------|
| Clear fails (not authorized) | Propagates exit 1 with cmd_clear error |
| Clear fails (session not found) | Propagates exit 1 |
| `--no-clear` | Proceeds directly to send |
| `--dry-run` | Skips clear, prints template only |

## Test plan

- [x] `TestNoClearFlag` (6 new tests): `--no-clear` parsed, default False, default clears before send, `--no-clear` skips clear, `--dry-run` skips clear, clear failure aborts send
- [x] Updated 8 existing tests that unpack `parse_dispatch_args` (6-tuple → 7-tuple)
- [x] Added `cmd_clear` mock to `TestFullDispatch` and `TestAutoRemindDispatch` (default behavior now calls clear)
- [x] Full suite: 887 passed, 1 pre-existing failure (`test_monitor_loop_gives_up_after_max_retries`)

Fixes #234