### PR TITLE
Auto-bootstrap maintainer on demand

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -193,6 +193,21 @@ codex_fork:
   # Control client/runtime contract pin.
   event_schema_version: 2
 
+# Optional auto-bootstrap config for `sm send maintainer ...`
+maintainer_agent:
+  working_dir: "/path/to/session-manager"
+  friendly_name: "sm-maintainer"
+  preferred_providers:
+    - "codex-fork"
+    - "claude"
+  bootstrap_prompt: |
+    As engineer, act as the Session Manager maintainer service agent for this repository.
+    - Own the incoming maintainer queue for Session Manager.
+    - Agents will report bugs via `sm send maintainer "..."`.
+    - Investigate against real behavior first, implement fixes with tests, restart SM with launchctl,
+      open a PR, comment `@codex review`, poll for feedback, merge when clean, and restart SM again.
+    - Do not send acknowledgements unless the reporter asks for one.
+
 # Durable codex lifecycle event stream (for /codex-events + activity_state)
 codex_events:
   db_path: "~/.local/share/claude-sessions/codex_events.db"

--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -292,6 +292,23 @@ class SessionManagerClient:
         )
         return success, unavailable
 
+    def ensure_maintainer(self, requester_session_id: Optional[str] = None) -> dict:
+        """Ensure the maintainer service session exists."""
+        payload = {}
+        if requester_session_id:
+            payload["requester_session_id"] = requester_session_id
+        data, status_code, unavailable = self._request_with_status(
+            "POST",
+            "/maintainer/ensure",
+            payload,
+            timeout=10,
+        )
+        if unavailable:
+            return {"ok": False, "unavailable": True, "status_code": None, "data": None, "detail": None}
+        ok = status_code in (200, 201)
+        detail = data.get("detail") if isinstance(data, dict) else None
+        return {"ok": ok, "unavailable": False, "status_code": status_code, "data": data, "detail": detail}
+
     def update_task(self, session_id: str, task: str) -> tuple[bool, bool]:
         """
         Update session current task.

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -1269,20 +1269,40 @@ def cmd_send(
         1: Session not found or send failed
         2: Session manager unavailable
     """
+    sender_session_id = client.session_id  # Set from CLAUDE_SESSION_MANAGER_ID in __init__
+
     # Resolve identifier to session ID and get session details
     session_id, session = resolve_session_id(client, identifier)
     if session_id is None:
-        # Check if it's unavailable or not found
-        sessions = client.list_sessions()
-        if sessions is None:
-            print("Error: Session manager unavailable", file=sys.stderr)
-            return 2
-        else:
-            print(f"Error: Session '{identifier}' not found", file=sys.stderr)
-            return 1
+        if identifier == "maintainer":
+            ensure_result = client.ensure_maintainer(requester_session_id=sender_session_id)
+            if ensure_result.get("unavailable"):
+                print("Error: Session manager unavailable", file=sys.stderr)
+                return 2
+            if not ensure_result.get("ok"):
+                detail = ensure_result.get("detail") or "Failed to bootstrap maintainer session"
+                print(f"Error: {detail}", file=sys.stderr)
+                return 1
 
-    # Get sender session ID from environment (if available)
-    sender_session_id = client.session_id  # Set from CLAUDE_SESSION_MANAGER_ID in __init__
+            payload = ensure_result.get("data") or {}
+            session = payload.get("session") or {}
+            session_id = session.get("id")
+            if not session_id:
+                print("Error: Maintainer bootstrap returned no session", file=sys.stderr)
+                return 1
+            if payload.get("created"):
+                maintainer_name = session.get("friendly_name") or session.get("name") or session_id
+                provider = session.get("provider") or "unknown"
+                print(f"Maintainer bootstrapped: {maintainer_name} ({session_id}) [{provider}]")
+        else:
+            # Check if it's unavailable or not found
+            sessions = client.list_sessions()
+            if sessions is None:
+                print("Error: Session manager unavailable", file=sys.stderr)
+                return 2
+            else:
+                print(f"Error: Session '{identifier}' not found", file=sys.stderr)
+                return 1
 
     # Self-sends are commonly used as delayed wakeups; do not advertise or request
     # stop-notify because it would wake the same agent on its next stop hook.

--- a/src/server.py
+++ b/src/server.py
@@ -151,6 +151,12 @@ class AgentRegistrationResponse(BaseModel):
     created_at: str
 
 
+class EnsureMaintainerResponse(BaseModel):
+    """Response payload for maintainer auto-bootstrap."""
+    created: bool
+    session: SessionResponse
+
+
 class SendInputRequest(BaseModel):
     """Request to send input to a session."""
     text: str
@@ -191,6 +197,11 @@ class SetRoleRequest(BaseModel):
 class SetMaintainerRequest(BaseModel):
     """Request to register or clear the maintainer alias."""
     requester_session_id: str
