### PR TITLE
Track codex-fork release sync and build maintenance state

### DIFF
--- a/specs/546_codex_fork_release_sync_mechanism.md
+++ b/specs/546_codex_fork_release_sync_mechanism.md
@@ -1,0 +1,72 @@
+# sm#546: Codex-fork release sync/build mechanism
+
+## Scope
+
+Give Session Manager maintainers one repeatable way to decide when the `rajeshgoli/codex` fork needs a sync/build pass because upstream `openai/codex` shipped a new release.
+
+The trigger should be upstream release movement, not raw branch divergence alone. Divergence is still useful context, but maintainers should not be rebasing the fork every time upstream moves.
+
+## Maintainer Signals
+
+Use `sm codex-fork-info` as the operator check.
+
+The command now reports:
+
+1. Current fork context:
+   - fork repo root
+   - current branch
+   - fork head
+   - upstream head
+   - ahead/behind divergence
+2. Binary freshness:
+   - local release binary mtime
+   - current fork HEAD commit time
+   - whether the binary predates the fork HEAD
+   - whether the binary predates the latest upstream release publish time
+3. Release trigger:
+   - latest upstream release tag, publish time, and commit
+   - whether the fork already contains that release commit
+   - `sync_recommended` only when the fork does not yet contain the latest upstream release
+4. Action paths:
+   - local release build script path
+   - this maintainer spec path
+
+## Repeatable Workflow
+
+1. Check the state:
+
+```bash
+sm codex-fork-info
+sm codex-fork-info --json
+```
+
+2. If `sync_recommended: True`, perform the upstream sync in the fork worktree:
+
+```bash
+cd /Users/rajesh/worktrees/codex-fork
+git fetch upstream main --tags
+```
+
+Then follow the fork sync playbook in:
+
+- `https://github.com/rajeshgoli/codex/blob/main/docs/session_manager_fork_strategy.md`
+
+3. If `build_recommended: True`, rebuild/publish artifacts intentionally from this repo:
+
+```bash
+scripts/codex_fork/release_artifacts.sh <codex_repo_path> <artifact_release> <artifact_ref> [github_repo]
+```
+
+The build/publish contract is also recorded in:
+
+- `specs/324_codex_fork_artifact_distribution_pinning_rollback.md`
+
+4. After a successful sync/build pass, update any needed Session Manager pin/config state and restart Session Manager before relying on the new artifact.
+
+## Acceptance Intent
+
+This mechanism is working when a maintainer can answer all of these from one place:
+
+1. Has upstream shipped a new Codex release that the fork does not contain yet?
+2. Is the local codex binary older than the fork source or the latest upstream release?
+3. What documented/scripted path should I use next?

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -2518,6 +2518,11 @@ def cmd_codex_fork_info(client: SessionManagerClient, json_output: bool = False)
         print("Error: Failed to fetch codex-fork runtime metadata (endpoint unavailable or incompatible)", file=sys.stderr)
         return 1
 
+    maintenance = _collect_codex_fork_maintenance_info(payload)
+    if maintenance:
+        payload = dict(payload)
+        payload["maintenance"] = maintenance
+
     if json_output:
         print(json_lib.dumps(payload, indent=2))
         return 0
@@ -2542,7 +2547,181 @@ def cmd_codex_fork_info(client: SessionManagerClient, json_output: bool = False)
     print(f"- artifact_platforms: {platforms}")
     print(f"- rollback_provider: {rollback_provider}")
     print(f"- rollback_command: {rollback_command}")
