### PR TITLE
Add Android artifact delivery and in-app updates

### DIFF
--- a/android-app/README.md
+++ b/android-app/README.md
@@ -25,9 +25,38 @@ cd android-app
 The app expects:
 - external Session Manager origin protected by Google auth
 - `/auth/device/google` enabled on the server
+- `/apps/session-manager-android/meta.json` and `/apps/session-manager-android/latest.apk` available on the server
 - Termux installed for direct tmux attach
 - SSH attach exposed through a tunnel such as Cloudflare Access SSH
 - SSH origin configured for public-key auth only; password auth should remain disabled
+
+## Publish a new APK
+
+Build the app:
+
+```
+cd android-app
+./gradlew assembleDebug
+```
+
+Then publish it to the local Session Manager artifact server:
+
+```
+cd ..
+VERSION_NAME=0.1.0 ./scripts/deploy_android_app.sh
+```
+
+By default the deploy script uploads:
+- app: `session-manager-android`
+- server: `http://127.0.0.1:8420`
+- APK: `android-app/app/build/outputs/apk/debug/app-debug.apk`
+
+You can override those with `APP_NAME`, `SERVER_URL`, `VERSION_CODE`, `VERSION_NAME`, or by passing a different APK path as the first argument.
+
+The server stores:
+- `latest.apk` for convenience
+- immutable hashed APKs for cache-safe installs
+- `meta.json` for in-app update checks
 
 ## Attach security model
 

