### PR TITLE
refactor: remove redundant child_id_short and use _TOOL_DB_DEFAULT constant (sm#255)

### DIFF
--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -1706,8 +1706,7 @@ def cmd_tail(
         return 0
 
     # --- Structured mode: query tool_usage.db ---
-    default_db = "~/.local/share/claude-sessions/tool_usage.db"
-    db_path = Path(db_path_override or default_db).expanduser()
+    db_path = Path(db_path_override or _TOOL_DB_DEFAULT).expanduser()
     if not db_path.exists():
         print(f"No tool usage data available (DB not found: {db_path})", file=sys.stderr)
         return 1

--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -1736,7 +1736,6 @@ class MessageQueueManager:
 
         if child_session:
             child_name = child_session.friendly_name or child_session.name or child_session_id
-            child_id_short = child_session_id[:8]
 
             # Status text and age
             if child_session.agent_status_text:


### PR DESCRIPTION
## Summary

Two small cleanups deferred from PR #253 architect review:

1. **Remove redundant `child_id_short` assignment** (`src/message_queue.py`): The variable was assigned twice — once before `if child_session:` and again inside it. The inner assignment is identical and unreachable for any different value, so it is removed.

2. **Replace hardcoded `tool_usage.db` path with constant** (`src/cli/commands.py`): `cmd_tail` had its own inline `default_db = "~/.local/share/claude-sessions/tool_usage.db"` string. Replaced with the existing `_TOOL_DB_DEFAULT` constant defined at line 1118 of the same file.

## Test Plan
- [x] 984 tests pass, 0 failures

Fixes #255