### PR TITLE
Stabilize friendly-name and maintainer tests

### DIFF
--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -20,6 +20,7 @@ def mock_session_manager():
     mock.tmux.list_sessions = MagicMock(return_value=[])
     mock.message_queue_manager = None
     mock.is_codex_rollout_enabled = MagicMock(return_value=True)
+    mock.validate_friendly_name_update = MagicMock(return_value=None)
     mock._save_state = MagicMock()
     return mock
 

--- a/tests/unit/test_maintainer_alias.py
+++ b/tests/unit/test_maintainer_alias.py
@@ -13,11 +13,16 @@ from src.session_manager import SessionManager
 
 
 def _manager(tmp_path) -> SessionManager:
-    return SessionManager(
+    manager = SessionManager(
         log_dir=str(tmp_path / "logs"),
         state_file=str(tmp_path / "sessions.json"),
         config={},
     )
+    manager.tmux = Mock()
+    manager.tmux.list_sessions.return_value = []
+    manager.tmux.session_exists.return_value = False
+    manager.tmux.set_status_bar.return_value = True
+    return manager
 
 
 def _session(session_id: str, tmp_path) -> Session:


### PR DESCRIPTION
Fixes #396
Fixes #392

## Summary
- default the integration API test fixture's `validate_friendly_name_update` hook to `None` so friendly-name PATCH tests model the normal success path
- replace the maintainer alias test helper's real tmux controller with a mock so registry/bootstrap tests stay hermetic under broader pytest runs

## Validation
- ./venv/bin/pytest tests/integration/test_api_endpoints.py -q -k 'update_friendly_name or patch_mixed_friendly_name_and_is_em'
- ./venv/bin/pytest tests/unit/test_codex_activity_state.py tests/unit/test_codex_fork_restore.py tests/unit/test_codex_fork_attach_descriptor.py tests/unit/test_maintainer_alias.py -q
