### PR TITLE
Fix restore watch controls

### DIFF
--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -3175,6 +3175,7 @@ def cmd_watch(
     interval: float = 2.0,
     restore_mode: bool = False,
     top_level: bool = False,
+    restore_sort: str = "retired",
 ) -> int:
     """Launch interactive watch dashboard."""
     if os.environ.get("CLAUDE_SESSION_MANAGER_ID"):
@@ -3198,6 +3199,7 @@ def cmd_watch(
         interval=interval,
         restore_mode=restore_mode,
         top_level=top_level,
+        restore_sort=restore_sort,
     )
 
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -609,6 +609,12 @@ def main():
         action="store_true",
         help="In --restore mode, start with only top-level stopped sessions expanded on demand",
     )
+    watch_parser.add_argument(
+        "--sort",
+        choices=("retired", "last-active", "name"),
+        default="retired",
+        help="In --restore mode, initial sort order (default: retired)",
+    )
 
     # sm tail <session> [-n N] [--raw] [--db-path PATH]
     tail_parser = subparsers.add_parser(
@@ -1128,6 +1134,7 @@ def main():
             interval=args.interval,
             restore_mode=args.restore,
             top_level=args.top_level,
+            restore_sort=args.sort,
         ))
     elif args.command == "tail":
         sys.exit(commands.cmd_tail(

--- a/src/cli/watch_tui.py
+++ b/src/cli/watch_tui.py
@@ -803,12 +803,15 @@ def build_restore_rows(
     stopped_sessions: list[dict],
     all_sessions: Optional[list[dict]] = None,
     expanded_session_ids: Optional[set[str]] = None,
+    collapsed_session_ids: Optional[set[str]] = None,
     top_level_only: bool = False,
+    sort_mode: str = "retired",
 ) -> tuple[list[WatchRow], list[str], int]:
     """Build grouped restore-browser rows for stopped sessions."""
     rows: list[WatchRow] = []
     selectable: list[str] = []
     expanded = expanded_session_ids or set()
+    collapsed = collapsed_session_ids or set()
     stopped_by_id = {session["id"]: session for session in stopped_sessions if session.get("id")}
     sessions_by_id = {
         session["id"]: session
@@ -833,11 +836,27 @@ def build_restore_rows(
         else:
             roots_by_repo.setdefault(key, []).append(session)
 
-    sort_key = lambda s: (_session_name(s).lower(), s.get("id", ""))
+    def _timestamp_sort_value(ts: Optional[str]) -> float:
+        parsed = _parse_iso(ts)
+        if not parsed:
+            return float("-inf")
+        try:
+            return parsed.timestamp()
+        except Exception:
+            return float("-inf")
+
+    def restore_sort_key(session: dict):
+        name_key = (_session_name(session).lower(), session.get("id", ""))
+        if sort_mode == "last-active":
+            return (-_timestamp_sort_value(session.get("last_activity")), *name_key)
+        if sort_mode == "retired":
+            return (-_timestamp_sort_value(session.get("stopped_at") or session.get("completed_at") or session.get("last_activity")), *name_key)
+        return name_key
+
     for root_list in roots_by_repo.values():
-        root_list.sort(key=sort_key)
+        root_list.sort(key=restore_sort_key)
     for child_list in children_by_parent.values():
-        child_list.sort(key=sort_key)
+        child_list.sort(key=restore_sort_key)
 
     def _tree_prefix(ancestors_last: list[bool], is_last: bool) -> str:
         connector = "`-" if is_last else "|-"
@@ -872,7 +891,7 @@ def build_restore_rows(
         if session_id:
             selectable.append(session_id)
 
-        if top_level_only and session_id not in expanded:
+        if (top_level_only and session_id not in expanded) or session_id in collapsed:
             return
         children = children_by_parent.get(session_id or "", [])
         for idx, child in enumerate(children):
@@ -1228,6 +1247,7 @@ def _render(
     flash_message: Optional[str],
     palette: dict[str, int],
     restore_mode: bool = False,
+    restore_sort: str = "retired",
 ):
     stdscr.erase()
     height, width = stdscr.getmaxyx()
@@ -1281,7 +1301,7 @@ def _render(
         )
 
     if restore_mode:
-        footer = "j/k: move  Enter: restore+attach  Tab: expand/collapse  E: expand all  C: collapse all  /: search  r: refresh  q: quit"
+        footer = f"j/k: move  Enter: restore+attach  o: sort={restore_sort}  Tab: expand/collapse  E: expand all  C: collapse all  /: search  r: refresh  q: quit"
     else:
         footer = "j/k: move  +: create  Enter: attach  s: send  K,K: retire  n: rename  A/X: adopt  Tab: details  /: filter  r: refresh  q: quit"
     stdscr.addnstr(height - 1, 0, footer, _render_columns(width, 0, reserve_last_cell=True))
@@ -1295,6 +1315,7 @@ def run_watch_tui(
     interval: float = 2.0,
     restore_mode: bool = False,
     top_level: bool = False,
+    restore_sort: str = "retired",
 ) -> int:
     """Run the sm watch curses UI."""
 
@@ -1321,6 +1342,9 @@ def run_watch_tui(
             latest_sessions: list[dict] = []
             latest_by_id: dict[str, dict] = {}
             expanded_session_ids: set[str] = set()
+            collapsed_session_ids: set[str] = set()
+            restore_tree_collapsed = top_level
+            restore_sort_mode = restore_sort
             repo_count = 0
             total_sessions = 0
             spinner_index = 0
@@ -1350,7 +1374,9 @@ def run_watch_tui(
                                 latest_sessions,
                                 all_sessions=listed,
                                 expanded_session_ids=expanded_session_ids,
-                                top_level_only=top_level,
+                                collapsed_session_ids=collapsed_session_ids,
+                                top_level_only=restore_tree_collapsed,
+                                sort_mode=restore_sort_mode,
                             )
                         else:
                             latest_sessions = filtered
@@ -1413,6 +1439,7 @@ def run_watch_tui(
                     flash_message=flash_message,
                     palette=palette,
                     restore_mode=restore_mode,
+                    restore_sort=restore_sort_mode,
                 )
 
                 key = stdscr.getch()
@@ -1460,6 +1487,19 @@ def run_watch_tui(
                 if key == 9:  # Tab
                     if not selected_session_id:
                         continue
+                    if restore_mode:
+                        if restore_tree_collapsed:
+                            if selected_session_id in expanded_session_ids:
+                                expanded_session_ids.remove(selected_session_id)
+                            else:
+                                expanded_session_ids.add(selected_session_id)
+                        else:
+                            if selected_session_id in collapsed_session_ids:
+                                collapsed_session_ids.remove(selected_session_id)
+                            else:
+                                collapsed_session_ids.add(selected_session_id)
+                        next_refresh = 0.0
+                        continue
                     if selected_session_id in expanded_session_ids:
                         expanded_session_ids.remove(selected_session_id)
                     else:
@@ -1470,12 +1510,23 @@ def run_watch_tui(
                     continue
 
                 if restore_mode and key in (ord("C"),):
+                    restore_tree_collapsed = True
                     expanded_session_ids.clear()
+                    collapsed_session_ids.clear()
                     next_refresh = 0.0
                     continue
 
                 if restore_mode and key in (ord("E"),):
-                    expanded_session_ids.update(selectable)
+                    restore_tree_collapsed = False
+                    expanded_session_ids.clear()
+                    collapsed_session_ids.clear()
+                    next_refresh = 0.0
+                    continue
+
+                if restore_mode and key in (ord("o"),):
+                    order = ["retired", "last-active", "name"]
+                    current_idx = order.index(restore_sort_mode) if restore_sort_mode in order else 0
+                    restore_sort_mode = order[(current_idx + 1) % len(order)]
                     next_refresh = 0.0
                     continue
 

--- a/tests/unit/test_cmd_watch.py
+++ b/tests/unit/test_cmd_watch.py
@@ -30,6 +30,7 @@ def test_cmd_watch_delegates_to_watch_tui():
         interval=2.5,
         restore_mode=False,
         top_level=False,
+        restore_sort="retired",
     )
 
 
@@ -56,7 +57,15 @@ def test_cmd_watch_delegates_restore_mode_to_watch_tui():
     client = MagicMock()
     with patch.dict(os.environ, {"CLAUDE_SESSION_MANAGER_ID": ""}, clear=False):
         with patch("src.cli.watch_tui.run_watch_tui", return_value=0) as mock_run:
-            rc = cmd_watch(client, repo=None, role=None, interval=1.0, restore_mode=True, top_level=True)
+            rc = cmd_watch(
+                client,
+                repo=None,
+                role=None,
+                interval=1.0,
+                restore_mode=True,
+                top_level=True,
+                restore_sort="last-active",
+            )
 
     assert rc == 0
     mock_run.assert_called_once_with(
@@ -66,4 +75,5 @@ def test_cmd_watch_delegates_restore_mode_to_watch_tui():
         interval=1.0,
         restore_mode=True,
         top_level=True,
+        restore_sort="last-active",
     )

--- a/tests/unit/test_watch_tui.py
+++ b/tests/unit/test_watch_tui.py
@@ -792,6 +792,45 @@ def test_build_restore_rows_top_level_collapses_children_until_expanded():
     assert child_row.columns["Session"].startswith("   `-child")
 
 
+
+
+def test_build_restore_rows_sorts_by_retired_descending_by_default():
+    sessions = [
+        _session("old", "old", "/tmp/repo", status="stopped", stopped_at="2026-02-21T20:00:00"),
+        _session("new", "new", "/tmp/repo", status="stopped", stopped_at="2026-02-21T22:00:00"),
+    ]
+
+    _, selectable, _ = build_restore_rows(sessions)
+
+    assert selectable == ["new", "old"]
+
+
+def test_build_restore_rows_sorts_by_last_active_or_name():
+    sessions = [
+        _session("beta", "beta", "/tmp/repo", status="stopped", last_action_at=None),
+        _session("alpha", "alpha", "/tmp/repo", status="stopped", last_action_at=None),
+    ]
+    sessions[0]["last_activity"] = "2026-02-21T21:00:00"
+    sessions[1]["last_activity"] = "2026-02-21T22:00:00"
+
+    _, selectable, _ = build_restore_rows(sessions, sort_mode="last-active")
+    assert selectable == ["alpha", "beta"]
+
+    _, selectable, _ = build_restore_rows(sessions, sort_mode="name")
+    assert selectable == ["alpha", "beta"]
+
+
+def test_build_restore_rows_collapsed_session_hides_children_when_default_expanded():
+    sessions = [
+        _session("p1", "parent", "/tmp/repo", status="stopped"),
+        _session("c1", "child", "/tmp/repo", status="stopped", parent_session_id="p1"),
+    ]
+
+    rows, selectable, _ = build_restore_rows(sessions, collapsed_session_ids={"p1"})
+
+    assert selectable == ["p1"]
+    assert all(row.session_id != "c1" for row in rows)
+
 def test_can_attach_session_supports_tmux_backed_codex_only():
     assert can_attach_session(_session("c1", "codex", "/tmp", provider="codex"))
     assert can_attach_session(_session("f1", "fork", "/tmp", provider="codex-fork"))


### PR DESCRIPTION
## Summary
- add restore watch sorting via `--sort retired|last-active|name` and in-TUI `o` cycling
- make restore-mode `C`, `E`, and `Tab` visibly control tree expansion in default and top-level modes
- add regression coverage for restore sort order and collapsed subtree rendering

Fixes #686

## Tests
- `./venv/bin/python -m pytest tests/unit/test_watch_tui.py tests/unit/test_cmd_watch.py -q`
- `./venv/bin/python -m src.cli.main watch --help | sed -n '1,90p'`