### PR TITLE
F: Telegram telemetry

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -311,6 +311,8 @@ class SessionManagerApp:
         tool_logging_config = config.get("tool_logging", {})
         db_path = tool_logging_config.get("db_path", "~/.local/share/claude-sessions/tool_usage.db")
         self.tool_logger = ToolLogger(db_path=db_path)
+        if self.telegram_bot:
+            self.telegram_bot.set_telemetry_logger(self.tool_logger)
 
         # Create ASGI lifespan — runs post-bind work only after uvicorn
         # successfully binds the port.  Doomed instances (port already in use)
@@ -518,13 +520,14 @@ class SessionManagerApp:
                     session = self.session_manager.get_session(session_id)
                     session_name = session.name if session else session_id
                     working_dir = session.working_dir if session else "unknown"
-                    await self.telegram_bot.bot.send_message(
+                    await self.telegram_bot.send_notification(
                         chat_id=chat_id,
+                        session_id=session_id,
                         message_thread_id=topic_id,
-                        text=f"Session created: {session_name}\n"
-                             f"ID: {session_id}\n"
-                             f"Directory: {working_dir}\n\n"
-                             "Send messages here to interact with Claude."
+                        message=f"Session created: {session_name}\n"
+                        f"ID: {session_id}\n"
+                        f"Directory: {working_dir}\n\n"
+                        "Send messages here to interact with Claude."
                     )
                 except Exception as e:
                     logger.warning(f"Failed to send welcome message in topic: {e}")

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -175,6 +175,7 @@ class Notifier:
         msg_id = await self.telegram.send_notification(
             chat_id=chat_id,
             message=message,
+            session_id=event.session_id,
             reply_to_message_id=reply_to if not topic_id else None,
             message_thread_id=topic_id,
             parse_mode=parse_mode,

--- a/src/output_monitor.py
+++ b/src/output_monitor.py
@@ -542,6 +542,7 @@ class OutputMonitor:
                     allow_reply_fallback=self._should_allow_reply_fallback(
                         session, telegram_bot
                     ),
+                    session_id=session_id,
                 )
 
                 if msg_id is not None:
@@ -609,6 +610,7 @@ class OutputMonitor:
                             allow_reply_fallback=self._should_allow_reply_fallback(
                                 session, telegram_bot
                             ),
+                            session_id=session_id,
                         ),
                         timeout=self._cleanup_notify_timeout,
                     )

--- a/src/server.py
+++ b/src/server.py
@@ -877,6 +877,7 @@ async def _handle_em_topic_inheritance(session, session_manager, telegram_bot):
             chat_id=new_chat_id,
             message=f"EM session [{session.id}] continuing",
             thread_id=old_thread_id,
+            session_id=session.id,
         )
     except Exception as e:
         logger.warning(f"EM topic inheritance: failed to post continuation message: {e}")
@@ -2884,6 +2885,7 @@ def create_app(
                 chat_id=chat_id,
                 message=cleared_msg,
                 thread_id=thread_id,
+                session_id=session_id,
             )
 
         # Cancel periodic remind and parent wake (context reset means task is over) (#188, #225-C)

--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -216,6 +216,7 @@ class TelegramBot:
         self._typing_indicator_tasks: dict[str, asyncio.Task] = {}
         # Track "/force next message" arming per (chat, user, session)
         self._force_next_inputs: set[tuple[int, int, str]] = set()
+        self._telemetry_logger = None
 
     @staticmethod
     def _is_known_command_text(text: Optional[str]) -> bool:
@@ -313,6 +314,75 @@ class TelegramBot:
     def set_get_subagents_handler(self, handler: Callable[[str], Awaitable[Optional[list]]]):
         """Set handler for getting subagents. Handler receives session_id."""
         self._on_get_subagents = handler
