### PR TITLE
Preserve inbound email subject context

### DIFF
--- a/src/email_handler.py
+++ b/src/email_handler.py
@@ -486,6 +486,22 @@ class EmailHandler:
             return content.strip()
         return normalized
 
+    def extract_subject_from_raw_email(self, raw_email: str) -> Optional[str]:
+        """Parse a raw RFC822 email and return a normalized Subject header."""
+        normalized = str(raw_email or "").strip()
+        if not normalized:
+            return None
+
+        try:
+            message = BytesParser(policy=policy.default).parsebytes(normalized.encode("utf-8", errors="replace"))
+        except Exception:
+            return None
+
+        subject = str(message.get("Subject") or "").strip()
+        if not subject:
+            return None
+        return WHITESPACE_RE.sub(" ", subject).strip()
+
     async def send_agent_email(
         self,
         *,

--- a/src/server.py
+++ b/src/server.py
@@ -1166,8 +1166,10 @@ def create_app(
 
         raw_email = str(payload.raw_email or "").strip()
         raw_body = ""
+        subject = None
         if raw_email:
             raw_body = str(getattr(handler, "extract_text_from_raw_email", lambda value: value)(raw_email) or "").strip()
+            subject = getattr(handler, "extract_subject_from_raw_email", lambda _value: None)(raw_email)
         if not raw_body:
             raw_body = str(payload.body or "").strip()
         if not raw_body:
@@ -1187,7 +1189,10 @@ def create_app(
                 "session_id": session_id,
                 "reason": "empty_reply_body",
             }
-        body = f"{{sm email from {payload.from_address}}}\n{body}"
+        prefix = f"{{sm email from {payload.from_address}}}"
+        if subject:
+            prefix = f"{{sm email from {payload.from_address} subj: {subject}}}"
+        body = f"{prefix}\n{body}"
 
         session = app.state.session_manager.get_session(session_id)
         if not session:

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -47,6 +47,7 @@ def mock_email_handler():
     mock.send_agent_email = AsyncMock(return_value={"to": [], "cc": [], "subject": "test"})
     mock.is_authorized_sender.return_value = True
     mock.extract_routed_session_id.return_value = None
+    mock.extract_subject_from_raw_email.return_value = None
     mock.extract_reply_message_body.side_effect = lambda value: value
     return mock
 
@@ -430,6 +431,7 @@ class TestEmailBridgeEndpoints:
         mock_email_handler.extract_text_from_raw_email.return_value = (
             "inbound footer test live\\n\\n> --\\n> SM: maintainer test123 codex-fork"
         )
+        mock_email_handler.extract_subject_from_raw_email.return_value = "Re: reply mailbox footer routing test 6"
         mock_email_handler.extract_routed_session_id.return_value = "test123"
         mock_email_handler.extract_reply_message_body.side_effect = None
         mock_email_handler.extract_reply_message_body.return_value = "inbound footer test live"
@@ -445,9 +447,10 @@ class TestEmailBridgeEndpoints:
         assert response.status_code == 200
         assert response.json()["session_id"] == "test123"
         mock_email_handler.extract_text_from_raw_email.assert_called_once_with(raw_email)
+        mock_email_handler.extract_subject_from_raw_email.assert_called_once_with(raw_email)
         mock_session_manager.send_input.assert_awaited_once_with(
             "test123",
-            "{sm email from rajesh@example.com}\ninbound footer test live",
+            "{sm email from rajesh@example.com subj: Re: reply mailbox footer routing test 6}\ninbound footer test live",
             sender_session_id=None,
             delivery_mode="sequential",
             from_sm_send=False,

--- a/tests/unit/test_email_handler.py
+++ b/tests/unit/test_email_handler.py
@@ -158,3 +158,4 @@ def test_extract_text_from_raw_email_prefers_text_plain_part(tmp_path):
 
     assert "inbound footer test live" in extracted
     assert "SM: maintainer 057f8de4 codex-fork" in extracted
+    assert handler.extract_subject_from_raw_email(raw_email) == "Re: test"


### PR DESCRIPTION
Fixes #507

## Summary
- extract the inbound email Subject header from raw RFC822 payloads
- include that subject in the delivered provenance prefix when available
- add regression coverage for raw-email subject preservation
