### PR TITLE
Fix Codex review list and repo parsing

### DIFF
--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -3675,7 +3675,7 @@ def cmd_request_codex_review_list(
         notify_target=effective_notify_target,
         repo=repo,
         pr_number=pr_number,
-        include_inactive=include_inactive,
+        include_inactive=include_inactive or list_all,
     )
     if result.get("unavailable"):
         print(UNAVAILABLE_MESSAGE, file=sys.stderr)

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -284,11 +284,15 @@ def main():
         nargs="?",
         help="Request ID for status/cancel",
     )
-    request_codex_review_parser.add_argument("--repo", help="Repository in owner/repo format")
+    request_codex_review_parser.add_argument("--repo", help="Repository in owner/repo or host/owner/repo format")
     request_codex_review_parser.add_argument("--notify", help="Session ID or registry role to notify")
     request_codex_review_parser.add_argument("--steer", help="Optional Codex review steer text")
     request_codex_review_parser.add_argument("--all", action="store_true", help="List/status across all notify targets")
-    request_codex_review_parser.add_argument("--inactive", action="store_true", help="Include inactive requests when listing")
+    request_codex_review_parser.add_argument(
+        "--inactive",
+        action="store_true",
+        help="Include inactive requests when listing a notify target; --all includes them by default",
+    )
     request_codex_review_parser.add_argument("--json", action="store_true", help="Output JSON for list/status")
     request_codex_review_parser.add_argument("--pr", dest="status_pr", type=int, help="Filter status/list by PR number")
     request_codex_review_parser.add_argument("--poll-interval", dest="poll_interval_seconds", type=int, default=30, help="Polling cadence in seconds (default: 30)")
@@ -880,7 +884,7 @@ def main():
                 current_session_id=session_id,
                 notify_target=args.notify,
                 list_all=args.all,
-                include_inactive=args.inactive,
+                include_inactive=args.inactive or args.all,
                 json_output=args.json,
                 repo=args.repo,
                 pr_number=args.status_pr,

--- a/src/github_reviews.py
+++ b/src/github_reviews.py
@@ -12,6 +12,7 @@ import subprocess
 import time
 from datetime import datetime, timezone
 from typing import Any, Optional
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -45,11 +46,17 @@ def _github_since_value(dt: datetime) -> str:
 
 
 def _split_repo(repo: str) -> tuple[str, str]:
-    """Split owner/repo into its path components."""
-    try:
-        return repo.split("/", 1)
-    except ValueError as exc:
-        raise RuntimeError(f"Invalid repo {repo!r}; expected owner/repo") from exc
+    """Split owner/repo or host/owner/repo into REST owner/repo components."""
+    normalized = repo.strip()
+    parsed = urlparse(normalized)
+    if parsed.scheme and parsed.netloc:
+        normalized = parsed.path
+    parts = [part for part in normalized.strip("/").split("/") if part]
+    if len(parts) == 2:
+        return parts[0], parts[1]
+    if len(parts) == 3:
+        return parts[1], parts[2]
+    raise RuntimeError(f"Invalid repo {repo!r}; expected owner/repo or host/owner/repo")
 
 
 def _gh_api_json(repo: str, endpoint: str, *, paginate: bool = False) -> Any:

--- a/tests/unit/test_codex_review_request.py
+++ b/tests/unit/test_codex_review_request.py
@@ -702,6 +702,17 @@ def test_cmd_request_codex_review_create_list_status_cancel(capsys):
     assert rc == 0
     assert "req123" in capsys.readouterr().out
 
+    rc = cmd_request_codex_review_list(
+        client,
+        current_session_id="agent618",
+        notify_target=None,
+        list_all=True,
+        include_inactive=False,
+        json_output=True,
+    )
+    assert rc == 0
+    assert client.list_codex_review_requests.call_args.kwargs["include_inactive"] is True
+
     rc = cmd_request_codex_review_status(
         client,
         current_session_id="agent618",

--- a/tests/unit/test_github_reviews.py
+++ b/tests/unit/test_github_reviews.py
@@ -20,6 +20,7 @@ from src.github_reviews import (
     poll_for_codex_review,
     validate_open_pr,
     get_pr_repo_from_git,
+    _split_repo,
 )
 
 
@@ -166,6 +167,14 @@ class TestGetPrRepoFromGit:
 
 class TestCodexHelpers:
     """Tests for newer GitHub review helper primitives (#618)."""
+
+    def test_split_repo_accepts_host_qualified_repo(self):
+        assert _split_repo("owner/repo") == ("owner", "repo")
+        assert _split_repo("github.com/owner/repo") == ("owner", "repo")
+        assert _split_repo("https://github.com/owner/repo") == ("owner", "repo")
+
+        with pytest.raises(RuntimeError, match="expected owner/repo or host/owner/repo"):
+            _split_repo("repo")
 
     @patch("src.github_reviews.subprocess.run")
     def test_validate_open_pr_returns_payload(self, mock_run):


### PR DESCRIPTION
## Summary
- Accept host-qualified repo inputs when polling Codex review state
- Make `sm request-codex-review list --all` include completed/inactive requests by default
- Update CLI help and regression coverage for both behaviors

Fixes #620
Fixes #631

## Tests
- `pytest tests/unit/test_github_reviews.py tests/unit/test_codex_review_request.py -q`
- `python -m py_compile src/github_reviews.py src/cli/main.py src/cli/commands.py`