### PR TITLE
[spec] Rate-limited CI queue runs

### DIFF
--- a/specs/680_rate_limited_ci_queue_runs.md
+++ b/specs/680_rate_limited_ci_queue_runs.md
@@ -1,27 +1,24 @@
-# sm#680: rate-limited CI queue runs
+# sm#680: configurable rate-limited queue runs
 
 ## Scope
 
-Add a CI-facing way to request a managed `sm queue` background run for a repository commit, while preventing push storms from flooding the local host.
+Extend `sm queue` with a generic configured admission policy for background queue submissions. The immediate consumer is CI, but the Session Manager feature should stay at the infrastructure level: SM admits or suppresses a queued command based on a named policy, not on project-specific concepts such as Fractal Market Simulator branches, tests, or GitHub workflow names.
 
 Primary UX:
 
 ```bash
 sm queue ci-run \
-  --repo rajeshgoli/Fractal-Market-Simulator \
-  --job full-pytest \
-  --commit "$GITHUB_SHA" \
-  --branch "$GITHUB_REF_NAME" \
-  --min-interval 30m \
-  --type tests \
-  --cwd /Users/rajesh/worktrees/fractal-ci \
-  --script-file .github/sm/full_pytest.zsh
+  --policy fractal-ci \
+  --dedupe-token "$GITHUB_SHA" \
+  --label "full-pytest@$GITHUB_SHA" \
+  -- \
+  bash -lc 'source venv/bin/activate && PYTHONPATH=. python -m pytest tests/ -q'
 ```
 
 Immediate response when admitted:
 
 ```text
-Accepted CI queue run ciq_abc123 (full-pytest @ 1a2b3c4).
+Accepted policy queue run qpol_abc123 (policy=fractal-ci token=1a2b3c4).
 Queue job: job_def456
 Log: /Users/rajesh/.local/share/claude-sessions/queue-runner/logs/job_def456.log
 ```
@@ -29,150 +26,212 @@ Log: /Users/rajesh/.local/share/claude-sessions/queue-runner/logs/job_def456.log
 Immediate response when suppressed:
 
 ```text
-Suppressed CI queue run for full-pytest @ 1a2b3c4: commit_already_admitted.
-Last admitted: 2026-04-29T10:00:00-07:00
+Suppressed policy queue run for fractal-ci: time_gate.
+Next admissible at: 2026-04-29T10:30:00-07:00
 ```
 
 ## Source Request
 
-The user-defined rate-limit semantics are the source of truth:
+The original user-defined rate-limit intent was:
 
-> Only one job run per 15 minutes or unique commit id, whichever is less frequent.
->
 > No more than one run every N minutes (say N=30) even if `sm queue` is free.
 >
 > No more than one run per commit even after 30 minutes.
 
-Interpretation: admissions must pass both gates. The time gate makes runs no more frequent than one per configured interval. The commit gate makes each job key run at most once per commit. The composed policy is stricter than either gate alone.
+The earlier brief also mentioned both 15 and 30 minutes. That was a typo: there is one configurable time constant per policy.
+
+The generalized interpretation is: each policy can enable a time gate, a bounded dedupe-token gate, or both. When both are enabled, a request must pass both gates before SM creates the underlying queue job. This composes to make admissions rarer, not more frequent.
 
 ## Problem
 
-Consumer repos want CI to ask the local Session Manager host to run heavyweight validation after pushes. The existing `sm queue run` command can serialize local work, but it trusts every submitter. A CI workflow can trigger multiple times for one commit, for multiple branches, or for a rapid push series. Without a durable rate limit, those events can enqueue duplicate or excessive jobs and recreate the host contention that `sm queue` was introduced to prevent.
+`sm queue run` serializes local execution but accepts every valid request. CI and other automation can fire repeatedly during bursts: repeated workflow events for the same commit, many rapid pushes, or retries while the local host is busy. Without a durable admission policy, those requests can create a backlog of redundant background work.
 
-CI also needs durable results. If a validation starts failing, a consumer should be able to ask which commits had passing or failing local queue runs, then use that history to guide `git bisect` or decide which commit needs a rerun.
+Session Manager should offer a reusable infrastructure primitive: named policy plus queued command. Consumers configure the policy once in `config.yaml`, then pass a small amount of request metadata at submission time. SM applies the configured gates, starts the job during normal queue lull periods, and records the outcome durably enough for later lookup.
 
 ## Goals
 
-1. Let CI request a queue run for a specific repo/job/commit.
-2. Enforce per-job minimum interval and at-most-once-per-commit admission before creating the underlying queue job.
-3. Persist gate decisions and run results across Session Manager restarts.
-4. Expose lookup commands for one commit and for a commit range.
-5. Keep the underlying execution model on the existing queue runner.
-6. Make simultaneous duplicate submissions deterministic.
+1. Add a generic `sm queue ci-run` admission wrapper over existing `sm queue run` execution.
+2. Configure rate limiting by named policy in `config.yaml`.
+3. Support one configurable minimum elapsed time between admitted runs per policy.
+4. Support bounded dedupe by a caller-supplied token, such as a commit SHA.
+5. Allow policies to enable time-only, token-only, or combined time+token gates.
+6. Persist admission decisions and run results across Session Manager restarts.
+7. Keep the underlying scheduling, resource gates, logs, and process management in the existing queue runner.
+8. Make simultaneous submissions deterministic.
 
 ## Non-goals
 
