### PR TITLE
Fix parent ownership for direct session creates

### DIFF
--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -677,23 +677,32 @@ class SessionManagerClient:
             return None
         return data
 
-    def create_session(self, working_dir: str, provider: Optional[str] = None) -> Optional[dict]:
+    def create_session(
+        self,
+        working_dir: str,
+        provider: Optional[str] = None,
+        parent_session_id: Optional[str] = None,
+    ) -> Optional[dict]:
         """
         Create a new Claude Code session.
 
         Args:
             working_dir: Working directory path
+            provider: Session provider
+            parent_session_id: Optional owning session for direct creates
 
         Returns:
             Session dict or None if unavailable
         """
-        encoded_dir = urllib.parse.quote(working_dir)
-        query = f"working_dir={encoded_dir}"
+        payload = {"working_dir": working_dir}
         if provider:
-            query += f"&provider={provider}"
+            payload["provider"] = provider
+        if parent_session_id is not None:
+            payload["parent_session_id"] = parent_session_id
         data, success, unavailable = self._request(
             "POST",
-            f"/sessions/create?{query}",
+            "/sessions",
+            payload,
             timeout=10
         )
         return data if success else None

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -1886,7 +1886,12 @@ def cmd_kill(
     return 0
 
 
-def cmd_new(client: SessionManagerClient, working_dir: Optional[str] = None, provider: str = "claude") -> int:
+def cmd_new(
+    client: SessionManagerClient,
+    working_dir: Optional[str] = None,
+    provider: str = "claude",
+    parent_session_id: Optional[str] = None,
+) -> int:
     """
     Create a new session (Claude/Codex attach; Codex app is headless).
 
@@ -1894,6 +1899,7 @@ def cmd_new(client: SessionManagerClient, working_dir: Optional[str] = None, pro
         client: API client
         working_dir: Working directory (optional, defaults to $PWD)
         provider: "claude", "codex", "codex-fork", or "codex-app"
+        parent_session_id: Owning session for direct creates launched from a managed session
 
     Exit codes:
         0: Successfully created (and attached for Claude/Codex)
@@ -1928,7 +1934,11 @@ def cmd_new(client: SessionManagerClient, working_dir: Optional[str] = None, pro
 
     # Create session via API
     print(f"Creating session in {working_dir}...")
-    session = client.create_session(working_dir, provider=provider)
+    session = client.create_session(
+        working_dir,
+        provider=provider,
+        parent_session_id=parent_session_id,
+    )
 
     if session is None:
         print("Error: Session manager unavailable", file=sys.stderr)
@@ -1966,13 +1976,18 @@ def cmd_new(client: SessionManagerClient, working_dir: Optional[str] = None, pro
         return 1
 
 
-def cmd_codex_2(client: SessionManagerClient, working_dir: Optional[str] = None) -> int:
+def cmd_codex_2(
+    client: SessionManagerClient,
+    working_dir: Optional[str] = None,
+    parent_session_id: Optional[str] = None,
+) -> int:
     """
     Create a new codex-fork session and immediately attach via attach-descriptor flow.
 
     Args:
         client: API client
         working_dir: Working directory (optional, defaults to $PWD)
+        parent_session_id: Owning session for direct creates launched from a managed session
 
     Exit codes:
         0: Successfully created and attached
@@ -1999,7 +2014,11 @@ def cmd_codex_2(client: SessionManagerClient, working_dir: Optional[str] = None)
         return 1
 
     print(f"Creating codex-fork session in {working_dir}...")
-    session = client.create_session(working_dir, provider="codex-fork")
+    session = client.create_session(
+        working_dir,
+        provider="codex-fork",
+        parent_session_id=parent_session_id,
+    )
     if session is None:
         print("Error: Session manager unavailable", file=sys.stderr)
         return 2

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -734,21 +734,21 @@ def main():
     elif args.command == "clean":
         sys.exit(commands.cmd_clean(client, session_ids=getattr(args, 'session_ids', None)))
     elif args.command == "claude":
-        sys.exit(commands.cmd_new(client, args.working_dir, provider="claude"))
+        sys.exit(commands.cmd_new(client, args.working_dir, provider="claude", parent_session_id=session_id))
     elif args.command == "codex":
-        sys.exit(commands.cmd_new(client, args.working_dir, provider="codex-fork"))
+        sys.exit(commands.cmd_new(client, args.working_dir, provider="codex-fork", parent_session_id=session_id))
     elif args.command == "codex-legacy":
-        sys.exit(commands.cmd_new(client, args.working_dir, provider="codex"))
+        sys.exit(commands.cmd_new(client, args.working_dir, provider="codex", parent_session_id=session_id))
     elif args.command in ("codex-fork", "codex_fork"):
-        sys.exit(commands.cmd_new(client, args.working_dir, provider="codex-fork"))
+        sys.exit(commands.cmd_new(client, args.working_dir, provider="codex-fork", parent_session_id=session_id))
     elif args.command == "codex-2":
-        sys.exit(commands.cmd_codex_2(client, args.working_dir))
+        sys.exit(commands.cmd_codex_2(client, args.working_dir, parent_session_id=session_id))
     elif args.command == "codex-app":
-        sys.exit(commands.cmd_new(client, args.working_dir, provider="codex-app"))
+        sys.exit(commands.cmd_new(client, args.working_dir, provider="codex-app", parent_session_id=session_id))
     elif args.command == "codex-server":
         sys.exit(commands.cmd_removed_entrypoint("codex-server"))
     elif args.command == "new":
-        sys.exit(commands.cmd_new(client, args.working_dir, provider="claude"))
+        sys.exit(commands.cmd_new(client, args.working_dir, provider="claude", parent_session_id=session_id))
     elif args.command == "attach":
         sys.exit(commands.cmd_attach(client, args.session))
     elif args.command == "output":

--- a/src/server.py
+++ b/src/server.py
@@ -103,6 +103,7 @@ class CreateSessionRequest(BaseModel):
     working_dir: str = "~"
     name: Optional[str] = None
     provider: Optional[str] = "claude"
+    parent_session_id: Optional[str] = None
 
 
 class AdoptionProposalResponse(BaseModel):
@@ -1316,6 +1317,7 @@ def create_app(
             working_dir=request.working_dir,
             name=request.name,
             provider=provider,
+            parent_session_id=request.parent_session_id,
         )
 
         if not session:
@@ -1328,7 +1330,11 @@ def create_app(
         return _session_to_response(session)
 
     @app.post("/sessions/create")
-    async def create_session_endpoint(working_dir: str, provider: str = "claude"):
+    async def create_session_endpoint(
+        working_dir: str,
+        provider: str = "claude",
+        parent_session_id: Optional[str] = None,
+    ):
         """
         Create a new Claude Code session.
 
@@ -1350,6 +1356,7 @@ def create_app(
             working_dir=working_dir,
             telegram_chat_id=None,  # No Telegram association
             provider=provider,
+            parent_session_id=parent_session_id,
         )
 
         if not session:

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -1769,6 +1769,7 @@ class SessionManager:
         name: Optional[str] = None,
         telegram_chat_id: Optional[int] = None,
         provider: str = "claude",
+        parent_session_id: Optional[str] = None,
     ) -> Optional[Session]:
         """
         Create a new Claude Code session (async, non-blocking).
@@ -1777,6 +1778,7 @@ class SessionManager:
             working_dir: Directory to run Claude in
             name: Optional session name (generated if not provided)
             telegram_chat_id: Telegram chat to associate with session
+            parent_session_id: Optional parent owner for direct creates from managed sessions
 
         Returns:
             Created Session or None on failure
@@ -1786,6 +1788,7 @@ class SessionManager:
             name=name,
             telegram_chat_id=telegram_chat_id,
             provider=provider,
+            parent_session_id=parent_session_id,
         )
 
     async def spawn_child_session(

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -359,6 +359,22 @@ class TestSessionEndpoints:
         assert data["id"] == "test123"
         assert data["working_dir"] == "/tmp/test"
 
+    def test_create_session_with_parent_ownership(self, test_client, mock_session_manager, sample_session):
+        """POST /sessions forwards parent_session_id for direct creates from managed sessions."""
+        mock_session_manager.create_session = AsyncMock(return_value=sample_session)
+
+        response = test_client.post(
+            "/sessions",
+            json={"working_dir": "/tmp/test", "provider": "codex-fork", "parent_session_id": "parent123"},
+        )
+        assert response.status_code == 200
+        mock_session_manager.create_session.assert_awaited_once_with(
+            working_dir="/tmp/test",
+            name=None,
+            provider="codex-fork",
+            parent_session_id="parent123",
+        )
+
     def test_create_session_failure(self, test_client, mock_session_manager):
         """POST /sessions returns 500 on creation failure."""
         mock_session_manager.create_session = AsyncMock(return_value=None)

--- a/tests/integration/test_session_lifecycle.py
+++ b/tests/integration/test_session_lifecycle.py
@@ -101,6 +101,18 @@ class TestSessionLifecycle:
         assert session_manager.get_session(session.id) == session
 
     @pytest.mark.asyncio
+    async def test_create_session_flow_preserves_parent_ownership(self, session_manager):
+        """Direct create path records parent ownership when launched from a managed session."""
+        session = await session_manager.create_session(
+            working_dir="/tmp/test-workspace",
+            parent_session_id="parent123",
+        )
+
+        assert session is not None
+        assert session.parent_session_id == "parent123"
+        assert session.spawned_at is not None
+
+    @pytest.mark.asyncio
     async def test_kill_session_flow(self, session_manager, mock_tmux, temp_state_file):
         """Full session kill: tmux killed, state updated."""
         # First create a session

--- a/tests/unit/test_cmd_new.py
+++ b/tests/unit/test_cmd_new.py
@@ -1,0 +1,49 @@
+"""Unit tests for direct session creation commands."""
+
+from unittest.mock import MagicMock, patch
+
+from src.cli.commands import cmd_codex_2, cmd_new
+
+
+def test_cmd_new_passes_parent_session_id(tmp_path):
+    client = MagicMock()
+    client.create_session.return_value = {
+        "id": "child1234",
+        "provider": "codex-fork",
+        "tmux_session": "codex-fork-child1234",
+    }
+
+    with patch("subprocess.run") as run_mock, patch("time.sleep"):
+        rc = cmd_new(
+            client,
+            working_dir=str(tmp_path),
+            provider="codex-fork",
+            parent_session_id="parent123",
+        )
+
+    assert rc == 0
+    client.create_session.assert_called_once_with(
+        str(tmp_path),
+        provider="codex-fork",
+        parent_session_id="parent123",
+    )
+    run_mock.assert_called_once_with(["tmux", "attach", "-t", "codex-fork-child1234"], check=True)
+
+
+def test_cmd_codex_2_passes_parent_session_id(tmp_path):
+    client = MagicMock()
+    client.create_session.return_value = {
+        "id": "child5678",
+        "provider": "codex-fork",
+    }
+
+    with patch("src.cli.commands.cmd_attach", return_value=0) as attach_mock:
+        rc = cmd_codex_2(client, working_dir=str(tmp_path), parent_session_id="parent123")
+
+    assert rc == 0
+    client.create_session.assert_called_once_with(
+        str(tmp_path),
+        provider="codex-fork",
+        parent_session_id="parent123",
+    )
+    attach_mock.assert_called_once_with(client, "child5678")


### PR DESCRIPTION
Fixes #395

## Summary
- pass parent session ownership through direct create flows used by `sm codex-fork`, `sm claude`, and related commands
- move the CLI create client onto the main `/sessions` JSON API so parent metadata can be carried consistently
- add CLI, API, and lifecycle regression coverage for parent-owned direct creates

## Testing
- ./venv/bin/pytest tests/unit/test_cmd_new.py tests/integration/test_session_lifecycle.py::TestSessionLifecycle::test_create_session_flow_preserves_parent_ownership tests/integration/test_api_endpoints.py::TestSessionEndpoints::test_create_session_with_parent_ownership -q
- PYTHONPATH=. ./venv/bin/python -m py_compile src/cli/client.py src/cli/commands.py src/cli/main.py src/server.py src/session_manager.py tests/unit/test_cmd_new.py tests/integration/test_session_lifecycle.py tests/integration/test_api_endpoints.py

## Notes
- Full tests in tests/integration/test_api_endpoints.py still hit the unrelated validator mocking failure tracked in #396.