+
+    def set_telemetry_logger(self, telemetry_logger) -> None:
+        """Set async telemetry logger for inbound/outbound Telegram events."""
+        self._telemetry_logger = telemetry_logger
+
+    def _queue_telegram_telemetry(
+        self,
+        *,
+        direction: str,
+        session_id: Optional[str],
+        chat_id: int,
+        result: str,
+    ) -> None:
+        """Log Telegram telemetry without blocking the current request path."""
+        telemetry_logger = getattr(self, "_telemetry_logger", None)
+        if not telemetry_logger:
+            return
+        try:
+            asyncio.create_task(
+                telemetry_logger.log_telegram_telemetry(
+                    direction=direction,
+                    session_id=session_id,
+                    chat_id=chat_id,
+                    result=result,
+                )
+            )
+        except RuntimeError:
+            logger.debug("Skipping Telegram telemetry because no event loop is running")
+
+    async def _send_logged_message(
+        self,
+        *,
+        chat_id: int,
+        text: str,
+        session_id: Optional[str] = None,
+        reply_to_message_id: Optional[int] = None,
+        message_thread_id: Optional[int] = None,
+        parse_mode: Optional[str] = None,
+        reply_markup: Optional[InlineKeyboardMarkup] = None,
+    ):
+        """Send a Telegram message and record outbound telemetry for the attempt."""
+        if not self.bot:
+            raise RuntimeError("Bot not initialized")
+
+        try:
+            message = await self.bot.send_message(
+                chat_id=chat_id,
+                text=text,
+                reply_to_message_id=reply_to_message_id,
+                message_thread_id=message_thread_id,
+                parse_mode=parse_mode,
+                reply_markup=reply_markup,
+            )
+        except Exception:
+            self._queue_telegram_telemetry(
+                direction="out",
+                session_id=session_id,
+                chat_id=chat_id,
+                result="FAILED",
+            )
+            raise
+
+        self._queue_telegram_telemetry(
+            direction="out",
+            session_id=session_id,
+            chat_id=chat_id,
+            result="DELIVERED",
+        )
+        return message
 
     async def _configure_bot_commands(self) -> None:
         """Register a curated bot command menu for private and group chats."""
@@ -588,6 +658,7 @@ class TelegramBot:
         self,
         chat_id: int,
         message: str,
+        session_id: Optional[str] = None,
         reply_to_message_id: Optional[int] = None,
         message_thread_id: Optional[int] = None,
         reply_markup: Optional[InlineKeyboardMarkup] = None,
@@ -602,9 +673,10 @@ class TelegramBot:
 
         for index, chunk in enumerate(chunks, start=1):
             prefix = f"[{index}/{total}]\n" if total > 1 else ""
