### PR TITLE
Fix Termux attach terminal smearing in app

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -1797,15 +1797,13 @@ def create_app(
             "stty sane 2>/dev/null || true; "
             "if [ -n \"${attach_pid:-}\" ]; then "
             "kill \"$attach_pid\" 2>/dev/null || true; "
-            "if command -v pkill >/dev/null 2>&1; then "
-            "pkill -P \"$attach_pid\" 2>/dev/null || true; "
-            "fi; "
             "fi; "
             "}; "
             "run_attach() { "
+            "set -m 2>/dev/null || true; "
             f"{ssh_command} & "
             "attach_pid=$!; "
-            "wait \"$attach_pid\"; "
+            "fg %1 >/dev/null 2>&1 || wait \"$attach_pid\"; "
             "attach_status=$?; "
             "attach_pid=''; "
             "return \"$attach_status\"; "
@@ -1830,7 +1828,7 @@ def create_app(
             "ssh_host": public_ssh_host,
             "ssh_username": ssh_username,
             "ssh_proxy_command": ssh_proxy_command or None,
-            "ssh_command": shlex.join(["sh", "-lc", local_attach_script]),
+            "ssh_command": shlex.join(["bash", "-lc", local_attach_script]),
             "tmux_session": tmux_session,
             "runtime_mode": descriptor.get("runtime_mode"),
             "termux_package": "com.termux",

--- a/tests/unit/test_android_api_surface.py
+++ b/tests/unit/test_android_api_surface.py
@@ -155,13 +155,15 @@ def test_client_sessions_include_termux_attach_metadata():
         "termux_package": "com.termux",
     }
     ssh_command = payload["termux_attach"]["ssh_command"]
-    assert ssh_command.startswith("sh -lc ")
+    assert ssh_command.startswith("bash -lc ")
     assert "Connecting to codex-fork-fork1001..." in ssh_command
     assert "Attach transport failed (255); retrying once..." in ssh_command
     assert "run_attach() {" in ssh_command
+    assert "stty sane" in ssh_command
     assert "attach_pid=$!" in ssh_command
+    assert "fg %1 >/dev/null 2>&1 || wait \"$attach_pid\"" in ssh_command
     assert "kill \"$attach_pid\"" in ssh_command
-    assert "pkill -P \"$attach_pid\"" in ssh_command
+    assert "pkill -P \"$attach_pid\"" not in ssh_command
     assert "ProxyCommand=cloudflared access ssh --hostname %h" in ssh_command
     assert "rajesh@ssh.sm.rajeshgo.li" in ssh_command
     assert "exec tmux attach-session -d -t \"$SM_TMUX_SESSION\"" in ssh_command


### PR DESCRIPTION
## Summary
- run the generated Termux attach ssh session in the foreground instead of backgrounding it
- keep retry and terminal cleanup behavior without killing a background interactive ssh tree
- cover the new wrapper shape in the Android API surface test

Fixes #540