### PR TITLE
Push Claude native /rename on explicit SM names

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -443,6 +443,10 @@ class SessionManagerApp:
                 session.friendly_name_is_explicit = True
             self.session_manager._save_state()
 
+            renamer = getattr(self.session_manager, "queue_claude_native_rename", None)
+            if callable(renamer):
+                await renamer(session, name)
+
             # Update tmux status bar to show friendly name
             if session.provider != "codex-app":
                 display_name = self.session_manager.get_effective_session_name(session) or name

--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -2183,6 +2183,28 @@ class MessageQueueManager:
             )
         return count
 
+    def cancel_queued_messages_for_target(self, target_session_id: str, message_category: str) -> int:
+        """Delete undelivered target-facing messages for one category."""
+        rows = self._execute_query(
+            "SELECT COUNT(*) FROM message_queue "
+            "WHERE target_session_id = ? AND message_category = ? AND delivered_at IS NULL",
+            (target_session_id, message_category),
+        )
+        count = rows[0][0] if rows else 0
+        if count:
+            self._execute(
+                "DELETE FROM message_queue "
+                "WHERE target_session_id = ? AND message_category = ? AND delivered_at IS NULL",
+                (target_session_id, message_category),
+            )
+            logger.info(
+                "Cancelled %s queued %s message(s) for target=%s",
+                count,
+                message_category,
+                target_session_id,
+            )
+        return count
+
     # =========================================================================
     # User Input Detection and Management
     # =========================================================================

--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -2414,8 +2414,17 @@ class MessageQueueManager:
                 logger.debug(f"User typing detected at final gate, aborting delivery")
                 return
 
-            # Batch messages (up to max_batch_size)
+            # Batch messages (up to max_batch_size), but keep native slash-control
+            # commands isolated so they are never concatenated into free-form text.
             batch = messages[:self.max_batch_size]
+            native_rename_index = next(
+                (index for index, msg in enumerate(batch) if msg.message_category == "native_rename"),
+                None,
+            )
+            if native_rename_index == 0:
+                batch = batch[:1]
+            elif native_rename_index is not None:
+                batch = batch[:native_rename_index]
 
             # Format batch payload
             if len(batch) == 1:

--- a/src/server.py
+++ b/src/server.py
@@ -3734,6 +3734,9 @@ def create_app(
 
         if friendly_name is not None or is_em is not None:
             app.state.session_manager._save_state()
+            renamer = getattr(app.state.session_manager, "queue_claude_native_rename", None)
+            if friendly_name is not None and callable(renamer):
+                await renamer(session, friendly_name)
             await _sync_session_display_identity(
                 session,
                 tmux_timeout_seconds=DISPLAY_IDENTITY_SYNC_TIMEOUT_SECONDS,
@@ -3934,6 +3937,9 @@ def create_app(
             registration = registrar(session_id, request.role)
         except ValueError as exc:
             raise HTTPException(status_code=409, detail=str(exc)) from exc
+        renamer = getattr(app.state.session_manager, "queue_claude_native_rename", None)
+        if callable(renamer):
+            await renamer(session, registration.role)
         await _sync_session_display_identity(session)
         return _registration_to_response(registration)
 

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -3170,6 +3170,41 @@ class SessionManager:
         session.friendly_name_updated_at_ns = updated_at_ns or time.time_ns()
         return True
 
+    async def queue_claude_native_rename(
+        self,
+        session_or_id: Session | str | None,
+        friendly_name: str,
+    ) -> bool:
+        """Best-effort enqueue of a Claude-native `/rename` for one explicit SM name."""
+        if session_or_id is None:
+            return False
+        if isinstance(session_or_id, Session):
+            session = session_or_id
+        else:
+            session = self.sessions.get(session_or_id)
+        if session is None:
+            return False
+        if session.provider != "claude" or session.status == SessionStatus.STOPPED:
+            return False
+        if not session.tmux_session:
+            return False
+
+        rename_command = f"/rename {friendly_name}"
+        if not self.message_queue_manager:
+            return await self._deliver_direct(session, rename_command)
+
+        self.message_queue_manager.cancel_queued_messages_for_target(
+            session.id,
+            "native_rename",
+        )
+        self.message_queue_manager.queue_message(
+            target_session_id=session.id,
+            text=rename_command,
+            delivery_mode="sequential",
+            message_category="native_rename",
+        )
+        return True
+
     @staticmethod
     def _session_label_sort_key(session: Session) -> tuple[int, int]:
         """Return comparable timestamps for SM-managed and provider-native labels."""

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -25,6 +25,7 @@ def mock_session_manager():
     mock.message_queue_manager = None
     mock.is_codex_rollout_enabled = MagicMock(return_value=True)
     mock.validate_friendly_name_update = MagicMock(return_value=None)
+    mock.queue_claude_native_rename = AsyncMock(return_value=True)
     mock.get_attach_descriptor = MagicMock(return_value=None)
     mock.get_session_aliases = MagicMock(return_value=[])
     mock.get_provider_create_rejection = MagicMock(return_value=None)
@@ -1375,6 +1376,7 @@ class TestUpdateSession:
 
         data = response.json()
         assert data["friendly_name"] == "new-name"
+        mock_session_manager.queue_claude_native_rename.assert_awaited_once_with(sample_session, "new-name")
 
     def test_update_friendly_name_rejects_empty(self, test_client, mock_session_manager, sample_session):
         """PATCH /sessions/{id} rejects empty friendly name (Issue #105)."""

--- a/tests/unit/test_agent_registry.py
+++ b/tests/unit/test_agent_registry.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import os
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -162,6 +162,7 @@ def test_output_monitor_cleanup_unregisters_roles(tmp_path):
 
 def test_registry_endpoints_register_lookup_and_roster(tmp_path):
     manager = _manager(tmp_path)
+    manager.queue_claude_native_rename = AsyncMock(return_value=True)
     session = _session("role1234", tmp_path)
     manager.sessions[session.id] = session
     client = TestClient(create_app(session_manager=manager))
@@ -186,6 +187,7 @@ def test_registry_endpoints_register_lookup_and_roster(tmp_path):
     assert sessions_response.status_code == 200
     payload = sessions_response.json()["sessions"][0]
     assert payload["aliases"] == ["sm-maintainer"]
+    manager.queue_claude_native_rename.assert_awaited_once_with(session, "sm-maintainer")
 
 
 def test_register_route_rejects_live_conflict(tmp_path):

--- a/tests/unit/test_claude_native_title.py
+++ b/tests/unit/test_claude_native_title.py
@@ -442,7 +442,11 @@ def test_claude_hook_resyncs_tmux_and_telegram_when_native_title_changes(tmp_pat
 
     assert response.status_code == 200
     assert session.native_title == "native-hook-title"
-    manager.tmux.set_status_bar.assert_called_with(session.tmux_session, "native-hook-title")
+    manager.tmux.set_status_bar.assert_called_with(
+        session.tmux_session,
+        "native-hook-title",
+        timeout_seconds=None,
+    )
     notifier.rename_session_topic.assert_awaited_with(session, "native-hook-title")
     assert session.display_identity_synced_name == "native-hook-title"
     assert isinstance(session.display_identity_synced_at_ns, int)

--- a/tests/unit/test_claude_native_title.py
+++ b/tests/unit/test_claude_native_title.py
@@ -258,7 +258,43 @@ def test_effective_name_prefers_newer_claude_native_title_over_older_explicit_sm
     manager.set_session_friendly_name(session, "older-sm-name", explicit=True, updated_at_ns=1)
 
     assert manager.get_effective_session_name(session.id) == "first-native-title"
-    assert session.native_title == "first-native-title"
+
+
+@pytest.mark.asyncio
+async def test_queue_claude_native_rename_queues_sequential_literal_command(tmp_path: Path) -> None:
+    manager = _manager(tmp_path)
+    session = _claude_session(tmp_path, None, friendly_name="before")
+    manager.sessions[session.id] = session
+    manager.message_queue_manager = MagicMock()
+
+    queued = await manager.queue_claude_native_rename(session, "after")
+
+    assert queued is True
+    manager.message_queue_manager.cancel_queued_messages_for_target.assert_called_once_with(
+        session.id,
+        "native_rename",
+    )
+    manager.message_queue_manager.queue_message.assert_called_once_with(
+        target_session_id=session.id,
+        text="/rename after",
+        delivery_mode="sequential",
+        message_category="native_rename",
+    )
+
+
+@pytest.mark.asyncio
+async def test_queue_claude_native_rename_ignores_non_claude_sessions(tmp_path: Path) -> None:
+    manager = _manager(tmp_path)
+    session = _claude_session(tmp_path, None)
+    session.provider = "codex-app"
+    manager.sessions[session.id] = session
+    manager.message_queue_manager = MagicMock()
+
+    queued = await manager.queue_claude_native_rename(session, "after")
+
+    assert queued is False
+    manager.message_queue_manager.cancel_queued_messages_for_target.assert_not_called()
+    manager.message_queue_manager.queue_message.assert_not_called()
 
 
 def test_effective_name_prefers_newer_sm_name_over_claude_native_title(tmp_path: Path) -> None:
@@ -277,6 +313,7 @@ def test_effective_name_prefers_newer_sm_name_over_claude_native_title(tmp_path:
     )
 
     assert manager.get_effective_session_name(session.id) == "sm-renamed-later"
+    assert session.native_title == "native-claude-title"
 
 
 def test_effective_name_refreshes_when_claude_transcript_title_changes(tmp_path: Path) -> None:

--- a/tests/unit/test_message_queue.py
+++ b/tests/unit/test_message_queue.py
@@ -1634,6 +1634,22 @@ class TestDirectDelivery244:
             VALUES (?, ?, ?, ?, ?)
         """, (msg_id, session_id, "Stuck message", "sequential", datetime.now().isoformat()))
 
+    def _insert_pending_message_with_category(
+        self,
+        mq,
+        session_id,
+        *,
+        msg_id,
+        text,
+        message_category,
+        delivery_mode="sequential",
+    ):
+        mq._execute("""
+            INSERT INTO message_queue
+            (id, target_session_id, text, delivery_mode, queued_at, message_category)
+            VALUES (?, ?, ?, ?, ?, ?)
+        """, (msg_id, session_id, text, delivery_mode, datetime.now().isoformat(), message_category))
+
     @pytest.mark.asyncio
     async def test_sequential_delivery_without_idle_gate(self, mock_session_manager, temp_db_path):
         """Sequential delivery proceeds even when is_idle=False (no idle gate, sm#244)."""
@@ -1951,6 +1967,66 @@ class TestDirectDelivery244:
         )
 
         assert deliver_call_count <= 1
+
+    @pytest.mark.asyncio
+    async def test_native_rename_batches_alone_when_first_pending(self, mock_session_manager, temp_db_path):
+        """A queued native rename must stay a standalone slash command."""
+        mq = self._make_mq(mock_session_manager, temp_db_path)
+
+        session = MagicMock()
+        session.id = "target244renamea"
+        session.provider = "claude"
+        session.tmux_session = "claude-target244renamea"
+        session.status = SessionStatus.IDLE
+        session.last_activity = datetime.now()
+        mock_session_manager.get_session = MagicMock(return_value=session)
+        mock_session_manager._deliver_direct = AsyncMock(return_value=True)
+
+        self._insert_pending_message_with_category(
+            mq,
+            "target244renamea",
+            msg_id="rename244a",
+            text="/rename fresh-name",
+            message_category="native_rename",
+        )
+        self._insert_pending_message(mq, "target244renamea", msg_id="after244a")
+        mq._get_pending_user_input_async = AsyncMock(return_value=None)
+
+        await mq._try_deliver_messages("target244renamea")
+
+        mock_session_manager._deliver_direct.assert_awaited_once_with(session, "/rename fresh-name")
+        remaining = mq.get_pending_messages("target244renamea")
+        assert [msg.id for msg in remaining] == ["after244a"]
+
+    @pytest.mark.asyncio
+    async def test_native_rename_is_not_concatenated_after_regular_message(self, mock_session_manager, temp_db_path):
+        """Regular sequential text must not absorb a later native rename."""
+        mq = self._make_mq(mock_session_manager, temp_db_path)
+
+        session = MagicMock()
+        session.id = "target244renameb"
+        session.provider = "claude"
+        session.tmux_session = "claude-target244renameb"
+        session.status = SessionStatus.IDLE
+        session.last_activity = datetime.now()
+        mock_session_manager.get_session = MagicMock(return_value=session)
+        mock_session_manager._deliver_direct = AsyncMock(return_value=True)
+
+        self._insert_pending_message(mq, "target244renameb", msg_id="before244b")
+        self._insert_pending_message_with_category(
+            mq,
+            "target244renameb",
+            msg_id="rename244b",
+            text="/rename fresh-name",
+            message_category="native_rename",
+        )
+        mq._get_pending_user_input_async = AsyncMock(return_value=None)
+
+        await mq._try_deliver_messages("target244renameb")
+
+        mock_session_manager._deliver_direct.assert_awaited_once_with(session, "Stuck message")
+        remaining = mq.get_pending_messages("target244renameb")
+        assert [msg.id for msg in remaining] == ["rename244b"]
 
 
 class TestSkipFence232:


### PR DESCRIPTION
## Summary
- enqueue a Claude-native `/rename` whenever `sm name` or `sm register` explicitly changes the session identity
- cancel stale pending native-rename messages so the latest explicit name wins
- keep queued `native_rename` commands out of sequential batch concatenation so slash commands always deliver standalone
- align the native-title hook test with the current timeout-aware tmux status sync call

## Testing
- `pytest tests/integration/test_api_endpoints.py -k "update_friendly_name" -q`
- `pytest tests/unit/test_agent_registry.py -q`
- `pytest tests/unit/test_claude_native_title.py -q`
- `pytest tests/unit/test_message_queue.py -k "native_rename or no_double_delivery_via_lock" -q`

Fixes #632
Fixes #633