### PR TITLE
Improve sm watch status/completion visibility and brightness

### DIFF
--- a/src/models.py
+++ b/src/models.py
@@ -236,6 +236,7 @@ class Session:
     # sm remind: self-reported status (#188)
     agent_status_text: Optional[str] = None  # Last sm status "<text>" from agent
     agent_status_at: Optional[datetime] = None  # When agent_status_text was last set
+    agent_task_completed_at: Optional[datetime] = None  # Last sm task-complete timestamp
 
     def __post_init__(self):
         if not self.name:
@@ -297,6 +298,7 @@ class Session:
             # sm remind fields (#188)
             "agent_status_text": self.agent_status_text,
             "agent_status_at": self.agent_status_at.isoformat() if self.agent_status_at else None,
+            "agent_task_completed_at": self.agent_task_completed_at.isoformat() if self.agent_task_completed_at else None,
             # EM role flag (#256)
             "is_em": self.is_em,
             # Role tag (#287)
@@ -375,6 +377,7 @@ class Session:
             # sm remind fields (#188)
             agent_status_text=data.get("agent_status_text"),
             agent_status_at=datetime.fromisoformat(data["agent_status_at"]) if data.get("agent_status_at") else None,
+            agent_task_completed_at=datetime.fromisoformat(data["agent_task_completed_at"]) if data.get("agent_task_completed_at") else None,
             # EM role flag (#256)
             is_em=data.get("is_em", False),
             # Role tag (#287): backward compat infers em role from legacy is_em

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -92,6 +92,7 @@ class TestSessionEndpoints:
         mock_session_manager.get_activity_state.return_value = "working"
         sample_session.agent_status_text = "running tests"
         sample_session.agent_status_at = datetime(2024, 1, 15, 11, 5, 0)
+        sample_session.agent_task_completed_at = datetime(2024, 1, 15, 11, 9, 0)
 
         response = test_client.get("/sessions")
         assert response.status_code == 200
@@ -104,6 +105,7 @@ class TestSessionEndpoints:
         assert data["sessions"][0]["activity_state"] == "working"
         assert data["sessions"][0]["agent_status_text"] == "running tests"
         assert data["sessions"][0]["agent_status_at"] == "2024-01-15T11:05:00"
+        assert data["sessions"][0]["agent_task_completed_at"] == "2024-01-15T11:09:00"
 
     def test_list_sessions_empty(self, test_client, mock_session_manager):
         """GET /sessions returns empty list when no sessions."""
@@ -121,6 +123,7 @@ class TestSessionEndpoints:
         mock_session_manager.get_activity_state.return_value = "thinking"
         sample_session.agent_status_text = "reviewing logs"
         sample_session.agent_status_at = datetime(2024, 1, 15, 11, 7, 0)
+        sample_session.agent_task_completed_at = datetime(2024, 1, 15, 11, 10, 0)
 
         response = test_client.get("/sessions/test123")
         assert response.status_code == 200
@@ -133,6 +136,7 @@ class TestSessionEndpoints:
         assert data["activity_state"] == "thinking"
         assert data["agent_status_text"] == "reviewing logs"
         assert data["agent_status_at"] == "2024-01-15T11:07:00"
+        assert data["agent_task_completed_at"] == "2024-01-15T11:10:00"
 
     def test_get_session_not_found(self, test_client, mock_session_manager):
         """GET /sessions/{id} returns 404 for unknown session."""

--- a/tests/unit/test_task_complete.py
+++ b/tests/unit/test_task_complete.py
@@ -82,6 +82,8 @@ class TestTaskCompleteCancelsRemind:
         assert resp.status_code == 200
         data = resp.json()
         assert data["status"] == "completed"
+        assert data.get("agent_task_completed_at")
+        assert mq.session_manager.get_session("abc12345").agent_task_completed_at is not None
 
         # remind should be cancelled
         assert "abc12345" not in mq._remind_registrations


### PR DESCRIPTION
## Summary
- add `agent_task_completed_at` session field and expose it via `/sessions` and `/sessions/{id}` responses
- persist self-reported completion timestamp in `POST /sessions/{id}/task-complete`
- clear self-reported status/completion metadata on cache invalidation, clear, and `context_reset`
- improve `sm watch` readability by removing dim defaults for idle/status/detail lines
- show richer watch rows:
  - `status: "<text>" (<age>)`
  - `task: completed (<age>)`

## Tests
- `./venv/bin/pytest tests/unit/test_watch_tui.py tests/unit/test_task_complete.py tests/regression/test_issue_283_agent_status_cleared_on_clear.py tests/integration/test_api_endpoints.py`
- `./venv/bin/pytest tests/regression/test_issue_182_stop_hook_suppression.py tests/regression/test_issue_174_skip_count_race.py`
- `./venv/bin/pytest tests/unit/test_models.py tests/unit/test_remind.py`

Fixes #312
