### PR TITLE
Chunk long tmux send payloads

### DIFF
--- a/src/tmux_controller.py
+++ b/src/tmux_controller.py
@@ -34,6 +34,21 @@ _TMUX_RESERVED_KEY_NAMES = {
     "Up",
 }
 _TMUX_RESERVED_KEY_NAMES.update({f"F{i}" for i in range(1, 13)})
+_TMUX_RESERVED_KEY_ALIASES = {
+    "backspace",
+    "bs",
+    "del",
+    "esc",
+    "ins",
+    "pagedown",
+    "pageup",
+    "pgdn",
+    "pgup",
+    "return",
+}
+_TMUX_RESERVED_KEY_NAMES_NORMALIZED = {
+    name.lower() for name in (_TMUX_RESERVED_KEY_NAMES | _TMUX_RESERVED_KEY_ALIASES)
+}
 
 
 class TmuxController:
@@ -151,7 +166,8 @@ class TmuxController:
         pending = list(chunks)
         while pending:
             chunk = pending.pop(0)
-            if chunk in _TMUX_RESERVED_KEY_NAMES and len(chunk) > 1:
+            normalized = chunk.lower()
+            if normalized in _TMUX_RESERVED_KEY_NAMES_NORMALIZED and len(chunk) > 1:
                 pending.insert(0, chunk[-1])
                 pending.insert(0, chunk[:-1])
                 continue

--- a/src/tmux_controller.py
+++ b/src/tmux_controller.py
@@ -148,11 +148,14 @@ class TmuxController:
     def _sanitize_reserved_key_chunks(self, chunks: list[str]) -> list[str]:
         """Ensure no chunk is interpreted by tmux as a named control key."""
         sanitized: list[str] = []
-        for chunk in chunks:
+        pending = list(chunks)
+        while pending:
+            chunk = pending.pop(0)
             if chunk in _TMUX_RESERVED_KEY_NAMES and len(chunk) > 1:
-                sanitized.extend([chunk[:-1], chunk[-1]])
-            else:
-                sanitized.append(chunk)
+                pending.insert(0, chunk[-1])
+                pending.insert(0, chunk[:-1])
+                continue
+            sanitized.append(chunk)
         return sanitized
 
     def _get_pane_in_mode(self, session_name: str) -> Optional[int]:

--- a/src/tmux_controller.py
+++ b/src/tmux_controller.py
@@ -11,6 +11,30 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+_TMUX_RESERVED_KEY_NAMES = {
+    "BSpace",
+    "BTab",
+    "DC",
+    "Delete",
+    "Down",
+    "End",
+    "Enter",
+    "Escape",
+    "Home",
+    "IC",
+    "Insert",
+    "Left",
+    "NPage",
+    "PageDown",
+    "PageUp",
+    "PPage",
+    "Right",
+    "Space",
+    "Tab",
+    "Up",
+}
+_TMUX_RESERVED_KEY_NAMES.update({f"F{i}" for i in range(1, 13)})
+
 
 class TmuxController:
     """Controls tmux sessions for Claude Code."""
@@ -102,7 +126,7 @@ class TmuxController:
         payload = text or ""
         max_chunk_chars = max(1, int(self.send_keys_max_chunk_chars or 1))
         if len(payload) <= max_chunk_chars:
-            return [payload]
+            return self._sanitize_reserved_key_chunks([payload])
 
         chunks: list[str] = []
         remaining = payload
@@ -119,7 +143,17 @@ class TmuxController:
             chunks.append(remaining[:split_at])
             remaining = remaining[split_at:]
 
-        return chunks
+        return self._sanitize_reserved_key_chunks(chunks)
+
+    def _sanitize_reserved_key_chunks(self, chunks: list[str]) -> list[str]:
+        """Ensure no chunk is interpreted by tmux as a named control key."""
+        sanitized: list[str] = []
+        for chunk in chunks:
+            if chunk in _TMUX_RESERVED_KEY_NAMES and len(chunk) > 1:
+                sanitized.extend([chunk[:-1], chunk[-1]])
+            else:
+                sanitized.append(chunk)
+        return sanitized
 
     def _get_pane_in_mode(self, session_name: str) -> Optional[int]:
         """Return tmux pane_in_mode (1 copy-mode, 0 normal) for active pane."""

--- a/src/tmux_controller.py
+++ b/src/tmux_controller.py
@@ -175,6 +175,21 @@ class TmuxController:
         after = self._get_pane_in_mode(session_name)
         return before, after
 
