### PR TITLE
Use longer CLI timeout for mutation requests

### DIFF
--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -12,6 +12,7 @@ import json
 DEFAULT_API_URL = "http://127.0.0.1:8420"
 DEFAULT_API_TIMEOUT = 5.0  # seconds
 DEFAULT_SEND_API_TIMEOUT = 15.0  # seconds
+DEFAULT_MUTATION_API_TIMEOUT = 15.0  # seconds
 KILL_TIMEOUT = 30  # seconds (kill triggers cleanup that may involve network I/O)
 
 
@@ -44,6 +45,22 @@ def _read_send_api_timeout() -> float:
 
 
 SEND_API_TIMEOUT = _read_send_api_timeout()
+
+
+def _read_mutation_api_timeout() -> float:
+    """Return the dedicated CLI timeout for mutation-style session requests."""
+    raw = os.environ.get("SM_MUTATION_API_TIMEOUT")
+    if raw:
+        try:
+            value = float(raw)
+            if value > 0:
+                return value
+        except ValueError:
+            pass
+    return max(_read_api_timeout(), DEFAULT_MUTATION_API_TIMEOUT)
+
+
+MUTATION_API_TIMEOUT = _read_mutation_api_timeout()
 
 
 class SessionManagerClient:
@@ -187,6 +204,7 @@ class SessionManagerClient:
             "POST",
             f"/sessions/{session_id}/registry",
             {"requester_session_id": session_id, "role": role},
+            timeout=MUTATION_API_TIMEOUT,
         )
         if unavailable:
             return {"ok": False, "unavailable": True, "status_code": None, "data": None, "detail": None}
@@ -200,6 +218,7 @@ class SessionManagerClient:
             "DELETE",
             f"/sessions/{session_id}/registry",
             {"requester_session_id": session_id, "role": role},
+            timeout=MUTATION_API_TIMEOUT,
         )
         if unavailable:
             return {"ok": False, "unavailable": True, "status_code": None, "data": None, "detail": None}
@@ -256,7 +275,8 @@ class SessionManagerClient:
         data, success, unavailable = self._request(
             "PATCH",
             f"/sessions/{session_id}",
-            {"friendly_name": friendly_name}
+            {"friendly_name": friendly_name},
+            timeout=MUTATION_API_TIMEOUT,
         )
         return success, unavailable
 
@@ -270,7 +290,8 @@ class SessionManagerClient:
         data, success, unavailable = self._request(
             "PATCH",
             f"/sessions/{session_id}",
-            {"is_em": True}
+            {"is_em": True},
+            timeout=MUTATION_API_TIMEOUT,
         )
         return success, unavailable
 
@@ -285,6 +306,7 @@ class SessionManagerClient:
             "PUT",
             f"/sessions/{session_id}/role",
             {"role": role},
+            timeout=MUTATION_API_TIMEOUT,
         )
         return success, unavailable
 
@@ -298,6 +320,7 @@ class SessionManagerClient:
         data, success, unavailable = self._request(
             "DELETE",
             f"/sessions/{session_id}/role",
+            timeout=MUTATION_API_TIMEOUT,
         )
         return success, unavailable
 
@@ -312,6 +335,7 @@ class SessionManagerClient:
             "PUT",
             f"/sessions/{session_id}/maintainer",
             {"requester_session_id": session_id},
+            timeout=MUTATION_API_TIMEOUT,
         )
         return success, unavailable
 
@@ -326,6 +350,7 @@ class SessionManagerClient:
             "DELETE",
             f"/sessions/{session_id}/maintainer",
             {"requester_session_id": session_id},
+            timeout=MUTATION_API_TIMEOUT,
         )
         return success, unavailable
 

--- a/tests/unit/test_client_codex_endpoints.py
+++ b/tests/unit/test_client_codex_endpoints.py
@@ -3,7 +3,7 @@
 import urllib.request
 from unittest.mock import patch
 
-from src.cli.client import SessionManagerClient
+from src.cli.client import MUTATION_API_TIMEOUT, SessionManagerClient
 from src.cli.client import KILL_TIMEOUT
 
 
@@ -63,6 +63,20 @@ def test_send_input_batch_result_uses_batch_endpoint():
             "from_sm_send": False,
         },
         timeout=None,
+    )
+
+
+def test_update_friendly_name_uses_mutation_timeout():
+    client = _make_client()
+    with patch.object(client, "_request", return_value=({}, True, False)) as req:
+        success, unavailable = client.update_friendly_name("abc123", "friendly")
+    assert success is True
+    assert unavailable is False
+    req.assert_called_once_with(
+        "PATCH",
+        "/sessions/abc123",
+        {"friendly_name": "friendly"},
+        timeout=MUTATION_API_TIMEOUT,
     )
 
 

--- a/tests/unit/test_client_role.py
+++ b/tests/unit/test_client_role.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from src.cli.client import SessionManagerClient
+from src.cli.client import MUTATION_API_TIMEOUT, SessionManagerClient
 
 
 def _make_client() -> SessionManagerClient:
@@ -17,6 +17,7 @@ def test_set_role_sends_put_role_payload():
         captured["method"] = method
         captured["path"] = path
         captured["data"] = data
