### PR TITLE
Restore immediate injection for busy Claude sends

### DIFF
--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -1671,22 +1671,6 @@ class MessageQueueManager:
                     return
             # No idle gate for sequential or important: tty buffer handles ordering (sm#244)
 
-            # Claude plain-text delivery is only safe at a prompt boundary. The in-memory
-            # status can drift after restart or a lost stop hook, so allow immediate
-            # delivery when tmux shows a real prompt even if session.status is stale.
-            provider = getattr(session, "provider", "claude")
-            if provider == "claude" and session.status != SessionStatus.IDLE:
-                tmux_session = getattr(session, "tmux_session", None)
-                prompt_visible = False
-                if tmux_session:
-                    prompt_visible = await self._check_idle_prompt(tmux_session)
-                if not prompt_visible:
-                    logger.debug(
-                        "Claude session %s not at prompt; leaving queued message pending",
-                        session_id,
-                    )
-                    return
-
             # Check for user input (final gate)
             current_input = None
             if getattr(session, "provider", "claude") != "codex-app":

--- a/tests/unit/test_message_queue.py
+++ b/tests/unit/test_message_queue.py
@@ -1616,8 +1616,8 @@ class TestDirectDelivery244:
         mock_session_manager._deliver_direct.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_running_claude_without_prompt_defers_sequential_delivery(self, mock_session_manager, temp_db_path):
-        """Running Claude sessions stay queued until tmux shows a prompt."""
+    async def test_running_claude_without_prompt_still_delivers_immediately(self, mock_session_manager, temp_db_path):
+        """Busy Claude sessions still receive immediate composer injection."""
         mq = self._make_mq(mock_session_manager, temp_db_path)
 
         session = MagicMock()
@@ -1635,13 +1635,11 @@ class TestDirectDelivery244:
 
         await mq._try_deliver_messages("target244busy")
 
-        mock_session_manager._deliver_direct.assert_not_called()
-        pending = mq.get_pending_messages("target244busy")
-        assert len(pending) == 1
+        mock_session_manager._deliver_direct.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_running_claude_with_prompt_stale_status_still_delivers(self, mock_session_manager, temp_db_path):
-        """tmux prompt visibility overrides stale running status for queued Claude sends."""
+        """Stale running status should not block immediate queued Claude delivery."""
         mq = self._make_mq(mock_session_manager, temp_db_path)
 
         session = MagicMock()
@@ -2083,12 +2081,9 @@ class TestSkipFence232:
         # Let delivery task run (direct delivery queues and delivers the timeout notification)
         await asyncio.sleep(0)
 
-        # Watch timed out (no false idle notification). For a running Claude session
-        # without a visible prompt, the timeout notification should remain queued
-        # rather than forcing an unsafe inject into the composer.
-        pending = mq.get_pending_messages("watcher232h")
-        assert len(pending) == 1
-        assert "Timeout" in pending[0].text
+        # Watch timed out (no false idle notification).
+        # With sm#244, the timeout notification is delivered immediately.
+        mock_session_manager._deliver_direct.assert_called()
 
 
 # =============================================================================


### PR DESCRIPTION
Fixes #443

## Summary
- remove the prompt-gated Claude queue behavior added in #441
- preserve immediate sequential/important injection for busy Claude sessions
- keep the `/force next message` and explicit-SM-rename fixes from #441 intact

## Validation
- ./venv/bin/pytest tests/unit/test_telegram_bot.py tests/unit/test_delivery_feedback.py tests/unit/test_claude_native_title.py -q
- ./venv/bin/pytest tests/unit/test_message_queue.py::TestStateManagement::test_successful_delivery_without_notify_on_stop_clears_delayed_spawn_arm tests/unit/test_message_queue.py::TestDirectDelivery244::test_sequential_delivery_without_idle_gate tests/unit/test_message_queue.py::TestDirectDelivery244::test_important_delivery_without_idle_gate tests/unit/test_message_queue.py::TestDirectDelivery244::test_running_claude_without_prompt_still_delivers_immediately tests/unit/test_message_queue.py::TestDirectDelivery244::test_running_claude_with_prompt_stale_status_still_delivers tests/unit/test_message_queue.py::TestDirectDelivery244::test_notify_on_stop_mid_turn_uses_paste_buffered tests/unit/test_message_queue.py::TestDirectDelivery244::test_notify_on_stop_idle_path_arms_directly tests/unit/test_message_queue.py::TestDirectDelivery244::test_no_double_delivery_via_lock tests/unit/test_message_queue.py::TestSkipFence232::test_watch_no_false_idle_after_clear_dispatch -q
- PYTHONPATH=. ./venv/bin/python -m py_compile src/message_queue.py tests/unit/test_message_queue.py
