### PR TITLE
Send --track reminders to requesters

### DIFF
--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -2261,6 +2261,7 @@ class MessageQueueManager:
                 sender_session_id,
                 cancel_on_reply_session_id=self._serialize_cancel_on_reply_session_ids(reg.cancel_on_reply_session_ids),
             )
+            self.cancel_queued_track_reminds(sender_session_id, recipient_session_id)
             logger.info(
                 "Tracked remind owner %s cleared for %s; remaining owners=%s",
                 recipient_session_id,
@@ -2268,6 +2269,7 @@ class MessageQueueManager:
                 reg.cancel_on_reply_session_ids,
             )
         else:
+            self.cancel_queued_track_reminds(sender_session_id, recipient_session_id)
             self.cancel_remind(sender_session_id)
             logger.info(
                 "Tracked remind auto-cancelled for %s after reply to %s",
@@ -2276,7 +2278,7 @@ class MessageQueueManager:
             )
         return True
 
-    def reset_remind(self, target_session_id: str):
+    def reset_remind(self, target_session_id: str, *, force_tracked: bool = False):
         """
         Reset the remind timer for a session (called when agent reports sm status).
 
@@ -2285,7 +2287,7 @@ class MessageQueueManager:
         reg = self._remind_registrations.get(target_session_id)
         if not reg or not reg.is_active:
             return
-        if reg.cancel_on_reply_session_ids:
+        if reg.cancel_on_reply_session_ids and not force_tracked:
             logger.debug(
                 "Ignoring reset_remind for tracked session %s; tracking cadence is requester-facing (#408)",
                 target_session_id,
@@ -2298,6 +2300,30 @@ class MessageQueueManager:
 
         self._update_remind_db(target_session_id, last_reset_at=now, soft_fired=False)
         logger.info(f"Remind timer reset for {target_session_id}")
+
+    def cancel_queued_track_reminds(self, tracked_session_id: str, owner_session_id: str) -> int:
+        """Delete undelivered requester-facing track reminders for one tracked-session/owner pair."""
+        rows = self._execute_query(
+            "SELECT COUNT(*) FROM message_queue "
+            "WHERE target_session_id = ? AND sender_session_id = ? "
+            "AND message_category = 'track_remind' AND delivered_at IS NULL",
+            (owner_session_id, tracked_session_id),
+        )
+        count = rows[0][0] if rows else 0
+        if count:
+            self._execute(
+                "DELETE FROM message_queue "
+                "WHERE target_session_id = ? AND sender_session_id = ? "
+                "AND message_category = 'track_remind' AND delivered_at IS NULL",
+                (owner_session_id, tracked_session_id),
+            )
+            logger.info(
+                "Cancelled %s queued track reminder(s) for owner=%s tracked=%s",
+                count,
+                owner_session_id,
+                tracked_session_id,
+            )
+        return count
 
     def _build_tracked_remind_text(self, target_session_id: str, reg: RemindRegistration, urgent: bool) -> str:
         """Build requester-facing tracked reminder text for one target session (#408)."""
@@ -2344,6 +2370,7 @@ class MessageQueueManager:
                     continue
             self.queue_message(
                 target_session_id=owner_session_id,
+                sender_session_id=target_session_id,
                 text=text,
                 delivery_mode=delivery_mode,
                 message_category="track_remind",

--- a/src/server.py
+++ b/src/server.py
@@ -3837,7 +3837,7 @@ Provide ONLY the summary, no preamble or questions."""
         if data.get("event") == "compaction_complete":
             session._is_compacting = False
             if queue_mgr:
-                queue_mgr.reset_remind(session_id)
+                queue_mgr.reset_remind(session_id, force_tracked=True)
             logger.info(
                 f"Compaction complete for {_effective_session_name(session)}, remind timer reset"
             )

--- a/tests/unit/test_remind.py
+++ b/tests/unit/test_remind.py
@@ -278,6 +278,26 @@ class TestStatusReset:
         assert reg.last_reset_at == old_reset
         assert reg.soft_fired is True
 
+    def test_reset_remind_force_resets_tracked_registration(self, mq):
+        """Compaction-complete can still force a fresh grace window for tracked reminders."""
+        with patch("asyncio.create_task", noop_create_task):
+            mq.register_periodic_remind(
+                "tracked-target-force",
+                soft_threshold=10,
+                hard_threshold=20,
+                cancel_on_reply_session_id="owner408",
+            )
+
+        reg = mq._remind_registrations["tracked-target-force"]
+        old_reset = datetime.now() - timedelta(seconds=30)
+        reg.last_reset_at = old_reset
+        reg.soft_fired = True
+
+        mq.reset_remind("tracked-target-force", force_tracked=True)
+
+        assert reg.last_reset_at > old_reset
+        assert reg.soft_fired is False
+
     def test_reset_remind_persists_to_db(self, mq):
         """reset_remind updates DB row."""
         with patch("asyncio.create_task", noop_create_task):
@@ -1084,6 +1104,29 @@ class TestTrackedReplyCancellation:
         assert reg.soft_threshold_seconds == 240
         assert reg.hard_threshold_seconds == 480
 
+    def test_cancel_tracked_remind_drops_queued_track_messages_for_owner(self, mq):
+        with patch("asyncio.create_task", noop_create_task):
+            mq.register_periodic_remind(
+                "child406queued",
+                soft_threshold=300,
+                hard_threshold=600,
+                cancel_on_reply_session_id="parent406queued",
+            )
+            mq.queue_message(
+                target_session_id="parent406queued",
+                sender_session_id="child406queued",
+                text="[sm track] Waiting on child406queued (child406)",
+                delivery_mode="important",
+                message_category="track_remind",
+                trigger_delivery=False,
+            )
+
+        cancelled = mq.cancel_tracked_remind_on_reply("child406queued", "parent406queued")
+
+        assert cancelled is True
+        pending = mq.get_pending_messages("parent406queued")
+        assert pending == []
+
     @pytest.mark.asyncio
     async def test_send_input_cancels_tracked_remind_on_reply(self, mq):
         """SessionManager.send_input auto-cancels tracked remind when the child replies to the owner."""
@@ -1174,6 +1217,7 @@ class TestTrackedReminderDelivery:
         target_pending = mq.get_pending_messages(target.id)
         assert len(owner_pending) == 1
         assert owner_pending[0].message_category == "track_remind"
+        assert owner_pending[0].sender_session_id == target.id
         assert owner_pending[0].delivery_mode == "important"
         assert "[sm track] Waiting on eng-target (target40)" in owner_pending[0].text
         assert "Awaiting explicit reply from target40." in owner_pending[0].text


### PR DESCRIPTION
Fixes #408

## Summary
- route tracked reminder notifications to the requester instead of the tracked agent
- keep tracked reminder cadence independent of the target agent's `sm status` resets
- preserve requester-facing tracking while retaining existing reply-cancel behavior

## Validation
- `./venv/bin/pytest tests/unit/test_remind.py tests/unit/test_dispatch.py tests/unit/test_em_spawn_auto_register.py -q`
- `PYTHONPATH=. ./venv/bin/python -m py_compile src/message_queue.py tests/unit/test_remind.py`
- live smoke: `sm send --urgent --track 5` to disposable child produced `track_remind` rows for requester `e42e669b`, not the child
- live trace for issue case: requester `a1c67412` received `track_remind` row for `433900ac` at `2026-03-18T12:24:53`
