### PR TITLE
Fix Termux attach exit 150 in app

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -1795,18 +1795,10 @@ def create_app(
         local_attach_script = (
             "attach_cleanup() { "
             "stty sane 2>/dev/null || true; "
-            "if [ -n \"${attach_pid:-}\" ]; then "
-            "kill \"$attach_pid\" 2>/dev/null || true; "
-            "fi; "
             "}; "
             "run_attach() { "
-            "set -m 2>/dev/null || true; "
-            f"{ssh_command} & "
-            "attach_pid=$!; "
-            "fg %1 >/dev/null 2>&1 || wait \"$attach_pid\"; "
-            "attach_status=$?; "
-            "attach_pid=''; "
-            "return \"$attach_status\"; "
+            f"{ssh_command}; "
+            "return \"$?\"; "
             "}; "
             "trap 'attach_cleanup; exit 130' INT TERM; "
             f"printf 'Connecting to {tmux_session}...\\r\\n' >/dev/tty 2>/dev/null || true; "
@@ -1828,7 +1820,7 @@ def create_app(
             "ssh_host": public_ssh_host,
             "ssh_username": ssh_username,
             "ssh_proxy_command": ssh_proxy_command or None,
-            "ssh_command": shlex.join(["bash", "-lc", local_attach_script]),
+            "ssh_command": shlex.join(["sh", "-lc", local_attach_script]),
             "tmux_session": tmux_session,
             "runtime_mode": descriptor.get("runtime_mode"),
             "termux_package": "com.termux",

--- a/tests/unit/test_android_api_surface.py
+++ b/tests/unit/test_android_api_surface.py
@@ -155,14 +155,14 @@ def test_client_sessions_include_termux_attach_metadata():
         "termux_package": "com.termux",
     }
     ssh_command = payload["termux_attach"]["ssh_command"]
-    assert ssh_command.startswith("bash -lc ")
+    assert ssh_command.startswith("sh -lc ")
     assert "Connecting to codex-fork-fork1001..." in ssh_command
     assert "Attach transport failed (255); retrying once..." in ssh_command
     assert "run_attach() {" in ssh_command
     assert "stty sane" in ssh_command
-    assert "attach_pid=$!" in ssh_command
-    assert "fg %1 >/dev/null 2>&1 || wait \"$attach_pid\"" in ssh_command
-    assert "kill \"$attach_pid\"" in ssh_command
+    assert "attach_pid=$!" not in ssh_command
+    assert "fg %1 >/dev/null 2>&1 || wait \"$attach_pid\"" not in ssh_command
+    assert "kill \"$attach_pid\"" not in ssh_command
     assert "pkill -P \"$attach_pid\"" not in ssh_command
     assert "ProxyCommand=cloudflared access ssh --hostname %h" in ssh_command
     assert "rajesh@ssh.sm.rajeshgo.li" in ssh_command


### PR DESCRIPTION
## Summary
- remove the inner Termux attach job-control wrapper and run ssh directly in the foreground again
- keep the reconnect banner, retry-on-255, and terminal cleanup behavior
- align the Android API surface regression test with the simpler wrapper

Fixes #542