### PR TITLE
Use non-destructive urgent delivery for Claude

### DIFF
--- a/specs/570_sm_remind_non_destructive_overdue_interrupts.md
+++ b/specs/570_sm_remind_non_destructive_overdue_interrupts.md
@@ -1,0 +1,190 @@
+# sm#570: non-destructive overdue remind handling
+
+Issue: #570
+
+## Goal
+
+When `sm remind` hits its hard threshold, avoid destructively interrupting tmux-backed Claude sessions before the overdue reminder is delivered. Also make the reminder text explicitly say the interrupt came from Session Manager, not from the user.
+
+## Observed current behavior
+
+### Source-level behavior
+
+- `src/message_queue.py` hard-remind delivery queues:
+  - `'[sm remind] Status overdue. Run: sm status "message" — if waiting on others: sm turn-complete — if done: sm task-complete'`
+  - `delivery_mode="urgent"`
+- tmux-backed urgent delivery in `src/message_queue.py` sends raw `Escape`, waits for the prompt, then injects the payload.
+- `codex-app` urgent delivery does not use tmux `Escape`; it calls the provider interrupt RPC (`turn/interrupt`) in `src/session_manager.py`.
+
+### Live behavior observed on April 14, 2026
+
+#### Claude Code v2.1.84 in tmux
+
+Disposable session probe:
+
+1. Started `claude --dangerously-skip-permissions --permission-mode bypassPermissions` in a detached tmux session.
+2. Prompted Claude to run `sleep 30` in Bash.
+3. Observed live tool state:
+   - `⏺ Bash(sleep 30)`
+   - `⎿ Running…`
+   - hint text: `(ctrl+b ctrl+b (twice) to run in background)`
+4. Injected tmux `Escape`.
+5. Result:
+   - `⎿ Interrupted · What should Claude do instead?`
+
+Second probe in the same Claude build:
+
+1. Started another `Bash(sleep 30)` run.
+2. Injected `Ctrl+B` via `tmux send-keys`.
+3. Result:
+   - `⎿ Running in the background (↓ to manage)`
+   - prompt returned immediately
+   - the task was not cancelled
+
+Follow-up probe against a real Session Manager Claude child on April 14, 2026:
+
+1. Spawned a disposable Claude child via `sm spawn claude ...`.
+2. Instructed it to run `sleep 300` in the foreground and `sm send maintainer` when the task was backgrounded.
+3. Injected a single tmux `Ctrl+B` to the child pane.
+4. Child reported:
+   - `probe result: sleep 300 backgrounded and still running`
+
+Negative probe against a second disposable Claude child:
+
+1. Spawned another Claude child running `sleep 300`.
+2. Injected `Ctrl+B b` to the child pane.
+3. Observed result in the pane:
+   - the `sleep 300` tool remained foreground
+   - a literal `b` appeared at the Claude prompt/composer
+4. `sm what` still showed the child waiting on the foreground sleep
+5. The probe child had to be terminated manually
+
+Interpretation:
+
+- Current `sm remind` hard-threshold behavior is destructive for tmux-backed Claude sessions because it uses the same raw `Escape` path as a true interrupt.
+- For tmux automation, a single injected `Ctrl+B` is sufficient.
+- We should **not** automate `Ctrl+B b`; it can leak a literal `b` into the Claude composer without backgrounding the task.
+- The Claude docs say tmux users press it twice because the first keypress is consumed by tmux as the interactive prefix. `tmux send-keys` bypasses that prefix handling and sends the control key directly to Claude.
+
+#### Codex CLI v0.120.0 in tmux
+
+Disposable session probe:
+
+1. Started `codex --no-alt-screen -a never -s danger-full-access` in a detached tmux session.
+2. Prompted Codex to run `sleep 30` in the shell.
+3. Observed live status:
+   - `• Working (3s • esc to interrupt)`
+4. Injected `Ctrl+B` once, then again.
+5. Observed no documented or visible backgrounding transition.
+6. Injected `Escape`.
+7. Result:
+   - `■ Conversation interrupted - tell the model what to do differently.`
+
+Interpretation:
+
+- Codex currently advertises `esc to interrupt`, not a background shortcut.
+- The tmux `Ctrl+B` experiment did not yield a reliable backgrounding behavior.
+- We should not reuse the Claude-specific backgrounding path for Codex.
+
+## External documentation
+
+- Claude Code interactive mode docs: `https://code.claude.com/docs/en/interactive-mode`
+- Current documented controls include:
+  - `Ctrl+B`: background running tasks
+  - note: `Tmux users press twice`
+  - `Ctrl+C`: cancel current input or generation
+
+## Chosen approach
+
+Split hard-remind delivery by provider family.
+
+### 1. tmux-backed Claude sessions: background first, then inject remind
+
+For providers that use the Claude tmux UI path, replace the hard-remind pre-injection interrupt with Claude-compatible backgrounding:
+
+1. Send exactly one `Ctrl+B` to the target tmux pane instead of `Escape`.
+2. Wait for Claude to return to a prompt-ready state.
+3. Inject the overdue reminder text as urgent/direct input.
+
+The overdue reminder text should change to something like:
+
+```text
+[sm remind] Status overdue. This interrupt came from Session Manager because your status is overdue, not from the user. Send a quick update with: sm status "message" — if waiting on others: sm turn-complete — if done: sm task-complete — then continue your prior work unless the reminder reveals a blocker.
+```
+
+Why this is the right behavior:
+
+- It preserves the running Claude task instead of cancelling it.
+- It tells the agent exactly why the prompt appeared.
+- It reduces the chance that the agent mistakes the interrupt for a user redirect and goes idle.
+
+### 2. Codex and codex-app: keep the existing interrupt path
+
+Do not apply the Claude `Ctrl+B` backgrounding path to:
+
+- `provider == "codex"`
+- `provider == "codex-app"`
+- `provider == "codex-fork"`
+
+For these providers:
+
+- keep the existing interrupt behavior
+- update the overdue reminder text to explicitly say the interrupt is from Session Manager, not the user
+
+Why:
+
+- `codex-app` does not use tmux keystroke interrupt delivery here; it uses an interrupt RPC.
+- live Codex tmux probing did not demonstrate a safe/documented `Ctrl+B` background behavior.
+- forcing an unverified keybinding into Codex adds risk without evidence.
+
+## Implementation shape
+
+### Queue / delivery logic
+
+- Introduce a provider-aware urgent remind pre-delivery path in `src/message_queue.py`.
+- Use Claude backgrounding only for tmux-backed Claude sessions.
+- Keep existing urgent delivery for all other providers.
+
+### tmux controller support
+
+- Add a small helper in `src/tmux_controller.py` for sending the Claude background key (`Ctrl+B`) so the behavior is named and testable.
+- Do not send repeated follow-up characters such as `b`; the child-agent probe showed that `Ctrl+B b` can leave stray prompt input behind.
+- Reuse the existing prompt-wait path after the keypress rather than adding a fixed sleep.
+
+### Reminder copy
+
+- Update the hard-threshold remind text in `src/message_queue.py`.
+- Keep the existing `"[sm remind]"` prefix so dedup and existing filtering continue to work.
+
+## Acceptance mapping
+
+1. For tmux-backed Claude sessions, hard-threshold remind no longer cancels a running Claude bash task before delivering the message.
+2. The Claude path sends exactly one injected `Ctrl+B`, not `Ctrl+B b`.
+3. The hard-threshold remind text explicitly states that the interrupt came from Session Manager because status is overdue, not from the user.
+4. The reminder text tells the agent to continue prior work after sending status unless blocked.
+5. Codex, codex-app, and codex-fork remain on their existing interrupt path.
+6. Existing remind dedup behavior still works because the prefix remains `"[sm remind]"`.
+
+## Tests to add during implementation
+
+- Unit test: hard remind for Claude-backed tmux session sends `Ctrl+B` instead of `Escape` before prompt wait.
+- Unit test: Claude-backed hard remind does not append a literal `b` or any extra key after the single `Ctrl+B` background key.
+- Unit test: hard remind for Codex-backed session still uses the existing urgent interrupt path.
+- Unit test: hard remind text contains `not from the user`.
+- Regression test: remind dedup still recognizes the new hard-remind text via the unchanged `"[sm remind]"` prefix.
+
+## Risks
+
+- Claude may background work only for certain active states, so prompt readiness must stay state-based rather than sleep-based.
+- If we accidentally apply the Claude path to Codex, we risk undefined provider behavior.
+- The longer reminder copy could affect tests or any code that asserts exact strings.
+
+## Mitigations
+
+- Limit the behavior change to tmux-backed Claude sessions only.
+- Reuse the existing prompt-wait flow after the background keypress.
+- Update exact-string tests together with the copy change.
+
+## Classification
+
+Single ticket.

