### PR TITLE
Implement queue policy runs

### DIFF
--- a/specs/680_rate_limited_ci_queue_runs.md
+++ b/specs/680_rate_limited_ci_queue_runs.md
@@ -93,6 +93,7 @@ Policy fields:
 | Field | Required | Meaning |
 | --- | --- | --- |
 | `type` | no | Underlying queue type: `tests`, `perf`, or `background`. Defaults to `background` for policy runs. |
+| `allow_type_override` | no | Boolean, default `false`. Allows `sm queue ci-run --type ...` to override configured `type`. |
 | `min_interval_seconds` | required for `mode=time|both` | Minimum elapsed time between admitted runs for this policy. |
 | `dedupe.mode` | no | `none`, `time`, `token`, or `both`. Defaults to `both` when `min_interval_seconds` and `token_window` are present; otherwise defaults to the gates that have enough config. |
 | `dedupe.token_window` | required for `mode=token|both` | Number of recent admitted dedupe tokens to remember. Small values such as 10 are expected. |

--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -1542,6 +1542,97 @@ class SessionManagerClient:
         detail = data.get("detail") if isinstance(data, dict) else None
         return {"ok": ok, "unavailable": False, "status_code": status_code, "data": data, "detail": detail}
 
+    def create_queue_policy_run(
+        self,
+        *,
+        policy: str,
+        dedupe_token: Optional[str],
+        label: Optional[str],
+        argv: Optional[list[str]],
+        script: Optional[str],
+        cwd: Optional[str],
+        env: dict[str, str],
+        requester_session_id: Optional[str],
+        timeout_seconds: Optional[int],
+        job_type: Optional[str],
+        metadata: Optional[dict[str, str]] = None,
+    ) -> dict:
+        """Create one configured policy-controlled queue run."""
+        payload = {
+            "policy": policy,
+            "dedupe_token": dedupe_token,
+            "label": label,
+            "argv": argv,
+            "script": script,
+            "cwd": cwd,
+            "env": env,
+            "requester_session_id": requester_session_id,
+            "timeout_seconds": timeout_seconds,
+            "type": job_type,
+            "metadata": metadata or {},
+        }
+        data, status_code, unavailable = self._request_with_status(
+            "POST",
+            "/queue-policy-runs",
+            payload,
+            timeout=MUTATION_API_TIMEOUT,
+        )
+        if unavailable:
+            return {"ok": False, "unavailable": True, "status_code": None, "data": None, "detail": None}
+        ok = status_code in (200, 201)
+        detail = data.get("detail") if isinstance(data, dict) else None
+        return {"ok": ok, "unavailable": False, "status_code": status_code, "data": data, "detail": detail}
+
+    def list_queue_policy_runs(
+        self,
+        *,
+        policy: str,
+        limit: int = 50,
+        include_suppressed: bool = False,
+    ) -> dict:
+        """List configured policy-controlled queue runs."""
+        params = [f"policy={urllib.parse.quote(policy)}", f"limit={int(limit)}"]
+        if include_suppressed:
+            params.append("include_suppressed=true")
+        data, status_code, unavailable = self._request_with_status("GET", f"/queue-policy-runs?{'&'.join(params)}")
+        if unavailable:
+            return {"ok": False, "unavailable": True, "status_code": None, "data": None, "detail": None}
+        ok = status_code in (200, 201)
+        detail = data.get("detail") if isinstance(data, dict) else None
+        return {"ok": ok, "unavailable": False, "status_code": status_code, "data": data, "detail": detail}
+
+    def get_queue_policy_run(self, run_id: str) -> dict:
+        """Fetch one configured policy-controlled queue run."""
+        data, status_code, unavailable = self._request_with_status(
+            "GET",
+            f"/queue-policy-runs/{urllib.parse.quote(run_id)}",
+        )
+        if unavailable:
+            return {"ok": False, "unavailable": True, "status_code": None, "data": None, "detail": None}
+        ok = status_code in (200, 201)
+        detail = data.get("detail") if isinstance(data, dict) else None
+        return {"ok": ok, "unavailable": False, "status_code": status_code, "data": data, "detail": detail}
+
+    def get_queue_policy_status(
+        self,
+        *,
+        policy: str,
+        dedupe_token: Optional[str] = None,
+        run_id: Optional[str] = None,
+    ) -> dict:
+        """Fetch status for the latest matching configured policy-controlled queue run."""
+        params = [f"policy={urllib.parse.quote(policy)}"]
+        if dedupe_token:
+            params.append(f"dedupe_token={urllib.parse.quote(dedupe_token)}")
+        if run_id:
+            params.append(f"id={urllib.parse.quote(run_id)}")
+        data, status_code, unavailable = self._request_with_status("GET", f"/queue-policy-runs/status?{'&'.join(params)}")
+        if unavailable:
+            return {"ok": False, "unavailable": True, "status_code": None, "data": None, "detail": None}
+        ok = status_code in (200, 201)
+        detail = data.get("detail") if isinstance(data, dict) else None
+        return {"ok": ok, "unavailable": False, "status_code": status_code, "data": data, "detail": detail}
+
     def list_queue_jobs(
         self,
         *,

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -3691,6 +3691,172 @@ def cmd_queue_run(
     return 0
 
 
+def _queue_metadata_from_cli(metadata_pairs: list[str]) -> dict[str, str]:
+    metadata: dict[str, str] = {}
+    for pair in metadata_pairs:
+        if "=" not in pair:
+            raise ValueError(f"--metadata must be KEY=VALUE, got {pair!r}")
+        key, value = pair.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError("--metadata key cannot be empty")
+        metadata[key] = value
+    return metadata
+
+
+def _print_queue_policy_run(payload: dict) -> None:
+    decision = payload.get("decision", "unknown")
+    run_id = payload.get("id", "unknown")
+    policy = payload.get("policy", "?")
+    print(f"Queue policy run {run_id} ({policy}): {decision}")
+    if decision == "admitted":
+        print(f"Job: {payload.get('queue_job_id') or '-'}")
+        print(f"State: {payload.get('status') or 'pending'}")
+        print(f"Log: {payload.get('log_path') or '-'}")
+    else:
+        print(f"Suppressed: {payload.get('suppression_reason') or '-'}")
+        gates = payload.get("failed_gates") or []
+        if gates:
+            print(f"Failed gates: {', '.join(str(gate) for gate in gates)}")
+
+
+def cmd_queue_ci_run(
+    client: SessionManagerClient,
+    current_session_id: Optional[str],
+    *,
+    policy: str,
+    dedupe_token: Optional[str],
+    label: Optional[str],
+    cwd: Optional[str],
+    timeout: Optional[str],
+    job_type: Optional[str],
+    env_pairs: list[str],
+    metadata_pairs: list[str],
+    command: list[str],
+    script_file: Optional[str],
+) -> int:
+    """Submit one configured policy-controlled queue run."""
+    argv = list(command or [])
+    if argv and argv[0] == "--":
+        argv = argv[1:]
+    script = None
+    if script_file:
+        if argv:
+            print("Error: Use either --script-file or command argv, not both.", file=sys.stderr)
+            return 1
+        if script_file == "-":
+            script = sys.stdin.read()
+        else:
+            script = Path(script_file).expanduser().read_text(encoding="utf-8")
+    elif not argv:
+        print("Error: Expected command after -- or --script-file.", file=sys.stderr)
+        return 1
+
+    try:
+        env = _queue_env_from_cli(env_pairs)
+        metadata = _queue_metadata_from_cli(metadata_pairs)
+        timeout_seconds = parse_duration(timeout) if timeout else None
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    result = client.create_queue_policy_run(
+        policy=policy,
+        dedupe_token=dedupe_token,
+        label=label,
+        argv=argv or None,
+        script=script,
+        cwd=str(Path(cwd).expanduser().resolve()) if cwd else None,
+        env=env,
+        requester_session_id=current_session_id,
+        timeout_seconds=timeout_seconds,
+        job_type=job_type,
+        metadata=metadata,
+    )
+    if result.get("unavailable"):
+        print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+        return 2
+    if not result.get("ok"):
+        detail = result.get("detail") or "Failed to create queue policy run"
+        print(f"Error: {detail}", file=sys.stderr)
+        return 1
+    _print_queue_policy_run(result.get("data") or {})
+    return 0
+
+
+def cmd_queue_ci_status(
+    client: SessionManagerClient,
+    *,
+    policy: str,
+    dedupe_token: Optional[str],
+    run_id: Optional[str],
+    json_output: bool = False,
+) -> int:
+    result = client.get_queue_policy_status(policy=policy, dedupe_token=dedupe_token, run_id=run_id)
+    if result.get("unavailable"):
+        print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+        return 2
+    if not result.get("ok"):
+        detail = result.get("detail") or "Queue policy run not found"
+        print(f"Error: {detail}", file=sys.stderr)
+        return 1
+    payload = result.get("data") or {}
+    if json_output:
+        print(json.dumps(payload, indent=2))
+        return 0
+    _print_queue_policy_run(payload)
+    if payload.get("exit_code") is not None:
+        print(f"Exit: {payload.get('exit_code')}")
+    return 0
+
+
+def cmd_queue_ci_history(
+    client: SessionManagerClient,
+    *,
+    policy: str,
+    limit: int,
+    include_suppressed: bool,
+    json_output: bool = False,
+) -> int:
+    result = client.list_queue_policy_runs(policy=policy, limit=limit, include_suppressed=include_suppressed)
+    if result.get("unavailable"):
+        print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+        return 2
+    if not result.get("ok"):
+        detail = result.get("detail") or "Failed to list queue policy runs"
+        print(f"Error: {detail}", file=sys.stderr)
+        return 1
+    runs = (result.get("data") or {}).get("runs", [])
+    if json_output:
+        print(json.dumps(runs, indent=2))
+        return 0
+    if not runs:
+        print("No queue policy runs.")
+        return 0
+    headers = ["ID", "Policy", "Decision", "Status", "Token", "Job", "Reason"]
+    rows = [
+        [
+            str(run.get("id", "")),
+            str(run.get("policy", "")),
+            str(run.get("decision", "")),
+            str(run.get("status") or "-"),
+            str(run.get("dedupe_token") or "-"),
+            str(run.get("queue_job_id") or "-"),
+            str(run.get("suppression_reason") or "-"),
+        ]
+        for run in runs
+    ]
+    widths = [len(header) for header in headers]
+    for row in rows:
+        for idx, value in enumerate(row):
+            widths[idx] = max(widths[idx], min(len(value), 80))
+    print("  ".join(header.ljust(widths[idx]) for idx, header in enumerate(headers)))
+    print("  ".join("-" * widths[idx] for idx in range(len(headers))))
+    for row in rows:
+        print("  ".join(value[: widths[idx]].ljust(widths[idx]) for idx, value in enumerate(row)))
+    return 0
+
+
 def cmd_queue_list(
     client: SessionManagerClient,
     current_session_id: Optional[str],

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -298,6 +298,30 @@ def main():
     queue_cancel_parser = queue_subparsers.add_parser("cancel", help="Cancel one queue runner job")
     queue_cancel_parser.add_argument("job_id", help="Queue job ID")
 
+    queue_ci_run_parser = queue_subparsers.add_parser("ci-run", help="Submit a configured policy-controlled queue run")
+    queue_ci_run_parser.add_argument("--policy", required=True, help="Configured queue policy name")
+    queue_ci_run_parser.add_argument("--dedupe-token", help="Bounded dedupe token, such as a commit SHA")
+    queue_ci_run_parser.add_argument("--label", help="Human-readable run label")
+    queue_ci_run_parser.add_argument("--cwd", help="Working directory override")
+    queue_ci_run_parser.add_argument("--timeout", help="Timeout duration override, e.g. 90s, 10m, 2h")
+    queue_ci_run_parser.add_argument("--type", dest="job_type", choices=["tests", "perf", "background"], help="Queue workload type override")
+    queue_ci_run_parser.add_argument("--env", dest="env_pairs", action="append", default=[], help="Environment override KEY=VALUE")
+    queue_ci_run_parser.add_argument("--metadata", dest="metadata_pairs", action="append", default=[], help="Metadata KEY=VALUE")
+    queue_ci_run_parser.add_argument("--script-file", help="Script file to run, or - for stdin")
+    queue_ci_run_parser.add_argument("queue_argv", nargs=argparse.REMAINDER, help="Command argv after --")
+
+    queue_ci_status_parser = queue_subparsers.add_parser("ci-status", help="Show one configured policy-controlled queue run")
+    queue_ci_status_parser.add_argument("--policy", required=True, help="Configured queue policy name")
+    queue_ci_status_parser.add_argument("--dedupe-token", help="Look up the latest admitted run by token")
+    queue_ci_status_parser.add_argument("--id", dest="run_id", help="Look up a specific queue policy run ID")
+    queue_ci_status_parser.add_argument("--json", action="store_true", help="Output JSON")
+
+    queue_ci_history_parser = queue_subparsers.add_parser("ci-history", help="List configured policy-controlled queue runs")
+    queue_ci_history_parser.add_argument("--policy", required=True, help="Configured queue policy name")
+    queue_ci_history_parser.add_argument("--limit", type=int, default=50, help="Maximum runs to show")
+    queue_ci_history_parser.add_argument("--include-suppressed", action="store_true", help="Include suppressed run attempts")
+    queue_ci_history_parser.add_argument("--json", action="store_true", help="Output JSON")
+
     # sm request-codex-review <pr>|list|status|cancel
     request_codex_review_parser = subparsers.add_parser(
         "request-codex-review",
@@ -934,7 +958,38 @@ def main():
             sys.exit(commands.cmd_queue_status(client, args.job_id, json_output=args.json))
         if args.queue_command == "cancel":
             sys.exit(commands.cmd_queue_cancel(client, args.job_id))
-        print("Error: queue subcommand required (run, list, status, cancel)", file=sys.stderr)
+        if args.queue_command == "ci-run":
+            sys.exit(commands.cmd_queue_ci_run(
+                client,
+                current_session_id=session_id,
+                policy=args.policy,
+                dedupe_token=args.dedupe_token,
+                label=args.label,
+                cwd=args.cwd,
+                timeout=args.timeout,
+                job_type=args.job_type,
+                env_pairs=args.env_pairs,
+                metadata_pairs=args.metadata_pairs,
+                command=args.queue_argv,
+                script_file=args.script_file,
+            ))
+        if args.queue_command == "ci-status":
+            sys.exit(commands.cmd_queue_ci_status(
+                client,
+                policy=args.policy,
+                dedupe_token=args.dedupe_token,
+                run_id=args.run_id,
+                json_output=args.json,
+            ))
+        if args.queue_command == "ci-history":
+            sys.exit(commands.cmd_queue_ci_history(
+                client,
+                policy=args.policy,
+                limit=args.limit,
+                include_suppressed=args.include_suppressed,
+                json_output=args.json,
+            ))
+        print("Error: queue subcommand required (run, list, status, cancel, ci-run, ci-status, ci-history)", file=sys.stderr)
         sys.exit(2)
     elif args.command == "request-codex-review":
         action = args.action_or_pr

--- a/src/queue_runner.py
+++ b/src/queue_runner.py
@@ -381,9 +381,11 @@ class QueueRunner:
 
     def _policy_retention_config(self, policy_config: dict[str, Any]) -> tuple[int, int]:
         retention = policy_config.get("retention", {}) if isinstance(policy_config.get("retention", {}), dict) else {}
+        dedupe = policy_config.get("dedupe", {}) if isinstance(policy_config.get("dedupe", {}), dict) else {}
+        token_window = int(dedupe.get("token_window", 0) or 0)
         admitted = int(retention.get("admitted_runs", 200) or 200)
         suppressed = int(retention.get("suppressed_runs", 200) or 200)
-        return max(1, admitted), max(1, suppressed)
+        return max(1, admitted, token_window), max(1, suppressed)
 
     def _prune_policy_runs(self, policy: str, policy_config: dict[str, Any]) -> None:
         admitted_keep, suppressed_keep = self._policy_retention_config(policy_config)
@@ -762,7 +764,10 @@ class QueueRunner:
 
     def get_policy_status(self, *, policy: str, dedupe_token: Optional[str] = None, run_id: Optional[str] = None) -> Optional[PolicyRun]:
         if run_id:
-            return self.get_policy_run(run_id)
+            run = self.get_policy_run(run_id)
+            if run is None or run.policy != policy:
+                return None
+            return run
         if not dedupe_token:
             raise ValueError("dedupe_token or run_id is required")
         self._reconcile_policy_results()

--- a/src/queue_runner.py
+++ b/src/queue_runner.py
@@ -23,6 +23,62 @@ DEFAULT_STATE_DIR = "~/.local/share/claude-sessions/queue-runner"
 
 
 @dataclass
+class PolicyRun:
+    """One configured policy-admitted queue run."""
+
+    id: str
+    policy: str
+    decision: str
+    suppression_reason: Optional[str]
+    failed_gates: list[str]
+    dedupe_token: Optional[str]
+    requested_at: datetime
+    admitted_at: Optional[datetime] = None
+    queue_job_id: Optional[str] = None
+    notify_session_id: Optional[str] = None
+    label: Optional[str] = None
+    cwd: Optional[str] = None
+    queue_type: Optional[str] = None
+    command: Optional[list[str]] = None
+    script_path: Optional[str] = None
+    metadata: Optional[dict[str, str]] = None
+    status: Optional[str] = None
+    exit_code: Optional[int] = None
+    queued_at: Optional[datetime] = None
+    started_at: Optional[datetime] = None
+    finished_at: Optional[datetime] = None
+    log_path: Optional[str] = None
+    updated_at: Optional[datetime] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "policy": self.policy,
+            "decision": self.decision,
+            "suppression_reason": self.suppression_reason,
+            "failed_gates": self.failed_gates,
+            "dedupe_token": self.dedupe_token,
+            "requested_at": self.requested_at.isoformat(),
+            "admitted_at": self.admitted_at.isoformat() if self.admitted_at else None,
+            "queue_job_id": self.queue_job_id,
+            "notify_session_id": self.notify_session_id,
+            "label": self.label,
+            "cwd": self.cwd,
+            "queue_type": self.queue_type,
+            "command": self.command,
+            "script_path": self.script_path,
+            "metadata": self.metadata or {},
+            "status": self.status,
+            "exit_code": self.exit_code,
+            "queued_at": self.queued_at.isoformat() if self.queued_at else None,
+            "started_at": self.started_at.isoformat() if self.started_at else None,
+            "finished_at": self.finished_at.isoformat() if self.finished_at else None,
+            "log_path": self.log_path,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }
+
+
+@dataclass
 class QueueJob:
     """One managed queue runner job."""
 
@@ -30,7 +86,7 @@ class QueueJob:
     type: str
     label: str
     requester_session_id: Optional[str]
-    notify_session_id: str
+    notify_session_id: Optional[str]
     cwd: str
     argv: Optional[list[str]]
     script_path: Optional[str]
@@ -114,6 +170,7 @@ class QueueRunner:
         self.state_dir = Path(str(self.config.get("state_dir", DEFAULT_STATE_DIR))).expanduser()
         self.log_dir = self.state_dir / "logs"
         self.db_path = self.state_dir / "queue_runner.db"
+        self.policy_db_path = self.state_dir / "policy_runs.db"
         self.state_dir.mkdir(parents=True, exist_ok=True)
         self.log_dir.mkdir(parents=True, exist_ok=True)
 
@@ -136,6 +193,7 @@ class QueueRunner:
         self._lock = asyncio.Lock()
         self._started = False
         self._init_db()
+        self._init_policy_db()
         self._load_jobs()
 
     def _load_type_config(self) -> dict[str, dict[str, int]]:
@@ -157,6 +215,11 @@ class QueueRunner:
 
     def _connect(self) -> sqlite3.Connection:
         conn = sqlite3.connect(str(self.db_path))
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _connect_policy(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self.policy_db_path))
         conn.row_factory = sqlite3.Row
         return conn
 
@@ -216,13 +279,62 @@ class QueueRunner:
                 """
             )
 
+    def _init_policy_db(self) -> None:
+        with self._connect_policy() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS queue_policy_runs (
+                    id TEXT PRIMARY KEY,
+                    policy TEXT NOT NULL,
+                    decision TEXT NOT NULL,
+                    suppression_reason TEXT,
+                    failed_gates_json TEXT NOT NULL,
+                    dedupe_token TEXT,
+                    requested_at TEXT NOT NULL,
+                    admitted_at TEXT,
+                    queue_job_id TEXT,
+                    notify_session_id TEXT,
+                    label TEXT,
+                    cwd TEXT,
+                    queue_type TEXT,
+                    command_json TEXT,
+                    script_path TEXT,
+                    metadata_json TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS queue_policy_results (
+                    policy_run_id TEXT PRIMARY KEY,
+                    queue_job_id TEXT NOT NULL,
+                    policy TEXT NOT NULL,
+                    dedupe_token TEXT,
+                    status TEXT NOT NULL,
+                    exit_code INTEGER,
+                    queued_at TEXT NOT NULL,
+                    started_at TEXT,
+                    finished_at TEXT,
+                    log_path TEXT,
+                    artifact_json TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_policy_runs_policy_requested ON queue_policy_runs(policy, requested_at)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_policy_runs_policy_admitted ON queue_policy_runs(policy, admitted_at)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_policy_runs_policy_token ON queue_policy_runs(policy, dedupe_token, admitted_at)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_policy_runs_queue_job ON queue_policy_runs(queue_job_id)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_policy_results_policy_token ON queue_policy_results(policy, dedupe_token)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_policy_results_policy_finished ON queue_policy_results(policy, finished_at)")
+
     def _row_to_job(self, row: sqlite3.Row) -> QueueJob:
         return QueueJob(
             id=row["id"],
             type=row["type"],
             label=row["label"],
             requester_session_id=row["requester_session_id"],
-            notify_session_id=row["notify_session_id"],
+            notify_session_id=row["notify_session_id"] or None,
             cwd=row["cwd"],
             argv=json.loads(row["argv_json"]) if row["argv_json"] else None,
             script_path=row["script_path"],
@@ -242,6 +354,112 @@ class QueueRunner:
             queued_notified_at=_parse_dt(row["queued_notified_at"]) if "queued_notified_at" in row.keys() else None,
             started_notified_at=_parse_dt(row["started_notified_at"]) if "started_notified_at" in row.keys() else None,
             completion_notified_at=_parse_dt(row["completion_notified_at"]),
+        )
+
+    def _policy_from_config(self, policy: str) -> dict[str, Any]:
+        policies = self.config.get("policies", {})
+        if not isinstance(policies, dict) or policy not in policies or not isinstance(policies[policy], dict):
+            raise ValueError(f"unknown queue policy: {policy}")
+        return policies[policy]
+
+    def _policy_dedupe_mode(self, policy_config: dict[str, Any]) -> str:
+        dedupe = policy_config.get("dedupe", {}) if isinstance(policy_config.get("dedupe", {}), dict) else {}
+        mode = dedupe.get("mode")
+        if mode:
+            mode = str(mode)
+        elif "min_interval_seconds" in policy_config and "token_window" in dedupe:
+            mode = "both"
+        elif "min_interval_seconds" in policy_config:
+            mode = "time"
+        elif "token_window" in dedupe:
+            mode = "token"
+        else:
+            mode = "none"
+        if mode not in {"none", "time", "token", "both"}:
+            raise ValueError(f"unknown queue policy dedupe mode: {mode}")
+        return mode
+
+    def _policy_retention_config(self, policy_config: dict[str, Any]) -> tuple[int, int]:
+        retention = policy_config.get("retention", {}) if isinstance(policy_config.get("retention", {}), dict) else {}
+        admitted = int(retention.get("admitted_runs", 200) or 200)
+        suppressed = int(retention.get("suppressed_runs", 200) or 200)
+        return max(1, admitted), max(1, suppressed)
+
+    def _prune_policy_runs(self, policy: str, policy_config: dict[str, Any]) -> None:
+        admitted_keep, suppressed_keep = self._policy_retention_config(policy_config)
+        with self._connect_policy() as conn:
+            for decision, keep in (("admitted", admitted_keep), ("suppressed", suppressed_keep)):
+                rows = conn.execute(
+                    """
+                    SELECT id FROM queue_policy_runs
+                    WHERE policy=? AND decision=?
+                    ORDER BY requested_at DESC
+                    LIMIT -1 OFFSET ?
+                    """,
+                    (policy, decision, keep),
+                ).fetchall()
+                stale_ids = [row["id"] for row in rows]
+                if not stale_ids:
+                    continue
+                placeholders = ",".join("?" for _ in stale_ids)
+                conn.execute(f"DELETE FROM queue_policy_results WHERE policy_run_id IN ({placeholders})", stale_ids)
+                conn.execute(f"DELETE FROM queue_policy_runs WHERE id IN ({placeholders})", stale_ids)
+
+    def _reconcile_policy_results(self) -> None:
+        with self._connect_policy() as conn:
+            rows = conn.execute(
+                """
+                SELECT * FROM queue_policy_runs
+                WHERE decision='admitted' AND queue_job_id IS NOT NULL
+                """
+            ).fetchall()
+        for row in rows:
+            job = self._jobs.get(row["queue_job_id"])
+            if job:
+                self._sync_policy_result_for_job(job)
+                continue
+            with self._connect_policy() as conn:
+                exists = conn.execute(
+                    "SELECT 1 FROM queue_policy_results WHERE policy_run_id=?",
+                    (row["id"],),
+                ).fetchone()
+                if exists:
+                    continue
+                now = datetime.now().isoformat()
+                conn.execute(
+                    """
+                    INSERT INTO queue_policy_results
+                    (policy_run_id, queue_job_id, policy, dedupe_token, status, exit_code, queued_at, started_at, finished_at, log_path, artifact_json, updated_at)
+                    VALUES (?, ?, ?, ?, 'lost', NULL, ?, NULL, ?, NULL, '{}', ?)
+                    """,
+                    (row["id"], row["queue_job_id"], row["policy"], row["dedupe_token"], row["admitted_at"] or row["requested_at"], now, now),
+                )
+
+    def _policy_row_to_run(self, row: sqlite3.Row, result_row: Optional[sqlite3.Row] = None) -> PolicyRun:
+        return PolicyRun(
+            id=row["id"],
+            policy=row["policy"],
+            decision=row["decision"],
+            suppression_reason=row["suppression_reason"],
+            failed_gates=json.loads(row["failed_gates_json"] or "[]"),
+            dedupe_token=row["dedupe_token"],
+            requested_at=datetime.fromisoformat(row["requested_at"]),
+            admitted_at=_parse_dt(row["admitted_at"]),
+            queue_job_id=row["queue_job_id"],
+            notify_session_id=row["notify_session_id"] or None,
+            label=row["label"],
+            cwd=row["cwd"],
+            queue_type=row["queue_type"],
+            command=json.loads(row["command_json"]) if row["command_json"] else None,
+            script_path=row["script_path"],
+            metadata=json.loads(row["metadata_json"] or "{}"),
+            status=result_row["status"] if result_row else None,
+            exit_code=result_row["exit_code"] if result_row else None,
+            queued_at=datetime.fromisoformat(result_row["queued_at"]) if result_row and result_row["queued_at"] else None,
+            started_at=_parse_dt(result_row["started_at"]) if result_row else None,
+            finished_at=_parse_dt(result_row["finished_at"]) if result_row else None,
+            log_path=result_row["log_path"] if result_row else None,
+            updated_at=datetime.fromisoformat(result_row["updated_at"]) if result_row and result_row["updated_at"] else None,
         )
 
     def _load_jobs(self) -> None:
@@ -266,7 +484,7 @@ class QueueRunner:
                     job.type,
                     job.label,
                     job.requester_session_id,
-                    job.notify_session_id,
+                    job.notify_session_id or "",
                     job.cwd,
                     json.dumps(job.argv) if job.argv else None,
                     job.script_path,
@@ -288,6 +506,7 @@ class QueueRunner:
                     job.completion_notified_at.isoformat() if job.completion_notified_at else None,
                 ),
             )
+        self._sync_policy_result_for_job(job)
 
     async def start(self) -> None:
         if not self.enabled or self._started:
@@ -325,7 +544,7 @@ class QueueRunner:
         script: Optional[str],
         cwd: str,
         env: Optional[dict[str, str]],
-        notify_session_id: str,
+        notify_session_id: Optional[str],
         requester_session_id: Optional[str],
         timeout: str | int | None,
     ) -> QueueJob:
@@ -338,7 +557,7 @@ class QueueRunner:
         cwd_path = Path(cwd).expanduser().resolve()
         if not cwd_path.exists() or not cwd_path.is_dir():
             raise ValueError(f"cwd does not exist or is not a directory: {cwd}")
-        if not self.session_manager.get_session(notify_session_id):
+        if notify_session_id and not self.session_manager.get_session(notify_session_id):
             raise ValueError("notify target not found")
 
         job_id = f"job_{uuid.uuid4().hex[:12]}"
@@ -386,6 +605,199 @@ class QueueRunner:
                 self._schedule()
         self._ensure_resource_sampler()
         return job
+
+    async def create_policy_run(
+        self,
+        *,
+        policy: str,
+        dedupe_token: Optional[str],
+        label: Optional[str],
+        argv: Optional[list[str]],
+        script: Optional[str],
+        cwd: Optional[str],
+        env: Optional[dict[str, str]],
+        requester_session_id: Optional[str],
+        timeout: str | int | None,
+        job_type: Optional[str] = None,
+        metadata: Optional[dict[str, str]] = None,
+    ) -> PolicyRun:
+        policy_config = self._policy_from_config(policy)
+        mode = self._policy_dedupe_mode(policy_config)
+        dedupe_config = policy_config.get("dedupe", {}) if isinstance(policy_config.get("dedupe", {}), dict) else {}
+        token_window = int(dedupe_config.get("token_window", 0) or 0)
+        min_interval = int(policy_config.get("min_interval_seconds", 0) or 0)
+        if mode in {"token", "both"} and not dedupe_token:
+            raise ValueError("--dedupe-token is required for this policy")
+        if mode in {"time", "both"} and min_interval <= 0:
+            raise ValueError("policy min_interval_seconds must be positive for time gating")
+        if mode in {"token", "both"} and token_window <= 0:
+            raise ValueError("policy dedupe.token_window must be positive for token gating")
+
+        run_id = f"qpol_{uuid.uuid4().hex[:12]}"
+        now = datetime.now()
+        failed_gates: list[str] = []
+        suppression_reason = None
+        with self._connect_policy() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            if mode in {"token", "both"}:
+                rows = conn.execute(
+                    """
+                    SELECT dedupe_token FROM queue_policy_runs
+                    WHERE policy = ? AND decision = 'admitted' AND dedupe_token IS NOT NULL
+                    ORDER BY admitted_at DESC
+                    LIMIT ?
+                    """,
+                    (policy, token_window),
+                ).fetchall()
+                recent_tokens = {row["dedupe_token"] for row in rows}
+                if dedupe_token in recent_tokens:
+                    failed_gates.append("dedupe_token")
+            if mode in {"time", "both"}:
+                row = conn.execute(
+                    """
+                    SELECT admitted_at FROM queue_policy_runs
+                    WHERE policy = ? AND decision = 'admitted' AND admitted_at IS NOT NULL
+                    ORDER BY admitted_at DESC LIMIT 1
+                    """,
+                    (policy,),
+                ).fetchone()
+                if row and (now - datetime.fromisoformat(row["admitted_at"])).total_seconds() < min_interval:
+                    failed_gates.append("time_gate")
+            if failed_gates:
+                suppression_reason = "dedupe_token" if "dedupe_token" in failed_gates else "time_gate"
+                conn.execute(
+                    """
+                    INSERT INTO queue_policy_runs
+                    (id, policy, decision, suppression_reason, failed_gates_json, dedupe_token, requested_at, metadata_json)
+                    VALUES (?, ?, 'suppressed', ?, ?, ?, ?, ?)
+                    """,
+                    (run_id, policy, suppression_reason, json.dumps(failed_gates), dedupe_token, now.isoformat(), json.dumps(metadata or {})),
+                )
+                conn.commit()
+                self._prune_policy_runs(policy, policy_config)
+                return self.get_policy_run(run_id) or PolicyRun(
+                    id=run_id, policy=policy, decision="suppressed", suppression_reason=suppression_reason,
+                    failed_gates=failed_gates, dedupe_token=dedupe_token, requested_at=now, metadata=metadata or {},
+                )
+
+            configured_type = str(policy_config.get("type") or "background")
+            if job_type and job_type != configured_type and not bool(policy_config.get("allow_type_override", False)):
+                raise ValueError("policy does not allow --type override")
+            effective_type = job_type or configured_type
+            effective_cwd = cwd or policy_config.get("cwd")
+            if not effective_cwd:
+                raise ValueError("cwd is required when policy does not configure one")
+            effective_timeout = timeout if timeout is not None else policy_config.get("timeout_seconds")
+            effective_label = label or (f"{policy}@{str(dedupe_token)[:12]}" if dedupe_token else policy)
+            notify_session_id = requester_session_id if requester_session_id and self.session_manager.get_session(requester_session_id) else None
+            conn.execute(
+                """
+                INSERT INTO queue_policy_runs
+                (id, policy, decision, suppression_reason, failed_gates_json, dedupe_token, requested_at, admitted_at,
+                 notify_session_id, label, cwd, queue_type, command_json, metadata_json)
+                VALUES (?, ?, 'admitted', NULL, '[]', ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    run_id, policy, dedupe_token, now.isoformat(), now.isoformat(), notify_session_id,
+                    effective_label, str(effective_cwd), effective_type, json.dumps(argv) if argv else None, json.dumps(metadata or {}),
+                ),
+            )
+            conn.commit()
+
+        try:
+            job = await self.create_job(
+                job_type=effective_type,
+                label=effective_label,
+                argv=argv,
+                script=script,
+                cwd=str(effective_cwd),
+                env=env,
+                notify_session_id=notify_session_id,
+                requester_session_id=requester_session_id,
+                timeout=effective_timeout,
+            )
+        except Exception:
+            with self._connect_policy() as conn:
+                conn.execute(
+                    "UPDATE queue_policy_runs SET decision='suppressed', suppression_reason='queue_create_failed', failed_gates_json=? WHERE id=?",
+                    (json.dumps(["queue_create_failed"]), run_id),
+                )
+            raise
+
+        with self._connect_policy() as conn:
+            conn.execute("UPDATE queue_policy_runs SET queue_job_id=?, script_path=? WHERE id=?", (job.id, job.script_path, run_id))
+        self._sync_policy_result_for_job(job)
+        self._prune_policy_runs(policy, policy_config)
+        return self.get_policy_run(run_id) or PolicyRun(id=run_id, policy=policy, decision="admitted", suppression_reason=None, failed_gates=[], dedupe_token=dedupe_token, requested_at=now)
+
+    def _sync_policy_result_for_job(self, job: QueueJob) -> None:
+        if not job.id:
+            return
+        with self._connect_policy() as conn:
+            row = conn.execute("SELECT * FROM queue_policy_runs WHERE queue_job_id=? AND decision='admitted'", (job.id,)).fetchone()
+            if not row:
+                return
+            now = datetime.now().isoformat()
+            conn.execute(
+                """
+                INSERT OR REPLACE INTO queue_policy_results
+                (policy_run_id, queue_job_id, policy, dedupe_token, status, exit_code, queued_at, started_at, finished_at, log_path, artifact_json, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    row["id"], job.id, row["policy"], row["dedupe_token"], job.state, job.exit_code,
+                    job.queued_at.isoformat(), job.started_at.isoformat() if job.started_at else None,
+                    job.finished_at.isoformat() if job.finished_at else None, job.log_path, "{}", now,
+                ),
+            )
+
+    def get_policy_run(self, run_id: str) -> Optional[PolicyRun]:
+        self._reconcile_policy_results()
+        with self._connect_policy() as conn:
+            row = conn.execute("SELECT * FROM queue_policy_runs WHERE id=?", (run_id,)).fetchone()
+            if not row:
+                return None
+            result = conn.execute("SELECT * FROM queue_policy_results WHERE policy_run_id=?", (run_id,)).fetchone()
+            return self._policy_row_to_run(row, result)
+
+    def get_policy_status(self, *, policy: str, dedupe_token: Optional[str] = None, run_id: Optional[str] = None) -> Optional[PolicyRun]:
+        if run_id:
+            return self.get_policy_run(run_id)
+        if not dedupe_token:
+            raise ValueError("dedupe_token or run_id is required")
+        self._reconcile_policy_results()
+        with self._connect_policy() as conn:
+            row = conn.execute(
+                """
+                SELECT * FROM queue_policy_runs
+                WHERE policy=? AND dedupe_token=? AND decision='admitted'
+                ORDER BY admitted_at DESC LIMIT 1
+                """,
+                (policy, dedupe_token),
+            ).fetchone()
+            if not row:
+                return None
+            result = conn.execute("SELECT * FROM queue_policy_results WHERE policy_run_id=?", (row["id"],)).fetchone()
+            return self._policy_row_to_run(row, result)
+
+    def list_policy_runs(self, *, policy: str, limit: int = 50, include_suppressed: bool = False) -> list[PolicyRun]:
+        self._reconcile_policy_results()
+        with self._connect_policy() as conn:
+            if include_suppressed:
+                rows = conn.execute(
+                    "SELECT * FROM queue_policy_runs WHERE policy=? ORDER BY requested_at DESC LIMIT ?",
+                    (policy, limit),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT * FROM queue_policy_runs WHERE policy=? AND decision='admitted' ORDER BY requested_at DESC LIMIT ?",
+                    (policy, limit),
+                ).fetchall()
+            runs = []
+            for row in rows:
+                result = conn.execute("SELECT * FROM queue_policy_results WHERE policy_run_id=?", (row["id"],)).fetchone()
+                runs.append(self._policy_row_to_run(row, result))
+            return runs
 
     def list_jobs(
         self,
@@ -749,7 +1161,7 @@ class QueueRunner:
 
     def _notify_completion(self, job: QueueJob) -> None:
         mq = getattr(self.session_manager, "message_queue_manager", None)
-        if not mq:
+        if not mq or not job.notify_session_id:
             return
         runtime = "-"
         if job.started_at and job.finished_at:
@@ -769,7 +1181,7 @@ class QueueRunner:
 
     def _notify_queued(self, job: QueueJob) -> None:
         mq = getattr(self.session_manager, "message_queue_manager", None)
-        if not mq:
+        if not mq or not job.notify_session_id:
             return
         position = len([other for other in self._jobs.values() if other.state == "pending" and other.type == job.type and other.queued_at <= job.queued_at])
         text = (
@@ -780,7 +1192,7 @@ class QueueRunner:
 
     def _notify_started(self, job: QueueJob) -> None:
         mq = getattr(self.session_manager, "message_queue_manager", None)
-        if not mq:
+        if not mq or not job.notify_session_id:
             return
         text = f"[sm queue] {job.id} started: {job.type}, pid {job.pid or '-'}. Log: {job.log_path or '-'}"
         mq.queue_message(target_session_id=job.notify_session_id, text=text, delivery_mode="sequential")

--- a/src/queue_runner.py
+++ b/src/queue_runner.py
@@ -191,6 +191,7 @@ class QueueRunner:
         self._scheduler_task: Optional[asyncio.Task[Any]] = None
         self._resource_sampler_task: Optional[asyncio.Task[Any]] = None
         self._lock = asyncio.Lock()
+        self._policy_lock = asyncio.Lock()
         self._started = False
         self._init_db()
         self._init_policy_db()
@@ -637,50 +638,50 @@ class QueueRunner:
 
         run_id = f"qpol_{uuid.uuid4().hex[:12]}"
         now = datetime.now()
-        failed_gates: list[str] = []
-        suppression_reason = None
-        with self._connect_policy() as conn:
-            conn.execute("BEGIN IMMEDIATE")
-            if mode in {"token", "both"}:
-                rows = conn.execute(
-                    """
-                    SELECT dedupe_token FROM queue_policy_runs
-                    WHERE policy = ? AND decision = 'admitted' AND dedupe_token IS NOT NULL
-                    ORDER BY admitted_at DESC
-                    LIMIT ?
-                    """,
-                    (policy, token_window),
-                ).fetchall()
-                recent_tokens = {row["dedupe_token"] for row in rows}
-                if dedupe_token in recent_tokens:
-                    failed_gates.append("dedupe_token")
-            if mode in {"time", "both"}:
-                row = conn.execute(
-                    """
-                    SELECT admitted_at FROM queue_policy_runs
-                    WHERE policy = ? AND decision = 'admitted' AND admitted_at IS NOT NULL
-                    ORDER BY admitted_at DESC LIMIT 1
-                    """,
-                    (policy,),
-                ).fetchone()
-                if row and (now - datetime.fromisoformat(row["admitted_at"])).total_seconds() < min_interval:
-                    failed_gates.append("time_gate")
-            if failed_gates:
-                suppression_reason = "dedupe_token" if "dedupe_token" in failed_gates else "time_gate"
-                conn.execute(
-                    """
-                    INSERT INTO queue_policy_runs
-                    (id, policy, decision, suppression_reason, failed_gates_json, dedupe_token, requested_at, metadata_json)
-                    VALUES (?, ?, 'suppressed', ?, ?, ?, ?, ?)
-                    """,
-                    (run_id, policy, suppression_reason, json.dumps(failed_gates), dedupe_token, now.isoformat(), json.dumps(metadata or {})),
-                )
-                conn.commit()
-                self._prune_policy_runs(policy, policy_config)
-                return self.get_policy_run(run_id) or PolicyRun(
-                    id=run_id, policy=policy, decision="suppressed", suppression_reason=suppression_reason,
-                    failed_gates=failed_gates, dedupe_token=dedupe_token, requested_at=now, metadata=metadata or {},
-                )
+        async with self._policy_lock:
+            failed_gates: list[str] = []
+            suppression_reason = None
+            with self._connect_policy() as conn:
+                if mode in {"token", "both"}:
+                    rows = conn.execute(
+                        """
+                        SELECT dedupe_token FROM queue_policy_runs
+                        WHERE policy = ? AND decision = 'admitted' AND dedupe_token IS NOT NULL
+                        ORDER BY admitted_at DESC
+                        LIMIT ?
+                        """,
+                        (policy, token_window),
+                    ).fetchall()
+                    recent_tokens = {row["dedupe_token"] for row in rows}
+                    if dedupe_token in recent_tokens:
+                        failed_gates.append("dedupe_token")
+                if mode in {"time", "both"}:
+                    row = conn.execute(
+                        """
+                        SELECT admitted_at FROM queue_policy_runs
+                        WHERE policy = ? AND decision = 'admitted' AND admitted_at IS NOT NULL
+                        ORDER BY admitted_at DESC LIMIT 1
+                        """,
+                        (policy,),
+                    ).fetchone()
+                    if row and (now - datetime.fromisoformat(row["admitted_at"])).total_seconds() < min_interval:
+                        failed_gates.append("time_gate")
+                if failed_gates:
+                    suppression_reason = "dedupe_token" if "dedupe_token" in failed_gates else "time_gate"
+                    conn.execute(
+                        """
+                        INSERT INTO queue_policy_runs
+                        (id, policy, decision, suppression_reason, failed_gates_json, dedupe_token, requested_at, metadata_json)
+                        VALUES (?, ?, 'suppressed', ?, ?, ?, ?, ?)
+                        """,
+                        (run_id, policy, suppression_reason, json.dumps(failed_gates), dedupe_token, now.isoformat(), json.dumps(metadata or {})),
+                    )
+                    conn.commit()
+                    self._prune_policy_runs(policy, policy_config)
+                    return self.get_policy_run(run_id) or PolicyRun(
+                        id=run_id, policy=policy, decision="suppressed", suppression_reason=suppression_reason,
+                        failed_gates=failed_gates, dedupe_token=dedupe_token, requested_at=now, metadata=metadata or {},
+                    )
 
             configured_type = str(policy_config.get("type") or "background")
             if job_type and job_type != configured_type and not bool(policy_config.get("allow_type_override", False)):
@@ -692,21 +693,7 @@ class QueueRunner:
             effective_timeout = timeout if timeout is not None else policy_config.get("timeout_seconds")
             effective_label = label or (f"{policy}@{str(dedupe_token)[:12]}" if dedupe_token else policy)
             notify_session_id = requester_session_id if requester_session_id and self.session_manager.get_session(requester_session_id) else None
-            conn.execute(
-                """
-                INSERT INTO queue_policy_runs
-                (id, policy, decision, suppression_reason, failed_gates_json, dedupe_token, requested_at, admitted_at,
-                 notify_session_id, label, cwd, queue_type, command_json, metadata_json)
-                VALUES (?, ?, 'admitted', NULL, '[]', ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    run_id, policy, dedupe_token, now.isoformat(), now.isoformat(), notify_session_id,
-                    effective_label, str(effective_cwd), effective_type, json.dumps(argv) if argv else None, json.dumps(metadata or {}),
-                ),
-            )
-            conn.commit()
 
-        try:
             job = await self.create_job(
                 job_type=effective_type,
                 label=effective_label,
@@ -718,19 +705,27 @@ class QueueRunner:
                 requester_session_id=requester_session_id,
                 timeout=effective_timeout,
             )
-        except Exception:
+
+            admitted_at = datetime.now()
             with self._connect_policy() as conn:
                 conn.execute(
-                    "UPDATE queue_policy_runs SET decision='suppressed', suppression_reason='queue_create_failed', failed_gates_json=? WHERE id=?",
-                    (json.dumps(["queue_create_failed"]), run_id),
+                    """
+                    INSERT INTO queue_policy_runs
+                    (id, policy, decision, suppression_reason, failed_gates_json, dedupe_token, requested_at, admitted_at,
+                     queue_job_id, notify_session_id, label, cwd, queue_type, command_json, script_path, metadata_json)
+                    VALUES (?, ?, 'admitted', NULL, '[]', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        run_id, policy, dedupe_token, now.isoformat(), admitted_at.isoformat(), job.id, notify_session_id,
+                        effective_label, str(effective_cwd), effective_type, json.dumps(argv) if argv else None, job.script_path, json.dumps(metadata or {}),
+                    ),
                 )
-            raise
-
-        with self._connect_policy() as conn:
-            conn.execute("UPDATE queue_policy_runs SET queue_job_id=?, script_path=? WHERE id=?", (job.id, job.script_path, run_id))
-        self._sync_policy_result_for_job(job)
-        self._prune_policy_runs(policy, policy_config)
-        return self.get_policy_run(run_id) or PolicyRun(id=run_id, policy=policy, decision="admitted", suppression_reason=None, failed_gates=[], dedupe_token=dedupe_token, requested_at=now)
+            self._sync_policy_result_for_job(job)
+            self._prune_policy_runs(policy, policy_config)
+            return self.get_policy_run(run_id) or PolicyRun(
+                id=run_id, policy=policy, decision="admitted", suppression_reason=None, failed_gates=[],
+                dedupe_token=dedupe_token, requested_at=now, admitted_at=admitted_at, queue_job_id=job.id,
+            )
 
     def _sync_policy_result_for_job(self, job: QueueJob) -> None:
         if not job.id:

--- a/src/queue_runner.py
+++ b/src/queue_runner.py
@@ -624,6 +624,8 @@ class QueueRunner:
         job_type: Optional[str] = None,
         metadata: Optional[dict[str, str]] = None,
     ) -> PolicyRun:
+        if not self.enabled:
+            raise ValueError("queue runner is disabled")
         policy_config = self._policy_from_config(policy)
         mode = self._policy_dedupe_mode(policy_config)
         dedupe_config = policy_config.get("dedupe", {}) if isinstance(policy_config.get("dedupe", {}), dict) else {}

--- a/src/server.py
+++ b/src/server.py
@@ -740,7 +740,7 @@ class QueueJobResponse(BaseModel):
     label: str
     requester_session_id: Optional[str] = None
     requester_name: Optional[str] = None
-    notify_session_id: str
+    notify_session_id: Optional[str] = None
     notify_name: Optional[str] = None
     cwd: str
     argv: Optional[list[str]] = None
@@ -755,6 +755,48 @@ class QueueJobResponse(BaseModel):
     process_group_id: Optional[int] = None
     exit_code: Optional[int] = None
     log_path: Optional[str] = None
+
+
+class QueuePolicyRunCreateRequest(BaseModel):
+    """Request to submit one configured policy-controlled queue run."""
+    policy: str
+    dedupe_token: Optional[str] = None
+    label: Optional[str] = None
+    argv: Optional[list[str]] = None
+    script: Optional[str] = None
+    cwd: Optional[str] = None
+    env: dict[str, str] = Field(default_factory=dict)
+    requester_session_id: Optional[str] = None
+    timeout_seconds: Optional[int] = Field(default=None, gt=0)
+    type: Optional[str] = None
+    metadata: dict[str, str] = Field(default_factory=dict)
+
+
+class QueuePolicyRunResponse(BaseModel):
+    """Response payload for one configured policy-controlled queue run."""
+    id: str
+    policy: str
+    decision: str
+    suppression_reason: Optional[str] = None
+    failed_gates: list[str] = Field(default_factory=list)
+    dedupe_token: Optional[str] = None
+    requested_at: str
+    admitted_at: Optional[str] = None
+    queue_job_id: Optional[str] = None
+    notify_session_id: Optional[str] = None
+    label: Optional[str] = None
+    cwd: Optional[str] = None
+    queue_type: Optional[str] = None
+    command: Optional[list[str]] = None
+    script_path: Optional[str] = None
+    metadata: dict[str, str] = Field(default_factory=dict)
+    status: Optional[str] = None
+    exit_code: Optional[int] = None
+    queued_at: Optional[str] = None
+    started_at: Optional[str] = None
+    finished_at: Optional[str] = None
+    log_path: Optional[str] = None
+    updated_at: Optional[str] = None
 
 
 class CodexReviewRequestCreateRequest(BaseModel):
@@ -1904,7 +1946,11 @@ def create_app(
             if job.requester_session_id
             else None
         )
-        notify = app.state.session_manager.get_session(job.notify_session_id)
+        notify = (
+            app.state.session_manager.get_session(job.notify_session_id)
+            if job.notify_session_id
+            else None
+        )
         return QueueJobResponse(
             id=job.id,
             type=job.type,
@@ -6173,6 +6219,88 @@ Provide ONLY the summary, no preamble or questions."""
         if job is None:
             raise HTTPException(status_code=404, detail="Queue job not found")
         return _queue_job_to_response(job)
+
+    @app.post("/queue-policy-runs", response_model=QueuePolicyRunResponse)
+    async def create_queue_policy_run(request: QueuePolicyRunCreateRequest):
+        """Submit one configured policy-controlled queue run (#680)."""
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
+
+        queue_runner = getattr(app.state.session_manager, "queue_runner", None)
+        if not queue_runner:
+            raise HTTPException(status_code=503, detail="Queue runner not configured")
+
+        try:
+            run = await queue_runner.create_policy_run(
+                policy=request.policy,
+                dedupe_token=request.dedupe_token,
+                label=request.label,
+                argv=request.argv,
+                script=request.script,
+                cwd=request.cwd,
+                env=request.env,
+                requester_session_id=request.requester_session_id,
+                timeout=request.timeout_seconds,
+                job_type=request.type,
+                metadata=request.metadata,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return QueuePolicyRunResponse(**run.to_dict())
+
+    @app.get("/queue-policy-runs")
+    async def list_queue_policy_runs(
+        policy: str = Query(...),
+        limit: int = Query(50, ge=1, le=500),
+        include_suppressed: bool = Query(False),
+    ):
+        """List configured policy-controlled queue runs (#680)."""
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
+
+        queue_runner = getattr(app.state.session_manager, "queue_runner", None)
+        if not queue_runner:
+            raise HTTPException(status_code=503, detail="Queue runner not configured")
+
+        runs = queue_runner.list_policy_runs(policy=policy, limit=limit, include_suppressed=include_suppressed)
+        return {"runs": [run.to_dict() for run in runs]}
+
+    @app.get("/queue-policy-runs/status", response_model=QueuePolicyRunResponse)
+    async def get_queue_policy_run_status(
+        policy: str = Query(...),
+        dedupe_token: Optional[str] = Query(None),
+        id: Optional[str] = Query(None),
+    ):
+        """Fetch latest status for a configured policy-controlled queue run (#680)."""
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
+
+        queue_runner = getattr(app.state.session_manager, "queue_runner", None)
+        if not queue_runner:
+            raise HTTPException(status_code=503, detail="Queue runner not configured")
+
+        try:
+            run = queue_runner.get_policy_status(policy=policy, dedupe_token=dedupe_token, run_id=id)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        if run is None:
+            raise HTTPException(status_code=404, detail="Queue policy run not found")
+        return QueuePolicyRunResponse(**run.to_dict())
+
+    @app.get("/queue-policy-runs/{run_id}", response_model=QueuePolicyRunResponse)
+    async def get_queue_policy_run(run_id: str):
+        """Fetch one configured policy-controlled queue run (#680)."""
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
+
+        queue_runner = getattr(app.state.session_manager, "queue_runner", None)
+        if not queue_runner:
+            raise HTTPException(status_code=503, detail="Queue runner not configured")
+
+        run = queue_runner.get_policy_run(run_id)
+        if run is None:
+            raise HTTPException(status_code=404, detail="Queue policy run not found")
+        return QueuePolicyRunResponse(**run.to_dict())
 
     @app.post("/codex-review-requests", response_model=CodexReviewRequestResponse)
     async def create_codex_review_request(request: CodexReviewRequestCreateRequest):

--- a/tests/unit/test_queue_runner.py
+++ b/tests/unit/test_queue_runner.py
@@ -542,6 +542,83 @@ async def test_policy_run_prunes_by_configured_retention(mock_sm, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_policy_retention_preserves_token_window(mock_sm, tmp_path):
+    runner = _runner(
+        mock_sm,
+        tmp_path,
+        extra_config={
+            "policies": {
+                "ci": {
+                    "type": "tests",
+                    "cwd": str(tmp_path),
+                    "dedupe": {"mode": "token", "token_window": 3},
+                    "retention": {"admitted_runs": 1, "suppressed_runs": 1},
+                }
+            }
+        },
+    )
+
+    for token in ["one", "two", "three"]:
+        await runner.create_policy_run(
+            policy="ci",
+            dedupe_token=token,
+            label=token,
+            argv=[sys.executable, "-c", f"print('{token}')"],
+            script=None,
+            cwd=None,
+            env={},
+            requester_session_id="agent672",
+            timeout=None,
+        )
+
+    duplicate = await runner.create_policy_run(
+        policy="ci",
+        dedupe_token="one",
+        label="duplicate",
+        argv=[sys.executable, "-c", "print('duplicate')"],
+        script=None,
+        cwd=None,
+        env={},
+        requester_session_id="agent672",
+        timeout=None,
+    )
+
+    admitted = runner.list_policy_runs(policy="ci")
+    assert len(admitted) == 3
+    assert duplicate.decision == "suppressed"
+    assert duplicate.suppression_reason == "dedupe_token"
+
+
+@pytest.mark.asyncio
+async def test_policy_status_by_id_enforces_policy_scope(mock_sm, tmp_path):
+    runner = _runner(
+        mock_sm,
+        tmp_path,
+        extra_config={
+            "policies": {
+                "ci": {"type": "tests", "cwd": str(tmp_path), "dedupe": {"mode": "none"}},
+                "other": {"type": "tests", "cwd": str(tmp_path), "dedupe": {"mode": "none"}},
+            }
+        },
+    )
+
+    run = await runner.create_policy_run(
+        policy="ci",
+        dedupe_token="one",
+        label="first",
+        argv=[sys.executable, "-c", "print('first')"],
+        script=None,
+        cwd=None,
+        env={},
+        requester_session_id="agent672",
+        timeout=None,
+    )
+
+    assert runner.get_policy_status(policy="ci", run_id=run.id).id == run.id
+    assert runner.get_policy_status(policy="other", run_id=run.id) is None
+
+
+@pytest.mark.asyncio
 async def test_policy_run_rejects_type_override_unless_enabled(mock_sm, tmp_path):
     runner = _runner(
         mock_sm,

--- a/tests/unit/test_queue_runner.py
+++ b/tests/unit/test_queue_runner.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock
 import pytest
 from fastapi.testclient import TestClient
 
-from src.cli.commands import cmd_queue_run
+from src.cli.commands import cmd_queue_ci_run, cmd_queue_run
 from src.models import Session, SessionStatus
 from src.queue_runner import QueueJob, QueueRunner
 import src.queue_runner as queue_runner_module
@@ -400,6 +400,261 @@ def test_cmd_queue_run_captures_argv_and_env(tmp_path, monkeypatch):
     assert call["argv"] == [sys.executable, "-m", "pytest"]
     assert call["env"]["PATH"] == "/bin"
     assert call["env"]["EXTRA"] == "1"
+    assert call["timeout_seconds"] == 10
+
+
+@pytest.mark.asyncio
+async def test_policy_run_suppresses_recent_token(mock_sm, tmp_path):
+    runner = _runner(
+        mock_sm,
+        tmp_path,
+        extra_config={
+            "policies": {
+                "ci": {
+                    "type": "tests",
+                    "cwd": str(tmp_path),
+                    "dedupe": {"mode": "token", "token_window": 3},
+                }
+            }
+        },
+    )
+
+    first = await runner.create_policy_run(
+        policy="ci",
+        dedupe_token="abc123",
+        label=None,
+        argv=[sys.executable, "-c", "print('first')"],
+        script=None,
+        cwd=None,
+        env={},
+        requester_session_id="agent672",
+        timeout=None,
+    )
+    second = await runner.create_policy_run(
+        policy="ci",
+        dedupe_token="abc123",
+        label=None,
+        argv=[sys.executable, "-c", "print('second')"],
+        script=None,
+        cwd=None,
+        env={},
+        requester_session_id="agent672",
+        timeout=None,
+    )
+
+    assert first.decision == "admitted"
+    assert first.queue_job_id
+    assert first.notify_session_id == "agent672"
+    assert second.decision == "suppressed"
+    assert second.suppression_reason == "dedupe_token"
+    assert second.failed_gates == ["dedupe_token"]
+
+
+@pytest.mark.asyncio
+async def test_policy_run_suppresses_min_interval(mock_sm, tmp_path):
+    runner = _runner(
+        mock_sm,
+        tmp_path,
+        extra_config={
+            "policies": {
+                "ci": {
+                    "type": "tests",
+                    "cwd": str(tmp_path),
+                    "min_interval_seconds": 60,
+                    "dedupe": {"mode": "time"},
+                }
+            }
+        },
+    )
+
+    first = await runner.create_policy_run(
+        policy="ci",
+        dedupe_token="one",
+        label="first",
+        argv=[sys.executable, "-c", "print('first')"],
+        script=None,
+        cwd=None,
+        env={},
+        requester_session_id="agent672",
+        timeout=None,
+    )
+    second = await runner.create_policy_run(
+        policy="ci",
+        dedupe_token="two",
+        label="second",
+        argv=[sys.executable, "-c", "print('second')"],
+        script=None,
+        cwd=None,
+        env={},
+        requester_session_id="agent672",
+        timeout=None,
+    )
+
+    assert first.decision == "admitted"
+    assert second.decision == "suppressed"
+    assert second.suppression_reason == "time_gate"
+    assert second.failed_gates == ["time_gate"]
+
+
+@pytest.mark.asyncio
+async def test_policy_run_prunes_by_configured_retention(mock_sm, tmp_path):
+    runner = _runner(
+        mock_sm,
+        tmp_path,
+        extra_config={
+            "policies": {
+                "ci": {
+                    "type": "tests",
+                    "cwd": str(tmp_path),
+                    "dedupe": {"mode": "none"},
+                    "retention": {"admitted_runs": 1, "suppressed_runs": 1},
+                }
+            }
+        },
+    )
+
+    first = await runner.create_policy_run(
+        policy="ci",
+        dedupe_token="one",
+        label="first",
+        argv=[sys.executable, "-c", "print('first')"],
+        script=None,
+        cwd=None,
+        env={},
+        requester_session_id="agent672",
+        timeout=None,
+    )
+    second = await runner.create_policy_run(
+        policy="ci",
+        dedupe_token="two",
+        label="second",
+        argv=[sys.executable, "-c", "print('second')"],
+        script=None,
+        cwd=None,
+        env={},
+        requester_session_id="agent672",
+        timeout=None,
+    )
+
+    runs = runner.list_policy_runs(policy="ci", include_suppressed=True)
+    assert [run.id for run in runs] == [second.id]
+    assert runner.get_policy_run(first.id) is None
+
+
+@pytest.mark.asyncio
+async def test_policy_run_rejects_type_override_unless_enabled(mock_sm, tmp_path):
+    runner = _runner(
+        mock_sm,
+        tmp_path,
+        extra_config={
+            "policies": {
+                "ci": {
+                    "type": "background",
+                    "cwd": str(tmp_path),
+                    "dedupe": {"mode": "none"},
+                }
+            }
+        },
+    )
+
+    with pytest.raises(ValueError, match="type override"):
+        await runner.create_policy_run(
+            policy="ci",
+            dedupe_token=None,
+            label="override",
+            argv=[sys.executable, "-c", "print('override')"],
+            script=None,
+            cwd=None,
+            env={},
+            requester_session_id="agent672",
+            timeout=None,
+            job_type="tests",
+        )
+
+
+def test_queue_policy_run_endpoints_roundtrip(tmp_path):
+    session_manager = SessionManager(
+        log_dir=str(tmp_path / "logs"),
+        state_file=str(tmp_path / "sessions.json"),
+        config={
+            "queue_runner": {
+                "state_dir": str(tmp_path / "queue-runner"),
+                "memory": {"min_free_bytes": 0},
+                "policies": {
+                    "ci": {
+                        "type": "tests",
+                        "cwd": str(tmp_path),
+                        "dedupe": {"mode": "token", "token_window": 3},
+                    }
+                },
+            }
+        },
+    )
+    session = _session("agent672", tmp_path)
+    session_manager.sessions[session.id] = session
+    session_manager.message_queue_manager = MagicMock()
+
+    app = create_app(session_manager=session_manager)
+    client = TestClient(app)
+
+    response = client.post(
+        "/queue-policy-runs",
+        json={
+            "policy": "ci",
+            "dedupe_token": "abc123",
+            "argv": [sys.executable, "-c", "print('api')"],
+            "requester_session_id": "agent672",
+            "timeout_seconds": 5,
+            "metadata": {"source": "test"},
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["decision"] == "admitted"
+    assert payload["queue_job_id"]
+    assert client.get(f"/queue-policy-runs/{payload['id']}").status_code == 200
+    assert client.get("/queue-policy-runs/status?policy=ci&dedupe_token=abc123").json()["id"] == payload["id"]
+    assert client.get("/queue-policy-runs?policy=ci").json()["runs"]
+
+
+def test_cmd_queue_ci_run_captures_policy_args(tmp_path, monkeypatch):
+    client = MagicMock()
+    client.create_queue_policy_run.return_value = {
+        "ok": True,
+        "data": {
+            "id": "qpol_cli",
+            "policy": "ci",
+            "decision": "admitted",
+            "queue_job_id": "job_cli",
+            "status": "pending",
+            "log_path": "/tmp/job.log",
+        },
+    }
+    monkeypatch.setenv("PATH", "/bin")
+
+    code = cmd_queue_ci_run(
+        client,
+        "agent672",
+        policy="ci",
+        dedupe_token="abc123",
+        label="cli",
+        cwd=str(tmp_path),
+        timeout="10s",
+        job_type="tests",
+        env_pairs=["EXTRA=1"],
+        metadata_pairs=["commit=abc123"],
+        command=["--", sys.executable, "-m", "pytest"],
+        script_file=None,
+    )
+
+    assert code == 0
+    call = client.create_queue_policy_run.call_args.kwargs
+    assert call["policy"] == "ci"
+    assert call["dedupe_token"] == "abc123"
+    assert call["argv"] == [sys.executable, "-m", "pytest"]
+    assert call["env"]["PATH"] == "/bin"
+    assert call["env"]["EXTRA"] == "1"
+    assert call["metadata"] == {"commit": "abc123"}
     assert call["timeout_seconds"] == 10
 
 

--- a/tests/unit/test_queue_runner.py
+++ b/tests/unit/test_queue_runner.py
@@ -542,6 +542,63 @@ async def test_policy_run_prunes_by_configured_retention(mock_sm, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_policy_run_create_job_failure_does_not_consume_gate(mock_sm, tmp_path):
+    runner = _runner(
+        mock_sm,
+        tmp_path,
+        extra_config={
+            "policies": {
+                "ci": {
+                    "type": "tests",
+                    "cwd": str(tmp_path),
+                    "dedupe": {"mode": "token", "token_window": 3},
+                }
+            }
+        },
+    )
+    original_create_job = runner.create_job
+    calls = 0
+
+    async def flaky_create_job(**kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise ValueError("boom")
+        return await original_create_job(**kwargs)
+
+    runner.create_job = flaky_create_job
+
+    with pytest.raises(ValueError, match="boom"):
+        await runner.create_policy_run(
+            policy="ci",
+            dedupe_token="same",
+            label="first",
+            argv=[sys.executable, "-c", "print('first')"],
+            script=None,
+            cwd=None,
+            env={},
+            requester_session_id="agent672",
+            timeout=None,
+        )
+
+    retry = await runner.create_policy_run(
+        policy="ci",
+        dedupe_token="same",
+        label="retry",
+        argv=[sys.executable, "-c", "print('retry')"],
+        script=None,
+        cwd=None,
+        env={},
+        requester_session_id="agent672",
+        timeout=None,
+    )
+
+    assert retry.decision == "admitted"
+    assert retry.queue_job_id
+    assert [run.dedupe_token for run in runner.list_policy_runs(policy="ci")] == ["same"]
+
+
+@pytest.mark.asyncio
 async def test_policy_retention_preserves_token_window(mock_sm, tmp_path):
     runner = _runner(
         mock_sm,

--- a/tests/unit/test_queue_runner.py
+++ b/tests/unit/test_queue_runner.py
@@ -542,6 +542,39 @@ async def test_policy_run_prunes_by_configured_retention(mock_sm, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_policy_run_fails_fast_when_queue_runner_disabled(mock_sm, tmp_path):
+    runner = _runner(
+        mock_sm,
+        tmp_path,
+        extra_config={
+            "enabled": False,
+            "policies": {
+                "ci": {
+                    "type": "tests",
+                    "cwd": str(tmp_path),
+                    "dedupe": {"mode": "token", "token_window": 3},
+                }
+            },
+        },
+    )
+
+    with pytest.raises(ValueError, match="queue runner is disabled"):
+        await runner.create_policy_run(
+            policy="ci",
+            dedupe_token="same",
+            label="disabled",
+            argv=[sys.executable, "-c", "print('disabled')"],
+            script=None,
+            cwd=None,
+            env={},
+            requester_session_id="agent672",
+            timeout=None,
+        )
+
+    assert runner.list_policy_runs(policy="ci", include_suppressed=True) == []
+
+
+@pytest.mark.asyncio
 async def test_policy_run_create_job_failure_does_not_consume_gate(mock_sm, tmp_path):
     runner = _runner(
         mock_sm,


### PR DESCRIPTION
## Summary
- add config-driven queue policy admission with time/token/both dedupe gates and bounded retention
- add durable policy_runs.db result projection and queue job reconciliation/lost status
- expose sm queue ci-run, ci-status, ci-history plus API/client support

## Tests
- ./venv/bin/python -m pytest tests/unit/test_queue_runner.py -q
- ./venv/bin/python -m pytest tests/unit -q

Fixes #680