### PR TITLE
Fix sm restore exit code after successful noninteractive restore

### DIFF
--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -2129,6 +2129,12 @@ def cmd_restore(client: SessionManagerClient, target_identifier: str) -> int:
     if provider == "codex-app":
         print("No tmux attach for Codex app sessions.")
         return 0
+    if not sys.stdin.isatty() or not sys.stdout.isatty():
+        print(
+            f"Automatic attach skipped: current shell is not interactive. "
+            f"Run `sm attach {target_session_id}` from an interactive terminal."
+        )
+        return 0
     return cmd_attach(client, target_session_id)
 
 

--- a/tests/unit/test_cmd_restore.py
+++ b/tests/unit/test_cmd_restore.py
@@ -39,6 +39,8 @@ def test_cmd_restore_attaches_to_tmux_session(monkeypatch, capsys):
         calls.append((args, check))
 
     monkeypatch.setattr("subprocess.run", _fake_run)
+    monkeypatch.setattr(commands.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(commands.sys.stdout, "isatty", lambda: True)
 
     session = {"id": "dead123", "friendly_name": "engineer-ticket2508", "status": "stopped"}
     restored = {
@@ -53,6 +55,26 @@ def test_cmd_restore_attaches_to_tmux_session(monkeypatch, capsys):
     assert calls == [(["tmux", "attach", "-t", "claude-dead123"], True)]
     stdout = capsys.readouterr().out
     assert "Session restored: dead123" in stdout
+
+
+def test_cmd_restore_skips_attach_without_interactive_terminal(monkeypatch, capsys):
+    monkeypatch.setattr(commands.sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(commands.sys.stdout, "isatty", lambda: False)
+
+    session = {"id": "deadtty", "friendly_name": "review-tty", "status": "stopped"}
+    restored = {
+        "id": "deadtty",
+        "provider": "codex-fork",
+        "tmux_session": "codex-fork-deadtty",
+    }
+
+    rc = commands.cmd_restore(_RestoreClient(session, restored), "review-tty")
+
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    assert "Session restored: deadtty" in stdout
+    assert "Automatic attach skipped: current shell is not interactive." in stdout
+    assert "sm attach deadtty" in stdout
 
 
 def test_cmd_restore_codex_app_is_headless(capsys):


### PR DESCRIPTION
## Summary
- treat successful restore as success even when the caller shell cannot support immediate tmux attach
- keep the existing auto-attach behavior for interactive terminals
- add regression coverage for the non-interactive restore path

## Test Plan
- [x] `./venv/bin/python -m pytest tests/unit/test_cmd_restore.py -v`
- [x] manual repro: kill and restore a real stopped `codex-fork` session from a non-interactive shell; restore now exits 0 and prints manual attach guidance

Fixes #574
