### PR TITLE
Add explicit adoption flow for orphaned agents

### DIFF
--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -127,6 +127,45 @@ class SessionManagerClient:
             return data.get("sessions", [])
         return None
 
+    def propose_adoption(self, target_session_id: str, requester_session_id: str) -> dict:
+        """Create an adoption proposal for explicit operator approval."""
+        data, status_code, unavailable = self._request_with_status(
+            "POST",
+            f"/sessions/{target_session_id}/adoption-proposals",
+            {"requester_session_id": requester_session_id},
+        )
+        if unavailable:
+            return {"ok": False, "unavailable": True, "status_code": None, "detail": None}
+        ok = status_code in (200, 201)
+        detail = data.get("detail") if isinstance(data, dict) else None
+        return {"ok": ok, "unavailable": False, "status_code": status_code, "data": data, "detail": detail}
+
+    def accept_adoption_proposal(self, proposal_id: str) -> dict:
+        """Accept a pending adoption proposal."""
+        data, status_code, unavailable = self._request_with_status(
+            "POST",
+            f"/adoption-proposals/{proposal_id}/accept",
+            {},
+        )
+        if unavailable:
+            return {"ok": False, "unavailable": True, "status_code": None, "detail": None}
+        ok = status_code in (200, 201)
+        detail = data.get("detail") if isinstance(data, dict) else None
+        return {"ok": ok, "unavailable": False, "status_code": status_code, "data": data, "detail": detail}
+
+    def reject_adoption_proposal(self, proposal_id: str) -> dict:
+        """Reject a pending adoption proposal."""
+        data, status_code, unavailable = self._request_with_status(
+            "POST",
+            f"/adoption-proposals/{proposal_id}/reject",
+            {},
+        )
+        if unavailable:
+            return {"ok": False, "unavailable": True, "status_code": None, "detail": None}
+        ok = status_code in (200, 201)
+        detail = data.get("detail") if isinstance(data, dict) else None
+        return {"ok": ok, "unavailable": False, "status_code": status_code, "data": data, "detail": detail}
+
     def update_friendly_name(self, session_id: str, friendly_name: str) -> tuple[bool, bool]:
         """
         Update session friendly name.

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -255,6 +255,49 @@ def cmd_name(client: SessionManagerClient, session_id: str, name_or_session: str
         return 1
 
 
+def cmd_adopt(client: SessionManagerClient, session_id: Optional[str], target_identifier: str) -> int:
+    """
+    Propose adopting an existing session. Requires explicit approval in sm watch.
+
+    Exit codes:
+        0: Proposal submitted
+        1: Validation or API failure
+        2: Session manager unavailable / not in managed session
+    """
+    if not session_id:
+        print("Error: CLAUDE_SESSION_MANAGER_ID environment variable not set", file=sys.stderr)
+        return 2
+
+    target_session_id, _ = resolve_session_id(client, target_identifier)
+    if target_session_id is None:
+        sessions = client.list_sessions()
+        if sessions is None:
+            print("Error: Session manager unavailable", file=sys.stderr)
+            return 2
+        print(f"Error: Session '{target_identifier}' not found", file=sys.stderr)
+        return 1
+
+    result = client.propose_adoption(target_session_id, session_id)
+    if result.get("unavailable"):
+        print("Error: Session manager unavailable", file=sys.stderr)
+        return 2
+    if not result.get("ok"):
+        detail = result.get("detail") or "Failed to submit adoption proposal"
+        print(f"Error: {detail}", file=sys.stderr)
+        return 1
+
+    proposal = (result.get("data") or {}).get("proposal") or {}
+    proposal_id = proposal.get("id")
+    if proposal_id:
+        print(
+            f"Adoption proposal submitted for {target_session_id} "
+            f"({proposal_id}). Approve or reject it in sm watch."
+        )
+    else:
+        print(f"Adoption proposal submitted for {target_session_id}. Approve or reject it in sm watch.")
+    return 0
+
+
 def cmd_role(client: SessionManagerClient, session_id: Optional[str], role: Optional[str], clear: bool = False) -> int:
     """
     Set or clear role tag for the current session.

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -460,6 +460,16 @@ def main():
         help="Name suffix (sets friendly name to em-<name>)",
     )
 
