### PR TITLE
Harden shared-mailbox email reply routing

### DIFF
--- a/config/email_send.yaml.example
+++ b/config/email_send.yaml.example
@@ -1,7 +1,9 @@
 resend:
   api_key: "re_PLACEHOLDER"
-  domain: "rajeshgo.li"
-  # Optional override when Email Routing receives replies on a different domain.
+  domain: "sm.rajeshgo.li"
+  # Optional stable mailbox address for friendly-name outbound mail and routed replies.
+  reply_address: "reply@sm.rajeshgo.li"
+  # Legacy fallback when Email Routing receives replies on a different domain.
   # reply_domain: "rajeshgo.li"
 
 users:
@@ -14,4 +16,7 @@ users:
 email_bridge:
   authorized_senders:
     - "rajeshgoli@gmail.com"
+  # Optional shared secret header enforced on inbound worker delivery.
+  # worker_secret: "set-a-random-secret"
+  # worker_secret_header: "x-email-worker-secret"
   webhook_path: "/api/email-inbound"

--- a/src/email_handler.py
+++ b/src/email_handler.py
@@ -8,6 +8,8 @@ import logging
 import re
 import sys
 from dataclasses import dataclass
+from email import policy
+from email.parser import BytesParser
 from pathlib import Path
 from typing import Any, Optional
 
@@ -20,6 +22,7 @@ logger = logging.getLogger(__name__)
 EMAIL_HARNESS_PATH = Path(__file__).parent.parent.parent.parent / "claude-email-automation"
 DEFAULT_BRIDGE_CONFIG_PATH = Path(__file__).resolve().parents[1] / "config" / "email_send.yaml"
 DEFAULT_EMAIL_WEBHOOK_PATH = "/api/email-inbound"