+
+
+class EnsureMaintainerRequest(BaseModel):
+    """Request to ensure the maintainer service session exists."""
+    requester_session_id: Optional[str] = None
 
 
 class RoleRegistrationRequest(BaseModel):
@@ -1583,6 +1594,31 @@ def create_app(
         if not callable(clearer) or not clearer(session_id):
             raise HTTPException(status_code=400, detail="Session is not the active maintainer")
         return _session_to_response(session)
+
+    @app.post("/maintainer/ensure", response_model=EnsureMaintainerResponse)
+    async def ensure_maintainer(request: EnsureMaintainerRequest):
+        """Ensure the maintainer service session exists, bootstrapping it when absent."""
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
+
+        ensurer = getattr(app.state.session_manager, "ensure_maintainer_session", None)
+        if not callable(ensurer):
+            raise HTTPException(status_code=503, detail="Maintainer bootstrap unavailable")
+
+        try:
+            session, created = await ensurer()
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except RuntimeError as exc:
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+        if created and app.state.output_monitor and getattr(session, "provider", "claude") != "codex-app":
+            await app.state.output_monitor.start_monitoring(session)
+
+        return EnsureMaintainerResponse(
+            created=created,
+            session=_session_to_response(session),
+        )
 
     @app.get("/registry")
     async def list_agent_registry():

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -4,8 +4,12 @@ import asyncio
 import contextlib
 import json
 import logging
+import os
 import re
+import shlex
+import shutil
 import subprocess
+import textwrap
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -38,6 +42,33 @@ from .codex_request_ledger import CodexRequestLedger
 from .github_reviews import post_pr_review_comment, poll_for_codex_review, get_pr_repo_from_git
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_MAINTAINER_BOOTSTRAP_PROMPT = textwrap.dedent(
+    """
+    As engineer, act as the Session Manager maintainer service agent for this repository.
+
+    Role:
+    - You own the incoming maintainer queue for Session Manager.
+    - Agents will report bugs and maintenance requests via `sm send maintainer "..."`.
+    - Keep the `maintainer` registry role for this session.
+
+    Workflow:
+    - Investigate against real behavior first; do not speculate from code alone.
+    - File or update a GitHub ticket when needed.
+    - Implement the fix with focused changes and tests.
+    - Restart Session Manager with `launchctl`.
+    - Open a PR, comment `@codex review`, poll about every 3 minutes, address feedback, and if review is clean or silent after reasonable polling, merge and delete the branch.
+    - Restart Session Manager again after merge.
+    - Keep working until the reported issue is resolved end-to-end.
+
+    Communication:
+    - Do not send acknowledgements unless the reporter asks for one.
+    - Use concise status updates only when needed for blockers or explicit follow-up.
+
+    Repository:
+    - Work in {working_dir}.
+    """
+).strip()
 
 ROLE_KEYWORDS = (
     "engineer",
@@ -119,6 +150,26 @@ class SessionManager:
         self._topic_creator: Optional[Callable[..., Awaitable[Optional[int]]]] = None
         self.adoption_proposals: dict[str, AdoptionProposal] = {}
         self.agent_registrations: dict[str, AgentRegistration] = {}
+        self._maintainer_bootstrap_lock = asyncio.Lock()
+
+        maintainer_config = self.config.get("maintainer_agent", {})
+        configured_working_dir = maintainer_config.get("working_dir")
+        default_working_dir = str(Path(__file__).resolve().parents[1])
+        self.maintainer_working_dir = str(configured_working_dir or default_working_dir)
+        self.maintainer_friendly_name = str(
+            maintainer_config.get("friendly_name", "sm-maintainer")
+        ).strip() or "sm-maintainer"
+        preferred_providers = maintainer_config.get("preferred_providers", ["codex-fork", "claude"])
+        if isinstance(preferred_providers, list):
+            normalized_providers = [str(provider).strip() for provider in preferred_providers if str(provider).strip()]
+        else:
+            normalized_providers = ["codex-fork", "claude"]
+        self.maintainer_preferred_providers = normalized_providers or ["codex-fork", "claude"]
+        raw_bootstrap_prompt = maintainer_config.get(
+            "bootstrap_prompt",
+            DEFAULT_MAINTAINER_BOOTSTRAP_PROMPT,
+        )
+        self.maintainer_bootstrap_prompt_template = str(raw_bootstrap_prompt).strip() or DEFAULT_MAINTAINER_BOOTSTRAP_PROMPT
 
         codex_config = self.config.get("codex", {})
         codex_app_config = self.config.get("codex_app_server", codex_config)
@@ -1893,6 +1944,109 @@ class SessionManager:
         registrations = list(self.agent_registrations.values())
         registrations.sort(key=lambda registration: registration.role)
         return registrations
+
+    def _maintainer_bootstrap_prompt(self, working_dir: str) -> str:
+        """Render the maintainer bootstrap prompt for a new service session."""
+        return self.maintainer_bootstrap_prompt_template.replace("{working_dir}", working_dir)
+
+    def _provider_entrypoint_available(self, provider: str) -> bool:
+        """Best-effort preflight for tmux-backed providers used during maintainer bootstrap."""
+        if provider == "codex-fork":
+            command = self.codex_fork_command
+        elif provider == "codex":
+            command = self.codex_cli_command
+        elif provider == "claude":
+            command = self.config.get("claude", {}).get("command", "claude")
+        else:
+            return True
+
+        if not command:
+            return False
+
+        try:
+            entrypoint = shlex.split(str(command))[0]
+        except ValueError:
+            entrypoint = str(command).strip()
+        if not entrypoint:
+            return False
+
+        if "/" in entrypoint or entrypoint.startswith("~"):
+            candidate = Path(entrypoint).expanduser()
+            return candidate.exists() and os.access(candidate, os.X_OK)
+
+        return shutil.which(entrypoint) is not None
+
+    def _resolve_maintainer_working_dir(self) -> str:
+        """Resolve the maintainer service working directory."""
+        candidate = Path(self.maintainer_working_dir).expanduser().resolve()
+        if not candidate.exists():
+            raise ValueError(f"Maintainer working directory does not exist: {candidate}")
+        if not candidate.is_dir():
+            raise ValueError(f"Maintainer working directory is not a directory: {candidate}")
+        return str(candidate)
+
+    async def ensure_maintainer_session(self) -> tuple[Session, bool]:
+        """Return the live maintainer session, spawning it if needed."""
+        existing = self.get_maintainer_session()
+        if existing:
+            return existing, False
+
+        async with self._maintainer_bootstrap_lock:
+            existing = self.get_maintainer_session()
+            if existing:
+                return existing, False
+
+            working_dir = self._resolve_maintainer_working_dir()
+            bootstrap_prompt = self._maintainer_bootstrap_prompt(working_dir)
+            last_error: Optional[str] = None
+
+            for provider in self.maintainer_preferred_providers:
+                if not self._provider_entrypoint_available(provider):
+                    last_error = f"{provider} entrypoint unavailable"
+                    logger.warning(
+                        "Skipping maintainer bootstrap provider %s: entrypoint unavailable",
+                        provider,
+                    )
+                    continue
+
+                session = await self._create_session_common(
+                    working_dir=working_dir,
+                    friendly_name=self.maintainer_friendly_name,
+                    initial_prompt=bootstrap_prompt,
+                    provider=provider,
+                )
+                if not session:
+                    last_error = f"{provider} session creation failed"
+                    logger.warning(
+                        "Maintainer bootstrap failed for provider %s during session creation",
+                        provider,
+                    )
+                    continue
+
+                session.role = "maintainer"
+                self._save_state()
+
+                try:
+                    self.register_agent_role(session.id, "maintainer")
+                except ValueError:
+                    adopted = self.get_maintainer_session()
+                    if adopted and adopted.id != session.id:
+                        self.kill_session(session.id)
+                        return adopted, False
+                    self.kill_session(session.id)
+                    raise
+
+                logger.info(
+                    "Bootstrapped maintainer session %s using provider %s",
+                    session.id,
+                    provider,
+                )
+                return session, True
+
+            detail = "Failed to bootstrap maintainer session"
+            if last_error:
+                detail = f"{detail}: {last_error}"
+            raise RuntimeError(detail)
 
     def set_maintainer_session(self, session_id: str) -> bool:
         """Register one session as the current maintainer alias."""

--- a/tests/unit/test_maintainer_alias.py
+++ b/tests/unit/test_maintainer_alias.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import asyncio
 import json
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 from fastapi.testclient import TestClient
 
-from src.cli.commands import cmd_maintainer, resolve_session_id
+from src.cli.commands import cmd_maintainer, cmd_send, resolve_session_id
 from src.models import Session, SessionStatus
 from src.server import create_app
 from src.session_manager import SessionManager
@@ -124,3 +125,127 @@ def test_cmd_maintainer_clear(capsys):
     assert rc == 0
     client.clear_maintainer.assert_called_once_with("maint123")
     assert "cleared" in capsys.readouterr().out
+
+
+def test_ensure_maintainer_session_prefers_codex_fork_and_registers_alias(tmp_path):
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    manager = _manager(tmp_path)
+    manager.maintainer_working_dir = str(repo_dir)
+
+    async def _fake_create_session_common(**kwargs):
+        session = Session(
+            id="maint001",
+            working_dir=kwargs["working_dir"],
+            provider=kwargs["provider"],
+            friendly_name=kwargs["friendly_name"],
+            log_file=str(tmp_path / "maint001.log"),
+            status=SessionStatus.RUNNING,
+        )
+        manager.sessions[session.id] = session
+        _fake_create_session_common.kwargs = kwargs
+        return session
+
+    manager._provider_entrypoint_available = Mock(return_value=True)
+    manager._create_session_common = AsyncMock(side_effect=_fake_create_session_common)
+
+    session, created = asyncio.run(manager.ensure_maintainer_session())
+
+    assert created is True
+    assert session.id == "maint001"
+    assert session.provider == "codex-fork"
+    assert session.role == "maintainer"
+    assert manager.lookup_agent_registration("maintainer").session_id == session.id
+    assert _fake_create_session_common.kwargs["working_dir"] == str(repo_dir)
+    assert "sm send maintainer" in _fake_create_session_common.kwargs["initial_prompt"]
+
+
+def test_ensure_maintainer_session_falls_back_to_claude(tmp_path):
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    manager = _manager(tmp_path)
+    manager.maintainer_working_dir = str(repo_dir)
+
+    async def _fake_create_session_common(**kwargs):
+        session = Session(
+            id="maint002",
+            working_dir=kwargs["working_dir"],
+            provider=kwargs["provider"],
+            friendly_name=kwargs["friendly_name"],
+            log_file=str(tmp_path / "maint002.log"),
+            status=SessionStatus.RUNNING,
+        )
+        manager.sessions[session.id] = session
+        return session
+
+    manager._provider_entrypoint_available = Mock(side_effect=lambda provider: provider != "codex-fork")
+    manager._create_session_common = AsyncMock(side_effect=_fake_create_session_common)
+
+    session, created = asyncio.run(manager.ensure_maintainer_session())
+
+    assert created is True
+    assert session.provider == "claude"
+    manager._create_session_common.assert_awaited_once()
+
+
+def test_post_ensure_maintainer_bootstraps_session(tmp_path):
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    manager = _manager(tmp_path)
+    manager.maintainer_working_dir = str(repo_dir)
+
+    async def _fake_create_session_common(**kwargs):
+        session = Session(
+            id="maint003",
+            working_dir=kwargs["working_dir"],
+            provider=kwargs["provider"],
+            friendly_name=kwargs["friendly_name"],
+            log_file=str(tmp_path / "maint003.log"),
+            status=SessionStatus.RUNNING,
+        )
+        manager.sessions[session.id] = session
+        return session
+
+    manager._provider_entrypoint_available = Mock(return_value=True)
+    manager._create_session_common = AsyncMock(side_effect=_fake_create_session_common)
+    client = TestClient(create_app(session_manager=manager))
+
+    response = client.post("/maintainer/ensure", json={})
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["created"] is True
+    assert payload["session"]["id"] == "maint003"
+    assert payload["session"]["aliases"] == ["maintainer"]
+    assert payload["session"]["provider"] == "codex-fork"
+
+
+def test_cmd_send_bootstraps_maintainer_when_missing(capsys):
+    client = Mock()
+    client.get_session.return_value = None
+    client.list_sessions.return_value = []
+    client.session_id = "sender123"
+    client.ensure_maintainer.return_value = {
+        "ok": True,
+        "unavailable": False,
+        "data": {
+            "created": True,
+            "session": {
+                "id": "maint004",
+                "friendly_name": "sm-maintainer",
+                "name": "codex-fork-maint004",
+                "provider": "codex-fork",
+            },
+        },
+    }
+    client.send_input.return_value = (True, False)
+
+    rc = cmd_send(client, "maintainer", "bug report")
+
+    assert rc == 0
+    client.ensure_maintainer.assert_called_once_with(requester_session_id="sender123")
+    client.send_input.assert_called_once()
+    assert client.send_input.call_args[0][0] == "maint004"
+    output = capsys.readouterr().out
+    assert "Maintainer bootstrapped: sm-maintainer (maint004) [codex-fork]" in output
+    assert "Input sent to sm-maintainer (maint004)" in output


### PR DESCRIPTION
## Summary
- add a server-side maintainer bootstrap path with codex-fork-first fallback to claude
- teach `sm send maintainer ...` to ensure the maintainer exists before delivery
- cover bootstrap, fallback, and delivery with unit tests

## Testing
- ./venv/bin/pytest tests/unit/test_maintainer_alias.py tests/unit/test_agent_registry.py tests/unit/test_dispatch.py -q
- PYTHONPATH=. python -m py_compile src/session_manager.py src/server.py src/cli/client.py src/cli/commands.py tests/unit/test_maintainer_alias.py
- live smoke: unregister maintainer, run `sm send maintainer ...`, verify codex-fork bootstrap, kill disposable maintainer, restore current maintainer

Fixes #371