+    # sm adopt <session>
+    adopt_parser = subparsers.add_parser(
+        "adopt",
+        help="Propose adopting an existing agent (requires approval in sm watch)",
+    )
+    adopt_parser.add_argument(
+        "session",
+        help="Session ID or friendly name to adopt",
+    )
+
     # sm setup [--overwrite]
     setup_parser = subparsers.add_parser(
         "setup",
@@ -506,8 +516,8 @@ def main():
         "codex-2", "codex-app", "codex-server",
         "attach", "output", "codex-tui", "codex-fork-info", "codex-rollout-gates", "watch", "tail", "clear", "review", "context-monitor", "remind", "setup", None
     ]
-    # Commands that require session_id: spawn (needs to set parent_session_id)
-    requires_session_id = ["spawn"]
+    # Commands that require session_id: self-directed managed-session actions
+    requires_session_id = ["spawn", "adopt"]
     if not session_id and args.command in requires_session_id:
         print("Error: CLAUDE_SESSION_MANAGER_ID environment variable not set", file=sys.stderr)
         print("This tool must be run inside a Claude Code session managed by Session Manager", file=sys.stderr)
@@ -657,6 +667,8 @@ def main():
         sys.exit(commands.cmd_context_monitor(client, session_id, args.action, args.target))
     elif args.command == "em":
         sys.exit(commands.cmd_em(client, session_id, args.name))
+    elif args.command == "adopt":
+        sys.exit(commands.cmd_adopt(client, session_id, args.session))
     elif args.command == "setup":
         sys.exit(commands.cmd_setup(overwrite=args.overwrite))
     elif args.command == "review":

--- a/src/cli/watch_tui.py
+++ b/src/cli/watch_tui.py
@@ -289,6 +289,23 @@ def _task_completion_line(session: dict) -> Optional[str]:
     return f"task: completed ({_age_from_iso(completed_at)})"
 
 
+def _pending_adoption_lines(session: dict) -> list[str]:
+    proposals = session.get("pending_adoption_proposals") or []
+    lines: list[str] = []
+    for proposal in proposals:
+        if proposal.get("status") != "pending":
+            continue
+        proposer_name = proposal.get("proposer_name") or proposal.get("proposer_session_id") or "unknown"
+        proposer_id = proposal.get("proposer_session_id") or "unknown"
+        created_at = proposal.get("created_at")
+        age = _age_from_iso(created_at)
+        age_suffix = f" ({age})" if age != "-" else ""
+        lines.append(
+            f"adopt: pending from {proposer_name} [{proposer_id}]{age_suffix}  [A accept / X reject]"
+        )
+    return lines
+
+
 def _format_age(last_activity: Optional[str], activity_state: str) -> str:
     parsed = _parse_iso(last_activity)
     if not parsed:
@@ -541,6 +558,15 @@ def build_watch_rows(
                     )
                 )
 
+            for adoption_line in _pending_adoption_lines(session):
+                rows.append(
+                    WatchRow(
+                        kind="status",
+                        text=f"{status_prefix}{adoption_line}",
+                        session_id=session_id,
+                    )
+                )
+
             if session_id and session_id in expanded:
                 detail = detail_cache.get(session_id) if detail_cache else None
                 for line in _detail_lines(session, detail, codex_projection_enabled):
@@ -778,7 +804,7 @@ def _render(
             _flash_attr(flash_message, palette),
         )
 
-    footer = "j/k: move  Enter: attach  s: send  K: kill  n: rename  Tab: details  /: filter  r: refresh  q: quit"
+    footer = "j/k: move  Enter: attach  s: send  K: kill  n: rename  A/X: adopt  Tab: details  /: filter  r: refresh  q: quit"
     stdscr.addnstr(height - 1, 0, footer, max(0, width - 1))
     stdscr.refresh()
 