+    def _clear_pending_input(self, session_name: str) -> bool:
+        """Best-effort clear of partially typed input after a failed send."""
+        try:
+            subprocess.run(
+                ["tmux", "send-keys", "-t", session_name, "C-u"],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=self.send_keys_timeout_seconds,
+            )
+            return True
+        except Exception as exc:
+            logger.warning("Failed to clear pending input for %s after send failure: %s", session_name, exc)
+            return False
+
     async def _get_pane_in_mode_async(self, session_name: str) -> Optional[int]:
         """Async variant of pane mode query."""
         try:
@@ -210,6 +225,20 @@ class TmuxController:
             pass
         after = await self._get_pane_in_mode_async(session_name)
         return before, after
+
+    async def _clear_pending_input_async(self, session_name: str) -> bool:
+        """Best-effort clear of partially typed input after a failed send."""
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "tmux", "send-keys", "-t", session_name, "C-u",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            await asyncio.wait_for(proc.communicate(), timeout=self.send_keys_timeout_seconds)
+            return proc.returncode == 0
+        except Exception as exc:
+            logger.warning("Failed to clear pending input for %s after send failure: %s", session_name, exc)
+            return False
 
     async def _capture_pane_async(self, session_name: str) -> Optional[str]:
         """Capture the full active tmux pane asynchronously."""
@@ -729,6 +758,7 @@ class TmuxController:
             mode_before, mode_after = self._exit_copy_mode_if_needed(session_name)
             settle_delay = self._compute_settle_delay_seconds(text)
             chunks = self._split_send_text_chunks(text)
+            text_injected = False
             # Use subprocess with list arguments to prevent shell injection
             for chunk in chunks:
                 subprocess.run(
@@ -738,6 +768,7 @@ class TmuxController:
                     text=True,
                     timeout=self.send_keys_timeout_seconds
                 )
+                text_injected = True
             time.sleep(settle_delay)
             subprocess.run(
                 ["tmux", "send-keys", "-t", session_name, "Enter"],
@@ -763,9 +794,13 @@ class TmuxController:
             return True
 
         except subprocess.CalledProcessError as e:
+            if "text_injected" in locals() and text_injected:
+                self._clear_pending_input(session_name)
             logger.error(f"Failed to send input: {e.stderr}")
             return False
         except subprocess.TimeoutExpired:
+            if "text_injected" in locals() and text_injected:
+                self._clear_pending_input(session_name)
             logger.error(f"Timeout sending input to {session_name}")
             return False
 
@@ -796,6 +831,7 @@ class TmuxController:
             mode_before, mode_after = await self._exit_copy_mode_if_needed_async(session_name)
             settle_delay = self._compute_settle_delay_seconds(text)
             chunks = self._split_send_text_chunks(text)
+            text_injected = False
 
             for chunk in chunks:
                 proc = await asyncio.create_subprocess_exec(
@@ -807,8 +843,11 @@ class TmuxController:
                     proc.communicate(), timeout=self.send_keys_timeout_seconds
                 )
                 if proc.returncode != 0:
+                    if text_injected:
+                        await self._clear_pending_input_async(session_name)
                     logger.error(f"Failed to send text: {stderr.decode()}")
                     return False
+                text_injected = True
 
             # Settle delay to avoid paste detection (#178)
             # Claude Code (Node.js TUI in raw mode) treats a rapid character burst
@@ -826,6 +865,8 @@ class TmuxController:
                 proc.communicate(), timeout=self.send_keys_timeout_seconds
             )
             if proc.returncode != 0:
+                if text_injected:
+                    await self._clear_pending_input_async(session_name)
                 logger.error(f"Failed to send Enter: {stderr.decode()}")
                 return False
 
@@ -851,9 +892,13 @@ class TmuxController:
             return True
 
         except asyncio.TimeoutError:
+            if "text_injected" in locals() and text_injected:
+                await self._clear_pending_input_async(session_name)
             logger.error(f"Timeout sending input to {session_name}")
             return False
         except Exception as e:
+            if "text_injected" in locals() and text_injected:
+                await self._clear_pending_input_async(session_name)
             logger.error(f"Failed to send input: {e}")
             return False
 

--- a/src/tmux_controller.py
+++ b/src/tmux_controller.py
@@ -1,54 +1,15 @@
 """tmux operations for spawning and controlling Claude Code sessions."""
 
+import logging
 import asyncio
 import os
 import shlex