-1. Do not add a GitHub App, webhook server, or hosted CI service integration in v1.
-2. Do not make Session Manager clone, fetch, or checkout repositories for the consumer.
-3. Do not infer the commit SHA from git state; CI must pass it explicitly.
-4. Do not auto-rerun suppressed commits later. Suppression is terminal for that request.
-5. Do not provide distributed locking across multiple Session Manager hosts.
-6. Do not replace `sm queue run`; this adds a rate-limited CI admission layer on top of it.
+1. Do not add project-specific fields such as `--repo`, `--branch`, or `--job` to the infrastructure primitive in v1.
+2. Do not add a GitHub App, webhook server, or hosted CI integration.
+3. Do not make Session Manager clone, fetch, checkout, or inspect git repositories.
+4. Do not infer dedupe tokens from git state; callers must pass them explicitly if the policy requires them.
+5. Do not maintain an infinite per-commit history solely for dedupe.
+6. Do not auto-rerun suppressed requests later.
+7. Do not provide distributed locking across multiple Session Manager hosts.
+8. Do not replace `sm queue run`; this adds a policy gate in front of it.
+
+## Configuration
+
+Add `queue_runner.policies` to `config.yaml`:
+
+```yaml
+queue_runner:
+  policies:
+    fractal-ci:
+      type: tests
+      min_interval_seconds: 1800
+      dedupe:
+        mode: both              # none|time|token|both
+        token_window: 10        # remember last K admitted tokens
+      cwd: /Users/rajesh/worktrees/3175-epic-to-dev
+      timeout_seconds: 1800
+      notify: maintainer
+      retention:
+        admitted_runs: 200
+        suppressed_runs: 200
+```
+
+Policy fields:
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `type` | no | Underlying queue type: `tests`, `perf`, or `background`. Defaults to `background` for policy runs. |
+| `min_interval_seconds` | required for `mode=time|both` | Minimum elapsed time between admitted runs for this policy. |
+| `dedupe.mode` | no | `none`, `time`, `token`, or `both`. Defaults to `both` when `min_interval_seconds` and `token_window` are present; otherwise defaults to the gates that have enough config. |
+| `dedupe.token_window` | required for `mode=token|both` | Number of recent admitted dedupe tokens to remember. Small values such as 10 are expected. |
+| `cwd` | no | Default working directory for admitted commands. CLI may override. |
+| `timeout_seconds` | no | Default timeout for the underlying queue job. CLI may override. |
+| `notify` | no | Default session or role to notify on start/completion. CLI may override. |
+| `retention.admitted_runs` | no | Number of admitted policy-run rows to retain per policy. |
+| `retention.suppressed_runs` | no | Number of suppressed request rows to retain per policy. |
+
+The policy name is an infrastructure key. `fractal-ci` is just an operator-defined name, not a built-in project concept.
 
 ## CLI
 
-Add a `sm queue ci-*` command family:
+Add a policy-run command family under `sm queue`:
 
 ```bash
-sm queue ci-run [options] -- COMMAND [ARG...]
-sm queue ci-run [options] --script-file PATH
-sm queue ci-status --repo REPO --job JOB --commit SHA [--json]
-sm queue ci-history --repo REPO --job JOB [--branch BRANCH] [--limit N] [--json]
-sm queue ci-range --repo REPO --job JOB --commits-file PATH [--json]
+sm queue ci-run --policy POLICY [options] -- COMMAND [ARG...]
+sm queue ci-run --policy POLICY [options] --script-file PATH
+sm queue ci-status --policy POLICY [--id RUN_ID | --dedupe-token TOKEN] [--json]
+sm queue ci-history --policy POLICY [--limit N] [--include-suppressed] [--json]
 ```
 
 `ci-run` options:
 
 ```text
---repo OWNER/NAME              required; consumer repo identity
---job NAME                     required; stable job key within the repo
---commit SHA                   required; full or abbreviated commit SHA
---branch NAME                  optional; included in history/filtering, not in uniqueness by default
---min-interval DURATION        default from config, initially 30m
---type tests|perf|background   default: background for CI-triggered work
---label TEXT                   default: "<repo>:<job>@<short-sha>"
---cwd PATH                     required unless config supplies a job cwd
---timeout DURATION             passed to underlying queue job
+--policy NAME                  required; configured policy key
+--dedupe-token TEXT            required when policy dedupe mode includes token
+--label TEXT                   default: "<policy>@<short-token>" when token is present
+--cwd PATH                     override policy cwd
+--timeout DURATION             override policy timeout
+--type tests|perf|background   override policy type only if policy allows overrides
 --env KEY=VALUE                repeatable explicit environment additions/overrides
---notify SESSION_OR_ROLE       optional; default from config or maintainer
---dedupe-scope repo|branch     default: repo
+--notify SESSION_OR_ROLE       override policy notify target
+--metadata KEY=VALUE           repeatable opaque caller metadata for lookup/debug
 ```
 
-Everything after `--` uses the existing `sm queue run` argv semantics. `--script-file` uses the existing stored-script execution model.
+Everything after `--` keeps existing `sm queue run` argv semantics. `--script-file` keeps the existing stored-script execution model.
 
-### Job Key
-
-The canonical job key is:
-
-```text
-repo + job + dedupe_scope_value
-```
-
-For the default `--dedupe-scope repo`, `branch` is metadata only. A commit admitted for `rajeshgoli/Fractal-Market-Simulator/full-pytest` suppresses later submissions for the same commit on any branch.
-
-For `--dedupe-scope branch`, the branch name becomes part of the key. This is useful for jobs where branch-specific environment or long-lived release branches should be tracked separately.
-
-The spec recommends defaulting to `repo` because the user requirement says "unique commit id" and because commit-level dedupe across branch aliases prevents accidental duplicate runs when the same SHA appears on a PR branch and a merge queue branch.
+The command name is `ci-run` because the first expected caller is CI, but the semantics are generic policy-based queue admission. If the name feels too CI-specific during review, the implementation can use `sm queue policy-run` with `ci-run` as an alias.
 
 ## Admission Semantics
 
 `sm queue ci-run` performs admission before creating an underlying queue job.
 
-For one canonical job key and commit SHA:
+For one policy:
 
-1. Begin a SQLite write transaction.
-2. If a prior admitted row exists for the same key and commit, suppress the request with reason `commit_already_admitted`.
-3. If the most recent admitted row for the key is newer than `min_interval`, suppress the request with reason `time_gate`.
-4. Otherwise create a CI run row with state `admitted`.
-5. Create the underlying `queue_jobs` row in the same transaction boundary or with compensating failure handling.
-6. Link the CI run row to the underlying queue job id.
+1. Load the policy config.
+2. Validate required request fields. If token dedupe is enabled, `--dedupe-token` is required.
+3. Begin a SQLite write transaction with `BEGIN IMMEDIATE`.
+4. Evaluate the configured gates against admitted runs for that policy.
+5. If any enabled gate fails, persist a suppressed request row and return `decision=suppressed` without creating a queue job.
+6. If all enabled gates pass, persist an admitted policy-run row and create one underlying `queue_jobs` row.
+7. Link the policy-run row to the queue job id and return `decision=admitted`.
 
-Both gates must pass. "Whichever is less frequent" means the stricter composed policy wins.
+### Time Gate
 
