### PR TITLE
Implement managed local queue runner

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -322,6 +322,30 @@ sm_send:
   # Delay after Escape in urgent mode (milliseconds)
   urgent_delay_ms: 500
 
+# Managed local queue runner for resource-contended commands
+queue_runner:
+  enabled: true
+  state_dir: "~/.local/share/claude-sessions/queue-runner"
+  max_running_jobs: 2
+  perf_cooldown_seconds: 30
+  cancel_grace_seconds: 10
+  memory:
+    min_free_bytes: 2147483648
+    retry_interval_seconds: 10
+  resource_sampling:
+    enabled: true
+    interval_seconds: 15
+  types:
+    tests:
+      max_concurrent: 2
+      default_timeout_seconds: 900
+    perf:
+      max_concurrent: 1
+      default_timeout_seconds: 2700
+    background:
+      max_concurrent: 2
+      default_timeout_seconds: 3600
+
 # Session defaults
 sessions:
   default_working_dir_behavior: "inherit"  # inherit | specify

--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -1505,6 +1505,94 @@ class SessionManagerClient:
         detail = data.get("detail") if isinstance(data, dict) else None
         return {"ok": ok, "unavailable": False, "status_code": status_code, "data": data, "detail": detail}
 
+    def create_queue_job(
+        self,
+        *,
+        job_type: str,
+        label: Optional[str],
+        argv: Optional[list[str]],
+        script: Optional[str],
+        cwd: str,
+        env: dict[str, str],
+        notify_target: Optional[str],
+        requester_session_id: Optional[str],
+        timeout_seconds: Optional[int],
+    ) -> dict:
+        """Create one managed local queue job."""
+        payload = {
+            "type": job_type,
+            "label": label,
+            "argv": argv,
+            "script": script,
+            "cwd": cwd,
+            "env": env,
+            "notify_target": notify_target,
+            "requester_session_id": requester_session_id,
+            "timeout_seconds": timeout_seconds,
+        }
+        data, status_code, unavailable = self._request_with_status(
+            "POST",
+            "/queue-jobs",
+            payload,
+            timeout=MUTATION_API_TIMEOUT,
+        )
+        if unavailable:
+            return {"ok": False, "unavailable": True, "status_code": None, "data": None, "detail": None}
+        ok = status_code in (200, 201)
+        detail = data.get("detail") if isinstance(data, dict) else None
+        return {"ok": ok, "unavailable": False, "status_code": status_code, "data": data, "detail": detail}
+
+    def list_queue_jobs(
+        self,
+        *,
+        notify_target: Optional[str] = None,
+        job_type: Optional[str] = None,
+        state: Optional[str] = None,
+        include_terminal: bool = False,
+    ) -> dict:
+        """List managed local queue jobs."""
+        params = []
+        if notify_target:
+            params.append(f"notify_target={urllib.parse.quote(notify_target)}")
+        if job_type:
+            params.append(f"type={urllib.parse.quote(job_type)}")
+        if state:
+            params.append(f"state={urllib.parse.quote(state)}")
+        if include_terminal:
+            params.append("include_terminal=true")
+        suffix = f"?{'&'.join(params)}" if params else ""
+        data, status_code, unavailable = self._request_with_status("GET", f"/queue-jobs{suffix}")
+        if unavailable:
+            return {"ok": False, "unavailable": True, "status_code": None, "data": None, "detail": None}
+        ok = status_code in (200, 201)
+        detail = data.get("detail") if isinstance(data, dict) else None
+        return {"ok": ok, "unavailable": False, "status_code": status_code, "data": data, "detail": detail}
+
+    def get_queue_job(self, job_id: str) -> dict:
+        """Fetch one managed local queue job."""
+        data, status_code, unavailable = self._request_with_status(
+            "GET",
+            f"/queue-jobs/{urllib.parse.quote(job_id)}",
+        )
+        if unavailable:
+            return {"ok": False, "unavailable": True, "status_code": None, "data": None, "detail": None}
+        ok = status_code in (200, 201)
+        detail = data.get("detail") if isinstance(data, dict) else None
+        return {"ok": ok, "unavailable": False, "status_code": status_code, "data": data, "detail": detail}
+
+    def cancel_queue_job(self, job_id: str) -> dict:
+        """Cancel one managed local queue job."""
+        data, status_code, unavailable = self._request_with_status(
+            "DELETE",
+            f"/queue-jobs/{urllib.parse.quote(job_id)}",
+            timeout=MUTATION_API_TIMEOUT,
+        )
+        if unavailable:
+            return {"ok": False, "unavailable": True, "status_code": None, "data": None, "detail": None}
+        ok = status_code in (200, 201)
+        detail = data.get("detail") if isinstance(data, dict) else None
+        return {"ok": ok, "unavailable": False, "status_code": status_code, "data": data, "detail": detail}
+
     def set_agent_status(self, session_id: str, text: str) -> tuple[bool, bool]:
         """Set agent self-reported status text and reset remind timer (#188)."""
         data, success, unavailable = self._request(

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -1,6 +1,7 @@
 """Command implementations for sm CLI."""
 
 import os
+import json
 import re
 import shutil
 import sqlite3
@@ -3598,6 +3599,192 @@ def cmd_watch_job_cancel(client: SessionManagerClient, watch_id: str) -> int:
 
     payload = result.get("data") or {}
     print(f"Cancelled job watch: {payload.get('label', watch_id)} ({payload.get('id', watch_id)})")
+    return 0
+
+
+def _queue_env_from_cli(env_pairs: list[str]) -> dict[str, str]:
+    env: dict[str, str] = {}
+    for key in ("PATH", "PYTHONPATH", "VIRTUAL_ENV"):
+        value = os.environ.get(key)
+        if value:
+            env[key] = value
+    for pair in env_pairs:
+        if "=" not in pair:
+            raise ValueError(f"--env must be KEY=VALUE, got {pair!r}")
+        key, value = pair.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError("--env key cannot be empty")
+        env[key] = value
+    return env
+
+
+def _print_queue_job(payload: dict) -> None:
+    print(f"Accepted queue job {payload.get('id', 'unknown')} ({payload.get('type', '?')}).")
+    print(f"State: {payload.get('state', '-')}")
+    if payload.get("holding_reason"):
+        print(f"Holding: {payload['holding_reason']}")
+    print(f"Log: {payload.get('log_path') or '-'}")
+
+
+def cmd_queue_run(
+    client: SessionManagerClient,
+    current_session_id: Optional[str],
+    *,
+    job_type: str,
+    label: Optional[str],
+    cwd: Optional[str],
+    timeout: Optional[str],
+    env_pairs: list[str],
+    notify_target: Optional[str],
+    command: list[str],
+    script_file: Optional[str],
+) -> int:
+    """Submit one managed local queue job."""
+    effective_notify = notify_target or current_session_id
+    if not effective_notify:
+        print("Error: No notify target. Use --notify or run from within a managed session.", file=sys.stderr)
+        return 2
+
+    argv = list(command or [])
+    if argv and argv[0] == "--":
+        argv = argv[1:]
+    script = None
+    if script_file:
+        if argv:
+            print("Error: Use either --script-file or command argv, not both.", file=sys.stderr)
+            return 1
+        if script_file == "-":
+            script = sys.stdin.read()
+        else:
+            script = Path(script_file).expanduser().read_text(encoding="utf-8")
+    elif not argv:
+        print("Error: Expected command after -- or --script-file.", file=sys.stderr)
+        return 1
+
+    try:
+        env = _queue_env_from_cli(env_pairs)
+        timeout_seconds = parse_duration(timeout) if timeout else None
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    result = client.create_queue_job(
+        job_type=job_type,
+        label=label,
+        argv=argv or None,
+        script=script,
+        cwd=str(Path(cwd or os.getcwd()).expanduser().resolve()),
+        env=env,
+        notify_target=effective_notify,
+        requester_session_id=current_session_id,
+        timeout_seconds=timeout_seconds,
+    )
+    if result.get("unavailable"):
+        print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+        return 2
+    if not result.get("ok"):
+        detail = result.get("detail") or "Failed to create queue job"
+        print(f"Error: {detail}", file=sys.stderr)
+        return 1
+    _print_queue_job(result.get("data") or {})
+    return 0
+
+
+def cmd_queue_list(
+    client: SessionManagerClient,
+    current_session_id: Optional[str],
+    *,
+    notify_target: Optional[str],
+    list_all: bool,
+    job_type: Optional[str],
+    state: Optional[str],
+    json_output: bool,
+) -> int:
+    effective_notify = notify_target
+    if not effective_notify and not list_all:
+        if current_session_id:
+            effective_notify = current_session_id
+        else:
+            print("Error: No session context. Use --notify or --all.", file=sys.stderr)
+            return 2
+    result = client.list_queue_jobs(
+        notify_target=effective_notify,
+        job_type=job_type,
+        state=state,
+        include_terminal=list_all or bool(state),
+    )
+    if result.get("unavailable"):
+        print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+        return 2
+    if not result.get("ok"):
+        detail = result.get("detail") or "Failed to list queue jobs"
+        print(f"Error: {detail}", file=sys.stderr)
+        return 1
+    jobs = (result.get("data") or {}).get("jobs", [])
+    if json_output:
+        print(json.dumps(jobs, indent=2))
+        return 0
+    if not jobs:
+        print("No queue jobs.")
+        return 0
+    headers = ["ID", "Type", "State", "Notify", "Label", "Holding", "Log"]
+    rows = [
+        [
+            str(job.get("id", "")),
+            str(job.get("type", "")),
+            str(job.get("state", "")),
+            str(job.get("notify_name") or job.get("notify_session_id") or ""),
+            str(job.get("label", "")),
+            str(job.get("holding_reason") or "-"),
+            str(job.get("log_path") or "-"),
+        ]
+        for job in jobs
+    ]
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for idx, value in enumerate(row):
+            widths[idx] = max(widths[idx], min(len(value), 80))
+    print("  ".join(header.ljust(widths[idx]) for idx, header in enumerate(headers)))
+    print("  ".join("-" * widths[idx] for idx in range(len(headers))))
+    for row in rows:
+        print("  ".join(value[: widths[idx]].ljust(widths[idx]) for idx, value in enumerate(row)))
+    return 0
+
+
+def cmd_queue_status(client: SessionManagerClient, job_id: str, json_output: bool = False) -> int:
+    result = client.get_queue_job(job_id)
+    if result.get("unavailable"):
+        print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+        return 2
+    if not result.get("ok"):
+        detail = result.get("detail") or "Queue job not found"
+        print(f"Error: {detail}", file=sys.stderr)
+        return 1
+    payload = result.get("data") or {}
+    if json_output:
+        print(json.dumps(payload, indent=2))
+        return 0
+    print(f"Job: {payload.get('id', job_id)}")
+    print(f"Type: {payload.get('type', '-')}")
+    print(f"State: {payload.get('state', '-')}")
+    print(f"Holding: {payload.get('holding_reason') or '-'}")
+    print(f"Exit: {payload.get('exit_code') if payload.get('exit_code') is not None else '-'}")
+    print(f"Log: {payload.get('log_path') or '-'}")
+    return 0
+
+
+def cmd_queue_cancel(client: SessionManagerClient, job_id: str) -> int:
+    result = client.cancel_queue_job(job_id)
+    if result.get("unavailable"):
+        print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+        return 2
+    if not result.get("ok"):
+        detail = result.get("detail") or "Failed to cancel queue job"
+        print(f"Error: {detail}", file=sys.stderr)
+        return 1
+    payload = result.get("data") or {}
+    print(f"Cancelled queue job: {payload.get('id', job_id)} ({payload.get('state', '-')})")
     return 0
 
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -270,6 +270,34 @@ def main():
     watch_job_cancel_parser = watch_job_subparsers.add_parser("cancel", help="Cancel a durable external job watch")
     watch_job_cancel_parser.add_argument("watch_id", help="Watch ID to cancel")
 
+    # sm queue run/list/status/cancel
+    queue_parser = subparsers.add_parser("queue", help="Manage local queue runner jobs")
+    queue_subparsers = queue_parser.add_subparsers(dest="queue_command")
+
+    queue_run_parser = queue_subparsers.add_parser("run", help="Submit a local command to the queue runner")
+    queue_run_parser.add_argument("--type", dest="job_type", choices=["tests", "perf", "background"], default="tests")
+    queue_run_parser.add_argument("--label", help="Human-readable job label")
+    queue_run_parser.add_argument("--cwd", help="Working directory (defaults to current directory)")
+    queue_run_parser.add_argument("--timeout", help="Timeout duration, e.g. 90s, 10m, 2h")
+    queue_run_parser.add_argument("--env", dest="env_pairs", action="append", default=[], help="Environment override KEY=VALUE")
+    queue_run_parser.add_argument("--notify", help="Session ID or registry role to notify")
+    queue_run_parser.add_argument("--script-file", help="Script file to run, or - for stdin")
+    queue_run_parser.add_argument("queue_argv", nargs=argparse.REMAINDER, help="Command argv after --")
+
+    queue_list_parser = queue_subparsers.add_parser("list", help="List queue runner jobs")
+    queue_list_parser.add_argument("--notify", help="Filter by notify session ID or registry role")
+    queue_list_parser.add_argument("--all", action="store_true", help="List all jobs instead of current session active jobs")
+    queue_list_parser.add_argument("--type", dest="job_type", choices=["tests", "perf", "background"])
+    queue_list_parser.add_argument("--state", choices=["pending", "running", "succeeded", "failed", "cancelled", "timed_out", "displaced", "done"])
+    queue_list_parser.add_argument("--json", action="store_true", help="Output JSON")
+
+    queue_status_parser = queue_subparsers.add_parser("status", help="Show one queue runner job")
+    queue_status_parser.add_argument("job_id", help="Queue job ID")
+    queue_status_parser.add_argument("--json", action="store_true", help="Output JSON")
+
+    queue_cancel_parser = queue_subparsers.add_parser("cancel", help="Cancel one queue runner job")
+    queue_cancel_parser.add_argument("job_id", help="Queue job ID")
+
     # sm request-codex-review <pr>|list|status|cancel
     request_codex_review_parser = subparsers.add_parser(
         "request-codex-review",
@@ -877,6 +905,36 @@ def main():
         if args.watch_job_command == "cancel":
             sys.exit(commands.cmd_watch_job_cancel(client, args.watch_id))
         print("Error: watch-job subcommand required (add, list, cancel)", file=sys.stderr)
+        sys.exit(2)
+    elif args.command == "queue":
+        if args.queue_command == "run":
+            sys.exit(commands.cmd_queue_run(
+                client,
+                current_session_id=session_id,
+                job_type=args.job_type,
+                label=args.label,
+                cwd=args.cwd,
+                timeout=args.timeout,
+                env_pairs=args.env_pairs,
+                notify_target=args.notify,
+                command=args.queue_argv,
+                script_file=args.script_file,
+            ))
+        if args.queue_command == "list":
+            sys.exit(commands.cmd_queue_list(
+                client,
+                current_session_id=session_id,
+                notify_target=args.notify,
+                list_all=args.all,
+                job_type=args.job_type,
+                state=args.state,
+                json_output=args.json,
+            ))
+        if args.queue_command == "status":
+            sys.exit(commands.cmd_queue_status(client, args.job_id, json_output=args.json))
+        if args.queue_command == "cancel":
+            sys.exit(commands.cmd_queue_cancel(client, args.job_id))
+        print("Error: queue subcommand required (run, list, status, cancel)", file=sys.stderr)
         sys.exit(2)
     elif args.command == "request-codex-review":
         action = args.action_or_pr

--- a/src/queue_runner.py
+++ b/src/queue_runner.py
@@ -659,6 +659,9 @@ class QueueRunner:
                 notify=job.completion_notified_at is None,
             )
             return
+        if self._job_timed_out(job):
+            await self._terminate_job_locked(job, state="timed_out")
+            return
         if job.pid and self._pid_exists(job.pid):
             task = asyncio.create_task(self._poll_recovered_job(job.id))
             self._completion_tasks[job.id] = task
@@ -682,12 +685,20 @@ class QueueRunner:
                             notify=job.completion_notified_at is None,
                         )
                         return