-            msg = await self.bot.send_message(
+            msg = await self._send_logged_message(
                 chat_id=chat_id,
                 text=f"{prefix}{chunk}",
+                session_id=session_id,
                 reply_to_message_id=reply_to_message_id,
                 message_thread_id=message_thread_id,
                 reply_markup=reply_markup if index == 1 else None,
@@ -688,13 +760,14 @@ class TelegramBot:
                         if topic_id:
                             self.register_topic_session(chat_id, topic_id, session.id)
 
-                            await self.bot.send_message(
+                            await self._send_logged_message(
                                 chat_id=chat_id,
                                 message_thread_id=topic_id,
+                                session_id=session.id,
                                 text=f"Session created: {session.name}\n"
-                                     f"ID: {session.id}\n"
-                                     f"Directory: {session.working_dir}\n\n"
-                                     "Send messages here to interact with Claude."
+                                f"ID: {session.id}\n"
+                                f"Directory: {session.working_dir}\n\n"
+                                "Send messages here to interact with Claude."
                             )
 
                             if self._on_update_topic:
@@ -1216,9 +1289,21 @@ Provide ONLY the summary, no preamble or questions."""
                     await update.message.reply_text(
                         "Could not identify session for this topic. The session may have been created before the server started."
                     )
+                self._queue_telegram_telemetry(
+                    direction="in",
+                    session_id=None,
+                    chat_id=chat_id,
+                    result="FAILED",
+                )
                 return  # Silently ignore in General topic
             await update.message.reply_text(
                 "Could not identify session. Reply to a message containing [session_id]."
+            )
+            self._queue_telegram_telemetry(
+                direction="in",
+                session_id=None,
+                chat_id=chat_id,
+                result="FAILED",
             )
             return
 
@@ -1246,6 +1331,7 @@ Provide ONLY the summary, no preamble or questions."""
                     chat_id,
                     update.message.message_thread_id,
                 )
+                telemetry_result = "DELIVERED"
             elif result == DeliveryResult.QUEUED:
                 msg = await update.message.reply_text(
                     f"[{session_id}] ⏳ Queued (delivery deferred)\n"
@@ -1253,17 +1339,33 @@ Provide ONLY the summary, no preamble or questions."""
                 )
                 # Track queued message for potential /force promotion
                 self._pending_input_msgs[session_id] = (chat_id, msg.message_id)
+                telemetry_result = "QUEUED"
             else:
                 await update.message.reply_text(f"[{session_id}] ❌ Failed to send input")
+                telemetry_result = "FAILED"
+
+            self._queue_telegram_telemetry(
+                direction="in",
+                session_id=session_id,
+                chat_id=chat_id,
+                result=telemetry_result,
+            )
 
         except Exception as e:
             logger.error(f"Error sending input: {e}")
             await update.message.reply_text(f"[{session_id}] Error: {e}")
+            self._queue_telegram_telemetry(
+                direction="in",
+                session_id=session_id,
+                chat_id=chat_id,
+                result="FAILED",
+            )
 
     async def send_notification(
         self,
         chat_id: int,
         message: str,
+        session_id: Optional[str] = None,
         reply_to_message_id: Optional[int] = None,
         message_thread_id: Optional[int] = None,
         parse_mode: Optional[str] = None,
@@ -1298,6 +1400,7 @@ Provide ONLY the summary, no preamble or questions."""
                 return await self._send_chunked_notification(
                     chat_id=chat_id,
                     message=plain_message,
+                    session_id=session_id,
                     reply_to_message_id=reply_to_message_id,
                     message_thread_id=message_thread_id,
                     reply_markup=reply_markup,
@@ -1310,9 +1413,10 @@ Provide ONLY the summary, no preamble or questions."""
                 return None
 
         try:
-            msg = await self.bot.send_message(
+            msg = await self._send_logged_message(
                 chat_id=chat_id,
                 text=message,
+                session_id=session_id,
                 reply_to_message_id=reply_to_message_id,
                 message_thread_id=message_thread_id,
                 parse_mode=parse_mode,
@@ -1331,13 +1435,15 @@ Provide ONLY the summary, no preamble or questions."""
                         return await self._send_chunked_notification(
                             chat_id=chat_id,
                             message=plain_message,
+                            session_id=session_id,
                             reply_to_message_id=reply_to_message_id,
                             message_thread_id=message_thread_id,
                             reply_markup=reply_markup,
                         )
-                    msg = await self.bot.send_message(
+                    msg = await self._send_logged_message(
                         chat_id=chat_id,
                         text=plain_message,
+                        session_id=session_id,
                         reply_to_message_id=reply_to_message_id,
                         message_thread_id=message_thread_id,
                         reply_markup=reply_markup,
@@ -1360,16 +1466,32 @@ Provide ONLY the summary, no preamble or questions."""
         thread_id: int,
         *,
         allow_reply_fallback: bool = True,
+        session_id: Optional[str] = None,
     ) -> Optional[int]:
         """Try forum-topic delivery; fall back to reply-thread if it fails.
 
         Returns the forum msg_id if forum delivery succeeded, None otherwise.
         """
-        msg_id = await self.send_notification(
-            chat_id=chat_id, message=message, message_thread_id=thread_id, silent=True
-        )
+        send_kwargs = {
+            "chat_id": chat_id,
+            "message": message,
+            "message_thread_id": thread_id,
+            "silent": True,
+        }
+        if session_id is not None:
+            send_kwargs["session_id"] = session_id
+
+        msg_id = await self.send_notification(**send_kwargs)
         if msg_id is None and allow_reply_fallback:
-            await self.send_notification(chat_id=chat_id, message=message, reply_to_message_id=thread_id, silent=True)
+            fallback_kwargs = {
+                "chat_id": chat_id,
+                "message": message,
+                "reply_to_message_id": thread_id,
+                "silent": True,
+            }
+            if session_id is not None:
+                fallback_kwargs["session_id"] = session_id
+            await self.send_notification(**fallback_kwargs)
         return msg_id
 
     def register_session_thread(self, session_id: str, chat_id: int, message_id: int):
@@ -1652,13 +1774,14 @@ Provide ONLY the summary, no preamble or questions."""
         self.register_topic_session(chat_id, topic_id, session.id)
 
         # Send welcome message in the new topic
-        await self.bot.send_message(
+        await self._send_logged_message(
             chat_id=chat_id,
             message_thread_id=topic_id,
+            session_id=session.id,
             text=f"Now following session: {session.name}\n"
-                 f"ID: {session.id}\n"
-                 f"Directory: {session.working_dir}\n\n"
-                 "Send messages here to interact with Claude."
+            f"ID: {session.id}\n"
+            f"Directory: {session.working_dir}\n\n"
+            "Send messages here to interact with Claude."
         )
 
         # Update session with topic info
@@ -1712,13 +1835,14 @@ Provide ONLY the summary, no preamble or questions."""
                         if topic_id:
                             self.register_topic_session(chat_id, topic_id, session.id)
 
-                            await self.bot.send_message(
+                            await self._send_logged_message(
                                 chat_id=chat_id,
                                 message_thread_id=topic_id,
+                                session_id=session.id,
                                 text=f"Session created: {session.name}\n"
-                                     f"ID: {session.id}\n"
-                                     f"Directory: {session.working_dir}\n\n"
-                                     "Send messages here to interact with Claude."
+                                f"ID: {session.id}\n"
+                                f"Directory: {session.working_dir}\n\n"
+                                "Send messages here to interact with Claude."
                             )
 
                             if self._on_update_topic:
@@ -1862,13 +1986,14 @@ Provide ONLY the summary, no preamble or questions."""
             self.register_topic_session(chat_id, topic_id, session.id)
 
             # Send welcome message in the new topic
-            await self.bot.send_message(
+            await self._send_logged_message(
                 chat_id=chat_id,
                 message_thread_id=topic_id,
+                session_id=session.id,
                 text=f"Now following session: {session.name}\n"
-                     f"ID: {session.id}\n"
-                     f"Directory: {session.working_dir}\n\n"
-                     "Send messages here to interact with Claude."
+                f"ID: {session.id}\n"
+                f"Directory: {session.working_dir}\n\n"
+                "Send messages here to interact with Claude."
             )
 
             # Update session with topic info

--- a/src/tool_logger.py
+++ b/src/tool_logger.py
@@ -135,6 +135,18 @@ class ToolLogger:
             cursor.execute("CREATE INDEX IF NOT EXISTS idx_agent_id ON tool_usage(agent_id)")
             cursor.execute("CREATE INDEX IF NOT EXISTS idx_project_name ON tool_usage(project_name)")
 
+            cursor.execute("""
+                CREATE TABLE IF NOT EXISTS telegram_telemetry (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    direction TEXT NOT NULL CHECK(direction IN ('in', 'out')),
+                    session_id TEXT,
+                    chat_id TEXT,
+                    result TEXT
+                )
+            """)
+            cursor.execute("CREATE INDEX IF NOT EXISTS idx_tg_timestamp ON telegram_telemetry(timestamp)")
+
             conn.commit()
 
     def _detect_destructive(self, tool_name: str, tool_input: dict) -> tuple[bool, Optional[str]]:
@@ -279,3 +291,47 @@ class ToolLogger:
             )
         except Exception as e:
             logger.error(f"Failed to log tool usage: {e}")
+
+    def _do_log_telegram_sync(
+        self,
+        direction: str,
+        session_id: Optional[str],
+        chat_id: Optional[int | str],
+        result: Optional[str],
+    ) -> None:
+        """Synchronously log a Telegram telemetry event."""
+        with self._lock:
+            conn = self._get_conn()
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                INSERT INTO telegram_telemetry (direction, session_id, chat_id, result)
+                VALUES (?, ?, ?, ?)
+                """,
+                (
+                    direction,
+                    session_id,
+                    str(chat_id) if chat_id is not None else None,
+                    result,
+                ),
+            )
+            conn.commit()
+
+    async def log_telegram_telemetry(
+        self,
+        direction: str,
+        session_id: Optional[str],
+        chat_id: Optional[int | str],
+        result: Optional[str],
+    ) -> None:
+        """Log a Telegram telemetry event without blocking the event loop."""
+        try:
+            await asyncio.to_thread(
+                self._do_log_telegram_sync,
+                direction,
+                session_id,
+                chat_id,
+                result,
+            )
+        except Exception as e:
+            logger.error(f"Failed to log Telegram telemetry: {e}")

--- a/tests/unit/test_telegram_bot.py
+++ b/tests/unit/test_telegram_bot.py
@@ -4,12 +4,36 @@ Covers internal logic not exercised by regression tests that mock at the
 whole-function boundary.
 """
 
-import pytest
-from unittest.mock import Mock, AsyncMock, MagicMock, call, patch
+import asyncio
+import sqlite3
+import time
 from types import SimpleNamespace
+from unittest.mock import Mock, AsyncMock, MagicMock, call, patch
+
+import pytest
 
 from src.models import DeliveryResult
 from src.telegram_bot import TelegramBot, TELEGRAM_MESSAGE_CHAR_LIMIT
+from src.tool_logger import ToolLogger
+
+
+async def _wait_for_telegram_telemetry_row(db_path, *, timeout: float = 1.0):
+    """Poll for the latest Telegram telemetry row inserted by async fire-and-forget logging."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        with sqlite3.connect(db_path) as conn:
+            row = conn.execute(
+                """
+                SELECT direction, session_id, chat_id, result
+                FROM telegram_telemetry
+                ORDER BY id DESC
+                LIMIT 1
+                """
+            ).fetchone()
+        if row is not None:
+            return row
+        await asyncio.sleep(0.01)
+    raise AssertionError("Timed out waiting for telegram_telemetry row")
 
 
 # ============================================================================
@@ -32,6 +56,57 @@ async def test_send_notification_silent_logs_warning_not_error():
     assert result is None
     mock_logger.warning.assert_called_once()
     mock_logger.error.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_message_logs_inbound_telegram_telemetry(tmp_path):
+    """Inbound message handling should enqueue a telegram_telemetry row."""
+    db_path = tmp_path / "tool_usage.db"
+    telemetry_logger = ToolLogger(db_path=str(db_path))
+    tg = TelegramBot(token="test-token")
+    tg.set_telemetry_logger(telemetry_logger)
+    tg._on_session_input = AsyncMock(return_value=DeliveryResult.DELIVERED)
+    tg._is_allowed = lambda chat_id, user_id=None: True
+    tg._get_session_from_context = lambda update: "sess123"
+    tg._start_typing_indicator = Mock()
+
+    update = SimpleNamespace(
+        effective_chat=SimpleNamespace(id=100, is_forum=True),
+        effective_user=SimpleNamespace(id=200),
+        message=SimpleNamespace(
+            text="hello",
+            message_id=3,
+            message_thread_id=10,
+            reply_text=AsyncMock(),
+        ),
+    )
+
+    await tg._handle_message(update, SimpleNamespace(args=[]))
+
+    row = await _wait_for_telegram_telemetry_row(str(db_path))
+    assert row == ("in", "sess123", "100", "DELIVERED")
+
+
+@pytest.mark.asyncio
+async def test_send_notification_logs_outbound_telegram_telemetry(tmp_path):
+    """Outbound bot sends should enqueue a telegram_telemetry row."""
+    db_path = tmp_path / "tool_usage.db"
+    telemetry_logger = ToolLogger(db_path=str(db_path))
+    tg = TelegramBot(token="test-token")
+    tg.set_telemetry_logger(telemetry_logger)
+    tg.bot = AsyncMock()
+    tg.bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=301))
+
+    result = await tg.send_notification(
+        chat_id=10000,
+        message="hello",
+        session_id="sess123",
+        message_thread_id=50000,
+    )
+
+    assert result == 301
+    row = await _wait_for_telegram_telemetry_row(str(db_path))
+    assert row == ("out", "sess123", "10000", "DELIVERED")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes rajeshgoli/session-manager#470

## Summary
- add `telegram_telemetry` schema/init support to the shared tool usage database
- log inbound Telegram message delivery outcomes without blocking message handling
- log outbound Telegram sends through the shared notification/fallback paths and add targeted unit coverage

## Testing
- ./venv/bin/pytest tests/unit/test_telegram_bot.py::test_handle_message_logs_inbound_telegram_telemetry tests/unit/test_telegram_bot.py::test_send_notification_logs_outbound_telegram_telemetry tests/unit/test_telegram_bot.py::test_send_notification_noisy_logs_error tests/unit/test_telegram_bot.py::test_send_notification_chunks_oversized_plain_text tests/unit/test_telegram_bot.py::test_send_with_fallback_forum_success_no_fallback tests/unit/test_telegram_bot.py::test_send_with_fallback_forum_failure_uses_reply_thread