### PR TITLE
Report actual immediate delivery status

### DIFF
--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -1096,7 +1096,7 @@ def cmd_send(
     # Success - show different message based on delivery mode
     name = session.get("friendly_name") or session.get("name") or session_id
     if delivery_mode == "sequential":
-        print(f"Queued for {name} ({session_id}) (will inject when idle)")
+        print(f"Input sent to {name} ({session_id})")
     elif delivery_mode == "urgent":
         print(f"Input sent to {name} ({session_id}) (interrupted)")
     else:  # important

--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -523,6 +523,7 @@ class MessageQueueManager:
         remind_hard_threshold: Optional[int] = None,
         parent_session_id: Optional[str] = None,
         message_category: Optional[str] = None,
+        trigger_delivery: bool = True,
     ) -> QueuedMessage:
         """
         Queue a message for delivery.
@@ -541,6 +542,7 @@ class MessageQueueManager:
             remind_hard_threshold: Seconds after delivery before hard remind fires (#188)
             parent_session_id: EM session to wake periodically after delivery (#225-C)
             message_category: Optional category tag, e.g. 'context_monitor', for scoped cancellation (#241)
+            trigger_delivery: If True, queue_message schedules immediate delivery based on mode.
 
         Returns:
             QueuedMessage with assigned ID
@@ -591,6 +593,37 @@ class MessageQueueManager:
         queue_len = self.get_queue_length(target_session_id)
         logger.info(f"Queued message {msg.id} for {target_session_id} (mode={delivery_mode}, queue={queue_len})")
 
+        if trigger_delivery:
+            self._trigger_delivery(target_session_id, delivery_mode, msg)
+
+        return msg
+
+    def _prepare_nonurgent_delivery(self, target_session_id: str) -> None:
+        """Apply provider-specific state needed before non-urgent direct delivery."""
+        session = self.session_manager.get_session(target_session_id)
+        is_codex = session and getattr(session, "provider", "claude") == "codex"
+        if not is_codex:
+            return
+
+        # Codex: set idle flag and deliver immediately, but skip the
+        # stop-notification side effects of mark_session_idle() since
+        # this isn't a real stop event.
+        # Reset any stale idle status from prior work cycle BEFORE setting is_idle=True.
+        # Without this, _watch_for_idle Phase 3 can see session.status=IDLE from
+        # OutputMonitor and fire a false idle during the delivery window. (#193)
+        # Mirror the urgent path: skip mark_session_active if session is paused for recovery.
+        if target_session_id not in self._paused_sessions:
+            self.mark_session_active(target_session_id)
+        state = self._get_or_create_state(target_session_id)
+        state.is_idle = True  # re-set: mark_session_active clears is_idle; need True to gate delivery
+
+    def _trigger_delivery(
+        self,
+        target_session_id: str,
+        delivery_mode: str,
+        msg: Optional[QueuedMessage] = None,
+    ) -> None:
+        """Schedule immediate delivery work for a queued message."""
         # Codex CLI sessions have no hooks so idle detection never triggers.
         # Force immediate delivery for all non-urgent modes.
         session = self.session_manager.get_session(target_session_id)
@@ -600,19 +633,12 @@ class MessageQueueManager:
         if delivery_mode == "urgent":
             if target_session_id not in self._paused_sessions:
                 self.mark_session_active(target_session_id)
+            if msg is None:
+                logger.warning("Urgent delivery requested without queued message for %s", target_session_id)
+                return
             asyncio.create_task(self._deliver_urgent(target_session_id, msg))
         elif is_codex:
-            # Codex: set idle flag and deliver immediately, but skip the
-            # stop-notification side effects of mark_session_idle() since
-            # this isn't a real stop event.
-            # Reset any stale idle status from prior work cycle BEFORE setting is_idle=True.
-            # Without this, _watch_for_idle Phase 3 can see session.status=IDLE from
-            # OutputMonitor and fire a false idle during the delivery window. (#193)
-            # Mirror the urgent path: skip mark_session_active if session is paused for recovery.
-            if target_session_id not in self._paused_sessions:
-                self.mark_session_active(target_session_id)
-            state = self._get_or_create_state(target_session_id)
-            state.is_idle = True  # re-set: mark_session_active clears is_idle; need True to gate delivery
+            self._prepare_nonurgent_delivery(target_session_id)
             asyncio.create_task(self._try_deliver_messages(target_session_id))
         # If important mode, trigger delivery directly (tty buffer handles ordering, sm#244)
         elif delivery_mode == "important":
@@ -621,7 +647,27 @@ class MessageQueueManager:
         elif delivery_mode == "sequential":
             asyncio.create_task(self._try_deliver_messages(target_session_id))
 
-        return msg
+    def was_message_delivered(self, message_id: str) -> bool:
+        """Return True when a queued message has been marked delivered."""
+        rows = self._execute_query(
+            "SELECT delivered_at FROM message_queue WHERE id = ? LIMIT 1",
+            (message_id,),
+        )
+        return bool(rows and rows[0][0])
+
+    async def deliver_queued_message_now(
+        self,
+        session_id: str,
+        message_id: str,
+        delivery_mode: str,
+    ) -> bool:
+        """Attempt immediate delivery for a specific queued message and report the result."""
+        self._prepare_nonurgent_delivery(session_id)
+        await self._try_deliver_messages(
+            session_id,
+            important_only=(delivery_mode == "important"),
+        )
+        return self.was_message_delivered(message_id)
 
     def get_pending_messages(self, session_id: str) -> List[QueuedMessage]:
         """Get all pending (undelivered) messages for a session."""

--- a/src/server.py
+++ b/src/server.py
@@ -1628,7 +1628,7 @@ def create_app(
             if queue_mgr:
                 queue_len = queue_mgr.get_queue_length(session_id)
                 response["queue_position"] = queue_len
-                response["estimated_delivery"] = "waiting_for_idle"
+                response["estimated_delivery"] = "deferred"
 
         return response
 

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -1765,13 +1765,10 @@ class SessionManager:
 
         # Handle delivery modes using the message queue manager
         if self.message_queue_manager:
-            # Check if session is idle (will be delivered immediately)
-            state = self.message_queue_manager.delivery_states.get(session_id)
-            is_idle = state.is_idle if state else True  # Assume idle if no state yet
-
-            # For sequential mode, always queue (queue manager handles idle detection)
+            # For sequential mode, queue first, then report whether the immediate
+            # delivery attempt actually injected the message.
             if delivery_mode == "sequential":
-                self.message_queue_manager.queue_message(
+                msg = self.message_queue_manager.queue_message(
                     target_session_id=session_id,
                     text=formatted_text,
                     sender_session_id=sender_session_id,
@@ -1784,6 +1781,7 @@ class SessionManager:
                     remind_soft_threshold=remind_soft_threshold,
                     remind_hard_threshold=remind_hard_threshold,
                     parent_session_id=parent_session_id,
+                    trigger_delivery=False,
                 )
                 # Record outgoing sm send for deferred stop notification suppression (#182)
                 # Placed after queue_message to ensure message was persisted first.
@@ -1791,11 +1789,44 @@ class SessionManager:
                     sender_state = self.message_queue_manager._get_or_create_state(sender_session_id)
                     sender_state.last_outgoing_sm_send_target = session_id
                     sender_state.last_outgoing_sm_send_at = datetime.now()
-                # Return DELIVERED if idle (will be delivered immediately), else QUEUED
-                return DeliveryResult.DELIVERED if is_idle else DeliveryResult.QUEUED
+                delivered = await self.message_queue_manager.deliver_queued_message_now(
+                    session_id=session_id,
+                    message_id=msg.id,
+                    delivery_mode=delivery_mode,
+                )
+                return DeliveryResult.DELIVERED if delivered else DeliveryResult.QUEUED
 
-            # For important/urgent, queue handles delivery logic
-            if delivery_mode in ("important", "urgent"):
+            # For important, queue first, then report the real immediate-delivery outcome.
+            if delivery_mode == "important":
+                msg = self.message_queue_manager.queue_message(
+                    target_session_id=session_id,
+                    text=formatted_text,
+                    sender_session_id=sender_session_id,
+                    sender_name=sender_name,
+                    delivery_mode=delivery_mode,
+                    timeout_seconds=timeout_seconds,
+                    notify_on_delivery=notify_on_delivery,
+                    notify_after_seconds=notify_after_seconds,
+                    notify_on_stop=notify_on_stop,
+                    remind_soft_threshold=remind_soft_threshold,
+                    remind_hard_threshold=remind_hard_threshold,
+                    parent_session_id=parent_session_id,
+                    trigger_delivery=False,
+                )
+                # Record outgoing sm send for deferred stop notification suppression (#182)
+                if from_sm_send and sender_session_id:
+                    sender_state = self.message_queue_manager._get_or_create_state(sender_session_id)
+                    sender_state.last_outgoing_sm_send_target = session_id
+                    sender_state.last_outgoing_sm_send_at = datetime.now()
+                delivered = await self.message_queue_manager.deliver_queued_message_now(
+                    session_id=session_id,
+                    message_id=msg.id,
+                    delivery_mode=delivery_mode,
+                )
+                return DeliveryResult.DELIVERED if delivered else DeliveryResult.QUEUED
+
+            # Urgent always delivers (sends Escape first).
+            if delivery_mode == "urgent":
                 self.message_queue_manager.queue_message(
                     target_session_id=session_id,
                     text=formatted_text,
@@ -1810,15 +1841,11 @@ class SessionManager:
                     remind_hard_threshold=remind_hard_threshold,
                     parent_session_id=parent_session_id,
                 )
-                # Record outgoing sm send for deferred stop notification suppression (#182)
                 if from_sm_send and sender_session_id:
                     sender_state = self.message_queue_manager._get_or_create_state(sender_session_id)
                     sender_state.last_outgoing_sm_send_target = session_id
                     sender_state.last_outgoing_sm_send_at = datetime.now()
-                # Urgent always delivers (sends Escape first), important waits
-                if delivery_mode == "urgent":
-                    return DeliveryResult.DELIVERED
-                return DeliveryResult.DELIVERED if is_idle else DeliveryResult.QUEUED
+                return DeliveryResult.DELIVERED
 
         # Fallback: send immediately (no queue manager or unknown mode)
         success = await self._deliver_direct(session, formatted_text)

--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -944,8 +944,8 @@ Provide ONLY the summary, no preamble or questions."""
                 asyncio.create_task(self._monitor_progress(session_id, chat_id, msg.message_id))
             elif result == DeliveryResult.QUEUED:
                 msg = await update.message.reply_text(
-                    f"[{session_id}] ⏳ Queued (session working)\n"
-                    f"Reply /force to deliver immediately"
+                    f"[{session_id}] ⏳ Queued (delivery deferred)\n"
+                    f"Reply /force to interrupt instead"
                 )
                 # Track queued message for potential /force promotion
                 self._pending_input_msgs[session_id] = (chat_id, msg.message_id)

