### PR TITLE
Add interactive restore browser

### DIFF
--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -3173,6 +3173,8 @@ def cmd_watch(
     repo: Optional[str] = None,
     role: Optional[str] = None,
     interval: float = 2.0,
+    restore_mode: bool = False,
+    top_level: bool = False,
 ) -> int:
     """Launch interactive watch dashboard."""
     if os.environ.get("CLAUDE_SESSION_MANAGER_ID"):
@@ -3194,6 +3196,8 @@ def cmd_watch(
         repo_filter=repo,
         role_filter=role,
         interval=interval,
+        restore_mode=restore_mode,
+        top_level=top_level,
     )
 
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -599,6 +599,16 @@ def main():
         default=2.0,
         help="Refresh interval seconds (default: 2.0)",
     )
+    watch_parser.add_argument(
+        "--restore",
+        action="store_true",
+        help="Browse restorable stopped sessions and restore the selected row",
+    )
+    watch_parser.add_argument(
+        "--top-level",
+        action="store_true",
+        help="In --restore mode, start with only top-level stopped sessions expanded on demand",
+    )
 
     # sm tail <session> [-n N] [--raw] [--db-path PATH]
     tail_parser = subparsers.add_parser(
@@ -1116,6 +1126,8 @@ def main():
             repo=args.repo,
             role=args.role,
             interval=args.interval,
+            restore_mode=args.restore,
+            top_level=args.top_level,
         ))
     elif args.command == "tail":
         sys.exit(commands.cmd_tail(

--- a/src/cli/watch_tui.py
+++ b/src/cli/watch_tui.py
@@ -57,6 +57,39 @@ _DYNAMIC_COLUMN_CAPS = {
     "Age": 6,
 }
 
+_RESTORE_COLUMN_SPECS = [
+    ("Session", 16, 4, "left"),
+    ("ID", 8, 0, "left"),
+    ("Parent", 18, 2, "left"),
+    ("Role", 8, 1, "left"),
+    ("Provider", 10, 1, "left"),
+    ("Repo", 12, 2, "left"),
+    ("Last Active", 11, 1, "left"),
+    ("Retired", 8, 1, "left"),
+    ("Restore", 10, 1, "left"),
+]
+_RESTORE_COLUMN_FLOORS = {
+    "Session": 8,
+    "ID": 4,
+    "Parent": 8,
+    "Role": 4,
+    "Provider": 6,
+    "Repo": 6,
+    "Last Active": 5,
+    "Retired": 5,
+    "Restore": 5,
+}
+_RESTORE_DYNAMIC_COLUMN_CAPS = {
+    "ID": 8,
+    "Parent": 36,
+    "Role": 16,
+    "Provider": 10,
+    "Repo": 28,
+    "Last Active": 12,
+    "Retired": 12,
+    "Restore": 12,
+}
+
 
 @dataclass
 class WatchRow:
@@ -476,11 +509,22 @@ def filter_sessions(
             continue
 
         if text_filter_norm:
+            parent = sessions_by_id.get(session.get("parent_session_id"))
+            aliases = session.get("aliases") or []
+            if isinstance(aliases, str):
+                aliases = [aliases]
             haystack = " ".join(
                 [
                     _session_name(session),
                     session.get("id", ""),
                     session.get("role", "") or "",
+                    session.get("provider", "") or "",
+                    session.get("status", "") or "",
+                    session.get("working_dir", "") or "",
+                    session.get("current_task", "") or "",
+                    _session_name(parent) if parent else "",
+                    session.get("parent_session_id", "") or "",
+                    " ".join(str(alias) for alias in aliases),
                 ]
             ).lower()
             if text_filter_norm not in haystack:
@@ -743,6 +787,110 @@ def build_watch_rows(
     return rows, selectable, len(groups)
 
 
+
+def _restore_status(session: dict) -> str:
+    provider = session.get("provider", "claude")
+    if provider == "codex-app":
+        return "headless"
+    return "ready" if session.get("tmux_session") else "no-tmux"
+
+
+def _restore_retired_age(session: dict) -> str:
+    return _age_from_iso(session.get("stopped_at") or session.get("completed_at") or session.get("last_activity"))
+
+
+def build_restore_rows(
+    stopped_sessions: list[dict],
+    all_sessions: Optional[list[dict]] = None,
+    expanded_session_ids: Optional[set[str]] = None,
+    top_level_only: bool = False,
+) -> tuple[list[WatchRow], list[str], int]:
+    """Build grouped restore-browser rows for stopped sessions."""
+    rows: list[WatchRow] = []
+    selectable: list[str] = []
+    expanded = expanded_session_ids or set()
+    stopped_by_id = {session["id"]: session for session in stopped_sessions if session.get("id")}
+    sessions_by_id = {
+        session["id"]: session
+        for session in (all_sessions or stopped_sessions)
+        if session.get("id")
+    }
+    groups: dict[str, list[dict]] = {}
+    roots_by_repo: dict[str, list[dict]] = {}
+    children_by_parent: dict[str, list[dict]] = {}
+
+    for session in stopped_sessions:
+        if session.get("status") != "stopped":
+            continue
+        session_id = session.get("id")
+        if not session_id:
+            continue
+        key = _repo_key(session.get("working_dir", ""))
+        groups.setdefault(key, []).append(session)
+        parent_id = session.get("parent_session_id")
+        if parent_id and parent_id in stopped_by_id:
+            children_by_parent.setdefault(parent_id, []).append(session)
+        else:
+            roots_by_repo.setdefault(key, []).append(session)
+
+    sort_key = lambda s: (_session_name(s).lower(), s.get("id", ""))
+    for root_list in roots_by_repo.values():
+        root_list.sort(key=sort_key)
+    for child_list in children_by_parent.values():
+        child_list.sort(key=sort_key)
+
+    def _tree_prefix(ancestors_last: list[bool], is_last: bool) -> str:
+        connector = "`-" if is_last else "|-"
+        prefix_parts = []
+        for ancestor_is_last in ancestors_last:
+            prefix_parts.append("   " if ancestor_is_last else "|  ")
+        return "".join(prefix_parts) + connector
+
+    def render_session(session: dict, ancestors_last: list[bool], is_last: bool):
+        tree_prefix = _tree_prefix(ancestors_last, is_last)
+        session_id = session.get("id")
+        repo_label = _repo_label(session.get("working_dir") or "")
+        columns = {
+            "Session": f"{tree_prefix}{_session_name(session)}",
+            "ID": session_id or "",
+            "Parent": _parent_label(session, sessions_by_id),
+            "Role": session.get("role") or "-",
+            "Provider": session.get("provider", "claude"),
+            "Repo": repo_label,
+            "Last Active": _age_from_iso(session.get("last_activity")),
+            "Retired": _restore_retired_age(session),
+            "Restore": _restore_status(session),
+        }
+        rows.append(
+            WatchRow(
+                kind="session",
+                session_id=session_id,
+                activity_state="idle",
+                columns=columns,
+            )
+        )
+        if session_id:
+            selectable.append(session_id)
+
+        if top_level_only and session_id not in expanded:
+            return
+        children = children_by_parent.get(session_id or "", [])
+        for idx, child in enumerate(children):
+            render_session(child, ancestors_last + [is_last], idx == len(children) - 1)
+
+    for repo_key in sorted(groups.keys()):
+        top_level_roots = roots_by_repo.get(repo_key, [])
+        if not top_level_roots:
+            continue
+        repo_header = _repo_label(repo_key) if repo_key != "unknown" else "unknown/"
+        if repo_key not in ("unknown",):
+            repo_header = f"{repo_header} ({repo_key})"
+        rows.append(WatchRow(kind="repo", text=repo_header))
+        for idx, root in enumerate(top_level_roots):
+            render_session(root, [], idx == len(top_level_roots) - 1)
+
+    return rows, selectable, len(groups)
+
 def _truncate(text: str, width: int, align: str = "left") -> str:
     if width <= 0:
         return ""
@@ -761,18 +909,24 @@ def _content_len(text: str) -> int:
     return len(ANSI_RE.sub("", text or ""))
 
 
-def _compute_static_column_widths(content_width: int) -> dict[str, int]:
+def _compute_static_column_widths(
+    content_width: int,
+    column_specs: Optional[list[tuple[str, int, int, str]]] = None,
+    column_floors: Optional[dict[str, int]] = None,
+) -> dict[str, int]:
+    specs = column_specs or _COLUMN_SPECS
+    floors = column_floors or _COLUMN_FLOORS
     if content_width <= 10:
-        return {name: 1 for name, _, _, _ in _COLUMN_SPECS}
+        return {name: 1 for name, _, _, _ in specs}
 
-    min_widths = {name: minimum for name, minimum, _, _ in _COLUMN_SPECS}
+    min_widths = {name: minimum for name, minimum, _, _ in specs}
     widths = dict(min_widths)
-    sep_total = len(_COLUMN_SEP) * (len(_COLUMN_SPECS) - 1)
+    sep_total = len(_COLUMN_SEP) * (len(specs) - 1)
     min_total = sum(min_widths.values()) + sep_total
 
     if content_width >= min_total:
         extra = content_width - min_total
-        weighted = [entry for entry in _COLUMN_SPECS if entry[2] > 0]
+        weighted = [entry for entry in specs if entry[2] > 0]
         total_weight = sum(weight for _, _, weight, _ in weighted) or 1
         for name, _, weight, _ in weighted:
             add = (extra * weight) // total_weight
@@ -788,11 +942,11 @@ def _compute_static_column_widths(content_width: int) -> dict[str, int]:
         return widths
 
     deficit = min_total - content_width
-    shrink_order = ["Last", "Session", "Parent", "Activity", "Role", "Provider", "Status", "Age"]
+    shrink_order = [name for name, _, _, _ in reversed(specs)]
     while deficit > 0:
         changed = False
         for name in shrink_order:
-            if widths[name] > _COLUMN_FLOORS[name] and deficit > 0:
+            if widths[name] > floors.get(name, 1) and deficit > 0:
                 widths[name] -= 1
                 deficit -= 1
                 changed = True
@@ -802,41 +956,51 @@ def _compute_static_column_widths(content_width: int) -> dict[str, int]:
     return widths
 
 
-def _compute_column_widths(content_width: int, rows: Optional[list[WatchRow]] = None) -> dict[str, int]:
+def _compute_column_widths(
+    content_width: int,
+    rows: Optional[list[WatchRow]] = None,
+    column_specs: Optional[list[tuple[str, int, int, str]]] = None,
+    column_floors: Optional[dict[str, int]] = None,
+    dynamic_caps: Optional[dict[str, int]] = None,
+) -> dict[str, int]:
+    specs = column_specs or _COLUMN_SPECS
+    floors = column_floors or _COLUMN_FLOORS
+    caps = dynamic_caps or _DYNAMIC_COLUMN_CAPS
     if not rows:
-        return _compute_static_column_widths(content_width)
+        return _compute_static_column_widths(content_width, specs, floors)
     if content_width <= 10:
-        return {name: 1 for name, _, _, _ in _COLUMN_SPECS}
+        return {name: 1 for name, _, _, _ in specs}
 
     session_rows = [row for row in rows if row.kind == "session"]
     if not session_rows:
-        return _compute_static_column_widths(content_width)
+        return _compute_static_column_widths(content_width, specs, floors)
 
     widths: dict[str, int] = {}
-    for name, _, _, _ in _COLUMN_SPECS:
+    for name, _, _, _ in specs:
         if name == "ID":
-            widths[name] = _DYNAMIC_COLUMN_CAPS["ID"]
+            widths[name] = caps.get("ID", 8)
             continue
         desired = len(name)
         for row in session_rows:
             desired = max(desired, _content_len(row.columns.get(name, "")))
-        cap = _DYNAMIC_COLUMN_CAPS.get(name)
+        cap = caps.get(name)
         if cap is not None:
             desired = min(desired, max(len(name), cap))
         widths[name] = max(1, desired)
 
-    sep_total = len(_COLUMN_SEP) * (len(_COLUMN_SPECS) - 1)
+    sep_total = len(_COLUMN_SEP) * (len(specs) - 1)
     used = sum(widths.values()) + sep_total
     if used <= content_width:
-        widths["Session"] += content_width - used
+        if "Session" in widths:
+            widths["Session"] += content_width - used
         return widths
 
     deficit = used - content_width
-    shrink_order = ["Last", "Parent", "Role", "Activity", "Provider", "Status", "Session", "Age", "ID"]
+    shrink_order = [name for name, _, _, _ in reversed(specs)]
     while deficit > 0:
         changed = False
         for name in shrink_order:
-            if widths[name] > _COLUMN_FLOORS[name] and deficit > 0:
+            if widths[name] > floors.get(name, 1) and deficit > 0:
                 widths[name] -= 1
                 deficit -= 1
                 changed = True
@@ -846,19 +1010,25 @@ def _compute_column_widths(content_width: int, rows: Optional[list[WatchRow]] = 
     return widths
 
 
-def _header_line(widths: dict[str, int]) -> str:
+def _header_line(
+    widths: dict[str, int],
+    column_specs: Optional[list[tuple[str, int, int, str]]] = None,
+) -> str:
     parts = []
-    for name, _, _, align in _COLUMN_SPECS:
+    for name, _, _, align in (column_specs or _COLUMN_SPECS):
         parts.append(_truncate(name, widths[name], align=align))
     return _COLUMN_SEP.join(parts)
 
 
-def _session_line(row: WatchRow, widths: dict[str, int]) -> str:
+def _session_line(
+    row: WatchRow,
+    widths: dict[str, int],
+    column_specs: Optional[list[tuple[str, int, int, str]]] = None,
+) -> str:
     parts = []
-    for name, _, _, align in _COLUMN_SPECS:
+    for name, _, _, align in (column_specs or _COLUMN_SPECS):
         parts.append(_truncate(row.columns.get(name, ""), widths[name], align=align))
     return _COLUMN_SEP.join(parts)
-
 
 def _prompt_input(stdscr, prompt: str) -> str:
     height, width = stdscr.getmaxyx()
@@ -1057,18 +1227,22 @@ def _render(
     filter_text: Optional[str],
     flash_message: Optional[str],
     palette: dict[str, int],
+    restore_mode: bool = False,
 ):
     stdscr.erase()
     height, width = stdscr.getmaxyx()
 
-    title = f"sm watch  {total_sessions} agents - {repo_count} repos"
+    title = f"sm watch{' --restore' if restore_mode else ''}  {total_sessions} agents - {repo_count} repos"
     if filter_text:
         title += f" - filter: {filter_text}"
     stdscr.addnstr(0, 0, title, _render_columns(width, 0), curses.A_BOLD | palette["header"])
 
     content_width = max(1, _render_columns(width, 2))
-    widths = _compute_column_widths(content_width, rows)
-    stdscr.addnstr(1, 2, _header_line(widths), _render_columns(width, 2), curses.A_BOLD | palette["header"])
+    column_specs = _RESTORE_COLUMN_SPECS if restore_mode else _COLUMN_SPECS
+    column_floors = _RESTORE_COLUMN_FLOORS if restore_mode else _COLUMN_FLOORS
+    dynamic_caps = _RESTORE_DYNAMIC_COLUMN_CAPS if restore_mode else _DYNAMIC_COLUMN_CAPS
+    widths = _compute_column_widths(content_width, rows, column_specs, column_floors, dynamic_caps)
+    stdscr.addnstr(1, 2, _header_line(widths, column_specs), _render_columns(width, 2), curses.A_BOLD | palette["header"])
 
     max_rows = max(0, height - _RESERVED_SCREEN_ROWS)
     display_rows = rows[scroll_offset: scroll_offset + max_rows]
@@ -1085,7 +1259,7 @@ def _render(
             attr = base_attr
             if is_selected:
                 attr = base_attr | curses.A_REVERSE | curses.A_BOLD
-            stdscr.addnstr(y, 0, f"{marker} {_session_line(row, widths)}", _render_columns(width, 0), attr)
+            stdscr.addnstr(y, 0, f"{marker} {_session_line(row, widths, column_specs)}", _render_columns(width, 0), attr)
         elif row.kind == "repo":
             stdscr.addnstr(y, 2, row.text, _render_columns(width, 2), curses.A_BOLD | palette["repo"])
         elif row.kind == "repo_ref":
@@ -1106,7 +1280,10 @@ def _render(
             _flash_attr(flash_message, palette),
         )
 
-    footer = "j/k: move  +: create  Enter: attach  s: send  K,K: retire  n: rename  A/X: adopt  Tab: details  /: filter  r: refresh  q: quit"
+    if restore_mode:
+        footer = "j/k: move  Enter: restore+attach  Tab: expand/collapse  E: expand all  C: collapse all  /: search  r: refresh  q: quit"
+    else:
+        footer = "j/k: move  +: create  Enter: attach  s: send  K,K: retire  n: rename  A/X: adopt  Tab: details  /: filter  r: refresh  q: quit"
     stdscr.addnstr(height - 1, 0, footer, _render_columns(width, 0, reserve_last_cell=True))
     stdscr.refresh()
 
@@ -1116,6 +1293,8 @@ def run_watch_tui(
     repo_filter: Optional[str] = None,
     role_filter: Optional[str] = None,
     interval: float = 2.0,
+    restore_mode: bool = False,
+    top_level: bool = False,
 ) -> int:
     """Run the sm watch curses UI."""
 
@@ -1130,7 +1309,7 @@ def run_watch_tui(
             rollout_flags and rollout_flags.get("enable_observability_projection", True)
         )
 
-        detail_worker = DetailFetchWorker(client=client, codex_projection_enabled=codex_projection_enabled)
+        detail_worker = None if restore_mode else DetailFetchWorker(client=client, codex_projection_enabled=codex_projection_enabled)
 
         try:
             selected_session_id: Optional[str] = None
@@ -1152,40 +1331,52 @@ def run_watch_tui(
             while True:
                 now = time.monotonic()
                 if now >= next_refresh:
-                    listed = client.list_sessions()
+                    listed = client.list_sessions(include_stopped=restore_mode)
                     if listed is None:
                         flash_message = "Session manager unavailable"
                         flash_until = now + 2.5
                     else:
-                        latest_sessions = filter_sessions(
+                        filtered = filter_sessions(
                             listed,
                             repo_filter=repo_filter,
                             role_filter=role_filter,
                             text_filter=text_filter,
                         )
-                        latest_by_id = {s.get("id", ""): s for s in latest_sessions if s.get("id")}
-                        total_sessions = len(latest_sessions)
-                        detail_cache = {
-                            sid: detail_worker.get(sid)
-                            for sid in expanded_session_ids
-                            if sid in latest_by_id
-                        }
-                        rows, selectable, repo_count = build_watch_rows(
-                            latest_sessions,
-                            spinner_index=spinner_index,
-                            expanded_session_ids=expanded_session_ids,
-                            detail_cache=detail_cache,
-                            codex_projection_enabled=codex_projection_enabled,
-                        )
-                        spinner_index += 1
+                        if restore_mode:
+                            latest_sessions = [s for s in filtered if s.get("status") == "stopped"]
+                            latest_by_id = {s.get("id", ""): s for s in latest_sessions if s.get("id")}
+                            total_sessions = len(latest_sessions)
+                            rows, selectable, repo_count = build_restore_rows(
+                                latest_sessions,
+                                all_sessions=listed,
+                                expanded_session_ids=expanded_session_ids,
+                                top_level_only=top_level,
+                            )
+                        else:
+                            latest_sessions = filtered
+                            latest_by_id = {s.get("id", ""): s for s in latest_sessions if s.get("id")}
+                            total_sessions = len(latest_sessions)
+                            detail_cache = {
+                                sid: detail_worker.get(sid)
+                                for sid in expanded_session_ids
+                                if sid in latest_by_id
+                            } if detail_worker else {}
+                            rows, selectable, repo_count = build_watch_rows(
+                                latest_sessions,
+                                spinner_index=spinner_index,
+                                expanded_session_ids=expanded_session_ids,
+                                detail_cache=detail_cache,
+                                codex_projection_enabled=codex_projection_enabled,
+                            )
+                            spinner_index += 1
+                            # Prune stale expanded IDs and enqueue refresh for active details.
+                            expanded_session_ids.intersection_update(set(selectable))
+                            for sid in expanded_session_ids:
+                                session = latest_by_id.get(sid)
+                                if session and detail_worker:
+                                    detail_worker.request(session)
                         if selected_session_id not in selectable:
                             selected_session_id = selectable[0] if selectable else None
-                        # Prune stale expanded IDs and enqueue refresh for active details.
-                        expanded_session_ids.intersection_update(set(selectable))
-                        for sid in expanded_session_ids:
-                            session = latest_by_id.get(sid)
-                            if session:
-                                detail_worker.request(session)
 
                     next_refresh = now + max(0.2, interval)
 
@@ -1221,6 +1412,7 @@ def run_watch_tui(
                     filter_text=text_filter,
                     flash_message=flash_message,
                     palette=palette,
+                    restore_mode=restore_mode,
                 )
 
                 key = stdscr.getch()
@@ -1247,10 +1439,11 @@ def run_watch_tui(
                     continue
 
                 if key in (ord("r"),):
-                    for sid in expanded_session_ids:
-                        session = latest_by_id.get(sid)
-                        if session:
-                            detail_worker.request(session)
+                    if detail_worker:
+                        for sid in expanded_session_ids:
+                            session = latest_by_id.get(sid)
+                            if session:
+                                detail_worker.request(session)
                     next_refresh = 0.0
                     continue
 
@@ -1271,9 +1464,24 @@ def run_watch_tui(
                         expanded_session_ids.remove(selected_session_id)
                     else:
                         expanded_session_ids.add(selected_session_id)
-                        if selected:
+                        if selected and detail_worker:
                             detail_worker.request(selected)
                     next_refresh = 0.0
+                    continue
+
+                if restore_mode and key in (ord("C"),):
+                    expanded_session_ids.clear()
+                    next_refresh = 0.0
+                    continue
+
+                if restore_mode and key in (ord("E"),):
+                    expanded_session_ids.update(selectable)
+                    next_refresh = 0.0
+                    continue
+
+                if restore_mode and key in (ord("s"), ord("+"), ord("K"), ord("n"), ord("A"), ord("X")):
+                    flash_message = "Not available in restore mode"
+                    flash_until = time.monotonic() + 2.0
                     continue
 
                 if key in (ord("s"),):
@@ -1447,6 +1655,24 @@ def run_watch_tui(
                         flash_message = "No session selected"
                         flash_until = time.monotonic() + 2.0
                         continue
+                    if restore_mode:
+                        result = client.restore_session_result(selected_session_id)
+                        if result.get("unavailable"):
+                            flash_message = "Session manager unavailable"
+                        elif result.get("ok"):
+                            restored = result.get("data") or selected
+                            selected_session_id = restored.get("id") or selected_session_id
+                            tmux_session = restored.get("tmux_session")
+                            if can_attach_session(restored) and tmux_session:
+                                _attach_tmux(stdscr, tmux_session)
+                                flash_message = f"Restored {selected_session_id}"
+                            else:
+                                flash_message = f"Restored {selected_session_id} (headless)"
+                        else:
+                            flash_message = str(result.get("detail") or result.get("error") or "Failed to restore session")
+                        flash_until = time.monotonic() + 2.5
+                        next_refresh = 0.0
+                        continue
                     if not can_attach_session(selected):
                         flash_message = "no terminal (use s to send)"
                         flash_until = time.monotonic() + 2.5
@@ -1459,7 +1685,8 @@ def run_watch_tui(
                     _attach_tmux(stdscr, tmux_session)
                     next_refresh = 0.0
         finally:
-            detail_worker.stop()
+            if detail_worker:
+                detail_worker.stop()
 
     curses.wrapper(_loop)
     return 0

--- a/src/models.py
+++ b/src/models.py
@@ -328,6 +328,7 @@ class Session:
     completion_message: Optional[str] = None  # Message when completed
     spawned_at: Optional[datetime] = None  # When this session was spawned
     completed_at: Optional[datetime] = None  # When this session completed
+    stopped_at: Optional[datetime] = None  # When this session was explicitly retired/stopped
     tokens_used: int = 0  # Approximate token count
     tools_used: dict[str, int] = field(default_factory=dict)  # {"Read": 5, "Write": 3}
     last_tool_call: Optional[datetime] = None  # Last tool usage timestamp
@@ -417,6 +418,7 @@ class Session:
             "completion_message": self.completion_message,
             "spawned_at": self.spawned_at.isoformat() if self.spawned_at else None,
             "completed_at": self.completed_at.isoformat() if self.completed_at else None,
+            "stopped_at": self.stopped_at.isoformat() if self.stopped_at else None,
             "tokens_used": self.tokens_used,
             "tools_used": self.tools_used,
             "last_tool_call": self.last_tool_call.isoformat() if self.last_tool_call else None,
@@ -508,6 +510,7 @@ class Session:
             completion_message=data.get("completion_message"),
             spawned_at=datetime.fromisoformat(data["spawned_at"]) if data.get("spawned_at") else None,
             completed_at=datetime.fromisoformat(data["completed_at"]) if data.get("completed_at") else None,
+            stopped_at=datetime.fromisoformat(data["stopped_at"]) if data.get("stopped_at") else None,
             tokens_used=data.get("tokens_used", 0),
             tools_used=data.get("tools_used", {}),
             last_tool_call=datetime.fromisoformat(data["last_tool_call"]) if data.get("last_tool_call") else None,

--- a/src/server.py
+++ b/src/server.py
@@ -509,6 +509,8 @@ class SessionResponse(BaseModel):
     status: str
     created_at: str
     last_activity: str
+    completed_at: Optional[str] = None
+    stopped_at: Optional[str] = None
     tmux_session: str
     provider: Optional[str] = "claude"
     friendly_name: Optional[str] = None
@@ -1836,6 +1838,8 @@ def create_app(
             status=session.status.value,
             created_at=session.created_at.isoformat(),
             last_activity=session.last_activity.isoformat(),
+            completed_at=session.completed_at.isoformat() if session.completed_at else None,
+            stopped_at=session.stopped_at.isoformat() if session.stopped_at else None,
             tmux_session=session.tmux_session,
             provider=provider,
             friendly_name=_effective_session_name(

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -1251,8 +1251,10 @@ class SessionManager:
                 session.status = SessionStatus.IDLE
             elif state in ("shutdown", "error"):
                 session.status = SessionStatus.STOPPED
+                session.stopped_at = now
             else:
                 session.status = SessionStatus.RUNNING
+                session.stopped_at = None
             session.last_activity = now
 
             if self.message_queue_manager:
@@ -4997,11 +4999,13 @@ class SessionManager:
         self.codex_last_delta_at.pop(session_id, None)
         self.codex_wait_states.pop(session_id, None)
 
+        now = datetime.now()
         session.status = SessionStatus.STOPPED
         session.completion_status = CompletionStatus.KILLED
         session.completion_message = reason
         session.error_message = reason
-        session.last_activity = datetime.now()
+        session.last_activity = now
+        session.stopped_at = now
         with contextlib.suppress(Exception):
             self.codex_event_store.append_event(
                 session_id=session_id,
@@ -5469,10 +5473,12 @@ class SessionManager:
                     cause_event_type="session_killed",
                 )
             self.tmux.kill_session(session.tmux_session)
+        now = datetime.now()
         session.status = SessionStatus.STOPPED
         session.completion_status = CompletionStatus.KILLED
         session.completion_message = "Terminated via sm kill"
-        session.completed_at = datetime.now()
+        session.completed_at = now
+        session.stopped_at = now
         self.unregister_session_roles(session_id, persist=False)
         self._save_state()
 
@@ -5582,6 +5588,7 @@ class SessionManager:
         session.completion_message = None
         session.completed_at = None
         session.agent_task_completed_at = None
+        session.stopped_at = None
         session.status = SessionStatus.IDLE if session.provider == "codex-app" else SessionStatus.RUNNING
         session.last_activity = datetime.now()
         if session.provider == "codex-fork":

--- a/tests/unit/test_cmd_watch.py
+++ b/tests/unit/test_cmd_watch.py
@@ -28,6 +28,8 @@ def test_cmd_watch_delegates_to_watch_tui():
         repo_filter="/tmp/repo",
         role_filter="engineer",
         interval=2.5,
+        restore_mode=False,
+        top_level=False,
     )
 
 
@@ -49,3 +51,19 @@ def test_main_watch_rejects_managed_session_before_dispatch():
 
     assert exc_info.value.code == 1
     mock_cmd_watch.assert_not_called()
+
+def test_cmd_watch_delegates_restore_mode_to_watch_tui():
+    client = MagicMock()
+    with patch.dict(os.environ, {"CLAUDE_SESSION_MANAGER_ID": ""}, clear=False):
+        with patch("src.cli.watch_tui.run_watch_tui", return_value=0) as mock_run:
+            rc = cmd_watch(client, repo=None, role=None, interval=1.0, restore_mode=True, top_level=True)
+
+    assert rc == 0
+    mock_run.assert_called_once_with(
+        client=client,
+        repo_filter=None,
+        role_filter=None,
+        interval=1.0,
+        restore_mode=True,
+        top_level=True,
+    )

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -48,6 +48,7 @@ class TestSession:
             completion_message="Task completed",
             spawned_at=datetime(2024, 1, 15, 10, 0, 0),
             completed_at=datetime(2024, 1, 15, 12, 0, 0),
+            stopped_at=datetime(2024, 1, 15, 12, 5, 0),
             tokens_used=5000,
             tools_used={"Read": 10, "Write": 5},
             last_tool_call=datetime(2024, 1, 15, 11, 30, 0),
@@ -86,6 +87,7 @@ class TestSession:
         assert restored.completion_message == original.completion_message
         assert restored.spawned_at == original.spawned_at
         assert restored.completed_at == original.completed_at
+        assert restored.stopped_at == original.stopped_at
         assert restored.tokens_used == original.tokens_used
         assert restored.tools_used == original.tools_used
         assert restored.last_tool_call == original.last_tool_call
@@ -117,6 +119,7 @@ class TestSession:
         assert session.tools_used == {}
         assert session.touched_repos == set()
         assert session.worktrees == []
+        assert session.stopped_at is None
         assert session.role is None
 
     def test_tmux_session_auto_generated(self):

--- a/tests/unit/test_watch_tui.py
+++ b/tests/unit/test_watch_tui.py
@@ -16,6 +16,7 @@ from src.cli.watch_tui import (
     _retire_confirmation_matches,
     _resolve_create_provider,
     _session_line,
+    build_restore_rows,
     build_watch_rows,
     can_attach_session,
     filter_sessions,
@@ -51,11 +52,19 @@ def _session(
     agent_status_at: str | None = None,
     agent_task_completed_at: str | None = None,
     pending_adoption_proposals: list[dict] | None = None,
+    friendly_name: str | None = None,
+    current_task: str | None = None,
+    aliases: list[str] | None = None,
+    stopped_at: str | None = None,
+    completed_at: str | None = None,
+    tmux_session: str | None = None,
+    provider_resume_id: str | None = None,
+    codex_thread_id: str | None = None,
 ):
     return {
         "id": session_id,
         "name": name,
-        "friendly_name": None,
+        "friendly_name": friendly_name,
         "working_dir": working_dir,
         "parent_session_id": parent_session_id,
         "role": role,
@@ -63,6 +72,11 @@ def _session(
         "activity_state": activity_state,
         "status": status,
         "last_activity": "2026-02-21T23:00:00",
+        "stopped_at": stopped_at,
+        "completed_at": completed_at,
+        "tmux_session": tmux_session or f"{provider}-{session_id}",
+        "provider_resume_id": provider_resume_id,
+        "codex_thread_id": codex_thread_id,
         "last_tool_name": last_tool_name,
         "last_tool_call": last_tool_call,
         "last_action_summary": last_action_summary,
@@ -73,6 +87,8 @@ def _session(
         "agent_status_at": agent_status_at,
         "agent_task_completed_at": agent_task_completed_at,
         "pending_adoption_proposals": pending_adoption_proposals or [],
+        "current_task": current_task,
+        "aliases": aliases or [],
     }
 
 
@@ -704,3 +720,79 @@ def test_detail_worker_does_not_block_request_path():
     assert snapshot.loading is False
     assert any("Read" in line for line in snapshot.action_lines)
     assert any("one" in line for line in snapshot.tail_lines)
+
+def test_filter_sessions_matches_restore_search_fields():
+    sessions = [
+        _session(
+            "parent1",
+            "em-parent",
+            "/tmp/repo-a",
+            provider="claude",
+            status="running",
+        ),
+        _session(
+            "child1",
+            "child",
+            "/tmp/repo-b",
+            parent_session_id="parent1",
+            provider="codex-fork",
+            status="stopped",
+            current_task="audit replay",
+            aliases=["reviewer-alias"],
+        ),
+    ]
+
+    assert [s["id"] for s in filter_sessions(sessions, text_filter="codex-fork")] == ["child1"]
+    assert [s["id"] for s in filter_sessions(sessions, text_filter="audit replay")] == ["child1"]
+    assert [s["id"] for s in filter_sessions(sessions, text_filter="reviewer-alias")] == ["child1"]
+    assert [s["id"] for s in filter_sessions(sessions, text_filter="em-parent")] == ["parent1", "child1"]
+
+
+def test_build_restore_rows_only_stopped_with_restore_columns():
+    sessions = [
+        _session("run1", "running", "/tmp/repo", status="running"),
+        _session(
+            "stop1",
+            "stopped-agent",
+            "/tmp/repo",
+            status="stopped",
+            provider="codex",
+            stopped_at="2026-02-21T22:00:00",
+        ),
+    ]
+
+    rows, selectable, repo_count = build_restore_rows(
+        [s for s in sessions if s["status"] == "stopped"],
+        all_sessions=sessions,
+    )
+
+    assert repo_count == 1
+    assert selectable == ["stop1"]
+    session_row = next(row for row in rows if row.kind == "session")
+    assert session_row.columns["ID"] == "stop1"
+    assert session_row.columns["Provider"] == "codex"
+    assert session_row.columns["Repo"] == "repo/"
+    assert session_row.columns["Retired"] != "-"
+    assert session_row.columns["Restore"] == "ready"
+
+
+def test_build_restore_rows_top_level_collapses_children_until_expanded():
+    sessions = [
+        _session("p1", "parent", "/tmp/repo", status="stopped"),
+        _session("c1", "child", "/tmp/repo", status="stopped", parent_session_id="p1"),
+    ]
+
+    rows, selectable, _ = build_restore_rows(sessions, top_level_only=True)
+    assert selectable == ["p1"]
+    assert all(row.session_id != "c1" for row in rows)
+
+    rows, selectable, _ = build_restore_rows(sessions, expanded_session_ids={"p1"}, top_level_only=True)
+    assert selectable == ["p1", "c1"]
+    child_row = next(row for row in rows if row.session_id == "c1")
+    assert child_row.columns["Session"].startswith("   `-child")
+
+
+def test_can_attach_session_supports_tmux_backed_codex_only():
+    assert can_attach_session(_session("c1", "codex", "/tmp", provider="codex"))
+    assert can_attach_session(_session("f1", "fork", "/tmp", provider="codex-fork"))
+    assert not can_attach_session(_session("a1", "app", "/tmp", provider="codex-app"))


### PR DESCRIPTION
## Summary
- add `sm watch --restore` and `--top-level` for browsing stopped restorable sessions
- persist and expose `Session.stopped_at` so restore mode can show retired age without live probes
- restore selected sessions from the TUI and attach tmux-backed Claude/Codex sessions after restore

Fixes #683

## Tests
- `./venv/bin/python -m pytest tests/unit/test_watch_tui.py tests/unit/test_cmd_watch.py tests/unit/test_models.py tests/unit/test_watch_api_309.py -q`
- `./venv/bin/python -m pytest tests/unit -q`
- `./venv/bin/python -m src.cli.main watch --help | sed -n '1,80p'`