### PR TITLE
Fix Claude native title recovery when transcript path is missing

### DIFF
--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -2426,15 +2426,57 @@ class SessionManager:
         aliases = self.get_session_aliases(session_id)
         return aliases[0] if aliases else None
 
-    def _extract_claude_native_title(self, transcript_path: str) -> tuple[Optional[str], Optional[int]]:
-        """Read Claude transcript metadata and return the latest native title plus file mtime."""
+    def _claude_transcript_root(self) -> Path:
+        """Return Claude's transcript project root."""
+        claude_config = self.config.get("claude", {})
+        configured_root = claude_config.get("transcript_root", "~/.claude/projects")
+        return Path(str(configured_root)).expanduser()
+
+    @staticmethod
+    def _claude_project_dir_name(working_dir: str) -> str:
+        """Map one working directory to Claude's per-project transcript directory."""
+        resolved = str(Path(working_dir).expanduser().resolve())
+        return resolved.replace(os.sep, "-")
+
+    @staticmethod
+    def _parse_claude_timestamp(raw_timestamp: Any) -> Optional[datetime]:
+        """Parse Claude transcript timestamps into UTC datetimes."""
+        if not raw_timestamp:
+            return None
+        try:
+            parsed = datetime.fromisoformat(str(raw_timestamp).replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.astimezone(timezone.utc)
+
+    @staticmethod
+    def _session_time_ns(session: Session, attr: str) -> int:
+        """Normalize one session timestamp attribute to epoch nanoseconds."""
+        value = getattr(session, attr, None)
+        if not isinstance(value, datetime):
+            return 0
+        if value.tzinfo is None:
+            value = value.astimezone()
+        return int(value.timestamp() * 1_000_000_000)
+
+    def _read_claude_transcript_metadata(self, transcript_path: str) -> dict[str, Any]:
+        """Read one Claude transcript and return title plus binding metadata."""
         transcript_file = Path(transcript_path).expanduser()
         if not transcript_file.exists():
-            return None, None
+            return {
+                "title": None,
+                "mtime_ns": None,
+                "cwd": None,
+                "started_at": None,
+            }
 
         stat = transcript_file.stat()
         latest_custom_title: Optional[str] = None
         latest_agent_name: Optional[str] = None
+        first_user_cwd: Optional[str] = None
+        first_user_timestamp: Optional[datetime] = None
 
         with transcript_file.open() as handle:
             for line in handle:
@@ -2444,6 +2486,11 @@ class SessionManager:
                     continue
                 if not isinstance(entry, dict):
                     continue
+                if entry.get("type") == "user" and first_user_cwd is None:
+                    candidate_cwd = str(entry.get("cwd") or "").strip()
+                    if candidate_cwd:
+                        first_user_cwd = str(Path(candidate_cwd).expanduser().resolve())
+                    first_user_timestamp = self._parse_claude_timestamp(entry.get("timestamp"))
                 if entry.get("type") == "custom-title":
                     candidate = str(entry.get("customTitle") or "").strip()
                     if candidate:
@@ -2453,7 +2500,97 @@ class SessionManager:
                     if candidate:
                         latest_agent_name = candidate
 
-        return latest_custom_title or latest_agent_name, stat.st_mtime_ns
+        return {
+            "title": latest_custom_title or latest_agent_name,
+            "mtime_ns": stat.st_mtime_ns,
+            "cwd": first_user_cwd,
+            "started_at": first_user_timestamp,
+        }
+
+    def _extract_claude_live_title(self, session: Session) -> Optional[str]:
+        """Read Claude's current native title from tmux when available."""
+        if session.provider != "claude" or not session.tmux_session:
+            return None
+
+        raw_title = self.tmux.get_pane_title(session.tmux_session)
+        if not isinstance(raw_title, str) or not raw_title:
+            return None
+
+        title = raw_title.strip()
+        first_token, _, remainder = title.partition(" ")
+        if remainder and not any(char.isalnum() for char in first_token):
+            title = remainder.strip()
+        title = title.strip()
+        if not title or title == "Claude Code":
+            return None
+        return title
+
+    def _discover_claude_transcript_path(
+        self,
+        session: Session,
+        *,
+        expected_title: Optional[str] = None,
+    ) -> Optional[str]:
+        """Bind a missing Claude transcript path using cwd plus recent activity."""
+        if session.provider != "claude" or session.transcript_path or not session.working_dir:
+            return session.transcript_path
+
+        project_dir = self._claude_transcript_root() / self._claude_project_dir_name(session.working_dir)
+        if not project_dir.is_dir():
+            return None
+
+        resolved_working_dir = str(Path(session.working_dir).expanduser().resolve())
+        claimed_paths: set[Path] = set()
+        for other_session in self.sessions.values():
+            if other_session.id == session.id or not other_session.transcript_path:
+                continue
+            try:
+                claimed_paths.add(Path(other_session.transcript_path).expanduser().resolve())
+            except OSError:
+                continue
+
+        target_time_ns = max(
+            self._session_time_ns(session, "last_activity"),
+            self._session_time_ns(session, "created_at"),
+        )
+        candidates: list[tuple[int, int, int, str]] = []
+
+        for transcript_file in project_dir.glob("*.jsonl"):
+            try:
+                resolved_transcript = transcript_file.expanduser().resolve()
+            except OSError:
+                continue
+            if resolved_transcript in claimed_paths:
+                continue
+            try:
+                metadata = self._read_claude_transcript_metadata(str(resolved_transcript))
+            except OSError:
+                continue
+            transcript_cwd = metadata.get("cwd")
+            if transcript_cwd and transcript_cwd != resolved_working_dir:
+                continue
+            transcript_title = metadata.get("title")
+            if expected_title and transcript_title != expected_title:
+                continue
+            transcript_mtime_ns = int(metadata.get("mtime_ns") or 0)
+            transcript_start_ns = 0
+            started_at = metadata.get("started_at")
+            if isinstance(started_at, datetime):
+                transcript_start_ns = int(started_at.timestamp() * 1_000_000_000)
+            distance = abs(target_time_ns - (transcript_mtime_ns or transcript_start_ns))
+            start_distance = abs(target_time_ns - transcript_start_ns) if transcript_start_ns else distance
+            candidates.append((distance, start_distance, -transcript_mtime_ns, str(resolved_transcript)))
+
+        if not candidates:
+            return None
+
+        candidates.sort()
+        return candidates[0][3]
+
+    def _extract_claude_native_title(self, transcript_path: str) -> tuple[Optional[str], Optional[int]]:
+        """Read Claude transcript metadata and return the latest native title plus file mtime."""
+        metadata = self._read_claude_transcript_metadata(transcript_path)
+        return metadata.get("title"), metadata.get("mtime_ns")
 
     def sync_claude_native_title(self, session_or_id: Session | str | None, persist: bool = True) -> Optional[str]:
         """Synchronize one Claude session's native title from transcript metadata."""
@@ -2466,25 +2603,65 @@ class SessionManager:
             if session is None:
                 return None
 
-        if session.provider != "claude" or not session.transcript_path:
+        if session.provider != "claude":
+            return session.native_title
+
+        live_title = self._extract_claude_live_title(session)
+        state_changed = False
+        if not session.transcript_path:
+            discovered_transcript_path = self._discover_claude_transcript_path(
+                session,
+                expected_title=live_title,
+            )
+            if discovered_transcript_path and session.transcript_path != discovered_transcript_path:
+                session.transcript_path = discovered_transcript_path
+                state_changed = True
+
+        if not session.transcript_path:
+            if live_title and live_title != session.native_title:
+                session.native_title = live_title
+                session.native_title_updated_at_ns = time.time_ns()
+                state_changed = True
+            if state_changed and persist:
+                self._save_state()
             return session.native_title
 
         transcript_file = Path(session.transcript_path).expanduser()
         if not transcript_file.exists():
+            if live_title and live_title != session.native_title:
+                session.native_title = live_title
+                session.native_title_updated_at_ns = time.time_ns()
+                state_changed = True
+            if state_changed and persist:
+                self._save_state()
             return session.native_title
 
         try:
             current_mtime_ns = transcript_file.stat().st_mtime_ns
         except OSError:
+            if live_title and live_title != session.native_title:
+                session.native_title = live_title
+                session.native_title_updated_at_ns = time.time_ns()
+                state_changed = True
+            if state_changed and persist:
+                self._save_state()
             return session.native_title
 
         if session.native_title_source_mtime_ns == current_mtime_ns:
+            if state_changed and persist:
+                self._save_state()
             return session.native_title
 
         try:
             native_title, synced_mtime_ns = self._extract_claude_native_title(session.transcript_path)
         except OSError as exc:
             logger.debug("Failed reading Claude transcript title for %s: %s", session.id, exc)
+            if live_title and live_title != session.native_title:
+                session.native_title = live_title
+                session.native_title_updated_at_ns = time.time_ns()
+                state_changed = True
+            if state_changed and persist:
+                self._save_state()
             return session.native_title
 
         title_changed = native_title != session.native_title
@@ -2492,7 +2669,7 @@ class SessionManager:
         session.native_title_source_mtime_ns = synced_mtime_ns
         if title_changed:
             session.native_title_updated_at_ns = synced_mtime_ns
-        if title_changed and persist:
+        if (state_changed or title_changed) and persist:
             self._save_state()
         return session.native_title
 

--- a/src/tmux_controller.py
+++ b/src/tmux_controller.py
@@ -68,6 +68,20 @@ class TmuxController:
         except Exception:
             return None
 
+    def get_pane_title(self, session_name: str) -> Optional[str]:
+        """Return the active pane title for one tmux session."""
+        try:
+            result = self._run_tmux(
+                "display-message", "-p", "-t", session_name, "#{pane_title}",
+                check=False,
+            )
+            if result.returncode != 0:
+                return None
+            title = (result.stdout or "").strip()
+            return title or None
+        except Exception:
+            return None
+
     def _exit_copy_mode_if_needed(self, session_name: str) -> tuple[Optional[int], Optional[int]]:
         """Exit tmux copy-mode on active pane when present."""
         before = self._get_pane_in_mode(session_name)

--- a/tests/unit/test_claude_native_title.py
+++ b/tests/unit/test_claude_native_title.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import os
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -14,7 +15,11 @@ def _manager(tmp_path: Path) -> SessionManager:
     return SessionManager(
         log_dir=str(tmp_path / "logs"),
         state_file=str(tmp_path / "sessions.json"),
-        config={},
+        config={
+            "claude": {
+                "transcript_root": str(tmp_path / ".claude" / "projects"),
+            }
+        },
     )
 
 
@@ -25,7 +30,13 @@ def _write_transcript(path: Path, *entries: dict) -> None:
             handle.write(json.dumps(entry) + "\n")
 
 
-def _claude_session(tmp_path: Path, transcript_path: Path, *, friendly_name: str | None = None) -> Session:
+def _claude_session(
+    tmp_path: Path,
+    transcript_path: Path | None,
+    *,
+    friendly_name: str | None = None,
+    created_at: datetime | None = None,
+) -> Session:
     return Session(
         id="claude123",
         name="claude-claude123",
@@ -34,9 +45,16 @@ def _claude_session(tmp_path: Path, transcript_path: Path, *, friendly_name: str
         provider="claude",
         log_file=str(tmp_path / "claude123.log"),
         status=SessionStatus.RUNNING,
-        transcript_path=str(transcript_path),
+        created_at=created_at or datetime.now(),
+        last_activity=created_at or datetime.now(),
+        transcript_path=str(transcript_path) if transcript_path else None,
         friendly_name=friendly_name,
     )
+
+
+def _claude_project_dir(tmp_path: Path, working_dir: Path) -> Path:
+    normalized = str(working_dir.expanduser().resolve()).replace("/", "-")
+    return tmp_path / ".claude" / "projects" / normalized
 
 
 def test_effective_name_uses_claude_custom_title_when_no_friendly_name(tmp_path: Path) -> None:
@@ -53,6 +71,123 @@ def test_effective_name_uses_claude_custom_title_when_no_friendly_name(tmp_path:
     assert manager.get_effective_session_name(session.id) == "native-claude-title"
     assert session.native_title == "native-claude-title"
     assert session.native_title_source_mtime_ns is not None
+
+
+def test_effective_name_uses_live_tmux_title_when_transcript_path_missing(tmp_path: Path) -> None:
+    manager = _manager(tmp_path)
+    manager.tmux = MagicMock()
+    manager.tmux.get_pane_title.return_value = "⠂ bork-investigator"
+    session = _claude_session(tmp_path, None)
+    manager.sessions[session.id] = session
+
+    assert manager.get_effective_session_name(session.id) == "bork-investigator"
+    assert session.native_title == "bork-investigator"
+    assert session.transcript_path is None
+
+
+def test_effective_name_discovers_matching_transcript_path_when_missing(tmp_path: Path) -> None:
+    manager = _manager(tmp_path)
+    manager.tmux = MagicMock()
+    manager.tmux.get_pane_title.return_value = "✳ bork-investigator"
+    working_dir = tmp_path / "repo"
+    working_dir.mkdir()
+    created_at = datetime.now(timezone.utc)
+    project_dir = _claude_project_dir(tmp_path, working_dir)
+    transcript = project_dir / "chosen.jsonl"
+    _write_transcript(
+        transcript,
+        {
+            "type": "user",
+            "timestamp": created_at.isoformat(),
+            "cwd": str(working_dir.resolve()),
+        },
+        {"type": "custom-title", "customTitle": "bork-investigator"},
+    )
+    other_transcript = project_dir / "other.jsonl"
+    _write_transcript(
+        other_transcript,
+        {
+            "type": "user",
+            "timestamp": (created_at + timedelta(seconds=2)).isoformat(),
+            "cwd": str(working_dir.resolve()),
+        },
+        {"type": "custom-title", "customTitle": "other-title"},
+    )
+    session = Session(
+        id="claude123",
+        name="claude-claude123",
+        working_dir=str(working_dir),
+        tmux_session="claude-claude123",
+        provider="claude",
+        log_file=str(tmp_path / "claude123.log"),
+        status=SessionStatus.RUNNING,
+        created_at=created_at,
+        last_activity=created_at,
+    )
+    manager.sessions[session.id] = session
+
+    assert manager.get_effective_session_name(session.id) == "bork-investigator"
+    assert session.native_title == "bork-investigator"
+    assert session.transcript_path == str(transcript.resolve())
+    assert session.native_title_source_mtime_ns is not None
+
+
+def test_effective_name_discovery_skips_transcript_claimed_by_other_session(tmp_path: Path) -> None:
+    manager = _manager(tmp_path)
+    manager.tmux = MagicMock()
+    manager.tmux.get_pane_title.return_value = "✳ bork-investigator"
+    working_dir = tmp_path / "repo"
+    working_dir.mkdir()
+    created_at = datetime.now(timezone.utc)
+    project_dir = _claude_project_dir(tmp_path, working_dir)
+    claimed_transcript = project_dir / "claimed.jsonl"
+    _write_transcript(
+        claimed_transcript,
+        {
+            "type": "user",
+            "timestamp": created_at.isoformat(),
+            "cwd": str(working_dir.resolve()),
+        },
+        {"type": "custom-title", "customTitle": "bork-investigator"},
+    )
+    chosen_transcript = project_dir / "chosen.jsonl"
+    _write_transcript(
+        chosen_transcript,
+        {
+            "type": "user",
+            "timestamp": (created_at + timedelta(seconds=1)).isoformat(),
+            "cwd": str(working_dir.resolve()),
+        },
+        {"type": "custom-title", "customTitle": "bork-investigator"},
+    )
+    claimed_session = Session(
+        id="claimed",
+        name="claude-claimed",
+        working_dir=str(working_dir),
+        tmux_session="claude-claimed",
+        provider="claude",
+        log_file=str(tmp_path / "claimed.log"),
+        status=SessionStatus.RUNNING,
+        created_at=created_at,
+        last_activity=created_at,
+        transcript_path=str(claimed_transcript.resolve()),
+    )
+    session = Session(
+        id="claude123",
+        name="claude-claude123",
+        working_dir=str(working_dir),
+        tmux_session="claude-claude123",
+        provider="claude",
+        log_file=str(tmp_path / "claude123.log"),
+        status=SessionStatus.RUNNING,
+        created_at=created_at,
+        last_activity=created_at,
+    )
+    manager.sessions[claimed_session.id] = claimed_session
+    manager.sessions[session.id] = session
+
+    assert manager.get_effective_session_name(session.id) == "bork-investigator"
+    assert session.transcript_path == str(chosen_transcript.resolve())
 
 
 def test_effective_name_prefers_claude_native_title_over_stale_friendly_name(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #461

## Summary
- recover Claude native titles from the live tmux pane when `transcript_path` is missing
- bind missing Claude transcript paths by scanning the matching per-project transcript directory and selecting the best unclaimed candidate
- add regressions for live-title fallback, transcript discovery, and claimed-path exclusion

## Validation
- `./venv/bin/pytest tests/unit/test_claude_native_title.py -q`
- `PYTHONPATH=. ./venv/bin/python -m py_compile src/session_manager.py src/tmux_controller.py tests/unit/test_claude_native_title.py`
- live check: `e6f963ff` resolves to `bork-investigator` and backfills its real transcript path under `~/.claude/projects/`
