### PR TITLE
Add id-addressed email worker example (#517)

### DIFF
--- a/config/email_send.yaml.example
+++ b/config/email_send.yaml.example
@@ -19,5 +19,6 @@ email_bridge:
   # Optional shared secret header enforced on inbound worker delivery.
   # worker_secret: "set-a-random-secret"
   # worker_secret_header: "x-email-worker-secret"
+  # For catch-all id-addressed workers, forward the local-part in this trusted header.
   # session_id_header: "x-email-session-id"
   webhook_path: "/api/email-inbound"

--- a/docs/product/email_worker_examples.md
+++ b/docs/product/email_worker_examples.md
@@ -1,0 +1,43 @@
+## Email Workers
+
+Session Manager supports two inbound email routing shapes:
+
+- `reply@sm.rajeshgo.li`: shared mailbox routing that extracts the `SM:` footer from the quoted thread
+- `session-id@sm.rajeshgo.li`: explicit id-addressed routing that trusts `x-email-session-id` only when the worker secret header is valid
+
+### Id-Addressed Worker
+
+Tracked example:
+
+- `examples/cloudflare/email_worker_id_routing.js`
+
+This worker is meant for a Cloudflare Email Routing catch-all on `*@sm.rajeshgo.li`.
+
+Behavior:
+
+- normalizes `message.from`
+- rejects senders not present in `ALLOWED_SENDERS`
+- rejects recipients whose local-part does not match the expected Session Manager id shape
+- forwards `raw_email`
+- sets `x-email-worker-secret`
+- sets `x-email-session-id` so Session Manager can skip footer parsing and route directly
+
+Required worker variables:
+
+- `ALLOWED_SENDERS=rajeshgoli@gmail.com`
+- `SM_WEBHOOK_URL=https://sm.rajeshgo.li/api/email-inbound`
+- `EMAIL_WORKER_SECRET=<same value as email_bridge.worker_secret>`
+
+Required Session Manager config:
+
+```yaml
+email_bridge:
+  authorized_senders:
+    - "rajeshgoli@gmail.com"
+  worker_secret: "<same value as EMAIL_WORKER_SECRET>"
+  worker_secret_header: "x-email-worker-secret"
+  session_id_header: "x-email-session-id"
+  webhook_path: "/api/email-inbound"
+```
+
+Use this mode only when Cloudflare Email Routing can deliver a catch-all or equivalent address pattern to the worker. If catch-all is unavailable, use the shared `reply@sm.rajeshgo.li` footer-routing mode instead.

--- a/examples/cloudflare/email_worker_id_routing.js
+++ b/examples/cloudflare/email_worker_id_routing.js
@@ -1,0 +1,71 @@
+function normalizeEmailAddress(value) {
+  const raw = String(value || "").trim().toLowerCase();
+  const match = raw.match(/<([^>]+)>/);
+  return (match ? match[1] : raw).trim();
+}
+
+async function readRawEmail(message) {
+  const chunks = [];
+  const reader = message.raw.getReader();
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+
+  const total = chunks.reduce((count, chunk) => count + chunk.length, 0);
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.length;
+  }
+
+  return new TextDecoder().decode(merged);
+}
+
+export default {
+  async email(message, env, ctx) {
+    const allowList = String(env.ALLOWED_SENDERS || "")
+      .split(",")
+      .map((value) => normalizeEmailAddress(value))
+      .filter(Boolean);
+
+    const from = normalizeEmailAddress(message.from);
+    if (!allowList.includes(from)) {
+      message.setReject(`Address not allowed: ${from}`);
+      return;
+    }
+
+    const to = normalizeEmailAddress(message.to);
+    const localPart = to.split("@")[0] || "";
+    if (!/^[a-z0-9]{8}$/.test(localPart)) {
+      message.setReject(`Invalid Session Manager recipient: ${to}`);
+      return;
+    }
+
+    const rawEmail = await readRawEmail(message);
+    if (!rawEmail) {
+      message.setReject("Empty raw email");
+      return;
+    }
+
+    const response = await fetch(env.SM_WEBHOOK_URL, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-email-worker-secret": env.EMAIL_WORKER_SECRET,
+        "x-email-session-id": localPart,
+      },
+      body: JSON.stringify({
+        raw_email: rawEmail,
+        from_address: from,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Webhook failed: ${response.status}`);
+    }
+  },
+};


### PR DESCRIPTION
## Summary
- add a tracked Cloudflare Email Worker example for session-id addressed inbound email
- document the required worker vars and Session Manager config for the trusted header path
- clarify the session id header comment in the email bridge example config

## Testing
- git diff --check

Fixes #517