-Suppressed requests do not create queue jobs. They are still persisted as suppression rows for auditability and for diagnosing CI behavior.
+If `dedupe.mode` is `time` or `both`, compare the latest admitted run for the policy to `min_interval_seconds`.
+
+A request is suppressed with reason `time_gate` when:
+
+```text
+now - latest_admitted_at < min_interval_seconds
+```
+
+The response includes `next_admissible_at`.
+
+### Token Gate
+
+If `dedupe.mode` is `token` or `both`, compare `--dedupe-token` to the last `token_window` admitted tokens for the policy.
+
+A request is suppressed with reason `dedupe_token` when the token appears in that bounded recent-token set.
+
+This deliberately does not enforce infinite commit uniqueness. It prevents duplicate retry storms and recent repeated commits while keeping state bounded. If a consumer needs stronger long-term lookup, it can use result history retention separately from admission dedupe.
+
+### Combined Gate
+
+If `dedupe.mode` is `both`, both gates must pass. A new token inside the time window is suppressed by `time_gate`; an old token outside the time window but still inside the recent-token window is suppressed by `dedupe_token`.
+
+If multiple gates fail, return the most actionable reason in this order:
+
+1. `dedupe_token`
+2. `time_gate`
+
+The response may include all failed gates in `failed_gates` for JSON callers.
+
+## Queue Interaction
+
+Admitted policy runs create normal queue jobs with policy-derived defaults. They then follow existing queue behavior:
+
+1. They may remain pending until queue capacity/resource gates pass.
+2. They may be displaced only if their underlying queue type can be displaced.
+3. They reuse existing logs, wrapper scripts, exit-code files, and completion notifications.
+4. They recover through the existing queue runner restart path.
+
+This means the policy layer controls admission frequency, not exact start time. A run admitted now may start later during a queue lull. The time gate is based on admission time, not process start time, because admission is the point where SM promises that a run will occur unless the queue job later fails, is cancelled, or is displaced.
 
 ## Concurrency
 
-The CI gate store uses SQLite with a uniqueness constraint:
+SQLite admission uses a transaction-level lock:
 
-```sql
-UNIQUE(job_key, commit_sha) WHERE decision = 'admitted'
-```
+1. `BEGIN IMMEDIATE` serializes writers.
+2. Gate evaluation and insertion happen in the same transaction.
+3. Simultaneous requests for the same policy observe a deterministic order.
 
-Implementation should acquire admission with `BEGIN IMMEDIATE` so simultaneous requests serialize deterministically. If two requests for the same key/commit arrive at the same time, one creates the admitted row and queue job; the other returns `commit_already_admitted` and points to the already admitted run.
+For duplicate token submissions, exactly one can be admitted within the recent-token window. Later requests persist as suppressed rows.
 
-If two different commits arrive at the same time for the same key, the transaction that commits first wins the time gate. The later request sees the updated latest admitted timestamp and returns `time_gate`.
+For different tokens submitted simultaneously under a time-gated policy, the first committed request wins; later requests see the updated latest admitted timestamp and suppress on `time_gate`.
 
 ## Durable Storage
 
 Use a new SQLite database under the queue runner state directory:
 
 ```text
-~/.local/share/claude-sessions/queue-runner/ci_runs.db
+~/.local/share/claude-sessions/queue-runner/policy_runs.db
 ```
 
-Keeping this adjacent to `queue_runner.db` makes backup/inspection straightforward without growing the queue runner's hot scheduling table. The implementation may share a connection helper, but the data model should be separate.
+Keeping policy admission state adjacent to `queue_runner.db` makes local inspection and backup simple while keeping policy-specific tables out of the queue runner's hot scheduling table.
 
 ### Tables
 
-`ci_run_requests`:
+`queue_policy_runs`:
 
 ```sql
-id TEXT PRIMARY KEY,                 -- ciq_<hex>
-job_key TEXT NOT NULL,
-repo TEXT NOT NULL,
-job_name TEXT NOT NULL,
-dedupe_scope TEXT NOT NULL,          -- repo|branch
-branch TEXT,
-commit_sha TEXT NOT NULL,
-requested_at TEXT NOT NULL,
+id TEXT PRIMARY KEY,                 -- qpol_<hex>
+policy TEXT NOT NULL,
 decision TEXT NOT NULL,              -- admitted|suppressed
-suppression_reason TEXT,             -- time_gate|commit_already_admitted
-min_interval_seconds INTEGER NOT NULL,
+suppression_reason TEXT,             -- time_gate|dedupe_token|invalid_policy|queue_create_failed
+failed_gates_json TEXT NOT NULL,
+dedupe_token TEXT,
+requested_at TEXT NOT NULL,
+admitted_at TEXT,
 queue_job_id TEXT,
 notify_session_id TEXT,
 label TEXT,
 cwd TEXT,
+queue_type TEXT,
 command_json TEXT,
 script_path TEXT,
 metadata_json TEXT NOT NULL
@@ -181,23 +240,19 @@ metadata_json TEXT NOT NULL
 Indexes:
 
 ```sql
-CREATE UNIQUE INDEX idx_ci_runs_admitted_key_commit
-  ON ci_run_requests(job_key, commit_sha)
-  WHERE decision = 'admitted';
-CREATE INDEX idx_ci_runs_key_requested ON ci_run_requests(job_key, requested_at);
-CREATE INDEX idx_ci_runs_queue_job ON ci_run_requests(queue_job_id);
+CREATE INDEX idx_policy_runs_policy_requested ON queue_policy_runs(policy, requested_at);
+CREATE INDEX idx_policy_runs_policy_admitted ON queue_policy_runs(policy, admitted_at);
+CREATE INDEX idx_policy_runs_policy_token ON queue_policy_runs(policy, dedupe_token, admitted_at);
+CREATE INDEX idx_policy_runs_queue_job ON queue_policy_runs(queue_job_id);
 ```
 
-`ci_run_results`:
+`queue_policy_results`:
 
 ```sql
-ci_run_id TEXT PRIMARY KEY,
+policy_run_id TEXT PRIMARY KEY,
 queue_job_id TEXT NOT NULL,
-job_key TEXT NOT NULL,
-repo TEXT NOT NULL,
-job_name TEXT NOT NULL,
-branch TEXT,
-commit_sha TEXT NOT NULL,
+policy TEXT NOT NULL,
+dedupe_token TEXT,
 status TEXT NOT NULL,                -- pending|running|succeeded|failed|timed_out|cancelled|displaced|lost
 exit_code INTEGER,
 queued_at TEXT NOT NULL,
@@ -211,165 +266,158 @@ updated_at TEXT NOT NULL
 Indexes:
 
 ```sql
-CREATE INDEX idx_ci_results_key_commit ON ci_run_results(job_key, commit_sha);
-CREATE INDEX idx_ci_results_key_finished ON ci_run_results(job_key, finished_at);
-CREATE INDEX idx_ci_results_repo_job ON ci_run_results(repo, job_name, finished_at);
+CREATE INDEX idx_policy_results_policy_token ON queue_policy_results(policy, dedupe_token);
+CREATE INDEX idx_policy_results_policy_finished ON queue_policy_results(policy, finished_at);
 ```
 
 ## Result Recording
 
