### PR TITLE
Surface Android app updates

### DIFF
--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/analytics/AnalyticsScreen.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/analytics/AnalyticsScreen.kt
@@ -81,6 +81,9 @@ import li.rajeshgo.sm.ui.theme.Rose
 import li.rajeshgo.sm.ui.theme.TextMuted
 import li.rajeshgo.sm.ui.theme.TextSecondary
 import li.rajeshgo.sm.ui.theme.Violet
+import li.rajeshgo.sm.ui.update.SettingsIconButtonWithUpdate
+import li.rajeshgo.sm.ui.update.UpdateAvailabilityViewModel
+import li.rajeshgo.sm.ui.update.UpdateReadyBanner
 
 private const val ANALYTICS_AUTO_REFRESH_MS = 10000L
 
@@ -90,8 +93,10 @@ fun AnalyticsScreen(
     onNavigateToSettings: () -> Unit,
     onOpenDetail: (String) -> Unit,
     viewModel: AnalyticsViewModel = viewModel(),
+    updateViewModel: UpdateAvailabilityViewModel = viewModel(),
 ) {
     val state by viewModel.uiState.collectAsState()
+    val updateState by updateViewModel.uiState.collectAsState()
     val lifecycleOwner = LocalLifecycleOwner.current
     var isResumed by remember {
         mutableStateOf(lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED))
@@ -110,6 +115,7 @@ fun AnalyticsScreen(
             return@LaunchedEffect
         }
         viewModel.refresh()
+        updateViewModel.refresh()
         while (coroutineContext.isActive) {
             delay(ANALYTICS_AUTO_REFRESH_MS)
             viewModel.refresh()
@@ -138,9 +144,19 @@ fun AnalyticsScreen(
                     userEmail = state.userEmail,
                     generatedAt = state.summary?.generatedAt,
                     refreshing = state.refreshing,
+                    hasUpdate = updateState.availableUpdate != null,
                     onRefresh = { viewModel.refresh() },
                     onOpenSettings = onNavigateToSettings,
                 )
+            }
+
+            updateState.availableUpdate?.let { update ->
+                item {
+                    UpdateReadyBanner(
+                        update = update,
+                        onOpenSettings = onNavigateToSettings,
+                    )
+                }
             }
 
             state.error?.takeIf { it.isNotBlank() }?.let { message ->
@@ -413,6 +429,7 @@ private fun AnalyticsHeader(
     userEmail: String,
     generatedAt: String?,
     refreshing: Boolean,
+    hasUpdate: Boolean,
     onRefresh: () -> Unit,
     onOpenSettings: () -> Unit,
 ) {
@@ -463,9 +480,7 @@ private fun AnalyticsHeader(
                             Icon(Icons.Rounded.Refresh, contentDescription = "Refresh", tint = TextSecondary)
                         }
                     }
-                    IconButton(onClick = onOpenSettings) {
-                        Icon(Icons.Rounded.Settings, contentDescription = "Settings", tint = TextSecondary)
-                    }
+                    SettingsIconButtonWithUpdate(hasUpdate = hasUpdate, onClick = onOpenSettings)
                 }
             }
             Box(

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/update/UpdateAvailabilityViewModel.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/update/UpdateAvailabilityViewModel.kt
@@ -1,0 +1,56 @@
+package li.rajeshgo.sm.ui.update
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import li.rajeshgo.sm.data.repository.AppUpdateRepository
+import li.rajeshgo.sm.data.repository.AvailableAppUpdate
+import li.rajeshgo.sm.data.repository.SettingsRepository
+
+data class UpdateAvailabilityUiState(
+    val availableUpdate: AvailableAppUpdate? = null,
+    val checking: Boolean = false,
+    val error: String? = null,
+)
+
+class UpdateAvailabilityViewModel(application: Application) : AndroidViewModel(application) {
+    private val settingsRepository = SettingsRepository(application)
+    private val appUpdateRepository = AppUpdateRepository(application, settingsRepository)
+    private var refreshJob: Job? = null
+
+    private val _uiState = MutableStateFlow(UpdateAvailabilityUiState())
+    val uiState: StateFlow<UpdateAvailabilityUiState> = _uiState
+
+    init {
+        refresh()
+    }
+
+    fun refresh() {
+        if (refreshJob?.isActive == true) {
+            return
+        }
+        refreshJob = viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(checking = true, error = null)
+            runCatching { appUpdateRepository.getAvailableUpdate() }
+                .onSuccess { update ->
+                    _uiState.value = UpdateAvailabilityUiState(
+                        availableUpdate = update,
+                        checking = false,
+                        error = null,
+                    )
+                }
+                .onFailure { error ->
+                    _uiState.value = UpdateAvailabilityUiState(
+                        availableUpdate = null,
+                        checking = false,
+                        error = error.message,
+                    )
+                }
+            refreshJob = null
+        }
+    }
+}

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/update/UpdateSurface.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/update/UpdateSurface.kt
@@ -1,0 +1,121 @@
+package li.rajeshgo.sm.ui.update
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Settings
+import androidx.compose.material.icons.rounded.SystemUpdateAlt
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import li.rajeshgo.sm.data.repository.AvailableAppUpdate
+import li.rajeshgo.sm.ui.theme.BorderStrong
+import li.rajeshgo.sm.ui.theme.Cyan
+import li.rajeshgo.sm.ui.theme.Emerald
+import li.rajeshgo.sm.ui.theme.PanelElevated
+import li.rajeshgo.sm.ui.theme.PanelMuted
+import li.rajeshgo.sm.ui.theme.TextSecondary
+
+@Composable
+fun SettingsIconButtonWithUpdate(
+    hasUpdate: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier) {
+        IconButton(onClick = onClick) {
+            Icon(
+                imageVector = Icons.Rounded.Settings,
+                contentDescription = "Settings",
+                tint = TextSecondary,
+            )
+        }
+        if (hasUpdate) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(top = 8.dp, end = 8.dp)
+                    .size(10.dp)
+                    .clip(CircleShape)
+                    .background(Emerald),
+            )
+        }
+    }
+}
+
+@Composable
+fun UpdateReadyBanner(
+    update: AvailableAppUpdate,
+    onOpenSettings: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onOpenSettings),
+        color = PanelElevated,
+        shape = RoundedCornerShape(10.dp),
+        border = androidx.compose.foundation.BorderStroke(1.dp, BorderStrong),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Row(
+                modifier = Modifier.weight(1f),
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(30.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(PanelMuted),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Icon(Icons.Rounded.SystemUpdateAlt, contentDescription = null, tint = Cyan)
+                }
+                Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                    Text(
+                        text = "App update ready",
+                        style = MaterialTheme.typography.labelMedium,
+                        color = MaterialTheme.colorScheme.onSurface,
+                        fontWeight = FontWeight.Bold,
+                    )
+                    Text(
+                        text = listOfNotNull(update.versionName.takeIf { it.isNotBlank() }, update.uploadedAt).joinToString("  •  "),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = TextSecondary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+            Text(
+                text = "Open",
+                style = MaterialTheme.typography.labelSmall,
+                color = Emerald,
+                fontWeight = FontWeight.Bold,
+            )
+        }
+    }
+}

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
@@ -82,6 +82,9 @@ import li.rajeshgo.sm.ui.theme.Rose
 import li.rajeshgo.sm.ui.theme.TextMuted
 import li.rajeshgo.sm.ui.theme.TextSecondary
 import li.rajeshgo.sm.ui.theme.Violet