+                    if self._job_timed_out(job):
+                        await self._terminate_job_locked(job, state="timed_out")
+                        return
                     if job.pid and not self._pid_exists(job.pid):
                         await self._finish_job_locked(job, "failed", exit_code=None, notify=job.completion_notified_at is None)
                         return
         finally:
             self._completion_tasks.pop(job_id, None)
             self._schedule()
+
+    def _job_timed_out(self, job: QueueJob) -> bool:
+        if not job.started_at:
+            return False
+        return (datetime.now() - job.started_at).total_seconds() >= job.timeout_seconds
 
     def _read_exit_code(self, job: QueueJob) -> Optional[int]:
         try:
@@ -793,18 +804,19 @@ class QueueRunner:
     async def _resource_sampler_loop(self) -> None:
         try:
             while True:
-                if not any(job.state in ACTIVE_STATES for job in self._jobs.values()):
+                jobs_snapshot = list(self._jobs.values())
+                if not any(job.state in ACTIVE_STATES for job in jobs_snapshot):
                     return
-                await asyncio.to_thread(self._record_resource_sample)
+                await asyncio.to_thread(self._record_resource_sample, jobs_snapshot)
                 await asyncio.sleep(self.resource_sampling_interval_seconds)
         except asyncio.CancelledError:
             raise
 
-    def _record_resource_sample(self) -> None:
-        pending = self._counts_by_type("pending")
-        running = self._counts_by_type("running")
+    def _record_resource_sample(self, jobs_snapshot: list[QueueJob]) -> None:
+        pending = self._counts_by_type("pending", jobs_snapshot)
+        running = self._counts_by_type("running", jobs_snapshot)
         memory = {"free_bytes": self._read_free_memory_bytes()}
