### PR TITLE
Batch pending changes: codex-2 command + concise [sm info] worktree prompt

### DIFF
--- a/.claude/workspace.lock
+++ b/.claude/workspace.lock
@@ -1,4 +1,0 @@
-session=33194522
-task=auto-acquired
-branch=feature/140-codex-app-review
-started=2026-02-14T23:02:49.979323

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -1715,6 +1715,53 @@ def cmd_new(client: SessionManagerClient, working_dir: Optional[str] = None, pro
         return 1
 
 
+def cmd_codex_2(client: SessionManagerClient, working_dir: Optional[str] = None) -> int:
+    """
+    Create a new codex-fork session and immediately attach via attach-descriptor flow.
+
+    Args:
+        client: API client
+        working_dir: Working directory (optional, defaults to $PWD)
+
+    Exit codes:
+        0: Successfully created and attached
+        1: Failed to create session or attach
+        2: Session manager unavailable
+    """
+    import os
+    from pathlib import Path
+
+    if working_dir is None:
+        working_dir = os.getcwd()
+
+    try:
+        path = Path(working_dir).expanduser().resolve()
+        if not path.exists():
+            print(f"Error: Directory does not exist: {working_dir}", file=sys.stderr)
+            return 1
+        if not path.is_dir():
+            print(f"Error: Not a directory: {working_dir}", file=sys.stderr)
+            return 1
+        working_dir = str(path)
+    except Exception as e:
+        print(f"Error: Invalid path: {e}", file=sys.stderr)
+        return 1
+
+    print(f"Creating codex-fork session in {working_dir}...")
+    session = client.create_session(working_dir, provider="codex-fork")
+    if session is None:
+        print("Error: Session manager unavailable", file=sys.stderr)
+        return 2
+
+    session_id = session.get("id")
+    if not session_id:
+        print("Error: Failed to create codex-fork session", file=sys.stderr)
+        return 1
+
+    print(f"Session created: {session_id}")
+    return cmd_attach(client, session_id)
+
+
 def cmd_attach(client: SessionManagerClient, identifier: Optional[str] = None) -> int:
     """
     Attach to an existing Claude Code session.

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -243,6 +243,17 @@ def main():
         help="Working directory (defaults to current directory)"
     )
 
+    # sm codex-2 [working_dir]
+    parser_codex_2 = subparsers.add_parser(
+        "codex-2",
+        help="Create a new Codex-fork session and attach via sm attach flow"
+    )
+    parser_codex_2.add_argument(
+        "working_dir",
+        nargs="?",
+        help="Working directory (defaults to current directory)"
+    )
+
     # sm codex-app [working_dir]
     parser_codex_app = subparsers.add_parser(
         "codex-app",
@@ -489,7 +500,7 @@ def main():
     no_session_needed = [
         "lock", "unlock", "subagent-start", "subagent-stop", "all", "send", "wait", "what",
         "subagents", "children", "kill", "new", "claude", "codex", "codex-fork", "codex_fork",
-        "codex-app", "codex-server",
+        "codex-2", "codex-app", "codex-server",
         "attach", "output", "codex-tui", "codex-fork-info", "codex-rollout-gates", "watch", "tail", "clear", "review", "context-monitor", "remind", "setup", None
     ]
     # Commands that require session_id: spawn (needs to set parent_session_id)
@@ -580,7 +591,8 @@ def main():
     elif args.command == "wait":
         sys.exit(commands.cmd_wait(client, args.session_id, args.seconds))
     elif args.command == "spawn":
-        sys.exit(commands.cmd_spawn(client, session_id, args.provider, args.prompt, args.name, args.wait, args.model, args.working_dir, args.json))
+        provider = "codex-fork" if args.provider == "codex" else args.provider
+        sys.exit(commands.cmd_spawn(client, session_id, provider, args.prompt, args.name, args.wait, args.model, args.working_dir, args.json))
     elif args.command == "children":
         # Use current session if not specified
         parent_id = args.session_id if args.session_id else session_id
@@ -595,6 +607,8 @@ def main():
         sys.exit(commands.cmd_new(client, args.working_dir, provider="codex"))
     elif args.command in ("codex-fork", "codex_fork"):
         sys.exit(commands.cmd_new(client, args.working_dir, provider="codex-fork"))
+    elif args.command == "codex-2":
+        sys.exit(commands.cmd_codex_2(client, args.working_dir))
     elif args.command == "codex-app":
         sys.exit(commands.cmd_new(client, args.working_dir, provider="codex-app"))
     elif args.command == "codex-server":

--- a/src/server.py
+++ b/src/server.py
@@ -2273,16 +2273,10 @@ Provide ONLY the summary, no preamble or questions."""
 
                     # Inject cleanup prompt if needed
                     if cleanup_needed:
-                        paths_str = "\n".join(f"  - {p}" for p, _ in cleanup_needed)
-                        cleanup_prompt = f"""You have uncommitted changes in worktree(s):
-{paths_str}
-
-Please choose:
-1. Push to branch and create PR: git push -u origin HEAD && gh pr create
-2. Push branch only: git push -u origin HEAD
-3. Abandon changes: git worktree remove <path>
-
-Or continue working if not done yet."""
+                        cleanup_prompt = (
+                            "[sm info] Uncommitted changes in this worktree. "
+                            "If work has completed, consider checking in."
+                        )
 
                         # Send cleanup prompt to session
                         await app.state.session_manager.send_input(

--- a/tests/regression/test_issue_51_auto_lock_worktree.py
+++ b/tests/regression/test_issue_51_auto_lock_worktree.py
@@ -417,8 +417,8 @@ class TestStopHookCleanup:
                     # Should have sent cleanup prompt
                     mock_send.assert_called_once()
                     call_args = mock_send.call_args
-                    assert "uncommitted changes" in call_args[0][1]
-                    assert "git push" in call_args[0][1]
+                    assert call_args[0][1].startswith("[sm info]")
+                    assert "uncommitted changes in this worktree" in call_args[0][1].lower()
                     assert call_args[1]["delivery_mode"] == "important"
 
     def test_stop_hook_does_not_repeat_cleanup_prompt_for_same_changes(self, test_client, session_manager, tmp_path):


### PR DESCRIPTION
## Summary
- add `sm codex-2` command that creates a `codex-fork` session and attaches immediately
- route `sm spawn --provider codex` through `codex-fork`
- shorten dirty-worktree stop-hook notification and prefix with `[sm info]`
- update regression assertion for the new cleanup prompt text
- include pending tracked deletion of `.claude/workspace.lock`

## Validation
- `pytest -q tests/regression/test_issue_51_auto_lock_worktree.py`
