### PR TITLE
Add sm retire alias

### DIFF
--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -2331,7 +2331,7 @@ def cmd_kill(
     target_identifier: str,
 ) -> int:
     """
-    Kill a child session (with parent-child ownership check).
+    Retire a child session (with parent-child ownership check).
 
     Args:
         client: API client
@@ -2355,7 +2355,8 @@ def cmd_kill(
             print(f"Error: Session '{target_identifier}' not found", file=sys.stderr)
             return 1
 
-    # Kill session with ownership check
+    # Retire session with ownership check. The API/client method retains the
+    # historical kill name for compatibility with existing callers.
     result = client.kill_session(
         requester_session_id=requester_session_id,
         target_session_id=target_session_id,
@@ -2375,12 +2376,12 @@ def cmd_kill(
         if detail:
             print(f"Error: {detail}", file=sys.stderr)
         else:
-            print("Error: Failed to kill session", file=sys.stderr)
+            print("Error: Failed to retire session", file=sys.stderr)
         return 1
 
     # Success - show friendly name if available
     name = session.get("friendly_name") or session.get("name") or target_session_id
-    print(f"Session {name} ({target_session_id}) terminated")
+    print(f"Session {name} ({target_session_id}) retired")
     return 0
 
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -334,14 +334,16 @@ def main():
         help="Parent session ID, friendly name, or registry alias (defaults to current)",
     )
     children_parser.add_argument("--recursive", action="store_true", help="Include grandchildren")
-    children_parser.add_argument("--terminated", action="store_true", help="Include children terminated via sm kill")
+    children_parser.add_argument("--terminated", action="store_true", help="Include children retired via sm retire/sm kill")
     children_parser.add_argument("--status", choices=["running", "completed", "error", "all"], help="Filter by status")
     children_parser.add_argument("--json", action="store_true", help="Output JSON")
     children_parser.add_argument("--db-path", default=None, help="Override tool_usage.db path")
 
-    # sm kill <session-id>
-    kill_parser = subparsers.add_parser("kill", help="Terminate a child session")
-    kill_parser.add_argument("session_id", help="Session ID to terminate")
+    # sm retire <session-id> / sm kill <session-id>
+    kill_parser = subparsers.add_parser("kill", help="Retire a child session")
+    kill_parser.add_argument("session_id", help="Session ID to retire")
+    retire_parser = subparsers.add_parser("retire", help="Retire a child session")
+    retire_parser.add_argument("session_id", help="Session ID to retire")
 
     # sm restore <session-id-or-name>
     restore_parser = subparsers.add_parser(
@@ -722,10 +724,10 @@ def main():
         )
         sys.exit(1)
 
-    # Commands that don't need session_id: lock, unlock, hooks, all, send, wait, what, subagents, children, kill, restore, new, attach, output, clear
+    # Commands that don't need session_id: lock, unlock, hooks, all, send, wait, what, subagents, children, kill/retire, restore, new, attach, output, clear
     no_session_needed = [
         "lock", "unlock", "subagent-start", "subagent-stop", "all", "send", "wait", "what",
-        "subagents", "children", "kill", "restore", "unkill", "new", "claude", "codex", "codex-legacy", "codex-fork", "codex_fork",
+        "subagents", "children", "kill", "retire", "restore", "unkill", "new", "claude", "codex", "codex-legacy", "codex-fork", "codex_fork",
         "codex-2", "codex-app", "codex-server",
         "attach", "output", "codex-tui", "codex-fork-info", "codex-rollout-gates", "watch", "tail", "clear", "review", "context-monitor", "remind", "setup", "lookup", "roster", "email", "request-codex-review", None
     ]
@@ -958,7 +960,7 @@ def main():
                 getattr(args, "db_path", None),
             )
         )
-    elif args.command == "kill":
+    elif args.command in ("kill", "retire"):
         sys.exit(commands.cmd_kill(client, session_id, args.session_id))
     elif args.command in ("restore", "unkill"):
         sys.exit(commands.cmd_restore(client, args.session))

--- a/src/cli/watch_tui.py
+++ b/src/cli/watch_tui.py
@@ -1080,7 +1080,7 @@ def _render(
             _flash_attr(flash_message, palette),
         )
 
-    footer = "j/k: move  +: create  Enter: attach  s: send  K: kill  n: rename  A/X: adopt  Tab: details  /: filter  r: refresh  q: quit"
+    footer = "j/k: move  +: create  Enter: attach  s: send  K: retire  n: rename  A/X: adopt  Tab: details  /: filter  r: refresh  q: quit"
     stdscr.addnstr(height - 1, 0, footer, _render_columns(width, 0, reserve_last_cell=True))
     stdscr.refresh()
 
@@ -1326,14 +1326,14 @@ def run_watch_tui(
                         flash_message = "No session selected"
                         flash_until = time.monotonic() + 2.0
                         continue
-                    confirm = _prompt_input(stdscr, f"Kill {selected_session_id}? type yes: ")
+                    confirm = _prompt_input(stdscr, f"Retire {selected_session_id}? type yes: ")
                     if confirm.lower() != "yes":
-                        flash_message = "Kill canceled"
+                        flash_message = "Retire canceled"
                         flash_until = time.monotonic() + 2.0
                         continue
                     result = client.kill_session(None, selected_session_id)
                     if result and result.get("status") == "killed":
-                        flash_message = f"Killed {selected_session_id}"
+                        flash_message = f"Retired {selected_session_id}"
                     elif result is None:
                         flash_message = "Session manager unavailable"
                     elif isinstance(result, dict) and result.get("error"):
@@ -1341,7 +1341,7 @@ def run_watch_tui(
                     elif isinstance(result, dict) and result.get("detail"):
                         flash_message = str(result.get("detail"))
                     else:
-                        flash_message = "Failed to kill session"
+                        flash_message = "Failed to retire session"
                     flash_until = time.monotonic() + 2.5
                     next_refresh = 0.0
                     continue

--- a/tests/unit/test_cli_parsing.py
+++ b/tests/unit/test_cli_parsing.py
@@ -129,6 +129,12 @@ class TestCliParsing:
         children_parser.add_argument("--json", action="store_true")
         children_parser.add_argument("--db-path", default=None)
 
+        # sm kill / sm retire
+        kill_parser = subparsers.add_parser("kill")
+        kill_parser.add_argument("session_id")
+        retire_parser = subparsers.add_parser("retire")
+        retire_parser.add_argument("session_id")
+
         # sm restore
         restore_parser = subparsers.add_parser("restore")
         restore_parser.add_argument("session")
@@ -624,6 +630,30 @@ class TestChildrenCommandDispatch:
 
         assert exc_info.value.code == 2
         assert "Session manager unavailable or request timed out" in capsys.readouterr().err
+
+
+class TestRetireCommand:
+    """Tests for 'sm retire' command parsing and dispatch."""
+
+    def test_retire_alias_parses_like_kill(self):
+        parser = TestCliParsing()
+        args = parser._get_parsed_args(["retire", "child123"])
+
+        assert args.command == "retire"
+        assert args.session_id == "child123"
+
+    def test_main_retire_routes_to_cmd_kill(self):
+        mock_client = MagicMock()
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(sys, "argv", ["sm", "retire", "child123"]):
+                with patch("src.cli.main.SessionManagerClient", return_value=mock_client):
+                    with patch("src.cli.main.commands.cmd_kill", return_value=0) as mock_cmd_kill:
+                        with pytest.raises(SystemExit) as exc_info:
+                            main()
+
+        assert exc_info.value.code == 0
+        mock_cmd_kill.assert_called_once_with(mock_client, None, "child123")
 
 
 class TestOutputCommand:

--- a/tests/unit/test_cmd_retire.py
+++ b/tests/unit/test_cmd_retire.py
@@ -1,0 +1,35 @@
+from unittest.mock import MagicMock, patch
+
+from src.cli.commands import cmd_kill
+
+
+def test_cmd_kill_uses_retire_language(capsys):
+    client = MagicMock()
+    client.kill_session.return_value = {"status": "killed", "session_id": "child123"}
+
+    with patch(
+        "src.cli.commands.resolve_session_id",
+        return_value=("child123", {"id": "child123", "friendly_name": "agent-one"}),
+    ):
+        rc = cmd_kill(client, "parent123", "agent-one")
+
+    assert rc == 0
+    assert "Session agent-one (child123) retired" in capsys.readouterr().out
+    client.kill_session.assert_called_once_with(
+        requester_session_id="parent123",
+        target_session_id="child123",
+    )
+
+
+def test_cmd_kill_failure_uses_retire_language(capsys):
+    client = MagicMock()
+    client.kill_session.return_value = {"status": "error"}
+
+    with patch(
+        "src.cli.commands.resolve_session_id",
+        return_value=("child123", {"id": "child123", "friendly_name": "agent-one"}),
+    ):
+        rc = cmd_kill(client, "parent123", "agent-one")
+
+    assert rc == 1
+    assert "Failed to retire session" in capsys.readouterr().err


### PR DESCRIPTION
## Summary
- Add `sm retire <session>` as a CLI alias for the existing session stop path
- Keep `sm kill` for backwards compatibility
- Update CLI/watch user-facing language to prefer retire
- Add parser/dispatch and command-output coverage

Fixes #668

## Tests
- `pytest tests/unit/test_cli_parsing.py tests/unit/test_cmd_retire.py -q`
- `python -m py_compile src/cli/main.py src/cli/commands.py src/cli/watch_tui.py`
- `python -m src.cli.main retire --help`