### PR TITLE
Preserve watch hierarchy in filtered views

### DIFF
--- a/src/cli/watch_tui.py
+++ b/src/cli/watch_tui.py
@@ -446,12 +446,13 @@ def filter_sessions(
     if not filtered_ids:
         return []
 
-    if not repo_filter:
-        return [session for session in sessions if session.get("id") in set(filtered_ids)]
+    filtered_id_set = set(filtered_ids)
+    if not repo_filter or role_filter_norm or text_filter_norm:
+        return [session for session in sessions if session.get("id") in filtered_id_set]
 
-    included_ids = set(filtered_ids)
+    included_ids = set(filtered_id_set)
 
-    # Repo-scoped watch views should preserve tree context so cross-worktree
+    # Pure repo-scoped watch views should preserve tree context so cross-worktree
     # children remain visibly attached to their parent session.
     for session_id in filtered_ids:
         parent_id = sessions_by_id.get(session_id, {}).get("parent_session_id")

--- a/tests/unit/test_watch_tui.py
+++ b/tests/unit/test_watch_tui.py
@@ -457,6 +457,28 @@ def test_filter_by_text_does_not_pull_hierarchy_context():
     assert [s["id"] for s in filtered] == ["c1"]
 
 
+def test_filter_by_repo_and_role_does_not_pull_hierarchy_context():
+    sessions = [
+        _session("p1", "architect-parent", "/tmp/repo-a", role="architect"),
+        _session("c1", "engineer-child", "/tmp/repo-b", parent_session_id="p1", role="engineer"),
+    ]
+
+    filtered = filter_sessions(sessions, repo_filter="/tmp/repo-b", role_filter="engineer")
+
+    assert [s["id"] for s in filtered] == ["c1"]
+
+
+def test_filter_by_repo_and_text_does_not_pull_hierarchy_context():
+    sessions = [
+        _session("p1", "architect-parent", "/tmp/repo-a"),
+        _session("c1", "engineer-child", "/tmp/repo-b", parent_session_id="p1"),
+    ]
+
+    filtered = filter_sessions(sessions, repo_filter="/tmp/repo-b", text_filter="engineer-child")
+
+    assert [s["id"] for s in filtered] == ["c1"]
+
+
 def test_codex_app_rows_are_not_attachable():
     session = _session("app1", "codex-app", "/tmp/repo", provider="codex-app")
     assert can_attach_session(session) is False


### PR DESCRIPTION
Fixes #402

## Summary
- keep ancestor context when a filtered `sm watch` view includes a child whose parent lives elsewhere
- keep descendant context when a filtered `sm watch` view includes a parent with children in other worktrees
- add coverage for both directions so cross-worktree trees stay connected in repo-scoped watch views

## Root cause
`filter_sessions()` filtered the session list before tree construction and only kept direct matches. That meant repo-scoped watch views could remove either the parent or the child from a cross-worktree relationship, leaving the remaining session to render as a root row.

## Testing
- ./venv/bin/pytest tests/unit/test_watch_tui.py tests/unit/test_cmd_watch.py tests/unit/test_watch_api_309.py -q
- PYTHONPATH=. ./venv/bin/python -m py_compile src/cli/watch_tui.py tests/unit/test_watch_tui.py