### PR TITLE
Fix codex-fork child activity state reporting

### DIFF
--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -1718,7 +1718,8 @@ def cmd_children(
         for child in children:
             name = child.get("friendly_name") or child["name"]
             child_id = child["id"]
-            status = child.get("completion_status") or child["status"]
+            activity_state = child.get("activity_state")
+            status = child.get("completion_status") or activity_state or child["status"]
             last_activity = child.get("last_activity", "")
             completion_msg = child.get("completion_message", "")
             provider = child.get("provider", "claude")
@@ -1738,7 +1739,7 @@ def cmd_children(
 
             # Thinking duration + last tool — only for running sessions
             raw_status = child.get("status", "")
-            if raw_status == "running":
+            if activity_state in {"working", "thinking"} or raw_status == "running":
                 thinking_str = None
                 last_tool_str = None
                 last_label = "last tool"

--- a/src/server.py
+++ b/src/server.py
@@ -3026,6 +3026,7 @@ Provide ONLY the summary, no preamble or questions."""
                     "name": s.name,
                     "friendly_name": s.friendly_name,
                     "status": s.status.value,
+                    "activity_state": _get_activity_state(s),
                     "completion_status": s.completion_status.value if s.completion_status else None,
                     "completion_message": s.completion_message,
                     "last_activity": s.last_activity.isoformat(),

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -980,6 +980,15 @@ class SessionManager:
         elif normalized == "turn_delta":
             if session_id in self.codex_fork_turns_in_flight:
                 next_state = "running"
+        elif current_state not in {"waiting_on_approval", "waiting_on_user_input"} and (
+            normalized == "turn_diff"
+            or normalized in {"item_started", "item_completed", "agent_message", "exec_command_end"}
+            or normalized.endswith("_begin")
+            or normalized.endswith("_delta")
+        ):
+            # After restart we may resume monitoring mid-turn without re-seeing the original
+            # turn_started event. Fresh deltas/tool events must still reassert active work.
+            next_state = "running"
         elif normalized == "shutdown_complete":
             self.codex_fork_turns_in_flight.discard(session_id)
             self.codex_fork_wait_resume_state.pop(session_id, None)

--- a/tests/unit/test_children_api.py
+++ b/tests/unit/test_children_api.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from src.models import Session, SessionStatus
+from src.server import create_app
+from src.session_manager import SessionManager
+
+
+def _manager(tmp_path) -> SessionManager:
+    manager = SessionManager(
+        log_dir=str(tmp_path / "logs"),
+        state_file=str(tmp_path / "sessions.json"),
+        config={},
+    )
+    return manager
+
+
+def test_children_endpoint_includes_activity_state(tmp_path):
+    manager = _manager(tmp_path)
+    parent = Session(
+        id="parent01",
+        working_dir=str(tmp_path),
+        provider="claude",
+        status=SessionStatus.RUNNING,
+    )
+    child = Session(
+        id="child001",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        parent_session_id=parent.id,
+        status=SessionStatus.IDLE,
+    )
+    manager.sessions[parent.id] = parent
+    manager.sessions[child.id] = child
+    manager.codex_fork_lifecycle[child.id] = {
+        "state": "running",
+        "cause_event_type": "turn_diff",
+        "updated_at": parent.last_activity.isoformat(),
+    }
+
+    client = TestClient(create_app(session_manager=manager))
+    response = client.get(f"/sessions/{parent.id}/children")
+
+    assert response.status_code == 200
+    payload = response.json()["children"]
+    assert len(payload) == 1
+    assert payload[0]["id"] == child.id
+    assert payload[0]["status"] == "idle"
+    assert payload[0]["activity_state"] == "working"

--- a/tests/unit/test_cmd_children.py
+++ b/tests/unit/test_cmd_children.py
@@ -78,6 +78,7 @@ def _child(
     agent_status_at: str = None,
     completion_message: str = None,
     activity_projection: dict = None,
+    activity_state: str = None,
 ) -> dict:
     if last_activity is None:
         last_activity = datetime.utcnow().isoformat()
@@ -93,6 +94,7 @@ def _child(
         "agent_status_at": agent_status_at,
         "completion_message": completion_message,
         "activity_projection": activity_projection,
+        "activity_state": activity_state,
     }
 
 
@@ -261,6 +263,25 @@ class TestCmdChildrenOutput:
         assert "last tool: n/a (no hooks)" in out
         assert "thinking" in out
         assert " | codex | " in out
+
+    def test_codex_fork_prefers_activity_state_over_raw_status(self, tmp_path, capsys):
+        child = _child(
+            child_id="fork0000002",
+            provider="codex-fork",
+            status="idle",
+            activity_state="working",
+        )
+        client = _make_client([child])
+
+        epoch = int(time.time()) - 90
+        with patch("src.cli.commands._get_tmux_session_activity", return_value=epoch):
+            rc = cmd_children(client, "parent1", db_path=str(tmp_path / "tool_usage.db"))
+
+        out = capsys.readouterr().out
+        assert rc == 0
+        assert " | codex-fork | working | " in out
+        assert "thinking" in out
+        assert "last tool: n/a (event-stream lifecycle)" in out
 
     def test_codex_app_session_uses_activity_projection(self, tmp_path, capsys):
         child = _child(

--- a/tests/unit/test_codex_activity_state.py
+++ b/tests/unit/test_codex_activity_state.py
@@ -258,7 +258,7 @@ def test_codex_fork_non_transition_events_do_not_mark_idle_again():
 
     calls = {"idle": 0, "active": 0}
     manager.message_queue_manager = SimpleNamespace(
-        mark_session_idle=lambda _sid: calls.__setitem__("idle", calls["idle"] + 1),
+        mark_session_idle=lambda _sid, **_kwargs: calls.__setitem__("idle", calls["idle"] + 1),
         mark_session_active=lambda _sid: calls.__setitem__("active", calls["active"] + 1),
     )
 
@@ -292,7 +292,7 @@ def test_codex_fork_marks_queue_idle_on_real_transitions_and_active_on_running_e
 
     calls = {"idle": 0, "active": 0}
     manager.message_queue_manager = SimpleNamespace(
-        mark_session_idle=lambda _sid: calls.__setitem__("idle", calls["idle"] + 1),
+        mark_session_idle=lambda _sid, **_kwargs: calls.__setitem__("idle", calls["idle"] + 1),
         mark_session_active=lambda _sid: calls.__setitem__("active", calls["active"] + 1),
     )
 
@@ -406,3 +406,37 @@ def test_codex_fork_non_transition_running_event_reactivates_stale_queue_state()
     )
 
     assert manager.message_queue_manager.is_session_idle(session.id) is False
+
+
+def test_codex_fork_turn_diff_reasserts_running_after_restart_without_turn_started():
+    manager = _make_manager()
+    session = Session(
+        id="cf8",
+        name="codex-fork-cf8",
+        working_dir="/tmp",
+        provider="codex-fork",
+        status=SessionStatus.IDLE,
+    )
+    manager.sessions[session.id] = session
+    manager.codex_fork_lifecycle[session.id] = {
+        "state": "idle",
+        "cause_event_type": "session_created",
+        "updated_at": datetime.now().isoformat(),
+    }
+    manager.codex_fork_last_seq[session.id] = 10
+
+    manager.ingest_codex_fork_event(
+        session.id,
+        {
+            "event_type": "turn_diff",
+            "seq": 11,
+            "session_epoch": 1,
+            "payload": {},
+        },
+    )
+
+    lifecycle = manager.get_codex_fork_lifecycle_state(session.id)
+    assert lifecycle is not None
+    assert lifecycle["state"] == "running"
+    assert lifecycle["cause_event_type"] == "turn_diff"
+    assert manager.get_activity_state(session.id) == "working"


### PR DESCRIPTION
## Summary
- teach the codex-fork lifecycle reducer to reassert running on fresh active events after restart/mid-turn recovery
- include computed activity_state in the children API payload
- have `sm children` prefer activity_state over raw status for display and thinking hints

## Testing
- ./venv/bin/pytest tests/unit/test_client_list_children.py tests/unit/test_codex_activity_state.py tests/unit/test_cmd_children.py tests/unit/test_children_api.py -q
- PYTHONPATH=. python -m py_compile src/session_manager.py src/server.py src/cli/commands.py tests/unit/test_codex_activity_state.py tests/unit/test_cmd_children.py tests/unit/test_children_api.py
- live check: `env CLAUDE_SESSION_MANAGER_ID=b10dc7a8 sm children` shows codex-fork child activity state from computed lifecycle

Fixes #373