### PR TITLE
Normalize remind completion behavior across providers

### DIFF
--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -335,7 +335,13 @@ class MessageQueueManager:
     # IDLE State Management (called by Stop hook handler)
     # =========================================================================
 
-    def mark_session_idle(self, session_id: str, last_output: Optional[str] = None, from_stop_hook: bool = False):
+    def mark_session_idle(
+        self,
+        session_id: str,
+        last_output: Optional[str] = None,
+        from_stop_hook: bool = False,
+        completion_transition: bool = False,
+    ):
         """
         Mark a session as idle (called when Stop hook fires).
 
@@ -347,6 +353,10 @@ class MessageQueueManager:
             last_output: Output from this specific Stop hook invocation
             from_stop_hook: True when called from the Stop hook handler;
                 only Stop hook invocations may consume skip_count slots (#174)
+            completion_transition: True when the provider has completed a real turn
+                and become idle, but there is no Claude Stop hook (codex-app /
+                codex-fork). This should cancel remind/parent-wake like a genuine
+                stop, without engaging skip-fence logic.
         """
         state = self._get_or_create_state(session_id)
         logger.info(f"Session {session_id} marked idle")
@@ -394,7 +404,7 @@ class MessageQueueManager:
 
         # NOT absorbed — agent genuinely completed a task.
         # Cancel periodic remind and parent wake (#188, #225-C, sm#263).
-        if from_stop_hook:
+        if from_stop_hook or completion_transition:
             self.cancel_remind(session_id)
             self.cancel_parent_wake(session_id)
 
@@ -1585,7 +1595,7 @@ class MessageQueueManager:
                     if not has_pending_remind:
                         self.queue_message(
                             target_session_id=target_session_id,
-                            text='[sm remind] Update your status: sm status "message" — or if done: sm task-complete',
+                            text='[sm remind] Update your status: sm status "message" — if waiting on others: sm turn-complete — if done: sm task-complete',
                             delivery_mode="important",
                         )
                     reg.soft_fired = True
@@ -1595,7 +1605,7 @@ class MessageQueueManager:
                 if elapsed >= reg.hard_threshold_seconds:
                     self.queue_message(
                         target_session_id=target_session_id,
-                        text='[sm remind] Status overdue. Run: sm status "message" — or if done: sm task-complete',
+                        text='[sm remind] Status overdue. Run: sm status "message" — if waiting on others: sm turn-complete — if done: sm task-complete',
                         delivery_mode="urgent",
                     )
                     # Reset cycle so it restarts

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -841,7 +841,10 @@ class SessionManager:
                 if state not in ("idle", "shutdown", "error"):
                     self.message_queue_manager.mark_session_active(session_id)
                 elif previous_state != state:
-                    self.message_queue_manager.mark_session_idle(session_id)
+                    self.message_queue_manager.mark_session_idle(
+                        session_id,
+                        completion_transition=True,
+                    )
 
             if session.status != status_before:
                 self._save_state()
@@ -1230,7 +1233,10 @@ class SessionManager:
         self._save_state()
 
         if self.message_queue_manager:
-            self.message_queue_manager.mark_session_idle(session_id)
+            self.message_queue_manager.mark_session_idle(
+                session_id,
+                completion_transition=True,
+            )
 
         if not getattr(self, "notifier", None):
             return
@@ -2323,7 +2329,10 @@ class SessionManager:
 
         # Mark idle for message queue delivery
         if self.message_queue_manager:
-            self.message_queue_manager.mark_session_idle(session_id)
+            self.message_queue_manager.mark_session_idle(
+                session_id,
+                completion_transition=True,
+            )
 
         # Send notification similar to Claude Stop hook
         if text and hasattr(self, "notifier") and self.notifier:
@@ -2441,7 +2450,10 @@ class SessionManager:
         self._save_state()
 
         if self.message_queue_manager:
-            self.message_queue_manager.mark_session_idle(session_id)
+            self.message_queue_manager.mark_session_idle(
+                session_id,
+                completion_transition=True,
+            )
 
         # Store review output
         if review_text and self.hook_output_store is not None:

