### PR TITLE
Keep spawn --track persistent across replies

### DIFF
--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -1499,7 +1499,7 @@ def cmd_spawn(
         model: Model override (opus, sonnet, haiku)
         working_dir: Working directory override
         json_output: Output JSON format
-        track_seconds: Auto-track the child with periodic remind until it replies (#406)
+        track_seconds: Auto-track the child with periodic remind until stopped (#480)
 
     Exit codes:
         0: Success

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -227,7 +227,7 @@ def main():
         const=300,
         type=int,
         metavar="SECONDS",
-        help="Track the child with periodic remind until it replies (default: 300s)",
+        help="Track the child with periodic remind until stopped (default: 300s)",
     )
 
     # sm children [session]

--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -228,6 +228,9 @@ class MessageQueueManager:
         if "tracked_status_nudge_fired" not in remind_columns:
             cursor.execute("ALTER TABLE remind_registrations ADD COLUMN tracked_status_nudge_fired INTEGER DEFAULT 0")
             logger.info("Migrated remind_registrations: added tracked_status_nudge_fired column")
+        if "persistent_tracking" not in remind_columns:
+            cursor.execute("ALTER TABLE remind_registrations ADD COLUMN persistent_tracking INTEGER DEFAULT 0")
+            logger.info("Migrated remind_registrations: added persistent_tracking column")
 
         # Parent wake-up registrations table (#225-C)
         cursor.execute("""
@@ -1724,6 +1727,10 @@ class MessageQueueManager:
                             sender_session_id=msg.sender_session_id,
                             recipient_session_id=msg.target_session_id,
                         )
+                        self.refresh_persistent_tracked_remind(
+                            target_session_id=msg.target_session_id,
+                            owner_session_id=msg.sender_session_id,
+                        )
 
                     # Mirror to Telegram (fire-and-forget)
                     if self.notifier:
@@ -1813,6 +1820,10 @@ class MessageQueueManager:
                             sender_session_id=msg.sender_session_id,
                             recipient_session_id=msg.target_session_id,
                         )
+                        self.refresh_persistent_tracked_remind(
+                            target_session_id=msg.target_session_id,
+                            owner_session_id=msg.sender_session_id,
+                        )
 
                     # Handle notifications
                     if msg.notify_on_delivery and msg.sender_session_id:
@@ -1892,6 +1903,10 @@ class MessageQueueManager:
                         self.cancel_tracked_remind_on_reply(
                             sender_session_id=msg.sender_session_id,
                             recipient_session_id=msg.target_session_id,
+                        )
+                        self.refresh_persistent_tracked_remind(
+                            target_session_id=msg.target_session_id,
+                            owner_session_id=msg.sender_session_id,
                         )
 
                     # Handle notifications
@@ -2163,6 +2178,7 @@ class MessageQueueManager:
         soft_threshold: int,
         hard_threshold: int,
         cancel_on_reply_session_id: Optional[str] = None,
+        persistent_tracking: bool = False,
         merge_with_existing: bool = False,
     ) -> str:
         """
@@ -2174,6 +2190,8 @@ class MessageQueueManager:
             hard_threshold: Seconds after last reset before hard (urgent) remind fires
             cancel_on_reply_session_id: Optional session ID that cancels the remind when the
                 target replies to it via sm send (#406)
+            persistent_tracking: Keep requester-facing tracking active across replies/status
+                updates until explicitly stopped (#480)
             merge_with_existing: Preserve existing tracked reply owners for this target (#406)
 
         Returns:
@@ -2189,6 +2207,7 @@ class MessageQueueManager:
             existing.soft_threshold_seconds = min(existing.soft_threshold_seconds, soft_threshold)
             existing.hard_threshold_seconds = min(existing.hard_threshold_seconds, hard_threshold)
             existing.last_reset_at = now
+            existing.persistent_tracking = existing.persistent_tracking or persistent_tracking
             existing.tracked_status_nudge_fired = False
             existing.soft_fired = False
             existing.cancel_on_reply_session_ids = tuple(sorted(owners))
@@ -2197,16 +2216,18 @@ class MessageQueueManager:
                 soft_threshold_seconds=existing.soft_threshold_seconds,
                 hard_threshold_seconds=existing.hard_threshold_seconds,
                 last_reset_at=now,
+                persistent_tracking=1 if existing.persistent_tracking else 0,
                 tracked_status_nudge_fired=False,
                 soft_fired=False,
                 cancel_on_reply_session_id=self._serialize_cancel_on_reply_session_ids(existing.cancel_on_reply_session_ids),
             )
             logger.info(
-                "Periodic remind merged for %s (soft=%ss, hard=%ss, owners=%s, id=%s)",
+                "Periodic remind merged for %s (soft=%ss, hard=%ss, owners=%s, persistent=%s, id=%s)",
                 target_session_id,
                 existing.soft_threshold_seconds,
                 existing.hard_threshold_seconds,
                 existing.cancel_on_reply_session_ids,
+                existing.persistent_tracking,
                 existing.id,
             )
             return existing.id
@@ -2224,6 +2245,7 @@ class MessageQueueManager:
             registered_at=now,
             last_reset_at=now,
             cancel_on_reply_session_ids=cancel_on_reply_session_ids,
+            persistent_tracking=persistent_tracking,
             tracked_status_nudge_fired=False,
         )
         self._remind_registrations[target_session_id] = reg
@@ -2232,8 +2254,8 @@ class MessageQueueManager:
         self._execute("""
             INSERT OR REPLACE INTO remind_registrations
             (id, target_session_id, soft_threshold_seconds, hard_threshold_seconds,
-             registered_at, last_reset_at, cancel_on_reply_session_id, tracked_status_nudge_fired, soft_fired, is_active)
-            VALUES (?, ?, ?, ?, ?, ?, ?, 0, 0, 1)
+             registered_at, last_reset_at, cancel_on_reply_session_id, persistent_tracking, tracked_status_nudge_fired, soft_fired, is_active)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, 0, 1)
         """, (
             reg_id,
             target_session_id,
@@ -2242,6 +2264,7 @@ class MessageQueueManager:
             now.isoformat(),
             now.isoformat(),
             self._serialize_cancel_on_reply_session_ids(cancel_on_reply_session_ids),
+            1 if persistent_tracking else 0,
         ))
 
         # Start async task
@@ -2250,7 +2273,8 @@ class MessageQueueManager:
 
         logger.info(
             f"Periodic remind registered for {target_session_id} "
-            f"(soft={soft_threshold}s, hard={hard_threshold}s, cancel_on_reply={cancel_on_reply_session_ids}, id={reg_id})"
+            f"(soft={soft_threshold}s, hard={hard_threshold}s, "
+            f"cancel_on_reply={cancel_on_reply_session_ids}, persistent={persistent_tracking}, id={reg_id})"
         )
         return reg_id
 
@@ -2262,6 +2286,14 @@ class MessageQueueManager:
         owners = set(reg.cancel_on_reply_session_ids)
         if recipient_session_id not in owners:
             return False
+        if reg.persistent_tracking:
+            self.refresh_persistent_tracked_remind(sender_session_id, recipient_session_id)
+            logger.info(
+                "Persistent tracked remind refreshed for %s after reply to %s",
+                sender_session_id,
+                recipient_session_id,
+            )
+            return True
         owners.discard(recipient_session_id)
         if owners:
             reg.cancel_on_reply_session_ids = tuple(sorted(owners))
@@ -2295,7 +2327,7 @@ class MessageQueueManager:
         reg = self._remind_registrations.get(target_session_id)
         if not reg or not reg.is_active:
             return
-        if reg.cancel_on_reply_session_ids and not force_tracked:
+        if reg.cancel_on_reply_session_ids and not (force_tracked or reg.persistent_tracking):
             logger.debug(
                 "Ignoring reset_remind for tracked session %s; tracking cadence is requester-facing (#408)",
                 target_session_id,
@@ -2314,6 +2346,18 @@ class MessageQueueManager:
             soft_fired=False,
         )
         logger.info(f"Remind timer reset for {target_session_id}")
+
+    def refresh_persistent_tracked_remind(self, target_session_id: str, owner_session_id: str) -> bool:
+        """Refresh persistent spawn tracking when work continues or a reply lands."""
+        reg = self._remind_registrations.get(target_session_id)
+        if not reg or not reg.is_active or not reg.persistent_tracking:
+            return False
+        if owner_session_id not in reg.cancel_on_reply_session_ids:
+            return False
+        self.cancel_queued_track_reminds(target_session_id, owner_session_id)
+        self.cancel_queued_track_status_nudges(target_session_id)
+        self.reset_remind(target_session_id, force_tracked=True)
+        return True
 
     def cancel_queued_track_reminds(self, tracked_session_id: str, owner_session_id: str) -> int:
         """Delete undelivered requester-facing track reminders for one tracked-session/owner pair."""
@@ -2379,7 +2423,10 @@ class MessageQueueManager:
                 lines.append(f'Status: "{status_text}"')
         else:
             lines.append("Status: (no agent status reported)")
-        lines.append(f"Awaiting explicit reply from {target_session_id[:8]}.")
+        if reg.persistent_tracking:
+            lines.append(f"Tracking remains active for {target_session_id[:8]} until you stop it.")
+        else:
+            lines.append(f"Awaiting explicit reply from {target_session_id[:8]}.")
         return "\n".join(lines)
 
     def _tracked_status_nudge_lead_seconds(self, soft_threshold_seconds: int) -> int:
@@ -2723,7 +2770,7 @@ class MessageQueueManager:
         """Recover active remind registrations on server restart."""
         rows = self._execute_query("""
             SELECT id, target_session_id, soft_threshold_seconds, hard_threshold_seconds,
-                   registered_at, last_reset_at, cancel_on_reply_session_id, tracked_status_nudge_fired, soft_fired
+                   registered_at, last_reset_at, cancel_on_reply_session_id, persistent_tracking, tracked_status_nudge_fired, soft_fired
             FROM remind_registrations
             WHERE is_active = 1
         """)
@@ -2737,6 +2784,7 @@ class MessageQueueManager:
                 registered_at_str,
                 last_reset_at_str,
                 cancel_on_reply_session_id,
+                persistent_tracking,
                 tracked_status_nudge_fired,
                 soft_fired,
             ) = row
@@ -2767,6 +2815,7 @@ class MessageQueueManager:
                 registered_at=datetime.fromisoformat(registered_at_str),
                 last_reset_at=last_reset_at,
                 cancel_on_reply_session_ids=cancel_on_reply_session_ids,
+                persistent_tracking=bool(persistent_tracking),
                 tracked_status_nudge_fired=bool(tracked_status_nudge_fired),
                 soft_fired=bool(soft_fired),
                 is_active=True,

--- a/src/models.py
+++ b/src/models.py
@@ -594,6 +594,7 @@ class RemindRegistration:
     registered_at: datetime
     last_reset_at: datetime  # updated by sm status; initialized on delivery
     cancel_on_reply_session_ids: tuple[str, ...] = field(default_factory=tuple)
+    persistent_tracking: bool = False
     tracked_status_nudge_fired: bool = False
     soft_fired: bool = False
     is_active: bool = True

--- a/src/server.py
+++ b/src/server.py
@@ -1102,6 +1102,7 @@ def create_app(
                     soft_threshold=track_seconds,
                     hard_threshold=_track_hard_threshold_seconds(track_seconds),
                     cancel_on_reply_session_id=parent_id,
+                    persistent_tracking=True,
                 )
             except Exception as exc:
                 _append_warning("failed to register spawn tracking", exc)

--- a/tests/unit/test_em_spawn_auto_register.py
+++ b/tests/unit/test_em_spawn_auto_register.py
@@ -255,6 +255,7 @@ class TestSpawnEndpointMonitoring:
             soft_threshold=300,
             hard_threshold=600,
             cancel_on_reply_session_id="eng111bb",
+            persistent_tracking=True,
         )
         assert child.context_monitor_enabled is False
         mock_sm.message_queue_manager.arm_stop_notify.assert_not_called()

--- a/tests/unit/test_remind.py
+++ b/tests/unit/test_remind.py
@@ -804,6 +804,16 @@ class TestCrashRecovery:
     @pytest.mark.asyncio
     async def test_recover_restores_cancel_on_reply_session_id(self, mock_session_manager, temp_db_path):
         """Crash recovery restores tracked-reply cancellation metadata."""
+        mock_session_manager.tmux.session_exists.return_value = True
+        tracked = Session(
+            id="agent10b",
+            name="agent10b",
+            working_dir="/tmp",
+            tmux_session="claude-agent10b",
+            status=SessionStatus.RUNNING,
+        )
+        mock_session_manager.sessions = {tracked.id: tracked}
+        mock_session_manager.get_session.side_effect = lambda sid: mock_session_manager.sessions.get(sid)
         mq1 = MessageQueueManager(
             session_manager=mock_session_manager,
             db_path=temp_db_path,
@@ -834,6 +844,16 @@ class TestCrashRecovery:
     @pytest.mark.asyncio
     async def test_recover_restores_tracked_status_nudge_state(self, mock_session_manager, temp_db_path):
         """Crash recovery restores tracked status nudge progress for tracked reminders."""
+        mock_session_manager.tmux.session_exists.return_value = True
+        tracked = Session(
+            id="agent10c",
+            name="agent10c",
+            working_dir="/tmp",
+            tmux_session="claude-agent10c",
+            status=SessionStatus.RUNNING,
+        )
+        mock_session_manager.sessions = {tracked.id: tracked}
+        mock_session_manager.get_session.side_effect = lambda sid: mock_session_manager.sessions.get(sid)
         mq = MessageQueueManager(
             session_manager=mock_session_manager,
             db_path=temp_db_path,
@@ -1207,6 +1227,7 @@ class TestDatabaseSchema:
         conn.close()
         assert "cancel_on_reply_session_id" in columns
         assert "tracked_status_nudge_fired" in columns
+        assert "persistent_tracking" in columns
 
 
 class TestTrackedReplyCancellation:
@@ -1286,6 +1307,45 @@ class TestTrackedReplyCancellation:
         assert cancelled is True
         pending = mq.get_pending_messages("parent406queued")
         assert pending == []
+
+    def test_persistent_tracked_reply_refreshes_instead_of_cancelling(self, mq):
+        with patch("asyncio.create_task", noop_create_task):
+            mq.register_periodic_remind(
+                "child406persist",
+                soft_threshold=300,
+                hard_threshold=600,
+                cancel_on_reply_session_id="parent406persist",
+                persistent_tracking=True,
+            )
+            mq.queue_message(
+                target_session_id="parent406persist",
+                sender_session_id="child406persist",
+                text="[sm track] Waiting on child406persist (child406)",
+                delivery_mode="important",
+                message_category="track_remind",
+                trigger_delivery=False,
+            )
+            mq.queue_message(
+                target_session_id="child406persist",
+                text='[sm remind] Update your status within the next minute',
+                delivery_mode="important",
+                message_category="track_status_nudge",
+                trigger_delivery=False,
+            )
+
+        reg = mq._remind_registrations["child406persist"]
+        reg.last_reset_at = datetime.now() - timedelta(seconds=120)
+
+        cancelled = mq.cancel_tracked_remind_on_reply("child406persist", "parent406persist")
+
+        assert cancelled is True
+        assert "child406persist" in mq._remind_registrations
+        reg = mq._remind_registrations["child406persist"]
+        assert reg.persistent_tracking is True
+        assert reg.cancel_on_reply_session_ids == ("parent406persist",)
+        assert (datetime.now() - reg.last_reset_at).total_seconds() < 5
+        assert mq.get_pending_messages("parent406persist") == []
+        assert mq.get_pending_messages("child406persist") == []
 
     @pytest.mark.asyncio
     async def test_send_input_cancels_tracked_remind_on_reply(self, mq):
@@ -1707,3 +1767,141 @@ class TestTrackedReminderDelivery:
 
         assert result == DeliveryResult.DELIVERED
         assert child.id not in mq._remind_registrations
+
+    @pytest.mark.asyncio
+    async def test_persistent_spawn_tracking_survives_reply_and_resets_timer(self, mq):
+        parent = Session(
+            id="parent480",
+            name="parent480",
+            working_dir="/tmp",
+            tmux_session="claude-parent480",
+            status=SessionStatus.IDLE,
+        )
+        child = Session(
+            id="child480",
+            name="child480",
+            working_dir="/tmp",
+            tmux_session="claude-child480",
+            status=SessionStatus.RUNNING,
+        )
+        mq.session_manager.sessions = {parent.id: parent, child.id: child}
+        mq.session_manager.get_session = lambda sid: mq.session_manager.sessions.get(sid)
+        mq._get_or_create_state(parent.id).is_idle = True
+
+        with patch("asyncio.create_task", noop_create_task):
+            mq.register_periodic_remind(
+                child.id,
+                soft_threshold=300,
+                hard_threshold=600,
+                cancel_on_reply_session_id=parent.id,
+                persistent_tracking=True,
+            )
+
+        reg = mq._remind_registrations[child.id]
+        reg.last_reset_at = datetime.now() - timedelta(seconds=180)
+
+        sm = SessionManager.__new__(SessionManager)
+        sm.sessions = mq.session_manager.sessions
+        sm.message_queue_manager = mq
+        sm.notifier = None
+        sm._save_state = MagicMock()
+        sm._deliver_direct = AsyncMock(return_value=True)
+
+        with patch("asyncio.create_task", noop_create_task):
+            result = await sm.send_input(
+                session_id=parent.id,
+                text="done",
+                sender_session_id=child.id,
+                delivery_mode="sequential",
+                from_sm_send=True,
+            )
+
+        assert result == DeliveryResult.DELIVERED
+        assert child.id in mq._remind_registrations
+        reg = mq._remind_registrations[child.id]
+        assert reg.persistent_tracking is True
+        assert (datetime.now() - reg.last_reset_at).total_seconds() < 5
+
+    @pytest.mark.asyncio
+    async def test_status_resets_persistent_tracking_timer(self, mq):
+        target = Session(
+            id="target480status",
+            name="target480status",
+            working_dir="/tmp",
+            tmux_session="claude-target480status",
+            status=SessionStatus.RUNNING,
+        )
+        mq.session_manager.sessions = {target.id: target}
+        mq.session_manager.get_session = lambda sid: mq.session_manager.sessions.get(sid)
+
+        with patch("asyncio.create_task", noop_create_task):
+            mq.register_periodic_remind(
+                target.id,
+                soft_threshold=300,
+                hard_threshold=600,
+                cancel_on_reply_session_id="owner480status",
+                persistent_tracking=True,
+            )
+
+        reg = mq._remind_registrations[target.id]
+        reg.last_reset_at = datetime.now() - timedelta(seconds=200)
+        previous = reg.last_reset_at
+
+        mq.reset_remind(target.id)
+
+        reg = mq._remind_registrations[target.id]
+        assert reg.last_reset_at > previous
+        assert reg.persistent_tracking is True
+
+    @pytest.mark.asyncio
+    async def test_followup_send_refreshes_persistent_spawn_tracking(self, mq):
+        parent = Session(
+            id="parent480follow",
+            name="parent480follow",
+            working_dir="/tmp",
+            tmux_session="claude-parent480follow",
+            status=SessionStatus.IDLE,
+        )
+        child = Session(
+            id="child480follow",
+            name="child480follow",
+            working_dir="/tmp",
+            tmux_session="claude-child480follow",
+            status=SessionStatus.IDLE,
+        )
+        mq.session_manager.sessions = {parent.id: parent, child.id: child}
+        mq.session_manager.get_session = lambda sid: mq.session_manager.sessions.get(sid)
+        mq._get_or_create_state(child.id).is_idle = True
+
+        with patch("asyncio.create_task", noop_create_task):
+            mq.register_periodic_remind(
+                child.id,
+                soft_threshold=300,
+                hard_threshold=600,
+                cancel_on_reply_session_id=parent.id,
+                persistent_tracking=True,
+            )
+
+        reg = mq._remind_registrations[child.id]
+        reg.last_reset_at = datetime.now() - timedelta(seconds=240)
+
+        sm = SessionManager.__new__(SessionManager)
+        sm.sessions = mq.session_manager.sessions
+        sm.message_queue_manager = mq
+        sm.notifier = None
+        sm._save_state = MagicMock()
+        sm._deliver_direct = AsyncMock(return_value=True)
+
+        with patch("asyncio.create_task", noop_create_task):
+            result = await sm.send_input(
+                session_id=child.id,
+                text="keep going",
+                sender_session_id=parent.id,
+                delivery_mode="sequential",
+                from_sm_send=True,
+            )
+
+        assert result == DeliveryResult.DELIVERED
+        reg = mq._remind_registrations[child.id]
+        assert reg.persistent_tracking is True
+        assert (datetime.now() - reg.last_reset_at).total_seconds() < 5


### PR DESCRIPTION
Fixes #480

## Summary
- keep `sm spawn --track` requester-facing tracking active across replies instead of auto-cancelling on the first child response
- refresh persistent spawn tracking on child replies, follow-up sends from the parent, and child status updates
- keep `sm send --track` semantics unchanged as reply-cancel tracking
- update spawn CLI/help text to match the persistent behavior

## Validation
- ./venv/bin/pytest tests/unit/test_remind.py tests/unit/test_em_spawn_auto_register.py -q
- ./venv/bin/pytest tests/unit/test_dispatch.py -q -k track
- ./venv/bin/pytest tests/unit/test_remind.py tests/unit/test_em_spawn_auto_register.py tests/unit/test_dispatch.py -q -k 'track or persistent or spawn'
- PYTHONPATH=. ./venv/bin/python -m py_compile src/models.py src/message_queue.py src/server.py src/cli/main.py src/cli/commands.py tests/unit/test_remind.py tests/unit/test_em_spawn_auto_register.py tests/unit/test_dispatch.py
