### PR TITLE
Fix busy Codex sm send deferred submit

### DIFF
--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -3970,7 +3970,11 @@ class SessionManager:
                 return False
 
             logger.warning("Falling back to tmux input path for codex-fork session %s", session.id)
-            fallback_success = await self.tmux.send_input_async(session.tmux_session, text)
+            fallback_success = await self.tmux.send_input_async(
+                session.tmux_session,
+                text,
+                verify_codex_submit=True,
+            )
             if fallback_success and self.message_queue_manager:
                 self.message_queue_manager.mark_session_active(session.id)
             return fallback_success
@@ -3979,6 +3983,7 @@ class SessionManager:
             session.tmux_session,
             text,
             verify_claude_submit=(session.provider == "claude"),
+            verify_codex_submit=(session.provider == "codex"),
         )
         if success and self.message_queue_manager:
             self.message_queue_manager.mark_session_active(session.id)

--- a/src/tmux_controller.py
+++ b/src/tmux_controller.py
@@ -249,6 +249,26 @@ class TmuxController:
         lowered = pane_text.lower()
         return "submitted after next tool call" in lowered
 
+    def _extract_active_codex_region(self, pane_text: Optional[str]) -> Optional[str]:
+        """Return the active bottom-of-pane Codex region near the live prompt/banner."""
+        if not pane_text:
+            return None
+
+        lines = pane_text.splitlines()
+        if not lines:
+            return None
+
+        prompt_indexes = [index for index, line in enumerate(lines) if line.lstrip().startswith("›")]
+        if prompt_indexes:
+            prompt_index = prompt_indexes[-1]
+            start = max(0, prompt_index - 8)
+            end = min(len(lines), prompt_index + 4)
+            region = "\n".join(lines[start:end]).strip()
+            return region or None
+
+        region = "\n".join(lines[-16:]).strip()
+        return region or None
+
     def _normalize_for_compare(self, text: str) -> str:
         """Collapse whitespace for approximate pane-vs-payload comparison."""
         return " ".join((text or "").split())
@@ -312,9 +332,10 @@ class TmuxController:
 
         async def _capture_deferred_payload() -> bool:
             pane = await self._capture_pane_async(session_name)
-            if not self._looks_like_codex_deferred_send_banner(pane):
+            active_region = self._extract_active_codex_region(pane)
+            if not self._looks_like_codex_deferred_send_banner(active_region):
                 return False
-            normalized_pane = self._normalize_for_compare(pane or "")
+            normalized_pane = self._normalize_for_compare(active_region or "")
             return normalized_preview in normalized_pane
 
         await asyncio.sleep(self.submit_verify_seconds)

--- a/src/tmux_controller.py
+++ b/src/tmux_controller.py
@@ -242,6 +242,13 @@ class TmuxController:
         lowered = composer_text.lower()
         return "queued messages" in lowered or "queued message" in lowered
 
+    def _looks_like_codex_deferred_send_banner(self, pane_text: Optional[str]) -> bool:
+        """Return True when Codex parked a message behind its deferred-send banner."""
+        if not pane_text:
+            return False
+        lowered = pane_text.lower()
+        return "submitted after next tool call" in lowered
+
     def _normalize_for_compare(self, text: str) -> str:
         """Collapse whitespace for approximate pane-vs-payload comparison."""
         return " ".join((text or "").split())