-When a CI run is admitted, insert a result row with `status=pending` and the linked queue job id. The queue runner completion path updates that row when the underlying job reaches a terminal state.
+When a policy run is admitted, insert a result row with `status=pending` and the linked queue job id. The queue runner completion path updates that row when the underlying job reaches a terminal state.
 
-If Session Manager restarts while the underlying queue job is running, existing queue recovery rules continue to own process recovery. The CI result projector reconciles from `queue_jobs` on startup and periodically while active jobs exist.
+If Session Manager restarts while the underlying queue job is running, existing queue recovery rules continue to own process recovery. A lightweight policy-result reconciler reads linked `queue_jobs` rows after startup and periodically while active policy jobs exist.
 
-If the queue job is lost or cannot be reconciled after restart, mark the CI result `lost`. A lost result still counts as an admitted run for both gates unless the user chooses the alternate policy below.
+If the queue job is lost or cannot be reconciled after restart, mark the policy result `lost`.
 
-### Crash Policy
+## Crash And Cancellation Policy
 
-Recommended policy: admission counts once the queue job is accepted, even if the process later crashes, times out, is cancelled, or is lost. This prevents a broken CI command from causing repeated local runs for the same commit.
+Recommended policy: an admitted run consumes the time gate and token slot once the queue job is accepted, even if the process later fails, times out, is cancelled, displaced, or lost. This prevents broken commands or flapping CI from repeatedly hammering the host.
 
-Alternative policy for user feedback: only terminal `succeeded|failed|timed_out` count as "ran"; `cancelled|displaced|lost` may be manually rerun with an explicit override. This is more flexible but adds more state and operator judgment.
+If a user needs a rerun, that should be a separate explicit override feature later, for example:
 
-The implementation spec should default to the recommended policy unless user review asks for the alternate policy.
+```bash
+sm queue ci-run --policy fractal-ci --dedupe-token SHA --force --reason "rerun after infra fix" -- ...
+```
+
+`--force` is out of scope for v1 because it needs explicit audit semantics.
 
 ## Lookup API
 
-### Single Commit
+### Single Run Or Token
 
 ```bash
-sm queue ci-status --repo rajeshgoli/Fractal-Market-Simulator --job full-pytest --commit 1a2b3c4
+sm queue ci-status --policy fractal-ci --dedupe-token 1a2b3c4
+sm queue ci-status --policy fractal-ci --id qpol_abc123
 ```
 
 Output:
 
 ```text
-full-pytest @ 1a2b3c4: failed exit=1 finished=2026-04-29T12:30:00-07:00
+fractal-ci token=1a2b3c4: failed exit=1 finished=2026-04-29T12:30:00-07:00
 Queue job: job_def456
 Log: /Users/rajesh/.local/share/claude-sessions/queue-runner/logs/job_def456.log
 ```
 
-If no admitted result exists, return exit code `1` and print `No CI queue result for <job> @ <commit>`.
+If no admitted result exists for a token, return exit code `1` and print `No policy result for <policy> token <token>`.
 
 ### History
 
 ```bash
-sm queue ci-history --repo rajeshgoli/Fractal-Market-Simulator --job full-pytest --limit 50
+sm queue ci-history --policy fractal-ci --limit 50 --include-suppressed
 ```
 
-Returns recent admitted runs and suppressed requests for that key. `--json` returns structured rows for dashboards or scripts.
+Returns recent admitted policy runs and optionally suppressed requests. `--json` returns structured rows for dashboards or scripts.
 
-### Commit Range
+### Range-Like Lookup
 
-Session Manager should not run `git` for v1. The range command consumes an ordered commit list from the caller:
+Session Manager should stay generic and should not run `git` for v1. For commit-oriented consumers, range analysis is caller-driven:
 
 ```bash
 git rev-list --reverse "$GOOD_SHA..$BAD_SHA" |
-  sm queue ci-range --repo rajeshgoli/Fractal-Market-Simulator --job full-pytest --commits-file -
+  xargs -I{} sm queue ci-status --policy fractal-ci --dedupe-token {}
 ```
 
-This avoids making SM depend on local repo checkout freshness. The command reports known result rows and marks missing commits as `unknown`.
+A convenience batch command can be added without git awareness:
+
+```bash
+sm queue ci-history --policy fractal-ci --tokens-file commits.txt --json
+```
+
+This reports known result rows and marks missing tokens as `unknown`.
 
 ## API
 
 Add HTTP endpoints parallel to the CLI:
 
 ```text
-POST /queue-ci-runs
-GET  /queue-ci-runs
-GET  /queue-ci-runs/{id}
-GET  /queue-ci-runs/status?repo=...&job=...&commit=...
-POST /queue-ci-runs/range
+POST /queue-policy-runs
+GET  /queue-policy-runs
+GET  /queue-policy-runs/{id}
+GET  /queue-policy-runs/status?policy=...&dedupe_token=...
 ```
 
-`POST /queue-ci-runs` returns:
+`POST /queue-policy-runs` returns:
 
 ```json
 {
-  "id": "ciq_abc123",
+  "id": "qpol_abc123",
+  "policy": "fractal-ci",
   "decision": "admitted",
   "suppression_reason": null,
+  "failed_gates": [],
   "queue_job_id": "job_def456",
-  "job_key": "rajeshgoli/Fractal-Market-Simulator:full-pytest",
-  "commit_sha": "1a2b3c4...",
+  "dedupe_token": "1a2b3c4...",
   "log_path": "..."
 }
 ```
 
 Suppressed requests return HTTP 200 with `decision=suppressed`, not an error. Invalid input returns 400. SM unavailability remains a client transport error.
 
-## Configuration
-
-Add optional per-job defaults:
-
-```yaml
-queue_runner:
-  ci_jobs:
-    "rajeshgoli/Fractal-Market-Simulator:full-pytest":
-      min_interval_seconds: 1800
-      type: tests
-      cwd: /Users/rajesh/worktrees/fractal-ci
-      notify: maintainer
-      dedupe_scope: repo
-      retention_days: 180
-```
-
-CLI flags override config for one request. If no config exists, callers must pass required execution fields explicitly.
-
-The commit gate is always enabled and cannot be disabled in v1.
-
 ## Retention
 
-Default retention:
+Retention is per policy and count-based by default, because the dedupe token window is intentionally bounded:
 
