### PR TITLE
Allow restore from shell and stale active records

### DIFF
--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -694,10 +694,10 @@ def main():
         )
         sys.exit(1)
 
-    # Commands that don't need session_id: lock, unlock, hooks, all, send, wait, what, subagents, children, kill, new, attach, output, clear
+    # Commands that don't need session_id: lock, unlock, hooks, all, send, wait, what, subagents, children, kill, restore, new, attach, output, clear
     no_session_needed = [
         "lock", "unlock", "subagent-start", "subagent-stop", "all", "send", "wait", "what",
-        "subagents", "children", "kill", "new", "claude", "codex", "codex-legacy", "codex-fork", "codex_fork",
+        "subagents", "children", "kill", "restore", "unkill", "new", "claude", "codex", "codex-legacy", "codex-fork", "codex_fork",
         "codex-2", "codex-app", "codex-server",
         "attach", "output", "codex-tui", "codex-fork-info", "codex-rollout-gates", "watch", "tail", "clear", "review", "context-monitor", "remind", "setup", "lookup", "roster", "email", None
     ]

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -4808,7 +4808,11 @@ class SessionManager:
         session = self.sessions.get(session_id)
         if not session:
             return False, None, "Session not found"
-        if session.status != SessionStatus.STOPPED:
+        tmux_runtime_missing = (
+            session.provider != "codex-app"
+            and not self.tmux.session_exists(session.tmux_session)
+        )
+        if session.status != SessionStatus.STOPPED and not tmux_runtime_missing:
             return False, session, "Session is not stopped"
 
         resume_id = self.get_session_resume_id(session)

--- a/tests/integration/test_session_lifecycle.py
+++ b/tests/integration/test_session_lifecycle.py
@@ -166,6 +166,38 @@ class TestSessionLifecycle:
         assert call_kwargs["args"] == ["--resume", "restore-uuid"]
 
     @pytest.mark.asyncio
+    async def test_restore_session_flow_stale_active_claude_missing_tmux(self, session_manager, mock_tmux):
+        """Idle/running Claude sessions with no tmux runtime are restoreable after reboot."""
+        session = await session_manager.create_session(working_dir="/tmp/test")
+        session.transcript_path = "/tmp/transcripts/stale-restore-uuid.jsonl"
+        session.status = SessionStatus.IDLE
+        mock_tmux.session_exists.return_value = False
+
+        success, restored, error = await session_manager.restore_session(session.id)
+
+        assert success is True
+        assert error is None
+        assert restored is session
+        assert restored.status == SessionStatus.RUNNING
+        call_kwargs = mock_tmux.create_session_with_command.call_args_list[-1][1]
+        assert call_kwargs["command"] == "claude"
+        assert call_kwargs["args"] == ["--resume", "stale-restore-uuid"]
+
+    @pytest.mark.asyncio
+    async def test_restore_session_rejects_live_nonstopped_claude(self, session_manager, mock_tmux):
+        """Live non-stopped sessions still cannot be restored in place."""
+        session = await session_manager.create_session(working_dir="/tmp/test")
+        session.transcript_path = "/tmp/transcripts/live-restore-uuid.jsonl"
+        session.status = SessionStatus.IDLE
+        mock_tmux.session_exists.return_value = True
+
+        success, restored, error = await session_manager.restore_session(session.id)
+
+        assert success is False
+        assert restored is session
+        assert error == "Session is not stopped"
+
+    @pytest.mark.asyncio
     async def test_restore_session_flow_codex_app(self, session_manager):
         """Stopped codex-app sessions resume by stored thread id."""
         session = Session(

--- a/tests/unit/test_cli_parsing.py
+++ b/tests/unit/test_cli_parsing.py
@@ -3,6 +3,7 @@
 import pytest
 import sys
 import argparse
+import os
 from unittest.mock import MagicMock, patch
 from io import StringIO
 
@@ -635,6 +636,19 @@ class TestRestoreCommand:
 
         assert args.command == "restore"
         assert args.session == "engineer-ticket2508"
+
+    def test_main_restore_allowed_without_managed_session(self):
+        mock_client = MagicMock()
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(sys, "argv", ["sm", "restore", "dead123"]):
+                with patch("src.cli.main.SessionManagerClient", return_value=mock_client):
+                    with patch("src.cli.main.commands.cmd_restore", return_value=0) as mock_cmd_restore:
+                        with pytest.raises(SystemExit) as exc_info:
+                            main()
+
+        assert exc_info.value.code == 0
+        mock_cmd_restore.assert_called_once_with(mock_client, "dead123")
 
 
 class TestSessionResolution:


### PR DESCRIPTION
## Summary
- allow `sm restore` / `sm unkill` from a plain shell without `CLAUDE_SESSION_MANAGER_ID`
- permit restore of tmux-backed sessions whose record is still `running`/`idle` but whose tmux runtime is gone after a reboot/crash
- keep rejecting truly live sessions whose runtime is still present

## Verification
- `./venv/bin/pytest tests/unit/test_cli_parsing.py tests/unit/test_cmd_restore.py tests/integration/test_session_lifecycle.py -q`
- live shell check: `env -u CLAUDE_SESSION_MANAGER_ID sm restore f8b25fed` now reaches restore logic and returns `Error: Session is not stopped` instead of the old managed-context error
- live investigation confirmed current `f8b25fed` and `c0d81432` are not dead examples right now: both still have live tmux sessions and active Claude panes

Fixes #533
