### PR TITLE
fix: use UTC now for tool timestamp age in parent wake digest

### DIFF
--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -7,7 +7,7 @@ import sqlite3
 import subprocess
 import threading
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional, Dict, List, Callable, Awaitable, Tuple
 
@@ -1778,7 +1778,7 @@ class MessageQueueManager:
         if tool_events:
             lines.append("")
             lines.append("Recent activity:")
-            now = datetime.now()
+            now = datetime.now(timezone.utc).replace(tzinfo=None)
             for event in tool_events:
                 tool = event.get("tool_name", "?")
                 ts_str = event.get("timestamp", "")


### PR DESCRIPTION
## Summary

- `_assemble_parent_wake_digest` used `datetime.now()` (naive local time) to compute tool event ages, while SQLite `CURRENT_TIMESTAMP` stores UTC naive strings
- On UTC-behind machines (e.g. UTC-8), this produced negative ages like `-475m ago` in "Recent activity" section
- Fix: change `datetime.now()` → `datetime.now(timezone.utc).replace(tzinfo=None)` at `src/message_queue.py:1781` and add `timezone` to the datetime import

## Spec Reference

`docs/specs/261_timestamp_relative_times.md`

## Test Plan

- [x] New deterministic test `test_digest_tool_timestamps_use_utc` uses `_FakeDatetime` mock to simulate a UTC-8 machine regardless of CI host timezone — old code produces `-478m`, fixed code produces `2m`
- [x] All 975 tests pass

Fixes #261