--- a/specs/570_sm_remind_non_destructive_overdue_interrupts.md
+++ b/specs/570_sm_remind_non_destructive_overdue_interrupts.md
@@ -1,10 +1,17 @@
-# sm#570: non-destructive overdue remind handling
+# sm#570: non-destructive urgent delivery for Claude
 
 Issue: #570
 
 ## Goal
 
-When `sm remind` hits its hard threshold, avoid destructively interrupting tmux-backed Claude sessions before the overdue reminder is delivered. Also make the reminder text explicitly say the interrupt came from Session Manager, not from the user.
+Avoid destructively interrupting tmux-backed Claude sessions when Session Manager needs immediate delivery.
+
+This applies to:
+
+- `sm remind` hard-threshold overdue interrupts
+- `sm send --urgent`
+
+For overdue remind copy specifically, also make the text explicitly say the interrupt came from Session Manager, not from the user.
 
 ## Observed current behavior
 
@@ -61,7 +68,7 @@ Negative probe against a second disposable Claude child:
 
 Interpretation:
 
-- Current `sm remind` hard-threshold behavior is destructive for tmux-backed Claude sessions because it uses the same raw `Escape` path as a true interrupt.
+- Current urgent delivery is destructive for tmux-backed Claude sessions because it uses the same raw `Escape` path as a true interrupt.
 - For tmux automation, a single injected `Ctrl+B` is sufficient.
 - We should **not** automate `Ctrl+B b`; it can leak a literal `b` into the Claude composer without backgrounding the task.
 - The Claude docs say tmux users press it twice because the first keypress is consumed by tmux as the interactive prefix. `tmux send-keys` bypasses that prefix handling and sends the control key directly to Claude.
