### PR TITLE
Harden managed tmux shell preparation

### DIFF
--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -5786,6 +5786,43 @@ class SessionManager:
             await asyncio.wait_for(proc.communicate(), timeout=5)
             await asyncio.sleep(0.3)
 
+            tmux_timeouts = self.config.get("timeouts", {}).get("tmux", {})
+            shell_fd_limit = int(tmux_timeouts.get("shell_fd_limit", 65536))
+            if shell_fd_limit > 0:
+                proc = await asyncio.create_subprocess_exec(
+                    "tmux", "send-keys", "-t", session.tmux_session,
+                    f"ulimit -n {shell_fd_limit}", "Enter",
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                await asyncio.wait_for(proc.communicate(), timeout=5)
+                await asyncio.sleep(0.3)
+
+            color_env = {
+                "TERM_PROGRAM": os.environ.get("TERM_PROGRAM"),
+                "TERM_PROGRAM_VERSION": os.environ.get("TERM_PROGRAM_VERSION"),
+                "COLORTERM": os.environ.get("COLORTERM"),
+                "CLICOLOR": os.environ.get("CLICOLOR"),
+                "CLICOLOR_FORCE": os.environ.get("CLICOLOR_FORCE"),
+                "FORCE_COLOR": os.environ.get("FORCE_COLOR"),
+            }
+            color_cmds = ["unset NO_COLOR"]
+            for name, value in color_env.items():
+                if value:
+                    color_cmds.append(f"export {name}={shlex.quote(value)}")
+                else:
+                    color_cmds.append(f"unset {name}")
+
+            for color_cmd in color_cmds:
+                proc = await asyncio.create_subprocess_exec(
+                    "tmux", "send-keys", "-t", session.tmux_session,
+                    color_cmd, "Enter",
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                await asyncio.wait_for(proc.communicate(), timeout=5)
+                await asyncio.sleep(0.1)
+
             # 7. Build resume command with config args
             claude_config = self.config.get("claude", {})
             command = claude_config.get("command", "claude")

--- a/src/tmux_controller.py
+++ b/src/tmux_controller.py
@@ -36,6 +36,7 @@ class TmuxController:
         self.send_keys_max_chunk_chars = int(tmux_timeouts.get("send_keys_max_chunk_chars", 4096))
         self.submit_verify_seconds = tmux_timeouts.get("submit_verify_seconds", 0.6)
         self.submit_retry_seconds = tmux_timeouts.get("submit_retry_seconds", 0.6)
+        self.shell_fd_limit = int(tmux_timeouts.get("shell_fd_limit", 65536))
 
     def _resolve_launch_command(
         self,
@@ -161,6 +162,67 @@ class TmuxController:
         except Exception:
             # Non-fatal: pane title is best-effort only.
             pass
+
+    def _prepare_managed_shell(self, session_name: str, session_id: Optional[str]) -> None:
+        """Set shell state inherited by Claude/Codex before launching the provider."""
+        if self.shell_fd_limit > 0:
+            self._run_tmux(
+                "send-keys",
+                "-t", session_name,
+                f"ulimit -n {self.shell_fd_limit}",
+                "Enter",
+            )
+
+        self._run_tmux(
+            "send-keys",
+            "-t", session_name,
+            "unset NO_COLOR",
+            "Enter",
+        )
+        color_env = {
+            "TERM_PROGRAM": os.environ.get("TERM_PROGRAM"),
+            "TERM_PROGRAM_VERSION": os.environ.get("TERM_PROGRAM_VERSION"),
+            "COLORTERM": os.environ.get("COLORTERM"),
+            "CLICOLOR": os.environ.get("CLICOLOR"),
+            "CLICOLOR_FORCE": os.environ.get("CLICOLOR_FORCE"),
+            "FORCE_COLOR": os.environ.get("FORCE_COLOR"),
+        }
+        for name, value in color_env.items():
+            if value:
+                color_cmd = f"export {name}={shlex.quote(value)}"
+            else:
+                color_cmd = f"unset {name}"
+            self._run_tmux(
+                "send-keys",
+                "-t", session_name,
+                color_cmd,
+                "Enter",
+            )
+
+        # Claude Code can leave this behind after exits; managed tmux panes are independent
+        # launches, so nested-session detection should not apply.
+        self._run_tmux(
+            "send-keys",
+            "-t", session_name,
+            "unset CLAUDECODE",
+            "Enter",
+        )
+        # Workaround for Claude Code bug: ToolSearch infinite loop (issues #20329, #20468, #20982)
+        self._run_tmux(
+            "send-keys",
+            "-t", session_name,
+            "export ENABLE_TOOL_SEARCH=false",
+            "Enter",
+        )
+
+        if session_id:
+            # Export session ID so it persists even if user exits and restarts the provider.
+            self._run_tmux(
+                "send-keys",
+                "-t", session_name,
+                f"export CLAUDE_SESSION_MANAGER_ID={session_id}",
+                "Enter",
+            )
 
     def _exit_copy_mode_if_needed(self, session_name: str) -> tuple[Optional[int], Optional[int]]:
         """Exit tmux copy-mode on active pane when present."""
@@ -544,31 +606,7 @@ class TmuxController:
                 f"cat >> {log_file}",
             )
 
-            # Set up environment variables first (persists in the shell)
-            # Unset CLAUDECODE to allow spawning Claude Code in child sessions
-            # (Claude Code sets this to detect nested sessions, but our tmux sessions are independent)
-            self._run_tmux(
-                "send-keys",
-                "-t", session_name,
-                "unset CLAUDECODE",
-                "Enter",
-            )
-            # Workaround for Claude Code bug: ToolSearch infinite loop (issues #20329, #20468, #20982)
-            self._run_tmux(
-                "send-keys",
-                "-t", session_name,
-                "export ENABLE_TOOL_SEARCH=false",
-                "Enter",
-            )
-
-            if session_id:
-                # Export session ID so it persists even if user exits and restarts Claude
-                self._run_tmux(
-                    "send-keys",
-                    "-t", session_name,
-                    f"export CLAUDE_SESSION_MANAGER_ID={session_id}",
-                    "Enter",
-                )
+            self._prepare_managed_shell(session_name, session_id)
 
             # Small delay to ensure exports complete
             import time
@@ -661,30 +699,7 @@ class TmuxController:
                 f"cat >> {log_file}",
             )
 
-            # Set up environment variables first (persists in the shell)
-            # Unset CLAUDECODE to allow spawning Claude Code in child sessions
-            self._run_tmux(
-                "send-keys",
-                "-t", session_name,
-                "unset CLAUDECODE",
-                "Enter",
-            )
-            # Workaround for Claude Code bug: ToolSearch infinite loop (issues #20329, #20468, #20982)
-            self._run_tmux(
-                "send-keys",
-                "-t", session_name,
-                "export ENABLE_TOOL_SEARCH=false",
-                "Enter",
-            )
-
-            if session_id:
-                # Export session ID so it persists
-                self._run_tmux(
-                    "send-keys",
-                    "-t", session_name,
-                    f"export CLAUDE_SESSION_MANAGER_ID={session_id}",
-                    "Enter",
-                )
+            self._prepare_managed_shell(session_name, session_id)
 
             # Small delay to ensure exports complete
             import time

--- a/tests/regression/test_issue_348_codex_spawn_enter.py
+++ b/tests/regression/test_issue_348_codex_spawn_enter.py
@@ -28,6 +28,24 @@ def test_create_session_with_command_sends_launch_and_enter_separately(tmp_path)
         )
 
     assert ok is True
