### PR TITLE
Fix codex spawn launch submission

### DIFF
--- a/src/tmux_controller.py
+++ b/src/tmux_controller.py
@@ -346,11 +346,17 @@ class TmuxController:
                 cmd_parts.append("--")
                 cmd_parts.append(shlex.quote(initial_prompt))
 
-            # Start Claude Code in the session
+            launch_command = " ".join(cmd_parts)
             self._run_tmux(
                 "send-keys",
                 "-t", session_name,
-                " ".join(cmd_parts),
+                "--",
+                launch_command,
+            )
+            time.sleep(self._compute_settle_delay_seconds(launch_command))
+            self._run_tmux(
+                "send-keys",
+                "-t", session_name,
                 "Enter",
             )
 

--- a/tests/regression/test_issue_348_codex_spawn_enter.py
+++ b/tests/regression/test_issue_348_codex_spawn_enter.py
@@ -1,0 +1,82 @@
+"""Regression tests for issue #348: codex spawn launcher must actually press Enter."""
+
+from unittest.mock import patch
+
+from src.tmux_controller import TmuxController
+
+
+def test_create_session_with_command_sends_launch_and_enter_separately(tmp_path):
+    controller = TmuxController(log_dir=str(tmp_path))
+    run_calls = []
+    sleep_calls = []
+
+    def mock_run_tmux(*args, **kwargs):
+        run_calls.append((args, kwargs))
+        return None
+
+    with patch.object(controller, "session_exists", return_value=False), \
+         patch.object(controller, "_run_tmux", side_effect=mock_run_tmux), \
+         patch("time.sleep", side_effect=lambda secs: sleep_calls.append(secs)):
+        ok = controller.create_session_with_command(
+            session_name="codex-test",
+            working_dir=str(tmp_path),
+            log_file=str(tmp_path / "codex-test.log"),
+            session_id="sess348",
+            command="codex",
+            args=["--dangerously-bypass-approvals-and-sandbox"],
+            initial_prompt="launch codex safely",
+        )
+
+    assert ok is True
+    launch_call = next(
+        call for call in run_calls
+        if call[0][:4] == ("send-keys", "-t", "codex-test", "--")
+    )
+    assert launch_call[0][4] == "codex --dangerously-bypass-approvals-and-sandbox -- 'launch codex safely'"
+    enter_call = next(
+        call for call in run_calls
+        if call[0] == ("send-keys", "-t", "codex-test", "Enter")
+    )
+    launch_index = run_calls.index(launch_call)
+    enter_index = run_calls.index(enter_call)
+    assert enter_index > launch_index
+    assert sleep_calls[0] == controller.shell_export_settle_seconds
+    assert sleep_calls[1] == controller._compute_settle_delay_seconds(launch_call[0][4])
+
+
+def test_create_session_with_command_without_prompt_keeps_single_enter(tmp_path):
+    controller = TmuxController(log_dir=str(tmp_path))
+    run_calls = []
+    sleep_calls = []
+
+    def mock_run_tmux(*args, **kwargs):
+        run_calls.append((args, kwargs))
+        return None
+
+    with patch.object(controller, "session_exists", return_value=False), \
+         patch.object(controller, "_run_tmux", side_effect=mock_run_tmux), \
+         patch("time.sleep", side_effect=lambda secs: sleep_calls.append(secs)):
+        ok = controller.create_session_with_command(
+            session_name="codex-test",
+            working_dir=str(tmp_path),
+            log_file=str(tmp_path / "codex-test.log"),
+            session_id="sess348",
+            command="codex",
+            args=["--dangerously-bypass-approvals-and-sandbox"],
+            initial_prompt=None,
+        )
+
+    assert ok is True
+    launch_call = next(
+        call for call in run_calls
+        if call[0][:4] == ("send-keys", "-t", "codex-test", "--")
+    )
+    assert launch_call[0][4] == "codex --dangerously-bypass-approvals-and-sandbox"
+    enter_call = next(
+        call for call in run_calls
+        if call[0] == ("send-keys", "-t", "codex-test", "Enter")
+    )
+    assert run_calls.index(enter_call) > run_calls.index(launch_call)
+    assert sleep_calls[0] == controller.shell_export_settle_seconds
+    assert sleep_calls[1] == controller._compute_settle_delay_seconds(launch_call[0][4])
+    assert sleep_calls[2] == controller.claude_init_no_prompt_seconds


### PR DESCRIPTION
## Summary
- launch codex/claude startup commands with separate tmux text and Enter sends
- reuse the existing adaptive settle delay before Enter so long spawn prompts submit reliably
- add a regression test covering the startup launcher path for issue #348

## Testing
- ./venv/bin/pytest tests/regression/test_issue_348_codex_spawn_enter.py -q
- ./venv/bin/pytest tests/regression/test_issue_42_session_creation_consistency.py -q
- ./venv/bin/pytest tests/regression/test_issue_37_blocking_io.py -q

Fixes #348