### PR TITLE
Avoid no-op Telegram topic rename retries

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -742,7 +742,18 @@ class SessionManagerApp:
                     display_name = self.session_manager.get_effective_session_name(session)
                     if display_name:
                         self.session_manager.tmux.set_status_bar(session.tmux_session, display_name)
-                        self._queue_telegram_topic_title_sync(session.id, display_name)
+                        if self._telegram_topic_title_needs_sync(session, display_name):
+                            self._queue_telegram_topic_title_sync(session.id, display_name)
+
+    @staticmethod
+    def _telegram_topic_title_needs_sync(session: Session, display_name: str) -> bool:
+        if not session.telegram_chat_id or not session.telegram_thread_id:
+            return False
+        return (
+            session.display_identity_synced_name != display_name
+            or session.display_identity_synced_chat_id != session.telegram_chat_id
+            or session.display_identity_synced_thread_id != session.telegram_thread_id
+        )
 
     def _queue_telegram_topic_title_sync(self, session_id: str, display_name: str) -> None:
         """Best-effort Telegram title convergence that never blocks startup/requests."""

--- a/src/telegram_bot.py
+++ b/src/telegram_bot.py
@@ -1589,9 +1589,20 @@ Provide ONLY the summary, no preamble or questions."""
             await self.bot.edit_forum_topic(chat_id=chat_id, message_thread_id=topic_id, name=name)
             return True
         except Exception as e:
-            if "Topic_not_modified" in str(e):
+            error_text = str(e).lower()
+            if "topic_not_modified" in error_text or "topic not modified" in error_text:
                 logger.debug("Forum topic already named %s: chat=%s, topic=%s", name, chat_id, topic_id)
                 return True
+            if self._is_forum_topic_absent_error(e):
+                session_id = self._topic_sessions.pop((chat_id, topic_id), None)
+                if session_id and self._session_threads.get(session_id) == (chat_id, topic_id):
+                    self._session_threads.pop(session_id, None)
+                logger.info(
+                    "Forum topic absent during rename: chat=%s, topic=%s",
+                    chat_id,
+                    topic_id,
+                )
+                return False
             logger.error(f"Failed to rename forum topic: {e}")
             return False
 

--- a/tests/unit/test_telegram_bot.py
+++ b/tests/unit/test_telegram_bot.py
@@ -142,6 +142,32 @@ async def test_rename_forum_topic_treats_not_modified_as_success():
 
 
 @pytest.mark.asyncio
+async def test_rename_forum_topic_treats_spaced_not_modified_as_success():
+    tg = TelegramBot.__new__(TelegramBot)
+    tg.bot = AsyncMock()
+    tg.bot.edit_forum_topic = AsyncMock(side_effect=Exception("Topic not modified"))
+
+    result = await tg.rename_forum_topic(chat_id=10000, topic_id=50000, name="agent [abc123]")
+
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_rename_forum_topic_clears_absent_topic_mapping():
+    tg = TelegramBot.__new__(TelegramBot)
+    tg.bot = AsyncMock()
+    tg.bot.edit_forum_topic = AsyncMock(side_effect=Exception("Topic_id_invalid"))
+    tg._topic_sessions = {(10000, 50000): "sess123"}
+    tg._session_threads = {"sess123": (10000, 50000)}
+
+    result = await tg.rename_forum_topic(chat_id=10000, topic_id=50000, name="agent [abc123]")
+
+    assert result is False
+    assert tg._topic_sessions == {}
+    assert tg._session_threads == {}
+
+
+@pytest.mark.asyncio
 async def test_delete_forum_topic_treats_absent_topic_as_success():
     tg = TelegramBot.__new__(TelegramBot)
     tg.bot = AsyncMock()

--- a/tests/unit/test_telegram_topic_title_sync.py
+++ b/tests/unit/test_telegram_topic_title_sync.py
@@ -115,3 +115,23 @@ async def test_restore_monitoring_queues_telegram_topic_title_sync():
         session.id,
         "3175-super-em",
     )
+
+
+@pytest.mark.asyncio
+async def test_restore_monitoring_skips_already_synced_telegram_topic_title():
+    session = _session()
+    session.display_identity_synced_name = "3175-super-em"
+    session.display_identity_synced_chat_id = session.telegram_chat_id
+    session.display_identity_synced_thread_id = session.telegram_thread_id
+    app = SessionManagerApp.__new__(SessionManagerApp)
+    app.session_manager = MagicMock()
+    app.session_manager.list_sessions.return_value = [session]
+    app.session_manager.get_effective_session_name.return_value = "3175-super-em"
+    app.session_manager.tmux.set_status_bar.return_value = True
+    app.output_monitor = MagicMock()
+    app.output_monitor.start_monitoring = AsyncMock()
+    app._queue_telegram_topic_title_sync = MagicMock()
+
+    await app._restore_monitoring()
+
+    app._queue_telegram_topic_title_sync.assert_not_called()


### PR DESCRIPTION
## Summary
- skip startup Telegram topic title sync when persisted display identity already matches the effective session name and topic
- treat both Telegram not-modified spellings as successful rename convergence
- clear in-memory topic mappings for absent-topic rename failures so retries stop on stale mappings

Follow-up to #662 / #661 after live restart showed unnecessary editForumTopic 400s for already-synced or stale topics.

## Tests
- python -m py_compile src/main.py src/telegram_bot.py
- pytest tests/unit/test_telegram_topic_title_sync.py tests/unit/test_telegram_bot.py::test_rename_forum_topic_treats_not_modified_as_success tests/unit/test_telegram_bot.py::test_rename_forum_topic_treats_spaced_not_modified_as_success tests/unit/test_telegram_bot.py::test_rename_forum_topic_clears_absent_topic_mapping