### PR TITLE
Add Android analytics tab

### DIFF
--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/model/ApiModels.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/model/ApiModels.kt
@@ -269,3 +269,118 @@ data class SessionDetail(
     val lastError: String? = null,
     val fetchedAt: Long = System.currentTimeMillis(),
 )
+
+@Serializable
+data class AnalyticsSummary(
+    @SerialName("generated_at")
+    val generatedAt: String,
+    @SerialName("window_hours")
+    val windowHours: Int = 24,
+    val kpis: AnalyticsKpiSet = AnalyticsKpiSet(),
+    val throughput: List<AnalyticsThroughputBucket> = emptyList(),
+    @SerialName("state_distribution")
+    val stateDistribution: List<AnalyticsDistributionItem> = emptyList(),
+    @SerialName("provider_distribution")
+    val providerDistribution: List<AnalyticsDistributionItem> = emptyList(),
+    @SerialName("repo_distribution")
+    val repoDistribution: List<AnalyticsRepoItem> = emptyList(),
+    @SerialName("longest_running")
+    val longestRunning: List<AnalyticsLongestRunningItem> = emptyList(),
+    @SerialName("health_checks")
+    val healthChecks: List<AnalyticsHealthCheck> = emptyList(),
+    val reliability: AnalyticsReliability = AnalyticsReliability(),
+    val totals: AnalyticsTotals = AnalyticsTotals(),
+    @SerialName("attach_available")
+    val attachAvailable: Boolean = false,
+)
+
+@Serializable
+data class AnalyticsKpiSet(
+    @SerialName("active_sessions")
+    val activeSessions: AnalyticsKpi = AnalyticsKpi(),
+    @SerialName("sends_24h")
+    val sends24h: AnalyticsKpi = AnalyticsKpi(),
+    @SerialName("spawns_24h")
+    val spawns24h: AnalyticsKpi = AnalyticsKpi(),
+    @SerialName("active_tracks")
+    val activeTracks: AnalyticsKpi = AnalyticsKpi(),
+    @SerialName("overdue_tracks")
+    val overdueTracks: AnalyticsKpi = AnalyticsKpi(),
+    @SerialName("incidents_24h")
+    val incidents24h: AnalyticsKpi = AnalyticsKpi(),
+)
+
+@Serializable
+data class AnalyticsKpi(
+    val label: String = "",
+    val value: Int = 0,
+    @SerialName("delta_pct")
+    val deltaPct: Float? = null,
+)
+
+@Serializable
+data class AnalyticsThroughputBucket(
+    @SerialName("bucket_start")
+    val bucketStart: String,
+    @SerialName("bucket_label")
+    val bucketLabel: String,
+    val sends: Int = 0,
+    val spawns: Int = 0,
+    @SerialName("track_reminders")
+    val trackReminders: Int = 0,
+)
+
+@Serializable
+data class AnalyticsDistributionItem(
+    val key: String,
+    val label: String,
+    val count: Int = 0,
+    @SerialName("share_pct")
+    val sharePct: Float? = null,
+)
+
+@Serializable
+data class AnalyticsRepoItem(
+    val key: String,
+    val label: String,
+    @SerialName("session_count")
+    val sessionCount: Int = 0,
+    @SerialName("tokens_used")
+    val tokensUsed: Int = 0,
+    @SerialName("share_pct")
+    val sharePct: Float = 0f,
+)
+
+@Serializable
+data class AnalyticsLongestRunningItem(
+    val id: String,
+    val name: String,
+    val repo: String,
+    val provider: String,
+    @SerialName("age_hours")
+    val ageHours: Float = 0f,
+)
+
+@Serializable
+data class AnalyticsHealthCheck(
+    val key: String,
+    val label: String,
+    val status: String? = null,
+    val message: String? = null,
+)
+
+@Serializable
+data class AnalyticsReliability(
+    @SerialName("restart_count_24h")
+    val restartCount24h: Int = 0,
+    @SerialName("self_heal_count_24h")
+    val selfHealCount24h: Int = 0,
+)
+
+@Serializable
+data class AnalyticsTotals(
+    @SerialName("tokens_live")
+    val tokensLive: Int = 0,
+    @SerialName("track_reminders_24h")
+    val trackReminders24h: Int = 0,
+)

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/remote/ApiService.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/remote/ApiService.kt
@@ -1,6 +1,7 @@
 package li.rajeshgo.sm.data.remote
 
 import li.rajeshgo.sm.data.model.ActivityActionsResponse
+import li.rajeshgo.sm.data.model.AnalyticsSummary
 import li.rajeshgo.sm.data.model.AppArtifactMetadata
 import li.rajeshgo.sm.data.model.AuthSessionResponse
 import li.rajeshgo.sm.data.model.ClientBootstrapResponse
