### PR TITLE
Implement #309: sm watch operator controls + observability dashboard

### DIFF
--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -584,6 +584,38 @@ class SessionManagerClient:
             return data.get("message")
         return None
 
+    def get_output(
+        self,
+        session_id: str,
+        lines: int = 10,
+        timeout: Optional[int] = None,
+    ) -> Optional[dict]:
+        """Get recent output payload for a session."""
+        data, success, unavailable = self._request(
+            "GET",
+            f"/sessions/{session_id}/output?lines={lines}",
+            timeout=timeout,
+        )
+        if unavailable or not success:
+            return None
+        return data
+
+    def get_tool_calls(
+        self,
+        session_id: str,
+        limit: int = 10,
+        timeout: Optional[int] = None,
+    ) -> Optional[dict]:
+        """Get last tool calls for a session (Claude hook-backed)."""
+        data, success, unavailable = self._request(
+            "GET",
+            f"/sessions/{session_id}/tool-calls?limit={limit}",
+            timeout=timeout,
+        )
+        if unavailable or not success:
+            return None
+        return data
+
     def watch_session(
         self,
         target_session_id: str,

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -1883,6 +1883,14 @@ def cmd_watch(
     interval: float = 2.0,
 ) -> int:
     """Launch interactive watch dashboard."""
+    if os.environ.get("CLAUDE_SESSION_MANAGER_ID"):
+        print(
+            "Error: sm watch is operator-only. Run it from a non-managed shell "
+            "(without CLAUDE_SESSION_MANAGER_ID).",
+            file=sys.stderr,
+        )
+        return 1
+
     if interval <= 0:
         print("Error: --interval must be > 0", file=sys.stderr)
         return 1

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -433,6 +433,14 @@ def main():
 
     # Check for CLAUDE_SESSION_MANAGER_ID
     session_id = os.environ.get("CLAUDE_SESSION_MANAGER_ID")
+    if args.command == "watch" and session_id:
+        print(
+            "Error: sm watch is operator-only. Run it from a non-managed shell "
+            "(without CLAUDE_SESSION_MANAGER_ID).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     # Commands that don't need session_id: lock, unlock, hooks, all, send, wait, what, subagents, children, kill, new, attach, output, clear
     no_session_needed = [
         "lock", "unlock", "subagent-start", "subagent-stop", "all", "send", "wait", "what",

--- a/src/cli/watch_tui.py
+++ b/src/cli/watch_tui.py
@@ -1,25 +1,210 @@
-"""Curses dashboard for sm watch (#289)."""
+"""Curses dashboard for sm watch (#309)."""
 
 from __future__ import annotations
 
 import curses
 import os
+import queue
+import re
 import subprocess
+import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
 SPINNER_FRAMES = ["|", "/", "-", "\\"]
+ANSI_RE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
+# (title + column header + flash + footer)
+_RESERVED_SCREEN_ROWS = 4
+
+# name, min_width, weight, align
+_COLUMN_SPECS = [
+    ("Session", 22, 3, "left"),
+    ("Role", 8, 1, "left"),
+    ("Provider", 10, 1, "left"),
+    ("Activity", 11, 1, "left"),
+    ("Status", 8, 1, "left"),
+    ("Last", 24, 3, "left"),
+    ("Age", 6, 0, "right"),
+]
+_COLUMN_ORDER = [name for name, _, _, _ in _COLUMN_SPECS]
+_COLUMN_SEP = "  "
 
 
 @dataclass
 class WatchRow:
     """A render row in sm watch."""
-    kind: str  # repo, session, status
-    text: str
+
+    kind: str  # repo, session, status, detail
+    text: str = ""
     session_id: Optional[str] = None
+    activity_state: str = "idle"
+    columns: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class DetailSnapshot:
+    """Cached detail payload for one session."""
+
+    action_lines: list[str]
+    tail_lines: list[str]
+    fetched_at: float
+    loading: bool = False
+    last_error: Optional[str] = None
+
+
+class DetailFetchWorker:
+    """Background worker for non-blocking detail reads."""
+
+    def __init__(self, client, codex_projection_enabled: bool):
+        self.client = client
+        self.codex_projection_enabled = codex_projection_enabled
+        self._queue: queue.Queue[dict] = queue.Queue(maxsize=256)
+        self._stop = threading.Event()
+        self._lock = threading.Lock()
+        self._queued_ids: set[str] = set()
+        self._cache: dict[str, DetailSnapshot] = {}
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def stop(self):
+        self._stop.set()
+        self._thread.join(timeout=1.0)
+
+    def request(self, session: dict):
+        session_id = session.get("id")
+        if not session_id:
+            return
+        with self._lock:
+            if session_id in self._queued_ids:
+                return
+            self._queued_ids.add(session_id)
+            existing = self._cache.get(session_id)
+            if existing is None:
+                self._cache[session_id] = DetailSnapshot(
+                    action_lines=[],
+                    tail_lines=[],
+                    fetched_at=0.0,
+                    loading=True,
+                )
+            else:
+                existing.loading = True
+
+        payload = {"session_id": session_id, "session": session}
+        try:
+            self._queue.put_nowait(payload)
+        except queue.Full:
+            with self._lock:
+                self._queued_ids.discard(session_id)
+
+    def get(self, session_id: str) -> Optional[DetailSnapshot]:
+        with self._lock:
+            return self._cache.get(session_id)
+
+    def _run(self):
+        while not self._stop.is_set():
+            try:
+                payload = self._queue.get(timeout=0.1)
+            except queue.Empty:
+                continue
+
+            session_id = payload["session_id"]
+            session = payload["session"]
+            with self._lock:
+                self._queued_ids.discard(session_id)
+
+            try:
+                snapshot = self._fetch(session)
+            except Exception as exc:
+                with self._lock:
+                    existing = self._cache.get(session_id)
+                    if existing is None:
+                        existing = DetailSnapshot([], [], time.monotonic())
+                        self._cache[session_id] = existing
+                    existing.loading = False
+                    existing.last_error = str(exc)
+                    existing.fetched_at = time.monotonic()
+                continue
+
+            with self._lock:
+                self._cache[session_id] = snapshot
+
+    def _fetch(self, session: dict) -> DetailSnapshot:
+        session_id = session.get("id")
+        provider = session.get("provider", "claude")
+
+        action_lines = self._fetch_actions(session_id, provider)
+        tail_lines = self._fetch_tail(session_id)
+
+        return DetailSnapshot(
+            action_lines=action_lines,
+            tail_lines=tail_lines,
+            fetched_at=time.monotonic(),
+            loading=False,
+            last_error=None,
+        )
+
+    def _fetch_actions(self, session_id: str, provider: str) -> list[str]:
+        if provider == "codex":
+            return ["n/a (no hooks)"]
+
+        if provider == "codex-app":
+            if not self.codex_projection_enabled:
+                return ["n/a (projection disabled)"]
+            payload = self.client.get_activity_actions(session_id, limit=10)
+            if payload is None:
+                return ["n/a (projection disabled)"]
+
+            actions = payload.get("actions") or []
+            if not actions:
+                return ["-"]
+
+            lines: list[str] = []
+            for action in actions[:10]:
+                summary = action.get("summary_text") or action.get("action_kind") or "action"
+                status = action.get("status")
+                when = action.get("ended_at") or action.get("started_at")
+                age = _age_from_iso(when)
+                suffix = f" [{status}]" if status else ""
+                age_suffix = f" ({age})" if age != "-" else ""
+                lines.append(f"{summary}{suffix}{age_suffix}")
+            return lines
+
+        payload = self.client.get_tool_calls(session_id, limit=10, timeout=2)
+        if payload is None:
+            return ["n/a (unavailable)"]
+
+        calls = payload.get("tool_calls") or []
+        if not calls:
+            return ["-"]
+
+        lines: list[str] = []
+        for row in calls[:10]:
+            tool = row.get("tool_name") or "-"
+            age = _age_from_iso(row.get("timestamp"))
+            if age != "-":
+                lines.append(f"{tool} ({age})")
+            else:
+                lines.append(tool)
+        return lines
+
+    def _fetch_tail(self, session_id: str) -> list[str]:
+        payload = self.client.get_output(session_id, lines=10, timeout=2)
+        if payload is None:
+            return ["n/a (unavailable)"]
+
+        output = payload.get("output") or ""
+        if not output:
+            return ["-"]
+
+        clean = ANSI_RE.sub("", output)
+        lines = clean.splitlines()
+        if not lines and clean.strip():
+            return [clean.strip()]
+        return lines[-10:] if lines else ["-"]
 
 
 def _session_name(session: dict) -> str:
@@ -45,10 +230,28 @@ def _repo_key(working_dir: str) -> str:
 def _parse_iso(ts: Optional[str]) -> Optional[datetime]:
     if not ts:
         return None
+    parsed = str(ts).replace("Z", "+00:00")
     try:
-        return datetime.fromisoformat(ts)
+        return datetime.fromisoformat(parsed)
     except Exception:
         return None
+
+
+def _elapsed_label(seconds: int) -> str:
+    if seconds < 60:
+        return f"{seconds}s"
+    if seconds < 3600:
+        return f"{seconds // 60}m"
+    return f"{seconds // 3600}h"
+
+
+def _age_from_iso(ts: Optional[str]) -> str:
+    parsed = _parse_iso(ts)
+    if not parsed:
+        return "-"
+    now = datetime.now(parsed.tzinfo) if parsed.tzinfo else datetime.now()
+    seconds = max(0, int((now - parsed).total_seconds()))
+    return _elapsed_label(seconds)
 
 
 def _format_age(last_activity: Optional[str], activity_state: str) -> str:
@@ -68,6 +271,50 @@ def _state_label(activity_state: str, spinner_index: int) -> str:
     if activity_state == "thinking":
         return f"thinking {SPINNER_FRAMES[spinner_index % len(SPINNER_FRAMES)]}"
     return activity_state
+
+
+def _last_column(session: dict, codex_projection_enabled: bool) -> str:
+    provider = session.get("provider", "claude")
+
+    if provider == "codex":
+        return "n/a (no hooks)"
+
+    if provider == "codex-app":
+        if not codex_projection_enabled:
+            return "n/a (projection disabled)"
+        summary = session.get("last_action_summary")
+        at = session.get("last_action_at")
+        if summary and at:
+            return f"{summary} ({_age_from_iso(at)})"
+        if summary:
+            return summary
+        return "-"
+
+    tool_name = session.get("last_tool_name")
+    tool_at = session.get("last_tool_call")
+    if tool_name and tool_at:
+        return f"{tool_name} ({_age_from_iso(tool_at)})"
+    if tool_name:
+        return str(tool_name)
+    if tool_at:
+        return f"tool ({_age_from_iso(tool_at)})"
+    return "-"
+
+
+def _thinking_duration(session: dict, codex_projection_enabled: bool) -> str:
+    provider = session.get("provider", "claude")
+    ts: Optional[str]
+
+    if provider == "codex-app":
+        ts = session.get("last_action_at") if codex_projection_enabled else None
+        if not ts:
+            ts = session.get("last_activity")
+    elif provider == "claude":
+        ts = session.get("last_tool_call") or session.get("last_activity")
+    else:
+        ts = session.get("last_activity")
+
+    return _age_from_iso(ts)
 
 
 def can_attach_session(session: dict) -> bool:
@@ -122,11 +369,60 @@ def filter_sessions(
     return filtered
 
 
-def build_watch_rows(sessions: list[dict], spinner_index: int = 0) -> tuple[list[WatchRow], list[str], int]:
-    """Build grouped tree rows and selectable session IDs."""
+def _detail_lines(
+    session: dict,
+    detail: Optional[DetailSnapshot],
+    codex_projection_enabled: bool,
+) -> list[str]:
+    activity_state = session.get("activity_state", "idle")
+    name = _session_name(session)
+    lines = [
+        (
+            f"meta: {name} [{session.get('id', '')}] "
+            f"provider={session.get('provider', 'claude')} "
+            f"activity={activity_state} status={session.get('status', '-') or '-'} "
+            f"role={session.get('role') or '-'}"
+        ),
+        f"thinking duration: {_thinking_duration(session, codex_projection_enabled)}",
+    ]
+
+    if session.get("context_monitor_enabled"):
+        tokens = int(session.get("tokens_used") or 0)
+        lines.append(f"context size: {tokens:,} tokens")
+    else:
+        lines.append("context size: n/a (monitor off)")
+
+    lines.append("last 10 tool calls/actions:")
+    if detail is None or detail.loading:
+        lines.append("  loading...")
+    else:
+        if detail.last_error:
+            lines.append(f"  warning: {detail.last_error}")
+        for item in detail.action_lines[:10]:
+            lines.append(f"  {item}")
+
+    lines.append("last 10 tail lines:")
+    if detail is None or detail.loading:
+        lines.append("  loading...")
+    else:
+        for item in detail.tail_lines[:10]:
+            lines.append(f"  {item}")
+
+    return lines
+
+
+def build_watch_rows(
+    sessions: list[dict],
+    spinner_index: int = 0,
+    expanded_session_ids: Optional[set[str]] = None,
+    detail_cache: Optional[dict[str, DetailSnapshot]] = None,
+    codex_projection_enabled: bool = True,
+) -> tuple[list[WatchRow], list[str], int]:
+    """Build grouped rows and selectable session IDs."""
     rows: list[WatchRow] = []
     selectable: list[str] = []
     groups: dict[str, list[dict]] = {}
+    expanded = expanded_session_ids or set()
 
     for session in sessions:
         key = _repo_key(session.get("working_dir", ""))
@@ -138,7 +434,8 @@ def build_watch_rows(sessions: list[dict], spinner_index: int = 0) -> tuple[list
         if repo_key not in ("unknown",):
             repo_header = f"{repo_header} ({repo_key})"
         rows.append(WatchRow(kind="repo", text=repo_header))
-        by_id = {s["id"]: s for s in group_sessions}
+
+        by_id = {s["id"]: s for s in group_sessions if s.get("id")}
         children: dict[str, list[dict]] = {}
         roots: list[dict] = []
 
@@ -162,22 +459,40 @@ def build_watch_rows(sessions: list[dict], spinner_index: int = 0) -> tuple[list
             tree_prefix = "".join(prefix_parts) + connector
 
             role = session.get("role") or "-"
+            provider = session.get("provider", "claude")
             activity_state = session.get("activity_state", "idle")
-            state_label = _state_label(activity_state, spinner_index)
-            age = _format_age(session.get("last_activity"), activity_state)
-            line = (
-                f"{tree_prefix}{_session_name(session)} "
-                f"[{session.get('id', '')}] {role:<10} {state_label:<18} {age}"
-            )
+            status = session.get("status") or "-"
+
+            columns = {
+                "Session": f"{tree_prefix}{_session_name(session)} [{session.get('id', '')}]",
+                "Role": role,
+                "Provider": provider,
+                "Activity": _state_label(activity_state, spinner_index),
+                "Status": status,
+                "Last": _last_column(session, codex_projection_enabled),
+                "Age": _format_age(session.get("last_activity"), activity_state),
+            }
+
             session_id = session.get("id")
-            rows.append(WatchRow(kind="session", text=line, session_id=session_id))
+            rows.append(
+                WatchRow(
+                    kind="session",
+                    session_id=session_id,
+                    activity_state=activity_state,
+                    columns=columns,
+                )
+            )
             if session_id:
                 selectable.append(session_id)
 
             status_text = session.get("agent_status_text")
             if status_text:
-                status_indent = " " * (len(tree_prefix) + 1)
-                rows.append(WatchRow(kind="status", text=f'{status_indent}"{status_text}"'))
+                rows.append(WatchRow(kind="status", text=f'"{status_text}"', session_id=session_id))
+
+            if session_id and session_id in expanded:
+                detail = detail_cache.get(session_id) if detail_cache else None
+                for line in _detail_lines(session, detail, codex_projection_enabled):
+                    rows.append(WatchRow(kind="detail", text=line, session_id=session_id))
 
             kid_sessions = children.get(session.get("id", ""), [])
             for idx, child in enumerate(kid_sessions):
@@ -187,6 +502,76 @@ def build_watch_rows(sessions: list[dict], spinner_index: int = 0) -> tuple[list
             walk(root, [], idx == len(roots) - 1)
 
     return rows, selectable, len(groups)
+
+
+def _truncate(text: str, width: int, align: str = "left") -> str:
+    if width <= 0:
+        return ""
+    value = text or ""
+    if len(value) > width:
+        if width <= 3:
+            value = value[:width]
+        else:
+            value = value[: width - 3] + "..."
+    if align == "right":
+        return value.rjust(width)
+    return value.ljust(width)
+
+
+def _compute_column_widths(content_width: int) -> dict[str, int]:
+    if content_width <= 10:
+        return {name: 1 for name, _, _, _ in _COLUMN_SPECS}
+
+    min_widths = {name: minimum for name, minimum, _, _ in _COLUMN_SPECS}
+    widths = dict(min_widths)
+    sep_total = len(_COLUMN_SEP) * (len(_COLUMN_SPECS) - 1)
+    min_total = sum(min_widths.values()) + sep_total
+
+    if content_width >= min_total:
+        extra = content_width - min_total
+        weighted = [entry for entry in _COLUMN_SPECS if entry[2] > 0]
+        total_weight = sum(weight for _, _, weight, _ in weighted) or 1
+        for name, _, weight, _ in weighted:
+            add = (extra * weight) // total_weight
+            widths[name] += add
+        used = sum(widths.values()) + sep_total
+        remainder = content_width - used
+        idx = 0
+        while remainder > 0 and weighted:
+            name = weighted[idx % len(weighted)][0]
+            widths[name] += 1
+            remainder -= 1
+            idx += 1
+        return widths
+
+    deficit = min_total - content_width
+    shrink_order = ["Last", "Session", "Activity", "Role", "Provider", "Status", "Age"]
+    floor = {"Session": 8, "Last": 8, "Age": 3, "Role": 4, "Provider": 6, "Activity": 7, "Status": 5}
+    while deficit > 0:
+        changed = False
+        for name in shrink_order:
+            if widths[name] > floor[name] and deficit > 0:
+                widths[name] -= 1
+                deficit -= 1
+                changed = True
+        if not changed:
+            break
+
+    return widths
+
+
+def _header_line(widths: dict[str, int]) -> str:
+    parts = []
+    for name, _, _, align in _COLUMN_SPECS:
+        parts.append(_truncate(name, widths[name], align=align))
+    return _COLUMN_SEP.join(parts)
+
+
+def _session_line(row: WatchRow, widths: dict[str, int]) -> str:
+    parts = []
+    for name, _, _, align in _COLUMN_SPECS:
+        parts.append(_truncate(row.columns.get(name, ""), widths[name], align=align))
+    return _COLUMN_SEP.join(parts)
 
 
 def _prompt_input(stdscr, prompt: str) -> str:
@@ -219,6 +604,71 @@ def _attach_tmux(stdscr, tmux_session: str):
         stdscr.clear()
 
 
+def _init_colors() -> dict[str, int]:
+    palette = {
+        "header": 0,
+        "repo": 0,
+        "working": 0,
+        "thinking": 0,
+        "waiting": 0,
+        "idle": 0,
+        "stopped": 0,
+        "flash_success": 0,
+        "flash_warn": 0,
+        "flash_error": 0,
+    }
+
+    if not curses.has_colors():
+        return palette
+
+    try:
+        curses.start_color()
+        curses.use_default_colors()
+        curses.init_pair(1, curses.COLOR_CYAN, -1)
+        curses.init_pair(2, curses.COLOR_GREEN, -1)
+        curses.init_pair(3, curses.COLOR_YELLOW, -1)
+        curses.init_pair(4, curses.COLOR_RED, -1)
+        curses.init_pair(5, curses.COLOR_WHITE, -1)
+
+        palette["header"] = curses.color_pair(1)
+        palette["repo"] = curses.color_pair(1)
+        palette["working"] = curses.color_pair(2)
+        palette["thinking"] = curses.color_pair(3)
+        palette["waiting"] = curses.color_pair(4)
+        palette["idle"] = curses.color_pair(5)
+        palette["stopped"] = curses.color_pair(4)
+        palette["flash_success"] = curses.color_pair(2)
+        palette["flash_warn"] = curses.color_pair(3)
+        palette["flash_error"] = curses.color_pair(4)
+    except curses.error:
+        return {k: 0 for k in palette}
+
+    return palette
+
+
+def _activity_attr(activity_state: str, palette: dict[str, int]) -> int:
+    if activity_state == "working":
+        return palette["working"]
+    if activity_state == "thinking":
+        return palette["thinking"]
+    if activity_state == "waiting_permission":
+        return palette["waiting"]
+    if activity_state == "stopped":
+        return palette["stopped"] | curses.A_DIM
+    if activity_state == "idle":
+        return palette["idle"] | curses.A_DIM
+    return curses.A_NORMAL
+
+
+def _flash_attr(flash_message: str, palette: dict[str, int]) -> int:
+    lowered = flash_message.lower()
+    if "failed" in lowered or "error" in lowered:
+        return palette["flash_error"] | curses.A_BOLD
+    if "canceled" in lowered or "cancel" in lowered or "warning" in lowered:
+        return palette["flash_warn"] | curses.A_BOLD
+    return palette["flash_success"] | curses.A_BOLD
+
+
 def _render(
     stdscr,
     rows: list[WatchRow],
@@ -228,33 +678,55 @@ def _render(
     repo_count: int,
     filter_text: Optional[str],
     flash_message: Optional[str],
+    palette: dict[str, int],
 ):
     stdscr.erase()
     height, width = stdscr.getmaxyx()
-    header = f"sm watch  {total_sessions} agents - {repo_count} repos"
-    if filter_text:
-        header += f" - filter: {filter_text}"
-    stdscr.addnstr(0, 0, header, max(0, width - 1), curses.A_BOLD)
 
-    max_rows = max(0, height - 3)
-    display_rows = rows[scroll_offset:scroll_offset + max_rows]
-    y = 1
+    title = f"sm watch  {total_sessions} agents - {repo_count} repos"
+    if filter_text:
+        title += f" - filter: {filter_text}"
+    stdscr.addnstr(0, 0, title, max(0, width - 1), curses.A_BOLD | palette["header"])
+
+    content_width = max(1, width - 2)
+    widths = _compute_column_widths(content_width)
+    stdscr.addnstr(1, 2, _header_line(widths), max(0, width - 3), curses.A_BOLD | palette["header"])
+
+    max_rows = max(0, height - _RESERVED_SCREEN_ROWS)
+    display_rows = rows[scroll_offset: scroll_offset + max_rows]
+
+    y = 2
     for row in display_rows:
+        if y >= height - 2:
+            break
+
         if row.kind == "session":
             is_selected = row.session_id == selected_session_id
             marker = ">" if is_selected else " "
-            attr = curses.A_REVERSE if is_selected else curses.A_NORMAL
-            stdscr.addnstr(y, 0, f"{marker} {row.text}", max(0, width - 1), attr)
+            base_attr = _activity_attr(row.activity_state, palette)
+            attr = base_attr
+            if is_selected:
+                attr = base_attr | curses.A_REVERSE | curses.A_BOLD
+            stdscr.addnstr(y, 0, f"{marker} {_session_line(row, widths)}", max(0, width - 1), attr)
         elif row.kind == "repo":
-            stdscr.addnstr(y, 0, f"  {row.text}", max(0, width - 1), curses.A_BOLD)
+            stdscr.addnstr(y, 2, row.text, max(0, width - 3), curses.A_BOLD | palette["repo"])
+        elif row.kind == "status":
+            stdscr.addnstr(y, 4, row.text, max(0, width - 5), curses.A_DIM)
         else:
-            stdscr.addnstr(y, 0, f"  {row.text}", max(0, width - 1))
+            stdscr.addnstr(y, 4, row.text, max(0, width - 5), curses.A_DIM)
+
         y += 1
 
     if flash_message and height >= 2:
-        stdscr.addnstr(height - 2, 0, flash_message, max(0, width - 1), curses.A_BOLD)
+        stdscr.addnstr(
+            height - 2,
+            0,
+            flash_message,
+            max(0, width - 1),
+            _flash_attr(flash_message, palette),
+        )
 
-    footer = "j/k or arrows: move  Enter: attach  s: send  K: kill child  /: filter  r: refresh  q: quit"
+    footer = "j/k: move  Enter: attach  s: send  K: kill  n: rename  Tab: details  /: filter  r: refresh  q: quit"
     stdscr.addnstr(height - 1, 0, footer, max(0, width - 1))
     stdscr.refresh()
 
@@ -271,175 +743,240 @@ def run_watch_tui(
         curses.curs_set(0)
         stdscr.nodelay(True)
         stdscr.keypad(True)
+        palette = _init_colors()
 
-        selected_session_id: Optional[str] = None
-        text_filter: Optional[str] = None
-        flash_message: Optional[str] = None
-        flash_until = 0.0
-        rows: list[WatchRow] = []
-        selectable: list[str] = []
-        latest_sessions: list[dict] = []
-        repo_count = 0
-        total_sessions = 0
-        spinner_index = 0
-        scroll_offset = 0
-        next_refresh = 0.0
+        rollout_flags = client.get_rollout_flags()
+        codex_projection_enabled = bool(
+            rollout_flags and rollout_flags.get("enable_observability_projection", True)
+        )
 
-        while True:
-            now = time.monotonic()
-            if now >= next_refresh:
-                latest_sessions = client.list_sessions() or []
-                latest_sessions = filter_sessions(
-                    latest_sessions,
-                    repo_filter=repo_filter,
-                    role_filter=role_filter,
-                    text_filter=text_filter,
-                )
-                total_sessions = len(latest_sessions)
-                rows, selectable, repo_count = build_watch_rows(latest_sessions, spinner_index=spinner_index)
-                spinner_index += 1
-                if selected_session_id not in selectable:
-                    selected_session_id = selectable[0] if selectable else None
-                next_refresh = now + max(0.2, interval)
+        detail_worker = DetailFetchWorker(client=client, codex_projection_enabled=codex_projection_enabled)
 
-            if flash_message and now >= flash_until:
-                flash_message = None
+        try:
+            selected_session_id: Optional[str] = None
+            text_filter: Optional[str] = None
+            flash_message: Optional[str] = None
+            flash_until = 0.0
+            rows: list[WatchRow] = []
+            selectable: list[str] = []
+            latest_sessions: list[dict] = []
+            latest_by_id: dict[str, dict] = {}
+            expanded_session_ids: set[str] = set()
+            repo_count = 0
+            total_sessions = 0
+            spinner_index = 0
+            scroll_offset = 0
+            next_refresh = 0.0
 
-            # Keep selected session visible in viewport when row count exceeds screen height.
-            max_rows = max(0, stdscr.getmaxyx()[0] - 3)
-            selected_row_idx = None
-            if selected_session_id:
-                for idx, row in enumerate(rows):
-                    if row.kind == "session" and row.session_id == selected_session_id:
-                        selected_row_idx = idx
-                        break
-            if selected_row_idx is not None and max_rows > 0:
-                if selected_row_idx < scroll_offset:
-                    scroll_offset = selected_row_idx
-                elif selected_row_idx >= scroll_offset + max_rows:
-                    scroll_offset = selected_row_idx - max_rows + 1
-                max_offset = max(0, len(rows) - max_rows)
-                scroll_offset = max(0, min(scroll_offset, max_offset))
-            else:
-                scroll_offset = 0
+            while True:
+                now = time.monotonic()
+                if now >= next_refresh:
+                    listed = client.list_sessions()
+                    if listed is None:
+                        flash_message = "Session manager unavailable"
+                        flash_until = now + 2.5
+                    else:
+                        latest_sessions = filter_sessions(
+                            listed,
+                            repo_filter=repo_filter,
+                            role_filter=role_filter,
+                            text_filter=text_filter,
+                        )
+                        latest_by_id = {s.get("id", ""): s for s in latest_sessions if s.get("id")}
+                        total_sessions = len(latest_sessions)
+                        detail_cache = {
+                            sid: detail_worker.get(sid)
+                            for sid in expanded_session_ids
+                            if sid in latest_by_id
+                        }
+                        rows, selectable, repo_count = build_watch_rows(
+                            latest_sessions,
+                            spinner_index=spinner_index,
+                            expanded_session_ids=expanded_session_ids,
+                            detail_cache=detail_cache,
+                            codex_projection_enabled=codex_projection_enabled,
+                        )
+                        spinner_index += 1
+                        if selected_session_id not in selectable:
+                            selected_session_id = selectable[0] if selectable else None
+                        # Prune stale expanded IDs and enqueue refresh for active details.
+                        expanded_session_ids.intersection_update(set(selectable))
+                        for sid in expanded_session_ids:
+                            session = latest_by_id.get(sid)
+                            if session:
+                                detail_worker.request(session)
 
-            _render(
-                stdscr,
-                rows=rows,
-                selected_session_id=selected_session_id,
-                scroll_offset=scroll_offset,
-                total_sessions=total_sessions,
-                repo_count=repo_count,
-                filter_text=text_filter,
-                flash_message=flash_message,
-            )
+                    next_refresh = now + max(0.2, interval)
 
-            key = stdscr.getch()
-            if key == -1:
-                time.sleep(0.05)
-                continue
+                if flash_message and now >= flash_until:
+                    flash_message = None
 
-            if key in (ord("q"), 27):
-                break
-
-            if key in (ord("j"), curses.KEY_DOWN):
-                if selectable:
-                    current_idx = selectable.index(selected_session_id) if selected_session_id in selectable else 0
-                    selected_session_id = selectable[min(current_idx + 1, len(selectable) - 1)]
-                continue
-
-            if key in (ord("k"), curses.KEY_UP):
-                if selectable:
-                    current_idx = selectable.index(selected_session_id) if selected_session_id in selectable else 0
-                    selected_session_id = selectable[max(current_idx - 1, 0)]
-                continue
-
-            if key in (ord("r"),):
-                next_refresh = 0.0
-                continue
-
-            selected = None
-            if selected_session_id:
-                selected = next((s for s in latest_sessions if s.get("id") == selected_session_id), None)
-
-            if key in (ord("/"),):
-                entered = _prompt_input(stdscr, "filter (blank=clear): ")
-                text_filter = entered or None
-                next_refresh = 0.0
-                continue
-
-            if key in (ord("s"),):
-                if not selected_session_id:
-                    flash_message = "No session selected"
-                    flash_until = time.monotonic() + 2.0
-                    continue
-                message = _prompt_input(stdscr, "send> ")
-                if not message:
-                    flash_message = "Send canceled"
-                    flash_until = time.monotonic() + 2.0
-                    continue
-                success, unavailable = client.send_input(
-                    selected_session_id,
-                    message,
-                    sender_session_id=client.session_id,
-                    delivery_mode="sequential",
-                    from_sm_send=True,
-                )
-                if success:
-                    flash_message = f"Sent to {selected_session_id}"
-                elif unavailable:
-                    flash_message = "Session manager unavailable"
+                max_rows = max(0, stdscr.getmaxyx()[0] - _RESERVED_SCREEN_ROWS)
+                selected_row_idx = None
+                if selected_session_id:
+                    for idx, row in enumerate(rows):
+                        if row.kind == "session" and row.session_id == selected_session_id:
+                            selected_row_idx = idx
+                            break
+                if selected_row_idx is not None and max_rows > 0:
+                    if selected_row_idx < scroll_offset:
+                        scroll_offset = selected_row_idx
+                    elif selected_row_idx >= scroll_offset + max_rows:
+                        scroll_offset = selected_row_idx - max_rows + 1
+                    max_offset = max(0, len(rows) - max_rows)
+                    scroll_offset = max(0, min(scroll_offset, max_offset))
                 else:
-                    flash_message = "Failed to send"
-                flash_until = time.monotonic() + 2.5
-                next_refresh = 0.0
-                continue
+                    scroll_offset = 0
 
-            if key in (ord("K"),):
-                if not selected:
-                    flash_message = "No session selected"
-                    flash_until = time.monotonic() + 2.0
-                    continue
-                if not selected.get("parent_session_id"):
-                    flash_message = "Kill is only allowed for child sessions"
-                    flash_until = time.monotonic() + 2.5
-                    continue
-                if client.session_id and selected.get("parent_session_id") != client.session_id:
-                    flash_message = "Kill is only allowed for your child sessions"
-                    flash_until = time.monotonic() + 2.5
-                    continue
-                confirm = _prompt_input(stdscr, f"Kill {selected_session_id}? type yes: ")
-                if confirm.lower() != "yes":
-                    flash_message = "Kill canceled"
-                    flash_until = time.monotonic() + 2.0
-                    continue
-                result = client.kill_session(client.session_id, selected_session_id)
-                if result and result.get("status") == "killed":
-                    flash_message = f"Killed {selected_session_id}"
-                elif result is None:
-                    flash_message = "Session manager unavailable"
-                else:
-                    flash_message = "Failed to kill session"
-                flash_until = time.monotonic() + 2.5
-                next_refresh = 0.0
-                continue
+                _render(
+                    stdscr,
+                    rows=rows,
+                    selected_session_id=selected_session_id,
+                    scroll_offset=scroll_offset,
+                    total_sessions=total_sessions,
+                    repo_count=repo_count,
+                    filter_text=text_filter,
+                    flash_message=flash_message,
+                    palette=palette,
+                )
 
-            if key in (10, 13, curses.KEY_ENTER):
-                if not selected:
-                    flash_message = "No session selected"
-                    flash_until = time.monotonic() + 2.0
+                key = stdscr.getch()
+                if key == -1:
+                    time.sleep(0.05)
                     continue
-                if not can_attach_session(selected):
-                    flash_message = "no terminal (use s to send)"
+
+                if key in (ord("q"), 27):
+                    break
+
+                if key in (ord("j"), curses.KEY_DOWN):
+                    if selectable:
+                        current_idx = selectable.index(selected_session_id) if selected_session_id in selectable else 0
+                        selected_session_id = selectable[min(current_idx + 1, len(selectable) - 1)]
+                    continue
+
+                if key in (ord("k"), curses.KEY_UP):
+                    if selectable:
+                        current_idx = selectable.index(selected_session_id) if selected_session_id in selectable else 0
+                        selected_session_id = selectable[max(current_idx - 1, 0)]
+                    continue
+
+                if key in (ord("r"),):
+                    for sid in expanded_session_ids:
+                        session = latest_by_id.get(sid)
+                        if session:
+                            detail_worker.request(session)
+                    next_refresh = 0.0
+                    continue
+
+                selected = None
+                if selected_session_id:
+                    selected = latest_by_id.get(selected_session_id)
+
+                if key in (ord("/"),):
+                    entered = _prompt_input(stdscr, "filter (blank=clear): ")
+                    text_filter = entered or None
+                    next_refresh = 0.0
+                    continue
+
+                if key == 9:  # Tab
+                    if not selected_session_id:
+                        continue
+                    if selected_session_id in expanded_session_ids:
+                        expanded_session_ids.remove(selected_session_id)
+                    else:
+                        expanded_session_ids.add(selected_session_id)
+                        if selected:
+                            detail_worker.request(selected)
+                    next_refresh = 0.0
+                    continue
+
+                if key in (ord("s"),):
+                    if not selected_session_id:
+                        flash_message = "No session selected"
+                        flash_until = time.monotonic() + 2.0
+                        continue
+                    message = _prompt_input(stdscr, "send> ")
+                    if not message:
+                        flash_message = "Send canceled"
+                        flash_until = time.monotonic() + 2.0
+                        continue
+                    success, unavailable = client.send_input(
+                        selected_session_id,
+                        message,
+                        sender_session_id=client.session_id,
+                        delivery_mode="sequential",
+                        from_sm_send=True,
+                    )
+                    if success:
+                        flash_message = f"Sent to {selected_session_id}"
+                    elif unavailable:
+                        flash_message = "Session manager unavailable"
+                    else:
+                        flash_message = "Failed to send"
                     flash_until = time.monotonic() + 2.5
+                    next_refresh = 0.0
                     continue
-                tmux_session = selected.get("tmux_session")
-                if not tmux_session:
-                    flash_message = "Selected session has no tmux target"
+
+                if key in (ord("K"),):
+                    if not selected_session_id:
+                        flash_message = "No session selected"
+                        flash_until = time.monotonic() + 2.0
+                        continue
+                    confirm = _prompt_input(stdscr, f"Kill {selected_session_id}? type yes: ")
+                    if confirm.lower() != "yes":
+                        flash_message = "Kill canceled"
+                        flash_until = time.monotonic() + 2.0
+                        continue
+                    result = client.kill_session(None, selected_session_id)
+                    if result and result.get("status") == "killed":
+                        flash_message = f"Killed {selected_session_id}"
+                    elif result is None:
+                        flash_message = "Session manager unavailable"
+                    else:
+                        flash_message = "Failed to kill session"
                     flash_until = time.monotonic() + 2.5
+                    next_refresh = 0.0
                     continue
-                _attach_tmux(stdscr, tmux_session)
-                next_refresh = 0.0
+
+                if key in (ord("n"),):
+                    if not selected_session_id:
+                        flash_message = "No session selected"
+                        flash_until = time.monotonic() + 2.0
+                        continue
+                    new_name = _prompt_input(stdscr, "name> ")
+                    if not new_name:
+                        flash_message = "Rename canceled"
+                        flash_until = time.monotonic() + 2.0
+                        continue
+                    success, unavailable = client.update_friendly_name(selected_session_id, new_name)
+                    if success:
+                        flash_message = f"Renamed {selected_session_id} -> {new_name}"
+                    elif unavailable:
+                        flash_message = "Session manager unavailable"
+                    else:
+                        flash_message = "Failed to rename session"
+                    flash_until = time.monotonic() + 2.5
+                    next_refresh = 0.0
+                    continue
+
+                if key in (10, 13, curses.KEY_ENTER):
+                    if not selected:
+                        flash_message = "No session selected"
+                        flash_until = time.monotonic() + 2.0
+                        continue
+                    if not can_attach_session(selected):
+                        flash_message = "no terminal (use s to send)"
+                        flash_until = time.monotonic() + 2.5
+                        continue
+                    tmux_session = selected.get("tmux_session")
+                    if not tmux_session:
+                        flash_message = "Selected session has no tmux target"
+                        flash_until = time.monotonic() + 2.5
+                        continue
+                    _attach_tmux(stdscr, tmux_session)
+                    next_refresh = 0.0
+        finally:
+            detail_worker.stop()
 
     curses.wrapper(_loop)
     return 0

--- a/src/models.py
+++ b/src/models.py
@@ -208,6 +208,7 @@ class Session:
     tokens_used: int = 0  # Approximate token count
     tools_used: dict[str, int] = field(default_factory=dict)  # {"Read": 5, "Write": 3}
     last_tool_call: Optional[datetime] = None  # Last tool usage timestamp
+    last_tool_name: Optional[str] = None  # Last tool name seen from PreToolUse hooks
 
     # Lock management fields
     touched_repos: set[str] = field(default_factory=set)  # Repo roots this session has written to
@@ -281,6 +282,7 @@ class Session:
             "tokens_used": self.tokens_used,
             "tools_used": self.tools_used,
             "last_tool_call": self.last_tool_call.isoformat() if self.last_tool_call else None,
+            "last_tool_name": self.last_tool_name,
             # Lock management fields
             "touched_repos": list(self.touched_repos),
             "worktrees": self.worktrees,
@@ -358,6 +360,7 @@ class Session:
             tokens_used=data.get("tokens_used", 0),
             tools_used=data.get("tools_used", {}),
             last_tool_call=datetime.fromisoformat(data["last_tool_call"]) if data.get("last_tool_call") else None,
+            last_tool_name=data.get("last_tool_name"),
             # Lock management fields
             touched_repos=set(data.get("touched_repos", [])),
             worktrees=data.get("worktrees", []),

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -1754,7 +1754,18 @@ class SessionManager:
 
         if session.provider == "codex-app":
             if self.hook_output_store:
-                return self.hook_output_store.get(session_id)
+                output = self.hook_output_store.get(session_id)
+                if output is None:
+                    return None
+                if lines <= 0:
+                    return ""
+                chunks = output.splitlines()
+                tail = chunks[-lines:] if chunks else []
+                if not tail:
+                    return ""
+                # Preserve trailing newline semantics from tmux capture where possible.
+                suffix = "\n" if output.endswith("\n") else ""
+                return "\n".join(tail) + suffix
             return None
 
         return self.tmux.capture_pane(session.tmux_session, lines)

--- a/tests/unit/test_client_codex_endpoints.py
+++ b/tests/unit/test_client_codex_endpoints.py
@@ -76,3 +76,21 @@ def test_get_rollout_flags_success():
     with patch.object(client, "_request", return_value=(payload, True, False)):
         result = client.get_rollout_flags()
     assert result == {"enable_codex_tui": False}
+
+
+def test_get_output_success_with_timeout():
+    client = _make_client()
+    payload = {"session_id": "abc123", "output": "line1\\nline2"}
+    with patch.object(client, "_request", return_value=(payload, True, False)) as req:
+        result = client.get_output("abc123", lines=7, timeout=4)
+    assert result == payload
+    req.assert_called_once_with("GET", "/sessions/abc123/output?lines=7", timeout=4)
+
+
+def test_get_tool_calls_success_with_timeout():
+    client = _make_client()
+    payload = {"session_id": "abc123", "tool_calls": []}
+    with patch.object(client, "_request", return_value=(payload, True, False)) as req:
+        result = client.get_tool_calls("abc123", limit=12, timeout=3)
+    assert result == payload
+    req.assert_called_once_with("GET", "/sessions/abc123/tool-calls?limit=12", timeout=3)

--- a/tests/unit/test_cmd_watch.py
+++ b/tests/unit/test_cmd_watch.py
@@ -1,20 +1,26 @@
 """Unit tests for cmd_watch (#289)."""
 
+import os
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from src.cli.commands import cmd_watch
+from src.cli.main import main
 
 
 def test_cmd_watch_rejects_non_positive_interval():
     client = MagicMock()
-    rc = cmd_watch(client, repo=None, role=None, interval=0.0)
+    with patch.dict(os.environ, {}, clear=False):
+        rc = cmd_watch(client, repo=None, role=None, interval=0.0)
     assert rc == 1
 
 
 def test_cmd_watch_delegates_to_watch_tui():
     client = MagicMock()
-    with patch("src.cli.watch_tui.run_watch_tui", return_value=0) as mock_run:
-        rc = cmd_watch(client, repo="/tmp/repo", role="engineer", interval=2.5)
+    with patch.dict(os.environ, {"CLAUDE_SESSION_MANAGER_ID": ""}, clear=False):
+        with patch("src.cli.watch_tui.run_watch_tui", return_value=0) as mock_run:
+            rc = cmd_watch(client, repo="/tmp/repo", role="engineer", interval=2.5)
 
     assert rc == 0
     mock_run.assert_called_once_with(
@@ -23,3 +29,23 @@ def test_cmd_watch_delegates_to_watch_tui():
         role_filter="engineer",
         interval=2.5,
     )
+
+
+def test_cmd_watch_rejects_managed_session(capsys):
+    client = MagicMock()
+    with patch.dict(os.environ, {"CLAUDE_SESSION_MANAGER_ID": "abc12345"}, clear=False):
+        rc = cmd_watch(client, repo=None, role=None, interval=2.0)
+
+    assert rc == 1
+    assert "operator-only" in capsys.readouterr().err
+
+
+def test_main_watch_rejects_managed_session_before_dispatch():
+    with patch.dict(os.environ, {"CLAUDE_SESSION_MANAGER_ID": "abc12345"}, clear=False):
+        with patch("sys.argv", ["sm", "watch"]):
+            with patch("src.cli.main.commands.cmd_watch") as mock_cmd_watch:
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+
+    assert exc_info.value.code == 1
+    mock_cmd_watch.assert_not_called()

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -47,6 +47,7 @@ class TestSession:
             tokens_used=5000,
             tools_used={"Read": 10, "Write": 5},
             last_tool_call=datetime(2024, 1, 15, 11, 30, 0),
+            last_tool_name="Read",
             touched_repos={"/repo1", "/repo2"},
             worktrees=["/worktree1", "/worktree2"],
         )
@@ -80,6 +81,7 @@ class TestSession:
         assert restored.tokens_used == original.tokens_used
         assert restored.tools_used == original.tools_used
         assert restored.last_tool_call == original.last_tool_call
+        assert restored.last_tool_name == original.last_tool_name
         assert restored.touched_repos == original.touched_repos
         assert restored.worktrees == original.worktrees
 

--- a/tests/unit/test_watch_api_309.py
+++ b/tests/unit/test_watch_api_309.py
@@ -1,0 +1,173 @@
+"""Unit tests for watch observability payloads and endpoints (#309)."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from fastapi.testclient import TestClient
+
+from src.models import Session, SessionStatus
+from src.server import create_app
+from src.session_manager import SessionManager
+
+
+class _QueueStub:
+    def __init__(self):
+        self.mark_session_active = MagicMock()
+        self.cancel_remind = MagicMock()
+        self.cancel_parent_wake = MagicMock()
+        self.cancel_context_monitor_messages_from = MagicMock()
+        self._get_or_create_state = MagicMock()
+        self.delivery_states = {}
+
+
+def _make_session(session_id: str, provider: str = "claude") -> Session:
+    return Session(
+        id=session_id,
+        name=f"{provider}-{session_id}",
+        working_dir="/tmp/test",
+        tmux_session=f"{provider}-{session_id}" if provider != "codex-app" else "",
+        provider=provider,
+        log_file="/tmp/test.log",
+        status=SessionStatus.RUNNING,
+    )
+
+
+def _make_sm(session: Session) -> MagicMock:
+    sm = MagicMock()
+    sm.get_session = MagicMock(return_value=session)
+    sm.list_sessions = MagicMock(return_value=[session])
+    sm.sessions = {session.id: session}
+    sm._save_state = MagicMock()
+    sm.get_activity_state = MagicMock(return_value="thinking")
+    sm.is_codex_rollout_enabled = MagicMock(return_value=True)
+    sm.message_queue_manager = _QueueStub()
+    return sm
+
+
+def test_sessions_payload_includes_watch_fields():
+    session = _make_session("abc12345")
+    session.last_tool_name = "Read"
+    session.last_tool_call = datetime(2026, 2, 20, 10, 0, 0)
+    session.tokens_used = 3210
+    session.context_monitor_enabled = True
+
+    app = create_app(session_manager=_make_sm(session))
+    client = TestClient(app)
+
+    payload = client.get("/sessions").json()["sessions"][0]
+    assert payload["last_tool_name"] == "Read"
+    assert payload["last_tool_call"] == "2026-02-20T10:00:00"
+    assert payload["tokens_used"] == 3210
+    assert payload["context_monitor_enabled"] is True
+
+
+def test_codex_app_projection_fields_hidden_when_rollout_disabled():
+    session = _make_session("codx1111", provider="codex-app")
+    sm = _make_sm(session)
+    sm.is_codex_rollout_enabled = MagicMock(return_value=False)
+    sm.get_codex_latest_activity_action = MagicMock(return_value={
+        "summary_text": "Completed command",
+        "ended_at": "2026-02-20T10:12:00",
+    })
+
+    app = create_app(session_manager=sm)
+    client = TestClient(app)
+
+    payload = client.get(f"/sessions/{session.id}").json()
+    assert payload["last_action_summary"] is None
+    assert payload["last_action_at"] is None
+
+
+def test_codex_app_projection_fields_exposed_when_rollout_enabled():
+    session = _make_session("codx2222", provider="codex-app")
+    sm = _make_sm(session)
+    sm.get_codex_latest_activity_action = MagicMock(return_value={
+        "summary_text": "Completed command",
+        "ended_at": "2026-02-20T10:12:00",
+    })
+
+    app = create_app(session_manager=sm)
+    client = TestClient(app)
+
+    payload = client.get(f"/sessions/{session.id}").json()
+    assert payload["last_action_summary"] == "Completed command"
+    assert payload["last_action_at"] == "2026-02-20T10:12:00"
+
+
+def test_tool_calls_endpoint_reads_pretooluse_rows(tmp_path):
+    session = _make_session("tool1234")
+    sm = _make_sm(session)
+    app = create_app(session_manager=sm)
+
+    db_path = tmp_path / "tool_usage.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE tool_usage (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp TEXT,
+            session_id TEXT,
+            hook_type TEXT,
+            tool_name TEXT
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO tool_usage (timestamp, session_id, hook_type, tool_name) VALUES (?, ?, ?, ?)",
+        ("2026-02-20 10:00:00", session.id, "PreToolUse", "Read"),
+    )
+    conn.execute(
+        "INSERT INTO tool_usage (timestamp, session_id, hook_type, tool_name) VALUES (?, ?, ?, ?)",
+        ("2026-02-20 10:00:01", session.id, "PostToolUse", "Read"),
+    )
+    conn.execute(
+        "INSERT INTO tool_usage (timestamp, session_id, hook_type, tool_name) VALUES (?, ?, ?, ?)",
+        ("2026-02-20 10:00:02", session.id, "PreToolUse", "Write"),
+    )
+    conn.commit()
+    conn.close()
+
+    app.state.tool_logger = SimpleNamespace(db_path=str(db_path))
+    client = TestClient(app)
+
+    payload = client.get(f"/sessions/{session.id}/tool-calls?limit=10").json()
+    names = [row["tool_name"] for row in payload["tool_calls"]]
+    assert names == ["Write", "Read"]
+
+
+def test_hook_tool_use_updates_last_tool_fields():
+    session = _make_session("hook1234")
+    sm = _make_sm(session)
+
+    app = create_app(session_manager=sm)
+    client = TestClient(app)
+
+    response = client.post(
+        "/hooks/tool-use",
+        json={
+            "session_manager_id": session.id,
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Read",
+            "tool_input": {"file_path": "README.md"},
+            "cwd": "/tmp/test",
+        },
+    )
+
+    assert response.status_code == 200
+    assert session.last_tool_name == "Read"
+    assert session.last_tool_call is not None
+    sm.message_queue_manager.mark_session_active.assert_called_once_with(session.id)
+
+
+def test_capture_output_codex_app_respects_lines(tmp_path):
+    sm = SessionManager(log_dir=str(tmp_path), state_file=str(tmp_path / "state.json"))
+    session = _make_session("codx3333", provider="codex-app")
+    sm.sessions[session.id] = session
+    sm.set_hook_output_store({session.id: "line1\nline2\nline3\n"})
+
+    assert sm.capture_output(session.id, lines=2) == "line2\nline3\n"
+    assert sm.capture_output(session.id, lines=1) == "line3\n"

--- a/tests/unit/test_watch_tui.py
+++ b/tests/unit/test_watch_tui.py
@@ -1,6 +1,18 @@
-"""Unit tests for sm watch row building and filtering (#289)."""
+"""Unit tests for sm watch rows/details (#309)."""
 
-from src.cli.watch_tui import build_watch_rows, can_attach_session, filter_sessions
+from __future__ import annotations
+
+import time
+
+from src.cli.watch_tui import (
+    DetailFetchWorker,
+    DetailSnapshot,
+    _compute_column_widths,
+    _session_line,
+    build_watch_rows,
+    can_attach_session,
+    filter_sessions,
+)
 
 
 def _session(
@@ -12,6 +24,13 @@ def _session(
     role: str | None = None,
     provider: str = "claude",
     activity_state: str = "idle",
+    status: str = "running",
+    last_tool_name: str | None = None,
+    last_tool_call: str | None = None,
+    last_action_summary: str | None = None,
+    last_action_at: str | None = None,
+    context_monitor_enabled: bool = False,
+    tokens_used: int = 0,
 ):
     return {
         "id": session_id,
@@ -22,7 +41,14 @@ def _session(
         "role": role,
         "provider": provider,
         "activity_state": activity_state,
+        "status": status,
         "last_activity": "2026-02-21T23:00:00",
+        "last_tool_name": last_tool_name,
+        "last_tool_call": last_tool_call,
+        "last_action_summary": last_action_summary,
+        "last_action_at": last_action_at,
+        "context_monitor_enabled": context_monitor_enabled,
+        "tokens_used": tokens_used,
         "agent_status_text": None,
     }
 
@@ -52,36 +78,115 @@ def test_build_rows_parent_before_child_with_tree_prefix():
     parent_idx = next(i for i, row in enumerate(session_rows) if row.session_id == "p1")
     child_idx = next(i for i, row in enumerate(session_rows) if row.session_id == "c1")
     assert parent_idx < child_idx
-    assert "|-" in session_rows[parent_idx].text or "`-" in session_rows[parent_idx].text
-    assert "|  " in session_rows[child_idx].text or "   " in session_rows[child_idx].text
+    assert session_rows[parent_idx].columns["Session"].startswith(("|-", "`-"))
+    assert "[c1]" in session_rows[child_idx].columns["Session"]
 
 
-def test_unparented_sessions_are_roots():
+def test_main_columns_include_provider_status_and_last():
+    rows, _, _ = build_watch_rows(
+        [
+            _session(
+                "s1",
+                "agent",
+                "/tmp/repo",
+                provider="claude",
+                status="running",
+                last_tool_name="Read",
+                last_tool_call="2026-02-21T22:59:00",
+            )
+        ]
+    )
+    session_row = next(row for row in rows if row.kind == "session")
+
+    assert session_row.columns["Provider"] == "claude"
+    assert session_row.columns["Status"] == "running"
+    assert "Read" in session_row.columns["Last"]
+
+
+def test_session_line_truncates_deterministically():
+    rows, _, _ = build_watch_rows(
+        [
+            _session(
+                "s1",
+                "very-long-session-name-that-should-truncate",
+                "/tmp/repo",
+                last_tool_name="AReallyLongToolNameThatShouldTruncate",
+                last_tool_call="2026-02-21T22:59:00",
+            )
+        ]
+    )
+    session_row = next(row for row in rows if row.kind == "session")
+
+    widths = _compute_column_widths(50)
+    rendered = _session_line(session_row, widths)
+    assert len(rendered) >= 20
+    assert "..." in rendered
+
+
+def test_tab_expansion_renders_details_for_selected_session():
+    session = _session(
+        "s1",
+        "agent",
+        "/tmp/repo",
+        context_monitor_enabled=True,
+        tokens_used=1234,
+    )
+    detail = DetailSnapshot(
+        action_lines=["Read (5s)", "Write (3s)"],
+        tail_lines=["line one", "line two"],
+        fetched_at=time.monotonic(),
+        loading=False,
+    )
+
+    rows, _, _ = build_watch_rows(
+        [session],
+        expanded_session_ids={"s1"},
+        detail_cache={"s1": detail},
+    )
+
+    detail_rows = [row.text for row in rows if row.kind == "detail"]
+    assert any("context size: 1,234 tokens" in line for line in detail_rows)
+    assert any("Read (5s)" in line for line in detail_rows)
+    assert any("line one" in line for line in detail_rows)
+
+
+def test_multi_expanded_sessions_render_independent_details():
     sessions = [
-        _session("r1", "root-1", "/tmp/repo"),
-        _session("r2", "root-2", "/tmp/repo", parent_session_id="missing-parent"),
+        _session("s1", "agent-1", "/tmp/repo", context_monitor_enabled=True, tokens_used=10),
+        _session("s2", "agent-2", "/tmp/repo", context_monitor_enabled=True, tokens_used=20),
     ]
-    rows, selectable, _ = build_watch_rows(sessions)
+    rows, _, _ = build_watch_rows(
+        sessions,
+        expanded_session_ids={"s1", "s2"},
+        detail_cache={
+            "s1": DetailSnapshot(["A1"], ["T1"], time.monotonic()),
+            "s2": DetailSnapshot(["A2"], ["T2"], time.monotonic()),
+        },
+    )
 
-    session_rows = [row for row in rows if row.kind == "session"]
-    assert len(session_rows) == 2
-    assert selectable == ["r1", "r2"]
+    details_s1 = [row.text for row in rows if row.kind == "detail" and row.session_id == "s1"]
+    details_s2 = [row.text for row in rows if row.kind == "detail" and row.session_id == "s2"]
+    assert any("A1" in line for line in details_s1)
+    assert any("A2" in line for line in details_s2)
 
 
-def test_build_rows_does_not_merge_same_basename_paths():
-    sessions = [
-        _session("a1", "alpha", "/tmp/a/repo"),
-        _session("b1", "beta", "/tmp/b/repo"),
-    ]
-    rows, selectable, repo_count = build_watch_rows(sessions)
+def test_codex_app_last_column_respects_projection_gate():
+    session = _session(
+        "app1",
+        "codex-app",
+        "/tmp/repo",
+        provider="codex-app",
+        last_action_summary="Completed command",
+        last_action_at="2026-02-21T22:59:00",
+    )
 
-    repo_rows = [row.text for row in rows if row.kind == "repo"]
-    assert repo_count == 2
-    assert len(repo_rows) == 2
-    assert repo_rows[0] != repo_rows[1]
-    assert all(row.startswith("repo/") for row in repo_rows)
-    assert all("(" in row and ")" in row for row in repo_rows)
-    assert selectable == ["a1", "b1"]
+    rows_enabled, _, _ = build_watch_rows([session], codex_projection_enabled=True)
+    row_enabled = next(row for row in rows_enabled if row.kind == "session")
+    assert "Completed command" in row_enabled.columns["Last"]
+
+    rows_disabled, _, _ = build_watch_rows([session], codex_projection_enabled=False)
+    row_disabled = next(row for row in rows_disabled if row.kind == "session")
+    assert row_disabled.columns["Last"] == "n/a (projection disabled)"
 
 
 def test_filter_by_role():
@@ -106,3 +211,41 @@ def test_filter_by_repo_prefix():
 def test_codex_app_rows_are_not_attachable():
     session = _session("app1", "codex-app", "/tmp/repo", provider="codex-app")
     assert can_attach_session(session) is False
+
+
+class _SlowClient:
+    def get_tool_calls(self, session_id: str, limit: int = 10, timeout: int | None = None):
+        time.sleep(0.2)
+        return {"tool_calls": [{"tool_name": "Read", "timestamp": "2026-02-21T22:59:00"}]}
+
+    def get_output(self, session_id: str, lines: int = 10, timeout: int | None = None):
+        time.sleep(0.2)
+        return {"output": "one\ntwo\n"}
+
+    def get_activity_actions(self, session_id: str, limit: int = 10):
+        return {"actions": []}
+
+
+def test_detail_worker_does_not_block_request_path():
+    worker = DetailFetchWorker(client=_SlowClient(), codex_projection_enabled=True)
+    session = _session("s1", "agent", "/tmp/repo")
+
+    started = time.monotonic()
+    worker.request(session)
+    elapsed = time.monotonic() - started
+    assert elapsed < 0.05
+
+    deadline = time.monotonic() + 2.0
+    snapshot = None
+    while time.monotonic() < deadline:
+        snapshot = worker.get("s1")
+        if snapshot and not snapshot.loading:
+            break
+        time.sleep(0.05)
+
+    worker.stop()
+
+    assert snapshot is not None
+    assert snapshot.loading is False
+    assert any("Read" in line for line in snapshot.action_lines)
+    assert any("one" in line for line in snapshot.tail_lines)


### PR DESCRIPTION
## Summary
- enforce `sm watch` as operator-only from both CLI dispatch points
- upgrade watch TUI to a true columnar dashboard with header, alignment, activity/status color semantics, and operator kill support
- add `Tab` inline detail mode with non-blocking background fetch for tool/action history and output tail
- add `n` rename support for selected session
- extend session/watch data payloads (`last_tool_name`, `last_tool_call`, codex projection summary/timestamp, tokens/context-monitor fields)
- add `/sessions/{id}/tool-calls` API and corresponding client helpers
- make codex-app `capture_output(lines=...)` return a true tail

## Testing
- `./venv/bin/python -m pytest tests/unit -q`

Fixes #309
