### PR TITLE
Improve Telegram typing UX and command menu

### DIFF
--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -49,6 +49,7 @@ _POLLING_CONNECT_TIMEOUT = 5.0
 _POLLING_WRITE_TIMEOUT = 5.0
 _POLLING_POOL_TIMEOUT = 5.0
 _TYPING_REFRESH_SECONDS = 4.0
+_TYPING_TIMEOUT_SECONDS = 300.0
 
 
 class _PollingTracker:
@@ -379,11 +380,23 @@ class TelegramBot:
         message_thread_id: Optional[int] = None,
     ) -> None:
         """Keep Telegram's native typing indicator active until the session responds."""
+        started_at = time.monotonic()
         try:
             while True:
                 if session_id in self._completed_sessions:
                     self._completed_sessions.discard(session_id)
                     return
+                if (time.monotonic() - started_at) >= _TYPING_TIMEOUT_SECONDS:
+                    return
+                if self._on_session_status:
+                    try:
+                        session = await self._on_session_status(session_id)
+                    except Exception as e:
+                        logger.debug(f"Could not resolve session {session_id} for typing indicator: {e}")
+                        session = None
+                    status_value = getattr(getattr(session, "status", None), "value", None) if session else None
+                    if session is None or status_value == "stopped":
+                        return
                 if not self.bot:
                     return
                 await self.bot.send_chat_action(

--- a/tests/unit/test_telegram_bot.py
+++ b/tests/unit/test_telegram_bot.py
@@ -419,3 +419,33 @@ async def test_configure_bot_commands_registers_private_and_group_menus():
     assert type(group_call.kwargs["scope"]).__name__ == "BotCommandScopeAllGroupChats"
     tg.bot.set_chat_menu_button.assert_awaited_once()
     assert type(tg.bot.set_chat_menu_button.await_args.kwargs["menu_button"]).__name__ == "MenuButtonCommands"
+
+
+@pytest.mark.asyncio
+async def test_run_typing_indicator_exits_for_stopped_session():
+    """Typing indicator should not run forever after the session stops."""
+    tg = TelegramBot(token="test-token")
+    tg.bot = AsyncMock()
+    tg._on_session_status = AsyncMock(
+        return_value=SimpleNamespace(status=SimpleNamespace(value="stopped"))
+    )
+    tg._completed_sessions = set()
+    tg._typing_indicator_tasks = {}
+
+    await tg._run_typing_indicator("sess123", 100, 10)
+
+    tg.bot.send_chat_action.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_run_typing_indicator_exits_when_session_missing():
+    """Typing indicator should stop when the target session disappears."""
+    tg = TelegramBot(token="test-token")
+    tg.bot = AsyncMock()
+    tg._on_session_status = AsyncMock(return_value=None)
+    tg._completed_sessions = set()
+    tg._typing_indicator_tasks = {}
+
+    await tg._run_typing_indicator("sess123", 100, 10)
+
+    tg.bot.send_chat_action.assert_not_awaited()


### PR DESCRIPTION
Fixes #463

## Summary
- replace the immediate-delivery Telegram progress stub with Telegram's native typing indicator
- stop typing indicators cleanly when the session responds
- register curated private/group Telegram command menus on bot startup

## Validation
- ./venv/bin/pytest tests/unit/test_telegram_bot.py -q
- PYTHONPATH=. ./venv/bin/python -m py_compile src/telegram_bot.py tests/unit/test_telegram_bot.py
