### PR TITLE
Suppress codex-fork stop-notify paging

### DIFF
--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -1307,6 +1307,8 @@ def cmd_send(
     # Self-sends are commonly used as delayed wakeups; do not advertise or request
     # stop-notify because it would wake the same agent on its next stop hook.
     effective_notify_on_stop = notify_on_stop and sender_session_id != session_id
+    if effective_notify_on_stop and session.get("provider") == "codex-fork":
+        effective_notify_on_stop = False
 
     # Use wait_seconds if provided, otherwise use notify_after_seconds
     effective_notify_after = wait_seconds if wait_seconds is not None else notify_after_seconds

--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -969,6 +969,18 @@ class MessageQueueManager:
             state.last_outgoing_sm_send_target = None
             state.last_outgoing_sm_send_at = None
 
+        session = self.session_manager.get_session(session_id) if self.session_manager else None
+        if session and getattr(session, "provider", "claude") == "codex-fork":
+            # Codex-fork turn boundaries are not reliable completion signals for parent
+            # wakeups. Drop any armed stop-notify state so live agents stop paging EMs
+            # mid-assignment (#400).
+            self._cancel_pending_stop_notification(session_id)
+            state.stop_notify_sender_id = None
+            state.stop_notify_sender_name = None
+            state.stop_notify_delay_seconds = 0
+            state.paste_buffered_notify_sender_id = None
+            state.paste_buffered_notify_sender_name = None
+
         # Send stop notification if a sender is waiting
         if state.stop_notify_sender_id:
             if state.stop_notify_delay_seconds > 0:

--- a/src/server.py
+++ b/src/server.py
@@ -1896,6 +1896,14 @@ def create_app(
         if not queue_mgr:
             raise HTTPException(status_code=503, detail="Message queue not configured")
 
+        if getattr(session, "provider", "claude") == "codex-fork":
+            return {
+                "status": "suppressed",
+                "session_id": session_id,
+                "sender_session_id": request.sender_session_id,
+                "reason": "notify_on_stop disabled for codex-fork sessions",
+            }
+
         sender_name = _effective_session_name(sender)
         queue_mgr.arm_stop_notify(
             session_id=session_id,

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -2314,6 +2314,11 @@ class SessionManager:
             if not sender_session or not sender_session.is_em:
                 notify_on_stop = False
 
+        # Codex-fork turn boundaries are not trustworthy as parent completion signals.
+        # Require explicit sm send / task-complete instead of arming stop-notify (#400).
+        if notify_on_stop and session.provider == "codex-fork":
+            notify_on_stop = False
+
         # Send Telegram notification if from sm send
         # Note: notifier will be set by server when calling send_input
         if from_sm_send and sender_session_id and hasattr(self, 'notifier'):

--- a/tests/unit/test_directional_notify_on_stop.py
+++ b/tests/unit/test_directional_notify_on_stop.py
@@ -19,7 +19,7 @@ from src.session_manager import SessionManager
 # ---------------------------------------------------------------------------
 
 
-def _make_session(session_id: str, is_em: bool = False) -> Session:
+def _make_session(session_id: str, is_em: bool = False, provider: str = "claude") -> Session:
     return Session(
         id=session_id,
         name=f"claude-{session_id}",
@@ -28,6 +28,7 @@ def _make_session(session_id: str, is_em: bool = False) -> Session:
         log_file=f"/tmp/{session_id}.log",
         status=SessionStatus.IDLE,
         is_em=is_em,
+        provider=provider,
     )
 
 
@@ -37,6 +38,7 @@ def _make_session_manager(sessions: dict[str, Session]) -> SessionManager:
     sm.sessions = sessions
     sm.message_queue_manager = MagicMock()
     sm.message_queue_manager.queue_message = MagicMock()
+    sm.message_queue_manager.deliver_queued_message_now = AsyncMock(return_value=True)
     sm.message_queue_manager.delivery_states = {}
     sm.message_queue_manager._get_or_create_state = MagicMock(return_value=MagicMock())
     sm.config = {}
@@ -206,6 +208,25 @@ class TestDirectionalNotifyOnStop:
 
         call_kwargs = sm.message_queue_manager.queue_message.call_args[1]
         assert call_kwargs["notify_on_stop"] is True
+
+    @pytest.mark.asyncio
+    async def test_codex_fork_target_suppresses_notify_on_stop(self):
+        """Codex-fork targets never arm notify_on_stop because turn boundaries are noisy."""
+        em = _make_session("em01", is_em=True)
+        target = _make_session("fork1", provider="codex-fork")
+        sm = _make_session_manager({"em01": em, "fork1": target})
+
+        with patch("asyncio.create_task", noop_create_task):
+            await sm.send_input(
+                session_id="fork1",
+                text="do task",
+                sender_session_id="em01",
+                delivery_mode="urgent",
+                notify_on_stop=True,
+            )
+
+        call_kwargs = sm.message_queue_manager.queue_message.call_args[1]
+        assert call_kwargs["notify_on_stop"] is False
 
     @pytest.mark.asyncio
     async def test_non_em_sender_important_mode_suppressed(self):

--- a/tests/unit/test_dispatch.py
+++ b/tests/unit/test_dispatch.py
@@ -740,6 +740,24 @@ class TestCmdSendRemindParams:
         captured = capsys.readouterr()
         assert "notify-on-stop" not in captured.out
 
+    def test_codex_fork_target_suppresses_notify_on_stop(self, capsys):
+        """Codex-fork targets must not request or print notify-on-stop."""
+        from src.cli.commands import cmd_send
+        mock_client = self._make_client()
+        mock_client.get_session.return_value = {
+            "id": "fork1",
+            "friendly_name": "fork-agent",
+            "status": "idle",
+            "provider": "codex-fork",
+        }
+
+        cmd_send(mock_client, "fork1", "hello")
+
+        call_kwargs = mock_client.send_input.call_args[1]
+        assert call_kwargs["notify_on_stop"] is False
+        captured = capsys.readouterr()
+        assert "notify-on-stop" not in captured.out
+
 
 # ---------------------------------------------------------------------------
 # sm setup tests (sm#225-D)

--- a/tests/unit/test_em_spawn_auto_register.py
+++ b/tests/unit/test_em_spawn_auto_register.py
@@ -583,3 +583,26 @@ class TestArmStopNotifyEndpoint:
         assert call_kwargs.kwargs["sender_session_id"] == "em001"
         assert call_kwargs.kwargs["sender_name"] == "em"  # friendly_name takes precedence
         assert call_kwargs.kwargs["delay_seconds"] == 8
+
+    def test_arm_stop_notify_codex_fork_target_is_suppressed(self, app_client):
+        """POST /sessions/{id}/notify-on-stop returns suppressed for codex-fork targets."""
+        tc, mock_sm = app_client
+
+        child_session = MagicMock()
+        child_session.parent_session_id = "em001"
+        child_session.provider = "codex-fork"
+        mock_sm.get_session.side_effect = lambda sid: {
+            "em001": MagicMock(is_em=True, friendly_name="em", name="claude-em001"),
+            "child001": child_session,
+        }.get(sid)
+
+        response = tc.post(
+            "/sessions/child001/notify-on-stop",
+            json={"sender_session_id": "em001", "requester_session_id": "em001", "delay_seconds": 8},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "suppressed"
+        assert data["reason"] == "notify_on_stop disabled for codex-fork sessions"
+        mock_sm.message_queue_manager.arm_stop_notify.assert_not_called()

--- a/tests/unit/test_message_queue.py
+++ b/tests/unit/test_message_queue.py
@@ -190,6 +190,29 @@ class TestStateManagement:
         message_queue.mark_session_active("session123")
         assert message_queue.is_session_idle("session123") is False
 
+    @pytest.mark.asyncio
+    async def test_codex_fork_mark_session_idle_drops_stop_notify(self, mock_session_manager, temp_db_path):
+        """Codex-fork idle transitions must not emit stop notifications to the sender."""
+        mq = MessageQueueManager(session_manager=mock_session_manager, db_path=temp_db_path, notifier=None)
+        session = MagicMock()
+        session.id = "fork400"
+        session.provider = "codex-fork"
+        mock_session_manager.get_session = MagicMock(return_value=session)
+
+        state = mq._get_or_create_state("fork400")
+        state.stop_notify_sender_id = "em400"
+        state.stop_notify_sender_name = "em"
+        state.stop_notify_delay_seconds = 0
+
+        with patch.object(mq, "_send_stop_notification", new=AsyncMock()) as mock_notify:
+            mq.mark_session_idle("fork400")
+            await asyncio.sleep(0)
+
+        mock_notify.assert_not_awaited()
+        assert state.stop_notify_sender_id is None
+        assert state.stop_notify_sender_name is None
+        assert state.stop_notify_delay_seconds == 0
+
     def test_is_session_idle_false_by_default(self, message_queue):
         """is_session_idle returns False for unknown sessions."""
         assert message_queue.is_session_idle("unknown") is False


### PR DESCRIPTION
Fixes #400

## Summary
- disable notify-on-stop for codex-fork targets in send/CLI/explicit arm paths
- clear any already-armed stop-notify state when a codex-fork session transitions idle
- add regression coverage for the queue, CLI, send path, and notify-on-stop endpoint

## Root cause
Real traces for session `31971742` showed stop-hook pages were not coming from a true session stop. They were coming from codex-fork idle transitions after noisy turn-boundary events, which are not reliable completion signals for EM workflows.

## Testing
- ./venv/bin/pytest tests/unit/test_directional_notify_on_stop.py tests/unit/test_dispatch.py tests/unit/test_em_spawn_auto_register.py tests/unit/test_message_queue.py -q
- PYTHONPATH=. ./venv/bin/python -m py_compile src/message_queue.py src/session_manager.py src/server.py src/cli/commands.py tests/unit/test_directional_notify_on_stop.py tests/unit/test_dispatch.py tests/unit/test_em_spawn_auto_register.py tests/unit/test_message_queue.py