### PR TITLE
Stop false codex-fork stop notifications on interrupted turns

### DIFF
--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -1003,6 +1003,8 @@ class SessionManager:
                 # They are not task completion and must not fire stop-notify side effects (#393).
                 if current_state in {"waiting_on_approval", "waiting_on_user_input"}:
                     next_state = current_state
+                elif session_id not in self.codex_fork_turns_in_flight:
+                    next_state = current_state
                 else:
                     next_state = "running"
             else:

--- a/tests/unit/test_codex_activity_state.py
+++ b/tests/unit/test_codex_activity_state.py
@@ -393,6 +393,60 @@ def test_codex_fork_interrupted_turn_abort_does_not_mark_idle():
     assert calls["idle"] == 0
 
 
+def test_codex_fork_interrupted_abort_after_completion_preserves_idle():
+    manager = _make_manager()
+    session = Session(
+        id="cf-abort-idle",
+        name="codex-fork-cf-abort-idle",
+        working_dir="/tmp",
+        provider="codex-fork",
+        status=SessionStatus.RUNNING,
+    )
+    manager.sessions[session.id] = session
+
+    calls = {"idle": 0, "active": 0}
+    manager.message_queue_manager = SimpleNamespace(
+        mark_session_idle=lambda _sid, **_kwargs: calls.__setitem__("idle", calls["idle"] + 1),
+        mark_session_active=lambda _sid: calls.__setitem__("active", calls["active"] + 1),
+    )
+
+    manager.ingest_codex_fork_event(
+        session.id,
+        {
+            "event_type": "TurnStarted",
+            "seq": 1,
+            "session_epoch": 1,
+            "payload": {"turn_id": "t1"},
+        },
+    )
+    manager.ingest_codex_fork_event(
+        session.id,
+        {
+            "event_type": "TurnComplete",
+            "seq": 2,
+            "session_epoch": 1,
+            "payload": {"turn_id": "t1"},
+        },
+    )
+    manager.ingest_codex_fork_event(
+        session.id,
+        {
+            "event_type": "turn_aborted",
+            "seq": 3,
+            "session_epoch": 1,
+            "payload": {"turn_id": "t1", "reason": "interrupted"},
+        },
+    )
+
+    assert session.status == SessionStatus.IDLE
+    assert manager.get_activity_state(session.id) == "idle"
+    lifecycle = manager.get_codex_fork_lifecycle_state(session.id)
+    assert lifecycle is not None
+    assert lifecycle["state"] == "idle"
+    assert lifecycle["cause_event_type"] == "turn_aborted"
+    assert calls["idle"] == 1
+
+
 def test_codex_fork_shutdown_complete_preserves_idle_completion_state():
     manager = _make_manager()
     session = Session(


### PR DESCRIPTION
Fixes #393

## Summary
- stop treating interrupted `turn_aborted` codex-fork events as completed turns
- stop treating `shutdown_complete` as a terminal session stop for codex-fork
- add reducer regressions for interrupted aborts and shutdown churn after normal completion

## Investigation
Live event-stream replay against the reported sessions showed the old reducer was misclassifying normal codex-fork churn:
- `ee0b31eb`: 23 interrupted aborts would have transitioned to idle, and 31 `shutdown_complete` events would have transitioned to terminal shutdown
- `9f01bb31`: 10 interrupted aborts would have transitioned to idle, and 19 `shutdown_complete` events would have transitioned to terminal shutdown

Those sequences were followed by fresh work, not actual agent stops.

## Tests
- `./venv/bin/pytest tests/unit/test_codex_activity_state.py tests/unit/test_codex_fork_restore.py tests/unit/test_maintainer_alias.py -q`
- `PYTHONPATH=. ./venv/bin/python -m py_compile src/session_manager.py tests/unit/test_codex_activity_state.py`
