### PR TITLE
Fix queue memory gate on macOS

### DIFF
--- a/src/queue_runner.py
+++ b/src/queue_runner.py
@@ -569,8 +569,8 @@ class QueueRunner:
     def _memory_gate_passes(self) -> bool:
         if self.min_free_bytes <= 0:
             return True
-        free = self._read_free_memory_bytes()
-        return free is None or free >= self.min_free_bytes
+        available = self._read_free_memory_bytes()
+        return available is None or available >= self.min_free_bytes
 
     def _read_free_memory_bytes(self) -> Optional[int]:
         try:
@@ -578,17 +578,20 @@ class QueueRunner:
         except Exception:
             return None
         page_size = 4096
-        free_pages = 0
+        available_pages = 0
         for line in output.splitlines():
             if "page size of" in line:
                 parts = [part for part in line.split() if part.isdigit()]
                 if parts:
                     page_size = int(parts[0])
-            if line.startswith(("Pages free:", "Pages speculative:")):
+            # macOS keeps reclaimable memory in the inactive queue. Literal
+            # free pages can be very low even when memory_pressure reports the
+            # machine is healthy, so the queue gate should use available pages.
+            if line.startswith(("Pages free:", "Pages speculative:", "Pages inactive:")):
                 digits = "".join(ch for ch in line if ch.isdigit())
                 if digits:
-                    free_pages += int(digits)
-        return free_pages * page_size if free_pages else None
+                    available_pages += int(digits)
+        return available_pages * page_size if available_pages else None
 
     async def _start_job_locked(self, job: QueueJob) -> None:
         assert job.wrapper_path and job.log_path

--- a/tests/unit/test_queue_runner.py
+++ b/tests/unit/test_queue_runner.py
@@ -14,6 +14,7 @@ from fastapi.testclient import TestClient
 from src.cli.commands import cmd_queue_run
 from src.models import Session, SessionStatus
 from src.queue_runner import QueueJob, QueueRunner
+import src.queue_runner as queue_runner_module
 from src.server import create_app
 from src.session_manager import SessionManager
 
@@ -62,6 +63,20 @@ def mock_sm(tmp_path):
     sm.lookup_agent_registration.return_value = None
     sm.message_queue_manager = MagicMock()
     return sm
+
+
+def test_memory_reader_counts_inactive_pages_as_available(mock_sm, tmp_path, monkeypatch):
+    runner = _runner(mock_sm, tmp_path, extra_config={"memory": {"min_free_bytes": 2 * 1024 * 1024 * 1024}})
+    vm_stat = """Mach Virtual Memory Statistics: (page size of 16384 bytes)
+Pages free:                                3773.
+Pages active:                            329631.
+Pages inactive:                          329351.
+Pages speculative:                          836.
+"""
+    monkeypatch.setattr(queue_runner_module.subprocess, "check_output", lambda *args, **kwargs: vm_stat)
+
+    assert runner._read_free_memory_bytes() > 2 * 1024 * 1024 * 1024
+    assert runner._memory_gate_passes() is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #678\n\n## Summary\n- Count macOS inactive pages as reclaimable/available memory for the queue runner preflight gate.\n- Keep the existing configurable min_free_bytes threshold, but avoid blocking on literal free pages when memory_pressure is healthy.\n- Add regression coverage with representative vm_stat output from the live incident.\n\n## Live verification\n- Before hotfix: job_c59c4051e5d3 was pending with holding_reason=memory_pressure, no log file content, and no pytest process.\n- memory_pressure reported System-wide memory free percentage: 58%.\n- After local hotfix restart: job_c59c4051e5d3 transitioned to running and spawned pytest.\n\n## Tests\n- ./venv/bin/python -m pytest tests/unit/test_queue_runner.py -q