+import li.rajeshgo.sm.ui.update.SettingsIconButtonWithUpdate
+import li.rajeshgo.sm.ui.update.UpdateAvailabilityViewModel
+import li.rajeshgo.sm.ui.update.UpdateReadyBanner
 import li.rajeshgo.sm.util.launchTermuxAttach
 import li.rajeshgo.sm.util.termuxAttachCommand
 
@@ -93,8 +96,10 @@ fun WatchScreen(
     onNavigateToSettings: () -> Unit,
     onNavigateToAnalytics: () -> Unit,
     viewModel: WatchViewModel = viewModel(),
+    updateViewModel: UpdateAvailabilityViewModel = viewModel(),
 ) {
     val state by viewModel.uiState.collectAsState()
+    val updateState by updateViewModel.uiState.collectAsState()
     var query by remember { mutableStateOf("") }
     var filter by remember { mutableStateOf("all") }
     var toast by remember { mutableStateOf<String?>(null) }
@@ -126,6 +131,7 @@ fun WatchScreen(
             return@LaunchedEffect
         }
         viewModel.refresh()
+        updateViewModel.refresh()
         while (coroutineContext.isActive) {
             delay(WATCH_AUTO_REFRESH_MS)
             viewModel.refresh()
@@ -154,9 +160,19 @@ fun WatchScreen(
                     userEmail = state.userEmail,
                     lastSync = state.lastSync,
                     refreshing = state.refreshing,
+                    hasUpdate = updateState.availableUpdate != null,
                     onRefresh = { viewModel.refresh() },
                     onOpenSettings = onNavigateToSettings,
                 )
+            }
+
+            updateState.availableUpdate?.let { update ->
+                item {
+                    UpdateReadyBanner(
+                        update = update,
+                        onOpenSettings = onNavigateToSettings,
+                    )
+                }
             }
 
             if (state.error != null) {
@@ -334,6 +350,7 @@ private fun HeaderBar(
     userEmail: String,
     lastSync: String?,
     refreshing: Boolean,
+    hasUpdate: Boolean,
     onRefresh: () -> Unit,
     onOpenSettings: () -> Unit,
 ) {
@@ -370,9 +387,7 @@ private fun HeaderBar(
                 IconButton(onClick = onRefresh) {
                     Icon(Icons.Rounded.Refresh, contentDescription = "Refresh", tint = if (refreshing) Cyan else TextSecondary)
                 }
-                IconButton(onClick = onOpenSettings) {
-                    Icon(Icons.Rounded.Settings, contentDescription = "Settings", tint = TextSecondary)
-                }
+                SettingsIconButtonWithUpdate(hasUpdate = hasUpdate, onClick = onOpenSettings)
             }
         }
     }


### PR DESCRIPTION
Fixes #478

## Summary
- surface available Android app updates directly on Watch and Analytics
- add a visible settings badge when an update is available
- add an inline update-ready banner that routes users to Settings for install/dismiss

## Validation
- JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./android-app/gradlew -p android-app assembleDebug
