### PR TITLE
Fix Telegram delivery for oversized messages

### DIFF
--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -360,6 +360,20 @@ class TelegramBot:
         result: list[str] = []
         i = 0
         while i < len(message):
+            if message[i:i+3] == "```":
+                end = message.find("```", i + 3)
+                if end != -1:
+                    result.append(message[i:end + 3])
+                    i = end + 3
+                    continue
+
+            if message[i] == "`":
+                end = message.find("`", i + 1)
+                if end != -1:
+                    result.append(message[i:end + 1])
+                    i = end + 1
+                    continue
+
             char = message[i]
             if char == "\\" and i + 1 < len(message) and message[i + 1] in MARKDOWN_V2_ESCAPE_CHARS:
                 result.append(message[i + 1])
@@ -369,10 +383,64 @@ class TelegramBot:
             i += 1
         return "".join(result)
 
+    def _markdown_v2_rendered_text(self, message: str) -> str:
+        """Approximate the rendered Telegram text after MarkdownV2 entity parsing."""
+        result: list[str] = []
+        i = 0
+        while i < len(message):
+            if message[i:i+3] == "```":
+                end = message.find("```", i + 3)
+                if end != -1:
+                    result.append(message[i + 3:end])
+                    i = end + 3
+                    continue
+
+            if message[i] == "`":
+                end = message.find("`", i + 1)
+                if end != -1:
+                    result.append(message[i + 1:end])
+                    i = end + 1
+                    continue
+
+            if message[i] == "[":
+                close_bracket = message.find("]", i + 1)
+                if close_bracket != -1 and message[close_bracket:close_bracket + 2] == "](":
+                    close_paren = message.find(")", close_bracket + 2)
+                    if close_paren != -1:
+                        result.append(
+                            self._markdown_v2_rendered_text(message[i + 1:close_bracket])
+                        )
+                        i = close_paren + 1
+                        continue
+
+            if message[i:i+2] == "||":
+                end = message.find("||", i + 2)
+                if end != -1:
+                    result.append(self._markdown_v2_rendered_text(message[i + 2:end]))
+                    i = end + 2
+                    continue
+
+            if message[i] in {"*", "_", "~"}:
+                end = message.find(message[i], i + 1)
+                if end != -1:
+                    result.append(self._markdown_v2_rendered_text(message[i + 1:end]))
+                    i = end + 1
+                    continue
+
+            if message[i] == "\\" and i + 1 < len(message) and message[i + 1] in MARKDOWN_V2_ESCAPE_CHARS:
+                result.append(message[i + 1])
+                i += 2
+                continue
+
+            result.append(message[i])
+            i += 1
+
+        return "".join(result)
+
     def _telegram_length_basis(self, message: str, parse_mode: Optional[str]) -> str:
         """Return the text basis used to decide if Telegram chunking is necessary."""
         if parse_mode == "MarkdownV2":
-            return self._markdown_v2_to_plain_text(message)
+            return self._markdown_v2_rendered_text(message)
         return message
 
     async def _send_chunked_notification(

--- a/tests/unit/test_telegram_bot.py
+++ b/tests/unit/test_telegram_bot.py
@@ -158,6 +158,35 @@ def test_split_message_chunks_preserves_indentation_after_newline_boundary():
     assert chunks == ["a" * 20, "    indented line"]
 
 
+def test_markdown_v2_to_plain_text_preserves_backslashes_inside_code():
+    """Plain-text fallback should keep literal backslashes inside code spans."""
+    tg = TelegramBot.__new__(TelegramBot)
+
+    plain = tg._markdown_v2_to_plain_text(r"Prefix `\\_` and `\\.py` suffix")
+
+    assert plain == r"Prefix `\\_` and `\\.py` suffix"
+
+
+@pytest.mark.asyncio
+async def test_send_notification_keeps_markdown_when_only_link_urls_exceed_limit():
+    """Link-heavy Markdown should stay formatted when rendered text is still within the limit."""
+    tg = TelegramBot.__new__(TelegramBot)
+    tg.bot = AsyncMock()
+    tg.bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=501))
+
+    message = ("[x](https://example.com/" + ("a" * 80) + ") " ) * 120
+    result = await tg.send_notification(
+        chat_id=10000,
+        message=message,
+        message_thread_id=50000,
+        parse_mode="MarkdownV2",
+    )
+
+    assert result == 501
+    tg.bot.send_message.assert_awaited_once()
+    assert tg.bot.send_message.await_args.kwargs["parse_mode"] == "MarkdownV2"
+
+
 # ============================================================================
 # send_with_fallback unit tests
 # ============================================================================


### PR DESCRIPTION
Fixes #411

## Summary
- proactively chunk oversized Telegram messages instead of dropping them
- degrade oversized Markdown messages to plain-text chunk delivery
- add unit coverage for oversized plain-text and Markdown cases

## Testing
- ./venv/bin/pytest tests/unit/test_telegram_bot.py -q
- PYTHONPATH=. ./venv/bin/python -m py_compile src/telegram_bot.py tests/unit/test_telegram_bot.py