@@ -292,6 +299,48 @@ class TmuxController:
 
         logger.warning(
             "Claude submit verification resent Enter for %s after composer stayed populated",
+            session_name,
+        )
+        return True
+
+    async def _verify_codex_submit_async(self, session_name: str, text: str) -> bool:
+        """Interrupt once if Codex parked the payload behind its deferred-send banner."""
+        normalized_text = self._normalize_for_compare(text)
+        if not normalized_text:
+            return False
+        normalized_preview = normalized_text[:120]
+
+        async def _capture_deferred_payload() -> bool:
+            pane = await self._capture_pane_async(session_name)
+            if not self._looks_like_codex_deferred_send_banner(pane):
+                return False
+            normalized_pane = self._normalize_for_compare(pane or "")
+            return normalized_preview in normalized_pane
+
+        await asyncio.sleep(self.submit_verify_seconds)
+        first_match = await _capture_deferred_payload()
+        if not first_match:
+            return False
+
+        await asyncio.sleep(self.submit_retry_seconds)
+        second_match = await _capture_deferred_payload()
+        if not second_match:
+            return False
+
+        proc = await asyncio.create_subprocess_exec(
+            "tmux", "send-keys", "-t", session_name, "Escape",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await asyncio.wait_for(
+            proc.communicate(), timeout=self.send_keys_timeout_seconds
+        )
+        if proc.returncode != 0:
+            logger.error(f"Failed to send Escape during Codex submit verification: {stderr.decode()}")
+            return False
+
+        logger.warning(
+            "Codex submit verification sent Escape for %s after deferred-send banner persisted",
             session_name,
         )
         return True
@@ -653,6 +702,7 @@ class TmuxController:
         session_name: str,
         text: str,
         verify_claude_submit: bool = False,
+        verify_codex_submit: bool = False,
     ) -> bool:
         """
         Send input text to a tmux session (ASYNC - non-blocking).
@@ -708,6 +758,8 @@ class TmuxController:
 
             if verify_claude_submit:
                 await self._verify_claude_submit_async(session_name, text)
+            if verify_codex_submit:
+                await self._verify_codex_submit_async(session_name, text)
 
             line_count = (text or "").count("\n") + 1
             if mode_before == 1 or settle_delay > self.send_keys_settle_seconds:

--- a/tests/regression/test_issue_598_codex_submit_verification.py
+++ b/tests/regression/test_issue_598_codex_submit_verification.py
@@ -1,0 +1,124 @@
+"""Regression tests for issue #598: Codex deferred-send submit verification."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.models import Session, SessionStatus
+from src.session_manager import SessionManager
+from src.tmux_controller import TmuxController
+
+
+@pytest.fixture
+def tmux_controller():
+    config = {
+        "timeouts": {
+            "tmux": {
+                "send_keys_timeout_seconds": 2,
+                "send_keys_settle_seconds": 0.01,
+                "submit_verify_seconds": 0.01,
+                "submit_retry_seconds": 0.01,
+            }
+        }
+    }
+    return TmuxController(log_dir="/tmp/test-sessions", config=config)
+
+
+@pytest.mark.asyncio
+async def test_send_input_async_interrupts_codex_deferred_send_banner(tmux_controller):
+    deferred_pane = """
+• Working (14s • esc to interrupt) · 1 background terminal running · /ps to view
+
+• Messages to be submitted after next tool call (press esc to interrupt and send immediately)
+  ↳ [Input from: maintainer (83f53095) via sm send]
+    busy repro ping: reply exactly DURING_SLEEP_OK
+
+› Summarize recent commits
+"""
+    subprocess_calls = []
+
+    async def mock_subprocess(*args, **kwargs):
+        subprocess_calls.append(args)
+        proc = AsyncMock()
+        if args[1] == "capture-pane":
+            proc.communicate = AsyncMock(return_value=(deferred_pane.encode(), b""))
+        else:
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+        proc.returncode = 0
+        return proc
+
+    with patch.object(tmux_controller, "session_exists", return_value=True), \
+         patch.object(tmux_controller, "_exit_copy_mode_if_needed_async", new=AsyncMock(return_value=(0, 0))), \
+         patch("asyncio.create_subprocess_exec", side_effect=mock_subprocess), \
+         patch("asyncio.sleep", new_callable=AsyncMock):
+        result = await tmux_controller.send_input_async(
+            "codex-test",
+            "[Input from: maintainer (83f53095) via sm send]\nbusy repro ping: reply exactly DURING_SLEEP_OK",
+            verify_codex_submit=True,
+        )
+
+    assert result is True
+    escape_calls = [call for call in subprocess_calls if call[1] == "send-keys" and call[-1] == "Escape"]
+    assert len(escape_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_send_input_async_does_not_interrupt_codex_without_deferred_banner(tmux_controller):
+    submitted_pane = """
+• DURING_SLEEP_OK
+
+  1 background terminal running · /ps to view · /stop to close
+"""
+    subprocess_calls = []
+
+    async def mock_subprocess(*args, **kwargs):
+        subprocess_calls.append(args)
+        proc = AsyncMock()
+        if args[1] == "capture-pane":
+            proc.communicate = AsyncMock(return_value=(submitted_pane.encode(), b""))
+        else:
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+        proc.returncode = 0
+        return proc
+
+    with patch.object(tmux_controller, "session_exists", return_value=True), \
+         patch.object(tmux_controller, "_exit_copy_mode_if_needed_async", new=AsyncMock(return_value=(0, 0))), \
+         patch("asyncio.create_subprocess_exec", side_effect=mock_subprocess), \
+         patch("asyncio.sleep", new_callable=AsyncMock):
+        result = await tmux_controller.send_input_async(
+            "codex-test",
+            "busy repro ping: reply exactly DURING_SLEEP_OK",
+            verify_codex_submit=True,
+        )
+
+    assert result is True
+    escape_calls = [call for call in subprocess_calls if call[1] == "send-keys" and call[-1] == "Escape"]
+    assert len(escape_calls) == 0
+
+
+@pytest.mark.asyncio
+async def test_deliver_direct_enables_codex_submit_verification(tmp_path):
+    manager = SessionManager(log_dir=str(tmp_path), state_file=str(tmp_path / "state.json"))
+    session = Session(
+        id="codex598",
+        name="codex-codex598",
+        working_dir=str(tmp_path),
+        tmux_session="codex-codex598",
+        provider="codex",
+        status=SessionStatus.RUNNING,
+    )
+    manager.sessions[session.id] = session
+    manager.message_queue_manager = MagicMock()
+    manager.message_queue_manager.mark_session_active = MagicMock()
+
+    with patch.object(manager.tmux, "send_input_async", new=AsyncMock(return_value=True)) as mock_send:
+        success = await manager._deliver_direct(session, "hello codex")
+
+    assert success is True
+    mock_send.assert_awaited_once_with(
+        "codex-codex598",
+        "hello codex",
+        verify_claude_submit=False,
+        verify_codex_submit=True,
+    )

--- a/tests/regression/test_issue_598_codex_submit_verification.py
+++ b/tests/regression/test_issue_598_codex_submit_verification.py
@@ -98,6 +98,48 @@ async def test_send_input_async_does_not_interrupt_codex_without_deferred_banner
 
 
 @pytest.mark.asyncio
+async def test_send_input_async_ignores_stale_codex_deferred_banner_history(tmux_controller):
+    stale_history_pane = """
+• Messages to be submitted after next tool call (press esc to interrupt and send immediately)
+  ↳ [Input from: maintainer (83f53095) via sm send]
+    busy repro ping: reply exactly DURING_SLEEP_OK
+
+... older output omitted ...
+
+• DURING_SLEEP_OK
+
+  1 background terminal running · /ps to view · /stop to close
+
+› Summarize recent commits
+"""
+    subprocess_calls = []
+
+    async def mock_subprocess(*args, **kwargs):
+        subprocess_calls.append(args)
+        proc = AsyncMock()
+        if args[1] == "capture-pane":
+            proc.communicate = AsyncMock(return_value=(stale_history_pane.encode(), b""))
+        else:
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+        proc.returncode = 0
+        return proc
+
+    with patch.object(tmux_controller, "session_exists", return_value=True), \
+         patch.object(tmux_controller, "_exit_copy_mode_if_needed_async", new=AsyncMock(return_value=(0, 0))), \
+         patch("asyncio.create_subprocess_exec", side_effect=mock_subprocess), \
+         patch("asyncio.sleep", new_callable=AsyncMock):
+        result = await tmux_controller.send_input_async(
+            "codex-test",
+            "busy repro ping: reply exactly DURING_SLEEP_OK",
+            verify_codex_submit=True,
+        )
+
+    assert result is True
+    escape_calls = [call for call in subprocess_calls if call[1] == "send-keys" and call[-1] == "Escape"]
+    assert len(escape_calls) == 0
+
+
+@pytest.mark.asyncio
 async def test_deliver_direct_enables_codex_submit_verification(tmp_path):
     manager = SessionManager(log_dir=str(tmp_path), state_file=str(tmp_path / "state.json"))
     session = Session(


### PR DESCRIPTION
## Summary
- detect when a busy tmux Codex session parks `sm send` payloads behind Codex's deferred-send banner
- send `Escape` automatically when that banner persists so the pending message becomes a real submitted turn instead of sitting in the composer
- add regression coverage for the tmux verification path and for `SessionManager._deliver_direct()` enabling Codex submit verification

## Test Plan
- [x] `./venv/bin/pytest tests/regression/test_issue_598_codex_submit_verification.py tests/regression/test_issue_410_claude_submit_verification.py -q`
- [x] Live verification with patched `TmuxController.send_input_async(..., verify_codex_submit=True)` against a busy Codex tmux session

Fixes #598