-1. Keep admitted result rows for 180 days.
-2. Keep suppressed request rows for 30 days.
-3. Do not delete queue logs independently in this feature; store log paths and rely on the queue runner's log retention policy.
-4. If a log path is missing during lookup, report the result row and show `log_missing=true`.
+1. Keep the latest `retention.admitted_runs` admitted rows per policy. Default: 200.
+2. Keep the latest `retention.suppressed_runs` suppressed rows per policy. Default: 200.
+3. Keep at least `dedupe.token_window` admitted rows regardless of retention settings.
+4. Do not delete queue logs independently in this feature; store log paths and rely on the queue runner's log retention policy.
+5. If a log path is missing during lookup, report the result row and show `log_missing=true`.
 
 Retention pruning must run in a background maintenance task, not on startup before uvicorn binds.
 
 ## Notifications
 
-For admitted runs, reuse existing queue notifications for start/completion, but include CI metadata:
+For admitted runs, reuse existing queue notifications for start/completion, but include policy metadata:
 
 ```text
-[sm queue ci] full-pytest @ 1a2b3c4 completed: failed exit=1. Queue job: job_def456. Log: ...
+[sm queue policy] fractal-ci token=1a2b3c4 completed: failed exit=1. Queue job: job_def456. Log: ...
 ```
 
-Suppressed requests do not notify by default. CI receives the suppression response synchronously. A future operator setting can mirror suppressions to a session if that proves useful.
+Suppressed requests do not notify by default. Automation receives the suppression response synchronously. A future operator setting can mirror suppressions to a session if that proves useful.
 
 ## Failure Modes
 
-1. Duplicate same-commit request: return `suppressed/commit_already_admitted` and include the prior CI run id.
-2. Different commit inside interval: return `suppressed/time_gate` and include `next_admissible_at`.
-3. Queue job creation fails after CI admission row: mark CI row `suppressed/internal_queue_create_failed` or `lost` and return 500. The implementation should prefer one transaction boundary where possible.
-4. SM restarts before job starts: pending queue job and CI row recover from durable storage.
-5. SM restarts while job runs: queue runner recovers via PID/exit-code file; CI result projector reconciles from queue job state.
-6. Log deleted: lookup still returns result metadata with `log_missing=true`.
-7. Consumer passes invalid SHA/job/repo: reject with 400 before gate evaluation.
+1. Missing policy: reject with 400 and do not persist a run row unless audit logging for invalid policy requests is explicitly enabled later.
+2. Missing dedupe token for token-gated policy: reject with 400 before gate evaluation.
+3. Duplicate recent token: return `suppressed/dedupe_token` and include the prior policy run id.
+4. Time window active: return `suppressed/time_gate` and include `next_admissible_at`.
+5. Queue job creation fails after policy admission row: mark the policy row `suppressed/queue_create_failed` or `lost` and return 500. Implementation should prefer one transaction boundary or compensating update.
+6. SM restarts before job starts: pending queue job and policy result recover from durable storage.
+7. SM restarts while job runs: queue runner recovers via PID/exit-code file; policy result reconciler updates from queue job state.
+8. Log deleted: lookup still returns result metadata with `log_missing=true`.
 
 ## Out Of Scope
 
 1. GitHub Actions workflow templates for consumer repos.
 2. GitHub Checks API publishing.
-3. Auto-checkout or worktree management.
-4. Manual force-rerun command. If needed, add `sm queue ci-rerun --commit SHA --reason TEXT` later with explicit audit fields.
-5. Web UI or `sm watch` queue panels for CI history.
+3. Auto-checkout, worktree management, or git range computation.
+4. Manual force-rerun command.
+5. Web UI or `sm watch` policy-run panels.
 6. Cross-host dedupe.
+7. Infinite dedupe history.
 
 ## Acceptance Criteria
 
-1. `ci-run` admits the first request for a job key/commit and creates one underlying queue job.
-2. A second request for the same job key/commit is suppressed, even after the time interval.
-3. A request for a different commit before the interval expires is suppressed by the time gate.
-4. A request for a different commit after the interval expires is admitted.
-5. Simultaneous duplicate requests produce exactly one admitted row.
-6. Queue completion updates the durable CI result row.
-7. `ci-status` can look up one commit result.
+1. `ci-run --policy P` admits the first request when all enabled gates pass and creates one underlying queue job.
+2. With `mode=time`, a second request before `min_interval_seconds` is suppressed by `time_gate`.
+3. With `mode=token`, a request whose token appears in the last `token_window` admitted tokens is suppressed by `dedupe_token`.
+4. With `mode=both`, both gates are enforced.
+5. Simultaneous requests for one policy produce deterministic admitted/suppressed decisions.
+6. Queue completion updates the durable policy result row.
+7. `ci-status` can look up one policy run by id or dedupe token.
 8. `ci-history` can show recent admitted and suppressed rows.
-9. `ci-range --commits-file -` reports known and unknown commits in caller-provided order.
+9. Retention never prunes below the configured dedupe token window.
 10. Startup does not run unbounded retention or result scans before the API binds.
 
 ## Ticket Classification
 
-Single implementation ticket. The feature spans CLI/API/storage and queue runner integration, but it is cohesive and can be implemented by one maintainer agent with focused tests. Consumer repo workflow changes are separate downstream tickets.
+Single implementation ticket. The feature is a generic policy-admission wrapper over the existing queue runner with bounded storage and focused CLI/API additions. Consumer repo workflow changes are separate downstream tickets.