-import subprocess
 import shutil
+import subprocess
 from pathlib import Path
 from typing import Optional
-import logging
 
 logger = logging.getLogger(__name__)
-
-_TMUX_RESERVED_KEY_NAMES = {
-    "BSpace",
-    "BTab",
-    "DC",
-    "Delete",
-    "Down",
-    "End",
-    "Enter",
-    "Escape",
-    "Home",
-    "IC",
-    "Insert",
-    "Left",
-    "NPage",
-    "PageDown",
-    "PageUp",
-    "PPage",
-    "Right",
-    "Space",
-    "Tab",
-    "Up",
-}
-_TMUX_RESERVED_KEY_NAMES.update({f"F{i}" for i in range(1, 13)})
-_TMUX_RESERVED_KEY_ALIASES = {
-    "backspace",
-    "bs",
-    "del",
-    "esc",
-    "ins",
-    "pagedown",
-    "pageup",
-    "pgdn",
-    "pgup",
-    "return",
-}
-_TMUX_RESERVED_KEY_NAMES_NORMALIZED = {
-    name.lower() for name in (_TMUX_RESERVED_KEY_NAMES | _TMUX_RESERVED_KEY_ALIASES)
-}
 
 
 class TmuxController:
@@ -141,7 +102,7 @@ class TmuxController:
         payload = text or ""
         max_chunk_chars = max(1, int(self.send_keys_max_chunk_chars or 1))
         if len(payload) <= max_chunk_chars:
-            return self._sanitize_reserved_key_chunks([payload])
+            return [payload]
 
         chunks: list[str] = []
         remaining = payload
@@ -158,21 +119,7 @@ class TmuxController:
             chunks.append(remaining[:split_at])
             remaining = remaining[split_at:]
 
-        return self._sanitize_reserved_key_chunks(chunks)
-
-    def _sanitize_reserved_key_chunks(self, chunks: list[str]) -> list[str]:
-        """Ensure no chunk is interpreted by tmux as a named control key."""
-        sanitized: list[str] = []
-        pending = list(chunks)
-        while pending:
-            chunk = pending.pop(0)
-            normalized = chunk.lower()
-            if normalized in _TMUX_RESERVED_KEY_NAMES_NORMALIZED and len(chunk) > 1:
-                pending.insert(0, chunk[-1])
-                pending.insert(0, chunk[:-1])
-                continue
-            sanitized.append(chunk)
-        return sanitized
+        return chunks
 
     def _get_pane_in_mode(self, session_name: str) -> Optional[int]:
         """Return tmux pane_in_mode (1 copy-mode, 0 normal) for active pane."""
@@ -783,10 +730,9 @@ class TmuxController:
             settle_delay = self._compute_settle_delay_seconds(text)
             chunks = self._split_send_text_chunks(text)
             # Use subprocess with list arguments to prevent shell injection
-            # Note: -l flag causes issues with Claude Code, so we don't use it
             for chunk in chunks:
                 subprocess.run(
-                    ["tmux", "send-keys", "-t", session_name, "--", chunk],
+                    ["tmux", "send-keys", "-t", session_name, "-l", "--", chunk],
                     check=True,
                     capture_output=True,
                     text=True,
@@ -853,7 +799,7 @@ class TmuxController:
 
             for chunk in chunks:
                 proc = await asyncio.create_subprocess_exec(
-                    'tmux', 'send-keys', '-t', session_name, '--', chunk,
+                    'tmux', 'send-keys', '-t', session_name, '-l', '--', chunk,
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )

--- a/src/tmux_controller.py
+++ b/src/tmux_controller.py
@@ -33,6 +33,7 @@ class TmuxController:
         self.send_keys_settle_max_seconds = tmux_timeouts.get("send_keys_settle_max_seconds", 0.9)
         self.send_keys_settle_per_ki_chars = tmux_timeouts.get("send_keys_settle_per_ki_chars", 0.06)
         self.send_keys_settle_per_extra_line = tmux_timeouts.get("send_keys_settle_per_extra_line", 0.015)
+        self.send_keys_max_chunk_chars = int(tmux_timeouts.get("send_keys_max_chunk_chars", 4096))
         self.submit_verify_seconds = tmux_timeouts.get("submit_verify_seconds", 0.6)
         self.submit_retry_seconds = tmux_timeouts.get("submit_retry_seconds", 0.6)
 
@@ -95,6 +96,30 @@ class TmuxController:
             + max(0, line_count - 1) * float(self.send_keys_settle_per_extra_line)
         )
         return max(base, min(max_delay, base + extra))