+DEFAULT_EMAIL_WORKER_SECRET_HEADER = "x-email-worker-secret"
 MAX_EMAIL_SUBJECT_LENGTH = 140
 MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\((https?://[^)\s]+)\)")
 MARKDOWN_CODE_RE = re.compile(r"`([^`]+)`")
@@ -27,6 +30,7 @@ MARKDOWN_STRONG_RE = re.compile(r"\*\*([^*]+)\*\*")
 MARKDOWN_EM_RE = re.compile(r"(?<!\*)\*([^*]+)\*(?!\*)")
 HTML_TAG_RE = re.compile(r"<[^>]+>")
 WHITESPACE_RE = re.compile(r"\s+")
+ROUTING_FOOTER_RE = re.compile(r"(?im)^\s*>*\s*SM:\s+(.+?)\s+([a-z0-9]{6,})\s+([a-z0-9-]+)\s*$")
 
 
 @dataclass(frozen=True)
@@ -126,6 +130,18 @@ class EmailHandler:
         raw_path = str(bridge.get("webhook_path") or DEFAULT_EMAIL_WEBHOOK_PATH).strip() or DEFAULT_EMAIL_WEBHOOK_PATH
         return raw_path if raw_path.startswith("/") else f"/{raw_path}"
 
+    def bridge_worker_secret_header(self) -> str:
+        """Return the header name used for the inbound worker shared secret."""
+        bridge = (self._load_bridge_config().get("email_bridge") or {})
+        raw_header = str(bridge.get("worker_secret_header") or DEFAULT_EMAIL_WORKER_SECRET_HEADER).strip().lower()
+        return raw_header or DEFAULT_EMAIL_WORKER_SECRET_HEADER
+
+    def bridge_worker_secret(self) -> Optional[str]:
+        """Return the configured inbound worker shared secret, if any."""
+        bridge = (self._load_bridge_config().get("email_bridge") or {})
+        secret = str(bridge.get("worker_secret") or "").strip()
+        return secret or None
+
     def authorized_senders(self) -> set[str]:
         """Return normalized allowlisted sender addresses for inbound replies."""
         bridge = (self._load_bridge_config().get("email_bridge") or {})
@@ -219,6 +235,15 @@ class EmailHandler:
         if not reply_domain:
             raise RuntimeError("Email bridge is missing resend.domain")
         return reply_domain
+
+    def _bridge_reply_address(self, sender_session_id: str) -> str:
+        """Return the reply-routable mailbox address for agent email."""
+        resend = (self._load_bridge_config().get("resend") or {})
+        reply_address = str(resend.get("reply_address") or resend.get("from_address") or "").strip()
+        if reply_address:
+            return reply_address
+        reply_domain = self._bridge_reply_domain()
+        return f"{sender_session_id}@{reply_domain}"
 
     def _bridge_api_key(self) -> str:
         resend = (self._load_bridge_config().get("resend") or {})
@@ -356,11 +381,117 @@ class EmailHandler:
             for paragraph in paragraphs
         )
 
+    def build_routing_footer(self, *, sender_name: str, sender_session_id: str, sender_provider: str) -> str:
+        """Build the compact routing footer embedded in outbound email bodies."""
+        normalized_name = WHITESPACE_RE.sub(" ", str(sender_name or "").strip()) or "session"
+        normalized_provider = WHITESPACE_RE.sub(" ", str(sender_provider or "").strip()) or "unknown"
+        return f"SM: {normalized_name} {sender_session_id} {normalized_provider}"
+
+    def append_routing_footer(self, *, body_text: str, body_html: str, footer_line: str) -> tuple[str, str]:
+        """Append a compact routing footer to both text and HTML email bodies."""
+        normalized_text = body_text.rstrip()
+        normalized_html = body_html.rstrip()
+        text_with_footer = f"{normalized_text}\n\n--\n{footer_line}" if normalized_text else f"--\n{footer_line}"
+        html_footer = f"<hr/>\n<p>{html.escape(footer_line)}</p>"
+        html_with_footer = f"{normalized_html}\n{html_footer}" if normalized_html else html_footer
+        return text_with_footer, html_with_footer
+
+    def extract_routed_session_id(self, body_text: str) -> Optional[str]:
+        """Extract the routed session id from the last compact footer in an inbound email body."""
+        normalized_body = str(body_text or "").replace("\r\n", "\n")
+        matches = list(ROUTING_FOOTER_RE.finditer(normalized_body))
+        if not matches:
+            return None
+        return matches[-1].group(2)
+
+    def extract_reply_message_body(self, body_text: str) -> str:
+        """Strip quoted history and the routing footer from an inbound email body."""
+        normalized_body = str(body_text or "").replace("\r\n", "\n").strip()
+        if not normalized_body:
+            return ""
+
+        lines = normalized_body.split("\n")
+        body_lines: list[str] = []
+        for line in lines:
+            trimmed = line.strip()
+            if (
+                line.startswith(">")
+                or re.match(r"^On .+wrote:$", trimmed, re.IGNORECASE)
+                or re.match(r"^From:\s", line)
+                or re.match(r"^Sent:\s", line)
+                or re.match(r"^Subject:\s", line)
+                or re.match(r"^To:\s", line)
+            ):
+                break
+            body_lines.append(line)
+
+        cleaned_lines = body_lines[:]
+        while cleaned_lines and not cleaned_lines[-1].strip():
+            cleaned_lines.pop()
+        if cleaned_lines and ROUTING_FOOTER_RE.match(cleaned_lines[-1].strip()):
+            cleaned_lines.pop()
+            while cleaned_lines and not cleaned_lines[-1].strip():
+                cleaned_lines.pop()
+            if cleaned_lines and cleaned_lines[-1].strip() == "--":
+                cleaned_lines.pop()
+        return "\n".join(cleaned_lines).strip()
+
+    def extract_text_from_raw_email(self, raw_email: str) -> str:
+        """Parse a raw RFC822 email and return the best-effort plain-text body."""
+        normalized = str(raw_email or "").strip()
+        if not normalized:
+            return ""
+
+        try:
+            message = BytesParser(policy=policy.default).parsebytes(normalized.encode("utf-8", errors="replace"))
+        except Exception:
+            return normalized
+
+        if message.is_multipart():
+            plain_parts: list[str] = []
+            html_parts: list[str] = []
+            for part in message.walk():
+                if part.is_multipart():
+                    continue
+                if str(part.get_content_disposition() or "").lower() == "attachment":
+                    continue
+                content_type = str(part.get_content_type() or "").lower()
+                try:
+                    content = part.get_content()
+                except Exception:
+                    try:
+                        payload = part.get_payload(decode=True) or b""
+                        charset = part.get_content_charset() or "utf-8"
+                        content = payload.decode(charset, errors="replace")
+                    except Exception:
+                        content = ""
+                if not isinstance(content, str):
+                    continue
+                if content_type == "text/plain":
+                    plain_parts.append(content)
+                elif content_type == "text/html":
+                    html_parts.append(content)
+            if plain_parts:
+                return "\n".join(part.strip() for part in plain_parts if part.strip()).strip()
+            if html_parts:
+                return self._strip_html("\n".join(part.strip() for part in html_parts if part.strip()))
+
+        try:
+            content = message.get_content()
+        except Exception:
+            return normalized
+        if isinstance(content, str):
+            if str(message.get_content_type() or "").lower() == "text/html":
+                return self._strip_html(content)
+            return content.strip()
+        return normalized
+
     async def send_agent_email(
         self,
         *,
         sender_session_id: str,
         sender_name: str,
+        sender_provider: str,
         to_identifiers: list[str],
         cc_identifiers: Optional[list[str]] = None,
         subject: Optional[str] = None,
@@ -399,8 +530,18 @@ class EmailHandler:
                 raise ValueError("Email subject is required")
             resolved_subject = self._default_subject(normalized_sender_name, text_payload)
 
-        reply_domain = self._bridge_reply_domain()
-        from_address = f"{normalized_sender_id}@{reply_domain}"
+        footer_line = self.build_routing_footer(
+            sender_name=normalized_sender_name,
+            sender_session_id=normalized_sender_id,
+            sender_provider=sender_provider,
+        )
+        text_payload, html_payload = self.append_routing_footer(
+            body_text=text_payload,
+            body_html=html_payload,
+            footer_line=footer_line,
+        )
+
+        from_address = self._bridge_reply_address(normalized_sender_id)
         from_header = f"{normalized_sender_name} <{from_address}>"
         payload = {
             "from": from_header,

--- a/src/server.py
+++ b/src/server.py
@@ -326,6 +326,7 @@ class GoogleAuthMiddleware(BaseHTTPMiddleware):
             "/logged-out",
             "/health",
             "/health/detailed",
+            DEFAULT_EMAIL_INBOUND_WEBHOOK_PATH,
             "/auth/google/login",
             "/auth/google/callback",
             "/auth/device/google",
@@ -665,8 +666,9 @@ class SendEmailRequest(BaseModel):
 
 class InboundEmailRequest(BaseModel):
     """Inbound email payload forwarded by the email worker/webhook bridge."""
-    session_id: str
-    body: str
+    session_id: Optional[str] = None
+    body: Optional[str] = None
+    raw_email: Optional[str] = None
     from_address: str
 
 
@@ -1129,6 +1131,7 @@ def create_app(
             return await handler.send_agent_email(
                 sender_session_id=sender_session.id,
                 sender_name=_effective_session_name(sender_session),
+                sender_provider=getattr(sender_session, "provider", "claude"),
                 to_identifiers=recipients,
                 cc_identifiers=cc,
                 subject=request.subject,
@@ -1144,21 +1147,47 @@ def create_app(
         except RuntimeError as exc:
             raise HTTPException(status_code=502, detail=str(exc)) from exc
 
-    async def _deliver_email_reply_to_session(payload: InboundEmailRequest) -> dict[str, Any]:
+    async def _deliver_email_reply_to_session(payload: InboundEmailRequest, request: Optional[Request] = None) -> dict[str, Any]:
         handler = _email_handler_or_503()
         if not getattr(handler, "bridge_is_available", lambda: False)():
             raise HTTPException(status_code=503, detail="Email bridge is unavailable")
+        configured_worker_secret = getattr(handler, "bridge_worker_secret", lambda: None)()
+        if configured_worker_secret:
+            secret_header_name = getattr(handler, "bridge_worker_secret_header", lambda: "x-email-worker-secret")()
+            provided_worker_secret = ""
+            if request is not None:
+                provided_worker_secret = str(request.headers.get(secret_header_name, "")).strip()
+            if provided_worker_secret != configured_worker_secret:
+                raise HTTPException(status_code=401, detail="Invalid email worker secret")
         if not getattr(handler, "is_authorized_sender", lambda _value: False)(payload.from_address):
             raise HTTPException(status_code=403, detail="Inbound sender is not authorized")
         if not app.state.session_manager:
             raise HTTPException(status_code=503, detail="Session manager not configured")
 
-        session_id = str(payload.session_id or "").strip()
-        body = str(payload.body or "").strip()
+        raw_email = str(payload.raw_email or "").strip()
+        raw_body = ""
+        if raw_email:
+            raw_body = str(getattr(handler, "extract_text_from_raw_email", lambda value: value)(raw_email) or "").strip()
+        if not raw_body:
+            raw_body = str(payload.body or "").strip()
+        if not raw_body:
+            raise HTTPException(status_code=400, detail="body or raw_email is required")
+        session_id = str(payload.session_id or "").strip() or getattr(handler, "extract_routed_session_id", lambda _value: None)(
+            raw_body
+        ) or ""
         if not session_id:
-            raise HTTPException(status_code=400, detail="session_id is required")
+            return {
+                "status": "ignored",
+                "reason": "missing_routing_footer",
+            }
+        body = getattr(handler, "extract_reply_message_body", lambda value: value)(raw_body).strip()
         if not body:
-            raise HTTPException(status_code=400, detail="body is required")
+            return {
+                "status": "ignored",
+                "session_id": session_id,
+                "reason": "empty_reply_body",
+            }
+        body = f"{{sm email from {payload.from_address}}}\n{body}"
 
         session = app.state.session_manager.get_session(session_id)
         if not session:
@@ -3829,9 +3858,9 @@ Provide ONLY the summary, no preamble or questions."""
         result = await _send_registered_email(request)
         return {"status": "sent", **result}
 
-    async def inbound_email_webhook(request: InboundEmailRequest):
+    async def inbound_email_webhook(http_request: Request, request: InboundEmailRequest):
         """Accept one validated inbound email reply and forward it into the target session."""
-        return await _deliver_email_reply_to_session(request)
+        return await _deliver_email_reply_to_session(request, http_request)
 
     app.add_api_route(
         DEFAULT_EMAIL_INBOUND_WEBHOOK_PATH,

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -42,8 +42,12 @@ def mock_email_handler():
     mock = MagicMock()
     mock.bridge_is_available.return_value = True
     mock.bridge_webhook_path.return_value = "/api/email-inbound"
+    mock.bridge_worker_secret.return_value = None
+    mock.bridge_worker_secret_header.return_value = "x-email-worker-secret"
     mock.send_agent_email = AsyncMock(return_value={"to": [], "cc": [], "subject": "test"})
     mock.is_authorized_sender.return_value = True
+    mock.extract_routed_session_id.return_value = None
+    mock.extract_reply_message_body.side_effect = lambda value: value
     return mock
 
 
@@ -202,6 +206,7 @@ class TestEmailBridgeEndpoints:
         mock_email_handler.send_agent_email.assert_awaited_once_with(
             sender_session_id="test123",
             sender_name="Test Session",
+            sender_provider="claude",
             to_identifiers=["rajesh"],
             cc_identifiers=[],
             subject="Reading list",
@@ -216,6 +221,7 @@ class TestEmailBridgeEndpoints:
         test_client,
         mock_session_manager,
         mock_output_monitor,
+        mock_email_handler,
         sample_session,
     ):
         stopped = sample_session
@@ -249,12 +255,13 @@ class TestEmailBridgeEndpoints:
         mock_session_manager.restore_session.assert_awaited_once_with("test123")
         mock_session_manager.send_input.assert_awaited_once_with(
             "test123",
-            "please continue",
+            "{sm email from rajesh@example.com}\nplease continue",
             sender_session_id=None,
             delivery_mode="sequential",
             from_sm_send=False,
         )
         mock_output_monitor.start_monitoring.assert_awaited_once_with(restored)
+        mock_email_handler.extract_reply_message_body.assert_called_once_with("please continue")
 
     def test_inbound_email_rejects_unauthorized_sender(
         self,
@@ -274,10 +281,52 @@ class TestEmailBridgeEndpoints:
 
         assert response.status_code == 403
 
+    def test_inbound_email_rejects_invalid_worker_secret(
+        self,
+        test_client,
+        mock_email_handler,
+    ):
+        mock_email_handler.bridge_worker_secret.return_value = "worker-secret-123"
+
+        response = test_client.post(
+            "/api/email-inbound",
+            json={
+                "body": "hello",
+                "from_address": "rajesh@example.com",
+            },
+        )
+
+        assert response.status_code == 401
+
+    def test_inbound_email_accepts_valid_worker_secret(
+        self,
+        test_client,
+        mock_email_handler,
+        mock_session_manager,
+        sample_session,
+    ):
+        mock_email_handler.bridge_worker_secret.return_value = "worker-secret-123"
+        mock_session_manager.get_session.return_value = sample_session
+        mock_session_manager.send_input = AsyncMock(return_value=DeliveryResult.DELIVERED)
+
+        response = test_client.post(
+            "/api/email-inbound",
+            headers={"x-email-worker-secret": "worker-secret-123"},
+            json={
+                "session_id": "test123",
+                "body": "hello",
+                "from_address": "rajesh@example.com",
+            },
+        )
+
+        assert response.status_code == 200
+        mock_session_manager.send_input.assert_awaited_once()
+
     def test_inbound_email_honors_codex_pending_request_gate(
         self,
         test_client,
         mock_session_manager,
+        mock_email_handler,
     ):
         codex_session = Session(
             id="codex123",
@@ -304,6 +353,105 @@ class TestEmailBridgeEndpoints:
         assert response.status_code == 409
         assert response.json()["detail"]["error_code"] == "pending_structured_request"
         mock_session_manager.send_input.assert_not_called()
+        mock_email_handler.extract_reply_message_body.assert_called_once_with("hello")
+
+    def test_inbound_email_parses_session_id_from_footer(
+        self,
+        test_client,
+        mock_session_manager,
+        mock_email_handler,
+        sample_session,
+    ):
+        mock_session_manager.get_session.return_value = sample_session
+        mock_session_manager.send_input = AsyncMock(return_value=DeliveryResult.DELIVERED)
+        body = "\n".join(
+            [
+                "Please continue with the rollout.",
+                "",
+                "On Sun, Apr 5, 2026 at 10:00 AM maintainer wrote:",
+                "> context",
+                "> --",
+                "> SM: maintainer test123 codex",
+            ]
+        )
+        mock_email_handler.extract_routed_session_id.return_value = "test123"
+        mock_email_handler.extract_reply_message_body.side_effect = None
+        mock_email_handler.extract_reply_message_body.return_value = "Please continue with the rollout."
+
+        response = test_client.post(
+            "/api/email-inbound",
+            json={
+                "body": body,
+                "from_address": "rajesh@example.com",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["session_id"] == "test123"
+        mock_session_manager.send_input.assert_awaited_once_with(
+            "test123",
+            "{sm email from rajesh@example.com}\nPlease continue with the rollout.",
+            sender_session_id=None,
+            delivery_mode="sequential",
+            from_sm_send=False,
+        )
+        mock_email_handler.extract_routed_session_id.assert_called_once_with(body)
+
+    def test_inbound_email_ignores_missing_routing_footer(
+        self,
+        test_client,
+        mock_session_manager,
+    ):
+        mock_session_manager.send_input = AsyncMock(return_value=DeliveryResult.DELIVERED)
+
+        response = test_client.post(
+            "/api/email-inbound",
+            json={
+                "body": "hello without routing metadata",
+                "from_address": "rajesh@example.com",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "ignored"
+        assert response.json()["reason"] == "missing_routing_footer"
+        mock_session_manager.send_input.assert_not_called()
+
+    def test_inbound_email_accepts_raw_email_payload(
+        self,
+        test_client,
+        mock_session_manager,
+        mock_email_handler,
+        sample_session,
+    ):
+        mock_session_manager.get_session.return_value = sample_session
+        mock_session_manager.send_input = AsyncMock(return_value=DeliveryResult.DELIVERED)
+        raw_email = "Content-Type: text/plain\\n\\ninbound footer test live\\n\\n> --\\n> SM: maintainer test123 codex-fork\\n"
+        mock_email_handler.extract_text_from_raw_email.return_value = (
+            "inbound footer test live\\n\\n> --\\n> SM: maintainer test123 codex-fork"
+        )
+        mock_email_handler.extract_routed_session_id.return_value = "test123"
+        mock_email_handler.extract_reply_message_body.side_effect = None
+        mock_email_handler.extract_reply_message_body.return_value = "inbound footer test live"
+
+        response = test_client.post(
+            "/api/email-inbound",
+            json={
+                "raw_email": raw_email,
+                "from_address": "rajesh@example.com",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["session_id"] == "test123"
+        mock_email_handler.extract_text_from_raw_email.assert_called_once_with(raw_email)
+        mock_session_manager.send_input.assert_awaited_once_with(
+            "test123",
+            "{sm email from rajesh@example.com}\ninbound footer test live",
+            sender_session_id=None,
+            delivery_mode="sequential",
+            from_sm_send=False,
+        )
 
     def test_get_session_not_found(self, test_client, mock_session_manager):
         """GET /sessions/{id} returns 404 for unknown session."""

--- a/tests/unit/test_email_handler.py
+++ b/tests/unit/test_email_handler.py
@@ -1,5 +1,7 @@
 """Unit tests for the Resend-backed email bridge."""
 
+from email.message import EmailMessage
+from email import policy
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -15,7 +17,8 @@ def _write_bridge_config(path: Path) -> None:
             [
                 "resend:",
                 "  api_key: re_test",
-                "  domain: rajeshgo.li",
+                "  domain: sm.rajeshgo.li",
+                "  reply_address: reply@sm.rajeshgo.li",
                 "users:",
                 "  rajesh:",
                 "    email: rajesh@example.com",
@@ -25,6 +28,7 @@ def _write_bridge_config(path: Path) -> None:
                 "email_bridge:",
                 "  authorized_senders:",
                 "    - rajesh@example.com",
+                "  worker_secret: worker-secret-123",
                 "  webhook_path: /api/email-inbound",
             ]
         ),
@@ -45,6 +49,8 @@ def test_lookup_user_and_authorized_sender(tmp_path):
     assert handler.is_authorized_sender("rajesh@example.com") is True
     assert handler.is_authorized_sender("other@example.com") is False
     assert handler.bridge_webhook_path() == "/api/email-inbound"
+    assert handler.bridge_worker_secret() == "worker-secret-123"
+    assert handler.bridge_worker_secret_header() == "x-email-worker-secret"
 
 
 @pytest.mark.asyncio
@@ -61,6 +67,7 @@ async def test_send_agent_email_builds_resend_payload(tmp_path):
         result = await handler.send_agent_email(
             sender_session_id="abc12345",
             sender_name="engineer-issue497",
+            sender_provider="codex",
             to_identifiers=["rajesh"],
             cc_identifiers=["architect"],
             subject="Reading list",
@@ -73,12 +80,14 @@ async def test_send_agent_email_builds_resend_payload(tmp_path):
     call = post_mock.await_args
     assert call.args[0] == "https://api.resend.com/emails"
     payload = call.kwargs["json"]
-    assert payload["from"] == "engineer-issue497 <abc12345@rajeshgo.li>"
-    assert payload["reply_to"] == "abc12345@rajeshgo.li"
+    assert payload["from"] == "engineer-issue497 <reply@sm.rajeshgo.li>"
+    assert payload["reply_to"] == "reply@sm.rajeshgo.li"
     assert payload["to"] == ["rajesh@example.com"]
     assert payload["cc"] == ["architect@example.com"]
     assert payload["subject"] == "Reading list"
     assert "<ul>" in payload["html"]
+    assert payload["text"].endswith("--\nSM: engineer-issue497 abc12345 codex")
+    assert "SM: engineer-issue497 abc12345 codex" in payload["html"]
     assert payload["headers"]["X-SM-Session-ID"] == "abc12345"
 
 
@@ -96,7 +105,56 @@ async def test_send_agent_email_wraps_transport_failure(tmp_path):
             await handler.send_agent_email(
                 sender_session_id="abc12345",
                 sender_name="engineer-issue497",
+                sender_provider="codex",
                 to_identifiers=["rajesh"],
                 subject="Reading list",
                 body_text="Hello",
             )
+
+
+def test_extract_routed_session_id_from_quoted_footer(tmp_path):
+    config_path = tmp_path / "email_send.yaml"
+    _write_bridge_config(config_path)
+    handler = EmailHandler(bridge_config=str(config_path))
+
+    body = "\n".join(
+        [
+            "Please take a look.",
+            "",
+            "On Sun, Apr 5, 2026 at 10:00 AM maintainer wrote:",
+            "> prior context",
+            "> --",
+            "> SM: maintainer abc12345 codex",
+        ]
+    )
+
+    assert handler.extract_routed_session_id(body) == "abc12345"
+    assert handler.extract_reply_message_body(body) == "Please take a look."
+
+
+def test_extract_text_from_raw_email_prefers_text_plain_part(tmp_path):
+    config_path = tmp_path / "email_send.yaml"
+    _write_bridge_config(config_path)
+    handler = EmailHandler(bridge_config=str(config_path))
+
+    message = EmailMessage()
+    message["From"] = "Rajesh <rajesh@example.com>"
+    message["To"] = "reply@sm.rajeshgo.li"
+    message["Subject"] = "Re: test"
+    message.set_content(
+        "inbound footer test live\n\n"
+        "On Sun, Apr 6, 2026 at 12:00 AM maintainer wrote:\n"
+        "> hello\n"
+        "> --\n"
+        "> SM: maintainer 057f8de4 codex-fork\n"
+    )
+    message.add_alternative(
+        "<div>inbound footer test live</div><blockquote>--<br>SM: maintainer 057f8de4 codex-fork</blockquote>",
+        subtype="html",
+    )
+
+    raw_email = message.as_bytes(policy=policy.SMTP).decode("utf-8", errors="replace")
+    extracted = handler.extract_text_from_raw_email(raw_email)
+
+    assert "inbound footer test live" in extracted
+    assert "SM: maintainer 057f8de4 codex-fork" in extracted

--- a/tests/unit/test_google_auth.py
+++ b/tests/unit/test_google_auth.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 
 from src.models import Session, SessionStatus
 from src.server import create_app
+from src.email_handler import EmailHandler
 
 
 def _auth_config() -> dict:
@@ -74,6 +75,42 @@ def test_external_sessions_requires_google_auth():
     assert response.status_code == 401
     assert response.json()["detail"] == "Authentication required"
     assert response.json()["login_url"] == "/auth/google/login?next=%2Fsessions"
+
+
+def test_external_email_inbound_webhook_is_exempt_from_google_auth(tmp_path):
+    config_path = tmp_path / "email_send.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "resend:",
+                "  api_key: re_test",
+                "  domain: sm.rajeshgo.li",
+                "users:",
+                "  rajesh: rajesh@example.com",
+                "email_bridge:",
+                "  authorized_senders:",
+                "    - rajeshgoli@gmail.com",
+                "  webhook_path: /api/email-inbound",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    manager = _session_manager()
+    manager.send_input.return_value = "delivered"
+    email_handler = EmailHandler(bridge_config=str(config_path))
+    client = TestClient(
+        create_app(session_manager=manager, config=_auth_config(), email_handler=email_handler),
+        base_url="https://sm.rajeshgo.li",
+    )
+
+    response = client.post(
+        "/api/email-inbound",
+        json={"body": "hello", "from_address": "rajeshgoli@gmail.com"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ignored"
+    assert response.json()["reason"] == "missing_routing_footer"
 
 
 def test_external_watch_redirects_to_google_login():


### PR DESCRIPTION
Fixes #500

## Summary
- switch routed email replies to a stable shared mailbox with an `SM:` footer in outbound bodies
- parse raw inbound RFC822 email server-side, add provenance, and protect the public webhook with an optional worker secret
- exempt `/api/email-inbound` from browser auth so the Cloudflare worker can deliver replies

## Testing
- /Users/rajesh/Desktop/automation/session-manager/venv/bin/pytest tests/unit/test_google_auth.py::test_external_email_inbound_webhook_is_exempt_from_google_auth tests/unit/test_email_handler.py tests/integration/test_api_endpoints.py -q