+    if maintenance:
+        print("Codex-fork maintenance status")
+        repo_root = maintenance.get("repo_root")
+        if repo_root:
+            print(f"- repo_root: {repo_root}")
+        branch = maintenance.get("branch")
+        if branch:
+            print(f"- branch: {branch}")
+        fork_head = maintenance.get("fork_head")
+        upstream_head = maintenance.get("upstream_head")
+        if fork_head:
+            print(f"- fork_head: {fork_head}")
+        if upstream_head:
+            print(f"- upstream_head: {upstream_head}")
+        ahead = maintenance.get("divergence_ahead")
+        behind = maintenance.get("divergence_behind")
+        if ahead is not None and behind is not None:
+            print(f"- divergence: ahead {ahead} / behind {behind}")
+        binary_mtime = maintenance.get("binary_mtime")
+        if binary_mtime:
+            print(f"- binary_mtime: {binary_mtime}")
+        release_tag = maintenance.get("latest_upstream_release_tag")
+        release_published_at = maintenance.get("latest_upstream_release_published_at")
+        if release_tag:
+            release_line = release_tag
+            if release_published_at:
+                release_line = f"{release_line} ({release_published_at})"
+            print(f"- latest_upstream_release: {release_line}")
+        release_commit = maintenance.get("latest_upstream_release_commit")
+        if release_commit:
+            print(f"- latest_upstream_release_commit: {release_commit}")
+        if "fork_contains_latest_upstream_release" in maintenance:
+            print(
+                f"- fork_contains_latest_upstream_release: "
+                f"{maintenance.get('fork_contains_latest_upstream_release')}"
+            )
+        print(f"- sync_recommended: {maintenance.get('sync_recommended', False)}")
+        for reason in maintenance.get("sync_reasons", []):
+            print(f"  reason: {reason}")
     return 0
