### PR TITLE
Disable notify-on-stop for self sm sends

### DIFF
--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -1062,6 +1062,10 @@ def cmd_send(
     # Get sender session ID from environment (if available)
     sender_session_id = client.session_id  # Set from CLAUDE_SESSION_MANAGER_ID in __init__
 
+    # Self-sends are commonly used as delayed wakeups; do not advertise or request
+    # stop-notify because it would wake the same agent on its next stop hook.
+    effective_notify_on_stop = notify_on_stop and sender_session_id != session_id
+
     # Use wait_seconds if provided, otherwise use notify_after_seconds
     effective_notify_after = wait_seconds if wait_seconds is not None else notify_after_seconds
 
@@ -1075,7 +1079,7 @@ def cmd_send(
         timeout_seconds=timeout_seconds,
         notify_on_delivery=notify_on_delivery,
         notify_after_seconds=effective_notify_after,
-        notify_on_stop=notify_on_stop,
+        notify_on_stop=effective_notify_on_stop,
         remind_soft_threshold=remind_soft_threshold,
         remind_hard_threshold=remind_hard_threshold,
         parent_session_id=parent_session_id,
@@ -1106,7 +1110,7 @@ def cmd_send(
         extras.append("notify-on-delivery")
     if effective_notify_after:
         extras.append(f"wait={effective_notify_after}s")
-    if notify_on_stop:
+    if effective_notify_on_stop:
         extras.append("notify-on-stop")
     if remind_soft_threshold:
         extras.append(f"remind={remind_soft_threshold}s soft"

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -1390,6 +1390,11 @@ class SessionManager:
         else:
             formatted_text = text
 
+        # Self-sends must never arm stop-notify: they are used for deferred wakeups
+        # and should not immediately wake the same agent on its next stop hook.
+        if notify_on_stop and sender_session_id == session_id:
+            notify_on_stop = False
+
         # Directional notify-on-stop (#256): only EM→agent sends should enroll recipient.
         # Fail-closed: unknown sender treated as non-EM.
         if notify_on_stop and sender_session_id:

--- a/tests/unit/test_directional_notify_on_stop.py
+++ b/tests/unit/test_directional_notify_on_stop.py
@@ -58,6 +58,24 @@ class TestDirectionalNotifyOnStop:
     """Tests for the is_em guard in session_manager.send_input()."""
 
     @pytest.mark.asyncio
+    async def test_em_self_send_suppresses_notify_on_stop(self):
+        """Self-sends must never arm stop-notify, even when the sender is EM."""
+        em = _make_session("em01", is_em=True)
+        sm = _make_session_manager({"em01": em})
+
+        with patch("asyncio.create_task", noop_create_task):
+            await sm.send_input(
+                session_id="em01",
+                text="wake me later",
+                sender_session_id="em01",
+                delivery_mode="sequential",
+                notify_on_stop=True,
+            )
+
+        call_kwargs = sm.message_queue_manager.queue_message.call_args[1]
+        assert call_kwargs["notify_on_stop"] is False
+
+    @pytest.mark.asyncio
     async def test_em_sender_preserves_notify_on_stop(self):
         """EM sender (is_em=True) → notify_on_stop=True preserved (queue called with True)."""
         em = _make_session("em01", is_em=True)

--- a/tests/unit/test_dispatch.py
+++ b/tests/unit/test_dispatch.py
@@ -727,6 +727,19 @@ class TestCmdSendRemindParams:
         assert call_kwargs["remind_soft_threshold"] is None
         assert call_kwargs["remind_hard_threshold"] is None
 
+    def test_self_send_suppresses_notify_on_stop(self, capsys):
+        """Self-send must not request or print notify-on-stop."""
+        from src.cli.commands import cmd_send
+        mock_client = self._make_client()
+        mock_client.session_id = "sess1"
+
+        cmd_send(mock_client, "sess1", "hello")
+
+        call_kwargs = mock_client.send_input.call_args[1]
+        assert call_kwargs["notify_on_stop"] is False
+        captured = capsys.readouterr()
+        assert "notify-on-stop" not in captured.out
+
 
 # ---------------------------------------------------------------------------
 # sm setup tests (sm#225-D)


### PR DESCRIPTION
Fixes #343

## Summary
- suppress `notify_on_stop` when `sm send` targets the current session
- enforce the guard server-side in `SessionManager.send_input()`
- mirror the effective behavior in `cmd_send()` so CLI output does not advertise a disabled stop-notify

## Testing
- `pytest tests/unit/test_directional_notify_on_stop.py -q`
- `pytest tests/unit/test_dispatch.py -q`