### PR TITLE
Route sm codex to codex-fork runtime

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -189,7 +189,7 @@ codex_fork:
     - "linux-x86_64"
   # Rollback guidance surfaced in sm codex-fork-info.
   rollback_provider: "codex"
-  rollback_command: "sm codex"
+  rollback_command: "sm codex-legacy"
   # Control client/runtime contract pin.
   event_schema_version: 2
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -223,9 +223,20 @@ def main():
     # sm codex [working_dir]
     parser_codex = subparsers.add_parser(
         "codex",
-        help="Create a new Codex session and attach to it"
+        help="Create a new Codex session (codex-fork runtime) and attach to it"
     )
     parser_codex.add_argument(
+        "working_dir",
+        nargs="?",
+        help="Working directory (defaults to current directory)"
+    )
+
+    # sm codex-legacy [working_dir]
+    parser_codex_legacy = subparsers.add_parser(
+        "codex-legacy",
+        help="Create a legacy Codex tmux session and attach to it"
+    )
+    parser_codex_legacy.add_argument(
         "working_dir",
         nargs="?",
         help="Working directory (defaults to current directory)"
@@ -523,7 +534,7 @@ def main():
     # Commands that don't need session_id: lock, unlock, hooks, all, send, wait, what, subagents, children, kill, new, attach, output, clear
     no_session_needed = [
         "lock", "unlock", "subagent-start", "subagent-stop", "all", "send", "wait", "what",
-        "subagents", "children", "kill", "new", "claude", "codex", "codex-fork", "codex_fork",
+        "subagents", "children", "kill", "new", "claude", "codex", "codex-legacy", "codex-fork", "codex_fork",
         "codex-2", "codex-app", "codex-server",
         "attach", "output", "codex-tui", "codex-fork-info", "codex-rollout-gates", "watch", "tail", "clear", "review", "context-monitor", "remind", "setup", None
     ]
@@ -628,6 +639,8 @@ def main():
     elif args.command == "claude":
         sys.exit(commands.cmd_new(client, args.working_dir, provider="claude"))
     elif args.command == "codex":
+        sys.exit(commands.cmd_new(client, args.working_dir, provider="codex-fork"))
+    elif args.command == "codex-legacy":
         sys.exit(commands.cmd_new(client, args.working_dir, provider="codex"))
     elif args.command in ("codex-fork", "codex_fork"):
         sys.exit(commands.cmd_new(client, args.working_dir, provider="codex-fork"))

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -162,7 +162,7 @@ class SessionManager:
         else:
             self.codex_fork_artifact_platforms = ["darwin-arm64", "darwin-x86_64", "linux-x86_64"]
         self.codex_fork_rollback_provider = str(codex_fork_config.get("rollback_provider", "codex"))
-        self.codex_fork_rollback_command = str(codex_fork_config.get("rollback_command", "sm codex"))
+        self.codex_fork_rollback_command = str(codex_fork_config.get("rollback_command", "sm codex-legacy"))
         self.codex_fork_event_poll_interval_seconds = float(
             codex_fork_config.get("event_poll_interval_seconds", 0.5)
         )

--- a/tests/unit/test_cli_parsing.py
+++ b/tests/unit/test_cli_parsing.py
@@ -245,6 +245,30 @@ class TestWaitCommand:
         assert args.seconds == 60
 
 
+class TestCodexCommandRouting:
+    """Tests for user-facing Codex command routing."""
+
+    def test_main_codex_routes_to_codex_fork(self):
+        with patch("sys.argv", ["sm", "codex", "/tmp/repo"]):
+            with patch("src.cli.main.commands.cmd_new", return_value=0) as mock_cmd_new:
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+
+        assert exc_info.value.code == 0
+        mock_cmd_new.assert_called_once()
+        assert mock_cmd_new.call_args.kwargs["provider"] == "codex-fork"
+
+    def test_main_codex_legacy_routes_to_legacy_provider(self):
+        with patch("sys.argv", ["sm", "codex-legacy", "/tmp/repo"]):
+            with patch("src.cli.main.commands.cmd_new", return_value=0) as mock_cmd_new:
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+
+        assert exc_info.value.code == 0
+        mock_cmd_new.assert_called_once()
+        assert mock_cmd_new.call_args.kwargs["provider"] == "codex"
+
+
 class TestWatchCommand:
     """Tests for 'sm watch' parsing."""
 

--- a/tests/unit/test_cmd_codex_fork_info.py
+++ b/tests/unit/test_cmd_codex_fork_info.py
@@ -24,7 +24,7 @@ def test_cmd_codex_fork_info_text_output(capsys):
             "event_schema_version": 2,
             "artifact_platforms": ["darwin-arm64", "linux-x86_64"],
             "rollback_provider": "codex",
-            "rollback_command": "sm codex",
+            "rollback_command": "sm codex-legacy",
         }
     )
     rc = commands.cmd_codex_fork_info(client)

--- a/tests/unit/test_codex_fork_runtime_metadata.py
+++ b/tests/unit/test_codex_fork_runtime_metadata.py
@@ -14,7 +14,7 @@ def test_codex_fork_runtime_metadata_uses_config_pin(tmp_path):
                 "artifact_ref": "f00dbabe1234",
                 "artifact_platforms": ["darwin-arm64"],
                 "rollback_provider": "codex",
-                "rollback_command": "sm codex",
+                "rollback_command": "sm codex-legacy",
             }
         },
     )
@@ -27,7 +27,7 @@ def test_codex_fork_runtime_metadata_uses_config_pin(tmp_path):
     assert metadata["artifact_ref"] == "f00dbabe1234"
     assert metadata["artifact_platforms"] == ["darwin-arm64"]
     assert metadata["rollback_provider"] == "codex"
-    assert metadata["rollback_command"] == "sm codex"
+    assert metadata["rollback_command"] == "sm codex-legacy"
     assert metadata["is_pinned"] is True
 
 
@@ -40,5 +40,5 @@ def test_codex_fork_runtime_metadata_defaults_to_unpinned(tmp_path):
 
     metadata = manager.get_codex_fork_runtime_info()
     assert metadata["artifact_ref"] == "local-unpinned"
+    assert metadata["rollback_command"] == "sm codex-legacy"
     assert metadata["is_pinned"] is False
-


### PR DESCRIPTION
Fixes #367

## Summary
- route the public `sm codex` CLI entrypoint to `codex-fork` so new Codex sessions use the bridged runtime
- add an explicit `sm codex-legacy` entrypoint for operators who still need the raw legacy provider
- update rollback metadata/defaults and add regressions for CLI routing

## Testing
- ./venv/bin/pytest tests/unit/test_cli_parsing.py tests/unit/test_cmd_codex_fork_info.py tests/unit/test_codex_fork_runtime_metadata.py -q
- PYTHONPATH=. python -m py_compile src/cli/main.py src/session_manager.py tests/unit/test_cli_parsing.py tests/unit/test_cmd_codex_fork_info.py tests/unit/test_codex_fork_runtime_metadata.py
- live check: created disposable `sm codex` session `9eb131d8` and verified it came up as `provider=codex-fork`