### PR TITLE
Support id-addressed inbound email routing

### DIFF
--- a/config/email_send.yaml.example
+++ b/config/email_send.yaml.example
@@ -19,4 +19,5 @@ email_bridge:
   # Optional shared secret header enforced on inbound worker delivery.
   # worker_secret: "set-a-random-secret"
   # worker_secret_header: "x-email-worker-secret"
+  # session_id_header: "x-email-session-id"
   webhook_path: "/api/email-inbound"

--- a/src/email_handler.py
+++ b/src/email_handler.py
@@ -23,6 +23,7 @@ EMAIL_HARNESS_PATH = Path(__file__).parent.parent.parent.parent / "claude-email-
 DEFAULT_BRIDGE_CONFIG_PATH = Path(__file__).resolve().parents[1] / "config" / "email_send.yaml"
 DEFAULT_EMAIL_WEBHOOK_PATH = "/api/email-inbound"
 DEFAULT_EMAIL_WORKER_SECRET_HEADER = "x-email-worker-secret"
+DEFAULT_EMAIL_SESSION_ID_HEADER = "x-email-session-id"
 MAX_EMAIL_SUBJECT_LENGTH = 140
 MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\((https?://[^)\s]+)\)")
 MARKDOWN_CODE_RE = re.compile(r"`([^`]+)`")
@@ -31,6 +32,7 @@ MARKDOWN_EM_RE = re.compile(r"(?<!\*)\*([^*]+)\*(?!\*)")
 HTML_TAG_RE = re.compile(r"<[^>]+>")
 WHITESPACE_RE = re.compile(r"\s+")
 ROUTING_FOOTER_RE = re.compile(r"(?im)^\s*>*\s*SM:\s+(.+?)\s+([a-z0-9]{6,})\s+([a-z0-9-]+)\s*$")
+SESSION_ID_RE = re.compile(r"^[a-z0-9]{6,}$")
 
 
 @dataclass(frozen=True)
@@ -142,6 +144,12 @@ class EmailHandler:
         secret = str(bridge.get("worker_secret") or "").strip()
         return secret or None
 
+    def bridge_session_id_header(self) -> str:
+        """Return the trusted inbound header name for explicit session-id routing."""
+        bridge = (self._load_bridge_config().get("email_bridge") or {})
+        raw_header = str(bridge.get("session_id_header") or DEFAULT_EMAIL_SESSION_ID_HEADER).strip().lower()
+        return raw_header or DEFAULT_EMAIL_SESSION_ID_HEADER
+
     def authorized_senders(self) -> set[str]:
         """Return normalized allowlisted sender addresses for inbound replies."""
         bridge = (self._load_bridge_config().get("email_bridge") or {})
@@ -159,6 +167,13 @@ class EmailHandler:
         normalized = str(address or "").strip().lower()
         allowlist = self.authorized_senders()
         return bool(normalized and normalized in allowlist)
+
+    def normalize_explicit_session_id(self, value: str) -> Optional[str]:
+        """Validate and normalize an explicit worker-supplied session id."""
+        normalized = str(value or "").strip().lower()
+        if not normalized or not SESSION_ID_RE.fullmatch(normalized):
+            return None
+        return normalized
 
     def lookup_user(self, identifier: str) -> Optional[RegisteredEmailUser]:
         """Resolve one registered user by username or alias."""

--- a/src/server.py
+++ b/src/server.py
@@ -1152,6 +1152,7 @@ def create_app(
         if not getattr(handler, "bridge_is_available", lambda: False)():
             raise HTTPException(status_code=503, detail="Email bridge is unavailable")
         configured_worker_secret = getattr(handler, "bridge_worker_secret", lambda: None)()
+        trusted_session_id = ""
         if configured_worker_secret:
             secret_header_name = getattr(handler, "bridge_worker_secret_header", lambda: "x-email-worker-secret")()
             provided_worker_secret = ""
@@ -1159,6 +1160,14 @@ def create_app(
                 provided_worker_secret = str(request.headers.get(secret_header_name, "")).strip()
             if provided_worker_secret != configured_worker_secret:
                 raise HTTPException(status_code=401, detail="Invalid email worker secret")
+            explicit_session_header = getattr(handler, "bridge_session_id_header", lambda: "x-email-session-id")()
+            if request is not None:
+                trusted_session_id = str(
+                    getattr(handler, "normalize_explicit_session_id", lambda value: value)(
+                        request.headers.get(explicit_session_header, "")
+                    )
+                    or ""
+                )
         if not getattr(handler, "is_authorized_sender", lambda _value: False)(payload.from_address):
             raise HTTPException(status_code=403, detail="Inbound sender is not authorized")
         if not app.state.session_manager:
@@ -1172,9 +1181,9 @@ def create_app(
             raw_body = str(payload.body or "").strip()
         if not raw_body:
             raise HTTPException(status_code=400, detail="body or raw_email is required")
-        session_id = str(payload.session_id or "").strip() or getattr(handler, "extract_routed_session_id", lambda _value: None)(
-            raw_body
-        ) or ""
+        session_id = trusted_session_id or str(payload.session_id or "").strip()
+        if not session_id:
+            session_id = getattr(handler, "extract_routed_session_id", lambda _value: None)(raw_body) or ""
         if not session_id:
             return {
                 "status": "ignored",

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -44,6 +44,8 @@ def mock_email_handler():
     mock.bridge_webhook_path.return_value = "/api/email-inbound"
     mock.bridge_worker_secret.return_value = None
     mock.bridge_worker_secret_header.return_value = "x-email-worker-secret"
+    mock.bridge_session_id_header.return_value = "x-email-session-id"
+    mock.normalize_explicit_session_id.side_effect = lambda value: value.strip().lower() if value else None
     mock.send_agent_email = AsyncMock(return_value={"to": [], "cc": [], "subject": "test"})
     mock.is_authorized_sender.return_value = True
     mock.extract_routed_session_id.return_value = None
@@ -321,6 +323,64 @@ class TestEmailBridgeEndpoints:
 
         assert response.status_code == 200
         mock_session_manager.send_input.assert_awaited_once()
+
+    def test_inbound_email_accepts_explicit_session_header_when_worker_secret_is_valid(
+        self,
+        test_client,
+        mock_email_handler,
+        mock_session_manager,
+        sample_session,
+    ):
+        mock_email_handler.bridge_worker_secret.return_value = "worker-secret-123"
+        mock_session_manager.get_session.return_value = sample_session
+        mock_session_manager.send_input = AsyncMock(return_value=DeliveryResult.DELIVERED)
+
+        response = test_client.post(
+            "/api/email-inbound",
+            headers={
+                "x-email-worker-secret": "worker-secret-123",
+                "x-email-session-id": "test123",
+            },
+            json={
+                "body": "hello from explicit route",
+                "from_address": "rajesh@example.com",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["session_id"] == "test123"
+        mock_email_handler.normalize_explicit_session_id.assert_called_once_with("test123")
+        mock_email_handler.extract_routed_session_id.assert_not_called()
+        mock_session_manager.send_input.assert_awaited_once_with(
+            "test123",
+            "{sm email from rajesh@example.com}\nhello from explicit route",
+            sender_session_id=None,
+            delivery_mode="sequential",
+            from_sm_send=False,
+        )
+
+    def test_inbound_email_ignores_explicit_session_header_without_worker_secret(
+        self,
+        test_client,
+        mock_email_handler,
+        mock_session_manager,
+    ):
+        mock_session_manager.send_input = AsyncMock(return_value=DeliveryResult.DELIVERED)
+
+        response = test_client.post(
+            "/api/email-inbound",
+            headers={"x-email-session-id": "test123"},
+            json={
+                "body": "hello without routing metadata",
+                "from_address": "rajesh@example.com",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "ignored"
+        assert response.json()["reason"] == "missing_routing_footer"
+        mock_email_handler.normalize_explicit_session_id.assert_not_called()
+        mock_session_manager.send_input.assert_not_called()
 
     def test_inbound_email_honors_codex_pending_request_gate(
         self,

--- a/tests/unit/test_email_handler.py
+++ b/tests/unit/test_email_handler.py
@@ -51,6 +51,9 @@ def test_lookup_user_and_authorized_sender(tmp_path):
     assert handler.bridge_webhook_path() == "/api/email-inbound"
     assert handler.bridge_worker_secret() == "worker-secret-123"
     assert handler.bridge_worker_secret_header() == "x-email-worker-secret"
+    assert handler.bridge_session_id_header() == "x-email-session-id"
+    assert handler.normalize_explicit_session_id("ABC12345") == "abc12345"
+    assert handler.normalize_explicit_session_id("reply@sm.rajeshgo.li") is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #504

## Summary
- trust an explicit worker-supplied session-id header only when the worker secret is valid
- route id-addressed inbound email without requiring the shared-mailbox footer parser
- document the new header in the example config and add regression coverage for the trusted and untrusted paths
