### PR TITLE
Sweep stale Telegram topics by tmux liveness

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -114,6 +114,9 @@ telegram:
   # allowed_chat_ids:
   #   - 123456789
   #   - 987654321
+  topic_cleanup:
+    enabled: false
+    interval_seconds: 900
 
 email:
   # Paths to email harness config files

--- a/src/main.py
+++ b/src/main.py
@@ -164,6 +164,12 @@ class SessionManagerApp:
             )
             self._setup_telegram_handlers()
             self._setup_topic_creator()
+        topic_cleanup_config = telegram_config.get("topic_cleanup", {})
+        self.telegram_topic_cleanup_enabled = bool(topic_cleanup_config.get("enabled", False))
+        self.telegram_topic_cleanup_interval_seconds = max(
+            60, int(topic_cleanup_config.get("interval_seconds", 900))
+        )
+        self._telegram_topic_cleanup_task: Optional[asyncio.Task] = None
 
         # Notifier
         self.notifier = Notifier(
@@ -428,6 +434,73 @@ class SessionManagerApp:
             if session.telegram_chat_id and not session.telegram_thread_id:
                 await self.session_manager._ensure_telegram_topic(session)
 
+    async def _cleanup_stale_telegram_topics_once(self) -> dict[str, int]:
+        """Delete Telegram topics for non-EM sessions whose tmux runtime is gone."""
+        if not self.telegram_bot or not self.telegram_topic_cleanup_enabled:
+            return {"deleted": 0, "skipped": 0}
+
+        default_chat_id = self.session_manager.default_forum_chat_id
+        if not default_chat_id:
+            return {"deleted": 0, "skipped": 0}
+
+        deleted = 0
+        skipped = 0
+        changed = False
+
+        for session in list(self.session_manager.sessions.values()):
+            if session.is_em or not session.telegram_thread_id or session.telegram_chat_id != default_chat_id:
+                skipped += 1
+                continue
+
+            if not session.tmux_session:
+                skipped += 1
+                continue
+
+            if self.session_manager.tmux.session_exists(session.tmux_session):
+                skipped += 1
+                continue
+
+            thread_id = session.telegram_thread_id
+            if await self.telegram_bot.delete_forum_topic(session.telegram_chat_id, thread_id):
+                session.telegram_thread_id = None
+                deleted += 1
+                changed = True
+                logger.info(
+                    "Deleted stale Telegram topic for session %s because tmux runtime %s no longer exists",
+                    session.id,
+                    session.tmux_session,
+                )
+            else:
+                skipped += 1
+
+        if changed:
+            self.session_manager._save_state()
+        return {"deleted": deleted, "skipped": skipped}
+
+    async def _run_telegram_topic_cleanup_loop(self):
+        """Periodically delete stale Telegram topics for inactive sessions."""
+        try:
+            await self._cleanup_stale_telegram_topics_once()
+            while True:
+                await asyncio.sleep(self.telegram_topic_cleanup_interval_seconds)
+                await self._cleanup_stale_telegram_topics_once()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("Telegram topic cleanup loop failed")
+
+    def _start_telegram_topic_cleanup_task(self):
+        """Start the periodic Telegram topic cleanup loop if enabled."""
+        if (
+            not self.telegram_bot
+            or not self.telegram_topic_cleanup_enabled
+            or self._telegram_topic_cleanup_task is not None
+        ):
+            return
+        self._telegram_topic_cleanup_task = asyncio.create_task(
+            self._run_telegram_topic_cleanup_loop()
+        )
+
     async def _post_bind_startup(self):
         """Run side-effect-bearing startup work after uvicorn binds the port.
 
@@ -437,6 +510,7 @@ class SessionManagerApp:
         # Reconcile Telegram topics
         if self.telegram_bot:
             await self._reconcile_telegram_topics()
+            self._start_telegram_topic_cleanup_task()
 
         # Restore monitoring for existing sessions
         await self._restore_monitoring()
@@ -536,6 +610,14 @@ class SessionManagerApp:
 
         # Stop SessionManager background maintenance
         await self.session_manager.stop_background_tasks()
+
+        if self._telegram_topic_cleanup_task:
+            self._telegram_topic_cleanup_task.cancel()
+            try:
+                await self._telegram_topic_cleanup_task
+            except asyncio.CancelledError:
+                pass
+            self._telegram_topic_cleanup_task = None
 
         # Stop Telegram bot
         if self.telegram_bot:

--- a/tests/unit/test_telegram_topic_cleanup.py
+++ b/tests/unit/test_telegram_topic_cleanup.py
@@ -1,0 +1,96 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from src.main import SessionManagerApp
+from src.models import Session, SessionStatus
+
+
+def _make_session(
+    session_id: str,
+    *,
+    chat_id: int = -1003506774897,
+    thread_id: int | None = 12345,
+    is_em: bool = False,
+    tmux_session: str | None = None,
+) -> Session:
+    session = Session(
+        id=session_id,
+        name=f"claude-{session_id}",
+        working_dir="/tmp",
+        tmux_session=tmux_session or f"claude-{session_id}",
+        log_file=f"/tmp/{session_id}.log",
+        status=SessionStatus.IDLE,
+        telegram_chat_id=chat_id,
+        telegram_thread_id=thread_id,
+        is_em=is_em,
+    )
+    return session
+
+
+def _make_app(
+    sessions: dict[str, Session],
+    *,
+    live_tmux_sessions: set[str] | None = None,
+    delete_ok: bool = True,
+) -> SessionManagerApp:
+    app = SessionManagerApp.__new__(SessionManagerApp)
+    app.telegram_bot = SimpleNamespace(delete_forum_topic=AsyncMock(return_value=delete_ok))
+    app.telegram_topic_cleanup_enabled = True
+    app.telegram_topic_cleanup_interval_seconds = 900
+    app._telegram_topic_cleanup_task = None
+    live_tmux_sessions = live_tmux_sessions or set()
+    app.session_manager = SimpleNamespace(
+        default_forum_chat_id=-1003506774897,
+        sessions=sessions,
+        _save_state=Mock(),
+        tmux=SimpleNamespace(session_exists=lambda tmux_name: tmux_name in live_tmux_sessions),
+    )
+    return app
+
+
+@pytest.mark.asyncio
+async def test_cleanup_deletes_topics_when_tmux_runtime_is_gone():
+    stale_idle = _make_session("idle1", tmux_session="claude-idle1")
+    stale_stopped = _make_session("stop1", tmux_session="claude-stop1")
+    app = _make_app({"idle1": stale_idle, "stop1": stale_stopped})
+
+    result = await app._cleanup_stale_telegram_topics_once()
+
+    assert result == {"deleted": 2, "skipped": 0}
+    assert stale_idle.telegram_thread_id is None
+    assert stale_stopped.telegram_thread_id is None
+    assert app.telegram_bot.delete_forum_topic.await_count == 2
+    app.session_manager._save_state.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_skips_em_live_tmux_non_forum_and_missing_thread():
+    sessions = {
+        "em1": _make_session("em1", is_em=True, tmux_session="claude-em1"),
+        "live1": _make_session("live1", tmux_session="claude-live1"),
+        "otherchat1": _make_session("otherchat1", chat_id=1234, tmux_session="claude-otherchat1"),
+        "nothread1": _make_session("nothread1", thread_id=None, tmux_session="claude-nothread1"),
+        "notmux1": _make_session("notmux1", tmux_session=None),
+    }
+    sessions["notmux1"].tmux_session = None
+    app = _make_app(sessions, live_tmux_sessions={"claude-live1"})
+
+    result = await app._cleanup_stale_telegram_topics_once()
+
+    assert result == {"deleted": 0, "skipped": 5}
+    app.telegram_bot.delete_forum_topic.assert_not_awaited()
+    app.session_manager._save_state.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_leaves_session_mapped_when_delete_fails():
+    stale_idle = _make_session("idle1", tmux_session="claude-idle1")
+    app = _make_app({"idle1": stale_idle}, delete_ok=False)
+
+    result = await app._cleanup_stale_telegram_topics_once()
+
+    assert result == {"deleted": 0, "skipped": 1}
+    assert stale_idle.telegram_thread_id == 12345
+    app.session_manager._save_state.assert_not_called()


### PR DESCRIPTION
## Summary
- add a periodic Telegram topic sweeper in SessionManagerApp
- treat topics as stale when their session no longer has a live tmux runtime
- cover the sweep rules with focused unit tests

## Testing
- `pytest tests/unit/test_telegram_topic_cleanup.py -q`
- `pytest tests/regression/test_issue_271_telegram_thread_cleanup.py -q`

## Follow-up
- Durable topic/session ID tracking is filed separately in #345.