### PR TITLE
Make registry aliases canonical display identity

### DIFF
--- a/specs/375_registry_identity_precedence.md
+++ b/specs/375_registry_identity_precedence.md
@@ -1,0 +1,36 @@
+# sm#375: registry identity precedence over friendly names
+
+## Scope
+
+Make the agent registry the canonical identity layer for system surfaces.
+
+## Design
+
+1. Registry roles are authoritative for routing and display.
+2. Effective display precedence is:
+   - primary registry role
+   - `friendly_name`
+   - internal session name / ID
+3. Reserved canonical aliases like `maintainer` cannot be claimed as free-form friendly names by unrelated sessions.
+4. Once a session has a registry role, conflicting `friendly_name` updates are rejected instead of creating two different visible identities.
+5. System-generated labels should prefer the canonical registry identity:
+   - `sm send` sender labels
+   - API session payloads
+   - registry/children/watch surfaces
+   - Telegram/notification headers
+   - queue/watch/compaction notices
+
+## Implementation choice
+
+Preserve the underlying user-provided `friendly_name` in state, but never let it override a canonical registry identity. This avoids discarding a previous human label when a role is registered, while still making the registry the only visible identity until the role is removed.
+
+## Acceptance mapping
+
+1. Registry alias wins in user-visible/system-generated labels.
+2. Reserved aliases are rejected for unrelated friendly-name updates.
+3. Registry-owned sessions reject conflicting friendly-name changes.
+4. Telegram/status-bar sync uses the canonical display name after alias changes.
+
+## Classification
+
+Single ticket.

--- a/src/child_monitor.py
+++ b/src/child_monitor.py
@@ -32,6 +32,17 @@ class ChildMonitor:
         """Set reference to OutputMonitor for topic cleanup on completion."""
         self._output_monitor = output_monitor
 
+    def _get_display_name(self, session) -> Optional[str]:
+        """Return canonical display identity for a session when available."""
+        if session is None:
+            return None
+        getter = getattr(self.session_manager, "get_effective_session_name", None)
+        if callable(getter):
+            display_name = getter(session)
+            if isinstance(display_name, str) and display_name:
+                return display_name
+        return getattr(session, "friendly_name", None) or getattr(session, "name", None) or getattr(session, "id", None)
+
     async def start(self):
         """Start the monitoring service."""
         self._running = True
@@ -232,7 +243,7 @@ class ChildMonitor:
         if not child_session:
             return
 
-        child_name = child_session.friendly_name or child_session.name or child_session_id
+        child_name = self._get_display_name(child_session) or child_session_id
 
         # Format notification message
         notification = f"Child {child_name} ({child_session_id[:8]}) completed: {completion_message}"

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 """Main entry point - orchestrates all components."""
 
 import asyncio
+import copy
 import logging
 import os
 import signal
@@ -24,6 +25,7 @@ from .server import create_app
 from .child_monitor import ChildMonitor
 from .message_queue import MessageQueueManager
 from .tool_logger import ToolLogger
+from .cli.commands import validate_friendly_name
 
 logger = logging.getLogger(__name__)
 
@@ -176,6 +178,7 @@ class SessionManagerApp:
             telegram_bot=self.telegram_bot,
             email_handler=self.email_handler,
         )
+        self.notifier.session_manager = self.session_manager
 
         # Set notifier reference in session manager for sm_send notifications
         self.session_manager.notifier = self.notifier
@@ -256,7 +259,16 @@ class SessionManagerApp:
             return session
 
         async def on_list_sessions() -> list[Session]:
-            return self.session_manager.list_sessions()
+            sessions = self.session_manager.list_sessions()
+            getter = getattr(self.session_manager, "get_effective_session_name", None)
+            if not callable(getter):
+                return sessions
+            display_sessions: list[Session] = []
+            for session in sessions:
+                display_session = copy.copy(session)
+                display_session.friendly_name = getter(session)
+                display_sessions.append(display_session)
+            return display_sessions
 
         async def on_kill_session(session_id: str) -> bool:
             await self.output_monitor.stop_monitoring(session_id)
