### PR TITLE
Reconcile plain Codex queue idle state after delivery

### DIFF
--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -120,6 +120,7 @@ class MessageQueueManager:
         # Value: datetime when stop notification was sent
         self._recent_stop_notifications: Dict[Tuple[str, str], datetime] = {}
         self._pending_stop_notify_tasks: Dict[str, asyncio.Task] = {}
+        self._codex_idle_reconcile_tasks: Dict[str, asyncio.Task] = {}
         self._telegram_mirror_queue: Optional[asyncio.Queue[tuple[str, object, str, str]]] = None
         self._telegram_mirror_worker_task: Optional[asyncio.Task] = None
 
@@ -949,6 +950,9 @@ class MessageQueueManager:
         for task in self._pending_stop_notify_tasks.values():
             task.cancel()
         self._pending_stop_notify_tasks.clear()
+        for task in self._codex_idle_reconcile_tasks.values():
+            task.cancel()
+        self._codex_idle_reconcile_tasks.clear()
         if self._monitor_task:
             self._monitor_task.cancel()
             try:
@@ -1006,6 +1010,7 @@ class MessageQueueManager:
                 stop, without engaging skip-fence logic.
         """
         state = self._get_or_create_state(session_id)
+        self._cancel_codex_idle_reconcile(session_id)
         logger.info(f"Session {session_id} marked idle")
 
         # Check for pending handoff — takes priority over all other Stop hook logic (#196).
@@ -1124,6 +1129,7 @@ class MessageQueueManager:
     def mark_session_active(self, session_id: str):
         """Mark a session as active (not idle)."""
         state = self._get_or_create_state(session_id)
+        self._cancel_codex_idle_reconcile(session_id)
         state.is_idle = False
         self._cancel_pending_stop_notification(session_id)
         if state.stop_notify_delay_seconds > 0:
@@ -1137,6 +1143,61 @@ class MessageQueueManager:
         if session and session.status != SessionStatus.STOPPED:
             session.status = SessionStatus.RUNNING
         logger.debug(f"Session {session_id} marked active")
+
+    def _cancel_codex_idle_reconcile(self, session_id: str) -> None:
+        """Cancel any in-flight plain-Codex idle reconcile task for one session."""
+        task = self._codex_idle_reconcile_tasks.pop(session_id, None)
+        if task:
+            task.cancel()
+
+    def _schedule_codex_idle_reconcile(self, session_id: str) -> None:
+        """Watch a plain tmux-backed Codex session for prompt return after delivery."""
+        self._cancel_codex_idle_reconcile(session_id)
+        task = asyncio.create_task(self._reconcile_codex_idle_after_delivery(session_id))
+        self._codex_idle_reconcile_tasks[session_id] = task
+
+    async def _reconcile_codex_idle_after_delivery(self, session_id: str) -> None:
+        """Mark plain Codex sessions idle once the prompt returns after a delivered turn."""
+        prompt_count = 0
+        timeout_at = datetime.now() + timedelta(seconds=60)
+        current_task = asyncio.current_task()
+
+        try:
+            while datetime.now() < timeout_at:
+                session = self.session_manager.get_session(session_id)
+                if not session or getattr(session, "provider", "claude") != "codex":
+                    return
+
+                if self.get_pending_messages(session_id):
+                    prompt_count = 0
+                    await asyncio.sleep(self.watch_poll_interval)
+                    continue
+
+                prompt_visible = False
+                if session.tmux_session:
+                    prompt_visible = await self._check_idle_prompt(session.tmux_session)
+
+                if prompt_visible:
+                    prompt_count += 1
+                    if prompt_count >= 2:
+                        self.mark_session_idle(session_id, completion_transition=True)
+                        session.status = SessionStatus.IDLE
+                        session.last_activity = datetime.now()
+                        self.session_manager._save_state()
+                        logger.info(
+                            "Reconciled plain codex session %s idle after prompt returned",
+                            session_id,
+                        )
+                        return
+                else:
+                    prompt_count = 0
+
+                await asyncio.sleep(self.watch_poll_interval)
+        except asyncio.CancelledError:
+            raise
+        finally:
+            if self._codex_idle_reconcile_tasks.get(session_id) is current_task:
+                self._codex_idle_reconcile_tasks.pop(session_id, None)
 
     def is_session_idle(self, session_id: str) -> bool:
         """Check if a session is idle."""
@@ -1803,6 +1864,8 @@ class MessageQueueManager:
                 session.last_activity = datetime.now()
                 session.status = SessionStatus.RUNNING
                 self.session_manager._save_state()
+                if getattr(session, "provider", "claude") == "codex":
+                    self._schedule_codex_idle_reconcile(session_id)
             else:
                 logger.error(f"Failed to deliver messages to {session_id}")
 

--- a/tests/unit/test_message_queue_codex_idle_reconcile.py
+++ b/tests/unit/test_message_queue_codex_idle_reconcile.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+from src.message_queue import MessageQueueManager
+from src.models import Session, SessionStatus
+
+
+def _make_session(session_id: str) -> Session:
+    return Session(
+        id=session_id,
+        name=f"codex-{session_id}",
+        working_dir="/tmp",
+        tmux_session=f"codex-{session_id}",
+        log_file=f"/tmp/{session_id}.log",
+        provider="codex",
+        status=SessionStatus.RUNNING,
+    )
+
+
+def _noop_create_task(coro):
+    coro.close()
+    return MagicMock()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_codex_idle_after_delivery_marks_queue_idle(tmp_path: Path):
+    session = _make_session("codex-idle-1")
+    sessions = {session.id: session}
+    session_manager = SimpleNamespace(
+        get_session=lambda session_id: sessions.get(session_id),
+        _save_state=Mock(),
+    )
+    mq = MessageQueueManager(session_manager, db_path=str(tmp_path / "mq.db"))
+    mq.watch_poll_interval = 0
+    mq._get_or_create_state(session.id).is_idle = False
+
+    prompt_results = iter([True, True])
+
+    async def fake_prompt(_tmux_session: str) -> bool:
+        return next(prompt_results)
+
+    mq._check_idle_prompt = fake_prompt  # type: ignore[method-assign]
+
+    with patch("asyncio.create_task", side_effect=_noop_create_task):
+        await mq._reconcile_codex_idle_after_delivery(session.id)
+
+    assert mq.delivery_states[session.id].is_idle is True
+    assert session.status == SessionStatus.IDLE
+    session_manager._save_state.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_successful_plain_codex_delivery_schedules_idle_reconcile(tmp_path: Path):
+    session = _make_session("codex-idle-2")
+    sessions = {session.id: session}
+    session_manager = SimpleNamespace(
+        get_session=lambda session_id: sessions.get(session_id),
+        _deliver_direct=AsyncMock(return_value=True),
+        _save_state=Mock(),
+    )
+    mq = MessageQueueManager(session_manager, db_path=str(tmp_path / "mq.db"))
+    mq._schedule_codex_idle_reconcile = Mock()
+    mq._get_pending_user_input_async = AsyncMock(return_value=None)
+
+    mq.queue_message(
+        target_session_id=session.id,
+        text="Reply exactly Done.",
+        delivery_mode="sequential",
+        trigger_delivery=False,
+    )
+    mq._prepare_nonurgent_delivery(session.id)
+
+    await mq._try_deliver_messages(session.id)
+
+    mq._schedule_codex_idle_reconcile.assert_called_once_with(session.id)


### PR DESCRIPTION
## Summary\n- watch for the plain Codex tmux prompt to return after a delivered turn and reconcile queue idle state\n- cancel stale reconcile tasks when a new turn starts or the session is already marked idle\n- add regression tests for prompt-based idle reconciliation after delivery\n\n## Testing\n- ./venv/bin/pytest tests/unit/test_message_queue_codex_idle_reconcile.py tests/unit/test_main_codex_status_reconcile.py tests/unit/test_codex_activity_state.py -q\n\nRefs #602