### PR TITLE
Fail closed for incomplete Google auth config

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -157,15 +157,14 @@ class GoogleAuthMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
         path = request.url.path
+        if path in self.exempt_paths:
+            return await call_next(request)
 
         if not self.ready:
             return JSONResponse(
                 status_code=503,
                 content={"detail": "Google auth is enabled but incomplete"},
             )
-
-        if path in self.exempt_paths:
-            return await call_next(request)
 
         session_state = getattr(request, "session", {}) or {}
         if session_state.get("google_authenticated") is True:
@@ -1052,6 +1051,14 @@ def create_app(
                 "email": None,
                 "name": None,
             }
+        if _is_local_bypass_request(request, app.state.config):
+            return {
+                "enabled": True,
+                "authenticated": True,
+                "bypass": True,
+                "email": None,
+                "name": None,
+            }
         if not _google_auth_ready(app.state.config):
             return {
                 "enabled": True,
@@ -1060,15 +1067,6 @@ def create_app(
                 "email": None,
                 "name": None,
                 "error": "misconfigured",
-            }
-
-        if _is_local_bypass_request(request, app.state.config):
-            return {
-                "enabled": True,
-                "authenticated": True,
-                "bypass": True,
-                "email": None,
-                "name": None,
             }
 
         session_state = getattr(request, "session", {}) or {}

--- a/tests/unit/test_google_auth.py
+++ b/tests/unit/test_google_auth.py
@@ -115,11 +115,39 @@ def test_external_requests_fail_closed_when_google_auth_is_misconfigured():
 
     sessions_response = client.get("/sessions")
     watch_response = client.get("/watch")
+    health_response = client.get("/health")
+    auth_session_response = client.get("/auth/session")
 
     assert sessions_response.status_code == 503
     assert sessions_response.json()["detail"] == "Google auth is enabled but incomplete"
     assert watch_response.status_code == 503
     assert watch_response.json()["detail"] == "Google auth is enabled but incomplete"
+    assert health_response.status_code == 200
+    assert health_response.json() == {"status": "healthy"}
+    assert auth_session_response.status_code == 200
+    assert auth_session_response.json() == {
+        "enabled": True,
+        "authenticated": False,
+        "bypass": False,
+        "email": None,
+        "name": None,
+        "error": "misconfigured",
+    }
+
+
+def test_local_auth_session_reports_bypass_when_google_auth_is_misconfigured():
+    client = TestClient(create_app(session_manager=_session_manager(), config=_misconfigured_auth_config()))
+
+    response = client.get("/auth/session")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "enabled": True,
+        "authenticated": True,
+        "bypass": True,
+        "email": None,
+        "name": None,
+    }
 
 
 def test_google_callback_authenticates_allowlisted_email(monkeypatch):


### PR DESCRIPTION
Fixes #420

## Summary
- fail closed for external requests when Google auth is requested but incomplete
- keep local loopback access working during incomplete external auth setup
- send logout to an unprotected route instead of bouncing straight back into login

## Validation
- ./venv/bin/pytest tests/unit/test_google_auth.py tests/unit/test_config_loading.py tests/unit/test_watch_api_309.py tests/unit/test_health_check.py tests/unit/test_registry_identity.py -q
- PYTHONPATH=. ./venv/bin/python -m py_compile src/server.py