--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -36,6 +36,7 @@ android {
 
         buildConfigField("String", "SM_DEFAULT_SERVER_URL", project.stringProp("SM_DEFAULT_SERVER_URL").toBuildConfigString())
         buildConfigField("String", "SM_GOOGLE_SERVER_CLIENT_ID", project.stringProp("SM_GOOGLE_SERVER_CLIENT_ID").toBuildConfigString())
+        buildConfigField("String", "SM_APK_HASH", project.stringProp("SM_APK_HASH").toBuildConfigString())
     }
 
     buildTypes {

--- a/android-app/app/src/main/AndroidManifest.xml
+++ b/android-app/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="com.termux.permission.RUN_COMMAND" />
 
     <queries>
@@ -25,6 +26,15 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/model/ApiModels.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/model/ApiModels.kt
@@ -80,6 +80,22 @@ data class DeviceGoogleAuthResponse(
 )
 
 @Serializable
+data class AppArtifactMetadata(
+    @SerialName("artifact_hash")
+    val artifactHash: String? = null,
+    @SerialName("size_bytes")
+    val sizeBytes: Long? = null,
+    @SerialName("uploaded_at")
+    val uploadedAt: String? = null,
+    @SerialName("uploaded_by")
+    val uploadedBy: String? = null,
+    @SerialName("version_code")
+    val versionCode: Int? = null,
+    @SerialName("version_name")
+    val versionName: String? = null,
+)
+
+@Serializable
 data class SessionListResponse(
     val sessions: List<ClientSession> = emptyList(),
 )

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/remote/ApiService.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/remote/ApiService.kt
@@ -1,6 +1,7 @@
 package li.rajeshgo.sm.data.remote
 
 import li.rajeshgo.sm.data.model.ActivityActionsResponse
+import li.rajeshgo.sm.data.model.AppArtifactMetadata
 import li.rajeshgo.sm.data.model.AuthSessionResponse
 import li.rajeshgo.sm.data.model.ClientBootstrapResponse
 import li.rajeshgo.sm.data.model.ClientSession
@@ -20,6 +21,9 @@ import retrofit2.http.Query
 interface ApiService {
     @GET("client/bootstrap")
     suspend fun getBootstrap(): ClientBootstrapResponse
+
+    @GET("apps/{app}/meta.json")
+    suspend fun getAppArtifactMetadata(@Path("app") app: String): AppArtifactMetadata
 
     @GET("auth/session")
     suspend fun getAuthSession(): AuthSessionResponse

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/AppUpdateRepository.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/AppUpdateRepository.kt
@@ -1,0 +1,160 @@
+package li.rajeshgo.sm.data.repository
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.FileProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import retrofit2.HttpException
+import retrofit2.Retrofit
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import li.rajeshgo.sm.BuildConfig
+import li.rajeshgo.sm.data.model.AppArtifactMetadata
+import li.rajeshgo.sm.data.remote.ApiService
+import java.io.File
+import java.io.IOException
+import java.security.MessageDigest
+import java.util.concurrent.TimeUnit
+
+data class AvailableAppUpdate(
+    val artifactHash: String,
+    val versionName: String,
+    val uploadedAt: String?,
+)
+
+class AppUpdateRepository(
+    private val context: Context,
+    private val settingsRepository: SettingsRepository,
+) {
+    private val json = Json { ignoreUnknownKeys = true; coerceInputValues = true }
+
+    @Volatile
+    private var cachedCurrentArtifactHash: String? = null
+
+    suspend fun getAvailableUpdate(): AvailableAppUpdate? {
+        val serverUrl = settingsRepository.serverUrl.first().trimEnd('/')
+        if (serverUrl.isBlank()) {
+            return null
+        }
+        val metadata = fetchMetadata(serverUrl) ?: return null
+        val serverArtifactHash = metadata.artifactHash?.trim()?.lowercase() ?: return null
+        val currentArtifactHash = currentBuildArtifactHash()
+        if (serverArtifactHash == currentArtifactHash) {
+            return null
+        }
+        if (settingsRepository.dismissedUpdateArtifactHash.first() == serverArtifactHash) {
+            return null
+        }
+        return AvailableAppUpdate(
+            artifactHash = serverArtifactHash,
+            versionName = metadata.versionName ?: serverArtifactHash,
+            uploadedAt = metadata.uploadedAt,
+        )
+    }
+
+    suspend fun dismissUpdate(artifactHash: String) {
+        settingsRepository.saveDismissedUpdateArtifactHash(artifactHash)
+    }
+
+    suspend fun downloadUpdate(update: AvailableAppUpdate): File = withContext(Dispatchers.IO) {
+        val serverUrl = settingsRepository.serverUrl.first().trimEnd('/')
+        val request = Request.Builder()
+            .url("$serverUrl/apps/session-manager-android/${update.artifactHash}.apk")
+            .build()
+
+        val updatesDir = File(context.cacheDir, "updates").apply { mkdirs() }
+        val apkFile = File(updatesDir, "session-manager-${update.artifactHash}.apk")
+
+        okHttpClient().newCall(request).execute().use { response ->
+            if (!response.isSuccessful) {
+                throw IOException("Update download failed: HTTP ${response.code}")
+            }
+            val responseBody = response.body ?: throw IOException("Update download returned no body")
+            responseBody.byteStream().use { input ->
+                apkFile.outputStream().use { output ->
+                    input.copyTo(output)
+                }
+            }
+        }
+
+        apkFile
+    }
+
+    fun launchInstaller(apkFile: File) {
+        val uri = FileProvider.getUriForFile(
+            context,
+            "${context.packageName}.fileprovider",
+            apkFile,
+        )
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(uri, "application/vnd.android.package-archive")
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+        context.startActivity(intent)
+    }
+
+    private suspend fun fetchMetadata(serverUrl: String): AppArtifactMetadata? = withContext(Dispatchers.IO) {
+        try {
+            apiService(serverUrl).getAppArtifactMetadata("session-manager-android")
+        } catch (error: HttpException) {
+            if (error.code() == 404) {
+                null
+            } else {
+                throw error
+            }
+        }
+    }
+
+    private suspend fun currentBuildArtifactHash(): String {
+        cachedCurrentArtifactHash?.let { return it }
+
+        val configuredHash = BuildConfig.SM_APK_HASH.trim().lowercase()
+        if (configuredHash.isNotEmpty()) {
+            cachedCurrentArtifactHash = configuredHash
+            return configuredHash
+        }
+
+        return withContext(Dispatchers.IO) {
+            val computedHash = sha256Prefix(File(context.packageCodePath))
+            cachedCurrentArtifactHash = computedHash
+            computedHash
+        }
+    }
+
+    private fun sha256Prefix(file: File): String {
+        val digest = MessageDigest.getInstance("SHA-256")
+        file.inputStream().use { input ->
+            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+            while (true) {
+                val bytesRead = input.read(buffer)
+                if (bytesRead <= 0) {
+                    break
+                }
+                digest.update(buffer, 0, bytesRead)
+            }
+        }
+        return digest.digest()
+            .joinToString(separator = "") { byte -> "%02x".format(byte) }
+            .take(8)
+    }
+
+    private fun apiService(serverUrl: String): ApiService {
+        val retrofit = Retrofit.Builder()
+            .baseUrl("$serverUrl/")
+            .client(okHttpClient())
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+        return retrofit.create(ApiService::class.java)
+    }
+
+    private fun okHttpClient(): OkHttpClient = OkHttpClient.Builder()
+        .connectTimeout(10, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .build()
+}

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SessionManagerRepository.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SessionManagerRepository.kt
@@ -27,6 +27,7 @@ import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFact
 open class SessionManagerRequestException(message: String, cause: Throwable? = null) : IllegalStateException(message, cause)
 class SessionManagerAuthException(message: String, cause: Throwable? = null) : SessionManagerRequestException(message, cause)
 class SessionManagerTransientException(message: String, cause: Throwable? = null) : SessionManagerRequestException(message, cause)
+class SessionManagerBackendUnavailableException(message: String, cause: Throwable? = null) : SessionManagerRequestException(message, cause)
 
 class SessionManagerRepository {
     private val json = Json { ignoreUnknownKeys = true }
@@ -36,7 +37,13 @@ class SessionManagerRepository {
         private const val READ_RETRY_BASE_DELAY_MS = 600L
         private const val GENERIC_TRANSIENT_READ_MESSAGE = "Server temporarily unavailable. Retrying soon."
         private const val GENERIC_TRANSIENT_WRITE_MESSAGE = "Server temporarily unavailable. Try again."
+        private const val BACKEND_UNREACHABLE_ERROR = "backend_unreachable"
     }
+
+    private data class ServerErrorPayload(
+        val code: String? = null,
+        val message: String? = null,
+    )
 
     private fun api(baseUrl: String, token: String = ""): ApiService {
         require(baseUrl.isNotBlank()) { "Server URL is required" }
@@ -54,23 +61,30 @@ class SessionManagerRepository {
             .create(ApiService::class.java)
     }
 
-    private fun extractServerMessage(error: HttpException): String? {
+    private fun extractServerError(error: HttpException): ServerErrorPayload? {
         val body = runCatching { error.response()?.errorBody()?.string() }.getOrNull()?.trim().orEmpty()
         if (body.isBlank()) {
             return null
         }
-        val parsedMessage = runCatching {
+        return runCatching {
             val obj = json.parseToJsonElement(body).jsonObject
-            listOf("detail", "message", "error")
+            val code = obj["error"]
+                ?.jsonPrimitive
+                ?.content
+                ?.trim()
+                ?.takeIf { it.isNotBlank() }
+            val message = listOf("detail", "message")
                 .firstNotNullOfOrNull { key ->
                     obj[key]
                         ?.jsonPrimitive
                         ?.content
                         ?.trim()
                         ?.takeIf { it.isNotBlank() }
-                }
-        }.getOrNull()
-        return parsedMessage ?: body.takeIf { !it.startsWith("<!DOCTYPE") && !it.startsWith("<html", ignoreCase = true) }
+                } ?: body.takeIf { !it.startsWith("<!DOCTYPE") && !it.startsWith("<html", ignoreCase = true) }
+            ServerErrorPayload(code = code, message = message)
+        }.getOrNull() ?: ServerErrorPayload(
+            message = body.takeIf { !it.startsWith("<!DOCTYPE") && !it.startsWith("<html", ignoreCase = true) }
+        )
     }
 
     private suspend fun <T> executeReadRequest(
@@ -86,16 +100,25 @@ class SessionManagerRepository {
                 when (error.code()) {
                     401, 403 -> throw SessionManagerAuthException("Session expired. Sign in again.", error)
                     502, 503, 504 -> {
-                        val serverMessage = extractServerMessage(error)
+                        val serverError = extractServerError(error)
+                        if (serverError?.code == BACKEND_UNREACHABLE_ERROR) {
+                            throw SessionManagerBackendUnavailableException(
+                                serverError.message ?: GENERIC_TRANSIENT_READ_MESSAGE,
+                                error,
+                            )
+                        }
                         lastTransient = error
                         if (attempt < READ_RETRY_ATTEMPTS - 1) {
                             delay(READ_RETRY_BASE_DELAY_MS * (attempt + 1))
                             return@repeat
                         }
-                        throw SessionManagerTransientException(serverMessage ?: GENERIC_TRANSIENT_READ_MESSAGE, error)
+                        throw SessionManagerTransientException(
+                            serverError?.message ?: GENERIC_TRANSIENT_READ_MESSAGE,
+                            error,
+                        )
                     }
                     else -> throw SessionManagerRequestException(
-                        extractServerMessage(error) ?: "Request failed (${error.code()})",
+                        extractServerError(error)?.message ?: "Request failed (${error.code()})",
                         error,
                     )
                 }
@@ -115,12 +138,22 @@ class SessionManagerRepository {
         if (error is HttpException) {
             return when (error.code()) {
                 401, 403 -> SessionManagerAuthException("Session expired. Sign in again.", error)
-                502, 503, 504 -> SessionManagerTransientException(
-                    extractServerMessage(error) ?: GENERIC_TRANSIENT_WRITE_MESSAGE,
-                    error,
-                )
+                502, 503, 504 -> {
+                    val serverError = extractServerError(error)
+                    if (serverError?.code == BACKEND_UNREACHABLE_ERROR) {
+                        SessionManagerBackendUnavailableException(
+                            serverError.message ?: GENERIC_TRANSIENT_WRITE_MESSAGE,
+                            error,
+                        )
+                    } else {
+                        SessionManagerTransientException(
+                            serverError?.message ?: GENERIC_TRANSIENT_WRITE_MESSAGE,
+                            error,
+                        )
+                    }
+                }
                 else -> SessionManagerRequestException(
-                    extractServerMessage(error) ?: "Request failed (${error.code()})",
+                    extractServerError(error)?.message ?: "Request failed (${error.code()})",
                     error,
                 )
             }

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SettingsRepository.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SettingsRepository.kt
@@ -19,6 +19,7 @@ class SettingsRepository(private val context: Context) {
         val USER_EMAIL = stringPreferencesKey("user_email")
         val USER_NAME = stringPreferencesKey("user_name")
         val EXPIRES_AT = stringPreferencesKey("expires_at")
+        val DISMISSED_UPDATE_ARTIFACT_HASH = stringPreferencesKey("dismissed_update_artifact_hash")
     }
 
     val serverUrl: Flow<String> = context.dataStore.data.map { prefs ->
@@ -43,6 +44,10 @@ class SettingsRepository(private val context: Context) {
 
     val isLoggedIn: Flow<Boolean> = accessToken.map { it.isNotBlank() }
 
+    val dismissedUpdateArtifactHash: Flow<String> = context.dataStore.data.map { prefs ->
+        prefs[Keys.DISMISSED_UPDATE_ARTIFACT_HASH] ?: ""
+    }
+
     suspend fun saveServerUrl(serverUrl: String) {
         context.dataStore.edit { prefs ->
             prefs[Keys.SERVER_URL] = serverUrl.trim().trimEnd('/')
@@ -55,6 +60,12 @@ class SettingsRepository(private val context: Context) {
             prefs[Keys.USER_EMAIL] = email
             prefs[Keys.USER_NAME] = name.orEmpty()
             prefs[Keys.EXPIRES_AT] = expiresAt
+        }
+    }
+
+    suspend fun saveDismissedUpdateArtifactHash(artifactHash: String) {
+        context.dataStore.edit { prefs ->
+            prefs[Keys.DISMISSED_UPDATE_ARTIFACT_HASH] = artifactHash.trim().lowercase()
         }
     }
 

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsScreen.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsScreen.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -24,9 +26,12 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import li.rajeshgo.sm.BuildConfig
 import li.rajeshgo.sm.auth.GoogleSignInManager
+import li.rajeshgo.sm.ui.theme.BorderStrong
 import li.rajeshgo.sm.ui.theme.Cyan
 import li.rajeshgo.sm.ui.theme.Emerald
+import li.rajeshgo.sm.ui.theme.PanelElevated
 import li.rajeshgo.sm.ui.theme.Rose
 import li.rajeshgo.sm.util.LocalDefaults
 import kotlinx.coroutines.launch
@@ -60,6 +65,13 @@ fun SettingsScreen(
             text = "Native Android watch client for sm.rajeshgo.li with direct Termux attach.",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = "App version ${BuildConfig.VERSION_NAME}",
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            fontFamily = FontFamily.Monospace,
         )
 
         Spacer(Modifier.height(24.dp))
@@ -106,6 +118,77 @@ fun SettingsScreen(
                 color = Cyan,
                 fontFamily = FontFamily.Monospace,
             )
+        }
+
+        Spacer(Modifier.height(24.dp))
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(containerColor = PanelElevated),
+            border = androidx.compose.foundation.BorderStroke(1.dp, BorderStrong),
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(
+                    text = "App updates",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Spacer(Modifier.height(8.dp))
+                val availableUpdate = state.availableUpdate
+                if (availableUpdate == null) {
+                    Text(
+                        text = "This build matches the latest published artifact.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(Modifier.height(12.dp))
+                    OutlinedButton(onClick = viewModel::refreshUpdate, modifier = Modifier.fillMaxWidth()) {
+                        Text("Check for update")
+                    }
+                } else {
+                    Text(
+                        text = "Update available: ${availableUpdate.versionName}",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = Emerald,
+                    )
+                    availableUpdate.uploadedAt?.let { uploadedAt ->
+                        Spacer(Modifier.height(4.dp))
+                        Text(
+                            text = "Published $uploadedAt",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    }
+                    Spacer(Modifier.height(12.dp))
+                    Button(
+                        onClick = viewModel::installUpdate,
+                        enabled = !state.updateInstalling,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        if (state.updateInstalling) {
+                            CircularProgressIndicator(strokeWidth = 2.dp, modifier = Modifier.height(18.dp))
+                        } else {
+                            Text("Install update")
+                        }
+                    }
+                    Spacer(Modifier.height(8.dp))
+                    OutlinedButton(
+                        onClick = viewModel::dismissUpdate,
+                        modifier = Modifier.fillMaxWidth(),
+                    ) {
+                        Text("Dismiss this version")
+                    }
+                }
+
+                state.updateError?.let { updateError ->
+                    Spacer(Modifier.height(12.dp))
+                    Text(
+                        text = updateError,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Rose,
+                    )
+                }
+            }
         }
 
         Spacer(Modifier.height(24.dp))

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsViewModel.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsViewModel.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import li.rajeshgo.sm.data.model.ClientBootstrapResponse
+import li.rajeshgo.sm.data.repository.AppUpdateRepository
+import li.rajeshgo.sm.data.repository.AvailableAppUpdate
 import li.rajeshgo.sm.data.repository.SessionManagerRepository
 import li.rajeshgo.sm.data.repository.SettingsRepository
 
@@ -19,12 +21,16 @@ data class SettingsUiState(
     val isLoggedIn: Boolean = false,
     val loading: Boolean = false,
     val bootstrap: ClientBootstrapResponse? = null,
+    val availableUpdate: AvailableAppUpdate? = null,
+    val updateInstalling: Boolean = false,
+    val updateError: String? = null,
     val error: String? = null,
 )
 
 class SettingsViewModel(application: Application) : AndroidViewModel(application) {
     private val settingsRepository = SettingsRepository(application)
     private val sessionRepository = SessionManagerRepository()
+    private val appUpdateRepository = AppUpdateRepository(application, settingsRepository)
 
     private val _uiState = MutableStateFlow(SettingsUiState())
     val uiState: StateFlow<SettingsUiState> = _uiState
@@ -38,6 +44,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                 isLoggedIn = settingsRepository.isLoggedIn.first(),
             )
             refreshBootstrap()
+            refreshUpdate()
         }
     }
 
@@ -48,7 +55,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     fun refreshBootstrap() {
         val serverUrl = _uiState.value.serverUrl.trim().trimEnd('/')
         if (serverUrl.isBlank()) {
-            _uiState.value = _uiState.value.copy(bootstrap = null)
+            _uiState.value = _uiState.value.copy(bootstrap = null, availableUpdate = null, updateError = null)
             return
         }
         viewModelScope.launch {
@@ -57,9 +64,22 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                 sessionRepository.fetchBootstrap(serverUrl)
             }.onSuccess { bootstrap ->
                 _uiState.value = _uiState.value.copy(bootstrap = bootstrap, error = null, serverUrl = serverUrl)
+                refreshUpdate()
             }.onFailure { error ->
                 _uiState.value = _uiState.value.copy(error = error.message ?: "Failed to load bootstrap")
             }
+        }
+    }
+
+    fun refreshUpdate() {
+        viewModelScope.launch {
+            runCatching { appUpdateRepository.getAvailableUpdate() }
+                .onSuccess { update ->
+                    _uiState.value = _uiState.value.copy(availableUpdate = update, updateError = null)
+                }
+                .onFailure { error ->
+                    _uiState.value = _uiState.value.copy(updateError = error.message ?: "Failed to check app update")
+                }
         }
     }
 
@@ -84,6 +104,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                     loading = false,
                     error = null,
                 )
+                refreshUpdate()
                 onSuccess()
             }.onFailure { error ->
                 _uiState.value = _uiState.value.copy(
@@ -109,5 +130,38 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                 error = null,
             )
         }
+    }
+
+    fun dismissUpdate() {
+        val update = _uiState.value.availableUpdate ?: return
+        viewModelScope.launch {
+            appUpdateRepository.dismissUpdate(update.artifactHash)
+            _uiState.value = _uiState.value.copy(availableUpdate = null, updateError = null)
+        }
+    }
+
+    fun installUpdate() {
+        val update = _uiState.value.availableUpdate ?: return
+        if (_uiState.value.updateInstalling) {
+            return
+        }
+        _uiState.value = _uiState.value.copy(updateInstalling = true, updateError = null)
+        viewModelScope.launch {
+            runCatching {
+                val apkFile = appUpdateRepository.downloadUpdate(update)
+                appUpdateRepository.launchInstaller(apkFile)
+            }.onFailure { error ->
+                _uiState.value = _uiState.value.copy(
+                    updateInstalling = false,
+                    updateError = error.message ?: "Update failed",
+                )
+                return@launch
+            }
+            _uiState.value = _uiState.value.copy(updateInstalling = false)
+        }
+    }
+
+    fun clearUpdateError() {
+        _uiState.value = _uiState.value.copy(updateError = null)
     }
 }

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchViewModel.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchViewModel.kt
@@ -12,6 +12,7 @@ import li.rajeshgo.sm.data.model.ClientBootstrapResponse
 import li.rajeshgo.sm.data.model.ClientSession
 import li.rajeshgo.sm.data.model.SessionDetail
 import li.rajeshgo.sm.data.repository.SessionManagerAuthException
+import li.rajeshgo.sm.data.repository.SessionManagerBackendUnavailableException
 import li.rajeshgo.sm.data.repository.SessionManagerRepository
 import li.rajeshgo.sm.data.repository.SessionManagerTransientException
 import li.rajeshgo.sm.data.repository.SettingsRepository
@@ -102,6 +103,19 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
                                     lastSync = null,
                                     userEmail = "",
                                     error = error.message ?: "Session expired. Sign in again.",
+                                )
+                            }
+                            is SessionManagerBackendUnavailableException -> {
+                                _uiState.value = _uiState.value.copy(
+                                    loading = false,
+                                    refreshing = false,
+                                    sessions = emptyList(),
+                                    expandedSessionIds = emptySet(),
+                                    detailsBySessionId = emptyMap(),
+                                    lastSync = null,
+                                    userEmail = userEmail,
+                                    error = error.message
+                                        ?: "Session Manager backend is unreachable from the ingress host.",
                                 )
                             }
                             is SessionManagerTransientException -> {

--- a/android-app/app/src/main/res/xml/file_paths.xml
+++ b/android-app/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path
+        name="apk_updates"
+        path="updates/" />
+</paths>

--- a/scripts/deploy_android_app.sh
+++ b/scripts/deploy_android_app.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_NAME="${APP_NAME:-session-manager-android}"
+SERVER_URL="${SERVER_URL:-http://127.0.0.1:8420}"
+APK_PATH="${1:-android-app/app/build/outputs/apk/debug/app-debug.apk}"
+VERSION_CODE="${VERSION_CODE:-}"
+VERSION_NAME="${VERSION_NAME:-}"
+
+if [[ ! -f "$APK_PATH" ]]; then
+  echo "APK not found: $APK_PATH" >&2
+  exit 1
+fi
+
+curl_args=(
+  --fail
+  --show-error
+  --silent
+  -X POST
+  "$SERVER_URL/deploy/$APP_NAME"
+  -F "file=@${APK_PATH};type=application/vnd.android.package-archive"
+)
+
+if [[ -n "$VERSION_CODE" ]]; then
+  curl_args+=(-F "version_code=$VERSION_CODE")
+fi
+
+if [[ -n "$VERSION_NAME" ]]; then
+  curl_args+=(-F "version_name=$VERSION_NAME")
+fi
+
+curl "${curl_args[@]}"
+printf '\n'

--- a/src/server.py
+++ b/src/server.py
@@ -3,13 +3,17 @@
 import asyncio
 import json
 import logging
+import os
 import secrets
+import shutil
 import subprocess
+import tempfile
 import time
 import shlex
 import base64
 import hashlib
 import hmac
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional, Dict, Any, Literal
@@ -19,7 +23,7 @@ import httpx
 from google.auth.transport.requests import Request as GoogleAuthRequest
 from google.oauth2 import id_token as google_id_token
 from fastapi import FastAPI, HTTPException, Body, Request, Query
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -54,6 +58,54 @@ LOCAL_TRUSTED_HOSTS = {"127.0.0.1", "localhost", "::1", "testserver"}
 GOOGLE_AUTH_SCOPES = "openid email profile"
 DEVICE_TOKEN_MAX_AGE_SECONDS = 60 * 60 * 24 * 14
 _EM_SPAWN_STOP_NOTIFY_DELAY_SECONDS = 8
+APP_ARTIFACT_NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+APP_ARTIFACT_HASH_PATTERN = re.compile(r"^[0-9a-f]{8}$")
+APP_ARTIFACT_MAX_SIZE_BYTES = 100 * 1024 * 1024
+DEFAULT_APP_ARTIFACTS_ROOT = Path(__file__).resolve().parents[1] / "data" / "apps"
+
+
+def _is_valid_app_artifact_name(app_name: str) -> bool:
+    return bool(APP_ARTIFACT_NAME_PATTERN.fullmatch(app_name))
+
+
+def _is_valid_app_artifact_hash(artifact_hash: str) -> bool:
+    return bool(APP_ARTIFACT_HASH_PATTERN.fullmatch(artifact_hash))
+
+
+def _write_json_atomically(path: Path, payload: dict[str, Any]) -> None:
+    """Write JSON metadata via temp file + replace to avoid partial writes."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_path = tempfile.mkstemp(dir=str(path.parent), prefix=".tmp-meta-", suffix=".json")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle)
+        os.replace(temp_path, path)
+    except Exception:
+        try:
+            os.unlink(temp_path)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _copy_file_atomically(source_path: Path, destination_path: Path) -> None:
+    """Copy file content via temp file + replace to publish immutable artifacts safely."""
+    destination_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temp_path = tempfile.mkstemp(
+        dir=str(destination_path.parent),
+        prefix=".tmp-artifact-copy-",
+        suffix=destination_path.suffix,
+    )
+    os.close(fd)
+    try:
+        shutil.copyfile(source_path, temp_path)
+        os.replace(temp_path, destination_path)
+    except Exception:
+        try:
+            os.unlink(temp_path)
+        except FileNotFoundError:
+            pass
+        raise
 
 
 class WatchStaticFiles(StaticFiles):
@@ -287,7 +339,7 @@ class GoogleAuthMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
 
         path = request.url.path
-        if path in self.exempt_paths:
+        if path in self.exempt_paths or path == "/apk" or path.startswith("/apps/"):
             return await call_next(request)
 
         if not self.ready:
@@ -464,6 +516,25 @@ class DeviceGoogleAuthResponse(BaseModel):
     expires_at: str
     email: str
     name: Optional[str] = None
+
+
+class AppArtifactMetadataResponse(BaseModel):
+    """Metadata describing the latest published Android client artifact."""
+    artifact_hash: str
+    size_bytes: int
+    uploaded_at: str
+    uploaded_by: Optional[str] = None
+    version_code: Optional[int] = None
+    version_name: Optional[str] = None
+
+
+class AppArtifactDeployResponse(BaseModel):
+    """Response for a successful app artifact upload."""
+    ok: bool = True
+    app: str
+    size_bytes: int
+    download_url: str
+    artifact_hash: str
 
 
 class SendInputRequest(BaseModel):
@@ -1203,6 +1274,47 @@ def create_app(
     def _external_access_config() -> dict:
         return (app.state.config or {}).get("external_access") or {}
 
+    def _app_artifacts_root() -> Path:
+        configured = ((app.state.config or {}).get("paths") or {}).get("app_artifacts_dir")
+        if configured:
+            return Path(configured).expanduser()
+        return DEFAULT_APP_ARTIFACTS_ROOT
+
+    def _app_artifact_dir(app_name: str) -> Path:
+        return _app_artifacts_root() / app_name
+
+    def _app_artifact_latest_path(app_name: str) -> Path:
+        return _app_artifact_dir(app_name) / "latest.apk"
+
+    def _app_artifact_hashed_path(app_name: str, artifact_hash: str) -> Path:
+        return _app_artifact_dir(app_name) / f"{artifact_hash}.apk"
+
+    def _app_artifact_meta_path(app_name: str) -> Path:
+        return _app_artifact_dir(app_name) / "meta.json"
+
+    def _read_app_artifact_metadata(app_name: str) -> dict[str, Any]:
+        metadata_path = _app_artifact_meta_path(app_name)
+        if not metadata_path.exists():
+            raise HTTPException(status_code=404, detail="Artifact metadata not found")
+        try:
+            return json.loads(metadata_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.error("Failed to read artifact metadata for %s: %s", app_name, exc)
+            raise HTTPException(status_code=500, detail="Artifact metadata unreadable") from exc
+
+    def _request_actor_email(request: Request) -> Optional[str]:
+        device_auth = _device_auth_from_request(request, app.state.config)
+        if isinstance(device_auth, dict):
+            email = str(device_auth.get("email") or "").strip().lower()
+            return email or None
+        session_state = getattr(request, "session", {}) or {}
+        email = str(session_state.get("google_email") or "").strip().lower()
+        if email:
+            return email
+        if _is_local_bypass_request(request, app.state.config):
+            return "local_bypass"
+        return None
+
     def _infra_check(name: str) -> Optional[dict[str, Any]]:
         supervisor = getattr(app.state, "infra_supervisor", None)
         getter = getattr(supervisor, "get_check", None) if supervisor else None
@@ -1556,6 +1668,144 @@ def create_app(
             email=email,
             name=str(tokeninfo.get("name") or email),
         )
+
+    @app.post("/deploy/{app_name}", response_model=AppArtifactDeployResponse)
+    async def deploy_app_artifact(request: Request, app_name: str):
+        """Upload the latest Android artifact for an app."""
+        if not _is_valid_app_artifact_name(app_name):
+            raise HTTPException(status_code=400, detail="Invalid app name")
+
+        actor_email = _request_actor_email(request)
+        if actor_email is None:
+            raise HTTPException(status_code=401, detail="Authentication required")
+
+        try:
+            form = await request.form()
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail="Expected multipart form upload") from exc
+
+        upload = form.get("file")
+        if upload is None or not hasattr(upload, "read"):
+            raise HTTPException(status_code=400, detail="Missing multipart field 'file'")
+
+        raw_version_code = str(form.get("version_code") or "").strip()
+        version_name = str(form.get("version_name") or "").strip() or None
+        version_code: Optional[int] = None
+        if raw_version_code:
+            try:
+                version_code = int(raw_version_code)
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail="version_code must be an integer") from exc
+
+        app_dir = _app_artifact_dir(app_name)
+        app_dir.mkdir(parents=True, exist_ok=True)
+        artifact_path = _app_artifact_latest_path(app_name)
+        fd, temp_path = tempfile.mkstemp(dir=str(app_dir), prefix=".tmp-artifact-", suffix=".apk")
+        size_bytes = 0
+        sha256 = hashlib.sha256()
+
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                while True:
+                    chunk = await upload.read(64 * 1024)
+                    if not chunk:
+                        break
+                    size_bytes += len(chunk)
+                    if size_bytes > APP_ARTIFACT_MAX_SIZE_BYTES:
+                        raise HTTPException(status_code=413, detail="Artifact exceeds 100 MB limit")
+                    sha256.update(chunk)
+                    handle.write(chunk)
+
+            if size_bytes <= 0:
+                raise HTTPException(status_code=400, detail="Uploaded artifact is empty")
+
+            os.replace(temp_path, artifact_path)
+            artifact_hash = sha256.hexdigest()[:8]
+            hashed_artifact_path = _app_artifact_hashed_path(app_name, artifact_hash)
+            if not hashed_artifact_path.exists():
+                _copy_file_atomically(artifact_path, hashed_artifact_path)
+
+            metadata: dict[str, Any] = {
+                "artifact_hash": artifact_hash,
+                "uploaded_at": datetime.now(timezone.utc).isoformat(),
+                "size_bytes": size_bytes,
+                "uploaded_by": actor_email,
+            }
+            if version_code is not None:
+                metadata["version_code"] = version_code
+            if version_name is not None:
+                metadata["version_name"] = version_name
+            _write_json_atomically(_app_artifact_meta_path(app_name), metadata)
+
+            return AppArtifactDeployResponse(
+                app=app_name,
+                size_bytes=size_bytes,
+                download_url=f"/apps/{app_name}/latest.apk",
+                artifact_hash=artifact_hash,
+            )
+        except HTTPException:
+            try:
+                os.unlink(temp_path)
+            except FileNotFoundError:
+                pass
+            raise
+        except Exception as exc:
+            logger.error("Failed to store app artifact for %s: %s", app_name, exc)
+            try:
+                os.unlink(temp_path)
+            except FileNotFoundError:
+                pass
+            raise HTTPException(status_code=500, detail="Failed to store artifact") from exc
+        finally:
+            close_upload = getattr(upload, "close", None)
+            if callable(close_upload):
+                maybe_coro = close_upload()
+                if asyncio.iscoroutine(maybe_coro):
+                    await maybe_coro
+
+    @app.get("/apps/{app_name}/latest.apk")
+    async def get_latest_app_artifact(app_name: str):
+        """Redirect callers to the immutable APK artifact for the current app build."""
+        if not _is_valid_app_artifact_name(app_name):
+            raise HTTPException(status_code=404, detail="Artifact not found")
+        metadata = _read_app_artifact_metadata(app_name)
+        artifact_hash = str(metadata.get("artifact_hash") or "").strip().lower()
+        if not _is_valid_app_artifact_hash(artifact_hash):
+            raise HTTPException(status_code=404, detail="Artifact not found")
+        return RedirectResponse(
+            url=f"/apps/{app_name}/{artifact_hash}.apk",
+            status_code=302,
+            headers={"Cache-Control": "no-cache"},
+        )
+
+    @app.get("/apps/{app_name}/{artifact_hash}.apk")
+    async def get_hashed_app_artifact(app_name: str, artifact_hash: str):
+        """Download a content-addressed immutable app artifact."""
+        if not _is_valid_app_artifact_name(app_name) or not _is_valid_app_artifact_hash(artifact_hash):
+            raise HTTPException(status_code=404, detail="Artifact not found")
+        artifact_path = _app_artifact_hashed_path(app_name, artifact_hash)
+        if not artifact_path.exists():
+            raise HTTPException(status_code=404, detail="Artifact not found")
+        response = FileResponse(
+            artifact_path,
+            media_type="application/vnd.android.package-archive",
+            filename=f"{app_name}.apk",
+        )
+        response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
+        return response
+
+    @app.get("/apps/{app_name}/meta.json", response_model=AppArtifactMetadataResponse)
+    async def get_app_artifact_metadata(app_name: str):
+        """Return metadata for the latest published app artifact."""
+        if not _is_valid_app_artifact_name(app_name):
+            raise HTTPException(status_code=404, detail="Artifact metadata not found")
+        metadata = _read_app_artifact_metadata(app_name)
+        return AppArtifactMetadataResponse(**metadata)
+
+    @app.get("/apk")
+    async def get_legacy_apk_download():
+        """Backward-compatible alias for the session-manager Android artifact."""
+        return RedirectResponse(url="/apps/session-manager-android/latest.apk", status_code=302)
 
     @app.get("/auth/google/login")
     async def google_login(request: Request, next: Optional[str] = Query(default="/watch/")):

--- a/tests/unit/test_app_artifact_server.py
+++ b/tests/unit/test_app_artifact_server.py
@@ -1,0 +1,129 @@
+import hashlib
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock
+
+from fastapi.testclient import TestClient
+
+from src.server import create_app, _issue_device_access_token
+
+
+def _artifact_config(root_dir: str) -> dict:
+    return {
+        "paths": {
+            "app_artifacts_dir": root_dir,
+        },
+        "auth": {
+            "google": {
+                "enabled": True,
+                "public_host": "sm.rajeshgo.li",
+                "client_id": "web-client-id",
+                "android_client_id": "android-client-id",
+                "client_secret": "web-client-secret",
+                "redirect_uri": "https://sm.rajeshgo.li/auth/google/callback",
+                "allowlist_emails": ["rajeshgoli@gmail.com"],
+                "session_cookie_secret": "test-session-secret",
+            }
+        },
+    }
+
+
+def _session_manager() -> MagicMock:
+    manager = MagicMock()
+    manager.list_sessions.return_value = []
+    manager.sessions = {}
+    manager.get_effective_session_name.side_effect = lambda session: getattr(session, "friendly_name", None) or getattr(session, "name", "")
+    manager.get_session_aliases.return_value = []
+    manager.list_adoption_proposals.return_value = []
+    return manager
+
+
+def test_deploy_upload_writes_artifact_and_metadata_for_local_bypass():
+    with TemporaryDirectory() as temp_dir:
+        client = TestClient(create_app(session_manager=_session_manager(), config=_artifact_config(temp_dir)))
+
+        response = client.post(
+            "/deploy/session-manager-android",
+            files={"file": ("app-debug.apk", b"apk-bytes", "application/vnd.android.package-archive")},
+            data={"version_code": "7", "version_name": "0.1.7"},
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        artifact_hash = hashlib.sha256(b"apk-bytes").hexdigest()[:8]
+        assert payload == {
+            "ok": True,
+            "app": "session-manager-android",
+            "size_bytes": len(b"apk-bytes"),
+            "download_url": "/apps/session-manager-android/latest.apk",
+            "artifact_hash": artifact_hash,
+        }
+
+        app_dir = Path(temp_dir) / "session-manager-android"
+        assert (app_dir / "latest.apk").read_bytes() == b"apk-bytes"
+        assert (app_dir / f"{artifact_hash}.apk").read_bytes() == b"apk-bytes"
+
+        metadata = json.loads((app_dir / "meta.json").read_text())
+        assert metadata["artifact_hash"] == artifact_hash
+        assert metadata["size_bytes"] == len(b"apk-bytes")
+        assert metadata["version_code"] == 7
+        assert metadata["version_name"] == "0.1.7"
+        assert metadata["uploaded_by"] == "local_bypass"
+
+
+def test_deploy_requires_auth_for_external_requests():
+    with TemporaryDirectory() as temp_dir:
+        client = TestClient(
+            create_app(session_manager=_session_manager(), config=_artifact_config(temp_dir)),
+            base_url="https://sm.rajeshgo.li",
+        )
+
+        response = client.post(
+            "/deploy/session-manager-android",
+            files={"file": ("app-debug.apk", b"apk-bytes", "application/vnd.android.package-archive")},
+        )
+
+        assert response.status_code == 401
+        assert response.json()["detail"] == "Authentication required"
+
+
+def test_deploy_accepts_external_device_bearer_and_public_downloads_work():
+    with TemporaryDirectory() as temp_dir:
+        config = _artifact_config(temp_dir)
+        issued = _issue_device_access_token(config, email="rajeshgoli@gmail.com", name="Rajesh Goli")
+        assert issued is not None
+
+        client = TestClient(
+            create_app(session_manager=_session_manager(), config=config),
+            base_url="https://sm.rajeshgo.li",
+        )
+
+        upload_response = client.post(
+            "/deploy/session-manager-android",
+            headers={"Authorization": f"Bearer {issued['access_token']}"},
+            files={"file": ("app-debug.apk", b"public-apk", "application/vnd.android.package-archive")},
+            data={"version_name": "0.2.0"},
+        )
+        assert upload_response.status_code == 200
+        artifact_hash = hashlib.sha256(b"public-apk").hexdigest()[:8]
+
+        latest_response = client.get("/apps/session-manager-android/latest.apk", follow_redirects=False)
+        assert latest_response.status_code == 302
+        assert latest_response.headers["location"] == f"/apps/session-manager-android/{artifact_hash}.apk"
+        assert latest_response.headers["cache-control"] == "no-cache"
+
+        hashed_response = client.get(f"/apps/session-manager-android/{artifact_hash}.apk")
+        assert hashed_response.status_code == 200
+        assert hashed_response.content == b"public-apk"
+        assert hashed_response.headers["cache-control"] == "public, max-age=31536000, immutable"
+
+        metadata_response = client.get("/apps/session-manager-android/meta.json")
+        assert metadata_response.status_code == 200
+        assert metadata_response.json()["artifact_hash"] == artifact_hash
+        assert metadata_response.json()["uploaded_by"] == "rajeshgoli@gmail.com"
+        assert metadata_response.json()["version_name"] == "0.2.0"
+
+        legacy_response = client.get("/apk", follow_redirects=False)
+        assert legacy_response.status_code == 302
+        assert legacy_response.headers["location"] == "/apps/session-manager-android/latest.apk"


### PR DESCRIPTION
Fixes #474

## Summary
- add office-automate-style Android artifact upload/download/meta endpoints with immutable hashed APK serving
- add an Android in-app update flow with artifact hash comparison, cached APK download, and package installer handoff
- clear stale session rosters on backend-unreachable failures instead of showing the last good list after reboot/backend loss
- add a deploy helper script and Android README notes for publishing new APKs

## Validation
- ./venv/bin/pytest tests/unit/test_app_artifact_server.py tests/unit/test_google_auth.py tests/unit/test_android_api_surface.py -q
- PYTHONPATH=. ./venv/bin/python -m py_compile src/server.py
- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./android-app/gradlew -p android-app assembleDebug