+        captured["timeout"] = timeout
         return {"id": "abc12345", "role": "engineer"}, True, False
 
     with patch.object(client, "_request", side_effect=fake_request):
@@ -25,6 +26,7 @@ def test_set_role_sends_put_role_payload():
     assert captured["method"] == "PUT"
     assert captured["path"] == "/sessions/abc12345/role"
     assert captured["data"] == {"role": "engineer"}
+    assert captured["timeout"] == MUTATION_API_TIMEOUT
     assert success is True
     assert unavailable is False
 
@@ -37,6 +39,7 @@ def test_clear_role_sends_delete():
         captured["method"] = method
         captured["path"] = path
         captured["data"] = data
+        captured["timeout"] = timeout
         return {"id": "abc12345", "role": None}, True, False
 
     with patch.object(client, "_request", side_effect=fake_request):
@@ -45,8 +48,24 @@ def test_clear_role_sends_delete():
     assert captured["method"] == "DELETE"
     assert captured["path"] == "/sessions/abc12345/role"
     assert captured["data"] is None
+    assert captured["timeout"] == MUTATION_API_TIMEOUT
     assert success is True
     assert unavailable is False
+
+
+def test_register_role_uses_mutation_timeout():
+    client = _make_client()
+
+    with patch.object(client, "_request_with_status", return_value=({"role": "reviewer"}, 200, False)) as req:
+        result = client.register_role("abc12345", "reviewer")
+
+    assert result["ok"] is True
+    req.assert_called_once_with(
+        "POST",
+        "/sessions/abc12345/registry",
+        {"requester_session_id": "abc12345", "role": "reviewer"},
+        timeout=MUTATION_API_TIMEOUT,
+    )
 
 
 def test_ensure_role_posts_generic_role_endpoint():

--- a/tests/unit/test_client_set_em_role.py
+++ b/tests/unit/test_client_set_em_role.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from src.cli.client import SessionManagerClient
+from src.cli.client import MUTATION_API_TIMEOUT, SessionManagerClient
 
 
 def _make_client() -> SessionManagerClient:
@@ -18,6 +18,7 @@ def test_set_em_role_sends_patch_with_is_em_true():
         captured["method"] = method
         captured["path"] = path
         captured["data"] = data
+        captured["timeout"] = timeout
         return {"id": "abc12345", "is_em": True}, True, False
 
     with patch.object(client, "_request", side_effect=fake_request):
@@ -26,6 +27,7 @@ def test_set_em_role_sends_patch_with_is_em_true():
     assert captured["method"] == "PATCH"
     assert captured["path"] == "/sessions/abc12345"
     assert captured["data"] == {"is_em": True}
+    assert captured["timeout"] == MUTATION_API_TIMEOUT
     assert success is True
     assert unavailable is False
 

--- a/tests/unit/test_client_timeout.py
+++ b/tests/unit/test_client_timeout.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from src.cli.client import _read_api_timeout
+from src.cli.client import _read_api_timeout, _read_mutation_api_timeout
 
 
 def test_read_api_timeout_defaults_to_five_seconds():
@@ -21,3 +21,18 @@ def test_read_api_timeout_rejects_invalid_or_non_positive_values():
 
     with patch.dict("os.environ", {"SM_API_TIMEOUT": "0"}, clear=False):
         assert _read_api_timeout() == 5.0
+
+
+def test_read_mutation_api_timeout_defaults_to_fifteen_seconds():
+    with patch.dict("os.environ", {}, clear=False):
+        assert _read_mutation_api_timeout() == 15.0
+
+
+def test_read_mutation_api_timeout_uses_positive_env_override():
+    with patch.dict("os.environ", {"SM_MUTATION_API_TIMEOUT": "12.5"}, clear=False):
+        assert _read_mutation_api_timeout() == 12.5
+
+
+def test_read_mutation_api_timeout_respects_higher_general_timeout():
+    with patch.dict("os.environ", {"SM_API_TIMEOUT": "20"}, clear=False):
+        assert _read_mutation_api_timeout() == 20.0


### PR DESCRIPTION
## Summary
- give mutation-style CLI requests a dedicated 15s timeout instead of the 5s generic default
- apply that longer timeout to `sm name`, registry mutations, role mutations, and maintainer alias mutations
- add focused client tests so these paths do not regress back to the 5s timeout

## Investigation
Live maintainer investigation after em-3047-how-doc-fanout reported repeated `Session manager unavailable or request timed out` during 6+ parallel post-spawn `sm` commands found:
- no explicit backend rate limiter in the server
- the service stayed healthy while the log showed `POST /sessions/input-batch` taking 4.99s and 3.69s under burst load
- `sm send` already uses a dedicated 15s client timeout
- `sm name` and other mutation-style client calls still used the 5s generic timeout, which can falsely surface as manager-unavailable during backlog and cause the surrounding tool batch to cancel

## Testing
- `pytest tests/unit/test_client_timeout.py tests/unit/test_client_codex_endpoints.py tests/unit/test_client_role.py tests/unit/test_client_set_em_role.py -q`

Fixes #635