### PR TITLE
Fix EM inherited Telegram topic registry revival

### DIFF
--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -440,6 +440,7 @@ class SessionManager:
         thread_id: int,
         *,
         persist: bool = True,
+        revive_deleted: bool = False,
     ) -> None:
         """Create or refresh a durable Telegram topic registry entry."""
         if not chat_id or not thread_id:
@@ -447,7 +448,7 @@ class SessionManager:
 
         key = (chat_id, thread_id)
         existing = self.telegram_topic_registry.get(key)
-        if existing is not None and existing.deleted_at is not None:
+        if existing is not None and existing.deleted_at is not None and not revive_deleted:
             return
         now = datetime.now()
         created_at = existing.created_at if existing else session.created_at
@@ -686,6 +687,14 @@ class SessionManager:
 
                     # Verify tmux session still exists (Claude/Codex CLI)
                     if self.tmux.session_exists(session.tmux_session):
+                        if session.telegram_chat_id and session.telegram_thread_id:
+                            self._upsert_telegram_topic_record(
+                                session,
+                                session.telegram_chat_id,
+                                session.telegram_thread_id,
+                                persist=True,
+                                revive_deleted=True,
+                            )
                         if (
                             session.provider == "codex-fork"
                             and session.status == SessionStatus.STOPPED
@@ -3047,7 +3056,12 @@ class SessionManager:
             session.telegram_chat_id = chat_id
             session.telegram_thread_id = message_id
             if message_id:
-                self._upsert_telegram_topic_record(session, chat_id, message_id)
+                self._upsert_telegram_topic_record(
+                    session,
+                    chat_id,
+                    message_id,
+                    revive_deleted=True,
+                )
             self._save_state()
 
     async def send_input(

--- a/tests/unit/test_telegram_topic_cleanup.py
+++ b/tests/unit/test_telegram_topic_cleanup.py
@@ -313,3 +313,135 @@ def test_load_state_preserves_deleted_topic_tombstone(tmp_path):
 
     record = manager.telegram_topic_registry[(-1003506774897, 24680)]
     assert record.deleted_at is not None
+
+
+def test_update_telegram_thread_revives_deleted_topic_tombstone(tmp_path):
+    state_file = tmp_path / "sessions.json"
+    registry_file = tmp_path / "telegram_topics.json"
+    state_file.write_text(
+        json.dumps(
+            {
+                "sessions": [
+                    {
+                        "id": "em123456",
+                        "name": "claude-em123456",
+                        "working_dir": "/tmp",
+                        "tmux_session": "claude-em123456",
+                        "log_file": "/tmp/em123456.log",
+                        "status": "idle",
+                        "created_at": "2026-03-06T10:00:00",
+                        "last_activity": "2026-03-06T10:00:00",
+                        "telegram_chat_id": -1003506774897,
+                        "telegram_thread_id": None,
+                        "is_em": True,
+                    }
+                ]
+            }
+        )
+    )
+    registry_file.write_text(
+        json.dumps(
+            {
+                "topics": [
+                    {
+                        "session_id": "oldem123",
+                        "chat_id": -1003506774897,
+                        "thread_id": 24680,
+                        "tmux_session": "claude-oldem123",
+                        "provider": "claude",
+                        "created_at": "2026-03-06T09:00:00",
+                        "last_seen_at": "2026-03-06T09:30:00",
+                        "deleted_at": "2026-03-06T10:30:00",
+                        "is_em_topic": True,
+                    }
+                ]
+            }
+        )
+    )
+    config = {
+        "telegram": {
+            "default_forum_chat_id": -1003506774897,
+            "topic_registry": {"path": str(registry_file)},
+        }
+    }
+
+    with patch("src.session_manager.TmuxController") as mock_tmux_cls:
+        mock_tmux_cls.return_value.session_exists.return_value = True
+        manager = SessionManager(
+            log_dir=str(tmp_path),
+            state_file=str(state_file),
+            config=config,
+        )
+
+    manager.update_telegram_thread("em123456", -1003506774897, 24680)
+
+    record = manager.telegram_topic_registry[(-1003506774897, 24680)]
+    assert record.session_id == "em123456"
+    assert record.tmux_session == "claude-em123456"
+    assert record.deleted_at is None
+    assert record.is_em_topic is True
+
+
+def test_load_state_revives_deleted_topic_tombstone_for_live_session(tmp_path):
+    state_file = tmp_path / "sessions.json"
+    registry_file = tmp_path / "telegram_topics.json"
+    state_file.write_text(
+        json.dumps(
+            {
+                "sessions": [
+                    {
+                        "id": "em123456",
+                        "name": "claude-em123456",
+                        "working_dir": "/tmp",
+                        "tmux_session": "claude-em123456",
+                        "log_file": "/tmp/em123456.log",
+                        "status": "idle",
+                        "created_at": "2026-03-06T10:00:00",
+                        "last_activity": "2026-03-06T10:00:00",
+                        "telegram_chat_id": -1003506774897,
+                        "telegram_thread_id": 24680,
+                        "is_em": True,
+                    }
+                ]
+            }
+        )
+    )
+    registry_file.write_text(
+        json.dumps(
+            {
+                "topics": [
+                    {
+                        "session_id": "oldem123",
+                        "chat_id": -1003506774897,
+                        "thread_id": 24680,
+                        "tmux_session": "claude-oldem123",
+                        "provider": "claude",
+                        "created_at": "2026-03-06T09:00:00",
+                        "last_seen_at": "2026-03-06T09:30:00",
+                        "deleted_at": "2026-03-06T10:30:00",
+                        "is_em_topic": True,
+                    }
+                ]
+            }
+        )
+    )
+    config = {
+        "telegram": {
+            "default_forum_chat_id": -1003506774897,
+            "topic_registry": {"path": str(registry_file)},
+        }
+    }
+
+    with patch("src.session_manager.TmuxController") as mock_tmux_cls:
+        mock_tmux_cls.return_value.session_exists.return_value = True
+        manager = SessionManager(
+            log_dir=str(tmp_path),
+            state_file=str(state_file),
+            config=config,
+        )
+
+    record = manager.telegram_topic_registry[(-1003506774897, 24680)]
+    assert record.session_id == "em123456"
+    assert record.tmux_session == "claude-em123456"
+    assert record.deleted_at is None
+    assert manager.get_session("em123456") is not None


### PR DESCRIPTION
## Summary
- revive deleted Telegram topic tombstones when a live session is explicitly rebound to a topic
- persist that repair during startup so inherited EM topics stay correct across restarts
- add unit coverage for direct rebinds and startup restoration

Fixes #521