-        cpu = self._read_cpu_sample()
+        cpu = self._read_cpu_sample(jobs_snapshot)
         with self._connect() as conn:
             conn.execute(
                 """
@@ -823,14 +835,14 @@ class QueueRunner:
                 ),
             )
 
-    def _counts_by_type(self, state: str) -> dict[str, int]:
+    def _counts_by_type(self, state: str, jobs_snapshot: list[QueueJob]) -> dict[str, int]:
         return {
-            job_type: sum(1 for job in self._jobs.values() if job.state == state and job.type == job_type)
+            job_type: sum(1 for job in jobs_snapshot if job.state == state and job.type == job_type)
             for job_type in self.type_config
         }
 
-    def _read_cpu_sample(self) -> dict[str, Any]:
-        pids = [str(job.pid) for job in self._jobs.values() if job.state == "running" and job.pid]
+    def _read_cpu_sample(self, jobs_snapshot: list[QueueJob]) -> dict[str, Any]:
+        pids = [str(job.pid) for job in jobs_snapshot if job.state == "running" and job.pid]
         sample: dict[str, Any] = {"loadavg": os.getloadavg() if hasattr(os, "getloadavg") else None}
         if not pids:
             return sample

--- a/src/queue_runner.py
+++ b/src/queue_runner.py
@@ -382,6 +382,8 @@ class QueueRunner:
                 self._notify_queued(job)
                 job.queued_notified_at = datetime.now()
                 self._persist_job(job)
+            if job.state == "pending":
+                self._schedule()
         self._ensure_resource_sampler()
         return job
 
@@ -597,6 +599,7 @@ class QueueRunner:
             stdout=log_handle,
             stderr=asyncio.subprocess.STDOUT,
             start_new_session=True,
+            env=self._subprocess_env(job),
         )
         log_handle.close()
         job.pid = process.pid
@@ -611,6 +614,12 @@ class QueueRunner:
         self._persist_job(job)
         task = asyncio.create_task(self._wait_for_job(job.id))
         self._completion_tasks[job.id] = task
+
+    def _subprocess_env(self, job: QueueJob) -> dict[str, str]:
+        env = {str(key): str(value) for key, value in job.env.items()}
+        if "PATH" not in env:
+            env["PATH"] = "/usr/bin:/bin:/usr/sbin:/sbin"
+        return env
 
     async def _wait_for_job(self, job_id: str) -> None:
         try:

--- a/src/queue_runner.py
+++ b/src/queue_runner.py
@@ -1,0 +1,833 @@
+"""Managed local queue runner for resource-contended commands."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import os
+import shlex
+import signal
+import sqlite3
+import subprocess
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Optional
+
+
+TERMINAL_STATES = {"succeeded", "failed", "timed_out", "cancelled", "displaced"}
+ACTIVE_STATES = {"pending", "running"}
+DEFAULT_STATE_DIR = "~/.local/share/claude-sessions/queue-runner"
+
+
+@dataclass
+class QueueJob:
+    """One managed queue runner job."""
+
+    id: str
+    type: str
+    label: str
+    requester_session_id: Optional[str]
+    notify_session_id: str
+    cwd: str
+    argv: Optional[list[str]]
+    script_path: Optional[str]
+    env: dict[str, str]
+    timeout_seconds: int
+    state: str
+    holding_reason: Optional[str]
+    queued_at: datetime
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    pid: Optional[int] = None
+    process_group_id: Optional[int] = None
+    exit_code: Optional[int] = None
+    log_path: Optional[str] = None
+    exit_code_path: Optional[str] = None
+    wrapper_path: Optional[str] = None
+    queued_notified_at: Optional[datetime] = None
+    started_notified_at: Optional[datetime] = None
+    completion_notified_at: Optional[datetime] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "type": self.type,
+            "label": self.label,
+            "requester_session_id": self.requester_session_id,
+            "notify_session_id": self.notify_session_id,
+            "cwd": self.cwd,
+            "argv": self.argv,
+            "script_path": self.script_path,
+            "env": self.env,
+            "timeout_seconds": self.timeout_seconds,
+            "state": self.state,
+            "holding_reason": self.holding_reason,
+            "queued_at": self.queued_at.isoformat(),
+            "started_at": self.started_at.isoformat() if self.started_at else None,
+            "finished_at": self.finished_at.isoformat() if self.finished_at else None,
+            "pid": self.pid,
+            "process_group_id": self.process_group_id,
+            "exit_code": self.exit_code,
+            "log_path": self.log_path,
+            "exit_code_path": self.exit_code_path,
+            "wrapper_path": self.wrapper_path,
+            "queued_notified_at": self.queued_notified_at.isoformat() if self.queued_notified_at else None,
+            "started_notified_at": self.started_notified_at.isoformat() if self.started_notified_at else None,
+            "completion_notified_at": self.completion_notified_at.isoformat() if self.completion_notified_at else None,
+        }
+
+
+def _parse_dt(value: Optional[str]) -> Optional[datetime]:
+    return datetime.fromisoformat(value) if value else None
+
+
+def _duration_seconds(value: str | int | None, default: int) -> int:
+    if value is None or value == "":
+        return default
+    if isinstance(value, int):
+        return value
+    raw = str(value).strip().lower()
+    try:
+        if raw.endswith("ms"):
+            return max(1, int(float(raw[:-2]) / 1000))
+        if raw.endswith("s"):
+            return max(1, int(float(raw[:-1])))
+        if raw.endswith("m"):
+            return max(1, int(float(raw[:-1]) * 60))
+        if raw.endswith("h"):
+            return max(1, int(float(raw[:-1]) * 3600))
+        return max(1, int(float(raw)))
+    except ValueError as exc:
+        raise ValueError(f"invalid duration: {value}") from exc
+
+
+class QueueRunner:
+    """Admits and runs local commands under shared machine resource policy."""
+
+    def __init__(self, session_manager: Any, config: Optional[dict[str, Any]] = None):
+        self.session_manager = session_manager
+        self.config = (config or {}).get("queue_runner", {})
+        self.enabled = bool(self.config.get("enabled", True))
+        self.state_dir = Path(str(self.config.get("state_dir", DEFAULT_STATE_DIR))).expanduser()
+        self.log_dir = self.state_dir / "logs"
+        self.db_path = self.state_dir / "queue_runner.db"
+        self.state_dir.mkdir(parents=True, exist_ok=True)
+        self.log_dir.mkdir(parents=True, exist_ok=True)
+
+        self.type_config = self._load_type_config()
+        self.max_running_jobs = int(self.config.get("max_running_jobs", 2))
+        self.cancel_grace_seconds = int(self.config.get("cancel_grace_seconds", 10))
+        self.perf_cooldown_seconds = int(self.config.get("perf_cooldown_seconds", 30))
+        memory_config = self.config.get("memory", {})
+        self.min_free_bytes = int(memory_config.get("min_free_bytes", 2 * 1024 * 1024 * 1024))
+        self.memory_retry_interval_seconds = int(memory_config.get("retry_interval_seconds", 10))
+        sampling_config = self.config.get("resource_sampling", {})
+        self.resource_sampling_enabled = bool(sampling_config.get("enabled", True))
+        self.resource_sampling_interval_seconds = int(sampling_config.get("interval_seconds", 15))
+
+        self._jobs: dict[str, QueueJob] = {}
+        self._processes: dict[str, asyncio.subprocess.Process] = {}
+        self._completion_tasks: dict[str, asyncio.Task[Any]] = {}
+        self._scheduler_task: Optional[asyncio.Task[Any]] = None
+        self._resource_sampler_task: Optional[asyncio.Task[Any]] = None
+        self._lock = asyncio.Lock()
+        self._started = False
+        self._init_db()
+        self._load_jobs()
+
+    def _load_type_config(self) -> dict[str, dict[str, int]]:
+        configured = self.config.get("types", {})
+        defaults = {
+            "tests": {"max_concurrent": 2, "default_timeout_seconds": 900},
+            "perf": {"max_concurrent": 1, "default_timeout_seconds": 2700},
+            "background": {"max_concurrent": 2, "default_timeout_seconds": 3600},
+        }
+        configured_items = configured.items() if isinstance(configured, dict) else []
+        for name, values in configured_items:
+            if name in defaults and isinstance(values, dict):
+                defaults[name].update({
+                    key: int(values[key])
+                    for key in ("max_concurrent", "default_timeout_seconds")
+                    if key in values
+                })
+        return defaults
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self.db_path))
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init_db(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS queue_jobs (
+                    id TEXT PRIMARY KEY,
+                    type TEXT NOT NULL,
+                    label TEXT NOT NULL,
+                    requester_session_id TEXT,
+                    notify_session_id TEXT NOT NULL,
+                    cwd TEXT NOT NULL,
+                    argv_json TEXT,
+                    script_path TEXT,
+                    env_json TEXT NOT NULL,
+                    timeout_seconds INTEGER NOT NULL,
+                    state TEXT NOT NULL,
+                    holding_reason TEXT,
+                    queued_at TEXT NOT NULL,
+                    started_at TEXT,
+                    finished_at TEXT,
+                    pid INTEGER,
+                    process_group_id INTEGER,
+                    exit_code INTEGER,
+                    log_path TEXT,
+                    exit_code_path TEXT,
+                    wrapper_path TEXT,
+                    queued_notified_at TEXT,
+                    started_notified_at TEXT,
+                    completion_notified_at TEXT
+                )
+                """
+            )
+            existing_columns = {
+                row[1] for row in conn.execute("PRAGMA table_info(queue_jobs)").fetchall()
+            }
+            for column in ("queued_notified_at", "started_notified_at"):
+                if column not in existing_columns:
+                    conn.execute(f"ALTER TABLE queue_jobs ADD COLUMN {column} TEXT")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_queue_jobs_state_type_queued ON queue_jobs(state, type, queued_at)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_queue_jobs_notify_state ON queue_jobs(notify_session_id, state)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_queue_jobs_finished ON queue_jobs(finished_at)")
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS queue_resource_samples (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    sampled_at TEXT NOT NULL,
+                    pending_by_type_json TEXT NOT NULL,
+                    running_by_type_json TEXT NOT NULL,
+                    total_running INTEGER NOT NULL,
+                    memory_json TEXT NOT NULL,
+                    cpu_json TEXT NOT NULL,
+                    gpu_json TEXT
+                )
+                """
+            )
+
+    def _row_to_job(self, row: sqlite3.Row) -> QueueJob:
+        return QueueJob(
+            id=row["id"],
+            type=row["type"],
+            label=row["label"],
+            requester_session_id=row["requester_session_id"],
+            notify_session_id=row["notify_session_id"],
+            cwd=row["cwd"],
+            argv=json.loads(row["argv_json"]) if row["argv_json"] else None,
+            script_path=row["script_path"],
+            env=json.loads(row["env_json"] or "{}"),
+            timeout_seconds=int(row["timeout_seconds"]),
+            state=row["state"],
+            holding_reason=row["holding_reason"],
+            queued_at=datetime.fromisoformat(row["queued_at"]),
+            started_at=_parse_dt(row["started_at"]),
+            finished_at=_parse_dt(row["finished_at"]),
+            pid=row["pid"],
+            process_group_id=row["process_group_id"],
+            exit_code=row["exit_code"],
+            log_path=row["log_path"],
+            exit_code_path=row["exit_code_path"],
+            wrapper_path=row["wrapper_path"],
+            queued_notified_at=_parse_dt(row["queued_notified_at"]) if "queued_notified_at" in row.keys() else None,
+            started_notified_at=_parse_dt(row["started_notified_at"]) if "started_notified_at" in row.keys() else None,
+            completion_notified_at=_parse_dt(row["completion_notified_at"]),
+        )
+
+    def _load_jobs(self) -> None:
+        with self._connect() as conn:
+            for row in conn.execute("SELECT * FROM queue_jobs"):
+                job = self._row_to_job(row)
+                self._jobs[job.id] = job
+
+    def _persist_job(self, job: QueueJob) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO queue_jobs
+                (id, type, label, requester_session_id, notify_session_id, cwd, argv_json,
+                 script_path, env_json, timeout_seconds, state, holding_reason, queued_at,
+                 started_at, finished_at, pid, process_group_id, exit_code, log_path,
+                 exit_code_path, wrapper_path, queued_notified_at, started_notified_at, completion_notified_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    job.id,
+                    job.type,
+                    job.label,
+                    job.requester_session_id,
+                    job.notify_session_id,
+                    job.cwd,
+                    json.dumps(job.argv) if job.argv else None,
+                    job.script_path,
+                    json.dumps(job.env),
+                    job.timeout_seconds,
+                    job.state,
+                    job.holding_reason,
+                    job.queued_at.isoformat(),
+                    job.started_at.isoformat() if job.started_at else None,
+                    job.finished_at.isoformat() if job.finished_at else None,
+                    job.pid,
+                    job.process_group_id,
+                    job.exit_code,
+                    job.log_path,
+                    job.exit_code_path,
+                    job.wrapper_path,
+                    job.queued_notified_at.isoformat() if job.queued_notified_at else None,
+                    job.started_notified_at.isoformat() if job.started_notified_at else None,
+                    job.completion_notified_at.isoformat() if job.completion_notified_at else None,
+                ),
+            )
+
+    async def start(self) -> None:
+        if not self.enabled or self._started:
+            return
+        self._started = True
+        async with self._lock:
+            for job in list(self._jobs.values()):
+                if job.state == "running":
+                    await self._recover_running_job_locked(job)
+                elif job.state == "pending":
+                    job.holding_reason = None
+                    self._persist_job(job)
+        self._schedule()
+        self._ensure_resource_sampler()
+
+    async def stop(self) -> None:
+        for task in [self._scheduler_task, self._resource_sampler_task, *self._completion_tasks.values()]:
+            if task:
+                task.cancel()
+        for task in [self._scheduler_task, self._resource_sampler_task, *self._completion_tasks.values()]:
+            if task:
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+        self._scheduler_task = None
+        self._resource_sampler_task = None
+        self._completion_tasks.clear()
+        self._started = False
+
+    async def create_job(
+        self,
+        *,
+        job_type: str,
+        label: Optional[str],
+        argv: Optional[list[str]],
+        script: Optional[str],
+        cwd: str,
+        env: Optional[dict[str, str]],
+        notify_session_id: str,
+        requester_session_id: Optional[str],
+        timeout: str | int | None,
+    ) -> QueueJob:
+        if not self.enabled:
+            raise ValueError("queue runner is disabled")
+        if job_type not in self.type_config:
+            raise ValueError(f"unknown queue job type: {job_type}")
+        if bool(argv) == bool(script):
+            raise ValueError("exactly one of argv or script is required")
+        cwd_path = Path(cwd).expanduser().resolve()
+        if not cwd_path.exists() or not cwd_path.is_dir():
+            raise ValueError(f"cwd does not exist or is not a directory: {cwd}")
+        if not self.session_manager.get_session(notify_session_id):
+            raise ValueError("notify target not found")
+
+        job_id = f"job_{uuid.uuid4().hex[:12]}"
+        job_dir = self.state_dir / job_id
+        job_dir.mkdir(parents=True, exist_ok=True)
+        script_path = None
+        if script is not None:
+            script_path = str(job_dir / "submitted.zsh")
+            Path(script_path).write_text(script, encoding="utf-8")
+        timeout_seconds = _duration_seconds(
+            timeout,
+            self.type_config[job_type]["default_timeout_seconds"],
+        )
+        safe_env = {str(k): str(v) for k, v in (env or {}).items()}
+        summary = label or (Path(argv[0]).name if argv else "script")
+        now = datetime.now()
+        job = QueueJob(
+            id=job_id,
+            type=job_type,
+            label=summary,
+            requester_session_id=requester_session_id,
+            notify_session_id=notify_session_id,
+            cwd=str(cwd_path),
+            argv=argv,
+            script_path=script_path,
+            env=safe_env,
+            timeout_seconds=timeout_seconds,
+            state="pending",
+            holding_reason=None,
+            queued_at=now,
+            log_path=str(self.log_dir / f"{job_id}.log"),
+            exit_code_path=str(job_dir / "exit.code"),
+            wrapper_path=str(job_dir / "run.zsh"),
+        )
+        self._write_wrapper(job)
+        async with self._lock:
+            self._jobs[job.id] = job
+            self._persist_job(job)
+            await self._admit_jobs_locked()
+            if job.state == "pending" and job.queued_notified_at is None:
+                self._notify_queued(job)
+                job.queued_notified_at = datetime.now()
+                self._persist_job(job)
+        self._ensure_resource_sampler()
+        return job
+
+    def list_jobs(
+        self,
+        *,
+        notify_session_id: Optional[str] = None,
+        job_type: Optional[str] = None,
+        state: Optional[str] = None,
+        include_terminal: bool = False,
+    ) -> list[QueueJob]:
+        jobs = list(self._jobs.values())
+        if notify_session_id:
+            jobs = [job for job in jobs if job.notify_session_id == notify_session_id]
+        if job_type:
+            jobs = [job for job in jobs if job.type == job_type]
+        if state:
+            if state == "done":
+                jobs = [job for job in jobs if job.state in TERMINAL_STATES]
+            else:
+                jobs = [job for job in jobs if job.state == state]
+        elif not include_terminal:
+            jobs = [job for job in jobs if job.state in ACTIVE_STATES]
+        return sorted(jobs, key=lambda job: job.queued_at)
+
+    def get_job(self, job_id: str) -> Optional[QueueJob]:
+        return self._jobs.get(job_id)
+
+    async def cancel_job(self, job_id: str) -> Optional[QueueJob]:
+        async with self._lock:
+            job = self._jobs.get(job_id)
+            if job is None:
+                return None
+            if job.state in TERMINAL_STATES:
+                return job
+            if job.state == "pending":
+                await self._finish_job_locked(job, "cancelled", exit_code=None, notify=True)
+                return job
+            await self._terminate_job_locked(job, state="cancelled")
+            return job
+
+    def _write_wrapper(self, job: QueueJob) -> None:
+        assert job.wrapper_path and job.exit_code_path
+        lines = [
+            "#!/bin/zsh",
+            "set +e",
+            f"cd {shlex.quote(job.cwd)} || exit 127",
+        ]
+        for key, value in job.env.items():
+            lines.append(f"export {shlex.quote(key)}={shlex.quote(value)}")
+        if job.argv:
+            command = " ".join(shlex.quote(part) for part in job.argv)
+            lines.append(command)
+        else:
+            lines.append(f"/bin/zsh {shlex.quote(str(job.script_path))}")
+        lines.extend([
+            "code=$?",
+            f"printf '%s\\n' \"$code\" > {shlex.quote(job.exit_code_path)}",
+            "exit \"$code\"",
+        ])
+        path = Path(job.wrapper_path)
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        path.chmod(0o700)
+
+    def _schedule(self) -> None:
+        if not self._started:
+            return
+        if self._scheduler_task and not self._scheduler_task.done():
+            return
+        self._scheduler_task = asyncio.create_task(self._scheduler_loop())
+
+    async def _scheduler_loop(self) -> None:
+        try:
+            while True:
+                async with self._lock:
+                    changed = await self._admit_jobs_locked()
+                    has_pending = any(job.state == "pending" for job in self._jobs.values())
+                if not has_pending:
+                    return
+                await asyncio.sleep(self.memory_retry_interval_seconds if not changed else 0.1)
+        except asyncio.CancelledError:
+            raise
+
+    async def _admit_jobs_locked(self) -> bool:
+        changed = False
+        while True:
+            if await self._maybe_displace_for_perf_locked():
+                changed = True
+                continue
+            candidate = self._next_admissible_job_locked()
+            if candidate is None:
+                break
+            if candidate.holding_reason:
+                candidate.holding_reason = None
+                self._persist_job(candidate)
+            await self._start_job_locked(candidate)
+            changed = True
+        return changed
+
+    async def _maybe_displace_for_perf_locked(self) -> bool:
+        perf_job = self._oldest_pending("perf")
+        if not perf_job:
+            return False
+        if self._running_count() < self.max_running_jobs:
+            return False
+        if self._running_count("perf") >= self.type_config["perf"]["max_concurrent"]:
+            return False
+        if not self._memory_gate_passes() or self._perf_cooldown_active() or self._perf_blocked_by_tests_after_perf():
+            return False
+        backgrounds = [job for job in self._jobs.values() if job.state == "running" and job.type == "background"]
+        if not backgrounds:
+            return False
+        oldest_background = min(backgrounds, key=lambda job: job.started_at or job.queued_at)
+        await self._terminate_job_locked(oldest_background, state="displaced")
+        return True
+
+    def _next_admissible_job_locked(self) -> Optional[QueueJob]:
+        if self._running_count() >= self.max_running_jobs:
+            self._mark_pending_holding("concurrency_cap")
+            return None
+        if not self._memory_gate_passes():
+            self._mark_pending_holding("memory_pressure")
+            return None
+        for job_type in ("perf", "tests", "background"):
+            job = self._oldest_pending(job_type)
+            if not job:
+                continue
+            if self._running_count(job_type) >= self.type_config[job_type]["max_concurrent"]:
+                job.holding_reason = "concurrency_cap"
+                self._persist_job(job)
+                continue
+            if job_type == "perf" and self._perf_cooldown_active():
+                job.holding_reason = "perf_cooldown"
+                self._persist_job(job)
+                continue
+            if job_type == "perf" and self._perf_blocked_by_tests_after_perf():
+                job.holding_reason = "awaiting_tests"
+                self._persist_job(job)
+                continue
+            return job
+        return None
+
+    def _mark_pending_holding(self, reason: str) -> None:
+        for job in self._jobs.values():
+            if job.state == "pending" and job.holding_reason != reason:
+                job.holding_reason = reason
+                self._persist_job(job)
+
+    def _running_count(self, job_type: Optional[str] = None) -> int:
+        return sum(
+            1
+            for job in self._jobs.values()
+            if job.state == "running" and (job_type is None or job.type == job_type)
+        )
+
+    def _oldest_pending(self, job_type: str) -> Optional[QueueJob]:
+        pending = [job for job in self._jobs.values() if job.state == "pending" and job.type == job_type]
+        return min(pending, key=lambda job: job.queued_at) if pending else None
+
+    def _perf_cooldown_active(self) -> bool:
+        now = datetime.now()
+        for job in self._jobs.values():
+            if job.type in {"perf", "tests"} and job.finished_at:
+                if (now - job.finished_at).total_seconds() < self.perf_cooldown_seconds:
+                    return True
+        return False
+
+    def _perf_blocked_by_tests_after_perf(self) -> bool:
+        finished = [
+            job for job in self._jobs.values()
+            if job.type in {"perf", "tests"} and job.finished_at is not None
+        ]
+        if not finished:
+            return False
+        latest = max(finished, key=lambda job: job.finished_at or datetime.min)
+        if latest.type != "perf":
+            return False
+        return any(
+            job.type == "tests" and job.state in {"pending", "running"}
+            for job in self._jobs.values()
+        )
+
+    def _memory_gate_passes(self) -> bool:
+        if self.min_free_bytes <= 0:
+            return True
+        free = self._read_free_memory_bytes()
+        return free is None or free >= self.min_free_bytes
+
+    def _read_free_memory_bytes(self) -> Optional[int]:
+        try:
+            output = subprocess.check_output(["vm_stat"], text=True, timeout=1)
+        except Exception:
+            return None
+        page_size = 4096
+        free_pages = 0
+        for line in output.splitlines():
+            if "page size of" in line:
+                parts = [part for part in line.split() if part.isdigit()]
+                if parts:
+                    page_size = int(parts[0])
+            if line.startswith(("Pages free:", "Pages speculative:")):
+                digits = "".join(ch for ch in line if ch.isdigit())
+                if digits:
+                    free_pages += int(digits)
+        return free_pages * page_size if free_pages else None
+
+    async def _start_job_locked(self, job: QueueJob) -> None:
+        assert job.wrapper_path and job.log_path
+        log_handle = open(job.log_path, "ab", buffering=0)
+        process = await asyncio.create_subprocess_exec(
+            "/bin/zsh",
+            job.wrapper_path,
+            stdout=log_handle,
+            stderr=asyncio.subprocess.STDOUT,
+            start_new_session=True,
+        )
+        log_handle.close()
+        job.pid = process.pid
+        job.process_group_id = process.pid
+        job.started_at = datetime.now()
+        job.state = "running"
+        job.holding_reason = None
+        self._processes[job.id] = process
+        if job.queued_notified_at is not None and job.started_notified_at is None:
+            self._notify_started(job)
+            job.started_notified_at = datetime.now()
+        self._persist_job(job)
+        task = asyncio.create_task(self._wait_for_job(job.id))
+        self._completion_tasks[job.id] = task
+
+    async def _wait_for_job(self, job_id: str) -> None:
+        try:
+            job = self._jobs.get(job_id)
+            process = self._processes.get(job_id)
+            if not job or not process:
+                return
+            try:
+                exit_code = await asyncio.wait_for(process.wait(), timeout=job.timeout_seconds)
+                async with self._lock:
+                    if job.state != "running":
+                        return
+                    await self._finish_job_locked(
+                        job,
+                        "succeeded" if exit_code == 0 else "failed",
+                        exit_code=exit_code,
+                        notify=True,
+                    )
+            except asyncio.TimeoutError:
+                async with self._lock:
+                    if job.state != "running":
+                        return
+                    await self._terminate_job_locked(job, state="timed_out")
+        finally:
+            self._processes.pop(job_id, None)
+            self._completion_tasks.pop(job_id, None)
+            self._schedule()
+            self._ensure_resource_sampler()
+
+    async def _recover_running_job_locked(self, job: QueueJob) -> None:
+        if job.exit_code_path and Path(job.exit_code_path).exists():
+            exit_code = self._read_exit_code(job)
+            await self._finish_job_locked(
+                job,
+                "succeeded" if exit_code == 0 else "failed",
+                exit_code=exit_code,
+                notify=job.completion_notified_at is None,
+            )
+            return
+        if job.pid and self._pid_exists(job.pid):
+            task = asyncio.create_task(self._poll_recovered_job(job.id))
+            self._completion_tasks[job.id] = task
+            return
+        await self._finish_job_locked(job, "failed", exit_code=None, notify=job.completion_notified_at is None)
+
+    async def _poll_recovered_job(self, job_id: str) -> None:
+        try:
+            while True:
+                await asyncio.sleep(2)
+                async with self._lock:
+                    job = self._jobs.get(job_id)
+                    if not job or job.state != "running":
+                        return
+                    if job.exit_code_path and Path(job.exit_code_path).exists():
+                        exit_code = self._read_exit_code(job)
+                        await self._finish_job_locked(
+                            job,
+                            "succeeded" if exit_code == 0 else "failed",
+                            exit_code=exit_code,
+                            notify=job.completion_notified_at is None,
+                        )
+                        return
+                    if job.pid and not self._pid_exists(job.pid):
+                        await self._finish_job_locked(job, "failed", exit_code=None, notify=job.completion_notified_at is None)
+                        return
+        finally:
+            self._completion_tasks.pop(job_id, None)
+            self._schedule()
+
+    def _read_exit_code(self, job: QueueJob) -> Optional[int]:
+        try:
+            return int(Path(str(job.exit_code_path)).read_text(encoding="utf-8").strip())
+        except Exception:
+            return None
+
+    def _pid_exists(self, pid: int) -> bool:
+        try:
+            os.kill(pid, 0)
+            return True
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+
+    async def _terminate_job_locked(self, job: QueueJob, *, state: str) -> None:
+        pgid = job.process_group_id or job.pid
+        if pgid:
+            with contextlib.suppress(ProcessLookupError, PermissionError):
+                os.killpg(pgid, signal.SIGTERM)
+            await asyncio.sleep(self.cancel_grace_seconds)
+            if job.pid and self._pid_exists(job.pid):
+                with contextlib.suppress(ProcessLookupError, PermissionError):
+                    os.killpg(pgid, signal.SIGKILL)
+        exit_code = self._read_exit_code(job)
+        await self._finish_job_locked(job, state, exit_code=exit_code, notify=True)
+
+    async def _finish_job_locked(
+        self,
+        job: QueueJob,
+        state: str,
+        *,
+        exit_code: Optional[int],
+        notify: bool,
+    ) -> None:
+        job.state = state
+        job.exit_code = exit_code
+        job.finished_at = datetime.now()
+        job.holding_reason = None
+        if notify and job.completion_notified_at is None:
+            self._notify_completion(job)
+            job.completion_notified_at = datetime.now()
+        self._persist_job(job)
+
+    def _notify_completion(self, job: QueueJob) -> None:
+        mq = getattr(self.session_manager, "message_queue_manager", None)
+        if not mq:
+            return
+        runtime = "-"
+        if job.started_at and job.finished_at:
+            runtime = f"{int((job.finished_at - job.started_at).total_seconds())}s"
+        queued = "-"
+        if job.finished_at:
+            queued = f"{int(((job.started_at or job.finished_at) - job.queued_at).total_seconds())}s"
+        exit_text = f" exit={job.exit_code}" if job.exit_code is not None else ""
+        stderr_tail = self._tail_log(job.log_path, max_bytes=8192)
+        text = (
+            f"[sm queue] {job.id} completed: {job.state}{exit_text} "
+            f"runtime={runtime} queue={queued}. Log: {job.log_path or '-'}"
+        )
+        if stderr_tail:
+            text += f"\nlog tail:\n{stderr_tail}"
+        mq.queue_message(target_session_id=job.notify_session_id, text=text, delivery_mode="sequential")
+
+    def _notify_queued(self, job: QueueJob) -> None:
+        mq = getattr(self.session_manager, "message_queue_manager", None)
+        if not mq:
+            return
+        position = len([other for other in self._jobs.values() if other.state == "pending" and other.type == job.type and other.queued_at <= job.queued_at])
+        text = (
+            f"[sm queue] {job.id} queued: {job.type}, position {position}, "
+            f"holding on {job.holding_reason or 'queue'}. Log: {job.log_path or '-'}"
+        )
+        mq.queue_message(target_session_id=job.notify_session_id, text=text, delivery_mode="sequential")
+
+    def _notify_started(self, job: QueueJob) -> None:
+        mq = getattr(self.session_manager, "message_queue_manager", None)
+        if not mq:
+            return
+        text = f"[sm queue] {job.id} started: {job.type}, pid {job.pid or '-'}. Log: {job.log_path or '-'}"
+        mq.queue_message(target_session_id=job.notify_session_id, text=text, delivery_mode="sequential")
+
+    def _tail_log(self, log_path: Optional[str], max_bytes: int) -> str:
+        if not log_path:
+            return ""
+        try:
+            path = Path(log_path)
+            size = path.stat().st_size
+            with path.open("rb") as handle:
+                handle.seek(max(0, size - max_bytes))
+                return handle.read().decode(errors="replace").strip()
+        except Exception:
+            return ""
+
+    def _ensure_resource_sampler(self) -> None:
+        if not self.resource_sampling_enabled or not self._started:
+            return
+        has_active = any(job.state in ACTIVE_STATES for job in self._jobs.values())
+        if has_active and (self._resource_sampler_task is None or self._resource_sampler_task.done()):
+            self._resource_sampler_task = asyncio.create_task(self._resource_sampler_loop())
+
+    async def _resource_sampler_loop(self) -> None:
+        try:
+            while True:
+                if not any(job.state in ACTIVE_STATES for job in self._jobs.values()):
+                    return
+                await asyncio.to_thread(self._record_resource_sample)
+                await asyncio.sleep(self.resource_sampling_interval_seconds)
+        except asyncio.CancelledError:
+            raise
+
+    def _record_resource_sample(self) -> None:
+        pending = self._counts_by_type("pending")
+        running = self._counts_by_type("running")
+        memory = {"free_bytes": self._read_free_memory_bytes()}
+        cpu = self._read_cpu_sample()
+        with self._connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO queue_resource_samples
+                (sampled_at, pending_by_type_json, running_by_type_json, total_running, memory_json, cpu_json, gpu_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    datetime.now().isoformat(),
+                    json.dumps(pending),
+                    json.dumps(running),
+                    sum(running.values()),
+                    json.dumps(memory),
+                    json.dumps(cpu),
+                    None,
+                ),
+            )
+
+    def _counts_by_type(self, state: str) -> dict[str, int]:
+        return {
+            job_type: sum(1 for job in self._jobs.values() if job.state == state and job.type == job_type)
+            for job_type in self.type_config
+        }
+
+    def _read_cpu_sample(self) -> dict[str, Any]:
+        pids = [str(job.pid) for job in self._jobs.values() if job.state == "running" and job.pid]
+        sample: dict[str, Any] = {"loadavg": os.getloadavg() if hasattr(os, "getloadavg") else None}
+        if not pids:
+            return sample
+        try:
+            output = subprocess.check_output(["ps", "-o", "pid=,%cpu=", "-p", ",".join(pids)], text=True, timeout=1)
+            sample["processes"] = output.strip()
+        except Exception:
+            sample["processes"] = None
+        return sample

