### PR TITLE
Cancel orphaned tracked reminders

### DIFF
--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -2581,6 +2581,8 @@ class MessageQueueManager:
                 "UPDATE remind_registrations SET is_active = 0 WHERE target_session_id = ?",
                 (target_session_id,)
             )
+            for owner_session_id in reg.cancel_on_reply_session_ids:
+                self.cancel_queued_track_reminds(target_session_id, owner_session_id)
             self.cancel_queued_track_status_nudges(target_session_id)
             logger.info(f"Periodic remind cancelled for {target_session_id}")
 
@@ -2609,6 +2611,23 @@ class MessageQueueManager:
             tuple(values)
         )
 
+    def _is_session_runtime_alive(self, session_id: str) -> bool:
+        """Return True only while the target session still has a live runtime."""
+        session = self.session_manager.get_session(session_id)
+        if not session:
+            return False
+        if getattr(session, "status", None) == SessionStatus.STOPPED:
+            return False
+
+        if getattr(session, "provider", "claude") == "codex-app":
+            return True
+
+        tmux_session = getattr(session, "tmux_session", None)
+        if not tmux_session:
+            return False
+
+        return bool(self.session_manager.tmux.session_exists(tmux_session))
+
     async def _run_remind_task(self, target_session_id: str):
         """
         Async loop that fires soft/hard remind messages for a target session.
@@ -2623,6 +2642,14 @@ class MessageQueueManager:
                 await asyncio.sleep(self._REMIND_CHECK_INTERVAL_SECONDS)
                 reg = self._remind_registrations.get(target_session_id)
                 if not reg or not reg.is_active:
+                    return
+
+                if reg.cancel_on_reply_session_ids and not self._is_session_runtime_alive(target_session_id):
+                    logger.info(
+                        "Tracked remind auto-cancelled for dead target=%s before notification dispatch",
+                        target_session_id,
+                    )
+                    self.cancel_remind(target_session_id)
                     return
 
                 # Skip this iteration if the session is mid-compaction (#249)
@@ -2713,6 +2740,23 @@ class MessageQueueManager:
                 tracked_status_nudge_fired,
                 soft_fired,
             ) = row
+            cancel_on_reply_session_ids = self._deserialize_cancel_on_reply_session_ids(cancel_on_reply_session_id)
+
+            if cancel_on_reply_session_ids and not self._is_session_runtime_alive(target_session_id):
+                self._execute(
+                    "UPDATE remind_registrations SET is_active = 0 WHERE target_session_id = ?",
+                    (target_session_id,),
+                )
+                for owner_session_id in cancel_on_reply_session_ids:
+                    self.cancel_queued_track_reminds(target_session_id, owner_session_id)
+                self.cancel_queued_track_status_nudges(target_session_id)
+                logger.info(
+                    "Skipped recovery for dead tracked remind registration %s: target=%s",
+                    reg_id,
+                    target_session_id,
+                )
+                continue
+
             last_reset_at = datetime.fromisoformat(last_reset_at_str)
 
             reg = RemindRegistration(
@@ -2722,7 +2766,7 @@ class MessageQueueManager:
                 hard_threshold_seconds=hard,
                 registered_at=datetime.fromisoformat(registered_at_str),
                 last_reset_at=last_reset_at,
-                cancel_on_reply_session_ids=self._deserialize_cancel_on_reply_session_ids(cancel_on_reply_session_id),
+                cancel_on_reply_session_ids=cancel_on_reply_session_ids,
                 tracked_status_nudge_fired=bool(tracked_status_nudge_fired),
                 soft_fired=bool(soft_fired),
                 is_active=True,

--- a/tests/unit/test_remind.py
+++ b/tests/unit/test_remind.py
@@ -469,6 +469,120 @@ class TestManualStop:
         assert len(pending) == 0
 
 
+class TestTrackedRemindDeadTargetCleanup:
+    """Tracked reminders auto-cancel when the tracked agent no longer has a live runtime."""
+
+    @pytest.mark.asyncio
+    async def test_tracked_remind_task_cancels_dead_target_and_queued_notifications(self, mq, mock_session_manager):
+        target_session = Session(
+            id="dead-track",
+            name="dead-track",
+            tmux_session="tmux-dead-track",
+            status=SessionStatus.RUNNING,
+        )
+        mock_session_manager.get_session.return_value = target_session
+        mock_session_manager.tmux.session_exists.return_value = False
+
+        with patch("asyncio.create_task", noop_create_task):
+            mq.register_periodic_remind(
+                "dead-track",
+                soft_threshold=10,
+                hard_threshold=20,
+                cancel_on_reply_session_id="owner-dead",
+            )
+            mq.queue_message(
+                target_session_id="owner-dead",
+                sender_session_id="dead-track",
+                text="[sm track] Waiting on dead-track (dead-tra)",
+                delivery_mode="important",
+                message_category="track_remind",
+            )
+            mq.queue_message(
+                target_session_id="dead-track",
+                text="[sm remind] Update your status",
+                delivery_mode="important",
+                message_category="track_status_nudge",
+            )
+
+        await run_one_iteration(mq, "dead-track")
+
+        assert "dead-track" not in mq._remind_registrations
+        assert mq.get_pending_messages("owner-dead") == []
+        assert mq.get_pending_messages("dead-track") == []
+
+        conn = sqlite3.connect(mq.db_path)
+        row = conn.execute(
+            "SELECT is_active FROM remind_registrations WHERE target_session_id = ?",
+            ("dead-track",),
+        ).fetchone()
+        conn.close()
+        assert row[0] == 0
+
+    @pytest.mark.asyncio
+    async def test_recover_skips_dead_tracked_registration_and_scrubs_queue(
+        self,
+        mock_session_manager,
+        temp_db_path,
+    ):
+        target_session = Session(
+            id="dead-recover",
+            name="dead-recover",
+            tmux_session="tmux-dead-recover",
+            status=SessionStatus.RUNNING,
+        )
+        mock_session_manager.get_session.return_value = target_session
+        mock_session_manager.tmux.session_exists.return_value = False
+
+        mq1 = MessageQueueManager(
+            session_manager=mock_session_manager,
+            db_path=temp_db_path,
+            config={"remind": {"soft_threshold_seconds": 180, "hard_gap_seconds": 120}},
+            notifier=None,
+        )
+        with patch("asyncio.create_task", noop_create_task):
+            mq1.register_periodic_remind(
+                "dead-recover",
+                soft_threshold=300,
+                hard_threshold=600,
+                cancel_on_reply_session_id="owner-recover",
+            )
+            mq1.queue_message(
+                target_session_id="owner-recover",
+                sender_session_id="dead-recover",
+                text="[sm track] Waiting on dead-recover (dead-rec)",
+                delivery_mode="important",
+                message_category="track_remind",
+            )
+            mq1.queue_message(
+                target_session_id="dead-recover",
+                text="[sm remind] Update your status",
+                delivery_mode="important",
+                message_category="track_status_nudge",
+            )
+
+        mq2 = MessageQueueManager(
+            session_manager=mock_session_manager,
+            db_path=temp_db_path,
+            config={"remind": {"soft_threshold_seconds": 180, "hard_gap_seconds": 120}},
+            notifier=None,
+        )
+
+        with patch("asyncio.create_task", noop_create_task):
+            await mq2._recover_remind_registrations()
+
+        assert "dead-recover" not in mq2._remind_registrations
+        assert mq2.get_pending_messages("owner-recover") == []
+        assert mq2.get_pending_messages("dead-recover") == []
+
+        conn = sqlite3.connect(temp_db_path)
+        row = conn.execute(
+            "SELECT is_active FROM remind_registrations WHERE target_session_id = ?",
+            ("dead-recover",),
+        ).fetchone()
+        conn.close()
+        assert row[0] == 0
+
+
 # ===========================================================================
 # 9 — Replacement policy
 # ===========================================================================


### PR DESCRIPTION
Fixes #455

## Summary
- auto-cancel tracked periodic reminders when the tracked target session no longer has a live runtime
- prune dead tracked reminders during startup recovery so stale rows do not resurrect after restart
- clear queued owner-facing `[sm track]` messages and target-facing status nudges when cancelling a tracked registration

## Validation
- `./venv/bin/pytest tests/unit/test_remind.py -q -k 'tracked_remind_task_cancels_dead_target or recover_skips_dead_tracked_registration or stop_hook_cancels_remind or completion_transition_idle_cancels_remind or cancel_prevents_future_reminders'`
- `./venv/bin/pytest tests/unit/test_parent_wake.py -q -k 'task_cancels_missing_child_before_digest or dead_child or recover_skips'`
- `PYTHONPATH=. ./venv/bin/python -m py_compile src/message_queue.py tests/unit/test_remind.py tests/unit/test_parent_wake.py`

## Notes
- a broad combined `test_remind.py` / `test_parent_wake.py` run still trips the existing repo-level file descriptor exhaustion problem during pytest teardown; this patch uses focused slices that cover the changed lifecycle paths.
