### PR TITLE
Sync Telegram topic titles asynchronously

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -454,7 +454,7 @@ class SessionManagerApp:
 
             if session.telegram_thread_id and self.notifier:
                 display_name = self.session_manager.get_effective_session_name(session) or name
-                await self.notifier.rename_session_topic(session, display_name)
+                self._queue_telegram_topic_title_sync(session.id, display_name)
 
             return True
 
@@ -742,6 +742,78 @@ class SessionManagerApp:
                     display_name = self.session_manager.get_effective_session_name(session)
                     if display_name:
                         self.session_manager.tmux.set_status_bar(session.tmux_session, display_name)
+                        self._queue_telegram_topic_title_sync(session.id, display_name)
+
+    def _queue_telegram_topic_title_sync(self, session_id: str, display_name: str) -> None:
+        """Best-effort Telegram title convergence that never blocks startup/requests."""
+        if not self.notifier or not getattr(self.notifier, "telegram", None):
+            return
+        try:
+            asyncio.create_task(
+                self._sync_telegram_topic_title_with_retries(session_id, display_name)
+            )
+        except RuntimeError:
+            logger.debug("Skipping Telegram topic title sync for %s: no event loop", session_id)
+
+    async def _sync_telegram_topic_title_with_retries(
+        self,
+        session_id: str,
+        display_name: str,
+        *,
+        attempts: int = 5,
+    ) -> None:
+        delay_seconds = 2.0
+        for attempt in range(1, attempts + 1):
+            session = self.session_manager.get_session(session_id)
+            if (
+                not session
+                or session.status == SessionStatus.STOPPED
+                or not session.telegram_chat_id
+                or not session.telegram_thread_id
+            ):
+                return
+
+            try:
+                success = await asyncio.wait_for(
+                    self.notifier.rename_session_topic(session, display_name),
+                    timeout=5.0,
+                )
+            except asyncio.TimeoutError:
+                success = False
+                logger.warning(
+                    "Timed out syncing Telegram topic title for session %s on attempt %s/%s",
+                    session_id,
+                    attempt,
+                    attempts,
+                )
+            except Exception as exc:
+                success = False
+                logger.warning(
+                    "Failed syncing Telegram topic title for session %s on attempt %s/%s: %s",
+                    session_id,
+                    attempt,
+                    attempts,
+                    exc,
+                )
+
+            if success:
+                session.display_identity_synced_name = display_name
+                session.display_identity_synced_at_ns = time.time_ns()
+                session.display_identity_synced_chat_id = session.telegram_chat_id
+                session.display_identity_synced_thread_id = session.telegram_thread_id
+                self.session_manager._save_state()
+                return
+
+            if attempt < attempts:
+                await asyncio.sleep(delay_seconds)
+                delay_seconds = min(delay_seconds * 2, 30.0)
+
+        logger.warning(
+            "Telegram topic title for session %s did not converge to %s after %s attempt(s)",
+            session_id,
+            display_name,
+            attempts,
+        )
 
     async def _handle_monitor_event(self, event: NotificationEvent):
         """Handle events from the output monitor."""

--- a/src/main.py
+++ b/src/main.py
@@ -774,10 +774,15 @@ class SessionManagerApp:
                 return
 
             try:
