### PR TITLE
docs: fix test count (194 → 984) in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ telegram:
 ## Testing
 
 ```bash
-# Run test suite (194 tests)
+# Run test suite (984 tests)
 pytest tests/ -v
 
 # Run with coverage


### PR DESCRIPTION
## Summary
- Fix incorrect test count in README.md line 330: `194 tests` → `984 tests`

## Test Plan
- [x] All 984 tests pass