### PR TITLE
Stop parent wake digests for dead child sessions

### DIFF
--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -1714,6 +1714,14 @@ class MessageQueueManager:
                 if not reg or not reg.is_active:
                     return
 
+                if not self._is_parent_wake_child_alive(child_session_id):
+                    logger.info(
+                        "Parent wake auto-cancelled for dead child=%s before digest dispatch",
+                        child_session_id,
+                    )
+                    self.cancel_parent_wake(child_session_id)
+                    return
+
                 # Assemble and queue digest
                 digest = await self._assemble_parent_wake_digest(child_session_id, reg)
                 self.queue_message(
@@ -1761,6 +1769,21 @@ class MessageQueueManager:
             logger.info(f"Parent wake task cancelled for child={child_session_id}")
         finally:
             self._parent_wake_tasks.pop(child_session_id, None)
+
+    def _is_parent_wake_child_alive(self, child_session_id: str) -> bool:
+        """Return True only while a parent-wake child still has a live runtime."""
+        child_session = self.session_manager.get_session(child_session_id)
+        if not child_session:
+            return False
+
+        if getattr(child_session, "provider", "claude") == "codex-app":
+            return True
+
+        tmux_session = getattr(child_session, "tmux_session", None)
+        if not tmux_session:
+            return False
+
+        return bool(self.session_manager.tmux.session_exists(tmux_session))
 
     async def _assemble_parent_wake_digest(
         self, child_session_id: str, reg: "ParentWakeRegistration"
@@ -1887,6 +1910,18 @@ class MessageQueueManager:
         for row in rows:
             (reg_id, child_session_id, parent_session_id, period_seconds,
              registered_at_str, last_wake_at_str, last_status_at_str, escalated) = row
+
+            if not self._is_parent_wake_child_alive(child_session_id):
+                self._execute(
+                    "UPDATE parent_wake_registrations SET is_active = 0 WHERE child_session_id = ?",
+                    (child_session_id,),
+                )
+                logger.info(
+                    "Skipped recovery for dead parent wake registration %s: child=%s",
+                    reg_id,
+                    child_session_id,
+                )
+                continue
 
             reg = ParentWakeRegistration(
                 id=reg_id,

--- a/tests/unit/test_parent_wake.py
+++ b/tests/unit/test_parent_wake.py
@@ -274,6 +274,9 @@ class TestParentWakeRecovery:
             config={},
             notifier=None,
         )
+        active_child = _make_session("child_r", provider="claude", tmux_session="claude-child_r")
+        mock_session_manager.get_session.return_value = active_child
+        mock_session_manager.tmux.session_exists.return_value = True
         with patch("asyncio.create_task", noop_create_task):
             await mq2._recover_parent_wake_registrations()
 
@@ -307,6 +310,85 @@ class TestParentWakeRecovery:
             await mq2._recover_parent_wake_registrations()
 
         assert "child_x" not in mq2._parent_wake_registrations
+
+    @pytest.mark.asyncio
+    async def test_recovery_cancels_dead_child_registrations(
+        self, mock_session_manager, temp_db_path
+    ):
+        """Recovered parent-wake rows are auto-cancelled when the child runtime is already gone."""
+        mq1 = MessageQueueManager(
+            session_manager=mock_session_manager,
+            db_path=temp_db_path,
+            config={},
+            notifier=None,
+        )
+        with patch("asyncio.create_task", noop_create_task):
+            mq1.register_parent_wake("child_dead", "parent_dead", period_seconds=300)
+
+        dead_child = _make_session("child_dead", provider="claude", tmux_session="claude-child_dead")
+        mock_session_manager.get_session.return_value = dead_child
+        mock_session_manager.tmux.session_exists.return_value = False
+
+        mq2 = MessageQueueManager(
+            session_manager=mock_session_manager,
+            db_path=temp_db_path,
+            config={},
+            notifier=None,
+        )
+        with patch("asyncio.create_task", noop_create_task):
+            await mq2._recover_parent_wake_registrations()
+
+        assert "child_dead" not in mq2._parent_wake_registrations
+
+        conn = sqlite3.connect(temp_db_path)
+        rows = conn.execute(
+            "SELECT is_active FROM parent_wake_registrations WHERE child_session_id = 'child_dead'"
+        ).fetchall()
+        conn.close()
+        assert rows[0][0] == 0
+
+
+class TestParentWakeDeadChildCancellation:
+
+    @pytest.mark.asyncio
+    async def test_parent_wake_task_cancels_missing_child_before_digest(self, mock_session_manager, temp_db_path):
+        """A missing child session stops the periodic wake loop instead of emitting <unknown> digests."""
+        mq = MessageQueueManager(
+            session_manager=mock_session_manager,
+            db_path=temp_db_path,
+            config={},
+            notifier=None,
+        )
+        reg = ParentWakeRegistration(
+            id="dead_reg",
+            child_session_id="child_missing",
+            parent_session_id="parent_dead",
+            period_seconds=1,
+            registered_at=datetime.now() - timedelta(minutes=5),
+            last_wake_at=None,
+            last_status_at_prev_wake=None,
+        )
+        mq._parent_wake_registrations["child_missing"] = reg
+        mock_session_manager.get_session.return_value = None
+
+        queue_calls = []
+
+        async def fake_sleep(_seconds):
+            return None
+
+        with patch("asyncio.sleep", side_effect=fake_sleep), \
+             patch.object(mq, "queue_message", side_effect=lambda **kwargs: queue_calls.append(kwargs)):
+            await mq._run_parent_wake_task("child_missing")
+
+        assert queue_calls == []
+        assert "child_missing" not in mq._parent_wake_registrations
+
+        conn = sqlite3.connect(temp_db_path)
+        rows = conn.execute(
+            "SELECT is_active FROM parent_wake_registrations WHERE child_session_id = 'child_missing'"
+        ).fetchall()
+        conn.close()
+        assert rows == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- auto-cancel parent-wake registrations when the child session is gone or its tmux runtime has died
- skip recovering parent-wake registrations for already-dead child sessions on restart
- add parent-wake regressions for dead-child cancellation and recovery behavior

## Testing
- ./venv/bin/pytest tests/unit/test_parent_wake.py -q
- ./venv/bin/pytest tests/unit/test_message_queue.py -q -k parent_wake
- ./venv/bin/pytest tests/unit/test_task_complete.py -q

Fixes #349