-                success = await asyncio.wait_for(
-                    self.notifier.rename_session_topic(session, display_name),
-                    timeout=5.0,
-                )
+                lock = getattr(self, "_telegram_topic_title_sync_lock", None)
+                if lock is None:
+                    lock = asyncio.Lock()
+                    self._telegram_topic_title_sync_lock = lock
+                async with lock:
+                    success = await asyncio.wait_for(
+                        self.notifier.rename_session_topic(session, display_name),
+                        timeout=5.0,
+                    )
             except asyncio.TimeoutError:
                 success = False
                 logger.warning(

--- a/src/main.py
+++ b/src/main.py
@@ -749,9 +749,17 @@ class SessionManagerApp:
         if not self.notifier or not getattr(self.notifier, "telegram", None):
             return
         try:
-            asyncio.create_task(
+            tasks = getattr(self, "_telegram_topic_title_sync_tasks", None)
+            if tasks is None:
+                tasks = {}
+                self._telegram_topic_title_sync_tasks = tasks
+            existing = tasks.pop(session_id, None)
+            if existing and not existing.done():
+                existing.cancel()
+            task = asyncio.create_task(
                 self._sync_telegram_topic_title_with_retries(session_id, display_name)
             )
+            tasks[session_id] = task
         except RuntimeError:
             logger.debug("Skipping Telegram topic title sync for %s: no event loop", session_id)
 
@@ -763,62 +771,79 @@ class SessionManagerApp:
         attempts: int = 5,
     ) -> None:
         delay_seconds = 2.0
-        for attempt in range(1, attempts + 1):
-            session = self.session_manager.get_session(session_id)
-            if (
-                not session
-                or session.status == SessionStatus.STOPPED
-                or not session.telegram_chat_id
-                or not session.telegram_thread_id
-            ):
-                return
-
-            try:
-                lock = getattr(self, "_telegram_topic_title_sync_lock", None)
-                if lock is None:
-                    lock = asyncio.Lock()
-                    self._telegram_topic_title_sync_lock = lock
-                async with lock:
-                    success = await asyncio.wait_for(
-                        self.notifier.rename_session_topic(session, display_name),
-                        timeout=5.0,
+        try:
+            for attempt in range(1, attempts + 1):
+                session = self.session_manager.get_session(session_id)
+                if (
+                    not session
+                    or session.status == SessionStatus.STOPPED
+                    or not session.telegram_chat_id
+                    or not session.telegram_thread_id
+                ):
+                    return
+                getter = getattr(self.session_manager, "get_effective_session_name", None)
+                current_display_name = getter(session) if callable(getter) else display_name
+                if current_display_name != display_name:
+                    logger.info(
+                        "Skipping stale Telegram topic title sync for session %s: %s != %s",
+                        session_id,
+                        display_name,
+                        current_display_name,
                     )
-            except asyncio.TimeoutError:
-                success = False
-                logger.warning(
-                    "Timed out syncing Telegram topic title for session %s on attempt %s/%s",
-                    session_id,
-                    attempt,
-                    attempts,
-                )
-            except Exception as exc:
-                success = False
-                logger.warning(
-                    "Failed syncing Telegram topic title for session %s on attempt %s/%s: %s",
-                    session_id,
-                    attempt,
-                    attempts,
-                    exc,
-                )
+                    return
 
-            if success:
-                session.display_identity_synced_name = display_name
-                session.display_identity_synced_at_ns = time.time_ns()
-                session.display_identity_synced_chat_id = session.telegram_chat_id
-                session.display_identity_synced_thread_id = session.telegram_thread_id
-                self.session_manager._save_state()
-                return
+                try:
+                    lock = getattr(self, "_telegram_topic_title_sync_lock", None)
+                    if lock is None:
+                        lock = asyncio.Lock()
+                        self._telegram_topic_title_sync_lock = lock
+                    async with lock:
+                        success = await asyncio.wait_for(
+                            self.notifier.rename_session_topic(session, display_name),
+                            timeout=5.0,
+                        )
+                except asyncio.TimeoutError:
+                    success = False
+                    logger.warning(
+                        "Timed out syncing Telegram topic title for session %s on attempt %s/%s",
+                        session_id,
+                        attempt,
+                        attempts,
+                    )
+                except Exception as exc:
+                    success = False
+                    logger.warning(
+                        "Failed syncing Telegram topic title for session %s on attempt %s/%s: %s",
+                        session_id,
+                        attempt,
+                        attempts,
+                        exc,
+                    )
 
-            if attempt < attempts:
-                await asyncio.sleep(delay_seconds)
-                delay_seconds = min(delay_seconds * 2, 30.0)
+                if success:
+                    session.display_identity_synced_name = display_name
+                    session.display_identity_synced_at_ns = time.time_ns()
+                    session.display_identity_synced_chat_id = session.telegram_chat_id
+                    session.display_identity_synced_thread_id = session.telegram_thread_id
+                    self.session_manager._save_state()
+                    return
 
-        logger.warning(
-            "Telegram topic title for session %s did not converge to %s after %s attempt(s)",
-            session_id,
-            display_name,
-            attempts,
-        )
+                if attempt < attempts:
+                    await asyncio.sleep(delay_seconds)
+                    delay_seconds = min(delay_seconds * 2, 30.0)
+
+            logger.warning(
+                "Telegram topic title for session %s did not converge to %s after %s attempt(s)",
+                session_id,
+                display_name,
+                attempts,
+            )
+        finally:
+            tasks = getattr(self, "_telegram_topic_title_sync_tasks", None)
+            if isinstance(tasks, dict):
+                current_task = asyncio.current_task()
+                if tasks.get(session_id) is current_task:
+                    tasks.pop(session_id, None)
 
     async def _handle_monitor_event(self, event: NotificationEvent):
         """Handle events from the output monitor."""

--- a/src/server.py
+++ b/src/server.py
@@ -2312,6 +2312,7 @@ def create_app(
                 if not success:
                     telegram_synced = False
                     logger.warning(f"Failed to rename Telegram topic for session {session.id}")
+                    _queue_telegram_display_identity_retry(session.id, display_name)
             else:
                 telegram_synced = False
         if tmux_synced and telegram_synced:
@@ -2326,6 +2327,73 @@ def create_app(
                 session.display_identity_synced_chat_id = session.telegram_chat_id
                 session.display_identity_synced_thread_id = session.telegram_thread_id
                 app.state.session_manager._save_state()
+
+    def _queue_telegram_display_identity_retry(
+        session_id: str,
+        display_name: str,
+        *,
+        attempts: int = 5,
+    ) -> None:
+        """Retry Telegram topic title convergence without blocking API paths."""
+        async def _retry() -> None:
+            delay_seconds = 2.0
+            for attempt in range(1, attempts + 1):
+                if not app.state.session_manager or not app.state.notifier:
+                    return
+                session = app.state.session_manager.get_session(session_id)
+                if (
+                    not session
+                    or session.status == SessionStatus.STOPPED
+                    or not session.telegram_chat_id
+                    or not session.telegram_thread_id
+                ):
+                    return
+                try:
+                    success = await asyncio.wait_for(
+                        app.state.notifier.rename_session_topic(session, display_name),
+                        timeout=5.0,
+                    )
+                except asyncio.TimeoutError:
+                    success = False
+                    logger.warning(
+                        "Timed out retrying Telegram topic rename for session %s on attempt %s/%s",
+                        session_id,
+                        attempt,
+                        attempts,
+                    )
+                except Exception as exc:
+                    success = False
+                    logger.warning(
+                        "Failed retrying Telegram topic rename for session %s on attempt %s/%s: %s",
+                        session_id,
+                        attempt,
+                        attempts,
+                        exc,
+                    )
+
+                if success:
+                    session.display_identity_synced_name = display_name
+                    session.display_identity_synced_at_ns = time.time_ns()
+                    session.display_identity_synced_chat_id = session.telegram_chat_id
+                    session.display_identity_synced_thread_id = session.telegram_thread_id
+                    await app.state.session_manager._save_state_async()
+                    return
+
+                if attempt < attempts:
+                    await asyncio.sleep(delay_seconds)
+                    delay_seconds = min(delay_seconds * 2, 30.0)
+
+            logger.warning(
+                "Telegram topic title for session %s did not converge to %s after %s attempt(s)",
+                session_id,
+                display_name,
+                attempts,
+            )
+
+        try:
+            asyncio.create_task(_retry())
+        except RuntimeError:
+            logger.debug("Skipping Telegram display identity retry for %s: no event loop", session_id)
 
     async def _ensure_session_display_identity_synced(session: Session) -> None:
         """Sync external display surfaces when lazy identity discovery changed the effective name."""

--- a/src/server.py
+++ b/src/server.py
@@ -2337,66 +2337,89 @@ def create_app(
         """Retry Telegram topic title convergence without blocking API paths."""
         async def _retry() -> None:
             delay_seconds = 2.0
-            for attempt in range(1, attempts + 1):
-                if not app.state.session_manager or not app.state.notifier:
-                    return
-                session = app.state.session_manager.get_session(session_id)
-                if (
-                    not session
-                    or session.status == SessionStatus.STOPPED
-                    or not session.telegram_chat_id
-                    or not session.telegram_thread_id
-                ):
-                    return
-                try:
-                    lock = getattr(app.state, "telegram_display_identity_sync_lock", None)
-                    if lock is None:
-                        lock = asyncio.Lock()
-                        app.state.telegram_display_identity_sync_lock = lock
-                    async with lock:
-                        success = await asyncio.wait_for(
-                            app.state.notifier.rename_session_topic(session, display_name),
-                            timeout=5.0,
+            try:
+                for attempt in range(1, attempts + 1):
+                    if not app.state.session_manager or not app.state.notifier:
+                        return
+                    session = app.state.session_manager.get_session(session_id)
+                    if (
+                        not session
+                        or session.status == SessionStatus.STOPPED
+                        or not session.telegram_chat_id
+                        or not session.telegram_thread_id
+                    ):
+                        return
+                    current_display_name = _effective_session_name(session, sync_native_title=False)
+                    if current_display_name != display_name:
+                        logger.info(
+                            "Skipping stale Telegram topic rename retry for session %s: %s != %s",
+                            session_id,
+                            display_name,
+                            current_display_name,
                         )
-                except asyncio.TimeoutError:
-                    success = False
-                    logger.warning(
-                        "Timed out retrying Telegram topic rename for session %s on attempt %s/%s",
-                        session_id,
-                        attempt,
-                        attempts,
-                    )
-                except Exception as exc:
-                    success = False
-                    logger.warning(
-                        "Failed retrying Telegram topic rename for session %s on attempt %s/%s: %s",
-                        session_id,
-                        attempt,
-                        attempts,
-                        exc,
-                    )
+                        return
+                    try:
+                        lock = getattr(app.state, "telegram_display_identity_sync_lock", None)
+                        if lock is None:
+                            lock = asyncio.Lock()
+                            app.state.telegram_display_identity_sync_lock = lock
+                        async with lock:
+                            success = await asyncio.wait_for(
+                                app.state.notifier.rename_session_topic(session, display_name),
+                                timeout=5.0,
+                            )
+                    except asyncio.TimeoutError:
+                        success = False
+                        logger.warning(
+                            "Timed out retrying Telegram topic rename for session %s on attempt %s/%s",
+                            session_id,
+                            attempt,
+                            attempts,
+                        )
+                    except Exception as exc:
+                        success = False
+                        logger.warning(
+                            "Failed retrying Telegram topic rename for session %s on attempt %s/%s: %s",
+                            session_id,
+                            attempt,
+                            attempts,
+                            exc,
+                        )
 
-                if success:
-                    session.display_identity_synced_name = display_name
-                    session.display_identity_synced_at_ns = time.time_ns()
-                    session.display_identity_synced_chat_id = session.telegram_chat_id
-                    session.display_identity_synced_thread_id = session.telegram_thread_id
-                    await app.state.session_manager._save_state_async()
-                    return
+                    if success:
+                        session.display_identity_synced_name = display_name
+                        session.display_identity_synced_at_ns = time.time_ns()
+                        session.display_identity_synced_chat_id = session.telegram_chat_id
+                        session.display_identity_synced_thread_id = session.telegram_thread_id
+                        await app.state.session_manager._save_state_async()
+                        return
 
-                if attempt < attempts:
-                    await asyncio.sleep(delay_seconds)
-                    delay_seconds = min(delay_seconds * 2, 30.0)
+                    if attempt < attempts:
+                        await asyncio.sleep(delay_seconds)
+                        delay_seconds = min(delay_seconds * 2, 30.0)
 
-            logger.warning(
-                "Telegram topic title for session %s did not converge to %s after %s attempt(s)",
-                session_id,
-                display_name,
-                attempts,
-            )
+                logger.warning(
+                    "Telegram topic title for session %s did not converge to %s after %s attempt(s)",
+                    session_id,
+                    display_name,
+                    attempts,
+                )
+            finally:
+                tasks = getattr(app.state, "telegram_display_identity_sync_tasks", None)
+                if isinstance(tasks, dict):
+                    current_task = asyncio.current_task()
+                    if tasks.get(session_id) is current_task:
+                        tasks.pop(session_id, None)
 
         try:
-            asyncio.create_task(_retry())
+            tasks = getattr(app.state, "telegram_display_identity_sync_tasks", None)
+            if tasks is None:
+                tasks = {}
+                app.state.telegram_display_identity_sync_tasks = tasks
+            existing = tasks.pop(session_id, None)
+            if existing and not existing.done():
+                existing.cancel()
+            tasks[session_id] = asyncio.create_task(_retry())
         except RuntimeError:
             logger.debug("Skipping Telegram display identity retry for %s: no event loop", session_id)
 

--- a/src/server.py
+++ b/src/server.py
@@ -2349,10 +2349,15 @@ def create_app(
                 ):
                     return
                 try:
-                    success = await asyncio.wait_for(
-                        app.state.notifier.rename_session_topic(session, display_name),
-                        timeout=5.0,
-                    )
+                    lock = getattr(app.state, "telegram_display_identity_sync_lock", None)
+                    if lock is None:
+                        lock = asyncio.Lock()
+                        app.state.telegram_display_identity_sync_lock = lock
+                    async with lock:
+                        success = await asyncio.wait_for(
+                            app.state.notifier.rename_session_topic(session, display_name),
+                            timeout=5.0,
+                        )
                 except asyncio.TimeoutError:
                     success = False
                     logger.warning(

--- a/tests/unit/test_telegram_topic_title_sync.py
+++ b/tests/unit/test_telegram_topic_title_sync.py
@@ -33,6 +33,7 @@ async def test_telegram_topic_title_retry_marks_identity_synced_on_success():
     app.notifier.rename_session_topic = AsyncMock(side_effect=[False, True])
     app.session_manager = MagicMock()
     app.session_manager.get_session.return_value = session
+    app.session_manager.get_effective_session_name.return_value = "3175-consultant"
     app.session_manager._save_state = MagicMock()
 
     await app._sync_telegram_topic_title_with_retries(
@@ -46,6 +47,50 @@ async def test_telegram_topic_title_retry_marks_identity_synced_on_success():
     assert session.display_identity_synced_chat_id == 123
     assert session.display_identity_synced_thread_id == 456
     app.session_manager._save_state.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_telegram_topic_title_retry_skips_stale_display_name():
+    session = _session()
+    app = SessionManagerApp.__new__(SessionManagerApp)
+    app.notifier = MagicMock()
+    app.notifier.rename_session_topic = AsyncMock(return_value=True)
+    app.session_manager = MagicMock()
+    app.session_manager.get_session.return_value = session
+    app.session_manager.get_effective_session_name.return_value = "newer-name"
+    app.session_manager._save_state = MagicMock()
+
+    await app._sync_telegram_topic_title_with_retries(
+        session.id,
+        "older-name",
+        attempts=1,
+    )
+
+    app.notifier.rename_session_topic.assert_not_awaited()
+    assert session.display_identity_synced_name is None
+    app.session_manager._save_state.assert_not_called()
+
+
+def test_queue_telegram_topic_title_sync_cancels_existing_task():
+    app = SessionManagerApp.__new__(SessionManagerApp)
+    app.notifier = MagicMock()
+    app.notifier.telegram = MagicMock()
+    existing = MagicMock()
+    existing.done.return_value = False
+    app._telegram_topic_title_sync_tasks = {"sess-title": existing}
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        created = MagicMock()
+
+        def fake_create_task(coro):
+            coro.close()
+            return created
+
+        monkeypatch.setattr("src.main.asyncio.create_task", fake_create_task)
+        app._queue_telegram_topic_title_sync("sess-title", "new-name")
+
+    existing.cancel.assert_called_once()
+    assert app._telegram_topic_title_sync_tasks["sess-title"] is created
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_telegram_topic_title_sync.py
+++ b/tests/unit/test_telegram_topic_title_sync.py
@@ -1,0 +1,72 @@
+"""Tests for asynchronous Telegram topic title convergence."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.main import SessionManagerApp
+from src.models import Session, SessionStatus
+
+
+def _session() -> Session:
+    return Session(
+        id="sess-title",
+        name="claude-sess-title",
+        working_dir="/tmp",
+        tmux_session="claude-sess-title",
+        status=SessionStatus.RUNNING,
+        telegram_chat_id=123,
+        telegram_thread_id=456,
+        created_at=datetime.now(),
+        last_activity=datetime.now(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_telegram_topic_title_retry_marks_identity_synced_on_success():
+    session = _session()
+    app = SessionManagerApp.__new__(SessionManagerApp)
+    app.notifier = MagicMock()
+    app.notifier.rename_session_topic = AsyncMock(side_effect=[False, True])
+    app.session_manager = MagicMock()
+    app.session_manager.get_session.return_value = session
+    app.session_manager._save_state = MagicMock()
+
+    await app._sync_telegram_topic_title_with_retries(
+        session.id,
+        "3175-consultant",
+        attempts=2,
+    )
+
+    assert app.notifier.rename_session_topic.await_count == 2
+    assert session.display_identity_synced_name == "3175-consultant"
+    assert session.display_identity_synced_chat_id == 123
+    assert session.display_identity_synced_thread_id == 456
+    app.session_manager._save_state.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_restore_monitoring_queues_telegram_topic_title_sync():
+    session = _session()
+    app = SessionManagerApp.__new__(SessionManagerApp)
+    app.session_manager = MagicMock()
+    app.session_manager.list_sessions.return_value = [session]
+    app.session_manager.get_effective_session_name.return_value = "3175-super-em"
+    app.session_manager.tmux.set_status_bar.return_value = True
+    app.output_monitor = MagicMock()
+    app.output_monitor.start_monitoring = AsyncMock()
+    app._queue_telegram_topic_title_sync = MagicMock()
+
+    await app._restore_monitoring()
+
+    app.session_manager.tmux.set_status_bar.assert_called_once_with(
+        session.tmux_session,
+        "3175-super-em",
+    )
+    app._queue_telegram_topic_title_sync.assert_called_once_with(
+        session.id,
+        "3175-super-em",
+    )


### PR DESCRIPTION
## Summary
- queue Telegram topic title convergence during restored monitoring so existing topics catch up to SM effective names
- retry failed/timed-out topic renames in detached background tasks instead of leaving stale names permanently
- make Telegram /name avoid waiting on topic rename while still converging asynchronously

Fixes #661

## Tests
- python -m py_compile src/main.py src/server.py
- pytest tests/unit/test_telegram_topic_title_sync.py tests/unit/test_claude_native_title.py::test_claude_hook_resyncs_tmux_and_telegram_when_native_title_changes tests/unit/test_claude_native_title.py::test_list_sessions_does_not_wait_for_lazy_display_sync
- pytest tests/integration/test_api_endpoints.py::TestUpdateSession::test_update_friendly_name_logs_telegram_failure tests/integration/test_api_endpoints.py::TestUpdateSession::test_update_friendly_name_times_out_slow_telegram_rename tests/integration/test_api_endpoints.py::TestUpdateSession::test_patch_is_em_syncs_telegram_topic_title