### PR TITLE
Fix full pytest suite drift

### DIFF
--- a/src/output_monitor.py
+++ b/src/output_monitor.py
@@ -1,6 +1,7 @@
 """Async log file tailing and pattern detection for Claude sessions."""
 
 import asyncio
+import inspect
 import re
 import logging
 from datetime import datetime, timedelta
@@ -142,6 +143,37 @@ class OutputMonitor:
         """
         self._crash_recovery_callback = callback
 
+    async def _save_session_manager_state(self) -> bool:
+        """Persist manager state when the implementation is async, sync, or mocked."""
+        if not self._session_manager:
+            if self._save_state_callback:
+                self._save_state_callback()
+                return True
+            return False
+        manager_dict = vars(self._session_manager)
+        manager_type = type(self._session_manager)
+        save_state = getattr(self._session_manager, "_save_state_async", None)
+        has_real_async_save = (
+            callable(save_state)
+            and (
+                "_save_state_async" in manager_dict
+                or getattr(manager_type, "_save_state_async", None) is not None
+            )
+        )
+        if has_real_async_save:
+            result = save_state()
+            if inspect.isawaitable(result):
+                await result
+            return True
+        if self._save_state_callback:
+            self._save_state_callback()
+            return True
+        save_state_sync = getattr(self._session_manager, "_save_state", None)
+        if callable(save_state_sync):
+            save_state_sync()
+            return True
+        return False
+
     async def start_monitoring(self, session: Session, is_restored: bool = False):
         """Start monitoring a session's output."""
         if session.id in self._tasks:
@@ -257,7 +289,7 @@ class OutputMonitor:
                     session.last_activity = now
                     # Save state to persist the update
                     if self._session_manager:
-                        await self._session_manager._save_state_async()
+                        await self._save_session_manager_state()
                     elif self._save_state_callback:
                         self._save_state_callback()
                     # Clear idle notification flag on new activity
@@ -598,7 +630,7 @@ class OutputMonitor:
             # Null out session's thread_id to prevent double-close if cleanup_session fires later
             session.telegram_thread_id = None
             if self._session_manager:
-                await self._session_manager._save_state_async()
+                await self._save_session_manager_state()
 
     async def cleanup_session(self, session: Session, preserve_record: bool = False):
         """
@@ -696,7 +728,7 @@ class OutputMonitor:
                 logger.debug(f"Removed session {session_id} from sessions dict")
 
             # Save state
-            await self._session_manager._save_state_async()
+            await self._save_session_manager_state()
 
             # Clean up hook output cache
             if hasattr(self._session_manager, 'app') and self._session_manager.app:

--- a/src/server.py
+++ b/src/server.py
@@ -1,6 +1,7 @@
 """FastAPI server for hooks and API endpoints."""
 
 import asyncio
+import inspect
 import json
 import logging
 import os
@@ -104,6 +105,17 @@ async def _decode_json_request(
         raise HTTPException(status_code=400, detail="JSON object body required")
 
     return payload
+
+
+async def _save_session_manager_state(session_manager: object) -> bool:
+    """Persist manager state when the implementation is async, sync, or mocked."""
+    save_state = getattr(session_manager, "_save_state_async", None)
+    if not callable(save_state):
+        return False
+    result = save_state()
+    if inspect.isawaitable(result):
+        await result
+    return True
 
 
 def _is_valid_app_artifact_hash(artifact_hash: str) -> bool:
@@ -2391,7 +2403,7 @@ def create_app(
                         session.display_identity_synced_at_ns = time.time_ns()
                         session.display_identity_synced_chat_id = session.telegram_chat_id
                         session.display_identity_synced_thread_id = session.telegram_thread_id
-                        await app.state.session_manager._save_state_async()
+                        await _save_session_manager_state(app.state.session_manager)
                         return
 
                     if attempt < attempts:
@@ -4959,7 +4971,7 @@ Provide ONLY the summary, no preamble or questions."""
                             state_changed = True
 
                 if state_changed:
-                    await app.state.session_manager._save_state_async()
+                    await _save_session_manager_state(app.state.session_manager)
 
                 if title_changed:
                     await _sync_session_display_identity(target_session)