@@ -80,11 +87,21 @@ Disposable session probe:
 7. Result:
    - `■ Conversation interrupted - tell the model what to do differently.`
 
+Additional live probe against `provider="codex-fork"` on April 14, 2026:
+
+1. Spawned a disposable `codex-fork` child via `sm spawn codex-fork ...`.
+2. Instructed it to run `sleep 300` in the foreground and report if an external keypress backgrounded it.
+3. Injected `Ctrl+B`, then later a second `Ctrl+B`.
+4. Observed result:
+   - child continued reporting `sleep 300` as foreground/alive
+   - no observable background transition
+   - no child report indicating backgrounding
+
 Interpretation:
 
-- Codex currently advertises `esc to interrupt`, not a background shortcut.
-- The tmux `Ctrl+B` experiment did not yield a reliable backgrounding behavior.
-- We should not reuse the Claude-specific backgrounding path for Codex.
+- Codex and codex-fork currently advertise `esc to interrupt`, not a background shortcut.
+- The live tmux `Ctrl+B` experiment did not yield a reliable backgrounding behavior for either Codex or codex-fork.
+- We should not reuse the Claude-specific backgrounding path for Codex or codex-fork.
 
 ## External documentation
 
@@ -94,17 +111,43 @@ Interpretation:
   - note: `Tmux users press twice`
   - `Ctrl+C`: cancel current input or generation
 
+### Claude `Ctrl+B` then `Escape` urgent probe
+
+Additional live probe against a real Claude child on April 14, 2026:
+
+1. Spawned a disposable Claude child via `sm spawn claude ...`.
+2. Instructed it to run `sleep 300` in Bash in the foreground.
+3. Injected exactly one `Ctrl+B`.
+4. Confirmed from the child output that `sleep 300` moved to the background and stayed alive.
+5. Injected `Escape`.
+6. Injected a probe message asking the child to verify whether the backgrounded sleep was still alive and whether the message arrived.
+7. Child reported:
+   - `claude urgent probe result: backgrounded, sleep alive, message received`
+
+Interpretation:
+
+- For tmux-backed Claude, `Ctrl+B` followed by `Escape` is a viable urgent-delivery sequence.
+- `Ctrl+B` preserves the running task by backgrounding it.
+- Follow-up `Escape` is still useful because it gets Claude out of passive task-watching mode and reliably accepts the injected urgent message.
+
 ## Chosen approach
 
-Split hard-remind delivery by provider family.
+Split urgent delivery by provider family.
 
-### 1. tmux-backed Claude sessions: background first, then inject remind
+### 1. tmux-backed Claude sessions: background, then interrupt, then inject
 
-For providers that use the Claude tmux UI path, replace the hard-remind pre-injection interrupt with Claude-compatible backgrounding:
+For providers that use the Claude tmux UI path, replace destructive urgent delivery with this sequence:
 
