### PR TITLE
Heal and prune codex-fork runtime artifacts (#509)

### DIFF
--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -297,6 +297,11 @@ class SessionManager:
         self.codex_fork_control_epoch: dict[str, str] = {}
         self.codex_fork_control_degraded: dict[str, str] = {}
         self.codex_fork_runtime_owner: dict[str, str] = {}
+        codex_fork_runtime_maintenance_config = self.config.get("codex_fork_runtime_maintenance", {})
+        self.codex_fork_runtime_maintenance_poll_interval_seconds = float(
+            codex_fork_runtime_maintenance_config.get("poll_interval_seconds", 300.0)
+        )
+        self._codex_fork_runtime_maintenance_task: Optional[asyncio.Task[Any]] = None
 
         # App-server config (can be overridden by codex_app_server section)
         self.codex_config = CodexAppServerConfig(
@@ -920,6 +925,24 @@ class SessionManager:
     def _codex_fork_control_socket_path(self, session: Session) -> Path:
         """Return control-socket path for one codex-fork session."""
         return self.log_dir / f"{session.id}.codex-fork.control.sock"
+
+    @staticmethod
+    def _codex_fork_session_id_from_artifact_name(name: str) -> Optional[str]:
+        """Extract the owning session id from one codex-fork runtime artifact filename."""
+        if name.endswith(".codex-fork.events.jsonl"):
+            return name[: -len(".codex-fork.events.jsonl")] or None
+        if name.endswith(".codex-fork.control.sock"):
+            return name[: -len(".codex-fork.control.sock")] or None
+        return None
+
+    def _iter_codex_fork_runtime_artifacts(self) -> list[Path]:
+        """List codex-fork runtime artifacts currently present in the log directory."""
+        return sorted(
+            [
+                *self.log_dir.glob("*.codex-fork.events.jsonl"),
+                *self.log_dir.glob("*.codex-fork.control.sock"),
+            ]
+        )
 
     @staticmethod
     def _normalize_codex_fork_event_type(event_type: Any) -> str:
@@ -3315,12 +3338,17 @@ class SessionManager:
     async def start_background_tasks(self):
         """Start periodic maintenance tasks owned by SessionManager."""
         await self.codex_observability_logger.start_periodic_prune()
+        await self.maintain_codex_fork_runtime_artifacts()
         for session in self.sessions.values():
             if session.provider == "codex-fork" and session.status != SessionStatus.STOPPED:
                 self._start_codex_fork_event_monitor(session, from_eof=True)
         if self._service_role_maintenance_task is None:
             self._service_role_maintenance_task = asyncio.create_task(
                 self._run_service_role_maintenance_loop()
+            )
+        if self._codex_fork_runtime_maintenance_task is None:
+            self._codex_fork_runtime_maintenance_task = asyncio.create_task(
+                self._run_codex_fork_runtime_maintenance_loop()
             )
 
     async def stop_background_tasks(self):
@@ -3331,6 +3359,11 @@ class SessionManager:
             with contextlib.suppress(asyncio.CancelledError):
                 await self._service_role_maintenance_task
             self._service_role_maintenance_task = None
+        if self._codex_fork_runtime_maintenance_task is not None:
+            self._codex_fork_runtime_maintenance_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._codex_fork_runtime_maintenance_task
+            self._codex_fork_runtime_maintenance_task = None
         for session_id in list(self.codex_fork_event_monitors.keys()):
             await self._stop_codex_fork_event_monitor(session_id)
         pending_topic_tasks = list(self._pending_telegram_topic_tasks)
@@ -3389,6 +3422,164 @@ class SessionManager:
                 except Exception:
                     logger.exception("Service role maintenance pass failed")
                 await asyncio.sleep(self.service_role_maintenance_poll_interval_seconds)
+        except asyncio.CancelledError:
+            raise
+
+    def prune_codex_fork_runtime_artifacts(self) -> list[str]:
+        """Remove codex-fork event/control artifacts that no longer belong to a live runtime."""
+        removed: list[str] = []
+        for artifact_path in self._iter_codex_fork_runtime_artifacts():
+            session_id = self._codex_fork_session_id_from_artifact_name(artifact_path.name)
+            if not session_id:
+                continue
+            session = self.sessions.get(session_id)
+            should_remove = False
+            if session is None:
+                should_remove = True
+            elif session.provider != "codex-fork":
+                should_remove = True
+            elif session.status == SessionStatus.STOPPED:
+                should_remove = True
+            elif not session.tmux_session or not self.tmux.session_exists(session.tmux_session):
+                should_remove = True
+
+            if not should_remove:
+                continue
+
+            with contextlib.suppress(FileNotFoundError):
+                artifact_path.unlink()
+                removed.append(artifact_path.name)
+
+        return removed
+
+    async def _restart_codex_fork_runtime(
+        self,
+        session: Session,
+        *,
+        reason: str,
+    ) -> tuple[bool, str]:
+        """Recreate one codex-fork runtime in place to restore missing bridge artifacts."""
+        if session.provider != "codex-fork":
+            return False, "session is not codex-fork"
+
+        resume_id = self.get_session_resume_id(session)
+        if not resume_id:
+            return False, "no Codex resume id is available for this session"
+
+        await self._stop_codex_fork_event_monitor(session.id)
+        self.codex_fork_event_offsets.pop(session.id, None)
+        self.codex_fork_event_buffers.pop(session.id, None)
+        self.codex_fork_turns_in_flight.discard(session.id)
+        self.codex_fork_wait_resume_state.pop(session.id, None)
+        self.codex_fork_wait_kind.pop(session.id, None)
+        self.codex_fork_last_seq.pop(session.id, None)
+        self.codex_fork_session_epoch.pop(session.id, None)
+        self.codex_fork_control_epoch.pop(session.id, None)
+        self.codex_fork_control_degraded.pop(session.id, None)
+
+        if session.tmux_session and self.tmux.session_exists(session.tmux_session):
+            self.tmux.kill_session(session.tmux_session)
+
+        command = self.codex_fork_command
+        args = ["resume", resume_id, *self.codex_fork_args]
+        event_stream_path = self._codex_fork_event_stream_path(session)
+        control_socket_path = self._codex_fork_control_socket_path(session)
+        event_stream_path.parent.mkdir(parents=True, exist_ok=True)
+        if event_stream_path.exists():
+            event_stream_path.unlink()
+        if control_socket_path.exists():
+            control_socket_path.unlink()
+        args.extend(
+            [
+                "--event-stream",
+                str(event_stream_path),
+                "--event-schema-version",
+                str(self.codex_fork_event_schema_version),
+                "--control-socket",
+                str(control_socket_path),
+            ]
+        )
+
+        if not self.tmux.create_session_with_command(
+            session.tmux_session,
+            session.working_dir,
+            session.log_file,
+            session_id=session.id,
+            command=command,
+            args=args,
+        ):
+            session.error_message = f"codex_fork_runtime_artifacts_missing: {reason}"
+            self._save_state()
+            return False, "failed to recreate Codex session runtime"
+
+        session.error_message = None
+        session.status = SessionStatus.RUNNING
+        session.last_activity = datetime.now()
+        self.codex_fork_runtime_owner[session.id] = session.parent_session_id or session.id
+        self._set_codex_fork_lifecycle_state(
+            session_id=session.id,
+            state="running",
+            cause_event_type="runtime_artifacts_restored",
+        )
+        self._start_codex_fork_event_monitor(session)
+        self._save_state()
+        logger.info("Recreated codex-fork runtime artifacts for %s after %s", session.id, reason)
+        return True, ""
+
+    async def maintain_codex_fork_runtime_artifacts(self) -> dict[str, list[str]]:
+        """Prune dead codex-fork artifacts and recreate missing live bridge artifacts when possible."""
+        removed = self.prune_codex_fork_runtime_artifacts()
+        healed: list[str] = []
+        degraded: list[str] = []
+
+        for session in list(self.sessions.values()):
+            if session.provider != "codex-fork" or session.status == SessionStatus.STOPPED:
+                continue
+            if not session.tmux_session or not self.tmux.session_exists(session.tmux_session):
+                continue
+
+            missing: list[str] = []
+            event_stream_path = self._codex_fork_event_stream_path(session)
+            control_socket_path = self._codex_fork_control_socket_path(session)
+            if not event_stream_path.exists():
+                missing.append("event_stream")
+            if not control_socket_path.exists():
+                missing.append("control_socket")
+
+            if not missing:
+                if session.id not in self.codex_fork_event_monitors:
+                    self._start_codex_fork_event_monitor(session, from_eof=True)
+                if session.error_message and session.error_message.startswith("codex_fork_runtime_artifacts_missing:"):
+                    session.error_message = None
+                    self._save_state()
+                continue
+
+            reason = ", ".join(missing)
+            ok, error = await self._restart_codex_fork_runtime(session, reason=reason)
+            if ok:
+                healed.append(session.id)
+            else:
+                if not session.error_message or not session.error_message.startswith(
+                    "codex_fork_runtime_artifacts_missing:"
+                ):
+                    session.error_message = (
+                        f"codex_fork_runtime_artifacts_missing: {reason}"
+                        + (f" ({error})" if error else "")
+                    )
+                    self._save_state()
+                degraded.append(session.id)
+
+        return {"removed": removed, "healed": healed, "degraded": degraded}
+
+    async def _run_codex_fork_runtime_maintenance_loop(self) -> None:
+        """Periodically heal missing codex-fork bridge artifacts and prune dead ones."""
+        try:
+            while True:
+                try:
+                    await self.maintain_codex_fork_runtime_artifacts()
+                except Exception:
+                    logger.exception("Codex-fork runtime maintenance pass failed")
+                await asyncio.sleep(self.codex_fork_runtime_maintenance_poll_interval_seconds)
         except asyncio.CancelledError:
             raise
 
@@ -4584,7 +4775,10 @@ class SessionManager:
                 self.codex_fork_control_epoch.pop(session_id, None)
                 self.codex_fork_control_degraded.pop(session_id, None)
                 self.codex_fork_runtime_owner.pop(session_id, None)
+                event_stream_path = self._codex_fork_event_stream_path(session)
                 control_socket_path = self._codex_fork_control_socket_path(session)
+                if event_stream_path.exists():
+                    event_stream_path.unlink()
                 if control_socket_path.exists():
                     control_socket_path.unlink()
                 self._set_codex_fork_lifecycle_state(

--- a/tests/unit/test_codex_fork_runtime_maintenance.py
+++ b/tests/unit/test_codex_fork_runtime_maintenance.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from src.models import Session, SessionStatus
+from src.session_manager import SessionManager
+
+
+def test_prune_codex_fork_runtime_artifacts_removes_dead_files(tmp_path):
+    manager = SessionManager(log_dir=str(tmp_path), state_file=str(tmp_path / "state.json"))
+    live = Session(
+        id="live1234",
+        name="codex-fork-live1234",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        status=SessionStatus.RUNNING,
+        log_file=str(tmp_path / "live1234.log"),
+        provider_resume_id="resume-live1234",
+    )
+    dead = Session(
+        id="dead1234",
+        name="codex-fork-dead1234",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        status=SessionStatus.STOPPED,
+        log_file=str(tmp_path / "dead1234.log"),
+        provider_resume_id="resume-dead1234",
+    )
+    manager.sessions[live.id] = live
+    manager.sessions[dead.id] = dead
+    manager.tmux.session_exists = lambda name: name == live.tmux_session
+
+    live_event = manager._codex_fork_event_stream_path(live)
+    dead_event = manager._codex_fork_event_stream_path(dead)
+    orphan_event = tmp_path / "orphan123.codex-fork.events.jsonl"
+    live_socket = manager._codex_fork_control_socket_path(live)
+    dead_socket = manager._codex_fork_control_socket_path(dead)
+    orphan_socket = tmp_path / "orphan123.codex-fork.control.sock"
+    for path in (live_event, dead_event, orphan_event, live_socket, dead_socket, orphan_socket):
+        path.write_text("x")
+
+    removed = sorted(manager.prune_codex_fork_runtime_artifacts())
+
+    assert removed == sorted(
+        [
+            dead_event.name,
+            dead_socket.name,
+            orphan_event.name,
+            orphan_socket.name,
+        ]
+    )
+    assert live_event.exists()
+    assert live_socket.exists()
+    assert not dead_event.exists()
+    assert not dead_socket.exists()
+    assert not orphan_event.exists()
+    assert not orphan_socket.exists()
+
+
+@pytest.mark.asyncio
+async def test_maintain_codex_fork_runtime_artifacts_restarts_live_session_when_bridge_files_are_missing(tmp_path):
+    manager = SessionManager(log_dir=str(tmp_path), state_file=str(tmp_path / "state.json"))
+    session = Session(
+        id="heal1234",
+        name="codex-fork-heal1234",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        status=SessionStatus.RUNNING,
+        log_file=str(tmp_path / "heal1234.log"),
+        provider_resume_id="resume-heal1234",
+    )
+    manager.sessions[session.id] = session
+    manager.tmux.session_exists = Mock(return_value=True)
+    manager.tmux.kill_session = Mock(return_value=True)
+    manager.tmux.create_session_with_command = Mock(return_value=True)
+    manager._stop_codex_fork_event_monitor = AsyncMock()
+    manager._start_codex_fork_event_monitor = Mock()
+
+    result = await manager.maintain_codex_fork_runtime_artifacts()
+
+    assert result["healed"] == [session.id]
+    assert result["degraded"] == []
+    manager.tmux.kill_session.assert_called_once_with(session.tmux_session)
+    manager.tmux.create_session_with_command.assert_called_once()
+    _, kwargs = manager.tmux.create_session_with_command.call_args
+    assert kwargs["session_id"] == session.id
+    assert kwargs["command"] == manager.codex_fork_command
+    assert kwargs["args"][:2] == ["resume", "resume-heal1234"]
+    assert "--event-stream" in kwargs["args"]
+    assert "--control-socket" in kwargs["args"]
+    manager._start_codex_fork_event_monitor.assert_called_once_with(session)
+    assert session.error_message is None
+    assert session.status == SessionStatus.RUNNING
+
+
+@pytest.mark.asyncio
+async def test_maintain_codex_fork_runtime_artifacts_marks_unhealable_session_degraded(tmp_path):
+    manager = SessionManager(log_dir=str(tmp_path), state_file=str(tmp_path / "state.json"))
+    session = Session(
+        id="stuck123",
+        name="codex-fork-stuck123",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        status=SessionStatus.RUNNING,
+        log_file=str(tmp_path / "stuck123.log"),
+    )
+    manager.sessions[session.id] = session
+    manager.tmux.session_exists = Mock(return_value=True)
+    manager.tmux.create_session_with_command = Mock(return_value=True)
+    manager._stop_codex_fork_event_monitor = AsyncMock()
+    manager._start_codex_fork_event_monitor = Mock()
+
+    result = await manager.maintain_codex_fork_runtime_artifacts()
+
+    assert result["healed"] == []
+    assert result["degraded"] == [session.id]
+    manager.tmux.create_session_with_command.assert_not_called()
+    assert session.error_message is not None
+    assert session.error_message.startswith("codex_fork_runtime_artifacts_missing: event_stream, control_socket")
+
+
+def test_kill_session_removes_codex_fork_event_stream(tmp_path):
+    manager = SessionManager(log_dir=str(tmp_path), state_file=str(tmp_path / "state.json"))
+    session = Session(
+        id="kill1234",
+        name="codex-fork-kill1234",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        status=SessionStatus.RUNNING,
+        log_file=str(tmp_path / "kill1234.log"),
+        provider_resume_id="resume-kill1234",
+    )
+    manager.sessions[session.id] = session
+    manager.tmux.kill_session = Mock(return_value=True)
+    event_stream_path = manager._codex_fork_event_stream_path(session)
+    control_socket_path = manager._codex_fork_control_socket_path(session)
+    event_stream_path.write_text("payload")
+    control_socket_path.write_text("payload")
+
+    assert manager.kill_session(session.id) is True
+    assert not event_stream_path.exists()
+    assert not control_socket_path.exists()


### PR DESCRIPTION
## Summary
- prune stale codex-fork event/control artifacts for stopped, unknown, or dead runtimes
- recreate missing live codex-fork bridge artifacts in place using provider resume IDs
- run codex-fork runtime maintenance at startup and on a periodic background loop

## Testing
- TMPDIR=/tmp /Users/rajesh/Desktop/automation/session-manager/venv/bin/pytest tests/unit/test_codex_fork_runtime_maintenance.py tests/unit/test_codex_fork_restore.py tests/unit/test_codex_fork_control_client.py -q

Fixes #509