--- a/src/server.py
+++ b/src/server.py
@@ -720,6 +720,43 @@ class JobWatchResponse(BaseModel):
     is_active: bool = True
 
 
+class QueueJobCreateRequest(BaseModel):
+    """Request to submit one managed local queue job."""
+    type: str = "tests"
+    label: Optional[str] = None
+    argv: Optional[list[str]] = None
+    script: Optional[str] = None
+    cwd: str
+    env: dict[str, str] = Field(default_factory=dict)
+    notify_target: Optional[str] = None
+    requester_session_id: Optional[str] = None
+    timeout_seconds: Optional[int] = Field(default=None, gt=0)
+
+
+class QueueJobResponse(BaseModel):
+    """Response payload for one managed local queue job."""
+    id: str
+    type: str
+    label: str
+    requester_session_id: Optional[str] = None
+    requester_name: Optional[str] = None
+    notify_session_id: str
+    notify_name: Optional[str] = None
+    cwd: str
+    argv: Optional[list[str]] = None
+    script_path: Optional[str] = None
+    timeout_seconds: int
+    state: str
+    holding_reason: Optional[str] = None
+    queued_at: str
+    started_at: Optional[str] = None
+    finished_at: Optional[str] = None
+    pid: Optional[int] = None
+    process_group_id: Optional[int] = None
+    exit_code: Optional[int] = None
+    log_path: Optional[str] = None
+
+
 class CodexReviewRequestCreateRequest(BaseModel):
     """Request to create a durable Codex PR review request."""
     pr_number: int = Field(gt=0)
