### PR TITLE
Follow-up: indent sm watch status rows under owning agent

### DIFF
--- a/src/cli/watch_tui.py
+++ b/src/cli/watch_tui.py
@@ -473,6 +473,7 @@ def build_watch_rows(
             for ancestor_is_last in ancestors_last:
                 prefix_parts.append("   " if ancestor_is_last else "|  ")
             tree_prefix = "".join(prefix_parts) + connector
+            status_prefix = "".join(prefix_parts) + "  "
 
             role = session.get("role") or "-"
             provider = session.get("provider", "claude")
@@ -503,11 +504,23 @@ def build_watch_rows(
 
             status_line = _status_line(session)
             if status_line:
-                rows.append(WatchRow(kind="status", text=status_line, session_id=session_id))
+                rows.append(
+                    WatchRow(
+                        kind="status",
+                        text=f"{status_prefix}{status_line}",
+                        session_id=session_id,
+                    )
+                )
 
             task_line = _task_completion_line(session)
             if task_line:
-                rows.append(WatchRow(kind="status", text=task_line, session_id=session_id))
+                rows.append(
+                    WatchRow(
+                        kind="status",
+                        text=f"{status_prefix}{task_line}",
+                        session_id=session_id,
+                    )
+                )
 
             if session_id and session_id in expanded:
                 detail = detail_cache.get(session_id) if detail_cache else None

--- a/tests/unit/test_watch_tui.py
+++ b/tests/unit/test_watch_tui.py
@@ -140,6 +140,33 @@ def test_task_completed_row_shows_age():
     assert any("task: completed (" in row.text for row in status_rows)
 
 
+def test_status_rows_follow_tree_indentation():
+    rows, _, _ = build_watch_rows(
+        [
+            _session(
+                "p1",
+                "parent",
+                "/tmp/repo",
+                agent_status_text="parent status",
+                agent_status_at="2026-02-21T22:59:00",
+            ),
+            _session(
+                "c1",
+                "child",
+                "/tmp/repo",
+                parent_session_id="p1",
+                agent_status_text="child status",
+                agent_status_at="2026-02-21T22:58:00",
+            ),
+        ]
+    )
+
+    parent_status = next(row for row in rows if row.kind == "status" and "parent status" in row.text)
+    child_status = next(row for row in rows if row.kind == "status" and "child status" in row.text)
+    assert parent_status.text.startswith("  status:")
+    assert child_status.text.startswith("     status:")
+
+
 def test_session_line_truncates_deterministically():
     rows, _, _ = build_watch_rows(
         [


### PR DESCRIPTION
## Summary
Follow-up to #313: make `sm watch` status/task sub-rows tree-depth aware so they visually nest under the owning agent row.

### Changes
- compute a per-node `status_prefix` from tree ancestry in `build_watch_rows`
- apply that prefix to both:
  - `status: "..." (<age>)`
  - `task: completed (<age>)`
- add unit test that verifies parent and child status rows have distinct indentation depth

## Test
- `./venv/bin/pytest tests/unit/test_watch_tui.py`