--- a/specs/680_rate_limited_ci_queue_runs.md
+++ b/specs/680_rate_limited_ci_queue_runs.md
@@ -1,0 +1,375 @@
+# sm#680: rate-limited CI queue runs
+
+## Scope
+
+Add a CI-facing way to request a managed `sm queue` background run for a repository commit, while preventing push storms from flooding the local host.
+
+Primary UX:
+
+```bash
+sm queue ci-run \
+  --repo rajeshgoli/Fractal-Market-Simulator \
+  --job full-pytest \
+  --commit "$GITHUB_SHA" \
+  --branch "$GITHUB_REF_NAME" \
+  --min-interval 30m \
+  --type tests \
+  --cwd /Users/rajesh/worktrees/fractal-ci \
+  --script-file .github/sm/full_pytest.zsh
+```
+
+Immediate response when admitted:
+
+```text
+Accepted CI queue run ciq_abc123 (full-pytest @ 1a2b3c4).
+Queue job: job_def456
+Log: /Users/rajesh/.local/share/claude-sessions/queue-runner/logs/job_def456.log
+```
+
+Immediate response when suppressed:
+
+```text
+Suppressed CI queue run for full-pytest @ 1a2b3c4: commit_already_admitted.
+Last admitted: 2026-04-29T10:00:00-07:00
+```
+
+## Source Request
+
+The user-defined rate-limit semantics are the source of truth:
+
+> Only one job run per 15 minutes or unique commit id, whichever is less frequent.
+>
+> No more than one run every N minutes (say N=30) even if `sm queue` is free.
+>
+> No more than one run per commit even after 30 minutes.
+
+Interpretation: admissions must pass both gates. The time gate makes runs no more frequent than one per configured interval. The commit gate makes each job key run at most once per commit. The composed policy is stricter than either gate alone.
+
+## Problem
+
+Consumer repos want CI to ask the local Session Manager host to run heavyweight validation after pushes. The existing `sm queue run` command can serialize local work, but it trusts every submitter. A CI workflow can trigger multiple times for one commit, for multiple branches, or for a rapid push series. Without a durable rate limit, those events can enqueue duplicate or excessive jobs and recreate the host contention that `sm queue` was introduced to prevent.
+
+CI also needs durable results. If a validation starts failing, a consumer should be able to ask which commits had passing or failing local queue runs, then use that history to guide `git bisect` or decide which commit needs a rerun.
+
+## Goals
+
+1. Let CI request a queue run for a specific repo/job/commit.
+2. Enforce per-job minimum interval and at-most-once-per-commit admission before creating the underlying queue job.
+3. Persist gate decisions and run results across Session Manager restarts.
+4. Expose lookup commands for one commit and for a commit range.
+5. Keep the underlying execution model on the existing queue runner.
+6. Make simultaneous duplicate submissions deterministic.
+
+## Non-goals
+
+1. Do not add a GitHub App, webhook server, or hosted CI service integration in v1.
+2. Do not make Session Manager clone, fetch, or checkout repositories for the consumer.
+3. Do not infer the commit SHA from git state; CI must pass it explicitly.
+4. Do not auto-rerun suppressed commits later. Suppression is terminal for that request.
+5. Do not provide distributed locking across multiple Session Manager hosts.
+6. Do not replace `sm queue run`; this adds a rate-limited CI admission layer on top of it.
+
+## CLI
+
+Add a `sm queue ci-*` command family:
+
+```bash
+sm queue ci-run [options] -- COMMAND [ARG...]
+sm queue ci-run [options] --script-file PATH
+sm queue ci-status --repo REPO --job JOB --commit SHA [--json]
+sm queue ci-history --repo REPO --job JOB [--branch BRANCH] [--limit N] [--json]
+sm queue ci-range --repo REPO --job JOB --commits-file PATH [--json]
+```
+
+`ci-run` options:
+
+```text
+--repo OWNER/NAME              required; consumer repo identity
+--job NAME                     required; stable job key within the repo
+--commit SHA                   required; full or abbreviated commit SHA
+--branch NAME                  optional; included in history/filtering, not in uniqueness by default
+--min-interval DURATION        default from config, initially 30m
+--type tests|perf|background   default: background for CI-triggered work
+--label TEXT                   default: "<repo>:<job>@<short-sha>"
+--cwd PATH                     required unless config supplies a job cwd
+--timeout DURATION             passed to underlying queue job
+--env KEY=VALUE                repeatable explicit environment additions/overrides
+--notify SESSION_OR_ROLE       optional; default from config or maintainer
+--dedupe-scope repo|branch     default: repo
+```
+
+Everything after `--` uses the existing `sm queue run` argv semantics. `--script-file` uses the existing stored-script execution model.
+
+### Job Key
+
+The canonical job key is:
+
+```text
+repo + job + dedupe_scope_value
+```
+
+For the default `--dedupe-scope repo`, `branch` is metadata only. A commit admitted for `rajeshgoli/Fractal-Market-Simulator/full-pytest` suppresses later submissions for the same commit on any branch.
+
+For `--dedupe-scope branch`, the branch name becomes part of the key. This is useful for jobs where branch-specific environment or long-lived release branches should be tracked separately.
+
+The spec recommends defaulting to `repo` because the user requirement says "unique commit id" and because commit-level dedupe across branch aliases prevents accidental duplicate runs when the same SHA appears on a PR branch and a merge queue branch.
+
+## Admission Semantics
+
+`sm queue ci-run` performs admission before creating an underlying queue job.
+
+For one canonical job key and commit SHA:
+
+1. Begin a SQLite write transaction.
+2. If a prior admitted row exists for the same key and commit, suppress the request with reason `commit_already_admitted`.
+3. If the most recent admitted row for the key is newer than `min_interval`, suppress the request with reason `time_gate`.
+4. Otherwise create a CI run row with state `admitted`.
+5. Create the underlying `queue_jobs` row in the same transaction boundary or with compensating failure handling.
+6. Link the CI run row to the underlying queue job id.
+
+Both gates must pass. "Whichever is less frequent" means the stricter composed policy wins.
+
+Suppressed requests do not create queue jobs. They are still persisted as suppression rows for auditability and for diagnosing CI behavior.
+
+## Concurrency
+
+The CI gate store uses SQLite with a uniqueness constraint:
+
+```sql
+UNIQUE(job_key, commit_sha) WHERE decision = 'admitted'
+```
+
+Implementation should acquire admission with `BEGIN IMMEDIATE` so simultaneous requests serialize deterministically. If two requests for the same key/commit arrive at the same time, one creates the admitted row and queue job; the other returns `commit_already_admitted` and points to the already admitted run.
+
+If two different commits arrive at the same time for the same key, the transaction that commits first wins the time gate. The later request sees the updated latest admitted timestamp and returns `time_gate`.
+
+## Durable Storage
+
+Use a new SQLite database under the queue runner state directory:
+
+```text
+~/.local/share/claude-sessions/queue-runner/ci_runs.db
+```
+
+Keeping this adjacent to `queue_runner.db` makes backup/inspection straightforward without growing the queue runner's hot scheduling table. The implementation may share a connection helper, but the data model should be separate.
+
+### Tables
+
+`ci_run_requests`:
+
+```sql
+id TEXT PRIMARY KEY,                 -- ciq_<hex>
+job_key TEXT NOT NULL,
+repo TEXT NOT NULL,
+job_name TEXT NOT NULL,
+dedupe_scope TEXT NOT NULL,          -- repo|branch
+branch TEXT,
+commit_sha TEXT NOT NULL,
+requested_at TEXT NOT NULL,
+decision TEXT NOT NULL,              -- admitted|suppressed
+suppression_reason TEXT,             -- time_gate|commit_already_admitted
+min_interval_seconds INTEGER NOT NULL,
+queue_job_id TEXT,
+notify_session_id TEXT,
+label TEXT,
+cwd TEXT,
+command_json TEXT,
+script_path TEXT,
+metadata_json TEXT NOT NULL
+```
+
+Indexes:
+
+```sql
+CREATE UNIQUE INDEX idx_ci_runs_admitted_key_commit
+  ON ci_run_requests(job_key, commit_sha)
+  WHERE decision = 'admitted';
+CREATE INDEX idx_ci_runs_key_requested ON ci_run_requests(job_key, requested_at);
+CREATE INDEX idx_ci_runs_queue_job ON ci_run_requests(queue_job_id);
+```
+
+`ci_run_results`:
+
+```sql
+ci_run_id TEXT PRIMARY KEY,
+queue_job_id TEXT NOT NULL,
+job_key TEXT NOT NULL,
+repo TEXT NOT NULL,
+job_name TEXT NOT NULL,
+branch TEXT,
+commit_sha TEXT NOT NULL,
+status TEXT NOT NULL,                -- pending|running|succeeded|failed|timed_out|cancelled|displaced|lost
+exit_code INTEGER,
+queued_at TEXT NOT NULL,
+started_at TEXT,
+finished_at TEXT,
+log_path TEXT,
+artifact_json TEXT NOT NULL,
+updated_at TEXT NOT NULL
+```
+
+Indexes:
+
+```sql
+CREATE INDEX idx_ci_results_key_commit ON ci_run_results(job_key, commit_sha);
+CREATE INDEX idx_ci_results_key_finished ON ci_run_results(job_key, finished_at);
+CREATE INDEX idx_ci_results_repo_job ON ci_run_results(repo, job_name, finished_at);
+```
+
+## Result Recording
+
+When a CI run is admitted, insert a result row with `status=pending` and the linked queue job id. The queue runner completion path updates that row when the underlying job reaches a terminal state.
+
+If Session Manager restarts while the underlying queue job is running, existing queue recovery rules continue to own process recovery. The CI result projector reconciles from `queue_jobs` on startup and periodically while active jobs exist.
+
+If the queue job is lost or cannot be reconciled after restart, mark the CI result `lost`. A lost result still counts as an admitted run for both gates unless the user chooses the alternate policy below.
+
+### Crash Policy
+
+Recommended policy: admission counts once the queue job is accepted, even if the process later crashes, times out, is cancelled, or is lost. This prevents a broken CI command from causing repeated local runs for the same commit.
+
+Alternative policy for user feedback: only terminal `succeeded|failed|timed_out` count as "ran"; `cancelled|displaced|lost` may be manually rerun with an explicit override. This is more flexible but adds more state and operator judgment.
+
+The implementation spec should default to the recommended policy unless user review asks for the alternate policy.
+
+## Lookup API
+
+### Single Commit
+
+```bash
+sm queue ci-status --repo rajeshgoli/Fractal-Market-Simulator --job full-pytest --commit 1a2b3c4
+```
+
+Output:
+
+```text
+full-pytest @ 1a2b3c4: failed exit=1 finished=2026-04-29T12:30:00-07:00
+Queue job: job_def456
+Log: /Users/rajesh/.local/share/claude-sessions/queue-runner/logs/job_def456.log
+```
+
+If no admitted result exists, return exit code `1` and print `No CI queue result for <job> @ <commit>`.
+
+### History
+
+```bash
+sm queue ci-history --repo rajeshgoli/Fractal-Market-Simulator --job full-pytest --limit 50
+```
+
+Returns recent admitted runs and suppressed requests for that key. `--json` returns structured rows for dashboards or scripts.
+
+### Commit Range
+
+Session Manager should not run `git` for v1. The range command consumes an ordered commit list from the caller:
+
+```bash
+git rev-list --reverse "$GOOD_SHA..$BAD_SHA" |
+  sm queue ci-range --repo rajeshgoli/Fractal-Market-Simulator --job full-pytest --commits-file -
+```
+
+This avoids making SM depend on local repo checkout freshness. The command reports known result rows and marks missing commits as `unknown`.
+
+## API
+
+Add HTTP endpoints parallel to the CLI:
+
+```text
+POST /queue-ci-runs
+GET  /queue-ci-runs
+GET  /queue-ci-runs/{id}
+GET  /queue-ci-runs/status?repo=...&job=...&commit=...
+POST /queue-ci-runs/range
+```
+
+`POST /queue-ci-runs` returns:
+
+```json
+{
+  "id": "ciq_abc123",
+  "decision": "admitted",
+  "suppression_reason": null,
+  "queue_job_id": "job_def456",
+  "job_key": "rajeshgoli/Fractal-Market-Simulator:full-pytest",
+  "commit_sha": "1a2b3c4...",
+  "log_path": "..."
+}
+```
+
+Suppressed requests return HTTP 200 with `decision=suppressed`, not an error. Invalid input returns 400. SM unavailability remains a client transport error.
+
+## Configuration
+
+Add optional per-job defaults:
+
+```yaml
+queue_runner:
+  ci_jobs:
+    "rajeshgoli/Fractal-Market-Simulator:full-pytest":
+      min_interval_seconds: 1800
+      type: tests
+      cwd: /Users/rajesh/worktrees/fractal-ci
+      notify: maintainer
+      dedupe_scope: repo
+      retention_days: 180
+```
+
+CLI flags override config for one request. If no config exists, callers must pass required execution fields explicitly.
+
+The commit gate is always enabled and cannot be disabled in v1.
+
+## Retention
+
+Default retention:
+
+1. Keep admitted result rows for 180 days.
+2. Keep suppressed request rows for 30 days.
+3. Do not delete queue logs independently in this feature; store log paths and rely on the queue runner's log retention policy.
+4. If a log path is missing during lookup, report the result row and show `log_missing=true`.
+
+Retention pruning must run in a background maintenance task, not on startup before uvicorn binds.
+
+## Notifications
+
+For admitted runs, reuse existing queue notifications for start/completion, but include CI metadata:
+
+```text
+[sm queue ci] full-pytest @ 1a2b3c4 completed: failed exit=1. Queue job: job_def456. Log: ...
+```
+
+Suppressed requests do not notify by default. CI receives the suppression response synchronously. A future operator setting can mirror suppressions to a session if that proves useful.
+
+## Failure Modes
+
+1. Duplicate same-commit request: return `suppressed/commit_already_admitted` and include the prior CI run id.
+2. Different commit inside interval: return `suppressed/time_gate` and include `next_admissible_at`.
+3. Queue job creation fails after CI admission row: mark CI row `suppressed/internal_queue_create_failed` or `lost` and return 500. The implementation should prefer one transaction boundary where possible.
+4. SM restarts before job starts: pending queue job and CI row recover from durable storage.
+5. SM restarts while job runs: queue runner recovers via PID/exit-code file; CI result projector reconciles from queue job state.
+6. Log deleted: lookup still returns result metadata with `log_missing=true`.
+7. Consumer passes invalid SHA/job/repo: reject with 400 before gate evaluation.
+
+## Out Of Scope
+
+1. GitHub Actions workflow templates for consumer repos.
+2. GitHub Checks API publishing.
+3. Auto-checkout or worktree management.
+4. Manual force-rerun command. If needed, add `sm queue ci-rerun --commit SHA --reason TEXT` later with explicit audit fields.
+5. Web UI or `sm watch` queue panels for CI history.
+6. Cross-host dedupe.
+
+## Acceptance Criteria
+
+1. `ci-run` admits the first request for a job key/commit and creates one underlying queue job.
+2. A second request for the same job key/commit is suppressed, even after the time interval.
+3. A request for a different commit before the interval expires is suppressed by the time gate.
+4. A request for a different commit after the interval expires is admitted.
+5. Simultaneous duplicate requests produce exactly one admitted row.
+6. Queue completion updates the durable CI result row.
+7. `ci-status` can look up one commit result.
+8. `ci-history` can show recent admitted and suppressed rows.
+9. `ci-range --commits-file -` reports known and unknown commits in caller-provided order.
+10. Startup does not run unbounded retention or result scans before the API binds.
+
+## Ticket Classification
+
+Single implementation ticket. The feature spans CLI/API/storage and queue runner integration, but it is cohesive and can be implemented by one maintainer agent with focused tests. Consumer repo workflow changes are separate downstream tickets.