+    assert (
+        ("send-keys", "-t", "codex-test", "ulimit -n 65536", "Enter"),
+        {},
+    ) in run_calls
+    ulimit_call = next(
+        call for call in run_calls
+        if call[0] == ("send-keys", "-t", "codex-test", "ulimit -n 65536", "Enter")
+    )
+    unset_call = next(
+        call for call in run_calls
+        if call[0] == ("send-keys", "-t", "codex-test", "unset CLAUDECODE", "Enter")
+    )
+    unset_no_color_call = next(
+        call for call in run_calls
+        if call[0] == ("send-keys", "-t", "codex-test", "unset NO_COLOR", "Enter")
+    )
+    assert run_calls.index(ulimit_call) < run_calls.index(unset_call)
+    assert run_calls.index(ulimit_call) < run_calls.index(unset_no_color_call) < run_calls.index(unset_call)
     launch_call = next(
         call for call in run_calls
         if call[0][:4] == ("send-keys", "-t", "codex-test", "--")
@@ -67,6 +85,24 @@ def test_create_session_with_command_without_prompt_keeps_single_enter(tmp_path)
         )
 
     assert ok is True
+    assert (
+        ("send-keys", "-t", "codex-test", "ulimit -n 65536", "Enter"),
+        {},
+    ) in run_calls
+    ulimit_call = next(
+        call for call in run_calls
+        if call[0] == ("send-keys", "-t", "codex-test", "ulimit -n 65536", "Enter")
+    )
+    unset_call = next(
+        call for call in run_calls
+        if call[0] == ("send-keys", "-t", "codex-test", "unset CLAUDECODE", "Enter")
+    )
+    unset_no_color_call = next(
+        call for call in run_calls
+        if call[0] == ("send-keys", "-t", "codex-test", "unset NO_COLOR", "Enter")
+    )
+    assert run_calls.index(ulimit_call) < run_calls.index(unset_call)
+    assert run_calls.index(ulimit_call) < run_calls.index(unset_no_color_call) < run_calls.index(unset_call)
     launch_call = next(
         call for call in run_calls
         if call[0][:4] == ("send-keys", "-t", "codex-test", "--")


### PR DESCRIPTION
## Summary
- consolidate managed tmux shell setup into one helper used by both provider launch paths
- raise the managed shell fd limit before launching Claude/Codex, configurable via `timeouts.tmux.shell_fd_limit`
- normalize color-related shell env and unset `NO_COLOR` before provider launch
- apply matching fd/color prep during Claude crash recovery

## Investigation
- Existing launch code duplicated shell setup and only handled `CLAUDECODE`, `ENABLE_TOOL_SEARCH`, and the Session Manager ID.
- The local patch was already present as an unstaged tmux hardening fix; verified it sends shell prep before provider launch and before the launch command.
- The recovery path separately rebuilt the Claude resume command and needed the same fd/color shell setup to avoid drift from fresh launch behavior.

## Testing
- `pytest tests/regression/test_issue_348_codex_spawn_enter.py -q`
- `python -m py_compile src/session_manager.py src/tmux_controller.py`
- `git diff --check`

Fixes #648
