### PR TITLE
Prefer codex-fork for maintainer bootstrap

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -224,6 +224,7 @@ service_roles:
     working_dir: "/path/to/session-manager"
     friendly_name: "maintainer"
     preferred_providers:
+      - "codex-fork"
       - "codex"
       - "claude"
     bootstrap_prompt_file: "docs/product/maintainer_bootstrap.md"

--- a/docs/product/lessons.md
+++ b/docs/product/lessons.md
@@ -6,7 +6,7 @@ Durable lessons from maintainer sessions. Read this before handling the maintain
 
 - Claude Code UI forks can create a new Session Manager session ID while continuing in the same tmux runtime. When that happens, inherited recurring reminders need to be self-identifying so the active fork can cancel them directly.
 - The repo already supports generic file-driven service-role bootstrap via `service_roles.<role>.bootstrap_prompt_file` in `config.yaml`. Prefer that path over hard-coded prompt text when workflow instructions need to evolve.
-- The maintainer role should prefer the `codex` provider by default. Keep the file-backed `service_roles.maintainer.preferred_providers` entry and the legacy maintainer fallback defaults aligned.
+- The maintainer role should prefer `codex-fork`, then `codex`, then `claude` by default. Keep the file-backed `service_roles.maintainer.preferred_providers` entry and the legacy maintainer fallback defaults aligned.
 - The local PR review workflow doc lives at `~/.agent-os/workflows/pr_review_process.md`. Use that file for the Codex review / merge loop.
 - Maintainer work is not done at PR creation. It is done only after review feedback is handled, the PR is merged, Session Manager is restarted on merged code, and the reporting agent has been notified of the fix.
 - Use the reporting agent for missing repro/debug details sparingly. Ask only for specific facts you cannot recover from the running system or repository state.

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -193,12 +193,12 @@ class SessionManager:
         self.maintainer_friendly_name = str(
             maintainer_config.get("friendly_name", "sm-maintainer")
         ).strip() or "sm-maintainer"
-        preferred_providers = maintainer_config.get("preferred_providers", ["codex", "claude"])
+        preferred_providers = maintainer_config.get("preferred_providers", ["codex-fork", "codex", "claude"])
         if isinstance(preferred_providers, list):
             normalized_providers = [str(provider).strip() for provider in preferred_providers if str(provider).strip()]
         else:
-            normalized_providers = ["codex", "claude"]
-        self.maintainer_preferred_providers = normalized_providers or ["codex", "claude"]
+            normalized_providers = ["codex-fork", "codex", "claude"]
+        self.maintainer_preferred_providers = normalized_providers or ["codex-fork", "codex", "claude"]
         raw_bootstrap_prompt = maintainer_config.get(
             "bootstrap_prompt",
             DEFAULT_MAINTAINER_BOOTSTRAP_PROMPT,

--- a/tests/unit/test_maintainer_alias.py
+++ b/tests/unit/test_maintainer_alias.py
@@ -132,7 +132,7 @@ def test_cmd_maintainer_clear(capsys):
     assert "cleared" in capsys.readouterr().out
 
 
-def test_ensure_maintainer_session_prefers_codex_and_registers_alias(tmp_path):
+def test_ensure_maintainer_session_prefers_codex_fork_and_registers_alias(tmp_path):
     repo_dir = tmp_path / "repo"
     repo_dir.mkdir()
     manager = _manager(tmp_path)
@@ -158,7 +158,7 @@ def test_ensure_maintainer_session_prefers_codex_and_registers_alias(tmp_path):
 
     assert created is True
     assert session.id == "maint001"
-    assert session.provider == "codex"
+    assert session.provider == "codex-fork"
     assert session.role == "maintainer"
     assert session.auto_bootstrapped_role == "maintainer"
     assert manager.lookup_agent_registration("maintainer").session_id == session.id
@@ -172,10 +172,11 @@ def test_maintainer_legacy_fallback_defaults_task_complete_ttl(tmp_path):
     spec = manager.get_service_role_bootstrap_spec("maintainer")
 
     assert spec is not None
+    assert spec["preferred_providers"] == ["codex-fork", "codex", "claude"]
     assert spec["task_complete_ttl_seconds"] == 600
 
 
-def test_ensure_maintainer_session_falls_back_to_claude(tmp_path):
+def test_ensure_maintainer_session_falls_back_to_codex_when_fork_unavailable(tmp_path):
     repo_dir = tmp_path / "repo"
     repo_dir.mkdir()
     manager = _manager(tmp_path)
@@ -193,7 +194,35 @@ def test_ensure_maintainer_session_falls_back_to_claude(tmp_path):
         manager.sessions[session.id] = session
         return session
 
-    manager._provider_entrypoint_available = Mock(side_effect=lambda provider: provider != "codex")
+    manager._provider_entrypoint_available = Mock(side_effect=lambda provider: provider != "codex-fork")
+    manager._create_session_common = AsyncMock(side_effect=_fake_create_session_common)
+
+    session, created = asyncio.run(manager.ensure_maintainer_session())
+
+    assert created is True
+    assert session.provider == "codex"
+    manager._create_session_common.assert_awaited_once()
+
+
+def test_ensure_maintainer_session_falls_back_to_claude_when_codex_and_fork_unavailable(tmp_path):
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+    manager = _manager(tmp_path)
+    manager.maintainer_working_dir = str(repo_dir)
+
+    async def _fake_create_session_common(**kwargs):
+        session = Session(
+            id="maint005",
+            working_dir=kwargs["working_dir"],
+            provider=kwargs["provider"],
+            friendly_name=kwargs["friendly_name"],
+            log_file=str(tmp_path / "maint005.log"),
+            status=SessionStatus.RUNNING,
+        )
+        manager.sessions[session.id] = session
+        return session
+
+    manager._provider_entrypoint_available = Mock(side_effect=lambda provider: provider == "claude")
     manager._create_session_common = AsyncMock(side_effect=_fake_create_session_common)
 
     session, created = asyncio.run(manager.ensure_maintainer_session())
@@ -232,7 +261,7 @@ def test_post_ensure_maintainer_bootstraps_session(tmp_path):
     assert payload["created"] is True
     assert payload["session"]["id"] == "maint003"
     assert payload["session"]["aliases"] == ["maintainer"]
-    assert payload["session"]["provider"] == "codex"
+    assert payload["session"]["provider"] == "codex-fork"
 
 
 def test_maintainer_fallback_uses_bootstrap_prompt_file(tmp_path):
@@ -393,8 +422,8 @@ def test_cmd_send_bootstraps_maintainer_when_missing(capsys):
             "session": {
                 "id": "maint004",
                 "friendly_name": "sm-maintainer",
-                "name": "codex-maint004",
-                "provider": "codex",
+                "name": "codex-fork-maint004",
+                "provider": "codex-fork",
             },
         },
     }
@@ -407,7 +436,7 @@ def test_cmd_send_bootstraps_maintainer_when_missing(capsys):
     client.send_input.assert_called_once()
     assert client.send_input.call_args[0][0] == "maint004"
     output = capsys.readouterr().out
-    assert "Role bootstrapped: maintainer -> sm-maintainer (maint004) [codex]" in output
+    assert "Role bootstrapped: maintainer -> sm-maintainer (maint004) [codex-fork]" in output
     assert "Input sent to sm-maintainer (maint004)" in output
 
 


### PR DESCRIPTION
Fixes #583

## Summary
- change the legacy maintainer bootstrap defaults to prefer `codex-fork`, then `codex`, then `claude`
- align the maintained example config and lessons doc with that provider order
- update maintainer bootstrap tests to cover the new fallback chain

## Verification
- `python -m pytest tests/unit/test_maintainer_alias.py -q`
- one-off bootstrap probe now reports `provider=codex-fork` and `preferred=["codex-fork", "codex", "claude"]`