--- a/specs/680_rate_limited_ci_queue_runs.md
+++ b/specs/680_rate_limited_ci_queue_runs.md
@@ -38,15 +38,13 @@ The original user-defined rate-limit intent was:
 >
 > No more than one run per commit even after 30 minutes.
 
-The earlier brief also mentioned both 15 and 30 minutes. That was a typo: there is one configurable time constant per policy.
-
 The generalized interpretation is: each policy can enable a time gate, a bounded dedupe-token gate, or both. When both are enabled, a request must pass both gates before SM creates the underlying queue job. This composes to make admissions rarer, not more frequent.
 
 ## Problem
 
 `sm queue run` serializes local execution but accepts every valid request. CI and other automation can fire repeatedly during bursts: repeated workflow events for the same commit, many rapid pushes, or retries while the local host is busy. Without a durable admission policy, those requests can create a backlog of redundant background work.
 
-Session Manager should offer a reusable infrastructure primitive: named policy plus queued command. Consumers configure the policy once in `config.yaml`, then pass a small amount of request metadata at submission time. SM applies the configured gates, starts the job during normal queue lull periods, and records the outcome durably enough for later lookup.
+Session Manager should offer a reusable infrastructure primitive: named policy plus queued command. Consumers configure the policy once in `config.yaml`, then pass a small amount of request metadata at submission time. SM applies the configured gates and records the outcome durably enough for later lookup.
 
 ## Goals
 
