### PR TITLE
Fix codex-fork background terminal activity projection

### DIFF
--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -4972,6 +4972,8 @@ class SessionManager:
         if state_name == "running":
             return ActivityState.WORKING.value
         if state_name == "idle":
+            if self._codex_fork_pane_indicates_working(session):
+                return ActivityState.WORKING.value
             return ActivityState.IDLE.value
         if state_name == "waiting_on_approval":
             return ActivityState.WAITING_PERMISSION.value
@@ -4980,6 +4982,30 @@ class SessionManager:
         if state_name in ("shutdown", "error"):
             return ActivityState.STOPPED.value
         return ActivityState.THINKING.value
+
+    @staticmethod
+    def _codex_fork_pane_text_indicates_working(pane_text: str) -> bool:
+        """Return True when codex-fork TUI text shows active work not modeled by events."""
+        if not pane_text:
+            return False
+        markers = (
+            "Working (",
+            "Waiting for background terminal",
+            "background terminal running",
+            "background terminals running",
+        )
+        return any(marker in pane_text for marker in markers)
+
+    def _codex_fork_pane_indicates_working(self, session: Session) -> bool:
+        """Use the live codex-fork pane as a bounded correction for idle reducer gaps."""
+        if not session.tmux_session:
+            return False
+        try:
+            pane_text = self.tmux.capture_pane(session.tmux_session, lines=20)
+        except Exception:
+            logger.debug("Failed to capture codex-fork pane for activity projection", exc_info=True)
+            return False
+        return self._codex_fork_pane_text_indicates_working(pane_text or "")
 
     def _compute_codex_app_activity(self, session: Session) -> str:
         """Compute activity state for codex-app sessions (no tmux/output monitor)."""

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -4988,20 +4988,25 @@ class SessionManager:
         """Return True when codex-fork TUI text shows active work not modeled by events."""
         if not pane_text:
             return False
+        pane_tail = "\n".join(
+            line
+            for line in pane_text.splitlines()[-5:]
+            if line.strip()
+        )
         markers = (
             "Working (",
             "Waiting for background terminal",
             "background terminal running",
             "background terminals running",
         )
-        return any(marker in pane_text for marker in markers)
+        return any(marker in pane_tail for marker in markers)
 
     def _codex_fork_pane_indicates_working(self, session: Session) -> bool:
         """Use the live codex-fork pane as a bounded correction for idle reducer gaps."""
         if not session.tmux_session:
             return False
         try:
-            pane_text = self.tmux.capture_pane(session.tmux_session, lines=20)
+            pane_text = self.tmux.capture_pane(session.tmux_session, lines=8)
         except Exception:
             logger.debug("Failed to capture codex-fork pane for activity projection", exc_info=True)
             return False

--- a/tests/unit/test_codex_activity_state.py
+++ b/tests/unit/test_codex_activity_state.py
@@ -717,3 +717,48 @@ def test_codex_fork_turn_diff_reasserts_running_after_restart_without_turn_start
     assert lifecycle["state"] == "running"
     assert lifecycle["cause_event_type"] == "turn_diff"
     assert manager.get_activity_state(session.id) == "working"
+
+
+def test_codex_fork_idle_reducer_checks_pane_for_background_terminal_work():
+    manager = _make_manager()
+    session = Session(
+        id="cf-bg",
+        name="codex-fork-cf-bg",
+        working_dir="/tmp",
+        tmux_session="codex-fork-cf-bg",
+        provider="codex-fork",
+        status=SessionStatus.IDLE,
+    )
+    manager.sessions[session.id] = session
+    manager.codex_fork_lifecycle[session.id] = {
+        "state": "idle",
+        "cause_event_type": "turn_complete",
+        "updated_at": datetime.now().isoformat(),
+    }
+    manager.tmux.capture_pane = MagicMock(
+        return_value="• Working (17m 46s • esc to interrupt) · 1 background terminal running · /ps to view"
+    )
+
+    assert manager.get_activity_state(session.id) == "working"
+    manager.tmux.capture_pane.assert_called_once_with(session.tmux_session, lines=20)
+
+
+def test_codex_fork_idle_reducer_remains_idle_without_active_pane_markers():
+    manager = _make_manager()
+    session = Session(
+        id="cf-bg-idle",
+        name="codex-fork-cf-bg-idle",
+        working_dir="/tmp",
+        tmux_session="codex-fork-cf-bg-idle",
+        provider="codex-fork",
+        status=SessionStatus.IDLE,
+    )
+    manager.sessions[session.id] = session
+    manager.codex_fork_lifecycle[session.id] = {
+        "state": "idle",
+        "cause_event_type": "turn_complete",
+        "updated_at": datetime.now().isoformat(),
+    }
+    manager.tmux.capture_pane = MagicMock(return_value="› tab to queue message")
+
+    assert manager.get_activity_state(session.id) == "idle"

--- a/tests/unit/test_codex_activity_state.py
+++ b/tests/unit/test_codex_activity_state.py
@@ -740,7 +740,7 @@ def test_codex_fork_idle_reducer_checks_pane_for_background_terminal_work():
     )
 
     assert manager.get_activity_state(session.id) == "working"
-    manager.tmux.capture_pane.assert_called_once_with(session.tmux_session, lines=20)
+    manager.tmux.capture_pane.assert_called_once_with(session.tmux_session, lines=8)
 
 
 def test_codex_fork_idle_reducer_remains_idle_without_active_pane_markers():
@@ -760,5 +760,37 @@ def test_codex_fork_idle_reducer_remains_idle_without_active_pane_markers():
         "updated_at": datetime.now().isoformat(),
     }
     manager.tmux.capture_pane = MagicMock(return_value="› tab to queue message")
+
+    assert manager.get_activity_state(session.id) == "idle"
+
+
+def test_codex_fork_idle_reducer_ignores_stale_background_terminal_scrollback():
+    manager = _make_manager()
+    session = Session(
+        id="cf-bg-stale",
+        name="codex-fork-cf-bg-stale",
+        working_dir="/tmp",
+        tmux_session="codex-fork-cf-bg-stale",
+        provider="codex-fork",
+        status=SessionStatus.IDLE,
+    )
+    manager.sessions[session.id] = session
+    manager.codex_fork_lifecycle[session.id] = {
+        "state": "idle",
+        "cause_event_type": "turn_complete",
+        "updated_at": datetime.now().isoformat(),
+    }
+    manager.tmux.capture_pane = MagicMock(
+        return_value="\n".join(
+            [
+                "• Working (17m 46s • esc to interrupt) · 1 background terminal running",
+                "old transcript line",
+                "• Waited for background terminal",
+                "",
+                "PR opened: https://github.com/example/repo/pull/1",
+                "› tab to queue message",
+            ]
+        )
+    )
 
     assert manager.get_activity_state(session.id) == "idle"


### PR DESCRIPTION
## Summary
- Treat codex-fork idle reducer state as working when the live TUI pane shows active background-terminal markers
- Add unit coverage for background-terminal pane text and normal idle pane text

Fixes #655

## Test
- ./venv/bin/python -m pytest tests/unit/test_codex_activity_state.py