@@ -1011,6 +1037,46 @@ def run_watch_tui(
                         flash_message = "Session manager unavailable"
                     else:
                         flash_message = "Failed to rename session"
+                    flash_until = time.monotonic() + 2.5
+                    next_refresh = 0.0
+                    continue
+
+                if key in (ord("A"), ord("X")):
+                    if not selected:
+                        flash_message = "No session selected"
+                        flash_until = time.monotonic() + 2.0
+                        continue
+
+                    proposals = [
+                        proposal
+                        for proposal in (selected.get("pending_adoption_proposals") or [])
+                        if proposal.get("status") == "pending"
+                    ]
+                    if not proposals:
+                        flash_message = "No pending adoption proposal"
+                        flash_until = time.monotonic() + 2.0
+                        continue
+
+                    proposal = proposals[0]
+                    proposal_id = proposal.get("id")
+                    if not proposal_id:
+                        flash_message = "Pending adoption proposal is missing an id"
+                        flash_until = time.monotonic() + 2.0
+                        continue
+
+                    if key == ord("A"):
+                        result = client.accept_adoption_proposal(proposal_id)
+                        action = "accepted"
+                    else:
+                        result = client.reject_adoption_proposal(proposal_id)
+                        action = "rejected"
+
+                    if result.get("unavailable"):
+                        flash_message = "Session manager unavailable"
+                    elif result.get("ok"):
+                        flash_message = f"Adoption {action} for {selected_session_id}"
+                    else:
+                        flash_message = str(result.get("detail") or f"Failed to {action} adoption proposal")
                     flash_until = time.monotonic() + 2.5
                     next_refresh = 0.0
                     continue

--- a/src/models.py
+++ b/src/models.py
@@ -60,6 +60,13 @@ class ActivityState(Enum):
     STOPPED = "stopped"
 
 
+class AdoptionProposalStatus(Enum):
+    """Lifecycle state for explicit agent adoption proposals."""
+    PENDING = "pending"
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+
+
 @dataclass
 class TelegramTopicRecord:
     """Durable registry entry for a Telegram forum topic."""
@@ -100,6 +107,43 @@ class TelegramTopicRecord:
             last_seen_at=datetime.fromisoformat(data["last_seen_at"]),
             deleted_at=datetime.fromisoformat(data["deleted_at"]) if data.get("deleted_at") else None,
             is_em_topic=bool(data.get("is_em_topic", False)),
+        )
+
+
+@dataclass
+class AdoptionProposal:
+    """A pending request for one session to adopt another as its child."""
+    id: str = field(default_factory=lambda: uuid.uuid4().hex[:12])
+    proposer_session_id: str = ""
+    target_session_id: str = ""
+    created_at: datetime = field(default_factory=datetime.now)
+    status: AdoptionProposalStatus = AdoptionProposalStatus.PENDING
+    decided_at: Optional[datetime] = None
+
+    def to_dict(self) -> dict:
+        """Convert proposal to a JSON-serializable dictionary."""
+        return {
+            "id": self.id,
+            "proposer_session_id": self.proposer_session_id,
+            "target_session_id": self.target_session_id,
+            "created_at": self.created_at.isoformat(),
+            "status": self.status.value,
+            "decided_at": self.decided_at.isoformat() if self.decided_at else None,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "AdoptionProposal":
+        """Restore a proposal from persisted state."""
+        status = data.get("status", AdoptionProposalStatus.PENDING.value)
+        if isinstance(status, str):
+            status = AdoptionProposalStatus(status)
+        return cls(
+            id=data["id"],
+            proposer_session_id=data["proposer_session_id"],
+            target_session_id=data["target_session_id"],
+            created_at=datetime.fromisoformat(data["created_at"]),
+            status=status,
+            decided_at=datetime.fromisoformat(data["decided_at"]) if data.get("decided_at") else None,
         )
 
 

--- a/src/server.py
+++ b/src/server.py
@@ -11,7 +11,7 @@ from typing import Optional, Dict, Any, Literal
 from fastapi import FastAPI, HTTPException, Body, Request, Query
 from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from .codex_provider_policy import (
@@ -20,7 +20,15 @@ from .codex_provider_policy import (
     REMOVED_CODEX_SERVER_ENTRYPOINT_MESSAGE,
     get_codex_app_policy,
 )
-from .models import Session, SessionStatus, NotificationChannel, Subagent, SubagentStatus, DeliveryResult
+from .models import (
+    AdoptionProposal,
+    Session,
+    SessionStatus,
+    NotificationChannel,
+    Subagent,
+    SubagentStatus,
+    DeliveryResult,
+)
 from .cli.commands import validate_friendly_name
 
 logger = logging.getLogger(__name__)
@@ -87,6 +95,17 @@ class CreateSessionRequest(BaseModel):
     provider: Optional[str] = "claude"
 
 
+class AdoptionProposalResponse(BaseModel):
+    """Response payload for a pending or resolved adoption proposal."""
+    id: str
+    proposer_session_id: str
+    proposer_name: Optional[str] = None
+    target_session_id: str
+    created_at: str
+    status: str
+    decided_at: Optional[str] = None
+
+
 class SessionResponse(BaseModel):
     """Response containing session info."""
     id: str
@@ -116,6 +135,7 @@ class SessionResponse(BaseModel):
     last_action_at: Optional[str] = None
     tokens_used: int = 0
     context_monitor_enabled: bool = False
+    pending_adoption_proposals: list[AdoptionProposalResponse] = Field(default_factory=list)
 
 
 class SendInputRequest(BaseModel):
@@ -229,6 +249,11 @@ class HandoffRequest(BaseModel):
 
 class TaskCompleteRequest(BaseModel):
     """Request to mark a session's task as complete (self-directed)."""
+    requester_session_id: str
+
+
+class CreateAdoptionProposalRequest(BaseModel):
+    """Request for an EM session to propose adopting another session."""
     requester_session_id: str
 
 
@@ -552,6 +577,7 @@ def create_app(
         provider = getattr(session, "provider", "claude")
         last_action_summary: Optional[str] = None
         last_action_at: Optional[str] = None
+        pending_adoption_proposals: list[AdoptionProposalResponse] = []
         if provider == "codex-app" and _codex_rollout_enabled("enable_observability_projection"):
             latest_action_getter = getattr(app.state.session_manager, "get_codex_latest_activity_action", None)
             if callable(latest_action_getter):
@@ -559,6 +585,13 @@ def create_app(
                 if action:
                     last_action_summary = action.get("summary_text")
                     last_action_at = action.get("ended_at") or action.get("started_at")
+
+        proposal_getter = getattr(app.state.session_manager, "list_adoption_proposals", None)
+        if callable(proposal_getter):
+            for proposal in proposal_getter(target_session_id=session.id, status=None):
+                if proposal.status.value != "pending":
+                    continue
+                pending_adoption_proposals.append(_proposal_to_response(proposal))
 
         return SessionResponse(
             id=session.id,
@@ -592,7 +625,29 @@ def create_app(
             last_action_at=last_action_at,
             tokens_used=getattr(session, "tokens_used", 0),
             context_monitor_enabled=bool(getattr(session, "context_monitor_enabled", False)),
+            pending_adoption_proposals=pending_adoption_proposals,
         )
+
+    def _proposal_to_response(proposal: AdoptionProposal) -> AdoptionProposalResponse:
+        proposer = app.state.session_manager.get_session(proposal.proposer_session_id)
+        proposer_name = None
+        if proposer is not None:
+            proposer_name = proposer.friendly_name or proposer.name or proposer.id
+        return AdoptionProposalResponse(
+            id=proposal.id,
+            proposer_session_id=proposal.proposer_session_id,
+            proposer_name=proposer_name,
+            target_session_id=proposal.target_session_id,
+            created_at=proposal.created_at.isoformat(),
+            status=proposal.status.value,
+            decided_at=proposal.decided_at.isoformat() if proposal.decided_at else None,
+        )
+
+    def _response_dict(model: BaseModel) -> dict:
+        dumper = getattr(model, "model_dump", None)
+        if callable(dumper):
+            return dumper()
+        return model.dict()
 
     def _configure_watch_frontend() -> None:
         """Serve the mobile dashboard if static assets exist in web/sm-watch/dist."""
@@ -2906,6 +2961,66 @@ Provide ONLY the summary, no preamble or questions."""
         state.pending_handoff_path = request.file_path
         logger.info(f"Handoff scheduled for {session_id}: {request.file_path}")
         return {"status": "scheduled"}
+
+    @app.post("/sessions/{target_session_id}/adoption-proposals")
+    async def create_adoption_proposal(target_session_id: str, request: CreateAdoptionProposalRequest):
+        """Create an explicit adoption proposal for user approval in sm watch."""
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
+
+        creator = getattr(app.state.session_manager, "create_adoption_proposal", None)
+        if not callable(creator):
+            raise HTTPException(status_code=503, detail="Adoption proposals unavailable")
+
+        try:
+            proposal = creator(request.requester_session_id, target_session_id)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        return {
+            "status": "pending",
+            "proposal": _response_dict(_proposal_to_response(proposal)),
+        }
+
+    @app.post("/adoption-proposals/{proposal_id}/accept")
+    async def accept_adoption_proposal(proposal_id: str):
+        """Accept an adoption proposal from the operator watch UI."""
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
+
+        decider = getattr(app.state.session_manager, "decide_adoption_proposal", None)
+        if not callable(decider):
+            raise HTTPException(status_code=503, detail="Adoption proposals unavailable")
+
+        try:
+            proposal = decider(proposal_id, accepted=True)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        return {
+            "status": "accepted",
+            "proposal": _response_dict(_proposal_to_response(proposal)),
+        }
+
+    @app.post("/adoption-proposals/{proposal_id}/reject")
+    async def reject_adoption_proposal(proposal_id: str):
+        """Reject an adoption proposal from the operator watch UI."""
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
+
+        decider = getattr(app.state.session_manager, "decide_adoption_proposal", None)
+        if not callable(decider):
+            raise HTTPException(status_code=503, detail="Adoption proposals unavailable")
+
+        try:
+            proposal = decider(proposal_id, accepted=False)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        return {
+            "status": "rejected",
+            "proposal": _response_dict(_proposal_to_response(proposal)),
+        }
 
     @app.post("/sessions/{session_id}/task-complete")
     async def task_complete(session_id: str, request: TaskCompleteRequest):

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -13,6 +13,8 @@ from typing import Optional, Callable, Awaitable, Any
 
 from .models import (
     ActivityState,
+    AdoptionProposal,
+    AdoptionProposalStatus,
     CompletionStatus,
     DeliveryResult,
     NotificationEvent,
@@ -114,6 +116,7 @@ class SessionManager:
         self.telegram_topic_registry_path.parent.mkdir(parents=True, exist_ok=True)
         self.telegram_topic_registry: dict[tuple[int, int], TelegramTopicRecord] = {}
         self._topic_creator: Optional[Callable[..., Awaitable[Optional[int]]]] = None
+        self.adoption_proposals: dict[str, AdoptionProposal] = {}
 
         codex_config = self.config.get("codex", {})
         codex_app_config = self.config.get("codex_app_server", codex_config)
@@ -399,6 +402,113 @@ class SessionManager:
             return None
         return max(matches, key=lambda record: record.last_seen_at)
 
+    def list_adoption_proposals(
+        self,
+        *,
+        target_session_id: Optional[str] = None,
+        status: Optional[AdoptionProposalStatus] = None,
+    ) -> list[AdoptionProposal]:
+        """Return adoption proposals filtered by target and/or status."""
+        proposals = list(self.adoption_proposals.values())
+        if target_session_id is not None:
+            proposals = [proposal for proposal in proposals if proposal.target_session_id == target_session_id]
+        if status is not None:
+            proposals = [proposal for proposal in proposals if proposal.status == status]
+        return sorted(proposals, key=lambda proposal: (proposal.created_at, proposal.id))
+
+    def create_adoption_proposal(
+        self,
+        proposer_session_id: str,
+        target_session_id: str,
+    ) -> AdoptionProposal:
+        """Create or return a pending adoption proposal for an EM session."""
+        proposer = self.sessions.get(proposer_session_id)
+        if proposer is None:
+            raise ValueError(f"Proposer session {proposer_session_id} not found")
+        if not proposer.is_em:
+            raise ValueError("Only EM sessions may propose adoption")
+        if proposer.status == SessionStatus.STOPPED:
+            raise ValueError("Stopped sessions cannot propose adoption")
+
+        target = self.sessions.get(target_session_id)
+        if target is None:
+            raise ValueError(f"Target session {target_session_id} not found")
+        if target.status == SessionStatus.STOPPED:
+            raise ValueError("Stopped sessions cannot be adopted")
+        if proposer_session_id == target_session_id:
+            raise ValueError("A session cannot adopt itself")
+        if target.parent_session_id == proposer_session_id:
+            raise ValueError(f"Session {target_session_id} is already managed by {proposer_session_id}")
+
+        pending = self.list_adoption_proposals(
+            target_session_id=target_session_id,
+            status=AdoptionProposalStatus.PENDING,
+        )
+        if pending:
+            existing = pending[0]
+            if existing.proposer_session_id == proposer_session_id:
+                return existing
+            raise ValueError(
+                f"Session {target_session_id} already has a pending adoption proposal "
+                f"from {existing.proposer_session_id}"
+            )
+
+        proposal = AdoptionProposal(
+            proposer_session_id=proposer_session_id,
+            target_session_id=target_session_id,
+        )
+        self.adoption_proposals[proposal.id] = proposal
+        self._save_state()
+        return proposal
+
+    def decide_adoption_proposal(
+        self,
+        proposal_id: str,
+        *,
+        accepted: bool,
+    ) -> AdoptionProposal:
+        """Accept or reject a pending adoption proposal."""
+        proposal = self.adoption_proposals.get(proposal_id)
+        if proposal is None:
+            raise ValueError(f"Adoption proposal {proposal_id} not found")
+        if proposal.status != AdoptionProposalStatus.PENDING:
+            raise ValueError(f"Adoption proposal {proposal_id} is already {proposal.status.value}")
+
+        target = self.sessions.get(proposal.target_session_id)
+        proposer = self.sessions.get(proposal.proposer_session_id)
+
+        if accepted:
+            if proposer is None:
+                raise ValueError(f"Proposer session {proposal.proposer_session_id} no longer exists")
+            if not proposer.is_em:
+                raise ValueError(f"Proposer session {proposal.proposer_session_id} is no longer an EM")
+            if proposer.status == SessionStatus.STOPPED:
+                raise ValueError(f"Proposer session {proposal.proposer_session_id} is stopped")
+            if target is None:
+                raise ValueError(f"Target session {proposal.target_session_id} no longer exists")
+            if target.status == SessionStatus.STOPPED:
+                raise ValueError(f"Target session {proposal.target_session_id} is stopped")
+            target.parent_session_id = proposal.proposer_session_id
+
+        proposal.status = (
+            AdoptionProposalStatus.ACCEPTED if accepted else AdoptionProposalStatus.REJECTED
+        )
+        proposal.decided_at = datetime.now()
+
+        if accepted:
+            for other in self.adoption_proposals.values():
+                if other.id == proposal.id:
+                    continue
+                if (
+                    other.target_session_id == proposal.target_session_id
+                    and other.status == AdoptionProposalStatus.PENDING
+                ):
+                    other.status = AdoptionProposalStatus.REJECTED
+                    other.decided_at = proposal.decided_at
+
+        self._save_state()
+        return proposal
+
     def _load_state(self) -> bool:
         """
         Load session state from disk.
@@ -491,12 +601,17 @@ class SessionManager:
                                 f"thread={session.telegram_thread_id} from dead session {session.name}"
                             )
                 if legacy_codex_sessions:
-                    self._rewrite_state_raw(cleaned_sessions)
+                    preserved_state = {key: value for key, value in data.items() if key != "sessions"}
+                    self._rewrite_state_raw(cleaned_sessions, extra_state=preserved_state)
                 if registry_backfilled:
                     self._save_telegram_topic_registry()
 
                 # Load EM topic continuity field (backward compat: missing = None)
                 self.em_topic = data.get("em_topic")
+                self.adoption_proposals = {}
+                for proposal_data in data.get("adoption_proposals", []):
+                    proposal = AdoptionProposal.from_dict(proposal_data)
+                    self.adoption_proposals[proposal.id] = proposal
                 if retired_codex_app_sessions:
                     self._save_state()
 
@@ -507,10 +622,12 @@ class SessionManager:
                 return False
         return True  # No state file is not an error
 
-    def _rewrite_state_raw(self, sessions_data: list[dict]) -> bool:
+    def _rewrite_state_raw(self, sessions_data: list[dict], extra_state: Optional[dict] = None) -> bool:
         """Rewrite state file with provided session data (used for one-time cleanup)."""
         try:
             data = {"sessions": sessions_data}
+            if extra_state:
+                data.update(extra_state)
             state_path = Path(self.state_file)
             temp_file = state_path.with_suffix(".tmp")
 
@@ -538,6 +655,13 @@ class SessionManager:
             data = {
                 "sessions": [s.to_dict() for s in self.sessions.values()],
                 "em_topic": self.em_topic,
+                "adoption_proposals": [
+                    proposal.to_dict()
+                    for proposal in sorted(
+                        self.adoption_proposals.values(),
+                        key=lambda proposal: (proposal.created_at, proposal.id),
+                    )
+                ],
             }
 
             # Write to temporary file first

--- a/tests/unit/test_adoption_flow.py
+++ b/tests/unit/test_adoption_flow.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+from fastapi.testclient import TestClient
+
+from src.models import AdoptionProposalStatus, Session, SessionStatus
+from src.server import create_app
+from src.session_manager import SessionManager
+from src.cli.commands import cmd_adopt
+
+
+def _session(
+    session_id: str,
+    tmp_path,
+    *,
+    is_em: bool = False,
+    parent_session_id: str | None = None,
+) -> Session:
+    return Session(
+        id=session_id,
+        name=f"claude-{session_id}",
+        working_dir=str(tmp_path),
+        tmux_session=f"claude-{session_id}",
+        provider="claude",
+        log_file=str(tmp_path / f"{session_id}.log"),
+        status=SessionStatus.RUNNING,
+        is_em=is_em,
+        role="em" if is_em else None,
+        parent_session_id=parent_session_id,
+    )
+
+
+def _manager(tmp_path) -> SessionManager:
+    return SessionManager(
+        log_dir=str(tmp_path / "logs"),
+        state_file=str(tmp_path / "sessions.json"),
+        config={},
+    )
+
+
+def test_adoption_proposal_persists_and_accept_rebinds_parent(tmp_path):
+    manager = _manager(tmp_path)
+    proposer = _session("em123456", tmp_path, is_em=True)
+    target = _session("child001", tmp_path)
+    manager.sessions[proposer.id] = proposer
+    manager.sessions[target.id] = target
+
+    proposal = manager.create_adoption_proposal(proposer.id, target.id)
+    assert proposal.status == AdoptionProposalStatus.PENDING
+
+    with patch("src.session_manager.TmuxController.session_exists", return_value=True):
+        restored = SessionManager(
+            log_dir=str(tmp_path / "logs"),
+            state_file=str(tmp_path / "sessions.json"),
+            config={},
+        )
+
+    restored_proposals = restored.list_adoption_proposals(
+        target_session_id=target.id,
+        status=AdoptionProposalStatus.PENDING,
+    )
+    assert len(restored_proposals) == 1
+    assert restored_proposals[0].id == proposal.id
+
+    accepted = restored.decide_adoption_proposal(proposal.id, accepted=True)
+    assert accepted.status == AdoptionProposalStatus.ACCEPTED
+    assert restored.get_session(target.id).parent_session_id == proposer.id
+
+
+def test_adoption_proposal_requires_em(tmp_path):
+    manager = _manager(tmp_path)
+    proposer = _session("worker001", tmp_path, is_em=False)
+    target = _session("child001", tmp_path)
+    manager.sessions[proposer.id] = proposer
+    manager.sessions[target.id] = target
+
+    try:
+        manager.create_adoption_proposal(proposer.id, target.id)
+    except ValueError as exc:
+        assert "Only EM sessions" in str(exc)
+    else:
+        raise AssertionError("Expected ValueError for non-EM proposer")
+
+
+def test_sessions_api_exposes_pending_adoption_proposals(tmp_path):
+    manager = _manager(tmp_path)
+    proposer = _session("em123456", tmp_path, is_em=True)
+    proposer.friendly_name = "em-ops"
+    target = _session("child001", tmp_path)
+    manager.sessions[proposer.id] = proposer
+    manager.sessions[target.id] = target
+    proposal = manager.create_adoption_proposal(proposer.id, target.id)
+
+    client = TestClient(create_app(session_manager=manager))
+    response = client.get("/sessions")
+
+    assert response.status_code == 200
+    sessions = response.json()["sessions"]
+    target_payload = next(item for item in sessions if item["id"] == target.id)
+    assert target_payload["pending_adoption_proposals"] == [
+        {
+            "id": proposal.id,
+            "proposer_session_id": proposer.id,
+            "proposer_name": "em-ops",
+            "target_session_id": target.id,
+            "created_at": proposal.created_at.isoformat(),
+            "status": "pending",
+            "decided_at": None,
+        }
+    ]
+
+
+def test_accept_adoption_route_rebinds_parent(tmp_path):
+    manager = _manager(tmp_path)
+    proposer = _session("em123456", tmp_path, is_em=True)
+    target = _session("child001", tmp_path)
+    manager.sessions[proposer.id] = proposer
+    manager.sessions[target.id] = target
+    proposal = manager.create_adoption_proposal(proposer.id, target.id)
+
+    client = TestClient(create_app(session_manager=manager))
+    response = client.post(f"/adoption-proposals/{proposal.id}/accept", json={})
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "accepted"
+    assert manager.get_session(target.id).parent_session_id == proposer.id
+
+
+def test_cmd_adopt_submits_proposal(capsys):
+    client = Mock()
+    client.get_session.return_value = {"id": "child001", "parent_session_id": None}
+    client.propose_adoption.return_value = {
+        "ok": True,
+        "unavailable": False,
+        "data": {"proposal": {"id": "proposal123"}},
+    }
+
+    rc = cmd_adopt(client, "em123456", "child001")
+
+    assert rc == 0
+    client.propose_adoption.assert_called_once_with("child001", "em123456")
+    assert "proposal123" in capsys.readouterr().out

--- a/tests/unit/test_watch_tui.py
+++ b/tests/unit/test_watch_tui.py
@@ -34,6 +34,7 @@ def _session(
     agent_status_text: str | None = None,
     agent_status_at: str | None = None,
     agent_task_completed_at: str | None = None,
+    pending_adoption_proposals: list[dict] | None = None,
 ):
     return {
         "id": session_id,
@@ -55,6 +56,7 @@ def _session(
         "agent_status_text": agent_status_text,
         "agent_status_at": agent_status_at,
         "agent_task_completed_at": agent_task_completed_at,
+        "pending_adoption_proposals": pending_adoption_proposals or [],
     }
 
 
@@ -138,6 +140,33 @@ def test_task_completed_row_shows_age():
     )
     status_rows = [row for row in rows if row.kind == "status"]
     assert any("task: completed (" in row.text for row in status_rows)
+
+
+def test_pending_adoption_row_shows_proposer_and_actions():
+    rows, _, _ = build_watch_rows(
+        [
+            _session(
+                "s1",
+                "agent",
+                "/tmp/repo",
+                pending_adoption_proposals=[
+                    {
+                        "id": "proposal123",
+                        "proposer_session_id": "em123456",
+                        "proposer_name": "em-ops",
+                        "target_session_id": "s1",
+                        "created_at": "2026-02-21T22:58:00",
+                        "status": "pending",
+                        "decided_at": None,
+                    }
+                ],
+            )
+        ]
+    )
+
+    status_rows = [row for row in rows if row.kind == "status"]
+    assert any("adopt: pending from em-ops [em123456]" in row.text for row in status_rows)
+    assert any("[A accept / X reject]" in row.text for row in status_rows)
 
 
 def test_status_rows_follow_tree_indentation():


### PR DESCRIPTION
Fixes #355

## Summary
- persist explicit adoption proposals outside live session memory
- add API/CLI support for `sm adopt` and operator accept/reject actions
- surface pending adoption requests in `sm watch` with approval keys

## Testing
- ./venv/bin/pytest tests/unit/test_adoption_flow.py tests/unit/test_watch_tui.py -q
- PYTHONPATH=. python -m py_compile src/models.py src/session_manager.py src/server.py src/cli/client.py src/cli/commands.py src/cli/main.py src/cli/watch_tui.py