### PR TITLE
Fix stale EM Telegram topic titles after handoff

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -2766,8 +2766,6 @@ def create_app(
 
         if friendly_name is not None or is_em is not None:
             app.state.session_manager._save_state()
-
-        if friendly_name is not None:
             await _sync_session_display_identity(session)
 
         return _session_to_response(session)

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -777,6 +777,37 @@ class TestUpdateSession:
         assert sample_session.role == "em"
         mock_session_manager._save_state.assert_called()
 
+    def test_patch_is_em_syncs_telegram_topic_title(self, mock_session_manager, mock_output_monitor, sample_session):
+        """PATCH /sessions/{id} with is_em=true also syncs the topic title for topic-backed sessions."""
+        sample_session.friendly_name = "em-e1-proximity"
+        sample_session.telegram_chat_id = 123456
+        sample_session.telegram_thread_id = 789
+        mock_session_manager.get_session.return_value = sample_session
+        mock_session_manager._save_state = MagicMock()
+        mock_session_manager.tmux.set_status_bar.return_value = True
+
+        mock_notifier = MagicMock()
+        mock_notifier.rename_session_topic = AsyncMock(return_value=True)
+
+        app = create_app(
+            session_manager=mock_session_manager,
+            notifier=mock_notifier,
+            output_monitor=mock_output_monitor,
+            config={},
+        )
+        client = TestClient(app)
+
+        response = client.patch(
+            "/sessions/test123",
+            json={"is_em": True}
+        )
+
+        assert response.status_code == 200
+        mock_notifier.rename_session_topic.assert_awaited_once_with(
+            sample_session,
+            "em-e1-proximity",
+        )
+
     def test_patch_is_em_false_clears_flag(self, test_client, mock_session_manager, sample_session):
         """PATCH /sessions/{id} with is_em=false clears flag if previously set (#256)."""
         sample_session.is_em = True

--- a/tests/regression/test_issue_271_telegram_thread_cleanup.py
+++ b/tests/regression/test_issue_271_telegram_thread_cleanup.py
@@ -372,6 +372,8 @@ def _make_app_for_em_tests(session, session_manager, telegram_bot):
 
     session_manager.sessions = {session.id: session}
     session_manager.get_session = Mock(side_effect=lambda sid: session_manager.sessions.get(sid))
+    session_manager.list_adoption_proposals = Mock(return_value=[])
+    session_manager.get_session_aliases = Mock(return_value=[])
 
     tmux = Mock()
     tmux.set_status_bar = Mock()
@@ -435,6 +437,50 @@ def test_em_topic_inherits_previous_em_topic():
     # em_topic updated to the inherited topic
     assert mgr.em_topic == {"chat_id": 10000, "thread_id": 42000}
     mgr._save_state.assert_called()
+
+
+def test_em_topic_inheritance_renames_reused_topic_to_new_em_identity():
+    """Inherited EM topics are renamed to the new EM session's display identity."""
+    session = _make_forum_session(session_id="em-second", chat_id=10000, thread_id=99999)
+    session.friendly_name = "em-e1-proximity"
+    tg = _make_telegram_bot()
+
+    mgr = Mock()
+    mgr.em_topic = {"chat_id": 10000, "thread_id": 42000}
+    mgr.sessions = {session.id: session}
+    mgr.get_session = Mock(side_effect=lambda sid: mgr.sessions.get(sid))
+    mgr._save_state = Mock()
+    mgr.list_adoption_proposals = Mock(return_value=[])
+    mgr.get_session_aliases = Mock(return_value=[])
+
+    tmux = Mock()
+    tmux.set_status_bar = Mock()
+    mgr.tmux = tmux
+
+    mqm = Mock()
+    mqm.cancel_remind = Mock()
+    mqm.cancel_parent_wake = Mock()
+    mqm.cancel_context_monitor_messages_from = Mock()
+    mqm.delivery_states = {}
+    mgr.message_queue_manager = mqm
+
+    notifier = Mock()
+    notifier.telegram = tg
+    notifier.rename_session_topic = AsyncMock(return_value=True)
+
+    app = create_app(
+        session_manager=mgr,
+        notifier=notifier,
+        output_monitor=None,
+        config={},
+    )
+    client = TestClient(app)
+
+    resp = client.patch(f"/sessions/{session.id}", json={"is_em": True})
+    assert resp.status_code == 200
+
+    assert session.telegram_thread_id == 42000
+    notifier.rename_session_topic.assert_awaited_once_with(session, "em-e1-proximity")
 
 
 def test_em_topic_different_chat_id_keeps_new_topic():
@@ -594,6 +640,8 @@ def test_em_topic_inheritance_clears_old_em_sessions():
     mgr.em_topic = {"chat_id": 10000, "thread_id": 42000}
     mgr.sessions = {old_em.id: old_em, new_em.id: new_em}
     mgr.get_session = Mock(side_effect=lambda sid: mgr.sessions.get(sid))
+    mgr.list_adoption_proposals = Mock(return_value=[])
+    mgr.get_session_aliases = Mock(return_value=[])
 
     tmux = Mock()
     tmux.set_status_bar = Mock()
@@ -706,6 +754,8 @@ def test_is_em_clears_other_sessions_em_flag():
     mgr.sessions = {session_a.id: session_a, session_b.id: session_b}
     mgr.get_session = Mock(side_effect=lambda sid: mgr.sessions.get(sid))
     mgr._save_state = Mock()
+    mgr.list_adoption_proposals = Mock(return_value=[])
+    mgr.get_session_aliases = Mock(return_value=[])
 
     tmux = Mock()
     tmux.set_status_bar = Mock()


### PR DESCRIPTION
## Summary
- sync display identity for `PATCH /sessions/{id}` when `is_em` changes, not just when `friendly_name` changes
- cover the generic `is_em` rename path in API integration tests
- add a regression test for reused EM topics being renamed to the new EM identity

## Testing
- ./venv/bin/pytest tests/integration/test_api_endpoints.py -k 'patch_is_em'\n- ./venv/bin/pytest tests/regression/test_issue_271_telegram_thread_cleanup.py -k 'em_topic'\n\nFixes #491