### PR TITLE
Show agent statuses in Android watch list

### DIFF
--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchModels.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchModels.kt
@@ -166,6 +166,8 @@ fun filterSections(sections: List<WatchSection>, statusFilter: String, query: St
             append(' ')
             append(session.provider ?: "")
             append(' ')
+            append(session.agentStatusText ?: "")
+            append(' ')
             append(session.aliases.joinToString(" "))
         }.lowercase()
         return haystack.contains(normalizedQuery)
@@ -246,6 +248,12 @@ fun lastSummary(session: ClientSession): String {
             session.lastToolCall?.let { "$tool (${ageFromIso(it)})" } ?: tool
         } ?: session.lastToolCall?.let { "tool (${ageFromIso(it)})" } ?: "-"
     }
+}
+
+fun statusSummary(session: ClientSession): String? {
+    val text = session.agentStatusText?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+    val ageSuffix = session.agentStatusAt?.let { " (${ageFromIso(it)})" } ?: ""
+    return "$text$ageSuffix"
 }
 
 fun parentLabel(session: ClientSession, sessionsById: Map<String, ClientSession>): String {

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
@@ -592,6 +592,16 @@ private fun SessionRow(
                             fontFamily = FontFamily.Monospace,
                         )
                         Spacer(Modifier.height(6.dp))
+                        statusSummary(session)?.let { status ->
+                            Text(
+                                text = status,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = Cyan,
+                                maxLines = 3,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            Spacer(Modifier.height(6.dp))
+                        }
                         val secondaryLine = buildString {
                             if (parentLabel != "-") {
                                 append("Parent ")


### PR DESCRIPTION
## Summary
- surface agent-reported statuses directly in collapsed Android watch rows when available
- keep status age visible inline
- include agent status text in watch search matching

Fixes #524