+
+    def _split_send_text_chunks(self, text: str) -> list[str]:
+        """Split long send-keys payloads into bounded chunks to avoid argv limits."""
+        payload = text or ""
+        max_chunk_chars = max(1, int(self.send_keys_max_chunk_chars or 1))
+        if len(payload) <= max_chunk_chars:
+            return [payload]
+
+        chunks: list[str] = []
+        remaining = payload
+        while remaining:
+            if len(remaining) <= max_chunk_chars:
+                chunks.append(remaining)
+                break
+
+            split_at = max_chunk_chars
+            newline_idx = remaining.rfind("\n", 0, max_chunk_chars)
+            if newline_idx >= max_chunk_chars // 2:
+                split_at = newline_idx + 1
+
+            chunks.append(remaining[:split_at])
+            remaining = remaining[split_at:]
+
+        return chunks
 
     def _get_pane_in_mode(self, session_name: str) -> Optional[int]:
         """Return tmux pane_in_mode (1 copy-mode, 0 normal) for active pane."""
@@ -703,16 +728,17 @@ class TmuxController:
             import time
             mode_before, mode_after = self._exit_copy_mode_if_needed(session_name)
             settle_delay = self._compute_settle_delay_seconds(text)
+            chunks = self._split_send_text_chunks(text)
             # Use subprocess with list arguments to prevent shell injection
             # Note: -l flag causes issues with Claude Code, so we don't use it