-1. Send exactly one `Ctrl+B` to the target tmux pane instead of `Escape`.
-2. Wait for Claude to return to a prompt-ready state.
-3. Inject the overdue reminder text as urgent/direct input.
+1. Send exactly one `Ctrl+B` to the target tmux pane.
+2. Wait for Claude to return to a prompt-ready state with the active task backgrounded.
+3. Send `Escape`.
+4. Wait for Claude to be prompt-ready again.
+5. Inject the urgent payload.
+
+Apply this to:
+
+- hard-threshold `sm remind` delivery
+- `sm send --urgent`
 
 The overdue reminder text should change to something like:
 
@@ -115,10 +158,11 @@ The overdue reminder text should change to something like:
 Why this is the right behavior:
 
 - It preserves the running Claude task instead of cancelling it.
+- It still gets Claude’s attention after the task is backgrounded.
 - It tells the agent exactly why the prompt appeared.
 - It reduces the chance that the agent mistakes the interrupt for a user redirect and goes idle.
 
-### 2. Codex and codex-app: keep the existing interrupt path
+### 2. Codex, codex-fork, and codex-app: keep the existing interrupt path
 
 Do not apply the Claude `Ctrl+B` backgrounding path to:
 
@@ -141,9 +185,15 @@ Why:
 
 ### Queue / delivery logic
 
-- Introduce a provider-aware urgent remind pre-delivery path in `src/message_queue.py`.
-- Use Claude backgrounding only for tmux-backed Claude sessions.
-- Keep existing urgent delivery for all other providers.
+- Introduce a provider-aware urgent pre-delivery path in `src/message_queue.py`.
+- For tmux-backed Claude urgent delivery:
+  - background with a single `Ctrl+B`
+  - wait for prompt
+  - send `Escape`
+  - wait for prompt again
+  - inject the urgent payload
+- Use this path for both hard-remind urgent delivery and `sm send --urgent`.
+- Keep existing urgent delivery for codex, codex-fork, and codex-app.
 
 ### tmux controller support
 
@@ -158,24 +208,28 @@ Why:
 
 ## Acceptance mapping
 
-1. For tmux-backed Claude sessions, hard-threshold remind no longer cancels a running Claude bash task before delivering the message.
+1. For tmux-backed Claude sessions, urgent delivery no longer cancels a running Claude bash task before delivering the message.
 2. The Claude path sends exactly one injected `Ctrl+B`, not `Ctrl+B b`.
-3. The hard-threshold remind text explicitly states that the interrupt came from Session Manager because status is overdue, not from the user.
-4. The reminder text tells the agent to continue prior work after sending status unless blocked.
-5. Codex, codex-app, and codex-fork remain on their existing interrupt path.
-6. Existing remind dedup behavior still works because the prefix remains `"[sm remind]"`.
+3. The Claude path follows backgrounding with `Escape` before injecting the urgent payload.
+4. `sm send --urgent` uses the same non-destructive Claude path.
+5. The hard-threshold remind text explicitly states that the interrupt came from Session Manager because status is overdue, not from the user.
+6. The reminder text tells the agent to continue prior work after sending status unless blocked.
+7. Codex, codex-app, and codex-fork remain on their existing interrupt path.
+8. Existing remind dedup behavior still works because the prefix remains `"[sm remind]"`.
 
 ## Tests to add during implementation
 
-- Unit test: hard remind for Claude-backed tmux session sends `Ctrl+B` instead of `Escape` before prompt wait.
-- Unit test: Claude-backed hard remind does not append a literal `b` or any extra key after the single `Ctrl+B` background key.
+- Unit test: Claude-backed urgent delivery sends `Ctrl+B`, waits for prompt, sends `Escape`, waits for prompt, then injects payload.
+- Unit test: Claude-backed urgent delivery does not append a literal `b` or any extra key after the single `Ctrl+B` background key.
+- Unit test: `sm send --urgent` for Claude uses the non-destructive path.
 - Unit test: hard remind for Codex-backed session still uses the existing urgent interrupt path.
+- Unit test: hard remind for codex-fork still uses the existing urgent interrupt path.
 - Unit test: hard remind text contains `not from the user`.
 - Regression test: remind dedup still recognizes the new hard-remind text via the unchanged `"[sm remind]"` prefix.
 
 ## Risks
 