@@ -1859,6 +1896,36 @@ def create_app(
             last_progress_text=registration.last_progress_text,
             last_event=registration.last_event,
             is_active=registration.is_active,
+        )
+
+    def _queue_job_to_response(job) -> QueueJobResponse:
+        requester = (
+            app.state.session_manager.get_session(job.requester_session_id)
+            if job.requester_session_id
+            else None
+        )
+        notify = app.state.session_manager.get_session(job.notify_session_id)
+        return QueueJobResponse(
+            id=job.id,
+            type=job.type,
+            label=job.label,
+            requester_session_id=job.requester_session_id,
+            requester_name=_effective_session_name(requester) if requester else None,
+            notify_session_id=job.notify_session_id,
+            notify_name=_effective_session_name(notify) if notify else job.notify_session_id,
+            cwd=job.cwd,
+            argv=job.argv,
+            script_path=job.script_path,
+            timeout_seconds=job.timeout_seconds,
+            state=job.state,
+            holding_reason=job.holding_reason,
+            queued_at=job.queued_at.isoformat(),
+            started_at=job.started_at.isoformat() if job.started_at else None,
+            finished_at=job.finished_at.isoformat() if job.finished_at else None,
+            pid=job.pid,
+            process_group_id=job.process_group_id,
+            exit_code=job.exit_code,
+            log_path=job.log_path,
         )
 
     def _codex_review_request_to_response(registration) -> CodexReviewRequestResponse:
@@ -6012,6 +6079,100 @@ Provide ONLY the summary, no preamble or questions."""
         if registration is None:
             raise HTTPException(status_code=404, detail="Job watch not found")
         return _job_watch_to_response(registration)
+
+    @app.post("/queue-jobs", response_model=QueueJobResponse)
+    async def create_queue_job(request: QueueJobCreateRequest):
+        """Submit one managed local queue job (#672)."""
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
+
+        queue_runner = getattr(app.state.session_manager, "queue_runner", None)
+        if not queue_runner:
+            raise HTTPException(status_code=503, detail="Queue runner not configured")
+
+        notify_identifier = request.notify_target or request.requester_session_id
+        if not notify_identifier:
+            raise HTTPException(status_code=400, detail="notify_target or requester_session_id is required")
+        notify_session = _resolve_session_or_registry_role(notify_identifier)
+        if not notify_session:
+            raise HTTPException(status_code=404, detail="Notify target not found")
+
+        try:
+            job = await queue_runner.create_job(
+                job_type=request.type,
+                label=request.label,
+                argv=request.argv,
+                script=request.script,
+                cwd=request.cwd,
+                env=request.env,
+                notify_session_id=notify_session.id,
+                requester_session_id=request.requester_session_id,
+                timeout=request.timeout_seconds,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        return _queue_job_to_response(job)
+
+    @app.get("/queue-jobs")
+    async def list_queue_jobs(
+        notify_target: Optional[str] = Query(None),
+        type: Optional[str] = Query(None),
+        state: Optional[str] = Query(None),
+        include_terminal: bool = Query(False),
+    ):
+        """List managed local queue jobs (#672)."""
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
+
+        queue_runner = getattr(app.state.session_manager, "queue_runner", None)
+        if not queue_runner:
+            raise HTTPException(status_code=503, detail="Queue runner not configured")
+
+        notify_session_id = None
+        if notify_target:
+            notify_session = _resolve_session_or_registry_role(notify_target)
+            if not notify_session:
+                raise HTTPException(status_code=404, detail="Notify target not found")
+            notify_session_id = notify_session.id
+
+        jobs = queue_runner.list_jobs(
+            notify_session_id=notify_session_id,
+            job_type=type,
+            state=state,
+            include_terminal=include_terminal,
+        )
+        return {"jobs": [_response_dict(_queue_job_to_response(job)) for job in jobs]}
+
+    @app.get("/queue-jobs/{job_id}", response_model=QueueJobResponse)
+    async def get_queue_job(job_id: str):
+        """Fetch one managed local queue job (#672)."""
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
+
+        queue_runner = getattr(app.state.session_manager, "queue_runner", None)
+        if not queue_runner:
+            raise HTTPException(status_code=503, detail="Queue runner not configured")
+
+        job = queue_runner.get_job(job_id)
+        if job is None:
+            raise HTTPException(status_code=404, detail="Queue job not found")
+        return _queue_job_to_response(job)
+
+    @app.delete("/queue-jobs/{job_id}", response_model=QueueJobResponse)
+    async def cancel_queue_job(job_id: str):
+        """Cancel one managed local queue job (#672)."""
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
+
+        queue_runner = getattr(app.state.session_manager, "queue_runner", None)
+        if not queue_runner:
+            raise HTTPException(status_code=503, detail="Queue runner not configured")
+
+        job = await queue_runner.cancel_job(job_id)
+        if job is None:
+            raise HTTPException(status_code=404, detail="Queue job not found")
+        return _queue_job_to_response(job)
 
     @app.post("/codex-review-requests", response_model=CodexReviewRequestResponse)
     async def create_codex_review_request(request: CodexReviewRequestCreateRequest):

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -43,6 +43,7 @@ from .codex_provider_policy import (
 )
 from .codex_request_ledger import CodexRequestLedger
 from .github_reviews import post_pr_review_comment, poll_for_codex_review, get_pr_repo_from_git
+from .queue_runner import QueueRunner
 
 logger = logging.getLogger(__name__)
 
@@ -381,6 +382,12 @@ class SessionManager:
 
         # Message queue manager (set by main app)
         self.message_queue_manager = None
+        queue_runner_config = dict(self.config)
+        if "queue_runner" not in queue_runner_config and self.state_file != self.default_state_file:
+            queue_runner_config["queue_runner"] = {
+                "state_dir": str(self.state_file.parent / "queue-runner")
+            }
+        self.queue_runner = QueueRunner(self, config=queue_runner_config)
 
         # Child monitor (set by main app)
         self.child_monitor = None
@@ -3906,6 +3913,7 @@ class SessionManager:
     async def start_background_tasks(self):
         """Start periodic maintenance tasks owned by SessionManager."""
         await self.codex_observability_logger.start_periodic_prune()
+        await self.queue_runner.start()
         await self.maintain_codex_fork_runtime_artifacts()
         for session in self.sessions.values():
             if session.provider == "codex-fork" and session.status != SessionStatus.STOPPED:
@@ -3922,6 +3930,7 @@ class SessionManager:
     async def stop_background_tasks(self):
         """Stop periodic maintenance tasks owned by SessionManager."""
         await self.codex_observability_logger.stop_periodic_prune()
+        await self.queue_runner.stop()
         if self._service_role_maintenance_task is not None:
             self._service_role_maintenance_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):

--- a/tests/unit/test_queue_runner.py
+++ b/tests/unit/test_queue_runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import sqlite3
 import sys
+from datetime import datetime
 from unittest.mock import MagicMock
 
 import pytest
@@ -12,7 +13,7 @@ from fastapi.testclient import TestClient
 
 from src.cli.commands import cmd_queue_run
 from src.models import Session, SessionStatus
-from src.queue_runner import QueueRunner
+from src.queue_runner import QueueJob, QueueRunner
 from src.server import create_app
 from src.session_manager import SessionManager
 
@@ -95,6 +96,7 @@ async def test_queue_job_runs_and_notifies(mock_sm, tmp_path):
 async def test_memory_gate_holds_and_pending_cancel(mock_sm, tmp_path):
     runner = _runner(mock_sm, tmp_path)
     runner._memory_gate_passes = MagicMock(return_value=False)
+    runner._started = True
 
     job = await runner.create_job(
         job_type="tests",
@@ -111,9 +113,18 @@ async def test_memory_gate_holds_and_pending_cancel(mock_sm, tmp_path):
     assert runner.get_job(job.id).state == "pending"
     assert runner.get_job(job.id).holding_reason == "memory_pressure"
     assert "queued:" in mock_sm.message_queue_manager.queue_message.call_args_list[-1].kwargs["text"]
+    assert runner._scheduler_task is not None
+
+    runner._memory_gate_passes = MagicMock(return_value=True)
+    for _ in range(20):
+        if runner.get_job(job.id).state in {"running", "succeeded"}:
+            break
+        await asyncio.sleep(0.1)
+    assert runner.get_job(job.id).state in {"running", "succeeded"}
 
     cancelled = await runner.cancel_job(job.id)
-    assert cancelled.state == "cancelled"
+    await runner.stop()
+    assert cancelled.state in {"cancelled", "succeeded"}
     mock_sm.message_queue_manager.queue_message.assert_called()
 
 
@@ -341,3 +352,25 @@ def test_cmd_queue_run_captures_argv_and_env(tmp_path, monkeypatch):
     assert call["env"]["PATH"] == "/bin"
     assert call["env"]["EXTRA"] == "1"
     assert call["timeout_seconds"] == 10
+
+
+def test_subprocess_env_uses_captured_values_only(mock_sm, tmp_path):
+    runner = _runner(mock_sm, tmp_path)
+    queue_job = QueueJob(
+        id="manual",
+        type="tests",
+        label="manual",
+        requester_session_id="agent672",
+        notify_session_id="agent672",
+        cwd=str(tmp_path),
+        argv=[sys.executable, "-c", "print('x')"],
+        script_path=None,
+        env={"PATH": "/captured/bin", "CUSTOM": "yes"},
+        timeout_seconds=5,
+        state="pending",
+        holding_reason=None,
+        queued_at=datetime.now(),
+    )
+
+    env = runner._subprocess_env(queue_job)
+    assert env == {"PATH": "/captured/bin", "CUSTOM": "yes"}

--- a/tests/unit/test_queue_runner.py
+++ b/tests/unit/test_queue_runner.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import sqlite3
 import sys
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest.mock import MagicMock
 
 import pytest
@@ -272,6 +272,40 @@ async def test_start_recovers_dead_running_job(mock_sm, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_start_times_out_recovered_running_job(mock_sm, tmp_path):
+    runner = _runner(mock_sm, tmp_path)
+    job = await runner.create_job(
+        job_type="tests",
+        label="recovered-timeout",
+        argv=[sys.executable, "-c", "import time; time.sleep(10)"],
+        script=None,
+        cwd=str(tmp_path),
+        env={},
+        notify_session_id="agent672",
+        requester_session_id="agent672",
+        timeout=1,
+    )
+
+    for _ in range(20):
+        if runner.get_job(job.id).state == "running":
+            break
+        await asyncio.sleep(0.1)
+    assert runner.get_job(job.id).state == "running"
+
+    await runner.stop()
+    with sqlite3.connect(runner.db_path) as conn:
+        conn.execute(
+            "UPDATE queue_jobs SET started_at=? WHERE id=?",
+            ((datetime.now() - timedelta(seconds=5)).isoformat(), job.id),
+        )
+
+    recovered = _runner(mock_sm, tmp_path)
+    await recovered.start()
+    assert recovered.get_job(job.id).state == "timed_out"
+    await recovered.stop()
+
+
+@pytest.mark.asyncio
 async def test_resource_sampling_records_when_queue_non_empty(mock_sm, tmp_path):
     runner = _runner(mock_sm, tmp_path)
     runner._memory_gate_passes = MagicMock(return_value=False)
@@ -352,6 +386,34 @@ def test_cmd_queue_run_captures_argv_and_env(tmp_path, monkeypatch):
     assert call["env"]["PATH"] == "/bin"
     assert call["env"]["EXTRA"] == "1"
     assert call["timeout_seconds"] == 10
+
+
+def test_resource_sample_uses_supplied_job_snapshot(mock_sm, tmp_path):
+    runner = _runner(mock_sm, tmp_path)
+    queue_job = QueueJob(
+        id="snapshot",
+        type="tests",
+        label="snapshot",
+        requester_session_id="agent672",
+        notify_session_id="agent672",
+        cwd=str(tmp_path),
+        argv=[sys.executable, "-c", "print('x')"],
+        script_path=None,
+        env={},
+        timeout_seconds=5,
+        state="pending",
+        holding_reason=None,
+        queued_at=datetime.now(),
+    )
+
+    runner._jobs.clear()
+    runner._record_resource_sample([queue_job])
+
+    with sqlite3.connect(runner.db_path) as conn:
+        pending_json = conn.execute(
+            "SELECT pending_by_type_json FROM queue_resource_samples ORDER BY sampled_at DESC LIMIT 1"
+        ).fetchone()[0]
+    assert '"tests": 1' in pending_json
 
 
 def test_subprocess_env_uses_captured_values_only(mock_sm, tmp_path):

--- a/tests/unit/test_queue_runner.py
+++ b/tests/unit/test_queue_runner.py
@@ -1,0 +1,343 @@
+"""Unit tests for managed local queue runner (#672)."""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.cli.commands import cmd_queue_run
+from src.models import Session, SessionStatus
+from src.queue_runner import QueueRunner
+from src.server import create_app
+from src.session_manager import SessionManager
+
+
+def _session(session_id: str, tmp_path) -> Session:
+    return Session(
+        id=session_id,
+        name=f"claude-{session_id}",
+        working_dir=str(tmp_path),
+        tmux_session=f"claude-{session_id}",
+        provider="claude",
+        log_file=str(tmp_path / f"{session_id}.log"),
+        status=SessionStatus.RUNNING,
+        friendly_name="queue-owner",
+    )
+
+
+def _runner(mock_sm, tmp_path, extra_config=None) -> QueueRunner:
+    config = {
+        "queue_runner": {
+            "state_dir": str(tmp_path / "queue-runner"),
+            "max_running_jobs": 2,
+            "perf_cooldown_seconds": 0,
+            "cancel_grace_seconds": 0,
+            "memory": {"min_free_bytes": 0, "retry_interval_seconds": 1},
+            "resource_sampling": {"enabled": True, "interval_seconds": 1},
+            "types": {
+                "tests": {"max_concurrent": 2, "default_timeout_seconds": 5},
+                "perf": {"max_concurrent": 1, "default_timeout_seconds": 5},
+                "background": {"max_concurrent": 2, "default_timeout_seconds": 5},
+            },
+        }
+    }
+    if extra_config:
+        config["queue_runner"].update(extra_config)
+    return QueueRunner(mock_sm, config=config)
+
+
+@pytest.fixture
+def mock_sm(tmp_path):
+    session = _session("agent672", tmp_path)
+    sm = MagicMock()
+    sm.sessions = {session.id: session}
+    sm.get_session.side_effect = lambda sid: sm.sessions.get(sid)
+    sm.get_effective_session_name.side_effect = lambda current: current.friendly_name if current else None
+    sm.lookup_agent_registration.return_value = None
+    sm.message_queue_manager = MagicMock()
+    return sm
+
+
+@pytest.mark.asyncio
+async def test_queue_job_runs_and_notifies(mock_sm, tmp_path):
+    runner = _runner(mock_sm, tmp_path)
+
+    job = await runner.create_job(
+        job_type="tests",
+        label="hello",
+        argv=[sys.executable, "-c", "print('queued hello')"],
+        script=None,
+        cwd=str(tmp_path),
+        env={},
+        notify_session_id="agent672",
+        requester_session_id="agent672",
+        timeout=None,
+    )
+
+    for _ in range(30):
+        if runner.get_job(job.id).state in {"succeeded", "failed"}:
+            break
+        await asyncio.sleep(0.1)
+
+    completed = runner.get_job(job.id)
+    assert completed.state == "succeeded"
+    assert completed.exit_code == 0
+    assert "queued hello" in (tmp_path / "queue-runner" / "logs" / f"{job.id}.log").read_text()
+    mock_sm.message_queue_manager.queue_message.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_memory_gate_holds_and_pending_cancel(mock_sm, tmp_path):
+    runner = _runner(mock_sm, tmp_path)
+    runner._memory_gate_passes = MagicMock(return_value=False)
+
+    job = await runner.create_job(
+        job_type="tests",
+        label="held",
+        argv=[sys.executable, "-c", "print('no start')"],
+        script=None,
+        cwd=str(tmp_path),
+        env={},
+        notify_session_id="agent672",
+        requester_session_id="agent672",
+        timeout=None,
+    )
+
+    assert runner.get_job(job.id).state == "pending"
+    assert runner.get_job(job.id).holding_reason == "memory_pressure"
+    assert "queued:" in mock_sm.message_queue_manager.queue_message.call_args_list[-1].kwargs["text"]
+
+    cancelled = await runner.cancel_job(job.id)
+    assert cancelled.state == "cancelled"
+    mock_sm.message_queue_manager.queue_message.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_timeout_terminates_job(mock_sm, tmp_path):
+    runner = _runner(mock_sm, tmp_path)
+
+    job = await runner.create_job(
+        job_type="tests",
+        label="timeout",
+        argv=[sys.executable, "-c", "import time; time.sleep(5)"],
+        script=None,
+        cwd=str(tmp_path),
+        env={},
+        notify_session_id="agent672",
+        requester_session_id="agent672",
+        timeout=1,
+    )
+
+    for _ in range(40):
+        if runner.get_job(job.id).state == "timed_out":
+            break
+        await asyncio.sleep(0.1)
+
+    assert runner.get_job(job.id).state == "timed_out"
+
+
+@pytest.mark.asyncio
+async def test_perf_displaces_running_background(mock_sm, tmp_path):
+    runner = _runner(mock_sm, tmp_path, extra_config={"max_running_jobs": 1})
+
+    background = await runner.create_job(
+        job_type="background",
+        label="background",
+        argv=[sys.executable, "-c", "import time; time.sleep(5)"],
+        script=None,
+        cwd=str(tmp_path),
+        env={},
+        notify_session_id="agent672",
+        requester_session_id="agent672",
+        timeout=10,
+    )
+    assert runner.get_job(background.id).state == "running"
+
+    perf = await runner.create_job(
+        job_type="perf",
+        label="perf",
+        argv=[sys.executable, "-c", "print('perf')"],
+        script=None,
+        cwd=str(tmp_path),
+        env={},
+        notify_session_id="agent672",
+        requester_session_id="agent672",
+        timeout=5,
+    )
+
+    for _ in range(40):
+        if runner.get_job(background.id).state == "displaced" and runner.get_job(perf.id).state in {"running", "succeeded"}:
+            break
+        await asyncio.sleep(0.1)
+
+    assert runner.get_job(background.id).state == "displaced"
+    assert runner.get_job(perf.id).state in {"running", "succeeded"}
+
+
+@pytest.mark.asyncio
+async def test_pending_tests_block_back_to_back_perf_after_perf_completion(mock_sm, tmp_path):
+    runner = _runner(mock_sm, tmp_path)
+
+    completed_perf = await runner.create_job(
+        job_type="perf",
+        label="perf1",
+        argv=[sys.executable, "-c", "print('perf1')"],
+        script=None,
+        cwd=str(tmp_path),
+        env={},
+        notify_session_id="agent672",
+        requester_session_id="agent672",
+        timeout=5,
+    )
+    for _ in range(30):
+        if runner.get_job(completed_perf.id).state == "succeeded":
+            break
+        await asyncio.sleep(0.1)
+
+    runner._memory_gate_passes = MagicMock(return_value=False)
+    tests_job = await runner.create_job(
+        job_type="tests",
+        label="tests",
+        argv=[sys.executable, "-c", "import time; time.sleep(0.1)"],
+        script=None,
+        cwd=str(tmp_path),
+        env={},
+        notify_session_id="agent672",
+        requester_session_id="agent672",
+        timeout=5,
+    )
+    perf2 = await runner.create_job(
+        job_type="perf",
+        label="perf2",
+        argv=[sys.executable, "-c", "print('perf2')"],
+        script=None,
+        cwd=str(tmp_path),
+        env={},
+        notify_session_id="agent672",
+        requester_session_id="agent672",
+        timeout=5,
+    )
+
+    runner._memory_gate_passes = MagicMock(return_value=True)
+    async with runner._lock:
+        await runner._admit_jobs_locked()
+
+    assert runner.get_job(tests_job.id).state in {"running", "succeeded"}
+    assert runner.get_job(perf2.id).state == "pending"
+
+
+@pytest.mark.asyncio
+async def test_start_recovers_dead_running_job(mock_sm, tmp_path):
+    runner = _runner(mock_sm, tmp_path)
+    job = await runner.create_job(
+        job_type="tests",
+        label="done",
+        argv=[sys.executable, "-c", "print('done')"],
+        script=None,
+        cwd=str(tmp_path),
+        env={},
+        notify_session_id="agent672",
+        requester_session_id="agent672",
+        timeout=None,
+    )
+    await runner.cancel_job(job.id)
+
+    with sqlite3.connect(runner.db_path) as conn:
+        conn.execute(
+            "UPDATE queue_jobs SET state='running', pid=99999999, process_group_id=99999999, "
+            "finished_at=NULL, exit_code=NULL, completion_notified_at=NULL WHERE id=?",
+            (job.id,),
+        )
+
+    recovered = _runner(mock_sm, tmp_path)
+    await recovered.start()
+    assert recovered.get_job(job.id).state == "failed"
+    await recovered.stop()
+
+
+@pytest.mark.asyncio
+async def test_resource_sampling_records_when_queue_non_empty(mock_sm, tmp_path):
+    runner = _runner(mock_sm, tmp_path)
+    runner._memory_gate_passes = MagicMock(return_value=False)
+    await runner.start()
+    await runner.create_job(
+        job_type="tests",
+        label="held",
+        argv=[sys.executable, "-c", "print('held')"],
+        script=None,
+        cwd=str(tmp_path),
+        env={},
+        notify_session_id="agent672",
+        requester_session_id="agent672",
+        timeout=None,
+    )
+    await asyncio.sleep(0.2)
+    with sqlite3.connect(runner.db_path) as conn:
+        count = conn.execute("SELECT COUNT(*) FROM queue_resource_samples").fetchone()[0]
+    await runner.stop()
+    assert count >= 1
+
+
+def test_queue_job_endpoints_roundtrip(tmp_path):
+    session_manager = SessionManager(
+        log_dir=str(tmp_path / "logs"),
+        state_file=str(tmp_path / "sessions.json"),
+        config={"queue_runner": {"state_dir": str(tmp_path / "queue-runner"), "memory": {"min_free_bytes": 0}}},
+    )
+    session = _session("agent672", tmp_path)
+    session_manager.sessions[session.id] = session
+    session_manager.message_queue_manager = MagicMock()
+
+    app = create_app(session_manager=session_manager)
+    client = TestClient(app)
+
+    response = client.post(
+        "/queue-jobs",
+        json={
+            "type": "tests",
+            "label": "api",
+            "argv": [sys.executable, "-c", "print('api')"],
+            "cwd": str(tmp_path),
+            "notify_target": "agent672",
+            "requester_session_id": "agent672",
+            "timeout_seconds": 5,
+        },
+    )
+    assert response.status_code == 200
+    job_id = response.json()["id"]
+    assert client.get(f"/queue-jobs/{job_id}").status_code == 200
+    assert client.get("/queue-jobs?notify_target=agent672").json()["jobs"]
+
+
+def test_cmd_queue_run_captures_argv_and_env(tmp_path, monkeypatch):
+    client = MagicMock()
+    client.create_queue_job.return_value = {
+        "ok": True,
+        "data": {"id": "job_cli", "type": "tests", "state": "pending", "log_path": "/tmp/job.log"},
+    }
+    monkeypatch.setenv("PATH", "/bin")
+
+    code = cmd_queue_run(
+        client,
+        "agent672",
+        job_type="tests",
+        label="cli",
+        cwd=str(tmp_path),
+        timeout="10s",
+        env_pairs=["EXTRA=1"],
+        notify_target=None,
+        command=["--", sys.executable, "-m", "pytest"],
+        script_file=None,
+    )
+
+    assert code == 0
+    call = client.create_queue_job.call_args.kwargs
+    assert call["argv"] == [sys.executable, "-m", "pytest"]
+    assert call["env"]["PATH"] == "/bin"
+    assert call["env"]["EXTRA"] == "1"
+    assert call["timeout_seconds"] == 10


### PR DESCRIPTION
## Summary
- Implements the approved managed local queue runner spec in `specs/670_managed_queue_runner.md`.
- Adds `sm queue run/list/status/cancel` and `/queue-jobs` API endpoints.
- Adds SQLite-backed queue state, detached wrapper execution, restart reconciliation, cancellation/timeout handling, queued/start/completion notifications, perf/background scheduling rules, memory preflight, and resource sampling.

## Spec Reference
- `specs/670_managed_queue_runner.md`

## Test Plan
- `python3 -m py_compile src/queue_runner.py src/session_manager.py src/server.py src/cli/client.py src/cli/commands.py src/cli/main.py tests/unit/test_queue_runner.py`
- `./venv/bin/python -m pytest tests/unit/test_queue_runner.py -q`
- `./venv/bin/python -m pytest tests/unit -q`

Fixes #672