### PR TITLE
Fix Termux attach shell quoting for zsh-backed SSH sessions

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -1145,21 +1145,21 @@ def create_app(
             "PATH=/opt/homebrew/bin:/usr/local/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/bin:/bin:$PATH; "
             "export PATH; "
             "if command -v tmux >/dev/null 2>&1; then "
-            "exec tmux attach-session -t \"$1\"; "
+            "exec tmux attach-session -t \"$SM_TMUX_SESSION\"; "
             "elif [ -x /opt/homebrew/bin/tmux ]; then "
-            "exec /opt/homebrew/bin/tmux attach-session -t \"$1\"; "
+            "exec /opt/homebrew/bin/tmux attach-session -t \"$SM_TMUX_SESSION\"; "
             "elif [ -x /usr/local/bin/tmux ]; then "
-            "exec /usr/local/bin/tmux attach-session -t \"$1\"; "
+            "exec /usr/local/bin/tmux attach-session -t \"$SM_TMUX_SESSION\"; "
             "else echo \"tmux not found on remote host\" >&2; exit 127; fi"
+        )
+        remote_command = (
+            f"SM_TMUX_SESSION={shlex.quote(tmux_session)} "
+            f"sh -lc {shlex.quote(remote_attach_script)}"
         )
         ssh_args.extend([
             "-t",
             f"{ssh_username}@{public_ssh_host}",
-            "sh",
-            "-lc",
-            remote_attach_script,
-            "sh",
-            tmux_session,
+            remote_command,
         ])
 
         return {

--- a/tests/unit/test_android_api_surface.py
+++ b/tests/unit/test_android_api_surface.py
@@ -149,7 +149,7 @@ def test_client_sessions_include_termux_attach_metadata():
         "ssh_host": "ssh.sm.rajeshgo.li",
         "ssh_username": "rajesh",
         "ssh_proxy_command": "cloudflared access ssh --hostname %h",
-        "ssh_command": "ssh -o 'ProxyCommand=cloudflared access ssh --hostname %h' -t rajesh@ssh.sm.rajeshgo.li sh -lc 'PATH=/opt/homebrew/bin:/usr/local/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/bin:/bin:$PATH; export PATH; if command -v tmux >/dev/null 2>&1; then exec tmux attach-session -t \"$1\"; elif [ -x /opt/homebrew/bin/tmux ]; then exec /opt/homebrew/bin/tmux attach-session -t \"$1\"; elif [ -x /usr/local/bin/tmux ]; then exec /usr/local/bin/tmux attach-session -t \"$1\"; else echo \"tmux not found on remote host\" >&2; exit 127; fi' sh codex-fork-fork1001",
+        "ssh_command": "ssh -o 'ProxyCommand=cloudflared access ssh --hostname %h' -t rajesh@ssh.sm.rajeshgo.li 'SM_TMUX_SESSION=codex-fork-fork1001 sh -lc '\"'\"'PATH=/opt/homebrew/bin:/usr/local/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/bin:/bin:$PATH; export PATH; if command -v tmux >/dev/null 2>&1; then exec tmux attach-session -t \"$SM_TMUX_SESSION\"; elif [ -x /opt/homebrew/bin/tmux ]; then exec /opt/homebrew/bin/tmux attach-session -t \"$SM_TMUX_SESSION\"; elif [ -x /usr/local/bin/tmux ]; then exec /usr/local/bin/tmux attach-session -t \"$SM_TMUX_SESSION\"; else echo \"tmux not found on remote host\" >&2; exit 127; fi'\"'\"''",
         "tmux_session": "codex-fork-fork1001",
         "runtime_mode": "detached_runtime",
         "termux_package": "com.termux",


### PR DESCRIPTION
Fixes #433

## Summary
- emit a single quoted remote shell command for Termux attach instead of a multi-argv `sh -lc ... sh <session>` form
- pass the tmux target through `SM_TMUX_SESSION` so the remote login shell cannot misparse the attach command
- keep the Android attach metadata tests aligned with the new command shape

## Validation
- `./venv/bin/pytest tests/unit/test_android_api_surface.py -q`
- `PYTHONPATH=. ./venv/bin/python -m py_compile src/server.py`
- reproduced the old `zsh: parse error near 'sh'` and verified the new command is `zsh -n` clean