@@ -274,7 +286,15 @@ class SessionManagerApp:
             return result
 
         async def on_session_status(session_id: str) -> Optional[Session]:
-            return self.session_manager.get_session(session_id)
+            session = self.session_manager.get_session(session_id)
+            if session is None:
+                return None
+            getter = getattr(self.session_manager, "get_effective_session_name", None)
+            if not callable(getter):
+                return session
+            display_session = copy.copy(session)
+            display_session.friendly_name = getter(session)
+            return display_session
 
         async def on_open_terminal(session_id: str) -> bool:
             return self.session_manager.open_terminal(session_id)
@@ -291,12 +311,27 @@ class SessionManagerApp:
             if not session:
                 return False
 
+            valid, _ = validate_friendly_name(name)
+            if not valid:
+                return False
+
+            validator = getattr(self.session_manager, "validate_friendly_name_update", None)
+            identity_error = validator(session_id, name) if callable(validator) else None
+            if identity_error:
+                logger.warning("Rejected Telegram name update for %s: %s", session_id, identity_error)
+                return False
+
             session.friendly_name = name
             self.session_manager._save_state()
 
             # Update tmux status bar to show friendly name
             if session.provider != "codex-app":
-                self.session_manager.tmux.set_status_bar(session.tmux_session, name)
+                display_name = self.session_manager.get_effective_session_name(session) or name
+                self.session_manager.tmux.set_status_bar(session.tmux_session, display_name)
+
+            if session.telegram_thread_id and self.notifier:
+                display_name = self.session_manager.get_effective_session_name(session) or name
+                await self.notifier.rename_session_topic(session, display_name)
 
             return True
 
@@ -561,9 +596,9 @@ class SessionManagerApp:
                     await self.output_monitor.start_monitoring(session, is_restored=True)
                     logger.info(f"Restored monitoring for session {session.name}")
 
-                    # Update tmux status bar if friendly name exists
-                    if session.friendly_name:
-                        self.session_manager.tmux.set_status_bar(session.tmux_session, session.friendly_name)
+                    display_name = self.session_manager.get_effective_session_name(session)
+                    if display_name:
+                        self.session_manager.tmux.set_status_bar(session.tmux_session, display_name)
 
     async def _handle_monitor_event(self, event: NotificationEvent):
         """Handle events from the output monitor."""

--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -208,6 +208,17 @@ class MessageQueueManager:
         self._db_conn.commit()
         logger.info(f"Message queue database initialized at {self.db_path} (WAL mode enabled)")
 
+    def _get_display_name(self, session) -> Optional[str]:
+        """Return canonical display identity for a session when available."""
+        if session is None:
+            return None
+        getter = getattr(self.session_manager, "get_effective_session_name", None)
+        if callable(getter):
+            display_name = getter(session)
+            if isinstance(display_name, str) and display_name:
+                return display_name
+        return getattr(session, "friendly_name", None) or getattr(session, "name", None) or getattr(session, "id", None)
+
     def _execute(self, query: str, params=()) -> sqlite3.Cursor:
         """
         Execute a database query with thread-safety.
@@ -1266,10 +1277,7 @@ class MessageQueueManager:
         """
         # Get recipient name for the notification
         recipient_session = self.session_manager.get_session(recipient_session_id)
-        recipient_name = (
-            recipient_session.friendly_name or recipient_session.name or recipient_session_id
-            if recipient_session else recipient_session_id
-        )
+        recipient_name = self._get_display_name(recipient_session) or recipient_session_id
 
         # Build notification with last output if available
         if last_output:
@@ -1858,7 +1866,7 @@ class MessageQueueManager:
         no_progress = False
 
         if child_session:
-            child_name = child_session.friendly_name or child_session.name or child_session_id
+            child_name = self._get_display_name(child_session) or child_session_id
 
             # Status text and age
             if child_session.agent_status_text:
@@ -2335,7 +2343,7 @@ class MessageQueueManager:
                     target_session = self.session_manager.get_session(target_session_id)
                     target_name = "unknown"
                     if target_session:
-                        target_name = target_session.friendly_name or target_session.name or target_session_id
+                        target_name = self._get_display_name(target_session) or target_session_id
 
                     if provider == "codex-fork" and codex_fork_state in ("shutdown", "error"):
                         notification = (
@@ -2368,7 +2376,7 @@ class MessageQueueManager:
             target_session = self.session_manager.get_session(target_session_id)
             target_name = "unknown"
             if target_session:
-                target_name = target_session.friendly_name or target_session.name or target_session_id
+                target_name = self._get_display_name(target_session) or target_session_id
 
             notification = (
                 f"[sm wait] Timeout: {target_name} still active after {timeout_seconds}s"

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -50,6 +50,19 @@ class Notifier:
         self.default_channel = default_channel
         # Track last response message ID per session (for idle replies)
         self._last_response_msg: dict[str, tuple[int, int]] = {}  # session_id -> (chat_id, msg_id)
+        self.session_manager = None
+
+    def _get_display_name(self, session: Optional[Session]) -> Optional[str]:
+        """Return canonical display identity for a session when available."""
+        if session is None:
+            return None
+        session_manager = getattr(self, "session_manager", None)
+        getter = getattr(session_manager, "get_effective_session_name", None) if session_manager else None
+        if callable(getter):
+            display_name = getter(session)
+            if isinstance(display_name, str) and display_name:
+                return display_name
+        return session.friendly_name or session.name or session.id
 
     async def notify(
         self,
@@ -177,7 +190,7 @@ class Notifier:
 
         # Build session label: "friendly-name [id]" or just "[id]"
         session_id = event.session_id
-        friendly_name = session.friendly_name if session else None
+        friendly_name = self._get_display_name(session)
 
         # For response events, use markdown formatting
         if event.event_type == "response":
@@ -238,7 +251,7 @@ class Notifier:
         # Header
         session_label = ""
         if session:
-            name = session.friendly_name or session.id
+            name = self._get_display_name(session) or session.id
             session_label = f" [{name}]"
         lines.append(f"Review Complete{session_label}")
         lines.append("")

--- a/src/server.py
+++ b/src/server.py
@@ -39,6 +39,16 @@ TRANSCRIPT_RETRY_DELAY_SECONDS = 0.3
 EMPTY_TRANSCRIPT_RETRY_DELAY_SECONDS = 0.5
 
 
+def _canonical_session_name(session_manager, session: Session, fallback: str) -> str:
+    """Return canonical display identity for a session when the manager can resolve one."""
+    getter = getattr(session_manager, "get_effective_session_name", None) if session_manager else None
+    if callable(getter):
+        display_name = getter(session)
+        if isinstance(display_name, str) and display_name:
+            return display_name
+    return fallback
+
+
 def _normalize_provider(provider: Optional[str]) -> str:
     """Normalize/validate provider string."""
     if not provider:
@@ -480,7 +490,9 @@ async def _handle_em_topic_inheritance(session, session_manager, telegram_bot):
             f"EM topic inheritance: failed to reopen old topic {old_thread_id}. "
             "Creating a new topic as EM thread."
         )
-        topic_name = f"{session.friendly_name or 'em'} [{session.id}]"
+        topic_name = (
+            f"{_canonical_session_name(session_manager, session, session.friendly_name or 'em')} [{session.id}]"
+        )
         brand_new_id = await telegram_bot.create_forum_topic(new_chat_id, topic_name)
         if brand_new_id:
             _set_session_topic(session, new_chat_id, brand_new_id)
@@ -572,6 +584,8 @@ def create_app(
     app.state.child_monitor = child_monitor
     app.state.last_claude_output = {}  # Store last output per session from hooks
     app.state.pending_stop_notifications = set()  # Sessions where Stop hook had empty transcript
+    if notifier is not None:
+        setattr(notifier, "session_manager", session_manager)
 
     # Wire _app back-reference so _execute_handoff can clear server-side caches (#196)
     if session_manager:
@@ -608,6 +622,16 @@ def create_app(
             return state
         return _fallback_activity_state(session)
 
+    def _effective_session_name(session: Session) -> str:
+        sm = app.state.session_manager
+        if sm:
+            getter = getattr(sm, "get_effective_session_name", None)
+            if callable(getter):
+                display_name = getter(session)
+                if isinstance(display_name, str) and display_name:
+                    return display_name
+        return session.friendly_name or session.name or session.id
+
     def _session_to_response(session: Session) -> SessionResponse:
         provider = getattr(session, "provider", "claude")
         last_action_summary: Optional[str] = None
@@ -640,7 +664,7 @@ def create_app(
             last_activity=session.last_activity.isoformat(),
             tmux_session=session.tmux_session,
             provider=provider,
-            friendly_name=session.friendly_name,
+            friendly_name=_effective_session_name(session),
             telegram_chat_id=session.telegram_chat_id,
             telegram_thread_id=session.telegram_thread_id,
             current_task=session.current_task,
@@ -672,7 +696,7 @@ def create_app(
         proposer = app.state.session_manager.get_session(proposal.proposer_session_id)
         proposer_name = None
         if proposer is not None:
-            proposer_name = proposer.friendly_name or proposer.name or proposer.id
+            proposer_name = _effective_session_name(proposer)
         return AdoptionProposalResponse(
             id=proposal.id,
             proposer_session_id=proposal.proposer_session_id,
@@ -690,7 +714,7 @@ def create_app(
         return AgentRegistrationResponse(
             role=registration.role,
             session_id=registration.session_id,
-            friendly_name=session.friendly_name or session.name or session.id,
+            friendly_name=_effective_session_name(session),
             provider=getattr(session, "provider", "claude"),
             status=session.status.value,
             activity_state=_get_activity_state(session),
@@ -702,6 +726,16 @@ def create_app(
         if callable(dumper):
             return dumper()
         return model.dict()
+
+    async def _sync_session_display_identity(session: Session) -> None:
+        """Propagate the canonical display name to tmux and Telegram surfaces."""
+        display_name = _effective_session_name(session)
+        if getattr(session, "provider", "claude") != "codex-app":
+            app.state.session_manager.tmux.set_status_bar(session.tmux_session, display_name)
+        if session.telegram_thread_id and app.state.notifier:
+            success = await app.state.notifier.rename_session_topic(session, display_name)
+            if not success:
+                logger.warning(f"Failed to rename Telegram topic for session {session.id}")
 
     def _configure_watch_frontend() -> None:
         """Serve the mobile dashboard if static assets exist in web/sm-watch/dist."""
@@ -1469,6 +1503,12 @@ def create_app(
             if not valid:
                 raise HTTPException(status_code=400, detail=error)
 
+            validator = getattr(app.state.session_manager, "validate_friendly_name_update", None)
+            if callable(validator):
+                identity_error = validator(session_id, friendly_name)
+                if identity_error:
+                    raise HTTPException(status_code=400, detail=identity_error)
+
             session.friendly_name = friendly_name
 
         if is_em is not None:
@@ -1497,14 +1537,7 @@ def create_app(
             app.state.session_manager._save_state()
 
         if friendly_name is not None:
-            # Update tmux status bar
-            if getattr(session, "provider", "claude") != "codex-app":
-                app.state.session_manager.tmux.set_status_bar(session.tmux_session, friendly_name)
-            # Update Telegram topic name if applicable
-            if session.telegram_thread_id and app.state.notifier:
-                success = await app.state.notifier.rename_session_topic(session, friendly_name)
-                if not success:
-                    logger.warning(f"Failed to rename Telegram topic for session {session_id}")
+            await _sync_session_display_identity(session)
 
         return _session_to_response(session)
 
@@ -1575,6 +1608,7 @@ def create_app(
             raise HTTPException(status_code=503, detail="Maintainer registry unavailable")
         if not setter(session_id):
             raise HTTPException(status_code=400, detail="Failed to register maintainer")
+        await _sync_session_display_identity(session)
         return _session_to_response(session)
 
     @app.delete("/sessions/{session_id}/maintainer", response_model=SessionResponse)
@@ -1593,6 +1627,7 @@ def create_app(
         clearer = getattr(app.state.session_manager, "clear_maintainer_session", None)
         if not callable(clearer) or not clearer(session_id):
             raise HTTPException(status_code=400, detail="Session is not the active maintainer")
+        await _sync_session_display_identity(session)
         return _session_to_response(session)
 
     @app.post("/maintainer/ensure", response_model=EnsureMaintainerResponse)
@@ -1614,6 +1649,7 @@ def create_app(
 
         if created and app.state.output_monitor and getattr(session, "provider", "claude") != "codex-app":
             await app.state.output_monitor.start_monitoring(session)
+        await _sync_session_display_identity(session)
 
         return EnsureMaintainerResponse(
             created=created,
@@ -1669,6 +1705,7 @@ def create_app(
             registration = registrar(session_id, request.role)
         except ValueError as exc:
             raise HTTPException(status_code=409, detail=str(exc)) from exc
+        await _sync_session_display_identity(session)
         return _registration_to_response(registration)
 
     @app.delete("/sessions/{session_id}/registry", response_model=AgentRegistrationResponse)
@@ -1696,6 +1733,7 @@ def create_app(
             raise HTTPException(status_code=409, detail="Role is not owned by this session")
         response = _registration_to_response(registration)
         clearer(session_id, request.role)
+        await _sync_session_display_identity(session)
         return response
 
     @app.post("/sessions/{session_id}/context-monitor")
@@ -1785,7 +1823,7 @@ def create_app(
         if not queue_mgr:
             raise HTTPException(status_code=503, detail="Message queue not configured")
 
-        sender_name = sender.friendly_name or sender.name or request.sender_session_id
+        sender_name = _effective_session_name(sender)
         queue_mgr.arm_stop_notify(
             session_id=session_id,
             sender_session_id=request.sender_session_id,
@@ -2836,7 +2874,7 @@ Provide ONLY the summary, no preamble or questions."""
         return {
             "session_id": child_session.id,
             "name": child_session.name,
-            "friendly_name": child_session.friendly_name,
+            "friendly_name": _effective_session_name(child_session),
             "working_dir": child_session.working_dir,
             "parent_session_id": child_session.parent_session_id,
             "tmux_session": child_session.tmux_session,
@@ -2952,7 +2990,7 @@ Provide ONLY the summary, no preamble or questions."""
         return {
             "session_id": session.id,
             "name": session.name,
-            "friendly_name": session.friendly_name,
+            "friendly_name": _effective_session_name(session),
             "review_mode": request.mode,
             "base_branch": request.base_branch,
             "status": "started",
@@ -3024,7 +3062,7 @@ Provide ONLY the summary, no preamble or questions."""
                 {
                     "id": s.id,
                     "name": s.name,
-                    "friendly_name": s.friendly_name,
+                    "friendly_name": _effective_session_name(s),
                     "status": s.status.value,
                     "activity_state": _get_activity_state(s),
                     "completion_status": s.completion_status.value if s.completion_status else None,
@@ -3262,7 +3300,7 @@ Provide ONLY the summary, no preamble or questions."""
         # 5. Notify EM if found
         em_notified = False
         if em_id:
-            friendly = session.friendly_name or session_id
+            friendly = _effective_session_name(session)
             queue_mgr.queue_message(
                 target_session_id=em_id,
                 text=f"[sm task-complete] agent {session_id}({friendly}) completed its task. Clear context with: sm clear {session_id}",
@@ -3443,7 +3481,7 @@ Provide ONLY the summary, no preamble or questions."""
 
         watch_id = await queue_mgr.watch_session(target_session_id, watcher_session_id, timeout_seconds)
 
-        target_name = target_session.friendly_name or target_session.name or target_session_id
+        target_name = _effective_session_name(target_session)
 
         return {
             "status": "watching",
@@ -3522,7 +3560,11 @@ Provide ONLY the summary, no preamble or questions."""
                         if app.state.session_manager:
                             other_session = app.state.session_manager.get_session(lock_result.owner_session_id)
 
-                        other_name = other_session.friendly_name if other_session and other_session.friendly_name else lock_result.owner_session_id
+                        other_name = (
+                            _effective_session_name(other_session)
+                            if other_session is not None
+                            else lock_result.owner_session_id
+                        )
 
                         return {
                             "status": "error",
@@ -3560,7 +3602,7 @@ Provide ONLY the summary, no preamble or questions."""
             asyncio.create_task(app.state.tool_logger.log(
                 session_id=session_manager_id,
                 claude_session_id=claude_session_id,
-                session_name=session.friendly_name if session else None,
+                session_name=_effective_session_name(session) if session else None,
                 parent_session_id=session.parent_session_id if session else None,
                 hook_type=hook_type,
                 tool_name=tool_name,
@@ -3606,7 +3648,7 @@ Provide ONLY the summary, no preamble or questions."""
         if data.get("event") == "compaction":
             trigger = data.get("trigger", "unknown")
             logger.warning(
-                f"Compaction fired for {session.friendly_name or session_id} (trigger={trigger})"
+                f"Compaction fired for {_effective_session_name(session)} (trigger={trigger})"
             )
             # Set compaction flag — suppress remind delivery until compaction_complete (#249).
             session._is_compacting = True
@@ -3622,7 +3664,7 @@ Provide ONLY the summary, no preamble or questions."""
             notify_target = session.context_monitor_notify or session.parent_session_id
             if notify_target and queue_mgr:
                 msg = (
-                    f"[sm context] Compaction fired for {session.friendly_name or session_id}. "
+                    f"[sm context] Compaction fired for {_effective_session_name(session)}. "
                     "Context was compacted — agent is still running."
                 )
                 queue_mgr.queue_message(
@@ -3642,7 +3684,7 @@ Provide ONLY the summary, no preamble or questions."""
             if queue_mgr:
                 queue_mgr.reset_remind(session_id)
             logger.info(
-                f"Compaction complete for {session.friendly_name or session_id}, remind timer reset"
+                f"Compaction complete for {_effective_session_name(session)}, remind timer reset"
             )
             return {"status": "compaction_complete_logged"}
 
@@ -3691,7 +3733,7 @@ Provide ONLY the summary, no preamble or questions."""
                             "Compaction is imminent."
                         )
                     else:
-                        child_label = session.friendly_name or session.id
+                        child_label = _effective_session_name(session)
                         msg = (
                             f"[sm context] Child {child_label} ({session.id}) context at {used_pct}% — critically high. "
                             "Compaction is imminent."
@@ -3715,7 +3757,7 @@ Provide ONLY the summary, no preamble or questions."""
                             "Consider writing a handoff doc and running `sm handoff <path>`."
                         )
                     else:
-                        child_label = session.friendly_name or session.id
+                        child_label = _effective_session_name(session)
                         msg = f"[sm context] Child {child_label} ({session.id}) context at {used_pct}%."
                     queue_mgr.queue_message(
                         target_session_id=session.context_monitor_notify,

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -1684,7 +1684,8 @@ class SessionManager:
 
         # 2. Create topic if chat_id is set but thread_id is missing
         if session.telegram_chat_id and not session.telegram_thread_id and self._topic_creator:
-            topic_name = f"{session.friendly_name or 'session'} [{session.id}]"
+            display_name = self.get_effective_session_name(session) or "session"
+            topic_name = f"{display_name} [{session.id}]"
             try:
                 thread_id = await self._topic_creator(
                     session.id, session.telegram_chat_id, topic_name
@@ -2086,6 +2087,43 @@ class SessionManager:
         ]
         return sorted(aliases)
 
+    def get_primary_session_alias(self, session_id: str) -> Optional[str]:
+        """Return the canonical registry alias for one session, if any."""
+        aliases = self.get_session_aliases(session_id)
+        return aliases[0] if aliases else None
+
+    def get_effective_session_name(self, session_or_id: Session | str | None) -> Optional[str]:
+        """Return canonical display identity: registry alias > friendly_name > internal name."""
+        if session_or_id is None:
+            return None
+        if isinstance(session_or_id, Session):
+            session = session_or_id
+        else:
+            session = self.sessions.get(session_or_id)
+            if session is None:
+                return None
+
+        primary_alias = self.get_primary_session_alias(session.id)
+        if primary_alias:
+            return primary_alias
+        return session.friendly_name or session.name or session.id
+
+    def validate_friendly_name_update(self, session_id: str, friendly_name: str) -> Optional[str]:
+        """Return an error when a friendly name conflicts with canonical registry identity."""
+        normalized_name = self.normalize_agent_role(friendly_name)
+        primary_alias = self.get_primary_session_alias(session_id)
+        if primary_alias and friendly_name != primary_alias:
+            return f'Session identity is controlled by registry role "{primary_alias}"'
+
+        reserved_aliases = {"maintainer"}
+        self._prune_agent_registrations(persist=True)
+        reserved_aliases.update(self.agent_registrations.keys())
+
+        if normalized_name in reserved_aliases and normalized_name != primary_alias:
+            return f'Name "{friendly_name}" is reserved for registry identity "{normalized_name}"'
+
+        return None
+
     def list_sessions(self, include_stopped: bool = False) -> list[Session]:
         """List all sessions."""
         sessions = list(self.sessions.values())
@@ -2184,7 +2222,7 @@ class SessionManager:
         if sender_session_id:
             sender_session = self.sessions.get(sender_session_id)
             if sender_session:
-                sender_name = sender_session.friendly_name or sender_session.name or sender_session_id
+                sender_name = self.get_effective_session_name(sender_session) or sender_session_id
                 formatted_text = f"[Input from: {sender_name} ({sender_session_id[:8]}) via sm send]\n{text}"
             else:
                 # Sender session not found, send without metadata
@@ -2349,7 +2387,7 @@ class SessionManager:
             return
 
         # Get sender friendly name
-        sender_name = sender_session.friendly_name or sender_session.name or sender_session_id
+        sender_name = self.get_effective_session_name(sender_session) or sender_session_id
 
         # Format delivery mode with icon
         mode_icons = {

--- a/tests/unit/test_registry_identity.py
+++ b/tests/unit/test_registry_identity.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.models import DeliveryResult, NotificationChannel, NotificationEvent, Session, SessionStatus
+from src.notifier import Notifier
+from src.server import create_app
+from src.session_manager import SessionManager
+
+
+def _manager(tmp_path) -> SessionManager:
+    return SessionManager(
+        log_dir=str(tmp_path / "logs"),
+        state_file=str(tmp_path / "sessions.json"),
+        config={},
+    )
+
+
+def _session(session_id: str, tmp_path, *, provider: str = "claude") -> Session:
+    return Session(
+        id=session_id,
+        name=f"{provider}-{session_id}",
+        working_dir=str(tmp_path),
+        tmux_session=f"{provider}-{session_id}",
+        provider=provider,
+        log_file=str(tmp_path / f"{session_id}.log"),
+        status=SessionStatus.RUNNING,
+    )
+
+
+def test_registry_alias_becomes_effective_api_name_and_syncs_surfaces(tmp_path):
+    manager = _manager(tmp_path)
+    session = _session("maint123", tmp_path)
+    session.friendly_name = "codex-345"
+    session.telegram_chat_id = 123
+    session.telegram_thread_id = 456
+    manager.sessions[session.id] = session
+    manager.tmux = MagicMock()
+
+    notifier = MagicMock()
+    notifier.rename_session_topic = AsyncMock(return_value=True)
+    client = TestClient(create_app(session_manager=manager, notifier=notifier))
+
+    response = client.post(
+        f"/sessions/{session.id}/registry",
+        json={"requester_session_id": session.id, "role": "maintainer"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["friendly_name"] == "maintainer"
+    assert session.friendly_name == "codex-345"
+
+    session_response = client.get(f"/sessions/{session.id}")
+    assert session_response.status_code == 200
+    payload = session_response.json()
+    assert payload["friendly_name"] == "maintainer"
+    assert payload["aliases"] == ["maintainer"]
+
+    manager.tmux.set_status_bar.assert_called_with(session.tmux_session, "maintainer")
+    notifier.rename_session_topic.assert_awaited_with(session, "maintainer")
+
+
+def test_update_session_rejects_reserved_registry_name_for_unregistered_session(tmp_path):
+    manager = _manager(tmp_path)
+    session = _session("worker01", tmp_path)
+    manager.sessions[session.id] = session
+    client = TestClient(create_app(session_manager=manager))
+
+    response = client.patch(f"/sessions/{session.id}", json={"friendly_name": "maintainer"})
+
+    assert response.status_code == 400
+    assert "reserved for registry identity" in response.json()["detail"]
+
+
+def test_update_session_rejects_conflicting_name_when_alias_controls_identity(tmp_path):
+    manager = _manager(tmp_path)
+    session = _session("maint123", tmp_path)
+    session.friendly_name = "codex-345"
+    manager.sessions[session.id] = session
+    manager.register_agent_role(session.id, "maintainer")
+    client = TestClient(create_app(session_manager=manager))
+
+    response = client.patch(f"/sessions/{session.id}", json={"friendly_name": "codex-345"})
+
+    assert response.status_code == 400
+    assert 'registry role "maintainer"' in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_send_input_prefers_registry_alias_for_sender_label(tmp_path):
+    manager = _manager(tmp_path)
+    sender = _session("sender01", tmp_path)
+    sender.friendly_name = "codex-345"
+    recipient = _session("target01", tmp_path)
+    manager.sessions[sender.id] = sender
+    manager.sessions[recipient.id] = recipient
+    manager.register_agent_role(sender.id, "maintainer")
+
+    queue = MagicMock()
+    queue.queue_message = MagicMock(return_value=MagicMock(id="msg-123"))
+    queue.deliver_queued_message_now = AsyncMock(return_value=True)
+    manager.message_queue_manager = queue
+
+    result = await manager.send_input(
+        session_id=recipient.id,
+        text="fix this bug",
+        sender_session_id=sender.id,
+        delivery_mode="sequential",
+    )
+
+    assert result == DeliveryResult.DELIVERED
+    assert queue.queue_message.call_args.kwargs["sender_name"] == "maintainer"
+    assert queue.queue_message.call_args.kwargs["text"].startswith(
+        f"[Input from: maintainer ({sender.id[:8]}) via sm send]\n"
+    )
+
+
+def test_notifier_response_message_prefers_registry_alias(tmp_path):
+    manager = _manager(tmp_path)
+    session = _session("maint123", tmp_path)
+    session.friendly_name = "codex-345"
+    manager.sessions[session.id] = session
+    manager.register_agent_role(session.id, "maintainer")
+
+    notifier = Notifier()
+    notifier.session_manager = manager
+    event = NotificationEvent(
+        session_id=session.id,
+        event_type="response",
+        message="",
+        context="done",
+        channel=NotificationChannel.TELEGRAM,
+    )
+
+    message = notifier._format_message(event, session)
+
+    assert message.startswith("maintainer \\[maint123\\] *Claude:*")


### PR DESCRIPTION
Fixes #375

## Summary
- make registry aliases the canonical display identity across API, notifications, and queue/watch surfaces
- reject friendly-name updates that conflict with reserved or active registry aliases
- document the design and add regression coverage for alias-first identity behavior

## Testing
- ./venv/bin/pytest tests/unit/test_registry_identity.py tests/unit/test_maintainer_alias.py tests/unit/test_agent_registry.py tests/unit/test_delivery_feedback.py -q
- PYTHONPATH=. python -m py_compile src/session_manager.py src/server.py src/notifier.py src/message_queue.py src/child_monitor.py src/main.py tests/unit/test_registry_identity.py