### PR TITLE
Resolve identifiers in sm children

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -230,9 +230,13 @@ def main():
         help="Track the child with periodic remind until it replies (default: 300s)",
     )
 
-    # sm children [session-id]
+    # sm children [session]
     children_parser = subparsers.add_parser("children", help="List child sessions")
-    children_parser.add_argument("session_id", nargs="?", help="Parent session ID (defaults to current)")
+    children_parser.add_argument(
+        "session_id",
+        nargs="?",
+        help="Parent session ID, friendly name, or registry alias (defaults to current)",
+    )
     children_parser.add_argument("--recursive", action="store_true", help="Include grandchildren")
     children_parser.add_argument("--status", choices=["running", "completed", "error", "all"], help="Filter by status")
     children_parser.add_argument("--json", action="store_true", help="Output JSON")
@@ -754,9 +758,28 @@ def main():
             getattr(args, "track", None),
         ))
     elif args.command == "children":
-        # Use current session if not specified
-        parent_id = args.session_id if args.session_id else session_id
-        sys.exit(commands.cmd_children(client, parent_id, args.recursive, args.status, args.json, getattr(args, 'db_path', None)))
+        if args.session_id:
+            parent_id, _ = commands.resolve_session_id(client, args.session_id)
+            if parent_id is None:
+                sessions = client.list_sessions()
+                if sessions is None:
+                    print(commands.UNAVAILABLE_MESSAGE, file=sys.stderr)
+                    sys.exit(2)
+                print(f"Error: Session '{args.session_id}' not found", file=sys.stderr)
+                sys.exit(1)
+        else:
+            parent_id = session_id
+
+        sys.exit(
+            commands.cmd_children(
+                client,
+                parent_id,
+                args.recursive,
+                args.status,
+                args.json,
+                getattr(args, "db_path", None),
+            )
+        )
     elif args.command == "kill":
         sys.exit(commands.cmd_kill(client, session_id, args.session_id))
     elif args.command == "clean":

--- a/tests/unit/test_cli_parsing.py
+++ b/tests/unit/test_cli_parsing.py
@@ -361,7 +361,7 @@ class TestChildrenCommand:
         assert args.session_id is None  # Will use current
 
     def test_children_with_session_id(self):
-        """sm children <session-id> specifies parent."""
+        """sm children <session> specifies parent."""
         parser = TestCliParsing()
         args = parser._get_parsed_args(["children", "parent123"])
 
@@ -402,6 +402,49 @@ class TestChildrenCommand:
         args = parser._get_parsed_args(["children"])
 
         assert args.db_path is None
+
+
+class TestChildrenCommandDispatch:
+    """Tests for 'sm children' runtime resolution and dispatch."""
+
+    def test_children_resolves_parent_identifier_before_dispatch(self):
+        mock_client = MagicMock()
+
+        with patch.object(sys, "argv", ["sm", "children", "chief-scientist"]):
+            with patch("src.cli.main.SessionManagerClient", return_value=mock_client):
+                with patch("src.cli.main.commands.resolve_session_id", return_value=("abc12345", {"id": "abc12345"})):
+                    with patch("src.cli.main.commands.cmd_children", return_value=0) as mock_cmd_children:
+                        with pytest.raises(SystemExit) as exc_info:
+                            main()
+
+        assert exc_info.value.code == 0
+        mock_cmd_children.assert_called_once_with(mock_client, "abc12345", False, None, False, None)
+
+    def test_children_reports_missing_named_parent(self, capsys):
+        mock_client = MagicMock()
+        mock_client.list_sessions.return_value = []
+
+        with patch.object(sys, "argv", ["sm", "children", "chief-scientist"]):
+            with patch("src.cli.main.SessionManagerClient", return_value=mock_client):
+                with patch("src.cli.main.commands.resolve_session_id", return_value=(None, None)):
+                    with pytest.raises(SystemExit) as exc_info:
+                        main()
+
+        assert exc_info.value.code == 1
+        assert "Error: Session 'chief-scientist' not found" in capsys.readouterr().err
+
+    def test_children_reports_unavailable_when_resolution_cannot_query_sessions(self, capsys):
+        mock_client = MagicMock()
+        mock_client.list_sessions.return_value = None
+
+        with patch.object(sys, "argv", ["sm", "children", "chief-scientist"]):
+            with patch("src.cli.main.SessionManagerClient", return_value=mock_client):
+                with patch("src.cli.main.commands.resolve_session_id", return_value=(None, None)):
+                    with pytest.raises(SystemExit) as exc_info:
+                        main()
+
+        assert exc_info.value.code == 2
+        assert "Session manager unavailable or request timed out" in capsys.readouterr().err
 
 
 class TestOutputCommand:


### PR DESCRIPTION
Fixes #457

## Summary
- resolve the optional `sm children` parent argument through the existing session-id/name/alias chain
- keep the existing current-session default when no parent is provided
- report not-found vs unavailable errors before dispatching to the existing children endpoint

## Validation
- ./venv/bin/pytest tests/unit/test_cli_parsing.py tests/unit/test_cmd_children.py tests/unit/test_client_list_children.py -q
- PYTHONPATH=. ./venv/bin/python -m py_compile src/cli/main.py tests/unit/test_cli_parsing.py
