### PR TITLE
Implement #294 codex observability DB ingestion and retention

### DIFF
--- a/src/codex_observability_logger.py
+++ b/src/codex_observability_logger.py
@@ -1,0 +1,430 @@
+"""Codex app observability storage for tool and turn lifecycle events."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sqlite3
+import threading
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class CodexObservabilityLogger:
+    """Persists codex-app observability events with bounded retention."""
+
+    def __init__(
+        self,
+        db_path: str,
+        retention_max_age_days: int = 14,
+        retention_tool_events_per_session: int = 20000,
+        retention_turn_events_per_session: int = 5000,
+        payload_max_chars: int = 4000,
+        prune_interval_seconds: int = 3600,
+    ):
+        self.db_path = Path(db_path).expanduser()
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+
+        self.retention_max_age_days = max(1, int(retention_max_age_days))
+        self.retention_tool_events_per_session = max(1, int(retention_tool_events_per_session))
+        self.retention_turn_events_per_session = max(1, int(retention_turn_events_per_session))
+        self.payload_max_chars = max(200, int(payload_max_chars))
+        self.prune_interval_seconds = max(60, int(prune_interval_seconds))
+
+        self._conn: Optional[sqlite3.Connection] = None
+        self._db_lock = threading.Lock()
+        self._prune_task: Optional[asyncio.Task] = None
+
+        self._init_db()
+
+    def _get_conn(self) -> sqlite3.Connection:
+        if self._conn is None:
+            self._conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
+            self._conn.execute("PRAGMA journal_mode=WAL")
+            self._conn.execute("PRAGMA busy_timeout=5000")
+        return self._conn
+
+    def _init_db(self):
+        with self._db_lock:
+            conn = self._get_conn()
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS codex_tool_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    session_id TEXT NOT NULL,
+                    thread_id TEXT,
+                    turn_id TEXT,
+                    item_id TEXT,
+                    request_id TEXT,
+                    event_type TEXT NOT NULL,
+                    item_type TEXT,
+                    phase TEXT,
+                    command TEXT,
+                    cwd TEXT,
+                    exit_code INTEGER,
+                    file_path TEXT,
+                    diff_summary TEXT,
+                    approval_decision TEXT,
+                    latency_ms INTEGER,
+                    final_status TEXT,
+                    error_code TEXT,
+                    error_message TEXT,
+                    raw_payload_json TEXT,
+                    created_at TEXT NOT NULL
+                )
+                """
+            )
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS codex_turn_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    session_id TEXT NOT NULL,
+                    thread_id TEXT,
+                    turn_id TEXT,
+                    event_type TEXT NOT NULL,
+                    status TEXT,
+                    delta_chars INTEGER,
+                    output_preview TEXT,
+                    error_code TEXT,
+                    error_message TEXT,
+                    raw_payload_json TEXT,
+                    created_at TEXT NOT NULL
+                )
+                """
+            )
+
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_codex_tool_events_session_created ON codex_tool_events(session_id, created_at, id)"
+            )
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_codex_tool_events_event ON codex_tool_events(session_id, event_type, created_at)"
+            )
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_codex_tool_events_turn ON codex_tool_events(turn_id, created_at)"
+            )
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_codex_turn_events_session_created ON codex_turn_events(session_id, created_at, id)"
+            )
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_codex_turn_events_turn ON codex_turn_events(turn_id, created_at)"
+            )
+
+            conn.commit()
+
+        self.prune()
+
+    def _bounded_payload_json(self, payload: Optional[dict[str, Any]]) -> Optional[str]:
+        if payload is None:
+            return None
+        try:
+            raw = json.dumps(payload, separators=(",", ":"), default=str)
+        except Exception:
+            raw = json.dumps({"raw": str(payload)})
+        if len(raw) <= self.payload_max_chars:
+            return raw
+        excerpt = raw[: self.payload_max_chars]
+        return json.dumps(
+            {
+                "truncated": True,
+                "preview": excerpt,
+                "original_chars": len(raw),
+            },
+            separators=(",", ":"),
+        )
+
+    def log_tool_event(
+        self,
+        *,
+        session_id: str,
+        event_type: str,
+        thread_id: Optional[str] = None,
+        turn_id: Optional[str] = None,
+        item_id: Optional[str] = None,
+        request_id: Optional[str] = None,
+        item_type: Optional[str] = None,
+        phase: Optional[str] = None,
+        command: Optional[str] = None,
+        cwd: Optional[str] = None,
+        exit_code: Optional[int] = None,
+        file_path: Optional[str] = None,
+        diff_summary: Optional[str] = None,
+        approval_decision: Optional[str] = None,
+        latency_ms: Optional[int] = None,
+        final_status: Optional[str] = None,
+        error_code: Optional[str] = None,
+        error_message: Optional[str] = None,
+        raw_payload: Optional[dict[str, Any]] = None,
+        created_at: Optional[datetime] = None,
+    ) -> None:
+        ts = (created_at or datetime.now(timezone.utc)).astimezone(timezone.utc).isoformat()
+        raw_payload_json = self._bounded_payload_json(raw_payload)
+        with self._db_lock:
+            conn = self._get_conn()
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                INSERT INTO codex_tool_events (
+                    session_id, thread_id, turn_id, item_id, request_id,
+                    event_type, item_type, phase, command, cwd, exit_code, file_path,
+                    diff_summary, approval_decision, latency_ms, final_status,
+                    error_code, error_message, raw_payload_json, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    session_id,
+                    thread_id,
+                    turn_id,
+                    item_id,
+                    request_id,
+                    event_type,
+                    item_type,
+                    phase,
+                    command,
+                    cwd,
+                    exit_code,
+                    file_path,
+                    diff_summary,
+                    approval_decision,
+                    latency_ms,
+                    final_status,
+                    error_code,
+                    error_message,
+                    raw_payload_json,
+                    ts,
+                ),
+            )
+            conn.commit()
+
+    def log_turn_event(
+        self,
+        *,
+        session_id: str,
+        turn_id: Optional[str],
+        event_type: str,
+        thread_id: Optional[str] = None,
+        status: Optional[str] = None,
+        delta_chars: Optional[int] = None,
+        output_preview: Optional[str] = None,
+        error_code: Optional[str] = None,
+        error_message: Optional[str] = None,
+        raw_payload: Optional[dict[str, Any]] = None,
+        created_at: Optional[datetime] = None,
+    ) -> None:
+        ts = (created_at or datetime.now(timezone.utc)).astimezone(timezone.utc).isoformat()
+        raw_payload_json = self._bounded_payload_json(raw_payload)
+        with self._db_lock:
+            conn = self._get_conn()
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                INSERT INTO codex_turn_events (
+                    session_id, thread_id, turn_id, event_type, status, delta_chars,
+                    output_preview, error_code, error_message, raw_payload_json, created_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    session_id,
+                    thread_id,
+                    turn_id,
+                    event_type,
+                    status,
+                    delta_chars,
+                    output_preview,
+                    error_code,
+                    error_message,
+                    raw_payload_json,
+                    ts,
+                ),
+            )
+            conn.commit()
+
+    def prune(self) -> dict[str, int]:
+        """Apply age and per-session row-cap retention to tool and turn tables."""
+        started = time.monotonic()
+        deleted_tool_age = 0
+        deleted_turn_age = 0
+        deleted_tool_cap = 0
+        deleted_turn_cap = 0
+
+        cutoff = datetime.now(timezone.utc) - timedelta(days=self.retention_max_age_days)
+        cutoff_iso = cutoff.isoformat()
+
+        with self._db_lock:
+            conn = self._get_conn()
+            cursor = conn.cursor()
+
+            cursor.execute("DELETE FROM codex_tool_events WHERE created_at < ?", (cutoff_iso,))
+            deleted_tool_age = cursor.rowcount
+            cursor.execute("DELETE FROM codex_turn_events WHERE created_at < ?", (cutoff_iso,))
+            deleted_turn_age = cursor.rowcount
+
+            deleted_tool_cap = self._prune_table_by_session_cap(
+                cursor=cursor,
+                table="codex_tool_events",
+                cap=self.retention_tool_events_per_session,
+            )
+            deleted_turn_cap = self._prune_table_by_session_cap(
+                cursor=cursor,
+                table="codex_turn_events",
+                cap=self.retention_turn_events_per_session,
+            )
+            conn.commit()
+
+        elapsed_ms = int((time.monotonic() - started) * 1000)
+        logger.info(
+            "codex observability prune completed: tool_age=%s turn_age=%s tool_cap=%s turn_cap=%s elapsed_ms=%s",
+            deleted_tool_age,
+            deleted_turn_age,
+            deleted_tool_cap,
+            deleted_turn_cap,
+            elapsed_ms,
+        )
+        return {
+            "tool_age": deleted_tool_age,
+            "turn_age": deleted_turn_age,
+            "tool_cap": deleted_tool_cap,
+            "turn_cap": deleted_turn_cap,
+            "elapsed_ms": elapsed_ms,
+        }
+
+    def _prune_table_by_session_cap(self, *, cursor: sqlite3.Cursor, table: str, cap: int) -> int:
+        deleted = 0
+        cursor.execute(
+            f"SELECT session_id, COUNT(*) FROM {table} GROUP BY session_id HAVING COUNT(*) > ?",
+            (cap,),
+        )
+        overflow_rows = cursor.fetchall()
+        for session_id, count in overflow_rows:
+            overflow = int(count) - cap
+            cursor.execute(
+                f"""
+                DELETE FROM {table}
+                WHERE id IN (
+                    SELECT id
+                    FROM {table}
+                    WHERE session_id = ?
+                    ORDER BY created_at ASC, id ASC
+                    LIMIT ?
+                )
+                """,
+                (session_id, overflow),
+            )
+            deleted += cursor.rowcount
+        return deleted
+
+    async def start_periodic_prune(self):
+        """Start periodic prune loop if not already active."""
+        if self._prune_task and not self._prune_task.done():
+            return
+        self._prune_task = asyncio.create_task(self._periodic_prune_loop())
+
+    async def stop_periodic_prune(self):
+        """Stop periodic prune loop."""
+        if not self._prune_task:
+            return
+        self._prune_task.cancel()
+        try:
+            await self._prune_task
+        except asyncio.CancelledError:
+            pass
+        self._prune_task = None
+
+    async def _periodic_prune_loop(self):
+        while True:
+            try:
+                await asyncio.sleep(self.prune_interval_seconds)
+                await asyncio.to_thread(self.prune)
+            except asyncio.CancelledError:
+                return
+            except Exception as exc:
+                logger.warning("codex observability periodic prune failed: %s", exc)
+
+    def list_recent_tool_events(self, session_id: str, limit: int = 50) -> list[dict[str, Any]]:
+        limit = max(1, min(int(limit), 500))
+        with self._db_lock:
+            conn = self._get_conn()
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT session_id, thread_id, turn_id, item_id, request_id, event_type, item_type, phase,
+                       command, cwd, exit_code, file_path, diff_summary, approval_decision,
+                       latency_ms, final_status, error_code, error_message, raw_payload_json, created_at
+                FROM codex_tool_events
+                WHERE session_id = ?
+                ORDER BY id DESC
+                LIMIT ?
+                """,
+                (session_id, limit),
+            )
+            rows = cursor.fetchall()
+        rows.reverse()
+        events = []
+        for row in rows:
+            events.append(
+                {
+                    "session_id": row[0],
+                    "thread_id": row[1],
+                    "turn_id": row[2],
+                    "item_id": row[3],
+                    "request_id": row[4],
+                    "event_type": row[5],
+                    "item_type": row[6],
+                    "phase": row[7],
+                    "command": row[8],
+                    "cwd": row[9],
+                    "exit_code": row[10],
+                    "file_path": row[11],
+                    "diff_summary": row[12],
+                    "approval_decision": row[13],
+                    "latency_ms": row[14],
+                    "final_status": row[15],
+                    "error_code": row[16],
+                    "error_message": row[17],
+                    "raw_payload_json": row[18],
+                    "created_at": row[19],
+                }
+            )
+        return events
+
+    def list_recent_turn_events(self, session_id: str, limit: int = 50) -> list[dict[str, Any]]:
+        limit = max(1, min(int(limit), 500))
+        with self._db_lock:
+            conn = self._get_conn()
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT session_id, thread_id, turn_id, event_type, status, delta_chars,
+                       output_preview, error_code, error_message, raw_payload_json, created_at
+                FROM codex_turn_events
+                WHERE session_id = ?
+                ORDER BY id DESC
+                LIMIT ?
+                """,
+                (session_id, limit),
+            )
+            rows = cursor.fetchall()
+        rows.reverse()
+        events = []
+        for row in rows:
+            events.append(
+                {
+                    "session_id": row[0],
+                    "thread_id": row[1],
+                    "turn_id": row[2],
+                    "event_type": row[3],
+                    "status": row[4],
+                    "delta_chars": row[5],
+                    "output_preview": row[6],
+                    "error_code": row[7],
+                    "error_message": row[8],
+                    "raw_payload_json": row[9],
+                    "created_at": row[10],
+                }
+            )
+        return events

--- a/src/codex_request_ledger.py
+++ b/src/codex_request_ledger.py
@@ -200,7 +200,7 @@ class CodexRequestLedger:
             cursor = conn.cursor()
             cursor.execute(
                 """
