### PR TITLE
Add durable agent registry commands

### DIFF
--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -127,6 +127,49 @@ class SessionManagerClient:
             return data.get("sessions", [])
         return None
 
+    def list_registry(self) -> Optional[list]:
+        """List all live agent registry entries."""
+        data, success, _ = self._request("GET", "/registry")
+        if success and data:
+            return data.get("registrations", [])
+        return None
+
+    def lookup_role(self, role: str) -> dict:
+        """Resolve one registry role."""
+        role_path = urllib.parse.quote(role, safe="")
+        data, status_code, unavailable = self._request_with_status("GET", f"/registry/{role_path}")
+        if unavailable:
+            return {"ok": False, "unavailable": True, "status_code": None, "data": None, "detail": None}
+        ok = status_code in (200, 201)
+        detail = data.get("detail") if isinstance(data, dict) else None
+        return {"ok": ok, "unavailable": False, "status_code": status_code, "data": data, "detail": detail}
+
+    def register_role(self, session_id: str, role: str) -> dict:
+        """Register the current session for one registry role."""
+        data, status_code, unavailable = self._request_with_status(
+            "POST",
+            f"/sessions/{session_id}/registry",
+            {"requester_session_id": session_id, "role": role},
+        )
+        if unavailable:
+            return {"ok": False, "unavailable": True, "status_code": None, "data": None, "detail": None}
+        ok = status_code in (200, 201)
+        detail = data.get("detail") if isinstance(data, dict) else None
+        return {"ok": ok, "unavailable": False, "status_code": status_code, "data": data, "detail": detail}
+
+    def unregister_role(self, session_id: str, role: str) -> dict:
+        """Remove one registry role from the current session."""
+        data, status_code, unavailable = self._request_with_status(
+            "DELETE",
+            f"/sessions/{session_id}/registry",
+            {"requester_session_id": session_id, "role": role},
+        )
+        if unavailable:
+            return {"ok": False, "unavailable": True, "status_code": None, "data": None, "detail": None}
+        ok = status_code in (200, 201)
+        detail = data.get("detail") if isinstance(data, dict) else None
+        return {"ok": ok, "unavailable": False, "status_code": status_code, "data": data, "detail": detail}
+
     def propose_adoption(self, target_session_id: str, requester_session_id: str) -> dict:
         """Create an adoption proposal for explicit operator approval."""
         data, status_code, unavailable = self._request_with_status(

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -379,6 +379,144 @@ def cmd_maintainer(client: SessionManagerClient, session_id: Optional[str], clea
     return 1
 
 
+def cmd_register(client: SessionManagerClient, session_id: Optional[str], role: str) -> int:
+    """
+    Register the current session for one durable agent registry role.
+
+    Exit codes:
+        0: Success
+        1: Validation/API error
+        2: Session manager unavailable / unmanaged session
+    """
+    if not session_id:
+        print("Error: sm register requires a managed session (CLAUDE_SESSION_MANAGER_ID not set)", file=sys.stderr)
+        return 2
+
+    normalized_role = (role or "").strip()
+    if not normalized_role:
+        print("Error: role is required", file=sys.stderr)
+        return 1
+
+    result = client.register_role(session_id, normalized_role)
+    if result.get("unavailable"):
+        print("Error: Session manager unavailable", file=sys.stderr)
+        return 2
+    if not result.get("ok"):
+        detail = result.get("detail") or "Failed to register role"
+        print(f"Error: {detail}", file=sys.stderr)
+        return 1
+
+    registration = result.get("data") or {}
+    role_name = registration.get("role") or normalized_role
+    target_session = registration.get("session_id") or session_id
+    print(f"Registered: {role_name} -> {target_session}")
+    return 0
+
+
+def cmd_unregister(client: SessionManagerClient, session_id: Optional[str], role: str) -> int:
+    """
+    Remove one durable registry role from the current session.
+
+    Exit codes:
+        0: Success
+        1: Validation/API error
+        2: Session manager unavailable / unmanaged session
+    """
+    if not session_id:
+        print("Error: sm unregister requires a managed session (CLAUDE_SESSION_MANAGER_ID not set)", file=sys.stderr)
+        return 2
+
+    normalized_role = (role or "").strip()
+    if not normalized_role:
+        print("Error: role is required", file=sys.stderr)
+        return 1
+
+    result = client.unregister_role(session_id, normalized_role)
+    if result.get("unavailable"):
+        print("Error: Session manager unavailable", file=sys.stderr)
+        return 2
+    if not result.get("ok"):
+        detail = result.get("detail") or "Failed to unregister role"
+        print(f"Error: {detail}", file=sys.stderr)
+        return 1
+
+    registration = result.get("data") or {}
+    role_name = registration.get("role") or normalized_role
+    print(f"Unregistered: {role_name}")
+    return 0
+
+
+def cmd_lookup(client: SessionManagerClient, role: str) -> int:
+    """
+    Resolve a durable registry role to its owning session ID.
+
+    Prints only the session ID on stdout so it can be used in command substitution.
+    """
+    normalized_role = (role or "").strip()
+    if not normalized_role:
+        print("Error: role is required", file=sys.stderr)
+        return 1
+
+    result = client.lookup_role(normalized_role)
+    if result.get("unavailable"):
+        print("Error: Session manager unavailable", file=sys.stderr)
+        return 2
+    if not result.get("ok"):
+        detail = result.get("detail") or "Role not registered"
+        print(f"Error: {detail}", file=sys.stderr)
+        return 1
+
+    registration = result.get("data") or {}
+    session_id = registration.get("session_id")
+    if not session_id:
+        print("Error: Role lookup returned no session ID", file=sys.stderr)
+        return 1
+    print(session_id)
+    return 0
+
+
+def cmd_roster(client: SessionManagerClient) -> int:
+    """
+    List all live durable registry roles.
+
+    Exit codes:
+        0: Success
+        1: API failure
+        2: Session manager unavailable
+    """
+    registrations = client.list_registry()
+    if registrations is None:
+        print("Error: Session manager unavailable", file=sys.stderr)
+        return 2
+    if not registrations:
+        print("No registered roles.")
+        return 0
+
+    headers = ("Role", "Session ID", "Name", "Provider", "State")
+    rows = [
+        (
+            str(entry.get("role") or ""),
+            str(entry.get("session_id") or ""),
+            str(entry.get("friendly_name") or ""),
+            str(entry.get("provider") or ""),
+            str(entry.get("activity_state") or entry.get("status") or ""),
+        )
+        for entry in registrations
+    ]
+    widths = [
+        max(len(header), *(len(row[idx]) for row in rows))
+        for idx, header in enumerate(headers)
+    ]
+
+    header_line = "  ".join(header.ljust(widths[idx]) for idx, header in enumerate(headers))
+    divider = "  ".join("-" * widths[idx] for idx in range(len(headers)))
+    print(header_line)
+    print(divider)
+    for row in rows:
+        print("  ".join(value.ljust(widths[idx]) for idx, value in enumerate(row)))
+    return 0
+
+
 def cmd_me(client: SessionManagerClient, session_id: str) -> int:
     """
     Show current session info.

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -482,6 +482,42 @@ def main():
         help="Clear the maintainer alias from this session",
     )
 
+    # sm register <role>
+    register_parser = subparsers.add_parser(
+        "register",
+        help="Register this session under a durable agent registry role",
+    )
+    register_parser.add_argument(
+        "role",
+        help="Registry role to claim (example: reviewer, sm-maintainer)",
+    )
+
+    # sm unregister <role>
+    unregister_parser = subparsers.add_parser(
+        "unregister",
+        help="Remove one durable agent registry role from this session",
+    )
+    unregister_parser.add_argument(
+        "role",
+        help="Registry role to release",
+    )
+
+    # sm lookup <role>
+    lookup_parser = subparsers.add_parser(
+        "lookup",
+        help="Resolve a durable agent registry role to its session ID",
+    )
+    lookup_parser.add_argument(
+        "role",
+        help="Registry role to resolve",
+    )
+
+    # sm roster
+    subparsers.add_parser(
+        "roster",
+        help="List live durable agent registry roles",
+    )
+
     # sm adopt <session>
     adopt_parser = subparsers.add_parser(
         "adopt",
@@ -536,10 +572,10 @@ def main():
         "lock", "unlock", "subagent-start", "subagent-stop", "all", "send", "wait", "what",
         "subagents", "children", "kill", "new", "claude", "codex", "codex-legacy", "codex-fork", "codex_fork",
         "codex-2", "codex-app", "codex-server",
-        "attach", "output", "codex-tui", "codex-fork-info", "codex-rollout-gates", "watch", "tail", "clear", "review", "context-monitor", "remind", "setup", None
+        "attach", "output", "codex-tui", "codex-fork-info", "codex-rollout-gates", "watch", "tail", "clear", "review", "context-monitor", "remind", "setup", "lookup", "roster", None
     ]
     # Commands that require session_id: self-directed managed-session actions
-    requires_session_id = ["spawn", "adopt", "maintainer"]
+    requires_session_id = ["spawn", "adopt", "maintainer", "register", "unregister"]
     if not session_id and args.command in requires_session_id:
         print("Error: CLAUDE_SESSION_MANAGER_ID environment variable not set", file=sys.stderr)
         print("This tool must be run inside a Claude Code session managed by Session Manager", file=sys.stderr)
@@ -693,6 +729,14 @@ def main():
         sys.exit(commands.cmd_em(client, session_id, args.name))
     elif args.command == "maintainer":
         sys.exit(commands.cmd_maintainer(client, session_id, clear=args.clear))
+    elif args.command == "register":
+        sys.exit(commands.cmd_register(client, session_id, args.role))
+    elif args.command == "unregister":
+        sys.exit(commands.cmd_unregister(client, session_id, args.role))
+    elif args.command == "lookup":
+        sys.exit(commands.cmd_lookup(client, args.role))
+    elif args.command == "roster":
+        sys.exit(commands.cmd_roster(client))
     elif args.command == "adopt":
         sys.exit(commands.cmd_adopt(client, session_id, args.session))
     elif args.command == "setup":

--- a/src/models.py
+++ b/src/models.py
@@ -68,6 +68,31 @@ class AdoptionProposalStatus(Enum):
 
 
 @dataclass
+class AgentRegistration:
+    """Durable mapping from a registry role to the current owning session."""
+    role: str
+    session_id: str
+    created_at: datetime = field(default_factory=datetime.now)
+
+    def to_dict(self) -> dict:
+        """Convert registration to a JSON-serializable dictionary."""
+        return {
+            "role": self.role,
+            "session_id": self.session_id,
+            "created_at": self.created_at.isoformat(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "AgentRegistration":
+        """Restore a registration from persisted state."""
+        return cls(
+            role=data["role"],
+            session_id=data["session_id"],
+            created_at=datetime.fromisoformat(data["created_at"]) if data.get("created_at") else datetime.now(),
+        )
+
+
+@dataclass
 class TelegramTopicRecord:
     """Durable registry entry for a Telegram forum topic."""
     session_id: str

--- a/src/output_monitor.py
+++ b/src/output_monitor.py
@@ -631,6 +631,9 @@ class OutputMonitor:
 
         # Remove from session manager
         if self._session_manager:
+            unregister_roles = getattr(self._session_manager, "unregister_session_roles", None)
+            if callable(unregister_roles):
+                unregister_roles(session_id, persist=False)
             if session_id in self._session_manager.sessions:
                 del self._session_manager.sessions[session_id]
                 logger.debug(f"Removed session {session_id} from sessions dict")

--- a/src/server.py
+++ b/src/server.py
@@ -140,6 +140,17 @@ class SessionResponse(BaseModel):
     is_maintainer: bool = False
 
 
+class AgentRegistrationResponse(BaseModel):
+    """Response payload for one live agent registry entry."""
+    role: str
+    session_id: str
+    friendly_name: Optional[str] = None
+    provider: Optional[str] = None
+    status: str
+    activity_state: str = "idle"
+    created_at: str
+
+
 class SendInputRequest(BaseModel):
     """Request to send input to a session."""
     text: str
@@ -180,6 +191,12 @@ class SetRoleRequest(BaseModel):
 class SetMaintainerRequest(BaseModel):
     """Request to register or clear the maintainer alias."""
     requester_session_id: str
+
+
+class RoleRegistrationRequest(BaseModel):
+    """Request to register or clear a generic agent registry role."""
+    requester_session_id: str
+    role: str
 
 
 class ClearSessionRequest(BaseModel):
@@ -653,6 +670,20 @@ def create_app(
             created_at=proposal.created_at.isoformat(),
             status=proposal.status.value,
             decided_at=proposal.decided_at.isoformat() if proposal.decided_at else None,
+        )
+
+    def _registration_to_response(registration) -> AgentRegistrationResponse:
+        session = app.state.session_manager.get_session(registration.session_id)
+        if session is None:
+            raise HTTPException(status_code=404, detail="Registered session not found")
+        return AgentRegistrationResponse(
+            role=registration.role,
+            session_id=registration.session_id,
+            friendly_name=session.friendly_name or session.name or session.id,
+            provider=getattr(session, "provider", "claude"),
+            status=session.status.value,
+            activity_state=_get_activity_state(session),
+            created_at=registration.created_at.isoformat(),
         )
 
     def _response_dict(model: BaseModel) -> dict:
@@ -1529,7 +1560,9 @@ def create_app(
             raise HTTPException(status_code=404, detail="Session not found")
 
         setter = getattr(app.state.session_manager, "set_maintainer_session", None)
-        if not callable(setter) or not setter(session_id):
+        if not callable(setter):
+            raise HTTPException(status_code=503, detail="Maintainer registry unavailable")
+        if not setter(session_id):
             raise HTTPException(status_code=400, detail="Failed to register maintainer")
         return _session_to_response(session)
 
@@ -1550,6 +1583,84 @@ def create_app(
         if not callable(clearer) or not clearer(session_id):
             raise HTTPException(status_code=400, detail="Session is not the active maintainer")
         return _session_to_response(session)
+
+    @app.get("/registry")
+    async def list_agent_registry():
+        """List live agent registry roles."""
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
+
+        lister = getattr(app.state.session_manager, "list_agent_registrations", None)
+        if not callable(lister):
+            raise HTTPException(status_code=503, detail="Agent registry unavailable")
+
+        registrations = [_registration_to_response(registration) for registration in lister()]
+        return {"registrations": [_response_dict(registration) for registration in registrations]}
+
+    @app.get("/registry/{role}", response_model=AgentRegistrationResponse)
+    async def lookup_agent_registry(role: str):
+        """Resolve one registry role to the owning live session."""
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
+
+        getter = getattr(app.state.session_manager, "lookup_agent_registration", None)
+        if not callable(getter):
+            raise HTTPException(status_code=503, detail="Agent registry unavailable")
+
+        registration = getter(role)
+        if registration is None:
+            raise HTTPException(status_code=404, detail="Role not registered")
+        return _registration_to_response(registration)
+
+    @app.post("/sessions/{session_id}/registry", response_model=AgentRegistrationResponse)
+    async def register_agent_role(session_id: str, request: RoleRegistrationRequest):
+        """Register the current session for one registry role."""
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
+
+        if request.requester_session_id != session_id:
+            raise HTTPException(status_code=400, detail="sm register is self-directed only")
+
+        session = app.state.session_manager.get_session(session_id)
+        if not session:
+            raise HTTPException(status_code=404, detail="Session not found")
+
+        registrar = getattr(app.state.session_manager, "register_agent_role", None)
+        if not callable(registrar):
+            raise HTTPException(status_code=503, detail="Agent registry unavailable")
+
+        try:
+            registration = registrar(session_id, request.role)
+        except ValueError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        return _registration_to_response(registration)
+
+    @app.delete("/sessions/{session_id}/registry", response_model=AgentRegistrationResponse)
+    async def unregister_agent_role(session_id: str, request: RoleRegistrationRequest):
+        """Remove one registry role owned by the current session."""
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
+
+        if request.requester_session_id != session_id:
+            raise HTTPException(status_code=400, detail="sm unregister is self-directed only")
+
+        session = app.state.session_manager.get_session(session_id)
+        if not session:
+            raise HTTPException(status_code=404, detail="Session not found")
+
+        getter = getattr(app.state.session_manager, "lookup_agent_registration", None)
+        clearer = getattr(app.state.session_manager, "unregister_agent_role", None)
+        if not callable(getter) or not callable(clearer):
+            raise HTTPException(status_code=503, detail="Agent registry unavailable")
+
+        registration = getter(request.role)
+        if registration is None:
+            raise HTTPException(status_code=404, detail="Role not registered")
+        if registration.session_id != session_id:
+            raise HTTPException(status_code=409, detail="Role is not owned by this session")
+        response = _registration_to_response(registration)
+        clearer(session_id, request.role)
+        return response
 
     @app.post("/sessions/{session_id}/context-monitor")
     async def set_context_monitor(session_id: str, request: ContextMonitorRequest):

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Optional, Callable, Awaitable, Any
 
 from .models import (
+    AgentRegistration,
     ActivityState,
     AdoptionProposal,
     AdoptionProposalStatus,
@@ -117,6 +118,7 @@ class SessionManager:
         self.telegram_topic_registry: dict[tuple[int, int], TelegramTopicRecord] = {}
         self._topic_creator: Optional[Callable[..., Awaitable[Optional[int]]]] = None
         self.adoption_proposals: dict[str, AdoptionProposal] = {}
+        self.agent_registrations: dict[str, AgentRegistration] = {}
 
         codex_config = self.config.get("codex", {})
         codex_app_config = self.config.get("codex_app_server", codex_config)
@@ -610,13 +612,21 @@ class SessionManager:
                 # Load EM topic continuity field (backward compat: missing = None)
                 self.em_topic = data.get("em_topic")
                 self.maintainer_session_id = data.get("maintainer_session_id")
+                self.agent_registrations = {}
+                for registration_data in data.get("agent_registrations", []):
+                    registration = AgentRegistration.from_dict(registration_data)
+                    self.agent_registrations[registration.role] = registration
+                if self.maintainer_session_id and "maintainer" not in self.agent_registrations:
+                    self.agent_registrations["maintainer"] = AgentRegistration(
+                        role="maintainer",
+                        session_id=self.maintainer_session_id,
+                    )
                 self.adoption_proposals = {}
                 for proposal_data in data.get("adoption_proposals", []):
                     proposal = AdoptionProposal.from_dict(proposal_data)
                     self.adoption_proposals[proposal.id] = proposal
-                if self.maintainer_session_id and self.maintainer_session_id not in self.sessions:
-                    self.maintainer_session_id = None
-                if retired_codex_app_sessions:
+                registry_changed = self._prune_agent_registrations(persist=False)
+                if retired_codex_app_sessions or registry_changed:
                     self._save_state()
 
                 return True
@@ -660,6 +670,13 @@ class SessionManager:
                 "sessions": [s.to_dict() for s in self.sessions.values()],
                 "em_topic": self.em_topic,
                 "maintainer_session_id": self.maintainer_session_id,
+                "agent_registrations": [
+                    registration.to_dict()
+                    for registration in sorted(
+                        self.agent_registrations.values(),
+                        key=lambda registration: (registration.role, registration.created_at),
+                    )
+                ],
                 "adoption_proposals": [
                     proposal.to_dict()
                     for proposal in sorted(
@@ -1762,41 +1779,149 @@ class SessionManager:
         self._save_state()
         return True
 
-    def set_maintainer_session(self, session_id: str) -> bool:
-        """Register one session as the current maintainer alias."""
+    @staticmethod
+    def normalize_agent_role(role: str) -> str:
+        """Canonicalize registry roles for stable lookup and CLI use."""
+        raw = (role or "").strip().lower()
+        if not raw:
+            return ""
+        normalized = re.sub(r"[^a-z0-9]+", "-", raw).strip("-")
+        return re.sub(r"-{2,}", "-", normalized)
+
+    def _synchronize_maintainer_alias(self) -> None:
+        """Keep the legacy maintainer compatibility field in sync with the registry."""
+        registration = self.agent_registrations.get("maintainer")
+        self.maintainer_session_id = registration.session_id if registration else None
+
+    def _get_live_registered_session(self, session_id: str) -> Optional[Session]:
+        """Return the owning session when it is still live for registry purposes."""
         session = self.sessions.get(session_id)
-        if not session:
-            return False
-        if session.status == SessionStatus.STOPPED:
-            return False
-        self.maintainer_session_id = session_id
-        self._save_state()
-        return True
-
-    def clear_maintainer_session(self, session_id: str) -> bool:
-        """Clear the maintainer alias if owned by the given session."""
-        if self.maintainer_session_id != session_id:
-            return False
-        self.maintainer_session_id = None
-        self._save_state()
-        return True
-
-    def get_maintainer_session(self) -> Optional[Session]:
-        """Return the active maintainer session if one is registered."""
-        if not self.maintainer_session_id:
-            return None
-        session = self.sessions.get(self.maintainer_session_id)
         if not session or session.status == SessionStatus.STOPPED:
             return None
         return session
 
+    def _prune_agent_registrations(self, persist: bool = True) -> bool:
+        """Drop registrations whose owning sessions no longer exist or are no longer live."""
+        removed = False
+        for role, registration in list(self.agent_registrations.items()):
+            if self._get_live_registered_session(registration.session_id):
+                continue
+            self.agent_registrations.pop(role, None)
+            removed = True
+        if removed:
+            self._synchronize_maintainer_alias()
+            if persist:
+                self._save_state()
+        return removed
+
+    def register_agent_role(self, session_id: str, role: str) -> AgentRegistration:
+        """Register one live session as the current owner for a registry role."""
+        normalized_role = self.normalize_agent_role(role)
+        if not normalized_role:
+            raise ValueError("Role cannot be empty")
+
+        session = self.sessions.get(session_id)
+        if not session:
+            raise ValueError("Session not found")
+        if session.status == SessionStatus.STOPPED:
+            raise ValueError("Stopped sessions cannot register roles")
+
+        self._prune_agent_registrations(persist=False)
+        existing = self.agent_registrations.get(normalized_role)
+        if existing and existing.session_id != session_id:
+            live_owner = self._get_live_registered_session(existing.session_id)
+            if live_owner:
+                raise ValueError(
+                    f'Role "{normalized_role}" is already registered to {existing.session_id}'
+                )
+
+        registration = existing or AgentRegistration(role=normalized_role, session_id=session_id)
+        registration.session_id = session_id
+        self.agent_registrations[normalized_role] = registration
+        self._synchronize_maintainer_alias()
+        self._save_state()
+        return registration
+
+    def unregister_agent_role(self, session_id: str, role: str) -> bool:
+        """Clear one registry role when owned by the given session."""
+        normalized_role = self.normalize_agent_role(role)
+        if not normalized_role:
+            return False
+        registration = self.agent_registrations.get(normalized_role)
+        if not registration or registration.session_id != session_id:
+            return False
+        self.agent_registrations.pop(normalized_role, None)
+        self._synchronize_maintainer_alias()
+        self._save_state()
+        return True
+
+    def unregister_session_roles(self, session_id: str, persist: bool = True) -> list[str]:
+        """Remove all registry roles owned by one session."""
+        removed_roles = [
+            role
+            for role, registration in self.agent_registrations.items()
+            if registration.session_id == session_id
+        ]
+        if not removed_roles:
+            return []
+        for role in removed_roles:
+            self.agent_registrations.pop(role, None)
+        self._synchronize_maintainer_alias()
+        if persist:
+            self._save_state()
+        return sorted(removed_roles)
+
+    def lookup_agent_registration(self, role: str) -> Optional[AgentRegistration]:
+        """Resolve one registry role to its current live registration."""
+        normalized_role = self.normalize_agent_role(role)
+        if not normalized_role:
+            return None
+        self._prune_agent_registrations(persist=True)
+        registration = self.agent_registrations.get(normalized_role)
+        if not registration:
+            return None
+        if not self._get_live_registered_session(registration.session_id):
+            self.agent_registrations.pop(normalized_role, None)
+            self._synchronize_maintainer_alias()
+            self._save_state()
+            return None
+        return registration
+
+    def list_agent_registrations(self) -> list[AgentRegistration]:
+        """List all live registry roles."""
+        self._prune_agent_registrations(persist=True)
+        registrations = list(self.agent_registrations.values())
+        registrations.sort(key=lambda registration: registration.role)
+        return registrations
+
+    def set_maintainer_session(self, session_id: str) -> bool:
+        """Register one session as the current maintainer alias."""
+        try:
+            self.register_agent_role(session_id, "maintainer")
+            return True
+        except ValueError:
+            return False
+
+    def clear_maintainer_session(self, session_id: str) -> bool:
+        """Clear the maintainer alias if owned by the given session."""
+        return self.unregister_agent_role(session_id, "maintainer")
+
+    def get_maintainer_session(self) -> Optional[Session]:
+        """Return the active maintainer session if one is registered."""
+        registration = self.lookup_agent_registration("maintainer")
+        if not registration:
+            return None
+        return self._get_live_registered_session(registration.session_id)
+
     def get_session_aliases(self, session_id: str) -> list[str]:
         """Return durable aliases that should resolve to this session."""
-        aliases: list[str] = []
-        maintainer = self.get_maintainer_session()
-        if maintainer and maintainer.id == session_id:
-            aliases.append("maintainer")
-        return aliases
+        self._prune_agent_registrations(persist=True)
+        aliases = [
+            role
+            for role, registration in self.agent_registrations.items()
+            if registration.session_id == session_id
+        ]
+        return sorted(aliases)
 
     def list_sessions(self, include_stopped: bool = False) -> list[Session]:
         """List all sessions."""
@@ -3296,6 +3421,7 @@ class SessionManager:
                 )
             self.tmux.kill_session(session.tmux_session)
         session.status = SessionStatus.STOPPED
+        self.unregister_session_roles(session_id, persist=False)
         self._save_state()
 
         logger.info(f"Killed session {session.name}")

--- a/tests/unit/test_agent_registry.py
+++ b/tests/unit/test_agent_registry.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import json
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.cli.commands import cmd_lookup, cmd_register, cmd_roster, cmd_unregister, resolve_session_id
+from src.cli.main import main
+from src.models import Session, SessionStatus
+from src.output_monitor import OutputMonitor
+from src.server import create_app
+from src.session_manager import SessionManager
+
+
+def _manager(tmp_path) -> SessionManager:
+    return SessionManager(
+        log_dir=str(tmp_path / "logs"),
+        state_file=str(tmp_path / "sessions.json"),
+        config={},
+    )
+
+
+def _session(session_id: str, tmp_path) -> Session:
+    return Session(
+        id=session_id,
+        name=f"claude-{session_id}",
+        working_dir=str(tmp_path),
+        tmux_session=f"claude-{session_id}",
+        provider="claude",
+        log_file=str(tmp_path / f"{session_id}.log"),
+        status=SessionStatus.RUNNING,
+    )
+
+
+def test_register_role_persists_and_exposes_aliases(tmp_path):
+    manager = _manager(tmp_path)
+    session = _session("role1234", tmp_path)
+    manager.sessions[session.id] = session
+
+    registration = manager.register_agent_role(session.id, "Reviewer")
+
+    assert registration.role == "reviewer"
+    assert manager.get_session_aliases(session.id) == ["reviewer"]
+    state_data = json.loads((tmp_path / "sessions.json").read_text())
+    assert state_data["agent_registrations"] == [
+        {
+            "role": "reviewer",
+            "session_id": session.id,
+            "created_at": registration.created_at.isoformat(),
+        }
+    ]
+
+
+def test_registering_maintainer_updates_compat_field(tmp_path):
+    manager = _manager(tmp_path)
+    session = _session("maint123", tmp_path)
+    manager.sessions[session.id] = session
+
+    manager.register_agent_role(session.id, "maintainer")
+
+    state_data = json.loads((tmp_path / "sessions.json").read_text())
+    assert state_data["maintainer_session_id"] == session.id
+    assert manager.get_maintainer_session().id == session.id
+
+
+def test_lookup_prunes_stopped_registration(tmp_path):
+    manager = _manager(tmp_path)
+    session = _session("stop1234", tmp_path)
+    manager.sessions[session.id] = session
+    manager.register_agent_role(session.id, "reviewer")
+
+    session.status = SessionStatus.STOPPED
+
+    assert manager.lookup_agent_registration("reviewer") is None
+    assert manager.list_agent_registrations() == []
+    state_data = json.loads((tmp_path / "sessions.json").read_text())
+    assert state_data["agent_registrations"] == []
+
+
+def test_kill_session_unregisters_roles(tmp_path):
+    manager = _manager(tmp_path)
+    session = _session("kill1234", tmp_path)
+    manager.sessions[session.id] = session
+    manager.register_agent_role(session.id, "reviewer")
+
+    assert manager.kill_session(session.id) is True
+    assert manager.lookup_agent_registration("reviewer") is None
+
+    state_data = json.loads((tmp_path / "sessions.json").read_text())
+    assert state_data["agent_registrations"] == []
+
+
+def test_output_monitor_cleanup_unregisters_roles(tmp_path):
+    manager = _manager(tmp_path)
+    session = _session("dead1234", tmp_path)
+    manager.sessions[session.id] = session
+    manager.register_agent_role(session.id, "reviewer")
+
+    monitor = OutputMonitor()
+    monitor.set_session_manager(manager)
+
+    import asyncio
+
+    asyncio.run(monitor.cleanup_session(session))
+
+    assert session.id not in manager.sessions
+    assert manager.lookup_agent_registration("reviewer") is None
+
+    state_data = json.loads((tmp_path / "sessions.json").read_text())
+    assert state_data["agent_registrations"] == []
+
+
+def test_registry_endpoints_register_lookup_and_roster(tmp_path):
+    manager = _manager(tmp_path)
+    session = _session("role1234", tmp_path)
+    manager.sessions[session.id] = session
+    client = TestClient(create_app(session_manager=manager))
+
+    register_response = client.post(
+        f"/sessions/{session.id}/registry",
+        json={"requester_session_id": session.id, "role": "SM Maintainer"},
+    )
+
+    assert register_response.status_code == 200
+    assert register_response.json()["role"] == "sm-maintainer"
+
+    lookup_response = client.get("/registry/sm-maintainer")
+    assert lookup_response.status_code == 200
+    assert lookup_response.json()["session_id"] == session.id
+
+    roster_response = client.get("/registry")
+    assert roster_response.status_code == 200
+    assert roster_response.json()["registrations"][0]["role"] == "sm-maintainer"
+
+    sessions_response = client.get("/sessions")
+    assert sessions_response.status_code == 200
+    payload = sessions_response.json()["sessions"][0]
+    assert payload["aliases"] == ["sm-maintainer"]
+
+
+def test_register_route_rejects_live_conflict(tmp_path):
+    manager = _manager(tmp_path)
+    reviewer = _session("review01", tmp_path)
+    other = _session("other001", tmp_path)
+    manager.sessions[reviewer.id] = reviewer
+    manager.sessions[other.id] = other
+    manager.register_agent_role(reviewer.id, "reviewer")
+    client = TestClient(create_app(session_manager=manager))
+
+    response = client.post(
+        f"/sessions/{other.id}/registry",
+        json={"requester_session_id": other.id, "role": "reviewer"},
+    )
+
+    assert response.status_code == 409
+    assert "already registered" in response.json()["detail"]
+
+
+def test_unregister_route_requires_owner(tmp_path):
+    manager = _manager(tmp_path)
+    owner = _session("owner001", tmp_path)
+    other = _session("other001", tmp_path)
+    manager.sessions[owner.id] = owner
+    manager.sessions[other.id] = other
+    manager.register_agent_role(owner.id, "reviewer")
+    client = TestClient(create_app(session_manager=manager))
+
+    response = client.request(
+        "DELETE",
+        f"/sessions/{other.id}/registry",
+        json={"requester_session_id": other.id, "role": "reviewer"},
+    )
+
+    assert response.status_code == 409
+    assert "not owned" in response.json()["detail"]
+
+
+def test_resolve_session_id_matches_generic_registry_alias():
+    client = Mock()
+    client.get_session.return_value = None
+    client.list_sessions.return_value = [
+        {"id": "role1234", "friendly_name": "codex-ops", "aliases": ["reviewer", "sm-maintainer"]},
+    ]
+
+    resolved_id, resolved_session = resolve_session_id(client, "reviewer")
+
+    assert resolved_id == "role1234"
+    assert resolved_session["friendly_name"] == "codex-ops"
+
+
+def test_cmd_register_lookup_unregister_and_roster(capsys):
+    client = Mock()
+    client.register_role.return_value = {
+        "ok": True,
+        "unavailable": False,
+        "data": {"role": "reviewer", "session_id": "sess1234"},
+    }
+    client.lookup_role.return_value = {
+        "ok": True,
+        "unavailable": False,
+        "data": {"role": "reviewer", "session_id": "sess1234"},
+    }
+    client.unregister_role.return_value = {
+        "ok": True,
+        "unavailable": False,
+        "data": {"role": "reviewer"},
+    }
+    client.list_registry.return_value = [
+        {
+            "role": "reviewer",
+            "session_id": "sess1234",
+            "friendly_name": "engineer-1",
+            "provider": "codex-fork",
+            "activity_state": "idle",
+        }
+    ]
+
+    assert cmd_register(client, "sess1234", "Reviewer") == 0
+    assert "reviewer -> sess1234" in capsys.readouterr().out
+
+    assert cmd_lookup(client, "reviewer") == 0
+    assert capsys.readouterr().out.strip() == "sess1234"
+
+    assert cmd_unregister(client, "sess1234", "reviewer") == 0
+    assert "Unregistered: reviewer" in capsys.readouterr().out
+
+    assert cmd_roster(client) == 0
+    roster_output = capsys.readouterr().out
+    assert "Role" in roster_output
+    assert "reviewer" in roster_output
+    assert "sess1234" in roster_output
+
+
+def test_main_register_lookup_roster_dispatch():
+    with patch.dict(os.environ, {"CLAUDE_SESSION_MANAGER_ID": "sess1234"}, clear=False):
+        with patch("sys.argv", ["sm", "register", "reviewer"]):
+            with patch("src.cli.main.commands.cmd_register", return_value=0) as mock_register:
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+    assert exc_info.value.code == 0
+    mock_register.assert_called_once()
+
+    with patch.dict(os.environ, {"CLAUDE_SESSION_MANAGER_ID": ""}, clear=False):
+        with patch("sys.argv", ["sm", "lookup", "reviewer"]):
+            with patch("src.cli.main.commands.cmd_lookup", return_value=0) as mock_lookup:
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+    assert exc_info.value.code == 0
+    mock_lookup.assert_called_once()
+
+    with patch.dict(os.environ, {"CLAUDE_SESSION_MANAGER_ID": ""}, clear=False):
+        with patch("sys.argv", ["sm", "roster"]):
+            with patch("src.cli.main.commands.cmd_roster", return_value=0) as mock_roster:
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+    assert exc_info.value.code == 0
+    mock_roster.assert_called_once()


### PR DESCRIPTION
## Summary
- add a durable agent registry with register, lookup, roster, and unregister flows
- keep the legacy maintainer alias as a thin compatibility layer over the registry
- prune dead registrations during lookup and lifecycle cleanup so roles do not orphan

## Testing
- ./venv/bin/pytest tests/unit/test_agent_registry.py tests/unit/test_maintainer_alias.py tests/unit/test_adoption_flow.py tests/unit/test_watch_tui.py -q
- PYTHONPATH=. python -m py_compile src/models.py src/session_manager.py src/output_monitor.py src/server.py src/cli/client.py src/cli/commands.py src/cli/main.py tests/unit/test_agent_registry.py

Fixes #369