+
+
+def _collect_codex_fork_maintenance_info(runtime_payload: dict) -> dict[str, object]:
+    """Best-effort local maintenance metadata for the codex-fork checkout."""
+    import json
+
+    command = str(runtime_payload.get("command") or "").strip()
+    if not command:
+        return {}
+
+    binary_path = Path(command).expanduser()
+    repo_root = _find_git_repo_root(binary_path)
+    if repo_root is None:
+        return {
+            "binary_path": str(binary_path),
+            "binary_exists": binary_path.exists(),
+            "sync_recommended": False,
+            "sync_reasons": [],
+        }
+
+    info: dict[str, object] = {
+        "binary_path": str(binary_path),
+        "binary_exists": binary_path.exists(),
+        "repo_root": str(repo_root),
+        "sync_recommended": False,
+        "sync_reasons": [],
+    }
+    reasons: list[str] = []
+    if binary_path.exists():
+        info["binary_mtime"] = datetime.fromtimestamp(binary_path.stat().st_mtime).isoformat(timespec="seconds")
+
+    branch = _run_text_command(["git", "-C", str(repo_root), "rev-parse", "--abbrev-ref", "HEAD"])
+    if branch:
+        info["branch"] = branch
+
+    fork_head = _run_text_command(["git", "-C", str(repo_root), "rev-parse", "--short", "HEAD"])
+    if fork_head:
+        info["fork_head"] = fork_head
+
+    fetch_rc = _run_command(["git", "-C", str(repo_root), "fetch", "upstream", "main", "--tags", "--quiet"])
+    if fetch_rc == 0:
+        upstream_head = _run_text_command(["git", "-C", str(repo_root), "rev-parse", "--short", "upstream/main"])
+        divergence = _run_text_command(["git", "-C", str(repo_root), "rev-list", "--left-right", "--count", "HEAD...upstream/main"])
+        if upstream_head:
+            info["upstream_head"] = upstream_head
+        if divergence:
+            parts = divergence.split()
+            if len(parts) == 2 and all(part.isdigit() for part in parts):
+                ahead, behind = (int(parts[0]), int(parts[1]))
+                info["divergence_ahead"] = ahead
+                info["divergence_behind"] = behind
+    else:
+        info["upstream_fetch_status"] = "unavailable"
+
+    release_raw = _run_text_command(
+        [
+            "gh",
+            "release",
+            "view",
+            "-R",
+            "openai/codex",
+            "--json",
+            "tagName,publishedAt,name",
+        ]
+    )
+    if release_raw:
+        try:
+            release_payload = json.loads(release_raw)
+        except Exception:
+            release_payload = {}
+        release_tag = str(release_payload.get("tagName") or "").strip()
+        release_published_at = str(release_payload.get("publishedAt") or "").strip()
+        if release_tag:
+            info["latest_upstream_release_tag"] = release_tag
+        if release_published_at:
+            info["latest_upstream_release_published_at"] = release_published_at
+        if fetch_rc == 0 and release_tag:
+            release_commit = _run_text_command(
+                ["git", "-C", str(repo_root), "rev-list", "-n", "1", f"refs/tags/{release_tag}"]
+            )
+            if release_commit:
+                info["latest_upstream_release_commit"] = release_commit
+                contains_release = _run_command(
+                    ["git", "-C", str(repo_root), "merge-base", "--is-ancestor", release_commit, "HEAD"]
+                )
+                if contains_release is not None:
+                    info["fork_contains_latest_upstream_release"] = contains_release == 0
+                    if contains_release != 0:
+                        reasons.append(f"fork does not yet contain upstream release {release_tag}")
+
+    info["sync_recommended"] = bool(reasons)
+    info["sync_reasons"] = reasons
+    return info
+
+
+def _find_git_repo_root(path: Path) -> Optional[Path]:
+    """Walk upward from a file path until a git repo root is found."""
+    candidate = path.expanduser().resolve()
+    if candidate.is_file():
+        candidate = candidate.parent
+    for current in [candidate, *candidate.parents]:
+        if (current / ".git").exists():
+            return current
+    return None
+
+
+def _run_command(args: list[str]) -> Optional[int]:
+    """Run one subprocess and return its exit code, or None when unavailable."""
+    try:
+        result = subprocess.run(
+            args,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, OSError):
+        return None
+    return result.returncode
+
+
+def _run_text_command(args: list[str]) -> Optional[str]:
+    """Run one subprocess and return stripped stdout on success."""
+    try:
+        result = subprocess.run(
+            args,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    output = result.stdout.strip()
+    return output or None
 
 
 def cmd_codex_rollout_gates(client: SessionManagerClient, json_output: bool = False) -> int:

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import shutil
 import sqlite3
 import subprocess
 import sys
@@ -2555,6 +2556,12 @@ def cmd_codex_fork_info(client: SessionManagerClient, json_output: bool = False)
         branch = maintenance.get("branch")
         if branch:
             print(f"- branch: {branch}")
+        maintenance_probe_status = maintenance.get("maintenance_probe_status")
+        if maintenance_probe_status:
+            print(f"- maintenance_probe_status: {maintenance_probe_status}")
+        maintenance_probe_reason = maintenance.get("maintenance_probe_reason")
+        if maintenance_probe_reason:
+            print(f"- maintenance_probe_reason: {maintenance_probe_reason}")
         fork_head = maintenance.get("fork_head")
         upstream_head = maintenance.get("upstream_head")
         if fork_head:
@@ -2616,11 +2623,24 @@ def _collect_codex_fork_maintenance_info(runtime_payload: dict) -> dict[str, obj
     if not command:
         return {}
 
-    binary_path = Path(command).expanduser()
+    binary_path = _resolve_runtime_binary_path(command)
+    binary_path_display = str(binary_path) if binary_path is not None else command
+    if binary_path is None:
+        return {
+            "binary_path": binary_path_display,
+            "binary_exists": False,
+            "maintenance_probe_status": "skipped",
+            "maintenance_probe_reason": "runtime command is not a filesystem path and could not be resolved via PATH",
+            "build_recommended": False,
+            "build_reasons": [],
+            "sync_recommended": False,
+            "sync_reasons": [],
+        }
+
     repo_root = _find_git_repo_root(binary_path)
     if repo_root is None:
         return {
-            "binary_path": str(binary_path),
+            "binary_path": binary_path_display,
             "binary_exists": binary_path.exists(),
             "build_recommended": not binary_path.exists(),
             "build_reasons": ["local codex binary is missing"] if not binary_path.exists() else [],
@@ -2632,7 +2652,7 @@ def _collect_codex_fork_maintenance_info(runtime_payload: dict) -> dict[str, obj
     release_build_script = checkout_root / "scripts" / "codex_fork" / "release_artifacts.sh"
     maintenance_spec = checkout_root / "specs" / "546_codex_fork_release_sync_mechanism.md"
     info: dict[str, object] = {
-        "binary_path": str(binary_path),
+        "binary_path": binary_path_display,
         "binary_exists": binary_path.exists(),
         "repo_root": str(repo_root),
         "build_recommended": False,
@@ -2775,6 +2795,19 @@ def _run_text_command(args: list[str]) -> Optional[str]:
         return None
     output = result.stdout.strip()
     return output or None
+
+
+def _resolve_runtime_binary_path(command: str) -> Optional[Path]:
+    """Resolve one runtime command into a local binary path when safe."""
+    command = (command or "").strip()
+    if not command:
+        return None
+    if os.path.sep in command or (os.path.altsep and os.path.altsep in command) or command.startswith("~"):
+        return Path(command).expanduser()
+    resolved = shutil.which(command)
+    if not resolved:
+        return None
+    return Path(resolved)
 
 
 def _parse_iso_datetime(value: Optional[str]) -> Optional[datetime]:

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -6,7 +6,7 @@ import sqlite3
 import subprocess
 import sys
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -2568,6 +2568,11 @@ def cmd_codex_fork_info(client: SessionManagerClient, json_output: bool = False)
         binary_mtime = maintenance.get("binary_mtime")
         if binary_mtime:
             print(f"- binary_mtime: {binary_mtime}")
+        head_commit_committed_at = maintenance.get("head_commit_committed_at")
+        if head_commit_committed_at:
+            print(f"- head_commit_committed_at: {head_commit_committed_at}")
+        if "binary_older_than_fork_head" in maintenance:
+            print(f"- binary_older_than_fork_head: {maintenance.get('binary_older_than_fork_head')}")
         release_tag = maintenance.get("latest_upstream_release_tag")
         release_published_at = maintenance.get("latest_upstream_release_published_at")
         if release_tag:
@@ -2575,6 +2580,11 @@ def cmd_codex_fork_info(client: SessionManagerClient, json_output: bool = False)
             if release_published_at:
                 release_line = f"{release_line} ({release_published_at})"
             print(f"- latest_upstream_release: {release_line}")
+        if "latest_upstream_release_newer_than_binary" in maintenance:
+            print(
+                f"- latest_upstream_release_newer_than_binary: "
+                f"{maintenance.get('latest_upstream_release_newer_than_binary')}"
+            )
         release_commit = maintenance.get("latest_upstream_release_commit")
         if release_commit:
             print(f"- latest_upstream_release_commit: {release_commit}")
@@ -2583,9 +2593,18 @@ def cmd_codex_fork_info(client: SessionManagerClient, json_output: bool = False)
                 f"- fork_contains_latest_upstream_release: "
                 f"{maintenance.get('fork_contains_latest_upstream_release')}"
             )
+        release_build_script = maintenance.get("release_build_script")
+        if release_build_script:
+            print(f"- release_build_script: {release_build_script}")
+        maintenance_spec = maintenance.get("maintenance_spec")
+        if maintenance_spec:
+            print(f"- maintenance_spec: {maintenance_spec}")
+        print(f"- build_recommended: {maintenance.get('build_recommended', False)}")
+        for reason in maintenance.get("build_reasons", []):
+            print(f"  build_reason: {reason}")
         print(f"- sync_recommended: {maintenance.get('sync_recommended', False)}")
         for reason in maintenance.get("sync_reasons", []):
-            print(f"  reason: {reason}")
+            print(f"  sync_reason: {reason}")
     return 0
 
 
@@ -2603,20 +2622,36 @@ def _collect_codex_fork_maintenance_info(runtime_payload: dict) -> dict[str, obj
         return {
             "binary_path": str(binary_path),
             "binary_exists": binary_path.exists(),
+            "build_recommended": not binary_path.exists(),
+            "build_reasons": ["local codex binary is missing"] if not binary_path.exists() else [],
             "sync_recommended": False,
             "sync_reasons": [],
         }
 
+    checkout_root = Path(__file__).resolve().parents[2]
+    release_build_script = checkout_root / "scripts" / "codex_fork" / "release_artifacts.sh"
+    maintenance_spec = checkout_root / "specs" / "546_codex_fork_release_sync_mechanism.md"
     info: dict[str, object] = {
         "binary_path": str(binary_path),
         "binary_exists": binary_path.exists(),
         "repo_root": str(repo_root),
+        "build_recommended": False,
+        "build_reasons": [],
         "sync_recommended": False,
         "sync_reasons": [],
     }
-    reasons: list[str] = []
+    build_reasons: list[str] = []
+    sync_reasons: list[str] = []
+    binary_mtime_dt: Optional[datetime] = None
     if binary_path.exists():
-        info["binary_mtime"] = datetime.fromtimestamp(binary_path.stat().st_mtime).isoformat(timespec="seconds")
+        binary_mtime_dt = datetime.fromtimestamp(binary_path.stat().st_mtime, tz=timezone.utc)
+        info["binary_mtime"] = binary_mtime_dt.isoformat(timespec="seconds").replace("+00:00", "Z")
+    else:
+        build_reasons.append("local codex binary is missing")
+    if release_build_script.exists():
+        info["release_build_script"] = str(release_build_script)
+    if maintenance_spec.exists():
+        info["maintenance_spec"] = str(maintenance_spec)
 
     branch = _run_text_command(["git", "-C", str(repo_root), "rev-parse", "--abbrev-ref", "HEAD"])
     if branch:
@@ -2625,6 +2660,15 @@ def _collect_codex_fork_maintenance_info(runtime_payload: dict) -> dict[str, obj
     fork_head = _run_text_command(["git", "-C", str(repo_root), "rev-parse", "--short", "HEAD"])
     if fork_head:
         info["fork_head"] = fork_head
+    head_commit_committed_at = _run_text_command(["git", "-C", str(repo_root), "log", "-1", "--format=%cI", "HEAD"])
+    head_commit_dt = _parse_iso_datetime(head_commit_committed_at)
+    if head_commit_committed_at:
+        info["head_commit_committed_at"] = head_commit_committed_at
+    if binary_mtime_dt and head_commit_dt is not None:
+        binary_older_than_fork_head = binary_mtime_dt < head_commit_dt
+        info["binary_older_than_fork_head"] = binary_older_than_fork_head
+        if binary_older_than_fork_head:
+            build_reasons.append("local codex binary predates the current fork HEAD commit")
 
     fetch_rc = _run_command(["git", "-C", str(repo_root), "fetch", "upstream", "main", "--tags", "--quiet"])
     if fetch_rc == 0:
@@ -2675,10 +2719,19 @@ def _collect_codex_fork_maintenance_info(runtime_payload: dict) -> dict[str, obj
                 if contains_release is not None:
                     info["fork_contains_latest_upstream_release"] = contains_release == 0
                     if contains_release != 0:
-                        reasons.append(f"fork does not yet contain upstream release {release_tag}")
+                        sync_reasons.append(f"fork does not yet contain upstream release {release_tag}")
+        if binary_mtime_dt and release_tag:
+            release_published_dt = _parse_iso_datetime(release_published_at)
+            if release_published_dt is not None:
+                release_newer_than_binary = release_published_dt > binary_mtime_dt
+                info["latest_upstream_release_newer_than_binary"] = release_newer_than_binary
+                if release_newer_than_binary:
+                    build_reasons.append(f"local codex binary predates upstream release {release_tag}")
 
-    info["sync_recommended"] = bool(reasons)
-    info["sync_reasons"] = reasons
+    info["build_recommended"] = bool(build_reasons)
+    info["build_reasons"] = build_reasons
+    info["sync_recommended"] = bool(sync_reasons)
+    info["sync_reasons"] = sync_reasons
     return info
 
 
@@ -2722,6 +2775,19 @@ def _run_text_command(args: list[str]) -> Optional[str]:
         return None
     output = result.stdout.strip()
     return output or None
+
+
+def _parse_iso_datetime(value: Optional[str]) -> Optional[datetime]:
+    """Parse one ISO timestamp, including GitHub's Z suffix."""
+    if not value:
+        return None
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
 
 
 def cmd_codex_rollout_gates(client: SessionManagerClient, json_output: bool = False) -> int:

--- a/tests/unit/test_cmd_codex_fork_info.py
+++ b/tests/unit/test_cmd_codex_fork_info.py
@@ -1,3 +1,5 @@
+import os
+
 from src.cli import commands
 
 
@@ -33,10 +35,21 @@ def test_cmd_codex_fork_info_text_output(monkeypatch, capsys):
         "upstream_head": "up123",
         "divergence_ahead": 10,
         "divergence_behind": 1226,
+        "binary_mtime": "2026-04-01T10:00:00Z",
+        "head_commit_committed_at": "2026-04-10T09:00:00+00:00",
+        "binary_older_than_fork_head": True,
         "latest_upstream_release_tag": "rust-v0.120.0",
         "latest_upstream_release_published_at": "2026-04-11T02:53:49Z",
+        "latest_upstream_release_newer_than_binary": True,
         "latest_upstream_release_commit": "96254a763",
         "fork_contains_latest_upstream_release": False,
+        "release_build_script": "/repo/scripts/codex_fork/release_artifacts.sh",
+        "maintenance_spec": "/repo/specs/546_codex_fork_release_sync_mechanism.md",
+        "build_recommended": True,
+        "build_reasons": [
+            "local codex binary predates the current fork HEAD commit",
+            "local codex binary predates upstream release rust-v0.120.0",
+        ],
         "sync_recommended": True,
         "sync_reasons": ["fork does not yet contain upstream release rust-v0.120.0"],
     })
@@ -46,9 +59,13 @@ def test_cmd_codex_fork_info_text_output(monkeypatch, capsys):
     assert "Codex-fork runtime metadata" in output
     assert "artifact_ref: abc123" in output
     assert "event_schema_version: 2" in output
+    assert "binary_older_than_fork_head: True" in output
     assert "latest_upstream_release: rust-v0.120.0 (2026-04-11T02:53:49Z)" in output
+    assert "latest_upstream_release_newer_than_binary: True" in output
+    assert "build_recommended: True" in output
+    assert "build_reason: local codex binary predates the current fork HEAD commit" in output
     assert "fork_contains_latest_upstream_release: False" in output
-    assert "reason: fork does not yet contain upstream release rust-v0.120.0" in output
+    assert "sync_reason: fork does not yet contain upstream release rust-v0.120.0" in output
 
 
 def test_cmd_codex_fork_info_json_output(monkeypatch, capsys):
@@ -87,6 +104,8 @@ def test_collect_codex_fork_maintenance_info_tracks_latest_release(monkeypatch, 
     binary_path = repo_root / "codex-rs" / "target" / "release" / "codex"
     binary_path.parent.mkdir(parents=True)
     binary_path.write_text("binary")
+    old_timestamp = 1_775_000_000
+    os.utime(binary_path, (old_timestamp, old_timestamp))
 
     def _fake_run_text(args):
         cmd = " ".join(args)
@@ -94,6 +113,8 @@ def test_collect_codex_fork_maintenance_info_tracks_latest_release(monkeypatch, 
             return "main"
         if "rev-parse --short HEAD" in cmd:
             return "fork123"
+        if "log -1 --format=%cI HEAD" in cmd:
+            return "2026-04-10T09:00:00+00:00"
         if "rev-parse --short upstream/main" in cmd:
             return "up456"
         if "rev-list --left-right --count HEAD...upstream/main" in cmd:
@@ -119,6 +140,11 @@ def test_collect_codex_fork_maintenance_info_tracks_latest_release(monkeypatch, 
 
     assert info["latest_upstream_release_tag"] == "rust-v0.120.0"
     assert info["latest_upstream_release_commit"] == "releasecommit"
+    assert info["binary_older_than_fork_head"] is True
+    assert info["latest_upstream_release_newer_than_binary"] is True
+    assert info["build_recommended"] is True
+    assert info["release_build_script"].endswith("scripts/codex_fork/release_artifacts.sh")
+    assert info["maintenance_spec"].endswith("specs/546_codex_fork_release_sync_mechanism.md")
     assert info["fork_contains_latest_upstream_release"] is False
     assert info["sync_recommended"] is True
     assert info["sync_reasons"] == ["fork does not yet contain upstream release rust-v0.120.0"]

--- a/tests/unit/test_cmd_codex_fork_info.py
+++ b/tests/unit/test_cmd_codex_fork_info.py
@@ -13,7 +13,7 @@ class _FakeClient:
         return self._rollout
 
 
-def test_cmd_codex_fork_info_text_output(capsys):
+def test_cmd_codex_fork_info_text_output(monkeypatch, capsys):
     client = _FakeClient(
         runtime={
             "command": "codex",
@@ -27,15 +27,31 @@ def test_cmd_codex_fork_info_text_output(capsys):
             "rollback_command": "sm codex-legacy",
         }
     )
+    monkeypatch.setattr(commands, "_collect_codex_fork_maintenance_info", lambda payload: {
+        "repo_root": "/tmp/codex-fork",
+        "fork_head": "fork123",
+        "upstream_head": "up123",
+        "divergence_ahead": 10,
+        "divergence_behind": 1226,
+        "latest_upstream_release_tag": "rust-v0.120.0",
+        "latest_upstream_release_published_at": "2026-04-11T02:53:49Z",
+        "latest_upstream_release_commit": "96254a763",
+        "fork_contains_latest_upstream_release": False,
+        "sync_recommended": True,
+        "sync_reasons": ["fork does not yet contain upstream release rust-v0.120.0"],
+    })
     rc = commands.cmd_codex_fork_info(client)
     assert rc == 0
     output = capsys.readouterr().out
     assert "Codex-fork runtime metadata" in output
     assert "artifact_ref: abc123" in output
     assert "event_schema_version: 2" in output
+    assert "latest_upstream_release: rust-v0.120.0 (2026-04-11T02:53:49Z)" in output
+    assert "fork_contains_latest_upstream_release: False" in output
+    assert "reason: fork does not yet contain upstream release rust-v0.120.0" in output
 
 
-def test_cmd_codex_fork_info_json_output(capsys):
+def test_cmd_codex_fork_info_json_output(monkeypatch, capsys):
     client = _FakeClient(
         runtime={
             "artifact_ref": "abc123",
@@ -43,10 +59,18 @@ def test_cmd_codex_fork_info_json_output(capsys):
             "is_pinned": True,
         }
     )
+    monkeypatch.setattr(commands, "_collect_codex_fork_maintenance_info", lambda payload: {
+        "latest_upstream_release_tag": "rust-v0.120.0",
+        "fork_contains_latest_upstream_release": True,
+        "sync_recommended": False,
+        "sync_reasons": [],
+    })
     rc = commands.cmd_codex_fork_info(client, json_output=True)
     assert rc == 0
     output = capsys.readouterr().out
     assert "\"artifact_ref\": \"abc123\"" in output
+    assert "\"maintenance\"" in output
+    assert "\"latest_upstream_release_tag\": \"rust-v0.120.0\"" in output
 
 
 def test_cmd_codex_fork_info_unavailable(capsys):
@@ -54,3 +78,47 @@ def test_cmd_codex_fork_info_unavailable(capsys):
     rc = commands.cmd_codex_fork_info(client)
     assert rc == 1
     assert "endpoint unavailable or incompatible" in capsys.readouterr().err
+
+
+def test_collect_codex_fork_maintenance_info_tracks_latest_release(monkeypatch, tmp_path):
+    repo_root = tmp_path / "codex-fork"
+    repo_root.mkdir()
+    (repo_root / ".git").write_text("")
+    binary_path = repo_root / "codex-rs" / "target" / "release" / "codex"
+    binary_path.parent.mkdir(parents=True)
+    binary_path.write_text("binary")
+
+    def _fake_run_text(args):
+        cmd = " ".join(args)
+        if "rev-parse --abbrev-ref HEAD" in cmd:
+            return "main"
+        if "rev-parse --short HEAD" in cmd:
+            return "fork123"
+        if "rev-parse --short upstream/main" in cmd:
+            return "up456"
+        if "rev-list --left-right --count HEAD...upstream/main" in cmd:
+            return "10\t1226"
+        if "gh release view" in cmd:
+            return '{"tagName":"rust-v0.120.0","publishedAt":"2026-04-11T02:53:49Z"}'
+        if "rev-list -n 1 refs/tags/rust-v0.120.0" in cmd:
+            return "releasecommit"
+        return None
+
+    def _fake_run(args):
+        cmd = " ".join(args)
+        if "fetch upstream main --tags --quiet" in cmd:
+            return 0
+        if "merge-base --is-ancestor releasecommit HEAD" in cmd:
+            return 1
+        return 0
+
+    monkeypatch.setattr(commands, "_run_text_command", _fake_run_text)
+    monkeypatch.setattr(commands, "_run_command", _fake_run)
+
+    info = commands._collect_codex_fork_maintenance_info({"command": str(binary_path)})
+
+    assert info["latest_upstream_release_tag"] == "rust-v0.120.0"
+    assert info["latest_upstream_release_commit"] == "releasecommit"
+    assert info["fork_contains_latest_upstream_release"] is False
+    assert info["sync_recommended"] is True
+    assert info["sync_reasons"] == ["fork does not yet contain upstream release rust-v0.120.0"]

--- a/tests/unit/test_cmd_codex_fork_info.py
+++ b/tests/unit/test_cmd_codex_fork_info.py
@@ -90,11 +90,46 @@ def test_cmd_codex_fork_info_json_output(monkeypatch, capsys):
     assert "\"latest_upstream_release_tag\": \"rust-v0.120.0\"" in output
 
 
+def test_cmd_codex_fork_info_reports_probe_skip(monkeypatch, capsys):
+    client = _FakeClient(
+        runtime={
+            "command": "codex",
+            "artifact_ref": "abc123",
+            "event_schema_version": 2,
+        }
+    )
+    monkeypatch.setattr(commands, "_collect_codex_fork_maintenance_info", lambda payload: {
+        "binary_path": "codex",
+        "binary_exists": False,
+        "maintenance_probe_status": "skipped",
+        "maintenance_probe_reason": "runtime command is not a filesystem path and could not be resolved via PATH",
+        "build_recommended": False,
+        "build_reasons": [],
+        "sync_recommended": False,
+        "sync_reasons": [],
+    })
+    rc = commands.cmd_codex_fork_info(client)
+    assert rc == 0
+    output = capsys.readouterr().out
+    assert "maintenance_probe_status: skipped" in output
+    assert "maintenance_probe_reason: runtime command is not a filesystem path" in output
+
+
 def test_cmd_codex_fork_info_unavailable(capsys):
     client = _FakeClient(runtime=None, rollout=None)
     rc = commands.cmd_codex_fork_info(client)
     assert rc == 1
     assert "endpoint unavailable or incompatible" in capsys.readouterr().err
+
+
+def test_collect_codex_fork_maintenance_info_skips_unresolved_bare_command(monkeypatch):
+    monkeypatch.setattr(commands, "_resolve_runtime_binary_path", lambda command: None)
+
+    info = commands._collect_codex_fork_maintenance_info({"command": "codex"})
+
+    assert info["maintenance_probe_status"] == "skipped"
+    assert info["build_recommended"] is False
+    assert info["sync_recommended"] is False
 
 
 def test_collect_codex_fork_maintenance_info_tracks_latest_release(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- extend `sm codex-fork-info` with release-triggered maintenance signals for the local codex-fork checkout
- surface whether the local binary is older than the fork HEAD or the latest upstream Codex release
- add a local maintainer spec that points to the repeatable sync/build path for `#546`

## Test Plan
- [x] `./venv/bin/python -m pytest tests/unit/test_cmd_codex_fork_info.py -q`
- [x] `sm codex-fork-info`
- [x] `sm codex-fork-info --json`

Fixes #546