-- Claude may background work only for certain active states, so prompt readiness must stay state-based rather than sleep-based.
+- Claude may background work only for certain active states, so both post-`Ctrl+B` and post-`Escape` readiness must stay state-based rather than sleep-based.
 - If we accidentally apply the Claude path to Codex, we risk undefined provider behavior.
 - The longer reminder copy could affect tests or any code that asserts exact strings.
 

--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -1807,7 +1807,7 @@ class MessageQueueManager:
                 logger.error(f"Failed to deliver messages to {session_id}")
 
     async def _deliver_urgent(self, session_id: str, msg: QueuedMessage):
-        """Deliver an urgent message immediately, interrupting Claude."""
+        """Deliver an urgent message immediately using provider-specific interrupt behavior."""
         # Skip delivery if session is paused for recovery
         if session_id in self._paused_sessions:
             logger.debug(f"Session {session_id} paused for recovery, deferring urgent delivery")
@@ -1819,7 +1819,11 @@ class MessageQueueManager:
             return
 
         try:
-            if getattr(session, "provider", "claude") == "codex-app":
+            provider = getattr(session, "provider", None)
+            if not isinstance(provider, str) or not provider:
+                provider = "claude"
+
+            if provider == "codex-app":
                 success = await self.session_manager._deliver_urgent(session, msg.text)
                 if success:
                     self._mark_delivered(msg.id)
@@ -1891,15 +1895,34 @@ class MessageQueueManager:
                     # Wait for Claude to show prompt after wake-up (#175)
                     await self._wait_for_claude_prompt_async(session.tmux_session)
 
-                # Send Escape to interrupt any streaming (async, non-blocking)
-                proc = await asyncio.create_subprocess_exec(
-                    "tmux", "send-keys", "-t", session.tmux_session, "Escape",
-                    stdout=asyncio.subprocess.PIPE,
-                    stderr=asyncio.subprocess.PIPE,
-                )
-                await asyncio.wait_for(proc.communicate(), timeout=self.subprocess_timeout)
+                if provider == "claude":
+                    backgrounded = await self.session_manager.tmux.background_claude_task_async(
+                        session.tmux_session
+                    )
+                    if not backgrounded:
+                        logger.error(f"Failed to background Claude task for urgent delivery to {session_id}")
+                        return
 
-                # Wait for Claude to show idle prompt before sending payload (#175)
+                    # Claude may remain focused on the live task output after backgrounding.
+                    # Wait for a prompt, then interrupt that watch state before injecting.
+                    await self._wait_for_claude_prompt_async(session.tmux_session)
+
+                    proc = await asyncio.create_subprocess_exec(
+                        "tmux", "send-keys", "-t", session.tmux_session, "Escape",
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.PIPE,
+                    )
+                    await asyncio.wait_for(proc.communicate(), timeout=self.subprocess_timeout)
+                else:
+                    # Non-Claude tmux providers retain the existing interrupt behavior.
+                    proc = await asyncio.create_subprocess_exec(
+                        "tmux", "send-keys", "-t", session.tmux_session, "Escape",
+                        stdout=asyncio.subprocess.PIPE,
+                        stderr=asyncio.subprocess.PIPE,
+                    )
+                    await asyncio.wait_for(proc.communicate(), timeout=self.subprocess_timeout)
+
+                # Wait for the prompt before sending payload (#175)
                 await self._wait_for_claude_prompt_async(session.tmux_session)
 
                 # Inject message directly (use async version to avoid blocking)
@@ -2922,7 +2945,7 @@ class MessageQueueManager:
                     else:
                         self.queue_message(
                             target_session_id=target_session_id,
-                            text='[sm remind] Status overdue. Run: sm status "message" — if waiting on others: sm turn-complete — if done: sm task-complete',
+                            text='[sm remind] Status overdue. This interrupt came from Session Manager because your status is overdue, not from the user. Run: sm status "message" — if waiting on others: sm turn-complete — if done: sm task-complete — then continue your prior work unless this reminder reveals a blocker.',
                             delivery_mode="urgent",
                         )
                     # Reset cycle so it restarts

--- a/src/tmux_controller.py
+++ b/src/tmux_controller.py
@@ -673,6 +673,42 @@ class TmuxController:
             logger.error(f"Failed to send input: {e}")
             return False
 
