### PR TITLE
Let sm lookup resolve live session names

### DIFF
--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -545,7 +545,7 @@ def cmd_unregister(client: SessionManagerClient, session_id: Optional[str], role
 
 def cmd_lookup(client: SessionManagerClient, role: str) -> int:
     """
-    Resolve a durable registry role to its owning session ID.
+    Resolve a durable registry role or live session identifier to a session ID.
 
     Prints only the session ID on stdout so it can be used in command substitution.
     """
@@ -559,7 +559,14 @@ def cmd_lookup(client: SessionManagerClient, role: str) -> int:
         print(UNAVAILABLE_MESSAGE, file=sys.stderr)
         return 2
     if not result.get("ok"):
-        detail = result.get("detail") or "Role not registered"
+        session_id, unavailable, error = _lookup_live_session_fallback(client, normalized_role)
+        if unavailable:
+            print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+            return 2
+        if session_id:
+            print(session_id)
+            return 0
+        detail = error or result.get("detail") or "Role not registered"
         print(f"Error: {detail}", file=sys.stderr)
         return 1
 
@@ -570,6 +577,56 @@ def cmd_lookup(client: SessionManagerClient, role: str) -> int:
         return 1
     print(session_id)
     return 0
+
+
+def _lookup_live_session_fallback(
+    client: SessionManagerClient,
+    identifier: str,
+) -> tuple[Optional[str], bool, Optional[str]]:
+    """Resolve lookup fallback by live session ID/name without changing send semantics."""
+    try:
+        session = client.get_session(identifier)
+    except TypeError:
+        session = client.get_session(identifier)
+    if session:
+        return session.get("id") or identifier, False, None
+
+    try:
+        sessions = client.list_sessions()
+    except TypeError:
+        sessions = client.list_sessions()
+    if sessions is None:
+        return None, True, None
+
+    for session in sessions:
+        aliases = session.get("aliases") or []
+        if identifier in aliases:
+            return session["id"], False, None
+
+    for session in sessions:
+        if session.get("friendly_name") == identifier or session.get("name") == identifier:
+            return session["id"], False, None
+
+    needle = identifier.casefold()
+    matches = [
+        session
+        for session in sessions
+        if any(
+            needle in str(value).casefold()
+            for value in (session.get("friendly_name"), session.get("name"))
+            if value
+        )
+    ]
+    if len(matches) == 1:
+        return matches[0]["id"], False, None
+    if len(matches) > 1:
+        labels = ", ".join(
+            f"{session.get('friendly_name') or session.get('name') or session['id']} ({session['id']})"
+            for session in matches[:5]
+        )
+        suffix = "" if len(matches) <= 5 else f", +{len(matches) - 5} more"
+        return None, False, f"Multiple sessions match '{identifier}': {labels}{suffix}"
+    return None, False, None
 
 
 def cmd_roster(client: SessionManagerClient) -> int:

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -559,6 +559,14 @@ def cmd_lookup(client: SessionManagerClient, role: str) -> int:
         print(UNAVAILABLE_MESSAGE, file=sys.stderr)
         return 2
     if not result.get("ok"):
+        is_registry_miss = (
+            result.get("status_code") == 404
+            or (result.get("detail") or "") == "Role not registered"
+        )
+        if not is_registry_miss:
+            detail = result.get("detail") or "Role lookup failed"
+            print(f"Error: {detail}", file=sys.stderr)
+            return 1
         session_id, unavailable, error = _lookup_live_session_fallback(client, normalized_role)
         if unavailable:
             print(UNAVAILABLE_MESSAGE, file=sys.stderr)
@@ -577,6 +585,15 @@ def cmd_lookup(client: SessionManagerClient, role: str) -> int:
         return 1
     print(session_id)
     return 0
+
+
+def _lookup_ambiguous_match_error(identifier: str, matches: list[dict]) -> str:
+    labels = ", ".join(
+        f"{session.get('friendly_name') or session.get('name') or session['id']} ({session['id']})"
+        for session in matches[:5]
+    )
+    suffix = "" if len(matches) <= 5 else f", +{len(matches) - 5} more"
+    return f"Multiple sessions match '{identifier}': {labels}{suffix}"
 
 
 def _lookup_live_session_fallback(
@@ -598,14 +615,17 @@ def _lookup_live_session_fallback(
     if sessions is None:
         return None, True, None
 
-    for session in sessions:
-        aliases = session.get("aliases") or []
-        if identifier in aliases:
-            return session["id"], False, None
-
-    for session in sessions:
-        if session.get("friendly_name") == identifier or session.get("name") == identifier:
-            return session["id"], False, None
+    exact_matches = [
+        session
+        for session in sessions
+        if identifier in (session.get("aliases") or [])
+        or session.get("friendly_name") == identifier
+        or session.get("name") == identifier
+    ]
+    if len(exact_matches) == 1:
+        return exact_matches[0]["id"], False, None
+    if len(exact_matches) > 1:
+        return None, False, _lookup_ambiguous_match_error(identifier, exact_matches)
 
     needle = identifier.casefold()
     matches = [
@@ -620,12 +640,7 @@ def _lookup_live_session_fallback(
     if len(matches) == 1:
         return matches[0]["id"], False, None
     if len(matches) > 1:
-        labels = ", ".join(
-            f"{session.get('friendly_name') or session.get('name') or session['id']} ({session['id']})"
-            for session in matches[:5]
-        )
-        suffix = "" if len(matches) <= 5 else f", +{len(matches) - 5} more"
-        return None, False, f"Multiple sessions match '{identifier}': {labels}{suffix}"
+        return None, False, _lookup_ambiguous_match_error(identifier, matches)
     return None, False, None
 
 

--- a/tests/unit/test_agent_registry.py
+++ b/tests/unit/test_agent_registry.py
@@ -299,6 +299,44 @@ def test_cmd_lookup_falls_back_to_exact_session_name(capsys):
     assert capsys.readouterr().out.strip() == "sess1234"
 
 
+def test_cmd_lookup_does_not_fallback_on_registry_error(capsys):
+    client = Mock()
+    client.lookup_role.return_value = {
+        "ok": False,
+        "unavailable": False,
+        "status_code": 500,
+        "detail": "registry exploded",
+    }
+
+    assert cmd_lookup(client, "super-orchestrator") == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "registry exploded" in captured.err
+    client.get_session.assert_not_called()
+    client.list_sessions.assert_not_called()
+
+
+def test_cmd_lookup_rejects_ambiguous_exact_session_name(capsys):
+    client = Mock()
+    client.lookup_role.return_value = {
+        "ok": False,
+        "unavailable": False,
+        "detail": "Role not registered",
+    }
+    client.get_session.return_value = None
+    client.list_sessions.return_value = [
+        {"id": "sess1234", "name": "claude-sess1234", "friendly_name": "super-orchestrator", "aliases": []},
+        {"id": "other123", "name": "claude-other123", "friendly_name": "super-orchestrator", "aliases": []},
+    ]
+
+    assert cmd_lookup(client, "super-orchestrator") == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Multiple sessions match 'super-orchestrator'" in captured.err
+    assert "super-orchestrator (sess1234)" in captured.err
+    assert "super-orchestrator (other123)" in captured.err
+
+
 def test_cmd_lookup_falls_back_to_unique_session_name_fragment(capsys):
     client = Mock()
     client.lookup_role.return_value = {

--- a/tests/unit/test_agent_registry.py
+++ b/tests/unit/test_agent_registry.py
@@ -283,6 +283,60 @@ def test_cmd_register_lookup_unregister_and_roster(capsys):
     assert "sess1234" in roster_output
 
 
+def test_cmd_lookup_falls_back_to_exact_session_name(capsys):
+    client = Mock()
+    client.lookup_role.return_value = {
+        "ok": False,
+        "unavailable": False,
+        "detail": "Role not registered",
+    }
+    client.get_session.return_value = None
+    client.list_sessions.return_value = [
+        {"id": "sess1234", "name": "claude-sess1234", "friendly_name": "super-orchestrator", "aliases": []},
+    ]
+
+    assert cmd_lookup(client, "super-orchestrator") == 0
+    assert capsys.readouterr().out.strip() == "sess1234"
+
+
+def test_cmd_lookup_falls_back_to_unique_session_name_fragment(capsys):
+    client = Mock()
+    client.lookup_role.return_value = {
+        "ok": False,
+        "unavailable": False,
+        "detail": "Role not registered",
+    }
+    client.get_session.return_value = None
+    client.list_sessions.return_value = [
+        {"id": "sess1234", "name": "claude-sess1234", "friendly_name": "em-super-orchestrator-3047", "aliases": []},
+        {"id": "other123", "name": "claude-other123", "friendly_name": "reviewer-3047", "aliases": []},
+    ]
+
+    assert cmd_lookup(client, "super-orchestrator") == 0
+    assert capsys.readouterr().out.strip() == "sess1234"
+
+
+def test_cmd_lookup_rejects_ambiguous_session_name_fragment(capsys):
+    client = Mock()
+    client.lookup_role.return_value = {
+        "ok": False,
+        "unavailable": False,
+        "detail": "Role not registered",
+    }
+    client.get_session.return_value = None
+    client.list_sessions.return_value = [
+        {"id": "sess1234", "name": "claude-sess1234", "friendly_name": "em-super-orchestrator-3047", "aliases": []},
+        {"id": "other123", "name": "claude-other123", "friendly_name": "backup-super-orchestrator", "aliases": []},
+    ]
+
+    assert cmd_lookup(client, "super-orchestrator") == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "Multiple sessions match 'super-orchestrator'" in captured.err
+    assert "em-super-orchestrator-3047 (sess1234)" in captured.err
+    assert "backup-super-orchestrator (other123)" in captured.err
+
+
 def test_main_register_lookup_roster_dispatch():
     with patch.dict(os.environ, {"CLAUDE_SESSION_MANAGER_ID": "sess1234"}, clear=False):
         with patch("sys.argv", ["sm", "register", "reviewer"]):


### PR DESCRIPTION
## Summary
- keep durable registry role lookup as the first resolution path
- when a role is unregistered, fall back to live session IDs, aliases, exact names, and unique friendly-name fragments
- fail clearly on ambiguous name fragments instead of selecting arbitrarily

## Investigation
Live repro:
- `sm lookup super-orchestrator` returned `Error: Role not registered`
- `sm all` showed `em-super-orchestrator-3047 [694fb26e]`
- `/sessions` confirmed the live session had `friendly_name=em-super-orchestrator-3047` and no `super-orchestrator` alias

This change is scoped to `sm lookup`; it does not widen `sm send` partial matching, because that could deliver messages to unintended sessions.

## Testing
- `pytest tests/unit/test_agent_registry.py -q`
- live: `sm lookup super-orchestrator` -> `694fb26e`
- live: `sm lookup maintainer` -> `9b134c6e`

Fixes #637