@@ -85,7 +83,6 @@ queue_runner:
         token_window: 10        # remember last K admitted tokens
       cwd: /Users/rajesh/worktrees/3175-epic-to-dev
       timeout_seconds: 1800
-      notify: maintainer
       retention:
         admitted_runs: 200
         suppressed_runs: 200
@@ -101,9 +98,10 @@ Policy fields:
 | `dedupe.token_window` | required for `mode=token|both` | Number of recent admitted dedupe tokens to remember. Small values such as 10 are expected. |
 | `cwd` | no | Default working directory for admitted commands. CLI may override. |
 | `timeout_seconds` | no | Default timeout for the underlying queue job. CLI may override. |
-| `notify` | no | Default session or role to notify on start/completion. CLI may override. |
 | `retention.admitted_runs` | no | Number of admitted policy-run rows to retain per policy. |
 | `retention.suppressed_runs` | no | Number of suppressed request rows to retain per policy. |
+
+Notification routing is not policy configuration. The runtime submitter owns the notification target: if a live managed agent submits the run, SM records that session id and wakes it on start/completion while it remains routable. If CI or another non-agent process submits the run, no default wake target is inferred.
 
 The policy name is an infrastructure key. `fractal-ci` is just an operator-defined name, not a built-in project concept.
 
@@ -128,7 +126,6 @@ sm queue ci-history --policy POLICY [--limit N] [--include-suppressed] [--json]
 --timeout DURATION             override policy timeout
 --type tests|perf|background   override policy type only if policy allows overrides
 --env KEY=VALUE                repeatable explicit environment additions/overrides
---notify SESSION_OR_ROLE       override policy notify target
 --metadata KEY=VALUE           repeatable opaque caller metadata for lookup/debug
 ```
 
@@ -190,7 +187,7 @@ Admitted policy runs create normal queue jobs with policy-derived defaults. They
 3. They reuse existing logs, wrapper scripts, exit-code files, and completion notifications.
 4. They recover through the existing queue runner restart path.
 
-This means the policy layer controls admission frequency, not exact start time. A run admitted now may start later during a queue lull. The time gate is based on admission time, not process start time, because admission is the point where SM promises that a run will occur unless the queue job later fails, is cancelled, or is displaced.
+This means the policy layer controls admission frequency, not exact start time. The time gate is based on admission time, not process start time, because admission is the point where SM promises that a run will occur unless the queue job later fails, is cancelled, or is displaced.
 
 ## Concurrency
 
@@ -382,7 +379,7 @@ For admitted runs, reuse existing queue notifications for start/completion, but 
 [sm queue policy] fractal-ci token=1a2b3c4 completed: failed exit=1. Queue job: job_def456. Log: ...
 ```
 
-Suppressed requests do not notify by default. Automation receives the suppression response synchronously. A future operator setting can mirror suppressions to a session if that proves useful.
+Suppressed requests do not notify by default. Automation receives the suppression response synchronously. For admitted runs, the notification target is captured from the submitting managed agent when there is one. If the submitter is not a live managed agent, the run still records durable status and logs, but no wake is attempted.
 
 ## Failure Modes
 


### PR DESCRIPTION
Spec-only PR for #680.\n\n## Summary\n- Specifies CI-facing rate-limited queue run admission on top of existing sm queue.\n- Captures the user-defined composed gates: per-job time interval and at-most-once per commit.\n- Specifies durable gate/result storage, lookup commands, concurrency behavior, failure modes, and retention.\n\n## Notes\n- No implementation in this PR.\n- User review/approval is expected directly on GitHub before implementation work starts.