### PR TITLE
Clean up orphaned Codex app Telegram topics

### DIFF
--- a/docs/product/lessons.md
+++ b/docs/product/lessons.md
@@ -17,3 +17,4 @@ Durable lessons from maintainer sessions. Read this before handling the maintain
 - List/readiness paths such as `/sessions`, `/client/sessions`, `sm all`, and `sm me` must not perform live display identity discovery or external sync. Use cached session identity there so stale tmux panes, transcript discovery, or Telegram topic drift cannot block the maintainer queue.
 - Mobile attach readiness depends on both local `sm-android-sshd` and the public cloudflared tunnel. If Termux reports `websocket: bad handshake`, check `com.rajesh.sm-android-tunnel` before debugging tmux or app code.
 - Telegram topic cleanup must treat `Topic_id_invalid` as already-cleaned remote state and tombstone the local registry record; otherwise one invalid topic can stay active and fail deletion forever.
+- Codex app Telegram topics may have no tmux session name. Cleanup must decide whether those records are routable from the live Session Manager session, not from tmux existence alone.

--- a/src/main.py
+++ b/src/main.py
@@ -650,13 +650,12 @@ class SessionManagerApp:
             else:
                 tmux_session = record.tmux_session
 
-            if provider == "codex-app":
-                skipped += 1
-                continue
-
             stale_reason = None
             if session and session.telegram_thread_id and record.thread_id != session.telegram_thread_id:
                 stale_reason = f"session now points to topic {session.telegram_thread_id}"
+            elif provider == "codex-app" and session:
+                skipped += 1
+                continue
             elif tmux_session and self.session_manager.tmux.session_exists(tmux_session):
                 skipped += 1
                 continue

--- a/tests/unit/test_telegram_topic_cleanup.py
+++ b/tests/unit/test_telegram_topic_cleanup.py
@@ -148,11 +148,23 @@ async def test_cleanup_deletes_topics_when_session_record_is_missing():
 
 
 @pytest.mark.asyncio
-async def test_cleanup_skips_em_live_tmux_non_forum_deleted_and_codex_app_topics():
+async def test_cleanup_deletes_orphaned_codex_app_topics():
+    record = _make_record("goneapp", thread_id=54321, provider="codex-app", tmux_session="")
+    app = _make_app({}, records=[record])
+
+    result = await app._cleanup_stale_telegram_topics_once()
+
+    assert result == {"deleted": 1, "skipped": 0}
+    assert record.deleted_at is not None
+    app.session_manager.mark_telegram_topic_deleted.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_skips_em_live_tmux_non_forum_deleted_and_live_codex_app_topics():
     live = _make_session("live1", thread_id=10002, tmux_session="claude-live1")
     sessions = {
         "live1": live,
-        "app1": _make_session("app1", provider="codex-app", tmux_session=""),
+        "app1": _make_session("app1", provider="codex-app", thread_id=10005, tmux_session=""),
     }
     records = [
         _make_record("em1", thread_id=10001, is_em_topic=True),
@@ -218,6 +230,22 @@ async def test_cleanup_deletes_duplicate_topic_for_live_session():
         live_tmux_sessions={"claude-live1"},
         records=[old_record, current_record],
     )
+
+    result = await app._cleanup_stale_telegram_topics_once()
+
+    assert result == {"deleted": 1, "skipped": 1}
+    assert old_record.deleted_at is not None
+    assert current_record.deleted_at is None
+    assert session.telegram_thread_id == 20002
+    app.telegram_bot.delete_forum_topic.assert_awaited_once_with(-1003506774897, 20001)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_deletes_duplicate_topic_for_live_codex_app_session():
+    session = _make_session("app1", provider="codex-app", thread_id=20002, tmux_session="")
+    old_record = _make_record("app1", provider="codex-app", thread_id=20001, tmux_session="")
+    current_record = _make_record("app1", provider="codex-app", thread_id=20002, tmux_session="")
+    app = _make_app({"app1": session}, records=[old_record, current_record])
 
     result = await app._cleanup_stale_telegram_topics_once()
 


### PR DESCRIPTION
## Summary
- follow up #560 so Telegram topic cleanup preserves live Codex app topics but deletes orphaned Codex app topic records
- add regression coverage for orphaned and duplicate Codex app topics
- record the maintainer lesson about Codex app topics not always having tmux names

## Tests
- `pytest tests/unit/test_telegram_topic_cleanup.py -q`
- `git diff --check`

Follow-up for #560.