### PR TITLE
fix: suppress remind delivery during compaction window (sm#249)

### DIFF
--- a/docs/specs/249_suppress_remind_during_compaction.md
+++ b/docs/specs/249_suppress_remind_during_compaction.md
@@ -1,0 +1,23 @@
+# sm#249: Suppress remind during active compaction
+
+## Problem
+
+When an agent is mid-compaction, `sm remind` delivers its overdue message anyway, interrupting the compaction process and triggering a second compaction cycle.
+
+Observed: engineer received a remind interrupt while compacting → second compaction fired immediately after the first completed.
+
+## Root Cause
+
+No compaction state is tracked server-side. The `Session` model has no `_is_compacting` flag. `PreCompact` hook notifies the server (compaction starting), but `SessionStart(compact)` hook only reads from the server — never signals completion. Both remind delivery paths (`_run_remind_task`, `_fire_reminder`) are blind to the compaction window.
+
+## Fix
+
+1. Add `Session._is_compacting: bool` runtime flag (not persisted, defaults `False`)
+2. Set `_is_compacting = True` on `event: "compaction"` (PreCompact hook)
+3. Clear `_is_compacting = False` + call `reset_remind()` on new `event: "compaction_complete"` — fired by updated `post_compact_recovery.sh` template in `scripts/install_context_hooks.sh`; timer reset here (not at PreCompact) so agent gets a fresh soft-threshold window exactly when it wakes
+4. `_run_remind_task`: skip delivery iteration when `_is_compacting` is True
+5. `_fire_reminder`: bounded wait (max 300s, poll every 5s) when `_is_compacting` is True; delivers after timeout to preserve one-shot guarantee
+
+## Classification
+
+Single ticket. Narrow scope: add compaction-state check to remind delivery path.

--- a/scripts/install_context_hooks.sh
+++ b/scripts/install_context_hooks.sh
@@ -101,6 +101,13 @@ if [ -z "$SM_SESSION_ID" ]; then
   exit 0
 fi
 
+# Notify sm that compaction is complete — clears _is_compacting flag and resets remind timer (#249)
+# sm server only listens on 127.0.0.1 — localhost-only trusted call
+curl -s --max-time 2 -X POST http://localhost:8420/hooks/context-usage \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --arg sid "$SM_SESSION_ID" '{session_id: $sid, event: "compaction_complete"}')" \
+  >/dev/null 2>&1
+
 # Query sm server for the last handoff path (set by sm#196 _execute_handoff)
 # sm server only listens on 127.0.0.1 — localhost-only trusted call
 HANDOFF_PATH=$(curl -s --max-time 2 http://localhost:8420/sessions/"$SM_SESSION_ID" \

--- a/src/models.py
+++ b/src/models.py
@@ -212,6 +212,7 @@ class Session:
     # Runtime-only flags — not persisted (reset to False on server restart / new cycle)
     _context_warning_sent: bool = field(default=False, init=False, repr=False)
     _context_critical_sent: bool = field(default=False, init=False, repr=False)
+    _is_compacting: bool = field(default=False, init=False, repr=False)  # True during PreCompact→SessionStart(compact) window (#249)
 
     # Context monitor registration (#206)
     context_monitor_enabled: bool = False  # Default off — opt-in only


### PR DESCRIPTION
## Summary

- Adds `Session._is_compacting` runtime flag (not persisted) set during the PreCompact→SessionStart(compact) window
- `_run_remind_task` skips the delivery iteration while the session is compacting
- `_fire_reminder` (one-shot scheduler) waits up to 300s for compaction to clear before delivering, then delivers anyway to preserve the one-shot guarantee
- `post_compact_recovery.sh` fires a new `compaction_complete` event to the server, which clears the flag and resets the remind timer so the agent gets a fresh window on wake

## Spec Reference

`docs/specs/249_suppress_remind_during_compaction.md`

## Test Plan

- [x] `TestSuppressRemindDuringCompaction` — 5 new tests covering: skip during compaction, fires after clear, one-shot waits for compaction, one-shot delivers after max timeout, no poll when not compacting
- [x] `TestCompactionSuppressRemind` — 8 new tests covering: server event sets/clears flag, compaction_complete resets remind timer, no-crash with null queue_mgr, flag not in to_dict, from_dict always False
- [x] Full suite: 950 passed

Fixes #249