### PR TITLE
Refresh cached Claude native titles after /rename

### DIFF
--- a/src/output_monitor.py
+++ b/src/output_monitor.py
@@ -105,6 +105,7 @@ class OutputMonitor:
         self._monitor_states: dict[str, MonitorState] = {}  # Activity projection state (#288)
         self._no_output_cycles: dict[str, int] = {}  # Consecutive polls without output (#288)
         self._output_history: dict[str, list[tuple[datetime, int]]] = {}  # Output bytes timestamps (#288)
+        self._last_native_title_refresh: dict[str, datetime] = {}  # Background Claude title syncs
 
         # Load timeout configuration with fallbacks
         timeouts = self.config.get("timeouts", {})
@@ -112,6 +113,7 @@ class OutputMonitor:
         self._idle_cooldown = monitor_timeouts.get("idle_cooldown_seconds", 300)
         self._permission_debounce = monitor_timeouts.get("permission_debounce_seconds", 30)
         self._cleanup_notify_timeout = monitor_timeouts.get("cleanup_notify_timeout_seconds", 2)
+        self._native_title_refresh_interval = monitor_timeouts.get("native_title_refresh_interval_seconds", 5)
 
     def set_event_callback(self, callback: Callable[[NotificationEvent], Awaitable[None]]):
         """Set the callback for notification events."""
@@ -187,12 +189,28 @@ class OutputMonitor:
         self._monitor_states.pop(session_id, None)
         self._no_output_cycles.pop(session_id, None)
         self._output_history.pop(session_id, None)
+        self._last_native_title_refresh.pop(session_id, None)
 
     async def stop_all(self):
         """Stop all monitoring tasks."""
         self._running = False
         for session_id in list(self._tasks.keys()):
             await self.stop_monitoring(session_id)
+
+    async def _refresh_claude_native_title_if_due(self, session: Session):
+        """Refresh cached Claude native titles without adding live work to read APIs."""
+        if getattr(session, "provider", "claude") != "claude" or not self._session_manager:
+            return
+
+        now = datetime.now()
+        last_refresh = self._last_native_title_refresh.get(session.id)
+        if last_refresh and (now - last_refresh).total_seconds() < self._native_title_refresh_interval:
+            return
+        self._last_native_title_refresh[session.id] = now
+
+        sync_title = getattr(self._session_manager, "sync_claude_native_title", None)
+        if callable(sync_title):
+            await asyncio.to_thread(sync_title, session, True)
 
     async def _monitor_loop(self, session: Session):
         """Main monitoring loop for a session."""
@@ -260,6 +278,8 @@ class OutputMonitor:
                         last_time, last_succeeded = recovery_state
                         if not last_succeeded and datetime.now() - last_time > CRASH_DEBOUNCE_FAILURE:
                             await self._flush_pending_crash_recovery(session)
+
+                await self._refresh_claude_native_title_if_due(session)
 
             except asyncio.CancelledError:
                 break

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -3091,6 +3091,10 @@ class SessionManager:
             return session.native_title
 
         if session.native_title_source_mtime_ns == current_mtime_ns:
+            if live_title and live_title != session.native_title:
+                session.native_title = live_title
+                session.native_title_updated_at_ns = time.time_ns()
+                state_changed = True
             if state_changed and persist:
                 self._save_state()
             return session.native_title
@@ -3107,11 +3111,15 @@ class SessionManager:
                 self._save_state()
             return session.native_title
 
-        title_changed = native_title != session.native_title
-        session.native_title = native_title
+        effective_native_title = live_title or native_title
+        title_changed = effective_native_title != session.native_title
+        session.native_title = effective_native_title
         session.native_title_source_mtime_ns = synced_mtime_ns
         if title_changed:
-            session.native_title_updated_at_ns = synced_mtime_ns
+            if live_title and live_title != native_title:
+                session.native_title_updated_at_ns = time.time_ns()
+            else:
+                session.native_title_updated_at_ns = synced_mtime_ns
         if (state_changed or title_changed) and persist:
             self._save_state()
         return session.native_title

--- a/tests/unit/test_claude_native_title.py
+++ b/tests/unit/test_claude_native_title.py
@@ -340,6 +340,25 @@ def test_transcript_mtime_churn_does_not_override_later_sm_name(tmp_path: Path) 
     assert manager.get_effective_session_name(session.id) == "sm-renamed-later"
 
 
+def test_sync_claude_native_title_uses_live_title_when_transcript_title_is_missing(tmp_path: Path) -> None:
+    manager = _manager(tmp_path)
+    manager.tmux = MagicMock()
+    manager.tmux.get_pane_title.return_value = "✳ test_speed_fix"
+
+    transcript = tmp_path / "transcript.jsonl"
+    _write_transcript(
+        transcript,
+        {"type": "assistant", "message": {"content": [{"type": "text", "text": "still working"}]}},
+    )
+    session = _claude_session(tmp_path, transcript)
+    session.native_title_source_mtime_ns = transcript.stat().st_mtime_ns
+    manager.sessions[session.id] = session
+
+    assert manager.sync_claude_native_title(session.id) == "test_speed_fix"
+    assert session.native_title == "test_speed_fix"
+    assert isinstance(session.native_title_updated_at_ns, int)
+
+
 def test_claude_hook_resyncs_tmux_and_telegram_when_native_title_changes(tmp_path: Path) -> None:
     manager = _manager(tmp_path)
     manager.tmux = MagicMock()

--- a/tests/unit/test_output_monitor_state.py
+++ b/tests/unit/test_output_monitor_state.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from datetime import datetime, timedelta
 from types import SimpleNamespace
+from unittest.mock import Mock
 
 import pytest
 
@@ -46,6 +47,20 @@ async def test_permission_pattern_takes_precedence_over_completion_when_batched(
     )
 
     assert monitor.get_session_state(session.id).last_pattern == "permission"
+
+
+@pytest.mark.asyncio
+async def test_refresh_claude_native_title_is_rate_limited():
+    monitor = OutputMonitor(config={"timeouts": {"output_monitor": {"native_title_refresh_interval_seconds": 60}}})
+    session = _make_session("title123")
+    sync = Mock(return_value="test_speed_fix")
+    session_manager = SimpleNamespace(sync_claude_native_title=sync)
+    monitor.set_session_manager(session_manager)
+
+    await monitor._refresh_claude_native_title_if_due(session)
+    await monitor._refresh_claude_native_title_if_due(session)
+
+    sync.assert_called_once_with(session, True)
 
 
 def test_output_bytes_window_tracks_last_10_seconds():


### PR DESCRIPTION
## Summary
- trust Claude's live pane title when transcript title metadata is missing or lagging
- refresh cached Claude native titles in the output monitor so watch/list surfaces converge after native /rename
- add regressions for transcript-lag and monitor refresh behavior

## Testing
- ./venv/bin/pytest tests/unit/test_claude_native_title.py tests/unit/test_output_monitor_state.py -q

Closes #606
