### PR TITLE
Fix sm send --track positional parsing

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -36,6 +36,9 @@ def _normalize_optional_track_args(argv: list[str]) -> list[str]:
     index = 1
     while index < len(argv):
         token = argv[index]
+        if token == "--":
+            normalized.extend(argv[index:])
+            break
         if token == "--track":
             next_token = argv[index + 1] if index + 1 < len(argv) else None
             if next_token is not None and _looks_like_int_token(next_token):

--- a/tests/unit/test_cli_parsing.py
+++ b/tests/unit/test_cli_parsing.py
@@ -229,6 +229,15 @@ class TestSendCommand:
 
         assert args.track == 420
 
+    def test_send_track_sentinel_preserves_literal_text(self):
+        """sm send target -- --track=420 keeps the payload literal."""
+        parser = TestCliParsing()
+        args = parser._get_parsed_args(["send", "target123", "--", "--track=420"])
+
+        assert args.track is None
+        assert args.session_id == "target123"
+        assert args.text == "--track=420"
+
 
 class TestSpawnCommand:
     """Tests for 'sm spawn' command parsing."""
@@ -276,6 +285,15 @@ class TestSpawnCommand:
         assert args.track == 300
         assert args.provider == "claude"
         assert args.prompt == "Test prompt"
+
+    def test_spawn_track_sentinel_preserves_literal_prompt(self):
+        """sm spawn claude -- --track=420 keeps the prompt literal."""
+        parser = TestCliParsing()
+        args = parser._get_parsed_args(["spawn", "claude", "--", "--track=420"])
+
+        assert args.track is None
+        assert args.provider == "claude"
+        assert args.prompt == "--track=420"
 
     def test_spawn_model_flag(self):
         """sm spawn --model opus sets model."""


### PR DESCRIPTION
## Summary
- stop argparse from letting `--track` greedily consume `session_id` or `text` when no explicit integer was supplied
- preserve bare `--track` as the 300-second default while still supporting `--track 420` and `--track=420`
- add focused parsing coverage for the broken send forms and the matching spawn edge case

## Testing
- ./venv/bin/python -m pytest tests/unit/test_cli_parsing.py tests/unit/test_dispatch.py -q
- python -m src.cli.main send --track 4958edf4 "message"
- python -m src.cli.main send 4958edf4 --track "message"

Fixes #489