@@ -21,6 +22,9 @@ import retrofit2.http.Query
 interface ApiService {
     @GET("client/bootstrap")
     suspend fun getBootstrap(): ClientBootstrapResponse
+
+    @GET("client/analytics/summary")
+    suspend fun getAnalyticsSummary(): AnalyticsSummary
 
     @GET("apps/{app}/meta.json")
     suspend fun getAppArtifactMetadata(@Path("app") app: String): AppArtifactMetadata

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SessionManagerRepository.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SessionManagerRepository.kt
@@ -10,6 +10,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import li.rajeshgo.sm.data.model.ActivityActionRow
+import li.rajeshgo.sm.data.model.AnalyticsSummary
 import li.rajeshgo.sm.data.model.ClientBootstrapResponse
 import li.rajeshgo.sm.data.model.ClientSession
 import li.rajeshgo.sm.data.model.DeviceGoogleAuthResponse
@@ -178,6 +179,10 @@ class SessionManagerRepository {
 
     suspend fun fetchSessions(baseUrl: String, token: String): List<ClientSession> = withContext(Dispatchers.IO) {
         executeReadRequest(baseUrl, token) { it.getClientSessions().sessions }
+    }
+
+    suspend fun fetchAnalytics(baseUrl: String, token: String): AnalyticsSummary = withContext(Dispatchers.IO) {
+        executeReadRequest(baseUrl, token) { it.getAnalyticsSummary() }
     }
 
     suspend fun killSession(baseUrl: String, token: String, sessionId: String): Result<Unit> = withContext(Dispatchers.IO) {

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/analytics/AnalyticsScreen.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/analytics/AnalyticsScreen.kt
@@ -1,0 +1,1341 @@
+package li.rajeshgo.sm.ui.analytics
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.Analytics
+import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.Settings
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.viewmodel.compose.viewModel
+import java.time.OffsetDateTime
+import kotlin.coroutines.coroutineContext
+import kotlin.math.absoluteValue
+import kotlin.math.max
+import kotlin.math.min
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import li.rajeshgo.sm.data.model.AnalyticsDistributionItem
+import li.rajeshgo.sm.data.model.AnalyticsHealthCheck
+import li.rajeshgo.sm.data.model.AnalyticsKpi
+import li.rajeshgo.sm.data.model.AnalyticsSummary
+import li.rajeshgo.sm.data.model.AnalyticsThroughputBucket
+import li.rajeshgo.sm.ui.navigation.AppBottomNav
+import li.rajeshgo.sm.ui.navigation.Routes
+import li.rajeshgo.sm.ui.theme.Amber
+import li.rajeshgo.sm.ui.theme.Border
+import li.rajeshgo.sm.ui.theme.Cyan
+import li.rajeshgo.sm.ui.theme.Emerald
+import li.rajeshgo.sm.ui.theme.Fuchsia
+import li.rajeshgo.sm.ui.theme.Panel
+import li.rajeshgo.sm.ui.theme.PanelElevated
+import li.rajeshgo.sm.ui.theme.PanelMuted
+import li.rajeshgo.sm.ui.theme.Rose
+import li.rajeshgo.sm.ui.theme.TextMuted
+import li.rajeshgo.sm.ui.theme.TextSecondary
+import li.rajeshgo.sm.ui.theme.Violet
+
+private const val ANALYTICS_AUTO_REFRESH_MS = 10000L
+
+@Composable
+fun AnalyticsScreen(
+    onNavigateToWatch: () -> Unit,
+    onNavigateToSettings: () -> Unit,
+    onOpenDetail: (String) -> Unit,
+    viewModel: AnalyticsViewModel = viewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    val lifecycleOwner = LocalLifecycleOwner.current
+    var isResumed by remember {
+        mutableStateOf(lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED))
+    }
+
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, _ ->
+            isResumed = lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    LaunchedEffect(isResumed, state.serverUrl, state.userEmail) {
+        if (!isResumed || state.serverUrl.isBlank()) {
+            return@LaunchedEffect
+        }
+        viewModel.refresh()
+        while (coroutineContext.isActive) {
+            delay(ANALYTICS_AUTO_REFRESH_MS)
+            viewModel.refresh()
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+    ) {
+        if (state.loading && state.summary == null) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator(color = Cyan)
+            }
+            return@Box
+        }
+
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 112.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item {
+                AnalyticsHeader(
+                    userEmail = state.userEmail,
+                    generatedAt = state.summary?.generatedAt,
+                    refreshing = state.refreshing,
+                    onRefresh = { viewModel.refresh() },
+                    onOpenSettings = onNavigateToSettings,
+                )
+            }
+
+            state.error?.takeIf { it.isNotBlank() }?.let { message ->
+                item {
+                    InlineErrorBanner(message = message)
+                }
+            }
+
+            val summary = state.summary
+            if (summary == null) {
+                item {
+                    EmptyAnalyticsState()
+                }
+            } else {
+                item {
+                    KpiGrid(
+                        summary = summary,
+                        onOpenDetail = onOpenDetail,
+                    )
+                }
+                item {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        StateDistributionCard(
+                            summary = summary,
+                            modifier = Modifier.weight(1f),
+                        )
+                        ReliabilityCard(
+                            summary = summary,
+                            modifier = Modifier.weight(1f),
+                            onOpenDetail = { onOpenDetail("reliability") },
+                        )
+                    }
+                }
+                item {
+                    ThroughputCard(
+                        summary = summary,
+                        onOpenDetail = { onOpenDetail("throughput") },
+                    )
+                }
+                item {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        CoordinationCard(
+                            summary = summary,
+                            modifier = Modifier.weight(1f),
+                        )
+                        LoadCard(
+                            summary = summary,
+                            modifier = Modifier.weight(1f),
+                            onOpenDetail = { onOpenDetail("load") },
+                        )
+                    }
+                }
+                item {
+                    DistributionCard(
+                        title = "Repository Contribution",
+                        subtitle = "Where the load is concentrated right now",
+                        rows = summary.repoDistribution.map {
+                            DistributionRowModel(
+                                label = it.label,
+                                valueText = "${it.sessionCount} live",
+                                progress = (it.sharePct / 100f).coerceIn(0f, 1f),
+                                meta = compactTokenCount(it.tokensUsed),
+                                color = repoColor(it.label),
+                            )
+                        },
+                        onClick = { onOpenDetail("repos") },
+                    )
+                }
+                item {
+                    DistributionCard(
+                        title = "Provider Split",
+                        subtitle = "Current runtime mix across active sessions",
+                        rows = summary.providerDistribution.map {
+                            DistributionRowModel(
+                                label = it.label,
+                                valueText = "${it.count}",
+                                progress = ((it.sharePct ?: 0f) / 100f).coerceIn(0f, 1f),
+                                meta = formatShare(it.sharePct),
+                                color = providerColor(it.label),
+                            )
+                        },
+                        onClick = { onOpenDetail("providers") },
+                    )
+                }
+                if (summary.longestRunning.isNotEmpty()) {
+                    item {
+                        LongestRunningCard(
+                            summary = summary,
+                            onOpenDetail = { onOpenDetail("longest") },
+                        )
+                    }
+                }
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(horizontal = 16.dp, vertical = 16.dp),
+        ) {
+            AppBottomNav(
+                currentRoute = Routes.ANALYTICS,
+                onWatch = onNavigateToWatch,
+                onAnalytics = {},
+            )
+        }
+    }
+}
+
+@Composable
+fun AnalyticsDetailScreen(
+    section: String,
+    onBack: () -> Unit,
+    onNavigateToWatch: () -> Unit,
+    onNavigateToAnalytics: () -> Unit,
+    onNavigateToSettings: () -> Unit,
+    viewModel: AnalyticsViewModel = viewModel(),
+) {
+    val state by viewModel.uiState.collectAsState()
+    val summary = state.summary
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background),
+    ) {
+        if (state.loading && summary == null) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator(color = Cyan)
+            }
+            return@Box
+        }
+
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(start = 16.dp, end = 16.dp, top = 16.dp, bottom = 112.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            item {
+                DetailHeader(
+                    title = detailTitle(section),
+                    subtitle = summary?.generatedAt?.let { "Live snapshot ${formatGeneratedAt(it)}" } ?: "No data",
+                    onBack = onBack,
+                    onOpenSettings = onNavigateToSettings,
+                )
+            }
+            state.error?.takeIf { it.isNotBlank() }?.let { message ->
+                item { InlineErrorBanner(message) }
+            }
+            if (summary == null) {
+                item { EmptyAnalyticsState() }
+            } else {
+                when (section) {
+                    "throughput" -> {
+                        item {
+                            ThroughputCard(summary = summary, onOpenDetail = {})
+                        }
+                        item {
+                            DenseTableCard(
+                                title = "Window Breakdown",
+                                columns = listOf("Window", "Send", "Spawn", "Track"),
+                                rows = summary.throughput.map {
+                                    listOf(it.bucketLabel, it.sends.toString(), it.spawns.toString(), it.trackReminders.toString())
+                                },
+                            )
+                        }
+                    }
+                    "reliability" -> {
+                        item { ReliabilityCard(summary = summary, modifier = Modifier.fillMaxWidth(), onOpenDetail = {}) }
+                        item {
+                            DenseTableCard(
+                                title = "Infra Checks",
+                                columns = listOf("Check", "State", "Detail"),
+                                rows = summary.healthChecks.map {
+                                    listOf(it.label, (it.status ?: "unknown").uppercase(), it.message ?: "-")
+                                },
+                            )
+                        }
+                    }
+                    "repos" -> {
+                        item {
+                            DenseTableCard(
+                                title = "Repository Contribution",
+                                columns = listOf("Repo", "Live", "Tokens", "Share"),
+                                rows = summary.repoDistribution.map {
+                                    listOf(it.label, it.sessionCount.toString(), compactTokenCount(it.tokensUsed), formatShare(it.sharePct))
+                                },
+                            )
+                        }
+                    }
+                    "providers" -> {
+                        item {
+                            DenseTableCard(
+                                title = "Provider Distribution",
+                                columns = listOf("Provider", "Live", "Share"),
+                                rows = summary.providerDistribution.map {
+                                    listOf(it.label, it.count.toString(), formatShare(it.sharePct))
+                                },
+                            )
+                        }
+                    }
+                    "load" -> {
+                        item { LoadCard(summary = summary, modifier = Modifier.fillMaxWidth(), onOpenDetail = {}) }
+                        item {
+                            DenseTableCard(
+                                title = "Load Snapshot",
+                                columns = listOf("Metric", "Value"),
+                                rows = listOf(
+                                    listOf("Tokens live", compactTokenCount(summary.totals.tokensLive)),
+                                    listOf("Top repo", summary.repoDistribution.firstOrNull()?.label ?: "-"),
+                                    listOf("Top provider", summary.providerDistribution.firstOrNull()?.label ?: "-"),
+                                    listOf("Track reminders", summary.totals.trackReminders24h.toString()),
+                                ),
+                            )
+                        }
+                    }
+                    "longest" -> {
+                        item {
+                            DenseTableCard(
+                                title = "Longest Running Sessions",
+                                columns = listOf("Session", "Repo", "Prov", "Age"),
+                                rows = summary.longestRunning.map {
+                                    listOf(it.name, it.repo, it.provider, "${it.ageHours}h")
+                                },
+                            )
+                        }
+                    }
+                    else -> {
+                        item {
+                            DenseTableCard(
+                                title = "Live Metrics",
+                                columns = listOf("Metric", "Value"),
+                                rows = listOf(
+                                    listOf(summary.kpis.activeSessions.label, summary.kpis.activeSessions.value.toString()),
+                                    listOf(summary.kpis.sends24h.label, summary.kpis.sends24h.value.toString()),
+                                    listOf(summary.kpis.spawns24h.label, summary.kpis.spawns24h.value.toString()),
+                                    listOf(summary.kpis.activeTracks.label, summary.kpis.activeTracks.value.toString()),
+                                    listOf(summary.kpis.overdueTracks.label, summary.kpis.overdueTracks.value.toString()),
+                                    listOf(summary.kpis.incidents24h.label, summary.kpis.incidents24h.value.toString()),
+                                ),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(horizontal = 16.dp, vertical = 16.dp),
+        ) {
+            AppBottomNav(
+                currentRoute = Routes.ANALYTICS,
+                onWatch = onNavigateToWatch,
+                onAnalytics = onNavigateToAnalytics,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AnalyticsHeader(
+    userEmail: String,
+    generatedAt: String?,
+    refreshing: Boolean,
+    onRefresh: () -> Unit,
+    onOpenSettings: () -> Unit,
+) {
+    Surface(
+        color = Panel,
+        shape = RoundedCornerShape(8.dp),
+    ) {
+        Column {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 14.dp, vertical = 12.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                    Icon(Icons.Rounded.Analytics, contentDescription = null, tint = Cyan)
+                    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                        Text(
+                            text = "sm analytics",
+                            style = MaterialTheme.typography.labelMedium,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            fontWeight = FontWeight.Black,
+                            letterSpacing = androidx.compose.ui.unit.TextUnit.Unspecified,
+                        )
+                        val subtitle = listOfNotNull(
+                            userEmail.takeIf { it.isNotBlank() },
+                            generatedAt?.let(::formatGeneratedAt)?.let { "Sync $it" },
+                        ).joinToString("  •  ")
+                        Text(
+                            text = subtitle.ifBlank { "Operational telemetry" },
+                            style = MaterialTheme.typography.bodySmall,
+                            color = TextSecondary,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    if (refreshing) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(16.dp),
+                            strokeWidth = 2.dp,
+                            color = Cyan,
+                        )
+                    } else {
+                        IconButton(onClick = onRefresh) {
+                            Icon(Icons.Rounded.Refresh, contentDescription = "Refresh", tint = TextSecondary)
+                        }
+                    }
+                    IconButton(onClick = onOpenSettings) {
+                        Icon(Icons.Rounded.Settings, contentDescription = "Settings", tint = TextSecondary)
+                    }
+                }
+            }
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(1.dp)
+                    .background(PanelMuted),
+            )
+        }
+    }
+}
+
+@Composable
+private fun DetailHeader(
+    title: String,
+    subtitle: String,
+    onBack: () -> Unit,
+    onOpenSettings: () -> Unit,
+) {
+    Surface(color = Panel, shape = RoundedCornerShape(8.dp)) {
+        Column {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 12.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Rounded.ArrowBack, contentDescription = "Back", tint = TextSecondary)
+                    }
+                    Column {
+                        Text(
+                            text = title,
+                            style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            fontWeight = FontWeight.Black,
+                        )
+                        Text(
+                            text = subtitle,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = TextSecondary,
+                        )
+                    }
+                }
+                IconButton(onClick = onOpenSettings) {
+                    Icon(Icons.Rounded.Settings, contentDescription = "Settings", tint = TextSecondary)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InlineErrorBanner(message: String) {
+    Surface(color = Rose.copy(alpha = 0.12f), shape = RoundedCornerShape(8.dp)) {
+        Text(
+            text = message,
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+            style = MaterialTheme.typography.bodySmall,
+            color = Rose,
+        )
+    }
+}
+
+@Composable
+private fun EmptyAnalyticsState() {
+    Surface(color = PanelElevated, shape = RoundedCornerShape(12.dp)) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = "Analytics unavailable",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.Bold,
+            )
+            Text(
+                text = "Sign in and wait for a live backend snapshot to populate charts and trend tables.",
+                style = MaterialTheme.typography.bodySmall,
+                color = TextSecondary,
+            )
+        }
+    }
+}
+
+@Composable
+private fun KpiGrid(
+    summary: AnalyticsSummary,
+    onOpenDetail: (String) -> Unit,
+) {
+    val throughput = summary.throughput
+    val kpis = listOf(
+        KpiCardModel(summary.kpis.activeSessions, throughput.map { maxOf(it.sends, it.spawns, it.trackReminders) }, "Overview", Cyan, "overview"),
+        KpiCardModel(summary.kpis.sends24h, throughput.map { it.sends }, "vs prev", Emerald, "throughput"),
+        KpiCardModel(summary.kpis.spawns24h, throughput.map { it.spawns }, "dispatch", Amber, "throughput"),
+        KpiCardModel(summary.kpis.activeTracks, throughput.map { it.trackReminders }, "armed", Violet, "throughput"),
+        KpiCardModel(summary.kpis.overdueTracks, throughput.map { if (it.trackReminders > 0) 1 else 0 }, "late", Rose, "reliability"),
+        KpiCardModel(summary.kpis.incidents24h, throughput.map { 0 }, "events", Fuchsia, "reliability"),
+    )
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        kpis.chunked(2).forEach { row ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                row.forEach { model ->
+                    KpiCard(model = model, modifier = Modifier.weight(1f), onClick = { onOpenDetail(model.section) })
+                }
+                if (row.size == 1) {
+                    Spacer(modifier = Modifier.weight(1f))
+                }
+            }
+        }
+    }
+}
+
+private data class KpiCardModel(
+    val kpi: AnalyticsKpi,
+    val series: List<Int>,
+    val suffix: String,
+    val accent: Color,
+    val section: String,
+)
+
+@Composable
+private fun KpiCard(
+    model: KpiCardModel,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    Surface(
+        modifier = modifier.clickable(onClick = onClick),
+        color = PanelElevated,
+        shape = RoundedCornerShape(8.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(96.dp)
+                .padding(12.dp),
+            verticalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Row(horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    text = model.kpi.label.uppercase(),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = TextMuted,
+                    fontWeight = FontWeight.Black,
+                )
+                model.kpi.deltaPct?.let {
+                    Text(
+                        text = formatDelta(it),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = if (it >= 0f) Emerald else Rose,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.Bottom,
+            ) {
+                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    Text(
+                        text = compactNumber(model.kpi.value),
+                        style = MaterialTheme.typography.titleLarge,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        fontWeight = FontWeight.Black,
+                        fontFamily = FontFamily.Monospace,
+                    )
+                    Text(
+                        text = model.suffix,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = TextSecondary,
+                    )
+                }
+                Sparkline(
+                    values = model.series,
+                    lineColor = model.accent,
+                    modifier = Modifier
+                        .width(58.dp)
+                        .height(22.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StateDistributionCard(
+    summary: AnalyticsSummary,
+    modifier: Modifier = Modifier,
+) {
+    Surface(modifier = modifier, color = PanelElevated, shape = RoundedCornerShape(8.dp)) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                text = "LIVE LOAD",
+                style = MaterialTheme.typography.labelSmall,
+                color = TextMuted,
+                fontWeight = FontWeight.Black,
+            )
+            StackedLoadBar(summary.stateDistribution)
+            summary.stateDistribution.forEach { item ->
+                LegendRow(label = item.label, value = item.count.toString(), color = stateColor(item.key))
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReliabilityCard(
+    summary: AnalyticsSummary,
+    modifier: Modifier = Modifier,
+    onOpenDetail: () -> Unit,
+) {
+    val bars = listOf(
+        ReliabilityBar("BKD", countUnhealthyChecks(summary.healthChecks), Rose),
+        ReliabilityBar("ATT", if (summary.attachAvailable) 0 else 1, if (summary.attachAvailable) Emerald else Rose),
+        ReliabilityBar("RST", summary.reliability.restartCount24h, Amber),
+        ReliabilityBar("HEAL", summary.reliability.selfHealCount24h, Cyan),
+    )
+    Surface(modifier = modifier.clickable(onClick = onOpenDetail), color = PanelElevated, shape = RoundedCornerShape(8.dp)) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text(
+                    text = "RELIABILITY",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = TextMuted,
+                    fontWeight = FontWeight.Black,
+                )
+                Text(
+                    text = if (summary.attachAvailable) "ATTACH READY" else "ATTACH DEGRADED",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = if (summary.attachAvailable) Emerald else Rose,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                verticalAlignment = Alignment.Bottom,
+            ) {
+                bars.forEach { bar ->
+                    ReliabilityBarView(bar = bar, modifier = Modifier.weight(1f))
+                }
+            }
+            summary.healthChecks.take(3).forEach { check ->
+                StatusRow(check = check)
+            }
+        }
+    }
+}
+
+private data class ReliabilityBar(
+    val label: String,
+    val value: Int,
+    val color: Color,
+)
+
+@Composable
+private fun ReliabilityBarView(bar: ReliabilityBar, modifier: Modifier = Modifier) {
+    val normalized = min(1f, max(0.08f, if (bar.value <= 0) 0.08f else bar.value / 6f))
+    Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
+        Box(
+            modifier = Modifier
+                .height(72.dp)
+                .fillMaxWidth(),
+            contentAlignment = Alignment.BottomCenter,
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.7f)
+                    .height((72f * normalized).dp)
+                    .background(bar.color.copy(alpha = 0.85f), RoundedCornerShape(topStart = 2.dp, topEnd = 2.dp)),
+            )
+        }
+        Text(
+            text = bar.label,
+            style = MaterialTheme.typography.labelSmall,
+            color = TextSecondary,
+            fontWeight = FontWeight.Bold,
+        )
+    }
+}
+
+@Composable
+private fun StatusRow(check: AnalyticsHealthCheck) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = check.label,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+        Text(
+            text = (check.status ?: "unknown").uppercase(),
+            style = MaterialTheme.typography.labelSmall,
+            color = healthStatusColor(check.status),
+            fontWeight = FontWeight.Bold,
+            textAlign = TextAlign.End,
+        )
+    }
+}
+
+@Composable
+private fun ThroughputCard(
+    summary: AnalyticsSummary,
+    onOpenDetail: () -> Unit,
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onOpenDetail),
+        color = PanelElevated,
+        shape = RoundedCornerShape(8.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Column {
+                    Text(
+                        text = "THROUGHPUT",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = TextMuted,
+                        fontWeight = FontWeight.Black,
+                    )
+                    Text(
+                        text = "Sends, dispatches, and track nudges over the last 24h",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = TextSecondary,
+                    )
+                }
+                Text(
+                    text = "${summary.windowHours}H",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = TextSecondary,
+                    fontWeight = FontWeight.Bold,
+                )
+            }
+            MultiSeriesChart(
+                buckets = summary.throughput,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(180.dp),
+            )
+            Row(
+                modifier = Modifier.horizontalScroll(rememberScrollState()),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                LegendRow(label = "Sends", value = summary.kpis.sends24h.value.toString(), color = Emerald)
+                LegendRow(label = "Dispatches", value = summary.kpis.spawns24h.value.toString(), color = Cyan)
+                LegendRow(label = "Track remind", value = summary.totals.trackReminders24h.toString(), color = Amber)
+            }
+        }
+    }
+}
+
+@Composable
+private fun CoordinationCard(
+    summary: AnalyticsSummary,
+    modifier: Modifier = Modifier,
+) {
+    Surface(modifier = modifier, color = PanelElevated, shape = RoundedCornerShape(8.dp)) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Text(
+                text = "COORDINATION",
+                style = MaterialTheme.typography.labelSmall,
+                color = TextMuted,
+                fontWeight = FontWeight.Black,
+            )
+            MetricLine("Tracks active", summary.kpis.activeTracks.value.toString(), Violet)
+            MetricLine("Overdue", summary.kpis.overdueTracks.value.toString(), Rose)
+            MetricLine("Track reminders", summary.totals.trackReminders24h.toString(), Amber)
+            MetricLine("Attach", if (summary.attachAvailable) "ready" else "blocked", if (summary.attachAvailable) Emerald else Rose)
+        }
+    }
+}
+
+@Composable
+private fun LoadCard(
+    summary: AnalyticsSummary,
+    modifier: Modifier = Modifier,
+    onOpenDetail: () -> Unit,
+) {
+    Surface(modifier = modifier.clickable(onClick = onOpenDetail), color = PanelElevated, shape = RoundedCornerShape(8.dp)) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Text(
+                text = "LOAD",
+                style = MaterialTheme.typography.labelSmall,
+                color = TextMuted,
+                fontWeight = FontWeight.Black,
+            )
+            MetricLine("Tokens live", compactTokenCount(summary.totals.tokensLive), Cyan)
+            MetricLine("Top repo", summary.repoDistribution.firstOrNull()?.label ?: "-", Amber)
+            MetricLine("Top provider", summary.providerDistribution.firstOrNull()?.label ?: "-", Fuchsia)
+            MetricLine("Longest run", summary.longestRunning.firstOrNull()?.let { "${it.ageHours}h" } ?: "-", Emerald)
+        }
+    }
+}
+
+private data class DistributionRowModel(
+    val label: String,
+    val valueText: String,
+    val progress: Float,
+    val meta: String,
+    val color: Color,
+)
+
+@Composable
+private fun DistributionCard(
+    title: String,
+    subtitle: String,
+    rows: List<DistributionRowModel>,
+    onClick: () -> Unit,
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick),
+        color = PanelElevated,
+        shape = RoundedCornerShape(8.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                Text(
+                    text = title.uppercase(),
+                    style = MaterialTheme.typography.labelSmall,
+                    color = TextMuted,
+                    fontWeight = FontWeight.Black,
+                )
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = TextSecondary,
+                )
+            }
+            rows.take(5).forEach { row ->
+                DistributionRow(row)
+            }
+        }
+    }
+}
+
+@Composable
+private fun DistributionRow(row: DistributionRowModel) {
+    Column(verticalArrangement = Arrangement.spacedBy(5.dp)) {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Text(
+                text = row.label,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.Medium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Text(
+                text = row.valueText,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(8.dp)
+                .background(PanelMuted, RoundedCornerShape(999.dp)),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(max(0.06f, row.progress))
+                    .height(8.dp)
+                    .background(row.color, RoundedCornerShape(999.dp)),
+            )
+        }
+        Text(
+            text = row.meta,
+            style = MaterialTheme.typography.labelSmall,
+            color = TextSecondary,
+        )
+    }
+}
+
+@Composable
+private fun LongestRunningCard(
+    summary: AnalyticsSummary,
+    onOpenDetail: () -> Unit,
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onOpenDetail),
+        color = PanelElevated,
+        shape = RoundedCornerShape(8.dp),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Text(
+                text = "LONGEST RUNNING",
+                style = MaterialTheme.typography.labelSmall,
+                color = TextMuted,
+                fontWeight = FontWeight.Black,
+            )
+            summary.longestRunning.take(5).forEach { item ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = item.name,
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            fontWeight = FontWeight.Medium,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Text(
+                            text = "${item.repo} • ${item.provider}",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = TextSecondary,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                    Text(
+                        text = "${item.ageHours}h",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = Amber,
+                        fontWeight = FontWeight.Bold,
+                        fontFamily = FontFamily.Monospace,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DenseTableCard(
+    title: String,
+    columns: List<String>,
+    rows: List<List<String>>,
+) {
+    Surface(color = PanelElevated, shape = RoundedCornerShape(8.dp)) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Text(
+                text = title.uppercase(),
+                style = MaterialTheme.typography.labelSmall,
+                color = TextMuted,
+                fontWeight = FontWeight.Black,
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                columns.forEach { column ->
+                    Text(
+                        text = column,
+                        modifier = Modifier.weight(1f),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = TextSecondary,
+                        fontWeight = FontWeight.Bold,
+                    )
+                }
+            }
+            rows.forEach { row ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    row.forEach { cell ->
+                        Text(
+                            text = cell,
+                            modifier = Modifier.weight(1f),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MetricLine(label: String, value: String, accent: Color) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Box(
+                modifier = Modifier
+                    .size(8.dp)
+                    .background(accent, RoundedCornerShape(2.dp)),
+            )
+            Text(
+                text = label,
+                style = MaterialTheme.typography.bodySmall,
+                color = TextSecondary,
+            )
+        }
+        Text(
+            text = value,
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+            fontWeight = FontWeight.Bold,
+            fontFamily = FontFamily.Monospace,
+        )
+    }
+}
+
+@Composable
+private fun LegendRow(label: String, value: String, color: Color) {
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+        Box(
+            modifier = Modifier
+                .size(9.dp)
+                .background(color, RoundedCornerShape(2.dp)),
+        )
+        Text(
+            text = "$label $value",
+            style = MaterialTheme.typography.labelSmall,
+            color = TextSecondary,
+        )
+    }
+}
+
+@Composable
+private fun StackedLoadBar(items: List<AnalyticsDistributionItem>) {
+    val total = items.sumOf { it.count }.coerceAtLeast(1)
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(28.dp)
+            .background(PanelMuted, RoundedCornerShape(4.dp)),
+    ) {
+        items.forEach { item ->
+            val fraction = (item.count.toFloat() / total.toFloat()).coerceIn(0f, 1f)
+            if (fraction <= 0f) return@forEach
+            Box(
+                modifier = Modifier
+                    .weight(item.count.toFloat())
+                    .height(28.dp)
+                    .background(stateColor(item.key)),
+                contentAlignment = Alignment.Center,
+            ) {
+                if (fraction > 0.18f) {
+                    Text(
+                        text = "${item.count}",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = if (item.key == "idle") InkOnDark else Color.Black,
+                        fontWeight = FontWeight.Black,
+                    )
+                }
+            }
+        }
+    }
+}
+
+private val InkOnDark = Color(0xFFD9DCE2)
+
+@Composable
+private fun Sparkline(
+    values: List<Int>,
+    lineColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    Canvas(modifier = modifier) {
+        val filtered = values.ifEmpty { listOf(0, 0, 0) }
+        val maxValue = filtered.maxOrNull()?.coerceAtLeast(1) ?: 1
+        val stepX = if (filtered.size <= 1) size.width else size.width / (filtered.size - 1)
+        val path = Path()
+        filtered.forEachIndexed { index, value ->
+            val x = stepX * index
+            val y = size.height - ((value.toFloat() / maxValue.toFloat()) * (size.height - 2.dp.toPx()))
+            if (index == 0) path.moveTo(x, y) else path.lineTo(x, y)
+        }
+        drawPath(path = path, color = lineColor, style = Stroke(width = 2.dp.toPx(), cap = StrokeCap.Round))
+    }
+}
+
+@Composable
+private fun MultiSeriesChart(
+    buckets: List<AnalyticsThroughputBucket>,
+    modifier: Modifier = Modifier,
+) {
+    val sends = buckets.map { it.sends }
+    val spawns = buckets.map { it.spawns }
+    val tracks = buckets.map { it.trackReminders }
+    val maxValue = max(1, max(sends.maxOrNull() ?: 0, max(spawns.maxOrNull() ?: 0, tracks.maxOrNull() ?: 0)))
+
+    Surface(color = Panel, shape = RoundedCornerShape(6.dp)) {
+        Column(
+            modifier = modifier.padding(10.dp),
+            verticalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Box(modifier = Modifier.weight(1f).fillMaxWidth()) {
+                Canvas(modifier = Modifier.fillMaxSize()) {
+                    val chartHeight = size.height
+                    val chartWidth = size.width
+                    val horizontalLines = 4
+                    repeat(horizontalLines) { index ->
+                        val y = chartHeight * index / (horizontalLines - 1)
+                        drawLine(
+                            color = Border.copy(alpha = 0.45f),
+                            start = Offset(0f, y),
+                            end = Offset(chartWidth, y),
+                            strokeWidth = 1.dp.toPx(),
+                        )
+                    }
+                    drawSeries(sends, chartWidth, chartHeight, maxValue, Emerald)
+                    drawSeries(spawns, chartWidth, chartHeight, maxValue, Cyan)
+                    drawSeries(tracks, chartWidth, chartHeight, maxValue, Amber)
+                }
+            }
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 8.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                buckets.filterIndexed { index, _ -> index % 3 == 0 }.forEach { bucket ->
+                    Text(
+                        text = bucket.bucketLabel,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = TextMuted,
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun androidx.compose.ui.graphics.drawscope.DrawScope.drawSeries(
+    values: List<Int>,
+    width: Float,
+    height: Float,
+    maxValue: Int,
+    color: Color,
+) {
+    if (values.isEmpty()) return
+    val path = Path()
+    val fillPath = Path()
+    val stepX = if (values.size <= 1) width else width / (values.size - 1)
+    values.forEachIndexed { index, value ->
+        val x = stepX * index
+        val y = height - ((value.toFloat() / maxValue.toFloat()) * (height - 8.dp.toPx()))
+        if (index == 0) {
+            path.moveTo(x, y)
+            fillPath.moveTo(x, height)
+            fillPath.lineTo(x, y)
+        } else {
+            path.lineTo(x, y)
+            fillPath.lineTo(x, y)
+        }
+    }
+    fillPath.lineTo(width, height)
+    fillPath.close()
+    drawPath(
+        path = fillPath,
+        brush = Brush.verticalGradient(listOf(color.copy(alpha = 0.18f), Color.Transparent)),
+    )
+    drawPath(path = path, color = color, style = Stroke(width = 2.dp.toPx(), cap = StrokeCap.Round))
+}
+
+private fun stateColor(key: String): Color = when (key.lowercase()) {
+    "working" -> Emerald
+    "thinking" -> Cyan
+    "waiting" -> Amber
+    else -> PanelMuted
+}
+
+private fun providerColor(key: String): Color = when (key.lowercase()) {
+    "claude" -> Violet
+    "codex-fork", "codex" -> Cyan
+    else -> Fuchsia
+}
+
+private fun repoColor(label: String): Color {
+    val palette = listOf(Cyan, Emerald, Amber, Violet, Fuchsia)
+    return palette[(label.hashCode().absoluteValue) % palette.size]
+}
+
+private fun healthStatusColor(status: String?): Color = when ((status ?: "").lowercase()) {
+    "ok" -> Emerald
+    "warning" -> Amber
+    else -> Rose
+}
+
+private fun compactNumber(value: Int): String = when {
+    value >= 1_000_000 -> String.format("%.1fm", value / 1_000_000f)
+    value >= 1_000 -> String.format("%.1fk", value / 1_000f)
+    else -> value.toString()
+}
+
+private fun compactTokenCount(value: Int): String = when {
+    value >= 1_000_000 -> String.format("%.1fM tok", value / 1_000_000f)
+    value >= 1_000 -> String.format("%.1fk tok", value / 1_000f)
+    else -> "$value tok"
+}
+
+private fun formatDelta(delta: Float): String = if (delta >= 0f) "+${delta.toInt()}%" else "${delta.toInt()}%"
+
+private fun formatShare(share: Float?): String = share?.let { String.format("%.0f%%", it) } ?: "-"
+
+private fun formatGeneratedAt(value: String): String = runCatching {
+    OffsetDateTime.parse(value).toLocalTime().withSecond(0).withNano(0).toString()
+}.getOrElse { value }
+
+private fun detailTitle(section: String): String = when (section) {
+    "throughput" -> "Throughput Detail"
+    "reliability" -> "Reliability Detail"
+    "repos" -> "Repository Contribution"
+    "providers" -> "Provider Split"
+    "load" -> "Load Detail"
+    "longest" -> "Longest Running"
+    else -> "Analytics Detail"
+}
+
+private fun countUnhealthyChecks(checks: List<AnalyticsHealthCheck>): Int =
+    checks.count { (it.status ?: "").lowercase() !in setOf("ok", "warning") }

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/analytics/AnalyticsViewModel.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/analytics/AnalyticsViewModel.kt
@@ -1,0 +1,113 @@
+package li.rajeshgo.sm.ui.analytics
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import li.rajeshgo.sm.data.model.AnalyticsSummary
+import li.rajeshgo.sm.data.repository.SessionManagerAuthException
+import li.rajeshgo.sm.data.repository.SessionManagerBackendUnavailableException
+import li.rajeshgo.sm.data.repository.SessionManagerRepository
+import li.rajeshgo.sm.data.repository.SessionManagerTransientException
+import li.rajeshgo.sm.data.repository.SettingsRepository
+
+data class AnalyticsUiState(
+    val serverUrl: String = "",
+    val userEmail: String = "",
+    val summary: AnalyticsSummary? = null,
+    val loading: Boolean = true,
+    val refreshing: Boolean = false,
+    val error: String? = null,
+)
+
+class AnalyticsViewModel(application: Application) : AndroidViewModel(application) {
+    private val settingsRepository = SettingsRepository(application)
+    private val sessionRepository = SessionManagerRepository()
+    private var refreshJob: Job? = null
+
+    private val _uiState = MutableStateFlow(AnalyticsUiState())
+    val uiState: StateFlow<AnalyticsUiState> = _uiState
+
+    init {
+        refresh(initial = true)
+    }
+
+    fun refresh(initial: Boolean = false) {
+        if (refreshJob?.isActive == true) {
+            return
+        }
+        refreshJob = viewModelScope.launch {
+            try {
+                val serverUrl = settingsRepository.serverUrl.first()
+                val accessToken = settingsRepository.accessToken.first()
+                val userEmail = settingsRepository.userEmail.first()
+                if (serverUrl.isBlank() || accessToken.isBlank()) {
+                    _uiState.value = _uiState.value.copy(
+                        loading = false,
+                        refreshing = false,
+                        userEmail = userEmail,
+                        error = "Sign in to load analytics",
+                    )
+                    return@launch
+                }
+                _uiState.value = _uiState.value.copy(loading = initial, refreshing = !initial, error = null)
+                runCatching { sessionRepository.fetchAnalytics(serverUrl, accessToken) }
+                    .onSuccess { summary ->
+                        _uiState.value = _uiState.value.copy(
+                            serverUrl = serverUrl,
+                            userEmail = userEmail,
+                            summary = summary,
+                            loading = false,
+                            refreshing = false,
+                            error = null,
+                        )
+                    }
+                    .onFailure { error ->
+                        when (error) {
+                            is SessionManagerAuthException -> {
+                                settingsRepository.clearAuth()
+                                _uiState.value = _uiState.value.copy(
+                                    summary = null,
+                                    loading = false,
+                                    refreshing = false,
+                                    userEmail = "",
+                                    error = error.message ?: "Session expired. Sign in again.",
+                                )
+                            }
+                            is SessionManagerBackendUnavailableException -> {
+                                _uiState.value = _uiState.value.copy(
+                                    summary = null,
+                                    loading = false,
+                                    refreshing = false,
+                                    userEmail = userEmail,
+                                    error = error.message ?: "Session Manager backend is unreachable from ingress.",
+                                )
+                            }
+                            is SessionManagerTransientException -> {
+                                _uiState.value = _uiState.value.copy(
+                                    loading = false,
+                                    refreshing = false,
+                                    userEmail = userEmail,
+                                    error = error.message ?: "Server temporarily unavailable. Retrying soon.",
+                                )
+                            }
+                            else -> {
+                                _uiState.value = _uiState.value.copy(
+                                    loading = false,
+                                    refreshing = false,
+                                    userEmail = userEmail,
+                                    error = error.message ?: "Failed to load analytics",
+                                )
+                            }
+                        }
+                    }
+            } finally {
+                refreshJob = null
+            }
+        }
+    }
+}

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/navigation/AppBottomNav.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/navigation/AppBottomNav.kt
@@ -1,0 +1,95 @@
+package li.rajeshgo.sm.ui.navigation
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.rounded.ViewList
+import androidx.compose.material.icons.rounded.Analytics
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import li.rajeshgo.sm.ui.theme.BorderStrong
+import li.rajeshgo.sm.ui.theme.Cyan
+import li.rajeshgo.sm.ui.theme.PanelElevated
+import li.rajeshgo.sm.ui.theme.TextMuted
+
+@Composable
+fun AppBottomNav(
+    currentRoute: String,
+    onWatch: () -> Unit,
+    onAnalytics: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier,
+        color = PanelElevated,
+        shape = RoundedCornerShape(18.dp),
+        border = androidx.compose.foundation.BorderStroke(1.dp, BorderStrong),
+        tonalElevation = 0.dp,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 8.dp),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+        ) {
+            AppBottomNavItem(
+                label = "Watch",
+                selected = currentRoute == Routes.WATCH,
+                icon = { Icon(Icons.AutoMirrored.Rounded.ViewList, contentDescription = null, modifier = Modifier.size(18.dp)) },
+                onClick = onWatch,
+            )
+            AppBottomNavItem(
+                label = "Analytics",
+                selected = currentRoute == Routes.ANALYTICS,
+                icon = { Icon(Icons.Rounded.Analytics, contentDescription = null, modifier = Modifier.size(18.dp)) },
+                onClick = onAnalytics,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AppBottomNavItem(
+    label: String,
+    selected: Boolean,
+    icon: @Composable () -> Unit,
+    onClick: () -> Unit,
+) {
+    val textColor = if (selected) MaterialTheme.colorScheme.onSurface else TextMuted
+    val iconTint = if (selected) Cyan else TextMuted
+    Row(
+        modifier = Modifier
+            .background(
+                color = if (selected) MaterialTheme.colorScheme.surface.copy(alpha = 0.55f) else androidx.compose.ui.graphics.Color.Transparent,
+                shape = RoundedCornerShape(14.dp),
+            )
+            .clickable(onClick = onClick)
+            .padding(horizontal = 18.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        androidx.compose.runtime.CompositionLocalProvider(
+            androidx.compose.material3.LocalContentColor provides iconTint,
+            content = icon,
+        )
+        Text(
+            text = label,
+            color = textColor,
+            style = MaterialTheme.typography.labelMedium,
+            fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium,
+        )
+    }
+}

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/navigation/AppNavigation.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/navigation/AppNavigation.kt
@@ -4,17 +4,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import li.rajeshgo.sm.data.repository.SettingsRepository
+import li.rajeshgo.sm.ui.analytics.AnalyticsDetailScreen
+import li.rajeshgo.sm.ui.analytics.AnalyticsScreen
 import li.rajeshgo.sm.ui.settings.SettingsScreen
 import li.rajeshgo.sm.ui.watch.WatchScreen
 
 object Routes {
     const val SETTINGS = "settings"
     const val WATCH = "watch"
+    const val ANALYTICS = "analytics"
+    const val ANALYTICS_DETAIL = "analytics/detail"
 }
 
 @Composable
@@ -42,6 +45,48 @@ fun AppNavigation() {
         }
         composable(Routes.WATCH) {
             WatchScreen(
+                onNavigateToSettings = {
+                    navController.navigate(Routes.SETTINGS)
+                },
+                onNavigateToAnalytics = {
+                    navController.navigate(Routes.ANALYTICS) {
+                        launchSingleTop = true
+                    }
+                },
+            )
+        }
+        composable(Routes.ANALYTICS) {
+            AnalyticsScreen(
+                onNavigateToWatch = {
+                    navController.navigate(Routes.WATCH) {
+                        popUpTo(Routes.WATCH) { inclusive = false }
+                        launchSingleTop = true
+                    }
+                },
+                onNavigateToSettings = {
+                    navController.navigate(Routes.SETTINGS)
+                },
+                onOpenDetail = { section ->
+                    navController.navigate("${Routes.ANALYTICS_DETAIL}/$section")
+                },
+            )
+        }
+        composable("${Routes.ANALYTICS_DETAIL}/{section}") { backStackEntry ->
+            AnalyticsDetailScreen(
+                section = backStackEntry.arguments?.getString("section").orEmpty(),
+                onBack = { navController.popBackStack() },
+                onNavigateToWatch = {
+                    navController.navigate(Routes.WATCH) {
+                        popUpTo(Routes.WATCH) { inclusive = false }
+                        launchSingleTop = true
+                    }
+                },
+                onNavigateToAnalytics = {
+                    navController.navigate(Routes.ANALYTICS) {
+                        popUpTo(Routes.ANALYTICS) { inclusive = false }
+                        launchSingleTop = true
+                    }
+                },
                 onNavigateToSettings = {
                     navController.navigate(Routes.SETTINGS)
                 },

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
@@ -67,6 +67,8 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import li.rajeshgo.sm.data.model.ClientSession
 import li.rajeshgo.sm.data.model.SessionDetail
+import li.rajeshgo.sm.ui.navigation.AppBottomNav
+import li.rajeshgo.sm.ui.navigation.Routes
 import li.rajeshgo.sm.ui.theme.Amber
 import li.rajeshgo.sm.ui.theme.Border
 import li.rajeshgo.sm.ui.theme.BorderStrong
@@ -89,6 +91,7 @@ private const val WATCH_AUTO_REFRESH_MS = 5000L
 @Composable
 fun WatchScreen(
     onNavigateToSettings: () -> Unit,
+    onNavigateToAnalytics: () -> Unit,
     viewModel: WatchViewModel = viewModel(),
 ) {
     val state by viewModel.uiState.collectAsState()
@@ -143,7 +146,7 @@ fun WatchScreen(
 
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
-            contentPadding = androidx.compose.foundation.layout.PaddingValues(16.dp),
+            contentPadding = androidx.compose.foundation.layout.PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 128.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             item {
@@ -294,10 +297,22 @@ fun WatchScreen(
             }
         }
 
+        Box(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .padding(horizontal = 16.dp, vertical = 16.dp),
+        ) {
+            AppBottomNav(
+                currentRoute = Routes.WATCH,
+                onWatch = {},
+                onAnalytics = onNavigateToAnalytics,
+            )
+        }
+
         if (toast != null) {
             Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.BottomCenter) {
                 Surface(
-                    modifier = Modifier.padding(16.dp),
+                    modifier = Modifier.padding(start = 16.dp, end = 16.dp, bottom = 88.dp),
                     shape = RoundedCornerShape(999.dp),
                     color = PanelElevated,
                     border = androidx.compose.foundation.BorderStroke(1.dp, BorderStrong),

--- a/src/mobile_analytics.py
+++ b/src/mobile_analytics.py
@@ -1,0 +1,356 @@
+"""Summary analytics for the Android client."""
+
+from __future__ import annotations
+
+import sqlite3
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+from .models import Session, SessionStatus
+
+
+_MESSAGE_QUEUE_DB_DEFAULT = Path("~/.local/share/claude-sessions/message_queue.db").expanduser()
+_SERVER_LOG_DEFAULT = Path("/tmp/session-manager.log")
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_any_datetime(value: datetime | str | None) -> Optional[datetime]:
+    if not value:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+    value = value.strip()
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError:
+        try:
+            parsed = datetime.strptime(value, "%Y-%m-%d %H:%M:%S")
+        except ValueError:
+            return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _parse_log_timestamp(line: str) -> Optional[datetime]:
+    prefix = line[:23]
+    try:
+        parsed = datetime.strptime(prefix, "%Y-%m-%d %H:%M:%S,%f")
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=timezone.utc)
+
+
+def _bucket_start(dt: datetime, bucket_hours: int) -> datetime:
+    dt = dt.astimezone(timezone.utc)
+    hour = (dt.hour // bucket_hours) * bucket_hours
+    return dt.replace(hour=hour, minute=0, second=0, microsecond=0)
+
+
+def _series_points(
+    timestamps: Iterable[datetime],
+    *,
+    window_start: datetime,
+    window_end: datetime,
+    bucket_hours: int,
+) -> list[tuple[datetime, int]]:
+    bucket_count = int((window_end - window_start).total_seconds() // (bucket_hours * 3600))
+    buckets = {
+        window_start + timedelta(hours=index * bucket_hours): 0
+        for index in range(bucket_count)
+    }
+    for ts in timestamps:
+        if ts < window_start or ts >= window_end:
+            continue
+        start = _bucket_start(ts, bucket_hours)
+        if start < window_start:
+            start = window_start
+        if start in buckets:
+            buckets[start] += 1
+    return list(buckets.items())
+
+
+def _delta_pct(current: int, previous: int) -> Optional[float]:
+    if previous <= 0:
+        return None
+    return round(((current - previous) / previous) * 100.0, 1)
+
+
+def _repo_label(working_dir: str) -> str:
+    normalized = working_dir.strip() or "unknown"
+    return normalized.rstrip("/").split("/")[-1] or normalized
+
+
+def _safe_int(value: Any) -> int:
+    try:
+        return int(value)
+    except Exception:
+        return 0
+
+
+@dataclass
+class MobileAnalyticsBuilder:
+    session_manager: Any
+    config: Optional[dict] = None
+
+    def __post_init__(self) -> None:
+        self.config = self.config or {}
+        paths = self.config.get("paths", {})
+        self.message_queue_db_path = Path(paths.get("message_queue_db", str(_MESSAGE_QUEUE_DB_DEFAULT))).expanduser()
+        self.server_log_path = Path(paths.get("server_log_file", str(_SERVER_LOG_DEFAULT))).expanduser()
+
+    def build_summary(self) -> dict[str, Any]:
+        now = _utc_now()
+        current_start = now - timedelta(hours=24)
+        previous_start = now - timedelta(hours=48)
+        sessions = list(self.session_manager.list_sessions()) if self.session_manager else []
+
+        send_times_current, send_times_previous = self._read_send_timestamps(current_start, previous_start, now)
+        track_times_current = self._read_track_remind_timestamps(current_start, now)
+        active_tracks, overdue_tracks = self._read_track_registration_counts()
+        spawn_times_current, spawn_times_previous, restart_count, self_heal_count = self._read_log_metrics(
+            current_start=current_start,
+            previous_start=previous_start,
+            now=now,
+        )
+
+        sends_series = _series_points(send_times_current, window_start=current_start, window_end=now, bucket_hours=2)
+        spawn_series = _series_points(spawn_times_current, window_start=current_start, window_end=now, bucket_hours=2)
+        track_series = _series_points(track_times_current, window_start=current_start, window_end=now, bucket_hours=2)
+
+        active_states = Counter(self._activity_state(session) for session in sessions)
+        provider_counts = Counter((getattr(session, "provider", None) or "claude") for session in sessions)
+        repo_counts: dict[str, dict[str, Any]] = defaultdict(lambda: {"session_count": 0, "tokens_used": 0})
+        total_tokens_live = 0
+        longest_running = []
+        for session in sessions:
+            working_dir = str(getattr(session, "working_dir", "") or "")
+            repo = _repo_label(working_dir)
+            repo_counts[repo]["session_count"] += 1
+            tokens_used = _safe_int(getattr(session, "tokens_used", 0))
+            repo_counts[repo]["tokens_used"] += tokens_used
+            total_tokens_live += tokens_used
+
+            created_at = _parse_any_datetime(getattr(session, "created_at", None))
+            if created_at:
+                age_hours = round((now - created_at).total_seconds() / 3600.0, 1)
+            else:
+                age_hours = 0.0
+            longest_running.append(
+                {
+                    "id": getattr(session, "id", ""),
+                    "name": self._display_name(session),
+                    "repo": repo,
+                    "provider": getattr(session, "provider", None) or "claude",
+                    "age_hours": age_hours,
+                }
+            )
+
+        total_sessions = len(sessions)
+        provider_distribution = [
+            {
+                "key": provider,
+                "label": provider,
+                "count": count,
+                "share_pct": round((count / total_sessions) * 100.0, 1) if total_sessions else 0.0,
+            }
+            for provider, count in provider_counts.most_common()
+        ]
+        repo_distribution = sorted(
+            (
+                {
+                    "key": repo,
+                    "label": repo,
+                    "session_count": payload["session_count"],
+                    "tokens_used": payload["tokens_used"],
+                    "share_pct": round((payload["session_count"] / total_sessions) * 100.0, 1) if total_sessions else 0.0,
+                }
+                for repo, payload in repo_counts.items()
+            ),
+            key=lambda item: (-item["session_count"], item["label"]),
+        )[:6]
+
+        summary = {
+            "generated_at": now.isoformat(),
+            "window_hours": 24,
+            "kpis": {
+                "active_sessions": {
+                    "label": "Active sessions",
+                    "value": total_sessions,
+                },
+                "sends_24h": {
+                    "label": "Sends",
+                    "value": len(send_times_current),
+                    "delta_pct": _delta_pct(len(send_times_current), len(send_times_previous)),
+                },
+                "spawns_24h": {
+                    "label": "Dispatches",
+                    "value": len(spawn_times_current),
+                    "delta_pct": _delta_pct(len(spawn_times_current), len(spawn_times_previous)),
+                },
+                "active_tracks": {
+                    "label": "Tracks active",
+                    "value": active_tracks,
+                },
+                "overdue_tracks": {
+                    "label": "Overdue tracks",
+                    "value": overdue_tracks,
+                },
+                "incidents_24h": {
+                    "label": "Incidents",
+                    "value": restart_count + self_heal_count,
+                },
+            },
+            "throughput": [
+                {
+                    "bucket_start": bucket.isoformat(),
+                    "bucket_label": bucket.strftime("%H:%M"),
+                    "sends": send_count,
+                    "spawns": dict(spawn_series).get(bucket, 0),
+                    "track_reminders": dict(track_series).get(bucket, 0),
+                }
+                for bucket, send_count in sends_series
+            ],
+            "state_distribution": [
+                {"key": key, "label": key.replace("_", " "), "count": active_states.get(key, 0)}
+                for key in ("working", "thinking", "waiting", "idle")
+            ],
+            "provider_distribution": provider_distribution,
+            "repo_distribution": repo_distribution,
+            "longest_running": sorted(longest_running, key=lambda item: (-item["age_hours"], item["name"]))[:5],
+            "reliability": {
+                "restart_count_24h": restart_count,
+                "self_heal_count_24h": self_heal_count,
+            },
+            "totals": {
+                "tokens_live": total_tokens_live,
+                "track_reminders_24h": len(track_times_current),
+            },
+        }
+        return summary
+
+    def _activity_state(self, session: Session) -> str:
+        getter = getattr(self.session_manager, "get_activity_state", None)
+        if callable(getter):
+            state = str(getter(session) or "").strip().lower()
+            if state in {"waiting_permission", "waiting_input"}:
+                return "waiting"
+            if state:
+                return state
+        status = getattr(session, "status", SessionStatus.IDLE)
+        if status == SessionStatus.RUNNING:
+            return "working"
+        return "idle"
+
+    def _display_name(self, session: Session) -> str:
+        getter = getattr(self.session_manager, "get_effective_session_name", None)
+        if callable(getter):
+            value = str(getter(session) or "").strip()
+            if value:
+                return value
+        return str(getattr(session, "friendly_name", None) or getattr(session, "name", "") or getattr(session, "id", ""))
+
+    def _read_send_timestamps(
+        self,
+        current_start: datetime,
+        previous_start: datetime,
+        now: datetime,
+    ) -> tuple[list[datetime], list[datetime]]:
+        if not self.message_queue_db_path.exists():
+            return [], []
+        query = """
+            SELECT queued_at
+            FROM message_queue
+            WHERE from_sm_send = 1
+              AND queued_at >= ?
+              AND queued_at < ?
+        """
+        try:
+            with sqlite3.connect(str(self.message_queue_db_path)) as conn:
+                rows = conn.execute(query, (previous_start.isoformat(), now.isoformat())).fetchall()
+        except sqlite3.Error:
+            return [], []
+        previous: list[datetime] = []
+        current: list[datetime] = []
+        for (raw_ts,) in rows:
+            parsed = _parse_any_datetime(raw_ts)
+            if parsed is None:
+                continue
+            if parsed >= current_start:
+                current.append(parsed)
+            else:
+                previous.append(parsed)
+        return current, previous
+
+    def _read_track_remind_timestamps(self, current_start: datetime, now: datetime) -> list[datetime]:
+        if not self.message_queue_db_path.exists():
+            return []
+        query = """
+            SELECT queued_at
+            FROM message_queue
+            WHERE message_category = 'track_remind'
+              AND queued_at >= ?
+              AND queued_at < ?
+        """
+        try:
+            with sqlite3.connect(str(self.message_queue_db_path)) as conn:
+                rows = conn.execute(query, (current_start.isoformat(), now.isoformat())).fetchall()
+        except sqlite3.Error:
+            return []
+        return [parsed for (raw_ts,) in rows if (parsed := _parse_any_datetime(raw_ts)) is not None]
+
+    def _read_track_registration_counts(self) -> tuple[int, int]:
+        if not self.message_queue_db_path.exists():
+            return 0, 0
+        query = """
+            SELECT
+                SUM(CASE WHEN is_active = 1 AND cancel_on_reply_session_id IS NOT NULL AND TRIM(cancel_on_reply_session_id) != '' THEN 1 ELSE 0 END),
+                SUM(CASE WHEN is_active = 1 AND soft_fired = 1 AND cancel_on_reply_session_id IS NOT NULL AND TRIM(cancel_on_reply_session_id) != '' THEN 1 ELSE 0 END)
+            FROM remind_registrations
+        """
+        try:
+            with sqlite3.connect(str(self.message_queue_db_path)) as conn:
+                row = conn.execute(query).fetchone()
+        except sqlite3.Error:
+            return 0, 0
+        if not row:
+            return 0, 0
+        return _safe_int(row[0]), _safe_int(row[1])
+
+    def _read_log_metrics(
+        self,
+        *,
+        current_start: datetime,
+        previous_start: datetime,
+        now: datetime,
+    ) -> tuple[list[datetime], list[datetime], int, int]:
+        if not self.server_log_path.exists():
+            return [], [], 0, 0
+        current_spawns: list[datetime] = []
+        previous_spawns: list[datetime] = []
+        restart_count = 0
+        self_heal_count = 0
+        for line in self.server_log_path.read_text(errors="ignore").splitlines():
+            timestamp = _parse_log_timestamp(line)
+            if timestamp is None or timestamp < previous_start or timestamp >= now:
+                continue
+            if "Created session " in line and "Created session with CLI prompt" not in line:
+                if timestamp >= current_start:
+                    current_spawns.append(timestamp)
+                else:
+                    previous_spawns.append(timestamp)
+            if "Starting Claude Session Manager..." in line and timestamp >= current_start:
+                restart_count += 1
+            if "Recovered " in line and timestamp >= current_start:
+                self_heal_count += 1
+        return current_spawns, previous_spawns, restart_count, self_heal_count

--- a/src/server.py
+++ b/src/server.py
@@ -46,6 +46,7 @@ from .models import (
 )
 from .cli.commands import validate_friendly_name
 from .cli.dispatch import get_auto_remind_config
+from .mobile_analytics import MobileAnalyticsBuilder
 
 logger = logging.getLogger(__name__)
 
@@ -1322,6 +1323,29 @@ def create_app(
             return None
         return getter(name)
 
+    def _analytics_health_checks() -> list[dict[str, Any]]:
+        supervisor = getattr(app.state, "infra_supervisor", None)
+        snapshotter = getattr(supervisor, "snapshot", None) if supervisor else None
+        if not callable(snapshotter):
+            return []
+        snapshot = snapshotter() or {}
+        labels = {
+            "android_sshd": "Android attach SSHD",
+            "tmux_base": "tmux base",
+            "ac_caffeinate": "AC caffeinate",
+        }
+        checks: list[dict[str, Any]] = []
+        for key, payload in snapshot.items():
+            checks.append(
+                {
+                    "key": key,
+                    "label": labels.get(key, key.replace("_", " ")),
+                    "status": payload.get("status"),
+                    "message": payload.get("message"),
+                }
+            )
+        return checks
+
     def _termux_attach_infra_issue() -> Optional[str]:
         now = time.time()
         if now < attach_infra_cache["expires_at"]:
@@ -1631,6 +1655,15 @@ def create_app(
                 "termux_package": "com.termux",
             },
         )
+
+    @app.get("/client/analytics/summary")
+    async def client_analytics_summary():
+        """Return mobile-friendly analytics summary derived from live state and local telemetry."""
+        builder = MobileAnalyticsBuilder(app.state.session_manager, app.state.config)
+        payload = builder.build_summary()
+        payload["health_checks"] = _analytics_health_checks()
+        payload["attach_available"] = not bool(_termux_attach_infra_issue())
+        return payload
 
     @app.post("/auth/device/google", response_model=DeviceGoogleAuthResponse)
     async def auth_device_google(request: DeviceGoogleAuthRequest):

--- a/tests/unit/test_android_analytics_api.py
+++ b/tests/unit/test_android_analytics_api.py
@@ -1,0 +1,153 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import MagicMock
+
+from fastapi.testclient import TestClient
+
+from src.models import Session, SessionStatus
+from src.server import create_app
+
+
+def _session(session_id: str, name: str, provider: str, working_dir: str, tokens_used: int = 0) -> Session:
+    session = Session(
+        id=session_id,
+        name=name,
+        working_dir=working_dir,
+        tmux_session=f"{provider}-{session_id}",
+        status=SessionStatus.RUNNING,
+        provider=provider,
+        log_file=f"/tmp/{session_id}.log",
+    )
+    session.tokens_used = tokens_used
+    return session
+
+
+def test_client_analytics_summary_reports_live_metrics():
+    with TemporaryDirectory() as temp_dir:
+        temp_root = Path(temp_dir)
+        message_queue_db = temp_root / "message_queue.db"
+        server_log = temp_root / "session-manager.log"
+
+        message_queue_db.write_bytes(b"")
+        server_log.write_text(
+            "\n".join(
+                [
+                    "2026-03-30 10:00:00,000 - __main__ - INFO - Starting Claude Session Manager...",
+                    "2026-03-30 10:10:00,000 - src.session_manager - INFO - Created session claude-11111111 (id=11111111)",
+                    "2026-03-30 10:20:00,000 - src.infra_supervisor - WARNING - Recovered android attach sshd via launchctl (bootstrap, kickstart)",
+                    "2026-03-30 11:10:00,000 - src.session_manager - INFO - Created session codex-fork-22222222 (id=22222222)",
+                ]
+            )
+        )
+
+        import sqlite3
+
+        with sqlite3.connect(str(message_queue_db)) as conn:
+            conn.executescript(
+                """
+                CREATE TABLE message_queue (
+                    id TEXT PRIMARY KEY,
+                    target_session_id TEXT NOT NULL,
+                    sender_session_id TEXT,
+                    sender_name TEXT,
+                    text TEXT NOT NULL,
+                    delivery_mode TEXT DEFAULT 'sequential',
+                    queued_at TIMESTAMP NOT NULL,
+                    timeout_at TIMESTAMP,
+                    notify_on_delivery INTEGER DEFAULT 0,
+                    notify_after_seconds INTEGER,
+                    delivered_at TIMESTAMP,
+                    notify_on_stop INTEGER DEFAULT 0,
+                    remind_soft_threshold INTEGER,
+                    remind_hard_threshold INTEGER,
+                    parent_session_id TEXT,
+                    message_category TEXT DEFAULT NULL,
+                    remind_cancel_on_reply_session_id TEXT,
+                    from_sm_send INTEGER DEFAULT 0
+                );
+                CREATE TABLE remind_registrations (
+                    id TEXT PRIMARY KEY,
+                    target_session_id TEXT NOT NULL UNIQUE,
+                    soft_threshold_seconds INTEGER NOT NULL,
+                    hard_threshold_seconds INTEGER NOT NULL,
+                    registered_at TIMESTAMP NOT NULL,
+                    last_reset_at TIMESTAMP NOT NULL,
+                    soft_fired INTEGER DEFAULT 0,
+                    is_active INTEGER DEFAULT 1,
+                    cancel_on_reply_session_id TEXT,
+                    tracked_status_nudge_fired INTEGER DEFAULT 0
+                );
+                """
+            )
+            conn.execute(
+                """
+                INSERT INTO message_queue
+                (id, target_session_id, text, queued_at, message_category, from_sm_send)
+                VALUES
+                ('m1', '11111111', 'msg', '2026-03-30T10:30:00+00:00', NULL, 1),
+                ('m2', '11111111', 'msg', '2026-03-30T11:30:00+00:00', NULL, 1),
+                ('m3', '22222222', 'track', '2026-03-30T11:45:00+00:00', 'track_remind', 0)
+                """
+            )
+            conn.execute(
+                """
+                INSERT INTO remind_registrations
+                (id, target_session_id, soft_threshold_seconds, hard_threshold_seconds, registered_at, last_reset_at, soft_fired, is_active, cancel_on_reply_session_id)
+                VALUES
+                ('r1', '11111111', 300, 600, '2026-03-30T10:00:00+00:00', '2026-03-30T10:00:00+00:00', 1, 1, 'owner-1'),
+                ('r2', '22222222', 300, 600, '2026-03-30T10:00:00+00:00', '2026-03-30T10:00:00+00:00', 0, 1, 'owner-2')
+                """
+            )
+            conn.commit()
+
+        session_a = _session("11111111", "claude-11111111", "claude", "/tmp/repo-a", tokens_used=1200)
+        session_b = _session("22222222", "codex-fork-22222222", "codex-fork", "/tmp/repo-b", tokens_used=800)
+
+        manager = MagicMock()
+        manager.list_sessions.return_value = [session_a, session_b]
+        manager.get_effective_session_name.side_effect = lambda current: current.name
+        manager.get_activity_state.side_effect = lambda current: {
+            "11111111": "working",
+            "22222222": "thinking",
+        }[current.id]
+
+        app = create_app(
+            session_manager=manager,
+            config={
+                "paths": {
+                    "message_queue_db": str(message_queue_db),
+                    "server_log_file": str(server_log),
+                }
+            },
+        )
+        app.state.infra_supervisor = MagicMock()
+        app.state.infra_supervisor.snapshot.return_value = {
+            "android_sshd": {"status": "ok", "message": "ready"},
+            "tmux_base": {"status": "warning", "message": "recreated"},
+        }
+        client = TestClient(app)
+
+        response = client.get("/client/analytics/summary")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["kpis"]["active_sessions"]["value"] == 2
+        assert payload["kpis"]["sends_24h"]["value"] == 2
+        assert payload["kpis"]["spawns_24h"]["value"] == 2
+        assert payload["kpis"]["active_tracks"]["value"] == 2
+        assert payload["kpis"]["overdue_tracks"]["value"] == 1
+        assert payload["totals"]["tokens_live"] == 2000
+        assert payload["reliability"]["restart_count_24h"] == 1
+        assert payload["reliability"]["self_heal_count_24h"] == 1
+        assert payload["state_distribution"] == [
+            {"key": "working", "label": "working", "count": 1},
+            {"key": "thinking", "label": "thinking", "count": 1},
+            {"key": "waiting", "label": "waiting", "count": 0},
+            {"key": "idle", "label": "idle", "count": 0},
+        ]
+        assert payload["provider_distribution"][0]["label"] in {"claude", "codex-fork"}
+        assert len(payload["throughput"]) == 12
+        assert payload["health_checks"] == [
+            {"key": "android_sshd", "label": "Android attach SSHD", "status": "ok", "message": "ready"},
+            {"key": "tmux_base", "label": "tmux base", "status": "warning", "message": "recreated"},
+        ]


### PR DESCRIPTION
Fixes #476

## Summary
- add a mobile analytics summary endpoint backed by live session state, queue telemetry, and server log metrics
- add native Android Analytics and Analytics Detail screens based on the UX guidance, with dense KPI cards, charts, reliability panels, and distribution tables
- add bottom navigation between Watch and Analytics and wire the client models/repository to the new analytics API

## Validation
- ./venv/bin/pytest tests/unit/test_android_analytics_api.py tests/unit/test_android_api_surface.py -q
- PYTHONPATH=. ./venv/bin/python -m py_compile src/mobile_analytics.py src/server.py tests/unit/test_android_analytics_api.py
- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./android-app/gradlew -p android-app assembleDebug