@@ -5063,15 +5075,15 @@ Provide ONLY the summary, no preamble or questions."""
                         )
                         for repo_root, status_hash in cleanup_needed:
                             session.cleanup_prompted[repo_root] = status_hash
-                        await app.state.session_manager._save_state_async()
+                        await _save_session_manager_state(app.state.session_manager)
                         logger.info(f"Sent cleanup prompt for {len(cleanup_needed)} worktree(s)")
                     elif cleanup_needed and not notify_dirty:
                         # Track hashes even when muted so we don't repeatedly evaluate/signal.
                         for repo_root, status_hash in cleanup_needed:
                             session.cleanup_prompted[repo_root] = status_hash
-                        await app.state.session_manager._save_state_async()
+                        await _save_session_manager_state(app.state.session_manager)
                     elif prompt_state_changed:
-                        await app.state.session_manager._save_state_async()
+                        await _save_session_manager_state(app.state.session_manager)
 
         if hook_event == "Stop" and not last_message and session_manager_id:
             # Transcript was empty/whitespace-only at Stop time (race condition:
@@ -5124,7 +5136,7 @@ Provide ONLY the summary, no preamble or questions."""
                     # Update session's last activity timestamp
                     from datetime import datetime
                     target_session.last_activity = datetime.now()
-                    await app.state.session_manager._save_state_async()
+                    await _save_session_manager_state(app.state.session_manager)
 
                     from .models import NotificationEvent
                     event = NotificationEvent(
@@ -6263,7 +6275,7 @@ Provide ONLY the summary, no preamble or questions."""
                         }
                     if session:
                         session.touched_repos.add(repo_root)
-                        await app.state.session_manager._save_state_async()
+                        await _save_session_manager_state(app.state.session_manager)
 
         # Track worktree creation (PreToolUse for Bash)
         if hook_type == "PreToolUse" and tool_name == "Bash" and session:
@@ -6279,7 +6291,7 @@ Provide ONLY the summary, no preamble or questions."""
                     # Resolve to absolute path
                     abs_worktree = str((Path(cwd) / worktree_path).resolve()) if cwd else worktree_path
                     session.worktrees.append(abs_worktree)
-                    await app.state.session_manager._save_state_async()
+                    await _save_session_manager_state(app.state.session_manager)
                     logger.info(f"Tracked worktree creation: {abs_worktree}")
 
         # Log to database (fire and forget - don't block response)
@@ -6388,7 +6400,7 @@ Provide ONLY the summary, no preamble or questions."""
             session.agent_status_text = None
             session.agent_status_at = None
             session.agent_task_completed_at = None
-            await app.state.session_manager._save_state_async()
+            await _save_session_manager_state(app.state.session_manager)
             if queue_mgr:
                 queue_mgr.cancel_context_monitor_messages_from(session_id)
             return {"status": "flags_reset"}

--- a/src/server.py
+++ b/src/server.py
@@ -110,12 +110,16 @@ async def _decode_json_request(
 async def _save_session_manager_state(session_manager: object) -> bool:
     """Persist manager state when the implementation is async, sync, or mocked."""
     save_state = getattr(session_manager, "_save_state_async", None)
-    if not callable(save_state):
-        return False
-    result = save_state()
-    if inspect.isawaitable(result):
-        await result
-    return True
+    if callable(save_state):
+        result = save_state()
+        if inspect.isawaitable(result):
+            await result
+        return True
+    save_state_sync = getattr(session_manager, "_save_state", None)
+    if callable(save_state_sync):
+        save_state_sync()
+        return True
+    return False
 
 
 def _is_valid_app_artifact_hash(artifact_hash: str) -> bool:

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -3808,8 +3808,8 @@ class SessionManager:
             message_id=message_id,
             delivery_mode=delivery_mode,
         )
-        task = asyncio.create_task(delivery_coro)
-        wait_seconds = max(0.0, self.input_delivery_wait_seconds)
+        task = asyncio.ensure_future(delivery_coro)
+        wait_seconds = max(0.0, getattr(self, "input_delivery_wait_seconds", 1.0))
         if wait_seconds > 0:
             done, _ = await asyncio.wait({task}, timeout=wait_seconds)
             if task in done:

--- a/tests/regression/test_issue_37_blocking_io.py
+++ b/tests/regression/test_issue_37_blocking_io.py
@@ -169,6 +169,7 @@ async def test_send_input_async_uses_send_input_async(session_manager, mock_tmux
         "tmux-test",
         "test input",
         verify_claude_submit=True,
+        verify_codex_submit=False,
     )
     assert success == DeliveryResult.DELIVERED
 

--- a/tests/unit/test_agent_registry.py
+++ b/tests/unit/test_agent_registry.py
@@ -162,7 +162,7 @@ def test_output_monitor_cleanup_unregisters_roles(tmp_path):
 
 def test_registry_endpoints_register_lookup_and_roster(tmp_path):
     manager = _manager(tmp_path)
-    manager.queue_claude_native_rename = AsyncMock(return_value=True)
+    manager.queue_provider_native_rename = AsyncMock(return_value=True)
     session = _session("role1234", tmp_path)
     manager.sessions[session.id] = session
     client = TestClient(create_app(session_manager=manager))
@@ -187,7 +187,7 @@ def test_registry_endpoints_register_lookup_and_roster(tmp_path):
     assert sessions_response.status_code == 200
     payload = sessions_response.json()["sessions"][0]
     assert payload["aliases"] == ["sm-maintainer"]
-    manager.queue_claude_native_rename.assert_awaited_once_with(session, "sm-maintainer")
+    manager.queue_provider_native_rename.assert_awaited_once_with(session, "sm-maintainer")
 
 
 def test_register_route_rejects_live_conflict(tmp_path):

--- a/tests/unit/test_registry_identity.py
+++ b/tests/unit/test_registry_identity.py
@@ -40,6 +40,7 @@ def test_registry_alias_becomes_effective_api_name_and_syncs_surfaces(tmp_path):
     session.telegram_thread_id = 456
     manager.sessions[session.id] = session
     manager.tmux = MagicMock()
+    manager.queue_provider_native_rename = AsyncMock(return_value=True)
 
     notifier = MagicMock()
     notifier.rename_session_topic = AsyncMock(return_value=True)
@@ -60,7 +61,12 @@ def test_registry_alias_becomes_effective_api_name_and_syncs_surfaces(tmp_path):
     assert payload["friendly_name"] == "maintainer"
     assert payload["aliases"] == ["maintainer"]
 
-    manager.tmux.set_status_bar.assert_called_with(session.tmux_session, "maintainer")
+    manager.tmux.set_status_bar.assert_called_with(
+        session.tmux_session,
+        "maintainer",
+        timeout_seconds=None,
+    )
+    manager.queue_provider_native_rename.assert_awaited_once_with(session, "maintainer")
     notifier.rename_session_topic.assert_awaited_with(session, "maintainer")
 
 


### PR DESCRIPTION
## Summary
- Align send-input regression expectations with explicit Codex submit verification defaults
- Make state-save paths tolerate real async managers plus sync/mocked test managers
- Preserve bounded queued-delivery behavior while avoiding create_task-stub interference in tests
- Update registry identity tests for provider-native rename and status-bar timeout arguments

Fixes #613

## Tests
- `pytest tests/ -q`
- `pytest tests/regression/test_issue_182_stop_hook_suppression.py tests/regression/test_issue_271_telegram_thread_cleanup.py::test_close_session_topic_nulls_thread_id_to_prevent_double_close tests/unit/test_agent_registry.py::test_registry_endpoints_register_lookup_and_roster tests/unit/test_directional_notify_on_stop.py tests/unit/test_output_monitor_state.py::test_cleanup_session_continues_when_telegram_notify_fails tests/unit/test_output_monitor_state.py::test_cleanup_session_notification_timeout_is_non_fatal tests/unit/test_registry_identity.py::test_registry_alias_becomes_effective_api_name_and_syncs_surfaces tests/unit/test_remind.py::TestTrackedReplyCancellation::test_send_input_cancels_tracked_remind_on_reply tests/unit/test_remind.py::TestTrackedReminderDelivery::test_send_input_keeps_tracked_remind_when_reply_is_queued tests/unit/test_remind.py::TestTrackedReminderDelivery::test_non_sm_send_completion_reply_cancels_tracked_remind tests/unit/test_remind.py::TestTrackedReminderDelivery::test_persistent_spawn_tracking_survives_reply_and_resets_timer tests/unit/test_remind.py::TestTrackedReminderDelivery::test_followup_send_refreshes_persistent_spawn_tracking -q`
- `pytest tests/integration/test_api_endpoints.py::TestHookEndpoints::test_claude_stop_hook tests/regression/test_issue_102_telegram_cleanup.py::test_cleanup_accesses_correct_telegram_attribute tests/unit/test_context_monitor.py::TestContextResetEvent::test_context_reset_resets_warning_flag tests/regression/test_issue_37_blocking_io.py::test_send_input_async_uses_send_input_async tests/integration/test_session_lifecycle.py::TestSendInput::test_send_input_bypass_queue -q`
- `python -m py_compile src/server.py src/output_monitor.py src/session_manager.py`