### PR TITLE
Preserve restore targets after runtime death

### DIFF
--- a/src/output_monitor.py
+++ b/src/output_monitor.py
@@ -722,7 +722,9 @@ class OutputMonitor:
         Handle tmux session death - called when monitor detects tmux no longer exists.
         """
         logger.info(f"Tmux session {session.tmux_session} died, performing cleanup")
-        await self.cleanup_session(session)
+        # Preserve the stopped record so dead sessions remain restorable and
+        # can produce useful diagnostics instead of disappearing from state.
+        await self.cleanup_session(session, preserve_record=True)
 
     def _get_context(self, content: str) -> str:
         """Extract recent context from content."""

--- a/tests/regression/test_issue_49_dead_session_cleanup.py
+++ b/tests/regression/test_issue_49_dead_session_cleanup.py
@@ -97,8 +97,8 @@ async def test_monitor_detects_tmux_death(output_monitor, mock_session, mock_ses
     await asyncio.sleep(3.5)
 
     # Verify cleanup happened
-    # Session should be removed from sessions dict
-    assert mock_session.id not in mock_session_manager.sessions
+    # Monitor-driven death should preserve the stopped record for sm restore.
+    assert mock_session.id in mock_session_manager.sessions
 
     # Status should be STOPPED
     assert mock_session.status == SessionStatus.STOPPED
@@ -111,6 +111,8 @@ async def test_monitor_detects_tmux_death(output_monitor, mock_session, mock_ses
         chat_id=12345,
         message=f"Session stopped [{mock_session.id}]",
         thread_id=67890,
+        allow_reply_fallback=True,
+        session_id=mock_session.id,
     )
 
     # Monitoring should have stopped
@@ -151,6 +153,8 @@ async def test_cleanup_session_full_workflow(output_monitor, mock_session, mock_
         chat_id=12345,
         message=f"Session stopped [{mock_session.id}]",
         thread_id=67890,
+        allow_reply_fallback=False,
+        session_id=mock_session.id,
     )
 
     # Hook output cache cleanup


### PR DESCRIPTION
Fixes #502

## Summary
- keep monitor-detected dead sessions as stopped records instead of deleting them from state
- preserve future `sm restore` targets when tmux-backed runtimes exit unexpectedly
- add a regression test covering the monitor-driven death path
