### PR TITLE
Treat piped sm email input as markdown

### DIFF
--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -1440,7 +1440,10 @@ def _load_email_body(
     if body is not None:
         return body, None, False
     if stdin_text is not None:
-        return stdin_text, None, False
+        # Pipe-friendly `sm email` examples commonly stream markdown via stdin.
+        # Treat stdin as markdown so headings/lists render to HTML consistently
+        # with `--text file.md`, while plain text still degrades cleanly.
+        return stdin_text, None, True
     if text_file is not None:
         path = Path(text_file)
         text = path.read_text(encoding="utf-8")

--- a/tests/unit/test_email_commands.py
+++ b/tests/unit/test_email_commands.py
@@ -1,5 +1,7 @@
 """Unit tests for email bridge CLI commands."""
-from unittest.mock import Mock
+
+import sys
+from unittest.mock import Mock, patch
 
 from src.cli.commands import cmd_email, cmd_send
 
@@ -87,5 +89,35 @@ def test_cmd_email_reads_markdown_file_and_calls_api(tmp_path, capsys):
     assert kwargs["cc"] == ["architect"]
     assert kwargs["subject"] == "Reading list"
     assert kwargs["body_text"] == body_path.read_text(encoding="utf-8")
+    assert kwargs["body_markdown"] is True
+    assert "Email sent to rajesh <rajesh@example.com>" in capsys.readouterr().out
+
+
+def test_cmd_email_treats_stdin_as_markdown(capsys):
+    client = Mock()
+    client.send_email_result.return_value = {
+        "ok": True,
+        "unavailable": False,
+        "data": {
+            "to": [{"username": "rajesh", "email": "rajesh@example.com"}],
+            "subject": "From stdin",
+        },
+    }
+
+    with patch.object(sys.stdin, "isatty", return_value=False), patch.object(
+        sys.stdin,
+        "read",
+        return_value="# Heading\n\n## Subhead\n",
+    ):
+        rc = cmd_email(
+            client,
+            sender_session_id="sender123",
+            recipients_raw="rajesh",
+            subject="From stdin",
+        )
+
+    assert rc == 0
+    kwargs = client.send_email_result.call_args.kwargs
+    assert kwargs["body_text"] == "# Heading\n\n## Subhead\n"
     assert kwargs["body_markdown"] is True
     assert "Email sent to rajesh <rajesh@example.com>" in capsys.readouterr().out


### PR DESCRIPTION
Fixes #499

## Summary
- treat piped stdin for `sm email` as markdown content instead of plain text
- preserve existing explicit text/html flags while rendering stdin markdown to HTML
- add a regression test for markdown headings coming from stdin
