### PR TITLE
Keep task-complete notices neutral

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -5328,7 +5328,7 @@ Provide ONLY the summary, no preamble or questions."""
             friendly = _effective_session_name(session)
             queue_mgr.queue_message(
                 target_session_id=em_id,
-                text=f"[sm task-complete] agent {session_id}({friendly}) completed its task. Clear context with: sm clear {session_id}",
+                text=f"[sm task-complete] agent {session_id}({friendly}) completed its task.",
                 delivery_mode="important",
             )
             em_notified = True

--- a/tests/unit/test_task_complete.py
+++ b/tests/unit/test_task_complete.py
@@ -167,8 +167,10 @@ class TestTaskCompleteNotifiesEmViaParentWake:
 
         # EM should have received a queued message
         msgs = mq.get_pending_messages("em000001")
-        assert any("[sm task-complete]" in m.text for m in msgs)
-        assert any("abc12345" in m.text for m in msgs)
+        assert any(
+            m.text == "[sm task-complete] agent abc12345(worker-1) completed its task."
+            for m in msgs
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -213,8 +215,10 @@ class TestTaskCompleteFallsBackToSessionParent:
         assert data["em_notified"] is True
 
         msgs = queue_mgr.get_pending_messages("em000001")
-        assert any("[sm task-complete]" in m.text for m in msgs)
-        assert any("child001" in m.text for m in msgs)
+        assert any(
+            m.text == "[sm task-complete] agent child001(child-worker) completed its task."
+            for m in msgs
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- remove the prescriptive `sm clear` instruction from `sm task-complete` EM notifications
- keep the notification as a neutral completion signal only
- tighten task-complete unit coverage to assert the exact queued message text

## Testing
- `./venv/bin/pytest tests/unit/test_task_complete.py -q`

Fixes #615