--- a/tests/unit/test_codex_observability_ingestion.py
+++ b/tests/unit/test_codex_observability_ingestion.py
@@ -255,3 +255,7 @@ async def test_codex_fork_turn_complete_updates_last_message_and_notifies(tmp_pa
     assert manager.hook_output_store["latest"] == "Final answer from codex-fork"
     assert session.status == SessionStatus.IDLE
     manager.notifier.notify.assert_awaited()
+    manager.message_queue_manager.mark_session_idle.assert_called_once_with(
+        session.id,
+        completion_transition=True,
+    )

--- a/tests/unit/test_codex_remind_parity.py
+++ b/tests/unit/test_codex_remind_parity.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.models import Session, SessionStatus
+from src.session_manager import SessionManager
+
+
+@pytest.mark.asyncio
+async def test_codex_app_turn_complete_marks_idle_as_completion_transition(tmp_path):
+    manager = SessionManager(log_dir=str(tmp_path), state_file=str(tmp_path / "state.json"))
+    session = Session(
+        id="appturn1",
+        name="codex-app-appturn1",
+        working_dir=str(tmp_path),
+        provider="codex-app",
+        status=SessionStatus.RUNNING,
+    )
+    manager.sessions[session.id] = session
+    manager.message_queue_manager = SimpleNamespace(mark_session_idle=MagicMock())
+    manager.notifier = SimpleNamespace(notify=AsyncMock())
+
+    await manager._handle_codex_turn_complete(
+        session_id=session.id,
+        text="final answer",
+        status="completed",
+    )
+
+    manager.message_queue_manager.mark_session_idle.assert_called_once_with(
+        session.id,
+        completion_transition=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_codex_app_review_complete_marks_idle_as_completion_transition(tmp_path):
+    manager = SessionManager(log_dir=str(tmp_path), state_file=str(tmp_path / "state.json"))
+    session = Session(
+        id="appreview1",
+        name="codex-app-appreview1",
+        working_dir=str(tmp_path),
+        provider="codex-app",
+        status=SessionStatus.RUNNING,
+    )
+    manager.sessions[session.id] = session
+    manager.message_queue_manager = SimpleNamespace(mark_session_idle=MagicMock())
+
+    await manager._handle_codex_review_complete(
+        session_id=session.id,
+        review_text="review output",
+    )
+
+    manager.message_queue_manager.mark_session_idle.assert_called_once_with(
+        session.id,
+        completion_transition=True,
+    )

--- a/tests/unit/test_parent_wake.py
+++ b/tests/unit/test_parent_wake.py
@@ -130,6 +130,13 @@ class TestParentWakeRegistration:
             mq.mark_session_idle("child7", from_stop_hook=False)
         assert "child7" in mq._parent_wake_registrations
 
+    def test_completion_transition_cancels_parent_wake(self, mq):
+        """Provider-native turn completion cancels parent wake like a real stop."""
+        with patch("asyncio.create_task", noop_create_task):
+            mq.register_parent_wake("child7b", "parent7b")
+            mq.mark_session_idle("child7b", completion_transition=True)
+        assert "child7b" not in mq._parent_wake_registrations
+
 
 # ---------------------------------------------------------------------------
 # TestQueueMessageParentSessionId

--- a/tests/unit/test_remind.py
+++ b/tests/unit/test_remind.py
@@ -321,6 +321,18 @@ class TestIdleCancelsRemind:
 
         assert "agent6" in mq._remind_registrations
 
+    def test_completion_transition_idle_cancels_remind(self, mq):
+        """Provider-native turn completion cancels remind even without a Claude Stop hook."""
+        with patch("asyncio.create_task", noop_create_task):
+            mq.register_periodic_remind("agent6b", soft_threshold=10, hard_threshold=20)
+
+        assert "agent6b" in mq._remind_registrations
+
+        with patch("asyncio.create_task", noop_create_task):
+            mq.mark_session_idle("agent6b", completion_transition=True)
+
+        assert "agent6b" not in mq._remind_registrations
+
 
 # ===========================================================================
 # 6 & 7 — Clear / Kill cancels remind

--- a/tests/unit/test_task_complete.py
+++ b/tests/unit/test_task_complete.py
@@ -290,26 +290,28 @@ class TestTaskCompleteSelfAuth:
 
 
 # ---------------------------------------------------------------------------
-# 8. Remind message includes task-complete hint
+# 8. Remind message includes turn-complete and task-complete hints
 # ---------------------------------------------------------------------------
 
 class TestRemindMessageIncludesTaskCompleteHint:
-    def test_soft_remind_message_contains_task_complete(self, mq):
-        """The soft remind message contains 'sm task-complete'."""
+    def test_soft_remind_message_contains_turn_and_task_complete(self, mq):
+        """The soft remind message contains both waiting and completion hints."""
         # Queue a message and check text directly by triggering the remind queue
         # We verify the constant text used in _run_remind_task
         import inspect
         import src.message_queue as mq_module
         source = inspect.getsource(mq_module.MessageQueueManager._run_remind_task)
         assert "sm task-complete" in source
+        assert "sm turn-complete" in source
 
-    def test_hard_remind_message_contains_task_complete(self, mq):
-        """The hard remind message contains 'sm task-complete'."""
+    def test_hard_remind_message_contains_turn_and_task_complete(self, mq):
+        """The hard remind message contains both waiting and completion hints."""
         import inspect
         import src.message_queue as mq_module
         source = inspect.getsource(mq_module.MessageQueueManager._run_remind_task)
         # Both soft and hard messages should have the hint
         assert source.count("sm task-complete") >= 2
+        assert source.count("sm turn-complete") >= 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #361

## Summary
- treat real codex-app/codex-fork turn completion as a remind-cancelling completion transition
- keep synthetic idle transitions separate from Claude stop-hook skip-fence logic
- update remind messaging to include `sm turn-complete` for waiting states

## Testing
- ./venv/bin/pytest tests/unit/test_remind.py tests/unit/test_parent_wake.py tests/unit/test_codex_observability_ingestion.py tests/unit/test_codex_remind_parity.py tests/unit/test_task_complete.py -q
- PYTHONPATH=. python -m py_compile src/message_queue.py src/session_manager.py tests/unit/test_codex_remind_parity.py