### PR TITLE
#292 codex-app activity state + durable codex-events timeline

### DIFF
--- a/src/codex_event_store.py
+++ b/src/codex_event_store.py
@@ -1,0 +1,339 @@
+"""Durable Codex app lifecycle event storage with cursor replay semantics."""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import threading
+from collections import defaultdict, deque
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class CodexEventStore:
+    """Persists codex-app lifecycle events and serves cursor-based history pages."""
+
+    def __init__(
+        self,
+        db_path: str,
+        ring_size: int = 1000,
+        retention_max_events_per_session: int = 5000,
+        retention_max_age_days: int = 14,
+        prune_every_writes: int = 200,
+        payload_preview_chars: int = 1500,
+    ):
+        self.db_path = Path(db_path).expanduser()
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+
+        self.ring_size = max(100, ring_size)
+        self.retention_max_events_per_session = max(1, retention_max_events_per_session)
+        self.retention_max_age_days = max(1, retention_max_age_days)
+        self.prune_every_writes = max(1, prune_every_writes)
+        self.payload_preview_chars = max(200, payload_preview_chars)
+
+        self._lock = threading.Lock()
+        self._conn: Optional[sqlite3.Connection] = None
+        self._ring_events: dict[str, deque[dict[str, Any]]] = defaultdict(
+            lambda: deque(maxlen=self.ring_size)
+        )
+        self._persistence_degraded: set[str] = set()
+        self._persisted_writes = 0
+
+        self._init_db()
+
+    def _get_conn(self) -> sqlite3.Connection:
+        if self._conn is None:
+            self._conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
+            self._conn.execute("PRAGMA journal_mode=WAL")
+            self._conn.execute("PRAGMA busy_timeout=5000")
+        return self._conn
+
+    def _init_db(self):
+        with self._lock:
+            conn = self._get_conn()
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS codex_session_events (
+                    session_id TEXT NOT NULL,
+                    seq INTEGER NOT NULL,
+                    timestamp TEXT NOT NULL,
+                    event_type TEXT NOT NULL,
+                    turn_id TEXT,
+                    payload_preview_json TEXT,
+                    PRIMARY KEY (session_id, seq)
+                )
+                """
+            )
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_codex_session_events_ts ON codex_session_events(session_id, timestamp)"
+            )
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_codex_session_events_event_type ON codex_session_events(event_type)"
+            )
+            self._prune_locked(cursor)
+            conn.commit()
+
+    def append_event(
+        self,
+        session_id: str,
+        event_type: str,
+        turn_id: Optional[str] = None,
+        payload: Optional[dict[str, Any]] = None,
+        timestamp: Optional[datetime] = None,
+    ) -> dict[str, Any]:
+        """Append one event. Falls back to in-memory-only event on persistence failure."""
+        event_ts = timestamp.astimezone(timezone.utc) if timestamp else datetime.now(timezone.utc)
+        payload_preview = self._serialize_payload_preview(payload)
+
+        with self._lock:
+            conn: Optional[sqlite3.Connection] = None
+            cursor: Optional[sqlite3.Cursor] = None
+            persisted_events: list[dict[str, Any]] = []
+            try:
+                conn = self._get_conn()
+                cursor = conn.cursor()
+                cursor.execute("BEGIN IMMEDIATE")
+                latest_seq = self._latest_seq_locked(cursor, session_id)
+
+                if session_id in self._persistence_degraded:
+                    latest_seq += 1
+                    marker = {
+                        "session_id": session_id,
+                        "seq": latest_seq,
+                        "timestamp": datetime.now(timezone.utc).isoformat(),
+                        "event_type": "event_persist_recovered",
+                        "turn_id": None,
+                        "payload_preview": {"reason": "persistence_recovered"},
+                        "persisted": True,
+                    }
+                    cursor.execute(
+                        """
+                        INSERT INTO codex_session_events
+                        (session_id, seq, timestamp, event_type, turn_id, payload_preview_json)
+                        VALUES (?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            marker["session_id"],
+                            marker["seq"],
+                            marker["timestamp"],
+                            marker["event_type"],
+                            marker["turn_id"],
+                            json.dumps(marker["payload_preview"], separators=(",", ":")),
+                        ),
+                    )
+                    persisted_events.append(marker)
+                    self._persistence_degraded.discard(session_id)
+
+                latest_seq += 1
+                event = {
+                    "session_id": session_id,
+                    "seq": latest_seq,
+                    "timestamp": event_ts.isoformat(),
+                    "event_type": event_type,
+                    "turn_id": turn_id,
+                    "payload_preview": payload_preview,
+                    "persisted": True,
+                }
+                cursor.execute(
+                    """
+                    INSERT INTO codex_session_events
+                    (session_id, seq, timestamp, event_type, turn_id, payload_preview_json)
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        event["session_id"],
+                        event["seq"],
+                        event["timestamp"],
+                        event["event_type"],
+                        event["turn_id"],
+                        json.dumps(payload_preview, separators=(",", ":")) if payload_preview else None,
+                    ),
+                )
+                persisted_events.append(event)
+                conn.commit()
+
+                for item in persisted_events:
+                    self._append_ring_event_locked(item)
+
+                self._persisted_writes += len(persisted_events)
+                if self._persisted_writes % self.prune_every_writes == 0:
+                    cursor.execute("BEGIN IMMEDIATE")
+                    self._prune_locked(cursor)
+                    conn.commit()
+
+                return event
+
+            except Exception as exc:
+                try:
+                    if conn is not None:
+                        conn.rollback()
+                except Exception:
+                    pass
+                self._persistence_degraded.add(session_id)
+                logger.warning("Failed to persist codex event for %s: %s", session_id, exc)
+                fallback_event = {
+                    "session_id": session_id,
+                    "seq": None,
+                    "timestamp": event_ts.isoformat(),
+                    "event_type": event_type,
+                    "turn_id": turn_id,
+                    "payload_preview": payload_preview,
+                    "persisted": False,
+                }
+                self._append_ring_event_locked(fallback_event)
+                return fallback_event
+
+    def get_events(self, session_id: str, since_seq: Optional[int] = None, limit: int = 200) -> dict[str, Any]:
+        """Read persisted events for a session using sequence cursor semantics."""
+        limit = max(1, min(limit, 500))
+
+        with self._lock:
+            conn = self._get_conn()
+            cursor = conn.cursor()
+
+            cursor.execute(
+                "SELECT MIN(seq), MAX(seq) FROM codex_session_events WHERE session_id = ?",
+                (session_id,),
+            )
+            earliest_seq, latest_seq = cursor.fetchone()
+
+            history_gap = False
+            gap_reason: Optional[str] = None
+            events: list[dict[str, Any]] = []
+
+            if earliest_seq is None or latest_seq is None:
+                next_seq = (since_seq + 1) if since_seq is not None else 1
+                if session_id in self._persistence_degraded:
+                    history_gap = True
+                    gap_reason = "persistence_error"
+                return {
+                    "events": events,
+                    "earliest_seq": None,
+                    "latest_seq": None,
+                    "next_seq": next_seq,
+                    "history_gap": history_gap,
+                    "gap_reason": gap_reason,
+                }
+
+            if since_seq is None:
+                start_seq = max(earliest_seq, latest_seq - limit + 1)
+            else:
+                if since_seq < (earliest_seq - 1):
+                    history_gap = True
+                    gap_reason = "retention"
+                    start_seq = earliest_seq
+                else:
+                    start_seq = since_seq + 1
+
+            cursor.execute(
+                """
+                SELECT seq, timestamp, event_type, turn_id, payload_preview_json
+                FROM codex_session_events
+                WHERE session_id = ? AND seq >= ?
+                ORDER BY seq ASC
+                LIMIT ?
+                """,
+                (session_id, start_seq, limit),
+            )
+            rows = cursor.fetchall()
+
+            for seq, ts, event_type, turn_id, payload_json in rows:
+                payload_preview = None
+                if payload_json:
+                    try:
+                        payload_preview = json.loads(payload_json)
+                    except Exception:
+                        payload_preview = {"raw": payload_json[: self.payload_preview_chars]}
+                events.append(
+                    {
+                        "session_id": session_id,
+                        "seq": seq,
+                        "timestamp": ts,
+                        "event_type": event_type,
+                        "turn_id": turn_id,
+                        "payload_preview": payload_preview,
+                        "persisted": True,
+                    }
+                )
+
+            if events:
+                next_seq = events[-1]["seq"] + 1
+            elif since_seq is not None:
+                next_seq = since_seq + 1
+            else:
+                next_seq = earliest_seq
+
+            if session_id in self._persistence_degraded and not history_gap:
+                history_gap = True
+                gap_reason = "persistence_error"
+
+            return {
+                "events": events,
+                "earliest_seq": earliest_seq,
+                "latest_seq": latest_seq,
+                "next_seq": next_seq,
+                "history_gap": history_gap,
+                "gap_reason": gap_reason,
+            }
+
+    def get_ring_events(self, session_id: str, limit: int = 200) -> list[dict[str, Any]]:
+        """Get recent in-memory events, including non-persisted fallback events."""
+        limit = max(1, min(limit, self.ring_size))
+        with self._lock:
+            ring = self._ring_events.get(session_id)
+            if not ring:
+                return []
+            return list(ring)[-limit:]
+
+    def _latest_seq_locked(self, cursor: sqlite3.Cursor, session_id: str) -> int:
+        cursor.execute(
+            "SELECT COALESCE(MAX(seq), 0) FROM codex_session_events WHERE session_id = ?",
+            (session_id,),
+        )
+        row = cursor.fetchone()
+        return int(row[0]) if row else 0
+
+    def _append_ring_event_locked(self, event: dict[str, Any]):
+        session_id = event["session_id"]
+        self._ring_events[session_id].append(event)
+
+    def _serialize_payload_preview(self, payload: Optional[dict[str, Any]]) -> Optional[dict[str, Any]]:
+        if payload is None:
+            return None
+
+        serialized = json.dumps(payload, separators=(",", ":"), default=str)
+        if len(serialized) <= self.payload_preview_chars:
+            return payload
+
+        excerpt = serialized[: self.payload_preview_chars]
+        return {
+            "truncated": True,
+            "preview": excerpt,
+            "original_chars": len(serialized),
+        }
+
+    def _prune_locked(self, cursor: sqlite3.Cursor):
+        cutoff = datetime.now(timezone.utc) - timedelta(days=self.retention_max_age_days)
+        cutoff_iso = cutoff.isoformat()
+        cursor.execute(
+            "DELETE FROM codex_session_events WHERE timestamp < ?",
+            (cutoff_iso,),
+        )
+
+        cursor.execute(
+            "SELECT session_id, MAX(seq) FROM codex_session_events GROUP BY session_id"
+        )
+        for session_id, max_seq in cursor.fetchall():
+            if max_seq is None:
+                continue
+            min_keep_seq = int(max_seq) - self.retention_max_events_per_session + 1
+            if min_keep_seq > 1:
+                cursor.execute(
+                    "DELETE FROM codex_session_events WHERE session_id = ? AND seq < ?",
+                    (session_id, min_keep_seq),
+                )

--- a/tests/unit/test_codex_activity_state.py
+++ b/tests/unit/test_codex_activity_state.py
@@ -1,0 +1,75 @@
+"""Unit tests for codex-app activity-state computation."""
+
+from __future__ import annotations
+
+import tempfile
+from datetime import datetime, timedelta
+
+from src.models import CompletionStatus, Session, SessionStatus
+from src.session_manager import SessionManager
+
+
+def _make_manager() -> SessionManager:
+    tmpdir = tempfile.TemporaryDirectory()
+    manager = SessionManager(log_dir=tmpdir.name, state_file=f"{tmpdir.name}/state.json")
+    manager._tmpdir = tmpdir  # keep alive for test scope
+    return manager
+
+
+def test_activity_state_for_non_codex_app_follows_status():
+    manager = _make_manager()
+    session = Session(
+        id="s1",
+        name="claude-s1",
+        working_dir="/tmp",
+        tmux_session="claude-s1",
+        provider="claude",
+        status=SessionStatus.RUNNING,
+    )
+    manager.sessions[session.id] = session
+
+    assert manager.get_activity_state(session.id) == "working"
+    session.status = SessionStatus.IDLE
+    assert manager.get_activity_state(session.id) == "idle"
+
+
+def test_codex_app_activity_thinking_and_working_transitions():
+    manager = _make_manager()
+    session = Session(
+        id="codex1",
+        name="codex-app-codex1",
+        working_dir="/tmp",
+        provider="codex-app",
+        status=SessionStatus.RUNNING,
+    )
+    manager.sessions[session.id] = session
+
+    manager.codex_turns_in_flight.add(session.id)
+    assert manager.get_activity_state(session.id) == "thinking"
+
+    manager.codex_last_delta_at[session.id] = datetime.now()
+    assert manager.get_activity_state(session.id) == "working"
+
+
+def test_codex_app_wait_states_and_waiting_input():
+    manager = _make_manager()
+    session = Session(
+        id="codex2",
+        name="codex-app-codex2",
+        working_dir="/tmp",
+        provider="codex-app",
+        status=SessionStatus.RUNNING,
+    )
+    manager.sessions[session.id] = session
+
+    manager.codex_wait_states[session.id] = ("waiting_permission", datetime.now())
+    assert manager.get_activity_state(session.id) == "waiting_permission"
+
+    manager.codex_wait_states[session.id] = (
+        "waiting_input",
+        datetime.now() - timedelta(seconds=20),
+    )
+    assert manager.get_activity_state(session.id) == "idle"
+
+    session.completion_status = CompletionStatus.COMPLETED
+    assert manager.get_activity_state(session.id) == "waiting_input"

--- a/tests/unit/test_codex_event_store.py
+++ b/tests/unit/test_codex_event_store.py
@@ -1,0 +1,93 @@
+"""Unit tests for codex event persistence and cursor replay semantics."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from src.codex_event_store import CodexEventStore
+
+
+def test_append_and_get_events_sequence(tmp_path):
+    store = CodexEventStore(db_path=str(tmp_path / "codex_events.db"))
+
+    first = store.append_event(
+        session_id="sess1",
+        event_type="turn_started",
+        turn_id="turn-1",
+        payload={"model": "sonnet"},
+    )
+    second = store.append_event(
+        session_id="sess1",
+        event_type="turn_delta",
+        turn_id="turn-1",
+        payload={"delta_preview": "hello"},
+    )
+
+    assert first["persisted"] is True
+    assert first["seq"] == 1
+    assert second["seq"] == 2
+
+    page = store.get_events(session_id="sess1", since_seq=0, limit=50)
+    assert page["earliest_seq"] == 1
+    assert page["latest_seq"] == 2
+    assert page["next_seq"] == 3
+    assert page["history_gap"] is False
+    assert [e["event_type"] for e in page["events"]] == ["turn_started", "turn_delta"]
+
+
+def test_history_gap_when_since_seq_is_older_than_retained(tmp_path):
+    store = CodexEventStore(
+        db_path=str(tmp_path / "codex_events.db"),
+        retention_max_events_per_session=3,
+        prune_every_writes=1,
+    )
+
+    for idx in range(5):
+        store.append_event(
+            session_id="sess-retention",
+            event_type="turn_delta",
+            turn_id="turn-1",
+            payload={"idx": idx},
+        )
+
+    page = store.get_events(session_id="sess-retention", since_seq=0, limit=10)
+    assert page["history_gap"] is True
+    assert page["gap_reason"] == "retention"
+    assert page["earliest_seq"] == 3
+    assert page["events"][0]["seq"] == 3
+
+
+def test_persistence_recovery_emits_marker_event(tmp_path):
+    store = CodexEventStore(db_path=str(tmp_path / "codex_events.db"))
+
+    original_get_conn = store._get_conn
+
+    def fail_get_conn():
+        raise sqlite3.OperationalError("forced failure")
+
+    store._get_conn = fail_get_conn
+    failed = store.append_event(
+        session_id="sess-recover",
+        event_type="turn_started",
+        turn_id="turn-x",
+        payload={"forced": True},
+    )
+    assert failed["persisted"] is False
+    assert failed["seq"] is None
+
+    store._get_conn = original_get_conn
+    succeeded = store.append_event(
+        session_id="sess-recover",
+        event_type="turn_started",
+        turn_id="turn-x",
+        payload={"forced": False},
+    )
+    assert succeeded["persisted"] is True
+    assert succeeded["seq"] == 2
+
+    page = store.get_events(session_id="sess-recover", since_seq=0, limit=10)
+    assert [event["event_type"] for event in page["events"]] == [
+        "event_persist_recovered",
+        "turn_started",
+    ]
+    assert page["history_gap"] is False


### PR DESCRIPTION
## Summary
Implements issue #292 from spec `docs/working/291_codex_app_tui_progress.md`.

- added durable codex lifecycle event storage in `src/codex_event_store.py` with cursor replay semantics (`since_seq`, `history_gap`, `gap_reason`)
- wired codex-app lifecycle tracking in `src/session_manager.py` (turn started/delta/completed + server request events)
- added computed `activity_state` on session responses
- added `GET /sessions/{id}/codex-events` API for `provider=codex-app`
- added unit/integration coverage for event store behavior, activity-state transitions, server-request callback wiring, and API responses

## Testing
- `./venv/bin/pytest -q tests/unit/test_codex_event_store.py tests/unit/test_codex_activity_state.py tests/unit/test_codex_app_review.py tests/integration/test_api_endpoints.py`
- `./venv/bin/pytest -q tests/unit tests/integration`

Fixes #292
