### PR TITLE
Decouple Telegram mirrors from message delivery

### DIFF
--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -12,6 +12,7 @@ import uuid
 from collections import deque
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Optional, Dict, List, Callable, Awaitable, Tuple
 
 from .models import (
@@ -68,6 +69,7 @@ class MessageQueueManager:
         self.input_stale_timeout = sm_send_config.get("input_stale_timeout", 120)  # seconds
         self.max_batch_size = sm_send_config.get("max_batch_size", 10)
         self.urgent_delay_ms = sm_send_config.get("urgent_delay_ms", 500)
+        self.telegram_mirror_max_queue = sm_send_config.get("telegram_mirror_max_queue", 256)
 
         # Remind configuration (#188)
         remind_config = config.get("remind", {})
@@ -809,11 +811,32 @@ class MessageQueueManager:
         except Exception as e:
             logger.warning(f"Telegram mirror failed (non-fatal): {e}")
 
+    def _snapshot_telegram_session(self, session):
+        """Capture Telegram routing at enqueue time to avoid later mutation races."""
+        if not session or not getattr(session, "telegram_chat_id", None):
+            return None
+        return SimpleNamespace(
+            id=getattr(session, "id", "unknown"),
+            telegram_chat_id=getattr(session, "telegram_chat_id", None),
+            telegram_thread_id=getattr(session, "telegram_thread_id", None),
+        )
+
     def _enqueue_telegram_mirror(self, text: str, session, event_type: str, description: str) -> None:
         """Queue a Telegram mirror without blocking the caller."""
+        if not self.notifier:
+            return
+        snapshot = self._snapshot_telegram_session(session)
+        if snapshot is None:
+            return
         if self._telegram_mirror_queue is None:
-            self._telegram_mirror_queue = asyncio.Queue()
-        self._telegram_mirror_queue.put_nowait((text, session, event_type, description))
+            self._telegram_mirror_queue = asyncio.Queue(maxsize=self.telegram_mirror_max_queue)
+        if self._telegram_mirror_queue.full():
+            dropped = self._telegram_mirror_queue.get_nowait()
+            self._telegram_mirror_queue.task_done()
+            logger.warning(
+                f"Telegram mirror queue full; dropped oldest mirror ({dropped[3]})"
+            )
+        self._telegram_mirror_queue.put_nowait((text, snapshot, event_type, description))
         if self._telegram_mirror_worker_task is None or self._telegram_mirror_worker_task.done():
             self._telegram_mirror_worker_task = asyncio.create_task(self._telegram_mirror_worker())
 

--- a/tests/unit/test_message_queue.py
+++ b/tests/unit/test_message_queue.py
@@ -1476,6 +1476,59 @@ class TestTelegramMirroring:
         assert seen == ["first", "second"]
         await mq.stop()
 
+    def test_telegram_mirror_queue_drops_oldest_when_full(self, mock_session_manager, temp_db_path):
+        """Mirror backlog must be bounded so Telegram outages cannot grow memory unbounded."""
+        mq = MessageQueueManager(
+            session_manager=mock_session_manager,
+            db_path=temp_db_path,
+            config={"sm_send": {"telegram_mirror_max_queue": 1}},
+            notifier=MagicMock(),
+        )
+
+        session = MagicMock()
+        session.id = "target123"
+        session.telegram_chat_id = 12345
+        session.telegram_thread_id = 678
+
+        mq._telegram_mirror_queue = asyncio.Queue(maxsize=1)
+        mq._telegram_mirror_worker_task = MagicMock()
+        mq._telegram_mirror_worker_task.done.return_value = False
+
+        mq._enqueue_telegram_mirror("first", session, "message_delivered", "first")
+        mq._enqueue_telegram_mirror("second", session, "message_delivered", "second")
+
+        assert mq._telegram_mirror_queue.qsize() == 1
+        queued = mq._telegram_mirror_queue.get_nowait()
+        assert queued[0] == "second"
+        assert queued[3] == "second"
+        mq._telegram_mirror_queue.task_done()
+
+    def test_telegram_mirror_queue_snapshots_routing(self, mock_session_manager, temp_db_path):
+        """Queued mirror work must use Telegram routing captured at enqueue time."""
+        mq = MessageQueueManager(
+            session_manager=mock_session_manager,
+            db_path=temp_db_path,
+            notifier=MagicMock(),
+        )
+
+        session = MagicMock()
+        session.id = "target123"
+        session.telegram_chat_id = 12345
+        session.telegram_thread_id = 678
+
+        mq._telegram_mirror_queue = asyncio.Queue(maxsize=4)
+        mq._telegram_mirror_worker_task = MagicMock()
+        mq._telegram_mirror_worker_task.done.return_value = False
+
+        mq._enqueue_telegram_mirror("snapshot-test", session, "message_delivered", "snapshot")
+        session.telegram_chat_id = 99999
+        session.telegram_thread_id = 111
+
+        _, snapshot, _, _ = mq._telegram_mirror_queue.get_nowait()
+        assert snapshot.telegram_chat_id == 12345
+        assert snapshot.telegram_thread_id == 678
+        mq._telegram_mirror_queue.task_done()
+
 
 class TestDirectDelivery244:
     """sm#244: Direct delivery — no idle gate for sequential/important; paste_buffered_notify."""


### PR DESCRIPTION
Fixes #404

## Summary
- stop awaiting Telegram mirror calls inline in message delivery and notification paths
- run Telegram mirrors as best-effort background tasks with centralized exception logging
- add a regression proving slow Telegram mirroring does not block `_try_deliver_messages()`

## Root cause
Live logs for session `5ae24124` showed the message queue had already queued and delivered `sm send` messages, but the HTTP request stayed open for 5s+ while Telegram mirror attempts timed out. The CLI only waits 2 seconds, so it reported `Session manager unavailable` even though the send had succeeded.

## Testing
- ./venv/bin/pytest tests/unit/test_message_queue.py -q -k "telegram or delivery_does_not_wait_for_slow_telegram_mirror"
- PYTHONPATH=. ./venv/bin/python -m py_compile src/message_queue.py tests/unit/test_message_queue.py
- live smoke: `time sm send e42e669b ...` returned in 0.34s and server logged `POST /sessions/e42e669b/input took 169ms`