--- a/tests/unit/test_delivery_feedback.py
+++ b/tests/unit/test_delivery_feedback.py
@@ -78,7 +78,8 @@ def mock_message_queue():
     """Create a mock MessageQueueManager."""
     mock = MagicMock()
     mock.delivery_states = {}
-    mock.queue_message = MagicMock()
+    mock.queue_message = MagicMock(return_value=MagicMock(id="msg-123"))
+    mock.deliver_queued_message_now = AsyncMock(return_value=True)
     mock.is_session_idle = MagicMock(return_value=True)
     mock.get_queue_length = MagicMock(return_value=0)
     return mock
@@ -162,21 +163,23 @@ class TestSendInputDeliveryResult:
         session_manager.sessions["test123"] = session
         session_manager.message_queue_manager = mock_message_queue
 
-        # Set up idle state
-        from src.message_queue import SessionDeliveryState
-        mock_message_queue.delivery_states["test123"] = MagicMock()
-        mock_message_queue.delivery_states["test123"].is_idle = True
-
         result = await session_manager.send_input(
             session_id="test123",
             text="hello",
             delivery_mode="sequential",
         )
         assert result == DeliveryResult.DELIVERED
+        mock_message_queue.queue_message.assert_called_once()
+        assert mock_message_queue.queue_message.call_args.kwargs["trigger_delivery"] is False
+        mock_message_queue.deliver_queued_message_now.assert_awaited_once_with(
+            session_id="test123",
+            message_id="msg-123",
+            delivery_mode="sequential",
+        )
 
     @pytest.mark.asyncio