-                SELECT request_id, session_id, request_type, request_method, status,
+                SELECT request_id, session_id, thread_id, turn_id, item_id, request_type, request_method, status,
                        requested_at, expires_at, resolved_payload_json, resolved_at,
                        resolution_source, error_code, error_message
                 FROM codex_pending_requests
@@ -220,6 +220,9 @@ class CodexRequestLedger:
             (
                 req_id,
                 session_id,
+                thread_id,
+                turn_id,
+                item_id,
                 request_type,
                 request_method,
                 status,
@@ -262,6 +265,9 @@ class CodexRequestLedger:
                     "request": {
                         "request_id": req_id,
                         "session_id": session_id,
+                        "thread_id": thread_id,
+                        "turn_id": turn_id,
+                        "item_id": item_id,
                         "request_type": request_type,
                         "request_method": request_method,
                         "status": "resolved",
@@ -282,6 +288,9 @@ class CodexRequestLedger:
                     "request": {
                         "request_id": req_id,
                         "session_id": session_id,
+                        "thread_id": thread_id,
+                        "turn_id": turn_id,
+                        "item_id": item_id,
                         "request_type": request_type,
                         "request_method": request_method,
                         "status": status,
@@ -319,7 +328,7 @@ class CodexRequestLedger:
             cursor = conn.cursor()
             cursor.execute(
                 """
-                SELECT request_id, session_id, request_type, request_method, status,
+                SELECT request_id, session_id, thread_id, turn_id, item_id, request_type, request_method, status,
                        requested_at, expires_at, resolved_payload_json, resolved_at,
                        resolution_source, error_code, error_message
                 FROM codex_pending_requests
@@ -335,6 +344,9 @@ class CodexRequestLedger:
         (
             req_id,
             session_id,
+            thread_id,
+            turn_id,
+            item_id,
             request_type,
             request_method,
             status,
@@ -350,6 +362,9 @@ class CodexRequestLedger:
         return {
             "request_id": req_id,
             "session_id": session_id,
+            "thread_id": thread_id,
+            "turn_id": turn_id,
+            "item_id": item_id,
             "request_type": request_type,
             "request_method": request_method,
             "status": status,
@@ -374,7 +389,7 @@ class CodexRequestLedger:
             cursor = conn.cursor()
             cursor.execute(
                 f"""
-                SELECT request_id, session_id, request_type, request_method, status,
+                SELECT request_id, session_id, thread_id, turn_id, item_id, request_type, request_method, status,
                        requested_at, expires_at, resolved_payload_json, resolved_at,
                        resolution_source, error_code, error_message
                 FROM codex_pending_requests
@@ -390,6 +405,9 @@ class CodexRequestLedger:
             (
                 req_id,
                 s_id,
+                thread_id,
+                turn_id,
+                item_id,
                 request_type,
                 request_method,
                 status,
@@ -405,6 +423,9 @@ class CodexRequestLedger:
                 {
                     "request_id": req_id,
                     "session_id": s_id,
+                    "thread_id": thread_id,
+                    "turn_id": turn_id,
+                    "item_id": item_id,
                     "request_type": request_type,
                     "request_method": request_method,
                     "status": status,

--- a/src/main.py
+++ b/src/main.py
@@ -490,6 +490,10 @@ class SessionManagerApp:
         await self.message_queue.start()
         logger.info("Message queue manager started")
 
+        # Start SessionManager background maintenance
+        await self.session_manager.start_background_tasks()
+        logger.info("Session manager background tasks started")
+
         # Start Telegram bot if configured
         if self.telegram_bot:
             await self.telegram_bot.start()
@@ -528,6 +532,9 @@ class SessionManagerApp:
 
         # Stop message queue manager
         await self.message_queue.stop()
+
+        # Stop SessionManager background maintenance
+        await self.session_manager.stop_background_tasks()
 
         # Stop Telegram bot
         if self.telegram_bot:

--- a/tests/unit/test_codex_observability_ingestion.py
+++ b/tests/unit/test_codex_observability_ingestion.py
@@ -1,0 +1,103 @@
+"""SessionManager ingestion tests for codex observability events."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from src.models import Session, SessionStatus
+from src.session_manager import SessionManager
+
+
+@pytest.mark.asyncio
+async def test_structured_request_and_response_logged(tmp_path):
+    manager = SessionManager(log_dir=str(tmp_path), state_file=str(tmp_path / "state.json"))
+    session = Session(
+        id="obsreq1",
+        name="codex-app-obsreq1",
+        working_dir=str(tmp_path),
+        provider="codex-app",
+        status=SessionStatus.RUNNING,
+        codex_thread_id="thread-req",
+    )
+    manager.sessions[session.id] = session
+    manager.codex_sessions[session.id] = SimpleNamespace(thread_id="thread-req")
+
+    request_task = asyncio.create_task(
+        manager._handle_codex_server_request(
+            session.id,
+            42,
+            "item/commandExecution/requestApproval",
+            {"turnId": "turn-req", "item": {"id": "item-req"}},
+        )
+    )
+    await asyncio.sleep(0)
+    pending = manager.list_codex_pending_requests(session.id)
+    assert len(pending) == 1
+
+    request_id = pending[0]["request_id"]
+    resolved = await manager.respond_codex_request(session.id, request_id, {"decision": "accept"})
+    assert resolved["ok"] is True
+    assert await request_task == {"decision": "accept"}
+
+    tool_events = manager.codex_observability_logger.list_recent_tool_events(session.id, limit=20)
+    event_types = [row["event_type"] for row in tool_events]
+    assert "request_approval" in event_types
+    assert "approval_decision" in event_types
+    approval_events = [row for row in tool_events if row["event_type"] == "approval_decision"]
+    assert approval_events[-1]["item_type"] == "commandExecution"
+
+
+@pytest.mark.asyncio
+async def test_item_lifecycle_notifications_logged(tmp_path):
+    manager = SessionManager(log_dir=str(tmp_path), state_file=str(tmp_path / "state.json"))
+    session = Session(
+        id="obsitem1",
+        name="codex-app-obsitem1",
+        working_dir=str(tmp_path),
+        provider="codex-app",
+        status=SessionStatus.RUNNING,
+        codex_thread_id="thread-item",
+    )
+    manager.sessions[session.id] = session
+    manager.codex_sessions[session.id] = SimpleNamespace(thread_id="thread-item")
+
+    await manager._handle_codex_item_notification(
+        session.id,
+        "item/started",
+        {
+            "turnId": "turn-item",
+            "item": {"id": "item-1", "type": "commandExecution", "command": "ls", "cwd": str(tmp_path)},
+        },
+    )
+    await manager._handle_codex_item_notification(
+        session.id,
+        "item/commandExecution/outputDelta",
+        {
+            "turnId": "turn-item",
+            "item": {"id": "item-1", "type": "commandExecution"},
+            "delta": "stdout line",
+        },
+    )
+    await manager._handle_codex_item_notification(
+        session.id,
+        "item/completed",
+        {
+            "turnId": "turn-item",
+            "item": {
+                "id": "item-1",
+                "type": "commandExecution",
+                "status": "failed",
+                "exitCode": 2,
+                "errorCode": "command_failed",
+                "errorMessage": "non-zero exit",
+            },
+        },
+    )
+
+    tool_events = manager.codex_observability_logger.list_recent_tool_events(session.id, limit=20)
+    assert [row["event_type"] for row in tool_events][-3:] == ["started", "output_delta", "failed"]
+    assert tool_events[-1]["final_status"] == "failed"
+    assert tool_events[-1]["error_code"] == "command_failed"

--- a/tests/unit/test_codex_observability_logger.py
+++ b/tests/unit/test_codex_observability_logger.py
@@ -1,0 +1,75 @@
+"""Unit tests for codex observability logger storage and retention."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from src.codex_observability_logger import CodexObservabilityLogger
+
+
+def test_log_tool_and_turn_events_with_bounded_payload(tmp_path):
+    logger = CodexObservabilityLogger(
+        db_path=str(tmp_path / "codex_observability.db"),
+        payload_max_chars=240,
+    )
+
+    logger.log_tool_event(
+        session_id="sess1",
+        thread_id="thread-1",
+        turn_id="turn-1",
+        item_id="item-1",
+        event_type="started",
+        item_type="commandExecution",
+        phase="running",
+        command="echo hello",
+        raw_payload={"blob": "x" * 2000},
+    )
+    logger.log_turn_event(
+        session_id="sess1",
+        thread_id="thread-1",
+        turn_id="turn-1",
+        event_type="turn_completed",
+        status="completed",
+        output_preview="done",
+    )
+
+    tool_events = logger.list_recent_tool_events("sess1", limit=10)
+    turn_events = logger.list_recent_turn_events("sess1", limit=10)
+
+    assert len(tool_events) == 1
+    assert len(turn_events) == 1
+    assert tool_events[0]["event_type"] == "started"
+    assert tool_events[0]["raw_payload_json"] is not None
+    assert "truncated" in tool_events[0]["raw_payload_json"]
+    assert turn_events[0]["event_type"] == "turn_completed"
+    assert turn_events[0]["status"] == "completed"
+
+
+def test_prune_applies_age_and_per_session_caps(tmp_path):
+    logger = CodexObservabilityLogger(
+        db_path=str(tmp_path / "codex_observability.db"),
+        retention_max_age_days=1,
+        retention_tool_events_per_session=2,
+        retention_turn_events_per_session=1,
+    )
+    now = datetime.now(timezone.utc)
+    old = now - timedelta(days=2)
+
+    logger.log_tool_event(session_id="sess2", event_type="started", created_at=old)
+    logger.log_tool_event(session_id="sess2", event_type="output_delta", created_at=now - timedelta(minutes=3))
+    logger.log_tool_event(session_id="sess2", event_type="completed", created_at=now - timedelta(minutes=2))
+    logger.log_tool_event(session_id="sess2", event_type="failed", created_at=now - timedelta(minutes=1))
+
+    logger.log_turn_event(session_id="sess2", turn_id="t1", event_type="turn_started", created_at=old)
+    logger.log_turn_event(session_id="sess2", turn_id="t2", event_type="turn_started", created_at=now - timedelta(minutes=1))
+
+    result = logger.prune()
+    assert result["tool_age"] >= 1
+    assert result["turn_age"] >= 1
+
+    tool_events = logger.list_recent_tool_events("sess2", limit=10)
+    turn_events = logger.list_recent_turn_events("sess2", limit=10)
+    assert len(tool_events) == 2
+    assert tool_events[-1]["event_type"] == "failed"
+    assert len(turn_events) == 1
+    assert turn_events[0]["turn_id"] == "t2"


### PR DESCRIPTION
## Summary
- add `src/codex_observability_logger.py` with `codex_observability.db` schema (`codex_tool_events`, `codex_turn_events`), WAL mode, bounded payload excerpts, and retention pruning
- enforce retention controls (age caps + per-session row caps) at startup and via periodic prune loop (hourly by default)
- wire codex observability logger into `SessionManager` and app lifecycle (`start_background_tasks`/`stop_background_tasks`)
- ingest codex-app lifecycle into observability tables:
  - structured requests/responses (`request_approval`, `request_user_input`, `approval_decision`, `user_input_submitted`)
  - item lifecycle notifications (`started`, `output_delta`, terminal status mapping)
  - turn lifecycle (`turn_started`, `turn_delta`, `turn_completed`)
  - synthetic stream failure marker (`failed` + `turn_stream_error`)
- enrich request ledger reads with `thread_id`/`turn_id`/`item_id` to support observability correlation
- add unit coverage for logger retention and SessionManager ingestion mapping

## Validation
- `./venv/bin/pytest -q tests/unit/test_codex_observability_logger.py tests/unit/test_codex_observability_ingestion.py tests/unit/test_codex_request_ledger.py`
- `./venv/bin/pytest -q tests/unit tests/integration`

Fixes #294
