### PR TITLE
Add multi-recipient sm send

### DIFF
--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -466,25 +466,20 @@ class SessionManagerClient:
         Returns:
             Tuple of (success, unavailable)
         """
-        payload = {"text": text, "delivery_mode": delivery_mode, "from_sm_send": from_sm_send}
-        if sender_session_id:
-            payload["sender_session_id"] = sender_session_id
-        if timeout_seconds is not None:
-            payload["timeout_seconds"] = timeout_seconds
-        if notify_on_delivery:
-            payload["notify_on_delivery"] = notify_on_delivery
-        if notify_after_seconds is not None:
-            payload["notify_after_seconds"] = notify_after_seconds
-        if notify_on_stop:
-            payload["notify_on_stop"] = notify_on_stop
-        if remind_soft_threshold is not None:
-            payload["remind_soft_threshold"] = remind_soft_threshold
-        if remind_hard_threshold is not None:
-            payload["remind_hard_threshold"] = remind_hard_threshold
-        if remind_cancel_on_reply_session_id is not None:
-            payload["remind_cancel_on_reply_session_id"] = remind_cancel_on_reply_session_id
-        if parent_session_id is not None:
-            payload["parent_session_id"] = parent_session_id
+        payload = self._build_send_input_payload(
+            text=text,
+            sender_session_id=sender_session_id,
+            delivery_mode=delivery_mode,
+            from_sm_send=from_sm_send,
+            timeout_seconds=timeout_seconds,
+            notify_on_delivery=notify_on_delivery,
+            notify_after_seconds=notify_after_seconds,
+            notify_on_stop=notify_on_stop,
+            remind_soft_threshold=remind_soft_threshold,
+            remind_hard_threshold=remind_hard_threshold,
+            remind_cancel_on_reply_session_id=remind_cancel_on_reply_session_id,
+            parent_session_id=parent_session_id,
+        )
 
         data, success, unavailable = self._request(
             "POST",
@@ -512,6 +507,96 @@ class SessionManagerClient:
         timeout: Optional[float] = None,
     ) -> dict:
         """Send input and return full API result metadata."""
+        payload = self._build_send_input_payload(
+            text=text,
+            sender_session_id=sender_session_id,
+            delivery_mode=delivery_mode,
+            from_sm_send=from_sm_send,
+            timeout_seconds=timeout_seconds,
+            notify_on_delivery=notify_on_delivery,
+            notify_after_seconds=notify_after_seconds,
+            notify_on_stop=notify_on_stop,
+            remind_soft_threshold=remind_soft_threshold,
+            remind_hard_threshold=remind_hard_threshold,
+            remind_cancel_on_reply_session_id=remind_cancel_on_reply_session_id,
+            parent_session_id=parent_session_id,
+        )
+
+        data, status_code, unavailable = self._request_with_status(
+            "POST",
+            f"/sessions/{session_id}/input",
+            payload,
+            timeout=timeout,
+        )
+        if unavailable:
+            return {"ok": False, "unavailable": True, "status_code": None, "detail": None}
+        ok = status_code in (200, 201)
+        detail = data.get("detail") if isinstance(data, dict) else None
+        return {"ok": ok, "unavailable": False, "status_code": status_code, "data": data, "detail": detail}
+
+    def send_input_batch_result(
+        self,
+        recipients: list[str],
+        text: str,
+        sender_session_id: Optional[str] = None,
+        delivery_mode: str = "sequential",
+        from_sm_send: bool = False,
+        timeout_seconds: Optional[int] = None,
+        notify_on_delivery: bool = False,
+        notify_after_seconds: Optional[int] = None,
+        notify_on_stop: bool = False,
+        remind_soft_threshold: Optional[int] = None,
+        remind_hard_threshold: Optional[int] = None,
+        remind_cancel_on_reply_session_id: Optional[str] = None,
+        parent_session_id: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> dict:
+        """Send the same input to multiple recipients in one API call."""
+        payload = self._build_send_input_payload(
+            text=text,
+            sender_session_id=sender_session_id,
+            delivery_mode=delivery_mode,
+            from_sm_send=from_sm_send,
+            timeout_seconds=timeout_seconds,
+            notify_on_delivery=notify_on_delivery,
+            notify_after_seconds=notify_after_seconds,
+            notify_on_stop=notify_on_stop,
+            remind_soft_threshold=remind_soft_threshold,
+            remind_hard_threshold=remind_hard_threshold,
+            remind_cancel_on_reply_session_id=remind_cancel_on_reply_session_id,
+            parent_session_id=parent_session_id,
+        )
+        payload["recipients"] = recipients
+
+        data, status_code, unavailable = self._request_with_status(
+            "POST",
+            "/sessions/input-batch",
+            payload,
+            timeout=timeout,
+        )
+        if unavailable:
+            return {"ok": False, "unavailable": True, "status_code": None, "detail": None}
+        ok = status_code in (200, 201)
+        detail = data.get("detail") if isinstance(data, dict) else None
+        return {"ok": ok, "unavailable": False, "status_code": status_code, "data": data, "detail": detail}
+
+    @staticmethod
+    def _build_send_input_payload(
+        *,
+        text: str,
+        sender_session_id: Optional[str] = None,
+        delivery_mode: str = "sequential",
+        from_sm_send: bool = False,
+        timeout_seconds: Optional[int] = None,
+        notify_on_delivery: bool = False,
+        notify_after_seconds: Optional[int] = None,
+        notify_on_stop: bool = False,
+        remind_soft_threshold: Optional[int] = None,
+        remind_hard_threshold: Optional[int] = None,
+        remind_cancel_on_reply_session_id: Optional[str] = None,
+        parent_session_id: Optional[str] = None,
+    ) -> dict:
+        """Build the shared request payload used by send endpoints."""
         payload = {"text": text, "delivery_mode": delivery_mode, "from_sm_send": from_sm_send}
         if sender_session_id:
             payload["sender_session_id"] = sender_session_id
@@ -531,18 +616,7 @@ class SessionManagerClient:
             payload["remind_cancel_on_reply_session_id"] = remind_cancel_on_reply_session_id
         if parent_session_id is not None:
             payload["parent_session_id"] = parent_session_id
-
-        data, status_code, unavailable = self._request_with_status(
-            "POST",
-            f"/sessions/{session_id}/input",
-            payload,
-            timeout=timeout,
-        )
-        if unavailable:
-            return {"ok": False, "unavailable": True, "status_code": None, "detail": None}
-        ok = status_code in (200, 201)
-        detail = data.get("detail") if isinstance(data, dict) else None
-        return {"ok": ok, "unavailable": False, "status_code": status_code, "data": data, "detail": detail}
+        return payload
 
     def get_codex_events(
         self,

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -1383,6 +1383,26 @@ def cmd_send(
         remind_hard_threshold = _track_hard_threshold_seconds(track_seconds)
 
     effective_notify_after = wait_seconds if wait_seconds is not None else notify_after_seconds
+    identifiers = _split_send_targets(identifier)
+    if not identifiers:
+        print("Error: at least one recipient is required", file=sys.stderr)
+        return 1
+    if len(identifiers) > 1:
+        return _cmd_send_batch(
+            client,
+            identifiers,
+            text,
+            delivery_mode=delivery_mode,
+            timeout_seconds=timeout_seconds,
+            notify_on_delivery=notify_on_delivery,
+            notify_after_seconds=effective_notify_after,
+            notify_on_stop=notify_on_stop,
+            remind_soft_threshold=remind_soft_threshold,
+            remind_hard_threshold=remind_hard_threshold,
+            parent_session_id=parent_session_id,
+            track_seconds=track_seconds,
+        )
+    identifier = identifiers[0]
 
     # Resolve identifier to session ID and get session details
     session_id, session, resolve_unavailable = resolve_session_id_with_status(
@@ -1492,23 +1512,158 @@ def cmd_send(
 
     # Show additional options if used
     extras = []
-    if timeout_seconds:
-        extras.append(f"timeout={timeout_seconds}s")
-    if notify_on_delivery:
-        extras.append("notify-on-delivery")
-    if effective_notify_after:
-        extras.append(f"wait={effective_notify_after}s")
-    if effective_notify_on_stop:
-        extras.append("notify-on-stop")
-    if remind_soft_threshold:
-        extras.append(f"remind={remind_soft_threshold}s soft"
-                      + (f"/{remind_hard_threshold}s hard" if remind_hard_threshold else ""))
-    if track_seconds:
-        extras.append(f"track={track_seconds}s")
+    extras = _send_option_labels(
+        timeout_seconds=timeout_seconds,
+        notify_on_delivery=notify_on_delivery,
+        notify_after_seconds=effective_notify_after,
+        notify_on_stop=effective_notify_on_stop,
+        remind_soft_threshold=remind_soft_threshold,
+        remind_hard_threshold=remind_hard_threshold,
+        track_seconds=track_seconds,
+    )
     if extras:
         print(f"  Options: {', '.join(extras)}")
 
     return 0
+
+
+def _cmd_send_batch(
+    client: SessionManagerClient,
+    identifiers: list[str],
+    text: str,
+    *,
+    delivery_mode: str,
+    timeout_seconds: Optional[int],
+    notify_on_delivery: bool,
+    notify_after_seconds: Optional[int],
+    notify_on_stop: bool,
+    remind_soft_threshold: Optional[int],
+    remind_hard_threshold: Optional[int],
+    parent_session_id: Optional[str],
+    track_seconds: Optional[int],
+) -> int:
+    """Send one message to multiple recipients in one backend request."""
+    sender_session_id = client.session_id
+    result = client.send_input_batch_result(
+        identifiers,
+        text,
+        sender_session_id=sender_session_id,
+        delivery_mode=delivery_mode,
+        from_sm_send=True,
+        timeout_seconds=timeout_seconds,
+        notify_on_delivery=notify_on_delivery,
+        notify_after_seconds=notify_after_seconds,
+        notify_on_stop=notify_on_stop,
+        remind_soft_threshold=remind_soft_threshold,
+        remind_hard_threshold=remind_hard_threshold,
+        remind_cancel_on_reply_session_id=sender_session_id if track_seconds is not None else None,
+        parent_session_id=parent_session_id,
+        timeout=SEND_API_TIMEOUT,
+    )
+    if result.get("unavailable"):
+        print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+        return 2
+
+    if not result.get("ok"):
+        detail = result.get("detail") or "Failed to send input"
+        print(f"Error: {detail}", file=sys.stderr)
+        return 1
+
+    payload = result.get("data") or {}
+    had_session_success = False
+    for item in payload.get("results") or []:
+        if item.get("bootstrapped"):
+            boot_name = item.get("target_name") or item.get("session_id") or item.get("identifier")
+            provider = item.get("provider") or "unknown"
+            print(f"Role bootstrapped: {item.get('identifier')} -> {boot_name} ({item.get('session_id')}) [{provider}]")
+
+        status = item.get("status")
+        if status == "emailed":
+            recipient_summary = _email_result_summary(item)
+            print(f"Email sent to {recipient_summary}")
+            continue
+
+        if status in {"delivered", "queued"}:
+            had_session_success = True
+            target_name = item.get("target_name") or item.get("session_id") or item.get("identifier")
+            session_id = item.get("session_id") or item.get("identifier")
+            if status == "queued":
+                print(f"Input queued for {target_name} ({session_id})")
+            elif delivery_mode == "urgent":
+                print(f"Input sent to {target_name} ({session_id}) (interrupted)")
+            else:
+                print(f"Input sent to {target_name} ({session_id})")
+            continue
+
+        identifier = item.get("identifier") or "<unknown>"
+        detail = item.get("detail") or "Failed to send input"
+        print(f"Error: {identifier}: {detail}", file=sys.stderr)
+
+    extras = _send_option_labels(
+        timeout_seconds=timeout_seconds,
+        notify_on_delivery=notify_on_delivery,
+        notify_after_seconds=notify_after_seconds,
+        notify_on_stop=notify_on_stop,
+        remind_soft_threshold=remind_soft_threshold,
+        remind_hard_threshold=remind_hard_threshold,
+        track_seconds=track_seconds,
+    )
+    if had_session_success and extras:
+        print(f"  Options: {', '.join(extras)}")
+
+    return 0 if (payload.get("failure_count") or 0) == 0 else 1
+
+
+def _email_result_summary(item: dict) -> str:
+    """Format one batch email result for CLI output."""
+    username = item.get("email_username")
+    email = item.get("email_address")
+    if username and email:
+        return f"{username} <{email}>"
+    return email or item.get("identifier") or "<unknown>"
+
+
+def _send_option_labels(
+    *,
+    timeout_seconds: Optional[int],
+    notify_on_delivery: bool,
+    notify_after_seconds: Optional[int],
+    notify_on_stop: bool,
+    remind_soft_threshold: Optional[int],
+    remind_hard_threshold: Optional[int],
+    track_seconds: Optional[int],
+) -> list[str]:
+    """Format the shared option summary shown after successful sends."""
+    extras = []
+    if timeout_seconds:
+        extras.append(f"timeout={timeout_seconds}s")
+    if notify_on_delivery:
+        extras.append("notify-on-delivery")
+    if notify_after_seconds:
+        extras.append(f"wait={notify_after_seconds}s")
+    if notify_on_stop:
+        extras.append("notify-on-stop")
+    if remind_soft_threshold:
+        extras.append(
+            f"remind={remind_soft_threshold}s soft"
+            + (f"/{remind_hard_threshold}s hard" if remind_hard_threshold else "")
+        )
+    if track_seconds:
+        extras.append(f"track={track_seconds}s")
+    return extras
+
+
+def _split_send_targets(raw_value: str) -> list[str]:
+    """Split and deduplicate comma-delimited send targets while preserving order."""
+    identifiers: list[str] = []
+    seen: set[str] = set()
+    for part in str(raw_value or "").split(","):
+        normalized = part.strip()
+        if not normalized or normalized in seen:
+            continue
+        identifiers.append(normalized)
+        seen.add(normalized)
+    return identifiers
 
 
 def _split_email_targets(raw_value: str) -> list[str]:

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -179,7 +179,7 @@ def main():
 
     # sm send <session-id> "<text>"
     send_parser = subparsers.add_parser("send", help="Send input to a session")
-    send_parser.add_argument("session_id", help="Target session ID")
+    send_parser.add_argument("session_id", help="Target session ID, friendly name, alias, or comma-delimited list")
     send_parser.add_argument("text", help="Text to send to the session")
     send_parser.add_argument("--sequential", action="store_true", help="Wait for idle before sending (default)")
     send_parser.add_argument("--important", action="store_true", help="Inject immediately, queue behind current work")

--- a/src/server.py
+++ b/src/server.py
@@ -620,6 +620,37 @@ class SendInputRequest(BaseModel):
     parent_session_id: Optional[str] = None  # EM session to wake periodically after delivery (#225-C)
 
 
+class SendInputBatchRequest(SendInputRequest):
+    """Request to send the same input to multiple recipients."""
+    recipients: list[str] = Field(default_factory=list)
+
+
+class SendInputBatchResult(BaseModel):
+    """Per-recipient result returned by batch send."""
+    identifier: str
+    status: Literal["delivered", "queued", "emailed", "failed"]
+    delivery_kind: Literal["session", "email", "none"]
+    session_id: Optional[str] = None
+    target_name: Optional[str] = None
+    provider: Optional[str] = None
+    bootstrapped: bool = False
+    queue_position: Optional[int] = None
+    estimated_delivery: Optional[str] = None
+    email_username: Optional[str] = None
+    email_address: Optional[str] = None
+    detail: Optional[str] = None
+
+
+class SendInputBatchResponse(BaseModel):
+    """Aggregate response for one multi-recipient send."""
+    ok: bool
+    requested_count: int
+    success_count: int
+    failure_count: int
+    delivery_mode: str
+    results: list[SendInputBatchResult]
+
+
 class CodexRequestRespondRequest(BaseModel):
     """Structured response payload for codex request resolution."""
     decision: Optional[Literal["accept", "acceptForSession", "decline", "cancel"]] = None
@@ -1247,6 +1278,61 @@ def create_app(
                     identifiers.append(normalized)
         return identifiers
 
+    def _unique_identifiers(values: list[str]) -> list[str]:
+        identifiers: list[str] = []
+        seen: set[str] = set()
+        for identifier in _normalize_identifier_list(values):
+            if identifier in seen:
+                continue
+            identifiers.append(identifier)
+            seen.add(identifier)
+        return identifiers
+
+    def _detail_text(detail: Any) -> str:
+        if isinstance(detail, dict):
+            message = detail.get("message")
+            error_code = detail.get("error_code")
+            if message and error_code:
+                return f"{message} ({error_code})"
+            if message:
+                return str(message)
+            return json.dumps(detail, sort_keys=True)
+        return str(detail)
+
+    def _send_request_supports_email_fallback(request: SendInputRequest) -> bool:
+        return (
+            request.delivery_mode == "sequential"
+            and request.notify_after_seconds is None
+            and request.remind_soft_threshold is None
+            and request.remind_hard_threshold is None
+            and request.remind_cancel_on_reply_session_id is None
+        )
+
+    def _resolve_live_send_target(identifier: str) -> Optional[Session]:
+        session = _resolve_session_or_registry_role(identifier)
+        if session is not None:
+            return session
+        if not app.state.session_manager:
+            return None
+
+        lister = getattr(app.state.session_manager, "list_sessions", None)
+        alias_getter = getattr(app.state.session_manager, "get_session_aliases", None)
+        if not callable(lister):
+            return None
+        try:
+            sessions = lister(include_stopped=False)
+        except TypeError:
+            sessions = lister()
+
+        for candidate in sessions or []:
+            aliases = alias_getter(candidate.id) if callable(alias_getter) else []
+            if identifier in aliases:
+                return candidate
+        for candidate in sessions or []:
+            if _effective_session_name(candidate, sync_native_title=False) == identifier:
+                return candidate
+        return None
+
     async def _send_registered_email(request: SendEmailRequest) -> dict[str, Any]:
         handler = _email_handler_or_503()
         if not getattr(handler, "bridge_is_available", lambda: False)():
@@ -1284,6 +1370,149 @@ def create_app(
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         except RuntimeError as exc:
             raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    async def _deliver_send_input_to_session(session: Session, request: SendInputRequest) -> dict[str, Any]:
+        """Deliver one send request to a resolved live session and serialize the outcome."""
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
+
+        _enforce_session_input_gates(session, session.id)
+
+        result = await app.state.session_manager.send_input(
+            session.id,
+            request.text,
+            sender_session_id=request.sender_session_id,
+            delivery_mode=request.delivery_mode,
+            from_sm_send=request.from_sm_send,
+            timeout_seconds=request.timeout_seconds,
+            notify_on_delivery=request.notify_on_delivery,
+            notify_after_seconds=request.notify_after_seconds,
+            notify_on_stop=request.notify_on_stop,
+            remind_soft_threshold=request.remind_soft_threshold,
+            remind_hard_threshold=request.remind_hard_threshold,
+            remind_cancel_on_reply_session_id=request.remind_cancel_on_reply_session_id,
+            parent_session_id=request.parent_session_id,
+        )
+
+        if result == DeliveryResult.FAILED:
+            raise HTTPException(status_code=500, detail="Failed to send input")
+
+        if app.state.output_monitor:
+            app.state.output_monitor.update_activity(session.id)
+
+        response = {
+            "status": result.value,
+            "session_id": session.id,
+            "delivery_mode": request.delivery_mode,
+        }
+        if result == DeliveryResult.QUEUED:
+            queue_mgr = app.state.session_manager.message_queue_manager
+            if queue_mgr:
+                queue_len = queue_mgr.get_queue_length(session.id)
+                response["queue_position"] = queue_len
+                response["estimated_delivery"] = "deferred"
+        return response
+
+    async def _deliver_send_input_to_identifier(
+        identifier: str,
+        request: SendInputBatchRequest,
+    ) -> SendInputBatchResult:
+        """Resolve and deliver one batch send target."""
+        session = _resolve_live_send_target(identifier)
+        bootstrapped = False
+
+        if session is None and app.state.session_manager:
+            ensurer = getattr(app.state.session_manager, "ensure_role_session", None)
+            if callable(ensurer):
+                try:
+                    session, bootstrapped = await ensurer(identifier)
+                except ValueError as exc:
+                    detail = str(exc)
+                    if "not configured for auto-bootstrap" not in detail:
+                        return SendInputBatchResult(
+                            identifier=identifier,
+                            status="failed",
+                            delivery_kind="none",
+                            detail=detail,
+                        )
+                except RuntimeError as exc:
+                    return SendInputBatchResult(
+                        identifier=identifier,
+                        status="failed",
+                        delivery_kind="none",
+                        detail=str(exc),
+                    )
+
+                if session is not None and bootstrapped:
+                    if app.state.output_monitor and getattr(session, "provider", "claude") != "codex-app":
+                        await app.state.output_monitor.start_monitoring(session)
+                    await _sync_session_display_identity(session)
+
+        if session is not None:
+            try:
+                delivery = await _deliver_send_input_to_session(session, request)
+            except HTTPException as exc:
+                return SendInputBatchResult(
+                    identifier=identifier,
+                    status="failed",
+                    delivery_kind="none",
+                    session_id=session.id,
+                    target_name=_effective_session_name(session, sync_native_title=False),
+                    provider=getattr(session, "provider", "claude"),
+                    bootstrapped=bootstrapped,
+                    detail=_detail_text(exc.detail),
+                )
+
+            return SendInputBatchResult(
+                identifier=identifier,
+                status=delivery["status"],
+                delivery_kind="session",
+                session_id=session.id,
+                target_name=_effective_session_name(session, sync_native_title=False),
+                provider=getattr(session, "provider", "claude"),
+                bootstrapped=bootstrapped,
+                queue_position=delivery.get("queue_position"),
+                estimated_delivery=delivery.get("estimated_delivery"),
+            )
+
+        if not _send_request_supports_email_fallback(request):
+            return SendInputBatchResult(
+                identifier=identifier,
+                status="failed",
+                delivery_kind="none",
+                detail="email fallback only supports plain sequential sends without --wait/--track/--urgent",
+            )
+
+        try:
+            email_payload = await _send_registered_email(
+                SendEmailRequest(
+                    requester_session_id=request.sender_session_id,
+                    recipients=[identifier],
+                    body_text=request.text,
+                    auto_subject=True,
+                )
+            )
+        except HTTPException as exc:
+            detail = exc.detail
+            if exc.status_code == 404 and str(detail).strip() == "Not Found":
+                detail = f"Session '{identifier}' not found"
+            return SendInputBatchResult(
+                identifier=identifier,
+                status="failed",
+                delivery_kind="none",
+                detail=_detail_text(detail),
+            )
+
+        recipients = email_payload.get("to") or []
+        first = recipients[0] if recipients and isinstance(recipients[0], dict) else {}
+        return SendInputBatchResult(
+            identifier=identifier,
+            status="emailed",
+            delivery_kind="email",
+            target_name=first.get("username"),
+            email_username=first.get("username"),
+            email_address=first.get("email"),
+        )
 
     async def _deliver_email_reply_to_session(payload: InboundEmailRequest, request: Optional[Request] = None) -> dict[str, Any]:
         handler = _email_handler_or_503()
@@ -3865,47 +4094,32 @@ def create_app(
         session = app.state.session_manager.get_session(session_id)
         if not session:
             raise HTTPException(status_code=404, detail="Session not found")
+        return await _deliver_send_input_to_session(session, request)
 
-        _enforce_session_input_gates(session, session_id)
+    @app.post("/sessions/input-batch", response_model=SendInputBatchResponse)
+    async def send_input_batch(request: SendInputBatchRequest):
+        """Send the same input to multiple recipients with per-target results."""
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
 
-        result = await app.state.session_manager.send_input(
-            session_id,
-            request.text,
-            sender_session_id=request.sender_session_id,
+        recipients = _unique_identifiers(request.recipients)
+        if not recipients:
+            raise HTTPException(status_code=400, detail="At least one recipient is required")
+
+        results: list[SendInputBatchResult] = []
+        for identifier in recipients:
+            results.append(await _deliver_send_input_to_identifier(identifier, request))
+
+        success_count = sum(1 for item in results if item.status in {"delivered", "queued", "emailed"})
+        failure_count = len(results) - success_count
+        return SendInputBatchResponse(
+            ok=failure_count == 0,
+            requested_count=len(recipients),
+            success_count=success_count,
+            failure_count=failure_count,
             delivery_mode=request.delivery_mode,
-            from_sm_send=request.from_sm_send,
-            timeout_seconds=request.timeout_seconds,
-            notify_on_delivery=request.notify_on_delivery,
-            notify_after_seconds=request.notify_after_seconds,
-            notify_on_stop=request.notify_on_stop,
-            remind_soft_threshold=request.remind_soft_threshold,
-            remind_hard_threshold=request.remind_hard_threshold,
-            remind_cancel_on_reply_session_id=request.remind_cancel_on_reply_session_id,
-            parent_session_id=request.parent_session_id,
+            results=results,
         )
-
-        if result == DeliveryResult.FAILED:
-            raise HTTPException(status_code=500, detail="Failed to send input")
-
-        # Update activity in monitor
-        if app.state.output_monitor:
-            app.state.output_monitor.update_activity(session_id)
-
-        # Return delivery result with queue info if queued
-        response = {
-            "status": result.value,  # "delivered", "queued", or "failed"
-            "session_id": session_id,
-            "delivery_mode": request.delivery_mode,
-        }
-
-        if result == DeliveryResult.QUEUED:
-            queue_mgr = app.state.session_manager.message_queue_manager
-            if queue_mgr:
-                queue_len = queue_mgr.get_queue_length(session_id)
-                response["queue_position"] = queue_len
-                response["estimated_delivery"] = "deferred"
-
-        return response
 
     @app.post("/sessions/{session_id}/key")
     async def send_key(session_id: str, key: str = Body(..., embed=True)):

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -1073,6 +1073,107 @@ class TestEmailBridgeEndpoints:
         )
         assert response.status_code == 404
 
+    def test_send_input_batch_delivers_to_multiple_sessions(self, test_client, mock_session_manager, sample_session):
+        """POST /sessions/input-batch sends one payload to multiple live sessions."""
+        second_session = Session(
+            id="other456",
+            name="other-session",
+            working_dir="/tmp/other",
+            tmux_session="claude-other456",
+            log_file="/tmp/other.log",
+            status=SessionStatus.RUNNING,
+            created_at=sample_session.created_at,
+            last_activity=sample_session.last_activity,
+            friendly_name="Other Session",
+        )
+        mock_session_manager.get_session.side_effect = lambda session_id: {
+            "test123": sample_session,
+            "other456": second_session,
+        }.get(session_id)
+        mock_session_manager.send_input = AsyncMock(
+            side_effect=[DeliveryResult.DELIVERED, DeliveryResult.QUEUED]
+        )
+        mock_session_manager.message_queue_manager = MagicMock()
+        mock_session_manager.message_queue_manager.get_queue_length.return_value = 2
+
+        response = test_client.post(
+            "/sessions/input-batch",
+            json={"recipients": ["test123", "other456"], "text": "Hello, team"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["ok"] is True
+        assert data["success_count"] == 2
+        assert data["failure_count"] == 0
+        assert [item["status"] for item in data["results"]] == ["delivered", "queued"]
+        assert data["results"][1]["queue_position"] == 2
+        assert data["results"][1]["estimated_delivery"] == "deferred"
+        assert mock_session_manager.send_input.await_count == 2
+
+    def test_send_input_batch_falls_back_to_email_per_recipient(
+        self,
+        test_client,
+        mock_session_manager,
+        mock_email_handler,
+        sample_session,
+    ):
+        """POST /sessions/input-batch can mix live session delivery with email fallback."""
+        sender_session = Session(
+            id="sender123",
+            name="sender-session",
+            working_dir="/tmp/sender",
+            tmux_session="claude-sender123",
+            log_file="/tmp/sender.log",
+            status=SessionStatus.RUNNING,
+            created_at=sample_session.created_at,
+            last_activity=sample_session.last_activity,
+            friendly_name="Sender Session",
+        )
+        mock_session_manager.get_session.side_effect = lambda session_id: {
+            "sender123": sender_session,
+            "test123": sample_session,
+        }.get(session_id)
+        mock_session_manager.ensure_role_session = AsyncMock(
+            side_effect=ValueError("Role not configured for auto-bootstrap")
+        )
+        mock_session_manager.send_input = AsyncMock(return_value=DeliveryResult.DELIVERED)
+        mock_email_handler.send_agent_email = AsyncMock(
+            return_value={
+                "to": [{"username": "orchestrator", "email": "orch@example.com"}],
+                "cc": [],
+                "subject": "status",
+            }
+        )
+
+        response = test_client.post(
+            "/sessions/input-batch",
+            json={
+                "recipients": ["test123", "d030a600"],
+                "text": "review landed",
+                "sender_session_id": "sender123",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["ok"] is True
+        assert [item["status"] for item in data["results"]] == ["delivered", "emailed"]
+        assert data["results"][1]["email_username"] == "orchestrator"
+        assert data["results"][1]["email_address"] == "orch@example.com"
+        mock_email_handler.send_agent_email.assert_awaited_once_with(
+            sender_session_id="sender123",
+            sender_name="Sender Session",
+            sender_provider="claude",
+            to_identifiers=["d030a600"],
+            cc_identifiers=[],
+            subject=None,
+            body_text="review landed",
+            body_html=None,
+            body_markdown=False,
+            auto_subject=True,
+        )
+
 
 class TestHookEndpoints:
     """Tests for Claude Code hook endpoints."""

--- a/tests/unit/test_client_codex_endpoints.py
+++ b/tests/unit/test_client_codex_endpoints.py
@@ -46,6 +46,26 @@ def test_send_input_with_result_returns_409_detail():
     assert result["detail"]["error_code"] == "pending_structured_request"
 
 
+def test_send_input_batch_result_uses_batch_endpoint():
+    client = _make_client()
+    payload = {"ok": True, "results": []}
+    with patch.object(client, "_request_with_status", return_value=(payload, 200, False)) as req:
+        result = client.send_input_batch_result(["abc123", "def456"], "hello")
+    assert result["ok"] is True
+    assert result["status_code"] == 200
+    req.assert_called_once_with(
+        "POST",
+        "/sessions/input-batch",
+        {
+            "recipients": ["abc123", "def456"],
+            "text": "hello",
+            "delivery_mode": "sequential",
+            "from_sm_send": False,
+        },
+        timeout=None,
+    )
+
+
 def test_respond_codex_request_validation_error():
     client = _make_client()
     result = client.respond_codex_request(

--- a/tests/unit/test_email_commands.py
+++ b/tests/unit/test_email_commands.py
@@ -143,6 +143,92 @@ def test_cmd_send_uses_extended_timeout_for_resolution_and_delivery(capsys):
     assert "Input sent to worker (live123)" in capsys.readouterr().out
 
 
+def test_cmd_send_multiple_recipients_uses_batch_endpoint(capsys):
+    client = Mock()
+    client.session_id = "sender123"
+    client.send_input_batch_result.return_value = {
+        "ok": True,
+        "unavailable": False,
+        "data": {
+            "failure_count": 0,
+            "results": [
+                {
+                    "identifier": "owner123",
+                    "status": "delivered",
+                    "delivery_kind": "session",
+                    "session_id": "owner123",
+                    "target_name": "spec-owner-3004",
+                },
+                {
+                    "identifier": "d030a600",
+                    "status": "emailed",
+                    "delivery_kind": "email",
+                    "email_username": "orchestrator",
+                    "email_address": "orch@example.com",
+                },
+            ],
+        },
+    }
+
+    rc = cmd_send(client, "owner123, d030a600, owner123,", "review landed")
+
+    assert rc == 0
+    client.send_input.assert_not_called()
+    client.send_input_batch_result.assert_called_once_with(
+        ["owner123", "d030a600"],
+        "review landed",
+        sender_session_id="sender123",
+        delivery_mode="sequential",
+        from_sm_send=True,
+        timeout_seconds=None,
+        notify_on_delivery=False,
+        notify_after_seconds=None,
+        notify_on_stop=True,
+        remind_soft_threshold=None,
+        remind_hard_threshold=None,
+        remind_cancel_on_reply_session_id=None,
+        parent_session_id=None,
+        timeout=SEND_API_TIMEOUT,
+    )
+    output = capsys.readouterr().out
+    assert "Input sent to spec-owner-3004 (owner123)" in output
+    assert "Email sent to orchestrator <orch@example.com>" in output
+
+
+def test_cmd_send_multiple_recipients_returns_nonzero_on_partial_failure(capsys):
+    client = Mock()
+    client.session_id = "sender123"
+    client.send_input_batch_result.return_value = {
+        "ok": True,
+        "unavailable": False,
+        "data": {
+            "failure_count": 1,
+            "results": [
+                {
+                    "identifier": "owner123",
+                    "status": "delivered",
+                    "delivery_kind": "session",
+                    "session_id": "owner123",
+                    "target_name": "spec-owner-3004",
+                },
+                {
+                    "identifier": "missing-user",
+                    "status": "failed",
+                    "delivery_kind": "none",
+                    "detail": "Session 'missing-user' not found",
+                },
+            ],
+        },
+    }
+
+    rc = cmd_send(client, "owner123,missing-user", "review landed")
+
+    assert rc == 1
+    output = capsys.readouterr()
+    assert "Input sent to spec-owner-3004 (owner123)" in output.out
+    assert "Error: missing-user: Session 'missing-user' not found" in output.err
+
+
 def test_cmd_email_reads_markdown_file_and_calls_api(tmp_path, capsys):
     body_path = tmp_path / "summary.md"
     body_path.write_text("# Summary\n\n- one\n- two\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- add a batch `sm send` path for comma-delimited recipients so one CLI invocation maps to one backend request
- resolve each recipient server-side with the existing live-session, role-bootstrap, and email-fallback routing semantics
- add CLI/client/server regression coverage for mixed session and email outcomes

## Testing
- pytest tests/unit/test_email_commands.py tests/unit/test_client_codex_endpoints.py tests/integration/test_api_endpoints.py

Fixes #627