### PR TITLE
Add session creation flow to sm watch

### DIFF
--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -677,6 +677,50 @@ class SessionManagerClient:
             return None
         return data
 
+    def create_session_result(
+        self,
+        working_dir: str,
+        provider: Optional[str] = None,
+        parent_session_id: Optional[str] = None,
+    ) -> dict:
+        """
+        Create a new Claude Code session and preserve API error details.
+
+        Args:
+            working_dir: Working directory path
+            provider: Session provider
+            parent_session_id: Optional owning session for direct creates
+
+        Returns:
+            Dict with ok/unavailable/status_code/data/detail
+        """
+        payload = {"working_dir": working_dir}
+        if provider:
+            payload["provider"] = provider
+        if parent_session_id is not None:
+            payload["parent_session_id"] = parent_session_id
+        data, status_code, unavailable = self._request_with_status(
+            "POST",
+            "/sessions",
+            payload,
+            timeout=10,
+        )
+        if unavailable:
+            return {"ok": False, "unavailable": True, "status_code": None, "data": None, "detail": None}
+
+        ok = status_code in (200, 201)
+        detail = None
+        if isinstance(data, dict):
+            detail = data.get("detail") or data.get("error") or data.get("raw")
+
+        return {
+            "ok": ok,
+            "unavailable": False,
+            "status_code": status_code,
+            "data": data,
+            "detail": detail,
+        }
+
     def create_session(
         self,
         working_dir: str,
@@ -692,20 +736,14 @@ class SessionManagerClient:
             parent_session_id: Optional owning session for direct creates
 
         Returns:
-            Session dict or None if unavailable
+            Session dict or None if unavailable or rejected
         """
-        payload = {"working_dir": working_dir}
-        if provider:
-            payload["provider"] = provider
-        if parent_session_id is not None:
-            payload["parent_session_id"] = parent_session_id
-        data, success, unavailable = self._request(
-            "POST",
-            "/sessions",
-            payload,
-            timeout=10
+        result = self.create_session_result(
+            working_dir,
+            provider=provider,
+            parent_session_id=parent_session_id,
         )
-        return data if success else None
+        return result.get("data") if result.get("ok") else None
 
     def get_queue_status(self, session_id: str) -> Optional[dict]:
         """

--- a/src/cli/watch_tui.py
+++ b/src/cli/watch_tui.py
@@ -800,13 +800,19 @@ def _create_watch_session(
     working_dir: str,
 ) -> tuple[Optional[dict], Optional[str], Optional[str]]:
     """Create a session from sm watch and return its attach target."""
-    session = client.create_session(
+    result = client.create_session_result(
         working_dir,
         provider=provider,
         parent_session_id=getattr(client, "session_id", None),
     )
-    if session is None:
+    if result.get("unavailable"):
         return None, None, "Session manager unavailable"
+    if not result.get("ok"):
+        return None, None, result.get("detail") or "Failed to create session"
+
+    session = result.get("data")
+    if not isinstance(session, dict):
+        return None, None, "Failed to create session"
 
     session_id = session.get("id")
     descriptor = client.get_attach_descriptor(session_id) if session_id else None

--- a/tests/unit/test_watch_tui.py
+++ b/tests/unit/test_watch_tui.py
@@ -443,13 +443,19 @@ def test_create_watch_session_passes_parent_session_id_and_returns_attach_target
         (),
         {
             "session_id": "parent123",
-            "create_session": staticmethod(
+            "create_session_result": staticmethod(
                 lambda working_dir, provider, parent_session_id: {
-                    "id": "child456",
-                    "tmux_session": "codex-fork-child456",
+                    "ok": True,
+                    "unavailable": False,
+                    "status_code": 200,
+                    "detail": None,
+                    "data": {
+                        "id": "child456",
+                        "tmux_session": "codex-fork-child456",
+                    },
                 }
                 if (working_dir, provider, parent_session_id) == ("/tmp/repo", "codex-fork", "parent123")
-                else None
+                else {"ok": False, "unavailable": False, "status_code": 400, "detail": "bad request", "data": None}
             ),
             "get_attach_descriptor": staticmethod(
                 lambda session_id: {"tmux_session": "descriptor-child456"} if session_id == "child456" else None
@@ -470,10 +476,16 @@ def test_create_watch_session_returns_attach_error_when_not_supported():
         (),
         {
             "session_id": "parent123",
-            "create_session": staticmethod(
+            "create_session_result": staticmethod(
                 lambda working_dir, provider, parent_session_id: {
-                    "id": "app789",
-                    "tmux_session": None,
+                    "ok": True,
+                    "unavailable": False,
+                    "status_code": 200,
+                    "detail": None,
+                    "data": {
+                        "id": "app789",
+                        "tmux_session": None,
+                    },
                 }
             ),
             "get_attach_descriptor": staticmethod(
@@ -487,6 +499,32 @@ def test_create_watch_session_returns_attach_error_when_not_supported():
     assert session["id"] == "app789"
     assert tmux_session is None
     assert error == "No terminal for this provider"
+
+
+def test_create_watch_session_preserves_api_error_detail():
+    client = type(
+        "_Client",
+        (),
+        {
+            "session_id": "parent123",
+            "create_session_result": staticmethod(
+                lambda working_dir, provider, parent_session_id: {
+                    "ok": False,
+                    "unavailable": False,
+                    "status_code": 422,
+                    "detail": "Provider not enabled",
+                    "data": {"detail": "Provider not enabled"},
+                }
+            ),
+            "get_attach_descriptor": staticmethod(lambda session_id: None),
+        },
+    )()
+
+    session, tmux_session, error = _create_watch_session(client, "codex-fork", "/tmp/repo")
+
+    assert session is None
+    assert tmux_session is None
+    assert error == "Provider not enabled"
 
 
 class _SlowClient:


### PR DESCRIPTION
Fixes #398

## Summary
- add a `+` flow in `sm watch` to create a new managed session without leaving the TUI
- prompt for provider and working directory, defaulting to the selected session or repo context
- immediately attach to the new tmux session so detaching drops back into the watch view

## Testing
- ./venv/bin/pytest tests/unit/test_watch_tui.py tests/unit/test_cmd_watch.py tests/unit/test_watch_api_309.py -q
- PYTHONPATH=. ./venv/bin/python -m py_compile src/cli/watch_tui.py tests/unit/test_watch_tui.py
- live smoke: create-and-kill a disposable codex-fork session through the new watch helper