-    async def test_returns_queued_when_session_busy(self, session_manager, mock_message_queue):
-        """Verify QUEUED is returned when session is busy."""
+    async def test_returns_queued_when_immediate_delivery_defers(self, session_manager, mock_message_queue):
+        """Verify QUEUED is returned when the queued message was not injected immediately."""
         session = Session(
             id="test123",
             name="test-session",
@@ -186,9 +189,7 @@ class TestSendInputDeliveryResult:
         session_manager.sessions["test123"] = session
         session_manager.message_queue_manager = mock_message_queue
 
-        # Set up busy state
-        mock_message_queue.delivery_states["test123"] = MagicMock()
-        mock_message_queue.delivery_states["test123"].is_idle = False
+        mock_message_queue.deliver_queued_message_now.return_value = False
 
         result = await session_manager.send_input(
             session_id="test123",
@@ -242,10 +243,6 @@ class TestAPIDeliveryResult:
         )
         session_manager.sessions["test123"] = session
 
-        # Set up idle state
-        mock_message_queue.delivery_states["test123"] = MagicMock()
-        mock_message_queue.delivery_states["test123"].is_idle = True
-
         response = test_client.post(
             "/sessions/test123/input",
             json={"text": "hello", "delivery_mode": "sequential"},
@@ -255,8 +252,8 @@ class TestAPIDeliveryResult:
         data = response.json()
         assert data["status"] == "delivered"
 
-    def test_api_returns_queued_status(self, test_client, session_manager, mock_message_queue):
-        """Verify API returns queued status when session busy."""
+    def test_api_returns_queued_status_when_delivery_is_deferred(self, test_client, session_manager, mock_message_queue):
+        """Verify API returns queued status when immediate delivery does not inject the message."""
         session = Session(
             id="test123",
             name="test-session",
@@ -265,9 +262,7 @@ class TestAPIDeliveryResult:
         )
         session_manager.sessions["test123"] = session
 
-        # Set up busy state
-        mock_message_queue.delivery_states["test123"] = MagicMock()
-        mock_message_queue.delivery_states["test123"].is_idle = False
+        mock_message_queue.deliver_queued_message_now.return_value = False
         mock_message_queue.get_queue_length.return_value = 2
 
         response = test_client.post(
@@ -279,6 +274,7 @@ class TestAPIDeliveryResult:
         data = response.json()
         assert data["status"] == "queued"
         assert data["queue_position"] == 2
+        assert data["estimated_delivery"] == "deferred"
 
     def test_api_returns_404_for_nonexistent_session(self, test_client):
         """Verify API returns 404 for nonexistent session."""


### PR DESCRIPTION
## Summary
- make `send_input()` report whether a queued message was actually injected immediately instead of guessing from stale idle state
- stop claiming sequential sends will wait for idle when they were already delivered, and make deferred sends explicitly say delivery was deferred
- add regression coverage for truthful delivery feedback through the session manager and API

## Testing
- ../session-manager/venv/bin/pytest tests/unit/test_delivery_feedback.py tests/regression/test_wait_features.py tests/unit/test_dispatch.py tests/integration/test_api_endpoints.py -q

Fixes #357