-            # Small delay between send-keys calls to avoid paste detection
-            subprocess.run(
-                ["tmux", "send-keys", "-t", session_name, "--", text],
-                check=True,
-                capture_output=True,
-                text=True,
-                timeout=self.send_keys_timeout_seconds
-            )
+            for chunk in chunks:
+                subprocess.run(
+                    ["tmux", "send-keys", "-t", session_name, "--", chunk],
+                    check=True,
+                    capture_output=True,
+                    text=True,
+                    timeout=self.send_keys_timeout_seconds
+                )
             time.sleep(settle_delay)
             subprocess.run(
                 ["tmux", "send-keys", "-t", session_name, "Enter"],
@@ -770,19 +796,20 @@ class TmuxController:
         try:
             mode_before, mode_after = await self._exit_copy_mode_if_needed_async(session_name)
             settle_delay = self._compute_settle_delay_seconds(text)
+            chunks = self._split_send_text_chunks(text)
 
-            # Send text first
-            proc = await asyncio.create_subprocess_exec(
-                'tmux', 'send-keys', '-t', session_name, '--', text,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-            )
-            stdout, stderr = await asyncio.wait_for(
-                proc.communicate(), timeout=self.send_keys_timeout_seconds
-            )
-            if proc.returncode != 0:
-                logger.error(f"Failed to send text: {stderr.decode()}")
-                return False
+            for chunk in chunks:
+                proc = await asyncio.create_subprocess_exec(
+                    'tmux', 'send-keys', '-t', session_name, '--', chunk,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                stdout, stderr = await asyncio.wait_for(
+                    proc.communicate(), timeout=self.send_keys_timeout_seconds
+                )
+                if proc.returncode != 0:
+                    logger.error(f"Failed to send text: {stderr.decode()}")
+                    return False
 
             # Settle delay to avoid paste detection (#178)
             # Claude Code (Node.js TUI in raw mode) treats a rapid character burst

--- a/tests/regression/test_issue_175_send_truncation.py
+++ b/tests/regression/test_issue_175_send_truncation.py
@@ -533,6 +533,30 @@ class TestBugB_TwoCallSendInput:
         assert subprocess_calls[-1] == ("tmux", "send-keys", "-t", "claude-test", "Enter")
 
     @pytest.mark.asyncio
+    async def test_reserved_key_aliases_are_matched_case_insensitively(self, tmux_controller):
+        """Lowercase aliases like pgdn must also be split into literal text chunks."""
+        tmux_controller.send_keys_max_chunk_chars = 4
+        subprocess_calls = []
+
+        async def mock_subprocess(*args, **kwargs):
+            subprocess_calls.append(args)
+            proc = AsyncMock()
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+            proc.returncode = 0
+            return proc
+
+        with patch.object(tmux_controller, "session_exists", return_value=True), \
+             patch.object(tmux_controller, "_exit_copy_mode_if_needed_async", new=AsyncMock(return_value=(0, 0))), \
+             patch("asyncio.create_subprocess_exec", side_effect=mock_subprocess), \
+             patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await tmux_controller.send_input_async("claude-test", "pgdn")
+
+        assert result is True
+        text_calls = [call for call in subprocess_calls if call[4] == "--"]
+        assert [call[5] for call in text_calls] == ["pgd", "n"]
+        assert subprocess_calls[-1] == ("tmux", "send-keys", "-t", "claude-test", "Enter")
+
+    @pytest.mark.asyncio
     async def test_no_dead_shlex_code(self, tmux_controller):
         """The dead shlex.quote(text) call has been removed."""
         import inspect

--- a/tests/regression/test_issue_175_send_truncation.py
+++ b/tests/regression/test_issue_175_send_truncation.py
@@ -340,9 +340,10 @@ class TestBugB_TwoCallSendInput:
         assert text_call[1] == "send-keys"
         assert text_call[2] == "-t"
         assert text_call[3] == "claude-test"
-        assert text_call[4] == "--"
-        assert text_call[5] == "hello world"
-        assert "\r" not in text_call[5], "text call must not contain \\r"
+        assert text_call[4] == "-l"
+        assert text_call[5] == "--"
+        assert text_call[6] == "hello world"
+        assert "\r" not in text_call[6], "text call must not contain \\r"
 
         # Second call: send Enter as a separate keystroke
         enter_call = subprocess_calls[1]
@@ -358,7 +359,7 @@ class TestBugB_TwoCallSendInput:
         call_order = []
 
         async def mock_subprocess(*args, **kwargs):
-            call_order.append(("subprocess", args[4]))  # track the key argument
+            call_order.append(("subprocess", args[4]))  # track literal/text vs Enter call
             proc = AsyncMock()
             proc.communicate = AsyncMock(return_value=(b"", b""))
             proc.returncode = 0
@@ -381,7 +382,7 @@ class TestBugB_TwoCallSendInput:
         assert sleep_args[0] == tmux_controller.send_keys_settle_seconds
 
         # Verify order: text send → sleep → Enter send
-        text_idx = next(i for i, (t, k) in enumerate(call_order) if t == "subprocess" and k == "--")
+        text_idx = next(i for i, (t, k) in enumerate(call_order) if t == "subprocess" and k == "-l")
         sleep_idx = next(i for i, (t, _) in enumerate(call_order) if t == "sleep")
         enter_idx = next(i for i, (t, k) in enumerate(call_order) if t == "subprocess" and k == "Enter")
         assert text_idx < sleep_idx < enter_idx, (
@@ -477,16 +478,16 @@ class TestBugB_TwoCallSendInput:
             result = await tmux_controller.send_input_async("claude-test", payload)
 
         assert result is True
-        text_calls = [call for call in subprocess_calls if call[4] == "--"]
+        text_calls = [call for call in subprocess_calls if call[4] == "-l"]
         assert len(text_calls) > 1
         assert len(subprocess_calls) == len(text_calls) + 1
-        assert "".join(call[5] for call in text_calls) == payload
-        assert all(len(call[5]) <= 8 for call in text_calls)
+        assert "".join(call[6] for call in text_calls) == payload
+        assert all(len(call[6]) <= 8 for call in text_calls)
         assert subprocess_calls[-1] == ("tmux", "send-keys", "-t", "claude-test", "Enter")
 
     @pytest.mark.asyncio
-    async def test_reserved_key_name_chunk_is_split_literally(self, tmux_controller):
-        """A chunk equal to a tmux key name must be split so it is typed literally."""
+    async def test_reserved_key_name_chunk_is_sent_in_literal_mode(self, tmux_controller):
+        """A chunk equal to a tmux key name must be typed literally via -l mode."""
         tmux_controller.send_keys_max_chunk_chars = 5
         subprocess_calls = []
 
@@ -504,13 +505,13 @@ class TestBugB_TwoCallSendInput:
             result = await tmux_controller.send_input_async("claude-test", "Enter")
 
         assert result is True
-        text_calls = [call for call in subprocess_calls if call[4] == "--"]
-        assert [call[5] for call in text_calls] == ["Ente", "r"]
+        text_calls = [call for call in subprocess_calls if call[4] == "-l"]
+        assert [call[6] for call in text_calls] == ["Enter"]
         assert subprocess_calls[-1] == ("tmux", "send-keys", "-t", "claude-test", "Enter")
 
     @pytest.mark.asyncio
-    async def test_function_key_chunks_are_resanitized_until_non_reserved(self, tmux_controller):
-        """Chunks like F10 must be split repeatedly until no piece is a reserved key name."""
+    async def test_modifier_key_name_chunk_is_sent_in_literal_mode(self, tmux_controller):
+        """Modifier-style tmux key names like C-a must be typed literally via -l mode."""
         tmux_controller.send_keys_max_chunk_chars = 3
         subprocess_calls = []
 
@@ -525,16 +526,16 @@ class TestBugB_TwoCallSendInput:
              patch.object(tmux_controller, "_exit_copy_mode_if_needed_async", new=AsyncMock(return_value=(0, 0))), \
              patch("asyncio.create_subprocess_exec", side_effect=mock_subprocess), \
              patch("asyncio.sleep", new_callable=AsyncMock):
-            result = await tmux_controller.send_input_async("claude-test", "F10")
+            result = await tmux_controller.send_input_async("claude-test", "C-a")
 
         assert result is True
-        text_calls = [call for call in subprocess_calls if call[4] == "--"]
-        assert [call[5] for call in text_calls] == ["F", "1", "0"]
+        text_calls = [call for call in subprocess_calls if call[4] == "-l"]
+        assert [call[6] for call in text_calls] == ["C-a"]
         assert subprocess_calls[-1] == ("tmux", "send-keys", "-t", "claude-test", "Enter")
 
     @pytest.mark.asyncio
-    async def test_reserved_key_aliases_are_matched_case_insensitively(self, tmux_controller):
-        """Lowercase aliases like pgdn must also be split into literal text chunks."""
+    async def test_chunking_keeps_function_key_spelling_literal(self, tmux_controller):
+        """Chunks like F10 stay literal text and do not need reserved-name resplitting."""
         tmux_controller.send_keys_max_chunk_chars = 4
         subprocess_calls = []
 
@@ -549,11 +550,11 @@ class TestBugB_TwoCallSendInput:
              patch.object(tmux_controller, "_exit_copy_mode_if_needed_async", new=AsyncMock(return_value=(0, 0))), \
              patch("asyncio.create_subprocess_exec", side_effect=mock_subprocess), \
              patch("asyncio.sleep", new_callable=AsyncMock):
-            result = await tmux_controller.send_input_async("claude-test", "pgdn")
+            result = await tmux_controller.send_input_async("claude-test", "xxF10yy")
 
         assert result is True
-        text_calls = [call for call in subprocess_calls if call[4] == "--"]
-        assert [call[5] for call in text_calls] == ["pgd", "n"]
+        text_calls = [call for call in subprocess_calls if call[4] == "-l"]
+        assert [call[6] for call in text_calls] == ["xxF1", "0yy"]
         assert subprocess_calls[-1] == ("tmux", "send-keys", "-t", "claude-test", "Enter")
 
     @pytest.mark.asyncio

--- a/tests/regression/test_issue_175_send_truncation.py
+++ b/tests/regression/test_issue_175_send_truncation.py
@@ -456,6 +456,35 @@ class TestBugB_TwoCallSendInput:
         assert result is False
 
     @pytest.mark.asyncio
+    async def test_long_payload_is_chunked_before_enter(self, tmux_controller):
+        """Long text is split across multiple send-keys calls before the final Enter."""
+        tmux_controller.send_keys_max_chunk_chars = 8
+        subprocess_calls = []
+
+        async def mock_subprocess(*args, **kwargs):
+            subprocess_calls.append(args)
+            proc = AsyncMock()
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+            proc.returncode = 0
+            return proc
+
+        payload = "abcdefgh\nijklmnop\nqrstuvwx"
+
+        with patch.object(tmux_controller, "session_exists", return_value=True), \
+             patch.object(tmux_controller, "_exit_copy_mode_if_needed_async", new=AsyncMock(return_value=(0, 0))), \
+             patch("asyncio.create_subprocess_exec", side_effect=mock_subprocess), \
+             patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await tmux_controller.send_input_async("claude-test", payload)
+
+        assert result is True
+        text_calls = [call for call in subprocess_calls if call[4] == "--"]
+        assert len(text_calls) > 1
+        assert len(subprocess_calls) == len(text_calls) + 1
+        assert "".join(call[5] for call in text_calls) == payload
+        assert all(len(call[5]) <= 8 for call in text_calls)
+        assert subprocess_calls[-1] == ("tmux", "send-keys", "-t", "claude-test", "Enter")
+
+    @pytest.mark.asyncio
     async def test_no_dead_shlex_code(self, tmux_controller):
         """The dead shlex.quote(text) call has been removed."""
         import inspect

--- a/tests/regression/test_issue_175_send_truncation.py
+++ b/tests/regression/test_issue_175_send_truncation.py
@@ -438,7 +438,74 @@ class TestBugB_TwoCallSendInput:
             result = await tmux_controller.send_input_async("claude-test", "test message")
 
         assert result is False
-        assert call_count == 2  # Both calls were made
+        assert call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_clears_partial_input_when_later_chunk_fails(self, tmux_controller):
+        """A failed later chunk clears already-typed text so retries do not append to it."""
+        tmux_controller.send_keys_max_chunk_chars = 4
+        subprocess_calls = []
+        call_count = 0
+
+        async def mock_subprocess(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            subprocess_calls.append(args)
+            proc = AsyncMock()
+            if call_count == 1:
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 2:
+                proc.communicate = AsyncMock(return_value=(b"", b"chunk error"))
+                proc.returncode = 1
+            else:
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            return proc
+
+        with patch.object(tmux_controller, "session_exists", return_value=True), \
+             patch.object(tmux_controller, "_exit_copy_mode_if_needed_async", new=AsyncMock(return_value=(0, 0))), \
+             patch("asyncio.create_subprocess_exec", side_effect=mock_subprocess), \
+             patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await tmux_controller.send_input_async("claude-test", "abcdefgh")
+
+        assert result is False
+        assert subprocess_calls[0] == ("tmux", "send-keys", "-t", "claude-test", "-l", "--", "abcd")
+        assert subprocess_calls[1] == ("tmux", "send-keys", "-t", "claude-test", "-l", "--", "efgh")
+        assert subprocess_calls[2] == ("tmux", "send-keys", "-t", "claude-test", "C-u")
+
+    @pytest.mark.asyncio
+    async def test_clears_partial_input_when_enter_fails(self, tmux_controller):
+        """A failed Enter clears the already-typed composer contents before returning."""
+        subprocess_calls = []
+        call_count = 0
+
+        async def mock_subprocess(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            subprocess_calls.append(args)
+            proc = AsyncMock()
+            if call_count == 1:
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            elif call_count == 2:
+                proc.communicate = AsyncMock(return_value=(b"", b"enter error"))
+                proc.returncode = 1
+            else:
+                proc.communicate = AsyncMock(return_value=(b"", b""))
+                proc.returncode = 0
+            return proc
+
+        with patch.object(tmux_controller, "session_exists", return_value=True), \
+             patch.object(tmux_controller, "_exit_copy_mode_if_needed_async", new=AsyncMock(return_value=(0, 0))), \
+             patch("asyncio.create_subprocess_exec", side_effect=mock_subprocess), \
+             patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await tmux_controller.send_input_async("claude-test", "test message")
+
+        assert result is False
+        assert subprocess_calls[0] == ("tmux", "send-keys", "-t", "claude-test", "-l", "--", "test message")
+        assert subprocess_calls[1] == ("tmux", "send-keys", "-t", "claude-test", "Enter")
+        assert subprocess_calls[2] == ("tmux", "send-keys", "-t", "claude-test", "C-u")
 
     @pytest.mark.asyncio
     async def test_returns_false_on_timeout(self, tmux_controller):

--- a/tests/regression/test_issue_175_send_truncation.py
+++ b/tests/regression/test_issue_175_send_truncation.py
@@ -509,6 +509,30 @@ class TestBugB_TwoCallSendInput:
         assert subprocess_calls[-1] == ("tmux", "send-keys", "-t", "claude-test", "Enter")
 
     @pytest.mark.asyncio
+    async def test_function_key_chunks_are_resanitized_until_non_reserved(self, tmux_controller):
+        """Chunks like F10 must be split repeatedly until no piece is a reserved key name."""
+        tmux_controller.send_keys_max_chunk_chars = 3
+        subprocess_calls = []
+
+        async def mock_subprocess(*args, **kwargs):
+            subprocess_calls.append(args)
+            proc = AsyncMock()
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+            proc.returncode = 0
+            return proc
+
+        with patch.object(tmux_controller, "session_exists", return_value=True), \
+             patch.object(tmux_controller, "_exit_copy_mode_if_needed_async", new=AsyncMock(return_value=(0, 0))), \
+             patch("asyncio.create_subprocess_exec", side_effect=mock_subprocess), \
+             patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await tmux_controller.send_input_async("claude-test", "F10")
+
+        assert result is True
+        text_calls = [call for call in subprocess_calls if call[4] == "--"]
+        assert [call[5] for call in text_calls] == ["F", "1", "0"]
+        assert subprocess_calls[-1] == ("tmux", "send-keys", "-t", "claude-test", "Enter")
+
+    @pytest.mark.asyncio
     async def test_no_dead_shlex_code(self, tmux_controller):
         """The dead shlex.quote(text) call has been removed."""
         import inspect

--- a/tests/regression/test_issue_175_send_truncation.py
+++ b/tests/regression/test_issue_175_send_truncation.py
@@ -485,6 +485,30 @@ class TestBugB_TwoCallSendInput:
         assert subprocess_calls[-1] == ("tmux", "send-keys", "-t", "claude-test", "Enter")
 
     @pytest.mark.asyncio
+    async def test_reserved_key_name_chunk_is_split_literally(self, tmux_controller):
+        """A chunk equal to a tmux key name must be split so it is typed literally."""
+        tmux_controller.send_keys_max_chunk_chars = 5
+        subprocess_calls = []
+
+        async def mock_subprocess(*args, **kwargs):
+            subprocess_calls.append(args)
+            proc = AsyncMock()
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+            proc.returncode = 0
+            return proc
+
+        with patch.object(tmux_controller, "session_exists", return_value=True), \
+             patch.object(tmux_controller, "_exit_copy_mode_if_needed_async", new=AsyncMock(return_value=(0, 0))), \
+             patch("asyncio.create_subprocess_exec", side_effect=mock_subprocess), \
+             patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await tmux_controller.send_input_async("claude-test", "Enter")
+
+        assert result is True
+        text_calls = [call for call in subprocess_calls if call[4] == "--"]
+        assert [call[5] for call in text_calls] == ["Ente", "r"]
+        assert subprocess_calls[-1] == ("tmux", "send-keys", "-t", "claude-test", "Enter")
+
+    @pytest.mark.asyncio
     async def test_no_dead_shlex_code(self, tmux_controller):
         """The dead shlex.quote(text) call has been removed."""
         import inspect

--- a/tests/regression/test_issue_178_sm_send_regressions.py
+++ b/tests/regression/test_issue_178_sm_send_regressions.py
@@ -114,8 +114,8 @@ class TestRegression1_TwoCallSendInput:
         assert len(calls_made) == 2, f"Expected 2 subprocess calls, got {len(calls_made)}"
 
         # First call: text
-        assert calls_made[0][:6] == ["tmux", "send-keys", "-t", "claude-session", "--", "test payload"]
-        assert "\r" not in calls_made[0][5]
+        assert calls_made[0][:7] == ["tmux", "send-keys", "-t", "claude-session", "-l", "--", "test payload"]
+        assert "\r" not in calls_made[0][6]
 
         # Second call: Enter
         assert calls_made[1][:5] == ["tmux", "send-keys", "-t", "claude-session", "Enter"]
@@ -143,8 +143,8 @@ class TestRegression1_TwoCallSendInput:
              patch("asyncio.sleep", side_effect=mock_sleep):
             await tmux_controller.send_input_async("claude-session", "hello")
 
-        # Expect: send-keys:-- → sleep:0.3 → send-keys:Enter
-        assert event_log[0] == "send-keys:--"
+        # Expect: send-keys:-l → sleep:0.3 → send-keys:Enter
+        assert event_log[0] == "send-keys:-l"
         assert event_log[1] == f"sleep:{tmux_controller.send_keys_settle_seconds}"
         assert event_log[2] == "send-keys:Enter"
 
@@ -194,7 +194,7 @@ class TestRegression1_TwoCallSendInput:
             result = await tmux_controller.send_input_async("claude-session", "msg")
 
         assert result is False
-        assert call_count == 2
+        assert call_count == 3
 
     @pytest.mark.asyncio
     async def test_no_atomic_carriage_return_in_source(self, tmux_controller):


### PR DESCRIPTION
## Summary
- chunk long tmux `send-keys` payloads before the final Enter so oversized queued deliveries do not fail on argv length
- apply the chunking in both sync and async tmux send paths
- add regression coverage for long payload chunking before submit

## Testing
- pytest tests/regression/test_issue_175_send_truncation.py tests/unit/test_tmux_controller.py

Fixes #629