+    async def send_key_async(self, session_name: str, key: str) -> bool:
+        """
+        Send a single key to a tmux session asynchronously.
+
+        Args:
+            session_name: Target session name
+            key: Key to send, e.g. "Escape" or "C-b"
+
+        Returns:
+            True if key sent successfully
+        """
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "tmux", "send-keys", "-t", session_name, key,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=self.send_keys_timeout_seconds
+            )
+            if proc.returncode != 0:
+                logger.error(f"Failed to send key async: {stderr.decode()}")
+                return False
+            logger.info(f"Sent key to {session_name} (async): {key}")
+            return True
+        except asyncio.TimeoutError:
+            logger.error(f"Timeout sending key {key} to {session_name}")
+            return False
+        except Exception as e:
+            logger.error(f"Failed to send key async: {e}")
+            return False
+
+    async def background_claude_task_async(self, session_name: str) -> bool:
+        """Send Claude's background-task keybinding to a tmux session."""
+        return await self.send_key_async(session_name, "C-b")
+
     def send_key(self, session_name: str, key: str) -> bool:
         """
         Send a single key to a tmux session (e.g., 'y', 'n', 'Enter').

--- a/tests/regression/test_issue_175_send_truncation.py
+++ b/tests/regression/test_issue_175_send_truncation.py
@@ -31,6 +31,7 @@ def mock_session_manager():
     manager.get_session = Mock()
     manager.tmux = Mock()
     manager.tmux.send_input_async = AsyncMock(return_value=True)
+    manager.tmux.background_claude_task_async = AsyncMock(return_value=True)
     manager._save_state = Mock()
     manager._deliver_direct = AsyncMock(return_value=True)
     return manager
@@ -105,16 +106,20 @@ class TestBugA_PromptDetectionBeforeDelivery:
         )
 
         call_order = []
-
-        # Track call order: Escape send-keys, then prompt wait, then deliver
-        original_wait = message_queue._wait_for_claude_prompt_async
+        wait_count = 0
 
         async def mock_wait(*args, **kwargs):
-            call_order.append("wait_for_prompt")
+            nonlocal wait_count
+            wait_count += 1
+            call_order.append(f"wait_for_prompt_{wait_count}")
             return True
 
         async def mock_deliver(*args, **kwargs):
             call_order.append("deliver_direct")
+            return True
+
+        async def mock_background(*args, **kwargs):
+            call_order.append("background_send")
             return True
 
         async def mock_subprocess(*args, **kwargs):
@@ -125,17 +130,22 @@ class TestBugA_PromptDetectionBeforeDelivery:
             return proc
 
         with patch("asyncio.create_subprocess_exec", side_effect=mock_subprocess):
+            mock_session_manager.tmux.background_claude_task_async = AsyncMock(side_effect=mock_background)
             message_queue._wait_for_claude_prompt_async = AsyncMock(side_effect=mock_wait)
             mock_session_manager._deliver_direct = AsyncMock(side_effect=mock_deliver)
 
             await message_queue._deliver_urgent("test-175a", msg)
 
-        # Verify order: escape first, then prompt wait, then deliver
+        # Verify order: background first, then prompt wait, escape, prompt wait, deliver
+        assert "background_send" in call_order
         assert "escape_send" in call_order
-        assert "wait_for_prompt" in call_order
+        assert "wait_for_prompt_1" in call_order
+        assert "wait_for_prompt_2" in call_order
         assert "deliver_direct" in call_order
-        assert call_order.index("escape_send") < call_order.index("wait_for_prompt")
-        assert call_order.index("wait_for_prompt") < call_order.index("deliver_direct")
+        assert call_order.index("background_send") < call_order.index("wait_for_prompt_1")
+        assert call_order.index("wait_for_prompt_1") < call_order.index("escape_send")
+        assert call_order.index("escape_send") < call_order.index("wait_for_prompt_2")
+        assert call_order.index("wait_for_prompt_2") < call_order.index("deliver_direct")
 
     @pytest.mark.asyncio
     async def test_urgent_delivery_no_longer_uses_sleep_delay(
@@ -172,6 +182,7 @@ class TestBugA_PromptDetectionBeforeDelivery:
 
         with patch("asyncio.create_subprocess_exec", side_effect=mock_subprocess), \
              patch("asyncio.sleep", side_effect=tracking_sleep):
+            mock_session_manager.tmux.background_claude_task_async = AsyncMock(return_value=True)
             message_queue._wait_for_claude_prompt_async = AsyncMock(return_value=True)
 
             await message_queue._deliver_urgent("test-175a2", msg)
@@ -467,3 +478,21 @@ class TestBugB_TwoCallSendInput:
         source = inspect.getsource(tmux_controller.send_input_async)
         assert 'text + "\\r"' not in source
         assert "payload = text" not in source
+
+    @pytest.mark.asyncio
+    async def test_background_claude_task_async_sends_single_ctrl_b(self, tmux_controller):
+        """background_claude_task_async sends exactly one Ctrl+B and no trailing key."""
+        subprocess_calls = []
+
+        async def mock_subprocess(*args, **kwargs):
+            subprocess_calls.append(args)
+            proc = AsyncMock()
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+            proc.returncode = 0
+            return proc
+
+        with patch("asyncio.create_subprocess_exec", side_effect=mock_subprocess):
+            result = await tmux_controller.background_claude_task_async("claude-test")
+
+        assert result is True
+        assert subprocess_calls == [("tmux", "send-keys", "-t", "claude-test", "C-b")]

--- a/tests/regression/test_issue_178_sm_send_regressions.py
+++ b/tests/regression/test_issue_178_sm_send_regressions.py
@@ -41,6 +41,7 @@ def mock_session_manager():
     manager.get_session = Mock()
     manager.tmux = Mock()
     manager.tmux.send_input_async = AsyncMock(return_value=True)
+    manager.tmux.background_claude_task_async = AsyncMock(return_value=True)
     manager._save_state = Mock()
     manager._deliver_direct = AsyncMock(return_value=True)
     return manager

--- a/tests/regression/test_issue_37_blocking_io.py
+++ b/tests/regression/test_issue_37_blocking_io.py
@@ -323,9 +323,11 @@ async def test_deliver_urgent_uses_async_escape():
     mock_session_manager = Mock()
     mock_session = Mock()
     mock_session.tmux_session = "tmux-test"
+    mock_session.provider = "claude"
     mock_session_manager.get_session = Mock(return_value=mock_session)
     mock_session_manager.tmux = Mock()
     mock_session_manager.tmux.send_input_async = AsyncMock(return_value=True)
+    mock_session_manager.tmux.background_claude_task_async = AsyncMock(return_value=True)
 
     manager = MessageQueueManager(
         session_manager=mock_session_manager,
@@ -367,9 +369,11 @@ async def test_message_queue_no_blocking_in_delivery_path():
     mock_session_manager = Mock()
     mock_session = Mock()
     mock_session.tmux_session = "tmux-test"
+    mock_session.provider = "claude"
     mock_session_manager.get_session = Mock(return_value=mock_session)
     mock_session_manager.tmux = Mock()
     mock_session_manager.tmux.send_input_async = AsyncMock(return_value=True)
+    mock_session_manager.tmux.background_claude_task_async = AsyncMock(return_value=True)
 
     manager = MessageQueueManager(
         session_manager=mock_session_manager,

--- a/tests/regression/test_issue_88_urgent_completed.py
+++ b/tests/regression/test_issue_88_urgent_completed.py
@@ -22,6 +22,7 @@ def mock_session_manager():
     manager.get_session = Mock()
     manager.tmux = Mock()
     manager.tmux.send_input_async = AsyncMock(return_value=True)
+    manager.tmux.background_claude_task_async = AsyncMock(return_value=True)
     manager._save_state = Mock()
     manager._deliver_direct = AsyncMock(return_value=True)
     return manager
@@ -102,7 +103,9 @@ async def test_urgent_delivery_to_completed_session_wakes_up_first(
     assert first_call[3] == "claude-test-123"
     assert first_call[4] == "Enter"
 
-    # Second call should be Escape (to interrupt)
+    mock_session_manager.tmux.background_claude_task_async.assert_awaited_once_with("claude-test-123")
+
+    # Second subprocess call should be Escape (after Claude backgrounding)
     second_call = subprocess_calls[1]
     assert second_call[0] == "tmux"
     assert second_call[1] == "send-keys"
@@ -155,7 +158,9 @@ async def test_urgent_delivery_to_running_session_no_wake_up(
     # Verify subprocess calls - should NOT start with wake-up Enter
     assert len(subprocess_calls) >= 1
 
-    # First call should be Escape (NOT Enter)
+    mock_session_manager.tmux.background_claude_task_async.assert_awaited_once_with("claude-test-456")
+
+    # First subprocess call should be Escape (wake-up Enter is not used)
     first_call = subprocess_calls[0]
     assert first_call[0] == "tmux"
     assert first_call[1] == "send-keys"
@@ -208,6 +213,8 @@ async def test_urgent_delivery_to_error_session_no_wake_up(
     # Verify subprocess calls - should NOT start with wake-up Enter
     assert len(subprocess_calls) >= 1
 
+    mock_session_manager.tmux.background_claude_task_async.assert_awaited_once_with("claude-test-error")
+
     # First call should be Escape (NOT Enter)
     first_call = subprocess_calls[0]
     assert first_call[4] == "Escape"
@@ -257,9 +264,51 @@ async def test_urgent_delivery_to_abandoned_session_no_wake_up(
     # Verify subprocess calls - should NOT start with wake-up Enter
     assert len(subprocess_calls) >= 1
 
+    mock_session_manager.tmux.background_claude_task_async.assert_awaited_once_with("claude-test-abandoned")
+
     # First call should be Escape (NOT Enter)
     first_call = subprocess_calls[0]
     assert first_call[4] == "Escape"
+
+
+@pytest.mark.asyncio
+async def test_urgent_delivery_to_codex_fork_session_keeps_escape_path(
+    message_queue, mock_session_manager
+):
+    """codex-fork urgent delivery keeps the existing Escape path."""
+    session = Session(
+        id="test-fork",
+        name="test-session",
+        working_dir="/tmp/test",
+        tmux_session="codex-fork-test",
+        provider="codex-fork",
+        completion_status=None,
+        friendly_name="fork-agent",
+    )
+    mock_session_manager.get_session.return_value = session
+
+    msg = QueuedMessage(
+        id="msg-fork",
+        target_session_id="test-fork",
+        text="urgent task",
+        delivery_mode="urgent",
+    )
+
+    subprocess_calls = []
+
+    async def mock_subprocess(*args, **kwargs):
+        subprocess_calls.append(args)
+        proc = AsyncMock()
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        proc.returncode = 0
+        return proc
+
+    with patch("asyncio.create_subprocess_exec", side_effect=mock_subprocess):
+        message_queue._wait_for_claude_prompt_async = AsyncMock(return_value=True)
+        await message_queue._deliver_urgent("test-fork", msg)
+
+    mock_session_manager.tmux.background_claude_task_async.assert_not_awaited()
+    assert subprocess_calls[0][4] == "Escape"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_message_queue.py
+++ b/tests/unit/test_message_queue.py
@@ -47,6 +47,7 @@ def mock_session_manager():
     mock.get_session = MagicMock(return_value=None)
     mock.tmux = MagicMock()
     mock.tmux.send_input_async = AsyncMock(return_value=True)
+    mock.tmux.background_claude_task_async = AsyncMock(return_value=True)
     mock._save_state = MagicMock()
     mock._deliver_direct = AsyncMock(return_value=True)
     return mock

--- a/tests/unit/test_remind.py
+++ b/tests/unit/test_remind.py
@@ -46,6 +46,7 @@ def mock_session_manager():
     mock.get_session = MagicMock(return_value=None)
     mock.tmux = MagicMock()
     mock.tmux.send_input_async = AsyncMock(return_value=True)
+    mock.tmux.background_claude_task_async = AsyncMock(return_value=True)
     mock._save_state = MagicMock()
     mock._deliver_direct = AsyncMock(return_value=True)
     return mock

--- a/tests/unit/test_task_complete.py
+++ b/tests/unit/test_task_complete.py
@@ -312,6 +312,7 @@ class TestRemindMessageIncludesTaskCompleteHint:
         # Both soft and hard messages should have the hint
         assert source.count("sm task-complete") >= 2
         assert source.count("sm turn-complete") >= 2
+        assert "not from the user" in source
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Use a non-destructive urgent-delivery path for tmux-backed Claude sessions.

This changes urgent Claude delivery to:
- send `Ctrl+B` once to background the active task
- wait for the prompt
- send `Escape`
- wait for the prompt again
- inject the urgent payload

The same Claude-only path now applies to both `sm send --urgent` and hard-threshold `sm remind` delivery. The overdue remind copy now explicitly says the interrupt came from Session Manager, not the user.

## Spec Reference
- `specs/570_sm_remind_non_destructive_overdue_interrupts.md`

## Test Plan
- [x] `./venv/bin/python -m pytest tests/regression/test_issue_175_send_truncation.py tests/regression/test_issue_88_urgent_completed.py tests/regression/test_issue_37_blocking_io.py tests/unit/test_task_complete.py tests/unit/test_remind.py -q`
- [x] `./venv/bin/python -m pytest tests/regression/test_issue_178_sm_send_regressions.py tests/unit/test_message_queue.py -q`
- [x] `./venv/bin/python -m pytest tests/ -q` (fails in unrelated areas reproduced on `origin/main`; tracked in #571)

Fixes #570
