### PR TITLE
Fix stale thinking activity for idle Claude sessions

### DIFF
--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -3293,6 +3293,11 @@ class SessionManager:
                 return ActivityState.WORKING.value
             return ActivityState.THINKING.value
 
+        if session.status == SessionStatus.IDLE:
+            if monitor_state and monitor_state.is_output_flowing:
+                return ActivityState.WORKING.value
+            return ActivityState.IDLE.value
+
         idle_seconds = (datetime.now() - session.last_activity).total_seconds()
         if idle_seconds < 30:
             return ActivityState.THINKING.value

--- a/tests/unit/test_codex_activity_state.py
+++ b/tests/unit/test_codex_activity_state.py
@@ -97,6 +97,24 @@ def test_non_codex_fallback_without_hook_data_uses_last_activity():
     assert manager.get_activity_state(session.id) == "idle"
 
 
+def test_non_codex_idle_status_beats_recent_last_activity_without_queue_state():
+    manager = _make_manager()
+    session = Session(
+        id="idle1",
+        name="claude-idle1",
+        working_dir="/tmp",
+        provider="claude",
+        status=SessionStatus.IDLE,
+    )
+    manager.sessions[session.id] = session
+    manager.output_monitor = SimpleNamespace(
+        get_session_state=lambda _sid: MonitorState(is_output_flowing=False)
+    )
+
+    session.last_activity = datetime.now() - timedelta(seconds=5)
+    assert manager.get_activity_state(session.id) == "idle"
+
+
 def test_codex_app_uses_queue_tristate_and_completion():
     manager = _make_manager()
     session = Session(


### PR DESCRIPTION
Fixes #383

## Summary
- treat persisted idle Claude sessions as idle when queue state is absent
- keep output-flowing sessions in working even without queue state
- add regression coverage for the idle-status precedence case