### PR TITLE
Clean up small queue regressions and stale test fixtures

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -1814,6 +1814,7 @@ def create_app(
         ssh_args = ["ssh"]
         if ssh_proxy_command:
             ssh_args.extend(["-o", f"ProxyCommand={ssh_proxy_command}"])
+        ssh_args.extend(["-o", "StrictHostKeyChecking=accept-new"])
         remote_attach_script = (
             "PATH=/opt/homebrew/bin:/usr/local/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/bin:/bin:$PATH; "
             "export PATH; "
@@ -2685,12 +2686,12 @@ def create_app(
             cursor = conn.cursor()
 
             # Count total pending
-            cursor.execute("SELECT COUNT(*) FROM messages WHERE delivered_at IS NULL")
+            cursor.execute("SELECT COUNT(*) FROM message_queue WHERE delivered_at IS NULL")
             pending_count = cursor.fetchone()[0]
 
             # Count stuck messages (queued > 1 hour ago and not delivered)
             cursor.execute("""
-                SELECT COUNT(*) FROM messages
+                SELECT COUNT(*) FROM message_queue
                 WHERE delivered_at IS NULL
                 AND datetime(queued_at) < datetime('now', '-1 hour')
             """)
@@ -2698,7 +2699,7 @@ def create_app(
 
             # Count expired messages still in queue
             cursor.execute("""
-                SELECT COUNT(*) FROM messages
+                SELECT COUNT(*) FROM message_queue
                 WHERE delivered_at IS NULL
                 AND timeout_at IS NOT NULL
                 AND datetime(timeout_at) < datetime('now')

--- a/tests/regression/test_issue_102_telegram_cleanup.py
+++ b/tests/regression/test_issue_102_telegram_cleanup.py
@@ -80,6 +80,7 @@ async def test_cleanup_accesses_correct_telegram_attribute(output_monitor, mock_
         message=f"Session stopped [{mock_session.id}]",
         thread_id=67890,
         allow_reply_fallback=False,
+        session_id=mock_session.id,
     )
 
 

--- a/tests/regression/test_issue_200_telegram_thread_cleanup.py
+++ b/tests/regression/test_issue_200_telegram_thread_cleanup.py
@@ -135,6 +135,8 @@ async def test_cleanup_kill_forum_mode(output_monitor_factory, forum_session):
         chat_id=chat_id,
         message=f"Session stopped [{forum_session.id}]",
         thread_id=thread_id,
+        allow_reply_fallback=True,
+        session_id=forum_session.id,
     )
 
     # close_forum_topic called because forum send succeeded
@@ -168,6 +170,8 @@ async def test_cleanup_kill_reply_thread_mode(output_monitor_factory, reply_sess
         chat_id=chat_id,
         message=f"Session stopped [{reply_session.id}]",
         thread_id=thread_id,
+        allow_reply_fallback=True,
+        session_id=reply_session.id,
     )
 
     # close_forum_topic NOT called (forum send failed, send_with_fallback returned None)
@@ -246,6 +250,8 @@ async def test_cleanup_notification_failure_still_cleans_mappings(
         chat_id=chat_id,
         message=f"Session stopped [{forum_session.id}]",
         thread_id=thread_id,
+        allow_reply_fallback=False,
+        session_id=forum_session.id,
     )
 
     # Mappings cleaned up despite notification failure
@@ -299,6 +305,7 @@ def test_clear_sends_notification_forum_mode(forum_session):
         chat_id=chat_id,
         message=f"Context cleared [{forum_session.id}] — ready for new task",
         thread_id=thread_id,
+        session_id=forum_session.id,
     )
 
 
@@ -319,6 +326,7 @@ def test_clear_sends_notification_reply_thread_mode(reply_session):
         chat_id=chat_id,
         message=f"Context cleared [{reply_session.id}] — ready for new task",
         thread_id=thread_id,
+        session_id=reply_session.id,
     )
 
 

--- a/tests/regression/test_issue_271_telegram_thread_cleanup.py
+++ b/tests/regression/test_issue_271_telegram_thread_cleanup.py
@@ -111,6 +111,8 @@ async def test_close_session_topic_sends_message_and_closes_forum_topic():
         chat_id=chat_id,
         message=f"Session completed [{session.id}]: Work done",
         thread_id=thread_id,
+        allow_reply_fallback=False,
+        session_id=session.id,
     )
 
     # Forum topic closed via bot

--- a/tests/unit/test_android_analytics_api.py
+++ b/tests/unit/test_android_analytics_api.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
 
 from fastapi.testclient import TestClient
@@ -27,15 +28,23 @@ def test_client_analytics_summary_reports_live_metrics():
         temp_root = Path(temp_dir)
         message_queue_db = temp_root / "message_queue.db"
         server_log = temp_root / "session-manager.log"
+        now = datetime.now(UTC)
+        start_time = now - timedelta(hours=2)
+        spawn_a = now - timedelta(hours=1, minutes=50)
+        self_heal = now - timedelta(hours=1, minutes=40)
+        spawn_b = now - timedelta(hours=50)
+        send_a = now - timedelta(hours=1, minutes=30)
+        send_b = now - timedelta(minutes=30)
+        track_send = now - timedelta(minutes=15)
 
         message_queue_db.write_bytes(b"")
         server_log.write_text(
             "\n".join(
                 [
-                    "2026-03-30 10:00:00,000 - __main__ - INFO - Starting Claude Session Manager...",
-                    "2026-03-30 10:10:00,000 - src.session_manager - INFO - Created session claude-11111111 (id=11111111)",
-                    "2026-03-30 10:20:00,000 - src.infra_supervisor - WARNING - Recovered android attach sshd via launchctl (bootstrap, kickstart)",
-                    "2026-03-30 11:10:00,000 - src.session_manager - INFO - Created session codex-fork-22222222 (id=22222222)",
+                    f"{start_time.strftime('%Y-%m-%d %H:%M:%S')},000 - __main__ - INFO - Starting Claude Session Manager...",
+                    f"{spawn_a.strftime('%Y-%m-%d %H:%M:%S')},000 - src.session_manager - INFO - Created session claude-11111111 (id=11111111)",
+                    f"{self_heal.strftime('%Y-%m-%d %H:%M:%S')},000 - src.infra_supervisor - WARNING - Recovered android attach sshd via launchctl (bootstrap, kickstart)",
+                    f"{spawn_b.strftime('%Y-%m-%d %H:%M:%S')},000 - src.session_manager - INFO - Created session codex-fork-22222222 (id=22222222)",
                 ]
             )
         )
@@ -84,19 +93,28 @@ def test_client_analytics_summary_reports_live_metrics():
                 INSERT INTO message_queue
                 (id, target_session_id, text, queued_at, message_category, from_sm_send)
                 VALUES
-                ('m1', '11111111', 'msg', '2026-03-30T10:30:00+00:00', NULL, 1),
-                ('m2', '11111111', 'msg', '2026-03-30T11:30:00+00:00', NULL, 1),
-                ('m3', '22222222', 'track', '2026-03-30T11:45:00+00:00', 'track_remind', 0)
+                ('m1', '11111111', 'msg', ?, NULL, 1),
+                ('m2', '11111111', 'msg', ?, NULL, 1),
+                ('m3', '22222222', 'track', ?, 'track_remind', 0)
                 """
+                ,
+                (send_a.isoformat(), send_b.isoformat(), track_send.isoformat()),
             )
             conn.execute(
                 """
                 INSERT INTO remind_registrations
                 (id, target_session_id, soft_threshold_seconds, hard_threshold_seconds, registered_at, last_reset_at, soft_fired, is_active, cancel_on_reply_session_id)
                 VALUES
-                ('r1', '11111111', 300, 600, '2026-03-30T10:00:00+00:00', '2026-03-30T10:00:00+00:00', 1, 1, 'owner-1'),
-                ('r2', '22222222', 300, 600, '2026-03-30T10:00:00+00:00', '2026-03-30T10:00:00+00:00', 0, 1, 'owner-2')
+                ('r1', '11111111', 300, 600, ?, ?, 1, 1, 'owner-1'),
+                ('r2', '22222222', 300, 600, ?, ?, 0, 1, 'owner-2')
                 """
+                ,
+                (
+                    start_time.isoformat(),
+                    start_time.isoformat(),
+                    start_time.isoformat(),
+                    start_time.isoformat(),
+                ),
             )
             conn.commit()
 
@@ -133,7 +151,7 @@ def test_client_analytics_summary_reports_live_metrics():
         payload = response.json()
         assert payload["kpis"]["active_sessions"]["value"] == 2
         assert payload["kpis"]["sends_24h"]["value"] == 2
-        assert payload["kpis"]["spawns_24h"]["value"] == 2
+        assert payload["kpis"]["spawns_24h"]["value"] == 1
         assert payload["kpis"]["active_tracks"]["value"] == 2
         assert payload["kpis"]["overdue_tracks"]["value"] == 1
         assert payload["totals"]["tokens_live"] == 2000

--- a/tests/unit/test_android_api_surface.py
+++ b/tests/unit/test_android_api_surface.py
@@ -165,6 +165,7 @@ def test_client_sessions_include_termux_attach_metadata():
     assert "kill \"$attach_pid\"" not in ssh_command
     assert "pkill -P \"$attach_pid\"" not in ssh_command
     assert "ProxyCommand=cloudflared access ssh --hostname %h" in ssh_command
+    assert "StrictHostKeyChecking=accept-new" in ssh_command
     assert "rajesh@ssh.sm.rajeshgo.li" in ssh_command
     assert "exec tmux attach-session -d -t \"$SM_TMUX_SESSION\"" in ssh_command
     assert payload["primary_action"] == {

--- a/tests/unit/test_codex_fork_control_client.py
+++ b/tests/unit/test_codex_fork_control_client.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import tempfile
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
@@ -21,61 +23,63 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.mark.asyncio
 async def test_deliver_direct_uses_control_socket_primary_path(tmp_path):
-    manager = SessionManager(log_dir=str(tmp_path), state_file=str(tmp_path / "state.json"))
-    session = Session(
-        id="cfctl1",
-        name="codex-fork-cfctl1",
-        working_dir=str(tmp_path),
-        provider="codex-fork",
-        status=SessionStatus.RUNNING,
-    )
-    manager.sessions[session.id] = session
-    manager.tmux.send_input_async = AsyncMock(return_value=True)
+    with tempfile.TemporaryDirectory(dir="/tmp", prefix="cfctl-") as short_dir:
+        short_root = Path(short_dir)
+        manager = SessionManager(log_dir=str(short_root), state_file=str(short_root / "state.json"))
+        session = Session(
+            id="cfctl1",
+            name="codex-fork-cfctl1",
+            working_dir=str(short_root),
+            provider="codex-fork",
+            status=SessionStatus.RUNNING,
+        )
+        manager.sessions[session.id] = session
+        manager.tmux.send_input_async = AsyncMock(return_value=True)
 
-    socket_path = manager._codex_fork_control_socket_path(session)
-    if socket_path.exists():
-        socket_path.unlink()
-
-    seen_commands: list[str] = []
-
-    async def handle_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
-        raw = await reader.readline()
-        request = json.loads(raw.decode("utf-8"))
-        seen_commands.append(request["command"])
-        if request["command"] == "get_epoch":
-            response = {
-                "request_id": request["request_id"],
-                "ok": True,
-                "epoch": "epoch-1",
-                "result": {"epoch": "epoch-1"},
-            }
-        else:
-            assert request["command"] == "submit_message"
-            assert request["expected_epoch"] == "epoch-1"
-            assert request["message"] == "hello world"
-            response = {
-                "request_id": request["request_id"],
-                "ok": True,
-                "epoch": "epoch-1",
-                "result": {"status": "accepted"},
-            }
-        writer.write((json.dumps(response) + "\n").encode("utf-8"))
-        await writer.drain()
-        writer.close()
-        await writer.wait_closed()
-
-    server = await asyncio.start_unix_server(handle_client, path=str(socket_path))
-    try:
-        success = await manager._deliver_direct(session, "hello world")
-        assert success is True
-        assert seen_commands == ["get_epoch", "submit_message"]
-        manager.tmux.send_input_async.assert_not_called()
-        assert session.error_message is None
-    finally:
-        server.close()
-        await server.wait_closed()
+        socket_path = manager._codex_fork_control_socket_path(session)
         if socket_path.exists():
             socket_path.unlink()
+
+        seen_commands: list[str] = []
+
+        async def handle_client(reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+            raw = await reader.readline()
+            request = json.loads(raw.decode("utf-8"))
+            seen_commands.append(request["command"])
+            if request["command"] == "get_epoch":
+                response = {
+                    "request_id": request["request_id"],
+                    "ok": True,
+                    "epoch": "epoch-1",
+                    "result": {"epoch": "epoch-1"},
+                }
+            else:
+                assert request["command"] == "submit_message"
+                assert request["expected_epoch"] == "epoch-1"
+                assert request["message"] == "hello world"
+                response = {
+                    "request_id": request["request_id"],
+                    "ok": True,
+                    "epoch": "epoch-1",
+                    "result": {"status": "accepted"},
+                }
+            writer.write((json.dumps(response) + "\n").encode("utf-8"))
+            await writer.drain()
+            writer.close()
+            await writer.wait_closed()
+
+        server = await asyncio.start_unix_server(handle_client, path=str(socket_path))
+        try:
+            success = await manager._deliver_direct(session, "hello world")
+            assert success is True
+            assert seen_commands == ["get_epoch", "submit_message"]
+            manager.tmux.send_input_async.assert_not_called()
+            assert session.error_message is None
+        finally:
+            server.close()
+            await server.wait_closed()
+            if socket_path.exists():
+                socket_path.unlink()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_context_monitor.py
+++ b/tests/unit/test_context_monitor.py
@@ -868,7 +868,7 @@ class TestCompactionSuppressRemind:
         session._is_compacting = True
         _post_event(client, session.id, event="compaction_complete")
         queue_mgr = mock_session_manager.message_queue_manager
-        queue_mgr.reset_remind.assert_called_once_with(session.id)
+        queue_mgr.reset_remind.assert_called_once_with(session.id, force_tracked=True)
 
     def test_compaction_complete_returns_logged_status(self, client, session):
         """compaction_complete returns compaction_complete_logged status."""

--- a/tests/unit/test_health_check.py
+++ b/tests/unit/test_health_check.py
@@ -9,6 +9,7 @@ Verifies all health check components:
 """
 
 import json
+import sqlite3
 import tempfile
 from datetime import datetime
 from pathlib import Path
@@ -301,6 +302,54 @@ class TestMessageQueueCheck:
 
         assert data["checks"]["message_queue"]["status"] == "warning"
         assert data["checks"]["message_queue"]["details"]["db_exists"] is False
+
+    def test_message_queue_uses_message_queue_table(self, mock_session_manager, mock_output_monitor, mock_child_monitor, mock_notifier):
+        """Health check reads the real message_queue table, not a legacy messages table."""
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            db_path = Path(f.name)
+
+        try:
+            with sqlite3.connect(str(db_path)) as conn:
+                conn.executescript(
+                    """
+                    CREATE TABLE message_queue (
+                        id TEXT PRIMARY KEY,
+                        target_session_id TEXT NOT NULL,
+                        sender_session_id TEXT,
+                        sender_name TEXT,
+                        text TEXT NOT NULL,
+                        delivery_mode TEXT DEFAULT 'sequential',
+                        queued_at TIMESTAMP NOT NULL,
+                        timeout_at TIMESTAMP,
+                        notify_on_delivery INTEGER DEFAULT 0,
+                        notify_after_seconds INTEGER,
+                        delivered_at TIMESTAMP
+                    );
+                    INSERT INTO message_queue (id, target_session_id, text, queued_at, delivered_at)
+                    VALUES ('msg-1', 'sess-1', 'hello', datetime('now', '-2 hours'), NULL);
+                    """
+                )
+
+            mock_mq = MagicMock()
+            mock_mq.db_path = db_path
+            mock_session_manager.message_queue_manager = mock_mq
+
+            app = create_app(
+                session_manager=mock_session_manager,
+                notifier=mock_notifier,
+                output_monitor=mock_output_monitor,
+                child_monitor=mock_child_monitor,
+            )
+            client = TestClient(app)
+
+            response = client.get("/health/detailed")
+            data = response.json()
+
+            assert data["checks"]["message_queue"]["status"] == "warning"
+            assert data["checks"]["message_queue"]["details"]["pending"] == 1
+            assert data["checks"]["message_queue"]["details"]["stuck"] == 1
+        finally:
+            db_path.unlink(missing_ok=True)
 
 
 class TestTelegramCheck:

--- a/tests/unit/test_role_tracking.py
+++ b/tests/unit/test_role_tracking.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import tempfile
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -58,6 +58,8 @@ async def test_send_input_detects_role_when_unset():
     queue_mgr = Mock()
     queue_mgr.delivery_states = {}
     queue_mgr.queue_message = Mock()
+    queue_mgr.deliver_queued_message_now = AsyncMock(return_value=True)
+    queue_mgr.queue_message.return_value = Mock(id="msg-1")
     manager.message_queue_manager = queue_mgr
 
     result = await manager.send_input(session.id, "As engineer, implement ticket 287.")
@@ -77,6 +79,8 @@ async def test_send_input_does_not_override_existing_role():
     queue_mgr = Mock()
     queue_mgr.delivery_states = {}
     queue_mgr.queue_message = Mock()
+    queue_mgr.deliver_queued_message_now = AsyncMock(return_value=True)
+    queue_mgr.queue_message.return_value = Mock(id="msg-2")
     manager.message_queue_manager = queue_mgr
 
     result = await manager.send_input(session.id, "As engineer, implement ticket 287.")


### PR DESCRIPTION
## Summary
- fix `/health/detailed` to read the real `message_queue` table
- add `StrictHostKeyChecking=accept-new` to Termux attach SSH commands
- update stale tests and fixtures to match current behavior and current time assumptions

## Test Plan
- [x] `./venv/bin/python -m pytest tests/unit/test_health_check.py tests/unit/test_android_api_surface.py tests/unit/test_codex_fork_control_client.py tests/unit/test_android_analytics_api.py tests/unit/test_context_monitor.py tests/unit/test_role_tracking.py tests/regression/test_issue_102_telegram_cleanup.py tests/regression/test_issue_200_telegram_thread_cleanup.py tests/regression/test_issue_271_telegram_thread_cleanup.py -q`

Fixes #556
Fixes #551
Fixes #536
Fixes #501
Fixes #495
Fixes #494
Fixes #485
