### PR TITLE
Detach existing tmux client for Termux attach (#519)

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -1596,11 +1596,11 @@ def create_app(
             "PATH=/opt/homebrew/bin:/usr/local/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/bin:/bin:$PATH; "
             "export PATH; "
             "if command -v tmux >/dev/null 2>&1; then "
-            "exec tmux attach-session -t \"$SM_TMUX_SESSION\"; "
+            "exec tmux attach-session -d -t \"$SM_TMUX_SESSION\"; "
             "elif [ -x /opt/homebrew/bin/tmux ]; then "
-            "exec /opt/homebrew/bin/tmux attach-session -t \"$SM_TMUX_SESSION\"; "
+            "exec /opt/homebrew/bin/tmux attach-session -d -t \"$SM_TMUX_SESSION\"; "
             "elif [ -x /usr/local/bin/tmux ]; then "
-            "exec /usr/local/bin/tmux attach-session -t \"$SM_TMUX_SESSION\"; "
+            "exec /usr/local/bin/tmux attach-session -d -t \"$SM_TMUX_SESSION\"; "
             "else echo \"tmux not found on remote host\" >&2; exit 127; fi"
         )
         remote_command = (

--- a/tests/unit/test_android_api_surface.py
+++ b/tests/unit/test_android_api_surface.py
@@ -149,7 +149,7 @@ def test_client_sessions_include_termux_attach_metadata():
         "ssh_host": "ssh.sm.rajeshgo.li",
         "ssh_username": "rajesh",
         "ssh_proxy_command": "cloudflared access ssh --hostname %h",
-        "ssh_command": "ssh -o 'ProxyCommand=cloudflared access ssh --hostname %h' -tt rajesh@ssh.sm.rajeshgo.li 'SM_TMUX_SESSION=codex-fork-fork1001 sh -lc '\"'\"'PATH=/opt/homebrew/bin:/usr/local/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/bin:/bin:$PATH; export PATH; if command -v tmux >/dev/null 2>&1; then exec tmux attach-session -t \"$SM_TMUX_SESSION\"; elif [ -x /opt/homebrew/bin/tmux ]; then exec /opt/homebrew/bin/tmux attach-session -t \"$SM_TMUX_SESSION\"; elif [ -x /usr/local/bin/tmux ]; then exec /usr/local/bin/tmux attach-session -t \"$SM_TMUX_SESSION\"; else echo \"tmux not found on remote host\" >&2; exit 127; fi'\"'\"''",
+        "ssh_command": "ssh -o 'ProxyCommand=cloudflared access ssh --hostname %h' -tt rajesh@ssh.sm.rajeshgo.li 'SM_TMUX_SESSION=codex-fork-fork1001 sh -lc '\"'\"'PATH=/opt/homebrew/bin:/usr/local/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/bin:/bin:$PATH; export PATH; if command -v tmux >/dev/null 2>&1; then exec tmux attach-session -d -t \"$SM_TMUX_SESSION\"; elif [ -x /opt/homebrew/bin/tmux ]; then exec /opt/homebrew/bin/tmux attach-session -d -t \"$SM_TMUX_SESSION\"; elif [ -x /usr/local/bin/tmux ]; then exec /usr/local/bin/tmux attach-session -d -t \"$SM_TMUX_SESSION\"; else echo \"tmux not found on remote host\" >&2; exit 127; fi'\"'\"''",
         "tmux_session": "codex-fork-fork1001",
         "runtime_mode": "detached_runtime",
         "termux_package": "com.termux",


### PR DESCRIPTION
## Summary
- generate Termux attach commands that use `tmux attach-session -d` so mobile attach works even when the tmux session is already attached locally
- keep the Homebrew fallback paths intact
- cover the generated Android API surface with an updated regression expectation

## Testing
- TMPDIR=/tmp /Users/rajesh/Desktop/automation/session-manager/venv/bin/pytest tests/unit/test_android_api_surface.py -q
- reproduced the old `websocket: bad handshake` failure locally against `057f8de4`, then verified the `-d` variant attached successfully

Fixes #519