### PR TITLE
[#690] Use SM tmux socket for native scrollback

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -26,6 +26,22 @@ worktree_cleanup:
   # Send "[sm info] Uncommitted changes in worktree(s)" notices after turns
   notify_dirty: true
 
+# tmux runtime configuration for managed Claude/Codex terminal sessions
+tmux:
+  # Optional SM-owned tmux socket. When set, new managed sessions use this
+  # server instead of the user's default tmux server, allowing SM-specific
+  # terminal behavior without mutating unrelated tmux sessions.
+  socket_name: "session-manager"
+
+  # When socket_name is set, prevent tmux from taking over the caller
+  # terminal's alternate screen so live attached output can enter native
+  # terminal scrollback.
+  native_scrollback: true
+
+  # Retained tmux pane history for new provider windows. tmux applies this
+  # only to windows created after the option is set.
+  history_limit: 100000
+
 # Timeout and delay configuration (all values in seconds unless specified)
 timeouts:
   # Tmux session creation and interaction timeouts

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -32,6 +32,55 @@ from ..codex_provider_policy import (
 _SEND_KEYS_SETTLE_SECONDS = 0.3
 
 
+def _tmux_command(args: list[str], tmux_socket_name: Optional[str] = None) -> list[str]:
+    """Build a tmux command, using an SM-owned socket when provided."""
+    cmd = ["tmux"]
+    if tmux_socket_name:
+        cmd.extend(["-L", tmux_socket_name])
+    cmd.extend(args)
+    return cmd
+
+
+def _tmux_socket_from_descriptor(descriptor: Optional[dict]) -> Optional[str]:
+    """Return the tmux socket name from an attach descriptor when present."""
+    if not isinstance(descriptor, dict):
+        return None
+    socket_name = str(descriptor.get("tmux_socket_name") or "").strip()
+    return socket_name or None
+
+
+def _attach_tmux_session(tmux_session: str, descriptor: Optional[dict] = None) -> int:
+    """Attach the current terminal to a tmux session."""
+    tmux_socket_name = _tmux_socket_from_descriptor(descriptor)
+    try:
+        subprocess.run(
+            _tmux_command(["attach", "-t", tmux_session], tmux_socket_name),
+            check=True,
+        )
+        return 0
+    except subprocess.CalledProcessError:
+        print(f"Error: Failed to attach to tmux session {tmux_session}", file=sys.stderr)
+        return 1
+    except FileNotFoundError:
+        print("Error: tmux not found. Is tmux installed?", file=sys.stderr)
+        return 1
+
+
+def _capture_tmux_pane(tmux_session: str, lines: int, descriptor: Optional[dict] = None) -> Optional[str]:
+    """Capture recent output from a tmux pane using descriptor socket metadata."""
+    tmux_socket_name = _tmux_socket_from_descriptor(descriptor)
+    try:
+        result = subprocess.run(
+            _tmux_command(["capture-pane", "-t", tmux_session, "-p", "-S", f"-{lines}"], tmux_socket_name),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+
 def _get_codex_app_policy_for_cli(client: SessionManagerClient) -> dict:
     """Get codex-app migration policy from rollout flags (or local defaults)."""
     rollout_flags = client.get_rollout_flags() or {}
@@ -2126,7 +2175,10 @@ def _query_last_tool(session_id: str, db_path: str) -> Optional[dict]:
     }
 
 
-def _get_tmux_session_activity(tmux_session_name: str) -> Optional[int]:
+def _get_tmux_session_activity(
+    tmux_session_name: str,
+    tmux_socket_name: Optional[str] = None,
+) -> Optional[int]:
     """
     Returns Unix epoch of last tmux session activity via:
       tmux display-message -p -t <name> '#{session_activity}'
@@ -2134,7 +2186,10 @@ def _get_tmux_session_activity(tmux_session_name: str) -> Optional[int]:
     """
     try:
         result = subprocess.run(
-            ["tmux", "display-message", "-p", "-t", tmux_session_name, "#{session_activity}"],
+            _tmux_command(
+                ["display-message", "-p", "-t", tmux_session_name, "#{session_activity}"],
+                tmux_socket_name,
+            ),
             capture_output=True,
             text=True,
             timeout=3,
@@ -2280,15 +2335,15 @@ def cmd_children(
                                     last_tool_str = f"{tool_name} ({_format_thinking_duration(delta_s)} ago)"
 
                 elif provider == "codex":
-                    tmux_name = f"codex-{child_id}"
-                    epoch = _get_tmux_session_activity(tmux_name)
+                    tmux_name = child.get("tmux_session") or f"codex-{child_id}"
+                    epoch = _get_tmux_session_activity(tmux_name, child.get("tmux_socket_name"))
                     if epoch is not None:
                         delta_s = max(0, int(time.time() - epoch))
                         thinking_str = _format_thinking_duration(delta_s)
                     last_tool_str = "n/a (no hooks)"
                 elif provider == "codex-fork":
-                    tmux_name = f"codex-fork-{child_id}"
-                    epoch = _get_tmux_session_activity(tmux_name)
+                    tmux_name = child.get("tmux_session") or f"codex-fork-{child_id}"
+                    epoch = _get_tmux_session_activity(tmux_name, child.get("tmux_socket_name"))
                     if epoch is not None:
                         delta_s = max(0, int(time.time() - epoch))
                         thinking_str = _format_thinking_duration(delta_s)
@@ -2455,7 +2510,6 @@ def cmd_new(
         2: Session manager unavailable
     """
     import os
-    import subprocess
     import time
     from pathlib import Path
 
@@ -2518,16 +2572,8 @@ def cmd_new(
     # Wait briefly for Claude to initialize
     time.sleep(1)
 
-    # Attach to tmux session (blocks until detach)
-    try:
-        subprocess.run(["tmux", "attach", "-t", tmux_session], check=True)
-        return 0
-    except subprocess.CalledProcessError:
-        print(f"Error: Failed to attach to tmux session {tmux_session}", file=sys.stderr)
-        return 1
-    except FileNotFoundError:
-        print("Error: tmux not found. Is tmux installed?", file=sys.stderr)
-        return 1
+    descriptor = client.get_attach_descriptor(session_id) if session_id else None
+    return _attach_tmux_session(tmux_session, descriptor)
 
 
 def cmd_codex_2(
@@ -2605,8 +2651,6 @@ def cmd_attach(client: SessionManagerClient, identifier: Optional[str] = None) -
         1: No sessions available or invalid selection
         2: Session manager unavailable
     """
-    import subprocess
-
     def _attach_with_descriptor(session: dict) -> int:
         session_id = session.get("id")
         descriptor = client.get_attach_descriptor(session_id) if session_id else None
@@ -2628,15 +2672,7 @@ def cmd_attach(client: SessionManagerClient, identifier: Optional[str] = None) -
             print("Error: Session has no tmux session", file=sys.stderr)
             return 1
 
-        try:
-            subprocess.run(["tmux", "attach", "-t", tmux_session], check=True)
-            return 0
-        except subprocess.CalledProcessError:
-            print(f"Error: Failed to attach to tmux session {tmux_session}", file=sys.stderr)
-            return 1
-        except FileNotFoundError:
-            print("Error: tmux not found. Is tmux installed?", file=sys.stderr)
-            return 1
+        return _attach_tmux_session(tmux_session, descriptor)
 
     # Case 1: Direct attach with identifier
     if identifier:
@@ -2725,8 +2761,6 @@ def cmd_output(client: SessionManagerClient, identifier: str, lines: int) -> int
         1: Session not found or no tmux session
         2: Session manager unavailable
     """
-    from ..tmux_controller import TmuxController
-
     # Resolve identifier to session ID and get session details
     session_id, session = resolve_session_id(client, identifier)
     if session_id is None:
@@ -2754,9 +2788,8 @@ def cmd_output(client: SessionManagerClient, identifier: str, lines: int) -> int
         print(f"Error: Session has no tmux session", file=sys.stderr)
         return 1
 
-    # Capture pane output
-    tmux_controller = TmuxController()
-    output = tmux_controller.capture_pane(tmux_session, lines=lines)
+    descriptor = client.get_attach_descriptor(session_id)
+    output = _capture_tmux_pane(tmux_session, lines=lines, descriptor=descriptor)
 
     if output is None:
         print(f"Error: Failed to capture output from {tmux_session}", file=sys.stderr)
@@ -3273,9 +3306,8 @@ def cmd_tail(
             print("Error: Session has no tmux session", file=sys.stderr)
             return 1
 
-        from ..tmux_controller import TmuxController
-        tmux = TmuxController()
-        output = tmux.capture_pane(tmux_session, lines=n)
+        descriptor = client.get_attach_descriptor(session_id)
+        output = _capture_tmux_pane(tmux_session, lines=n, descriptor=descriptor)
         if output is None:
             print(f"Error: Failed to capture output from {tmux_session}", file=sys.stderr)
             return 1
@@ -4367,7 +4399,10 @@ def cmd_review(
 
 
 def _wait_for_claude_prompt(
-    tmux_session: str, timeout: float = 3.0, poll_interval: float = 0.1
+    tmux_session: str,
+    timeout: float = 3.0,
+    poll_interval: float = 0.1,
+    tmux_socket_name: Optional[str] = None,
 ) -> bool:
     """Poll capture-pane until Claude Code shows bare '>' prompt, or timeout.
 
@@ -4381,7 +4416,7 @@ def _wait_for_claude_prompt(
     while time.monotonic() < deadline:
         try:
             result = subprocess.run(
-                ["tmux", "capture-pane", "-p", "-t", tmux_session],
+                _tmux_command(["capture-pane", "-p", "-t", tmux_session], tmux_socket_name),
                 capture_output=True,
                 text=True,
                 timeout=2,
@@ -4475,6 +4510,8 @@ def cmd_clear(
     if not tmux_session:
         print(f"Error: Session {target_session_id} has no tmux session", file=sys.stderr)
         return 1
+    descriptor = client.get_attach_descriptor(target_session_id)
+    tmux_socket_name = _tmux_socket_from_descriptor(descriptor) or session.get("tmux_socket_name")
 
     clear_command = "/new" if provider in ("codex", "codex-fork") else "/clear"
 
@@ -4503,56 +4540,56 @@ def cmd_clear(
         if completion_status == "completed":
             # Wake up the session by sending Enter
             subprocess.run(
-                ["tmux", "send-keys", "-t", tmux_session, "Enter"],
+                _tmux_command(["send-keys", "-t", tmux_session, "Enter"], tmux_socket_name),
                 check=True,
                 capture_output=True,
                 text=True,
             )
             # Wait for Claude to show prompt after wake-up (#175)
-            _wait_for_claude_prompt(tmux_session)
+            _wait_for_claude_prompt(tmux_session, tmux_socket_name=tmux_socket_name)
 
         # First, send ESC to interrupt any ongoing stream
         subprocess.run(
-            ["tmux", "send-keys", "-t", tmux_session, "Escape"],
+            _tmux_command(["send-keys", "-t", tmux_session, "Escape"], tmux_socket_name),
             check=True,
             capture_output=True,
             text=True,
         )
 
         # Wait for Claude to show idle prompt before sending payload (#175)
-        _wait_for_claude_prompt(tmux_session)
+        _wait_for_claude_prompt(tmux_session, tmux_socket_name=tmux_socket_name)
 
         # Send clear command, then Enter as a separate call after a settle delay (#178).
         # Sending text+"\r" atomically fails because Claude Code (Node.js TUI in raw
         # mode) treats the rapid burst as pasted text, in which \r is literal, not submit.
         subprocess.run(
-            ["tmux", "send-keys", "-t", tmux_session, "--", clear_command],
+            _tmux_command(["send-keys", "-t", tmux_session, "--", clear_command], tmux_socket_name),
             check=True,
             capture_output=True,
             text=True,
         )
         time.sleep(_SEND_KEYS_SETTLE_SECONDS)  # Allow paste mode to end before Enter arrives
         subprocess.run(
-            ["tmux", "send-keys", "-t", tmux_session, "Enter"],
+            _tmux_command(["send-keys", "-t", tmux_session, "Enter"], tmux_socket_name),
             check=True,
             capture_output=True,
             text=True,
         )
 
         # Wait for clear to finish and prompt to reappear (#175)
-        _wait_for_claude_prompt(tmux_session, timeout=5.0)
+        _wait_for_claude_prompt(tmux_session, timeout=5.0, tmux_socket_name=tmux_socket_name)
 
         # Send new prompt if provided
         if new_prompt:
             subprocess.run(
-                ["tmux", "send-keys", "-t", tmux_session, "--", new_prompt],
+                _tmux_command(["send-keys", "-t", tmux_session, "--", new_prompt], tmux_socket_name),
                 check=True,
                 capture_output=True,
                 text=True,
             )
             time.sleep(_SEND_KEYS_SETTLE_SECONDS)  # Allow paste mode to end before Enter arrives
             subprocess.run(
-                ["tmux", "send-keys", "-t", tmux_session, "Enter"],
+                _tmux_command(["send-keys", "-t", tmux_session, "Enter"], tmux_socket_name),
                 check=True,
                 capture_output=True,
                 text=True,

--- a/src/cli/watch_tui.py
+++ b/src/cli/watch_tui.py
@@ -1161,15 +1161,25 @@ def _create_watch_session(
     tmux_session = (descriptor or {}).get("tmux_session") or session.get("tmux_session")
     if not tmux_session:
         return session, None, "Created session has no tmux target"
+    if descriptor and descriptor.get("tmux_socket_name"):
+        session["tmux_socket_name"] = descriptor.get("tmux_socket_name")
 
     return session, tmux_session, None
 
 
-def _attach_tmux(stdscr, tmux_session: str):
+def _tmux_attach_command(tmux_session: str, tmux_socket_name: str | None = None) -> list[str]:
+    cmd = ["tmux"]
+    if tmux_socket_name:
+        cmd.extend(["-L", tmux_socket_name])
+    cmd.extend(["attach-session", "-t", tmux_session])
+    return cmd
+
+
+def _attach_tmux(stdscr, tmux_session: str, tmux_socket_name: str | None = None):
     curses.def_prog_mode()
     curses.endwin()
     try:
-        subprocess.run(["tmux", "attach-session", "-t", tmux_session], check=False)
+        subprocess.run(_tmux_attach_command(tmux_session, tmux_socket_name), check=False)
     finally:
         curses.reset_prog_mode()
         curses.curs_set(0)
@@ -1634,7 +1644,7 @@ def run_watch_tui(
 
                     selected_session_id = session.get("id") or selected_session_id
                     next_refresh = 0.0
-                    _attach_tmux(stdscr, tmux_session)
+                    _attach_tmux(stdscr, tmux_session, session.get("tmux_socket_name"))
                     flash_message = f"Created {selected_session_id}"
                     flash_until = time.monotonic() + 2.5
                     next_refresh = 0.0
@@ -1743,7 +1753,7 @@ def run_watch_tui(
                             selected_session_id = restored.get("id") or selected_session_id
                             tmux_session = restored.get("tmux_session")
                             if can_attach_session(restored) and tmux_session:
-                                _attach_tmux(stdscr, tmux_session)
+                                _attach_tmux(stdscr, tmux_session, restored.get("tmux_socket_name"))
                                 flash_message = f"Restored {selected_session_id}"
                             else:
                                 flash_message = f"Restored {selected_session_id} (headless)"
@@ -1761,7 +1771,7 @@ def run_watch_tui(
                         flash_message = "Selected session has no tmux target"
                         flash_until = time.monotonic() + 2.5
                         continue
-                    _attach_tmux(stdscr, tmux_session)
+                    _attach_tmux(stdscr, tmux_session, selected.get("tmux_socket_name"))
                     next_refresh = 0.0
         finally:
             if detail_worker:

--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -148,6 +148,16 @@ class MessageQueueManager:
         # Initialize database
         self._init_db()
 
+    def _tmux_cmd_for_session(self, tmux_session: str, *args: str) -> list[str]:
+        """Build a tmux command, using SessionManager's socket-aware controller when available."""
+        tmux = getattr(self.session_manager, "tmux", None)
+        builder = getattr(tmux, "tmux_cmd_for_session", None)
+        if callable(builder):
+            cmd = builder(tmux_session, *args)
+            if isinstance(cmd, (list, tuple)):
+                return list(cmd)
+        return ["tmux", *args]
+
     def _init_db(self):
         """Initialize SQLite database schema with persistent connection."""
         # Create persistent connection with thread-safety enabled
@@ -2217,7 +2227,7 @@ class MessageQueueManager:
         """
         try:
             proc = await asyncio.create_subprocess_exec(
-                "tmux", "capture-pane", "-p", "-t", tmux_session,
+                *self._tmux_cmd_for_session(tmux_session, "capture-pane", "-p", "-t", tmux_session),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -2249,7 +2259,7 @@ class MessageQueueManager:
         """Clear the current input line using Ctrl+U (async, non-blocking)."""
         try:
             proc = await asyncio.create_subprocess_exec(
-                "tmux", "send-keys", "-t", tmux_session, "C-u",
+                *self._tmux_cmd_for_session(tmux_session, "send-keys", "-t", tmux_session, "C-u"),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -2264,7 +2274,7 @@ class MessageQueueManager:
         try:
             # Use list-based subprocess with "--" to handle text starting with "-"
             proc = await asyncio.create_subprocess_exec(
-                "tmux", "send-keys", "-t", tmux_session, "--", text,
+                *self._tmux_cmd_for_session(tmux_session, "send-keys", "-t", tmux_session, "--", text),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -2613,7 +2623,7 @@ class MessageQueueManager:
                     logger.info(f"Session {session_id} is completed, sending Enter to wake up")
                     # Send Enter to wake up the completed session
                     proc = await asyncio.create_subprocess_exec(
-                        "tmux", "send-keys", "-t", session.tmux_session, "Enter",
+                        *self._tmux_cmd_for_session(session.tmux_session, "send-keys", "-t", session.tmux_session, "Enter"),
                         stdout=asyncio.subprocess.PIPE,
                         stderr=asyncio.subprocess.PIPE,
                     )
@@ -2635,7 +2645,7 @@ class MessageQueueManager:
                     await self._wait_for_claude_prompt_async(session.tmux_session)
 
                     proc = await asyncio.create_subprocess_exec(
-                        "tmux", "send-keys", "-t", session.tmux_session, "Escape",
+                        *self._tmux_cmd_for_session(session.tmux_session, "send-keys", "-t", session.tmux_session, "Escape"),
                         stdout=asyncio.subprocess.PIPE,
                         stderr=asyncio.subprocess.PIPE,
                     )
@@ -2643,7 +2653,7 @@ class MessageQueueManager:
                 else:
                     # Non-Claude tmux providers retain the existing interrupt behavior.
                     proc = await asyncio.create_subprocess_exec(
-                        "tmux", "send-keys", "-t", session.tmux_session, "Escape",
+                        *self._tmux_cmd_for_session(session.tmux_session, "send-keys", "-t", session.tmux_session, "Escape"),
                         stdout=asyncio.subprocess.PIPE,
                         stderr=asyncio.subprocess.PIPE,
                     )
@@ -4148,7 +4158,7 @@ class MessageQueueManager:
         while asyncio.get_event_loop().time() < deadline:
             try:
                 proc = await asyncio.create_subprocess_exec(
-                    "tmux", "capture-pane", "-p", "-t", tmux_session,
+                    *self._tmux_cmd_for_session(tmux_session, "capture-pane", "-p", "-t", tmux_session),
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
@@ -4229,7 +4239,7 @@ class MessageQueueManager:
 
                 # 2. Send Escape to ensure idle
                 proc = await asyncio.create_subprocess_exec(
-                    "tmux", "send-keys", "-t", tmux_session, "Escape",
+                    *self._tmux_cmd_for_session(tmux_session, "send-keys", "-t", tmux_session, "Escape"),
                     stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
                 )
                 await asyncio.wait_for(proc.communicate(), timeout=self.subprocess_timeout)
@@ -4240,13 +4250,13 @@ class MessageQueueManager:
                 # 4. Send /clear (with settle delay before Enter)
                 clear_command = "/new" if session.provider in ("codex", "codex-fork") else "/clear"
                 proc = await asyncio.create_subprocess_exec(
-                    "tmux", "send-keys", "-t", tmux_session, "--", clear_command,
+                    *self._tmux_cmd_for_session(tmux_session, "send-keys", "-t", tmux_session, "--", clear_command),
                     stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
                 )
                 await asyncio.wait_for(proc.communicate(), timeout=self.subprocess_timeout)
                 await asyncio.sleep(0.3)  # Settle delay: allow paste mode to end before Enter
                 proc = await asyncio.create_subprocess_exec(
-                    "tmux", "send-keys", "-t", tmux_session, "Enter",
+                    *self._tmux_cmd_for_session(tmux_session, "send-keys", "-t", tmux_session, "Enter"),
                     stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
                 )
                 await asyncio.wait_for(proc.communicate(), timeout=self.subprocess_timeout)
@@ -4259,13 +4269,13 @@ class MessageQueueManager:
                 # 6. Send handoff prompt (with settle delay before Enter)
                 handoff_prompt = f"Read {file_path} and continue from where you left off."
                 proc = await asyncio.create_subprocess_exec(
-                    "tmux", "send-keys", "-t", tmux_session, "--", handoff_prompt,
+                    *self._tmux_cmd_for_session(tmux_session, "send-keys", "-t", tmux_session, "--", handoff_prompt),
                     stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
                 )
                 await asyncio.wait_for(proc.communicate(), timeout=self.subprocess_timeout)
                 await asyncio.sleep(0.3)  # Settle delay
                 proc = await asyncio.create_subprocess_exec(
-                    "tmux", "send-keys", "-t", tmux_session, "Enter",
+                    *self._tmux_cmd_for_session(tmux_session, "send-keys", "-t", tmux_session, "Enter"),
                     stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
                 )
                 await asyncio.wait_for(proc.communicate(), timeout=self.subprocess_timeout)
@@ -4290,7 +4300,7 @@ class MessageQueueManager:
         """Check if CLI is showing the input prompt (idle). Works for both Claude Code and Codex CLI."""
         try:
             proc = await asyncio.create_subprocess_exec(
-                "tmux", "capture-pane", "-p", "-t", tmux_session,
+                *self._tmux_cmd_for_session(tmux_session, "capture-pane", "-p", "-t", tmux_session),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )

--- a/src/models.py
+++ b/src/models.py
@@ -294,6 +294,7 @@ class Session:
     name: str = ""  # Internal identifier (auto-generated: claude-{id})
     working_dir: str = ""
     tmux_session: str = ""
+    tmux_socket_name: Optional[str] = None  # tmux -L socket for managed sessions; None means default server
     provider: str = "claude"  # "claude", "codex"/"codex-fork" (tmux), or "codex-app" (app-server)
     log_file: str = ""
     status: SessionStatus = SessionStatus.RUNNING
@@ -385,6 +386,7 @@ class Session:
             "name": self.name,
             "working_dir": self.working_dir,
             "tmux_session": self.tmux_session,
+            "tmux_socket_name": self.tmux_socket_name,
             "provider": self.provider,
             "log_file": self.log_file,
             "status": self.status.value,
@@ -477,6 +479,7 @@ class Session:
             name=data["name"],
             working_dir=data["working_dir"],
             tmux_session=data["tmux_session"],
+            tmux_socket_name=data.get("tmux_socket_name"),
             provider=data.get("provider", "claude"),
             log_file=data["log_file"],
             status=SessionStatus(mapped_status),

--- a/src/server.py
+++ b/src/server.py
@@ -2280,6 +2280,9 @@ def create_app(
             tmux_session = str(descriptor.get("tmux_session") or "").strip()
         if not tmux_session:
             tmux_session = str(getattr(session, "tmux_session", "") or "").strip()
+        tmux_socket_name = ""
+        if descriptor:
+            tmux_socket_name = str(descriptor.get("tmux_socket_name") or "").strip()
 
         if not descriptor:
             return {
@@ -2321,15 +2324,22 @@ def create_app(
             "PATH=/opt/homebrew/bin:/usr/local/bin:/opt/homebrew/sbin:/usr/local/sbin:/usr/bin:/bin:$PATH; "
             "export PATH; "
             "if command -v tmux >/dev/null 2>&1; then "
-            "exec tmux attach-session -d -t \"$SM_TMUX_SESSION\"; "
+            "if [ -n \"${SM_TMUX_SOCKET:-}\" ]; then "
+            "exec tmux -L \"$SM_TMUX_SOCKET\" attach-session -d -t \"$SM_TMUX_SESSION\"; "
+            "else exec tmux attach-session -d -t \"$SM_TMUX_SESSION\"; fi; "
             "elif [ -x /opt/homebrew/bin/tmux ]; then "
-            "exec /opt/homebrew/bin/tmux attach-session -d -t \"$SM_TMUX_SESSION\"; "
+            "if [ -n \"${SM_TMUX_SOCKET:-}\" ]; then "
+            "exec /opt/homebrew/bin/tmux -L \"$SM_TMUX_SOCKET\" attach-session -d -t \"$SM_TMUX_SESSION\"; "
+            "else exec /opt/homebrew/bin/tmux attach-session -d -t \"$SM_TMUX_SESSION\"; fi; "
             "elif [ -x /usr/local/bin/tmux ]; then "
-            "exec /usr/local/bin/tmux attach-session -d -t \"$SM_TMUX_SESSION\"; "
+            "if [ -n \"${SM_TMUX_SOCKET:-}\" ]; then "
+            "exec /usr/local/bin/tmux -L \"$SM_TMUX_SOCKET\" attach-session -d -t \"$SM_TMUX_SESSION\"; "
+            "else exec /usr/local/bin/tmux attach-session -d -t \"$SM_TMUX_SESSION\"; fi; "
             "else echo \"tmux not found on remote host\" >&2; exit 127; fi"
         )
         remote_command = (
             f"SM_TMUX_SESSION={shlex.quote(tmux_session)} "
+            f"SM_TMUX_SOCKET={shlex.quote(tmux_socket_name)} "
             f"sh -lc {shlex.quote(remote_attach_script)}"
         )
         ssh_args.extend([
@@ -2360,7 +2370,7 @@ def create_app(
             "exit \"$attach_status\""
         )
 
-        return {
+        metadata = {
             "supported": True,
             "transport": "termux-ssh-tmux",
             "ssh_host": public_ssh_host,
@@ -2371,6 +2381,9 @@ def create_app(
             "runtime_mode": descriptor.get("runtime_mode"),
             "termux_package": "com.termux",
         }
+        if tmux_socket_name:
+            metadata["tmux_socket_name"] = tmux_socket_name
+        return metadata
 
     def _mobile_primary_action(termux_attach: dict[str, Any], descriptor: Optional[dict[str, Any]]) -> dict[str, Any]:
         if termux_attach.get("supported"):

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -156,7 +156,7 @@ class SessionManager:
             mq_timeouts.get("input_delivery_wait_seconds", 1.0)
         )
 
-        self.tmux = TmuxController(log_dir=log_dir)
+        self.tmux = TmuxController(log_dir=log_dir, config=self.config)
         self.sessions: dict[str, Session] = {}
         self._event_handlers: list[Callable[[NotificationEvent], Awaitable[None]]] = []
         self.codex_sessions: dict[str, CodexAppServerSession] = {}
@@ -404,6 +404,27 @@ class SessionManager:
         self._load_state()
         if self.sync_codex_native_titles_from_index(persist=False):
             self._save_state()
+
+    def _tmux_socket_name(self) -> Optional[str]:
+        """Return configured tmux socket name, treating partial mocks as legacy default-server."""
+        socket_name = getattr(self.tmux, "socket_name", None)
+        return socket_name if isinstance(socket_name, str) and socket_name else None
+
+    def _tmux_history_limit(self) -> Optional[int]:
+        """Return configured tmux history limit when available."""
+        history_limit = getattr(self.tmux, "history_limit", None)
+        return history_limit if isinstance(history_limit, int) else None
+
+    def _tmux_session_history_limit(self, tmux_session: str) -> Optional[int]:
+        """Return a session's current tmux history limit when the controller can provide it."""
+        getter = getattr(self.tmux, "get_history_limit", None)
+        if not callable(getter):
+            return None
+        try:
+            history_limit = getter(tmux_session)
+        except Exception:
+            return None
+        return history_limit if isinstance(history_limit, int) else None
 
     def _migrate_legacy_state_file_if_needed(self) -> None:
         """Copy a pre-durable temp-backed session registry into the configured path once."""
@@ -2309,6 +2330,7 @@ class SessionManager:
                 else:
                     logger.error(f"Failed to create tmux session for {session.name}")
                 return None
+            session.tmux_socket_name = self._tmux_socket_name()
         elif provider == "codex-app":
             try:
                 codex_session = CodexAppServerSession(
@@ -4143,6 +4165,7 @@ class SessionManager:
 
         session.error_message = None
         session.status = SessionStatus.RUNNING
+        session.tmux_socket_name = self._tmux_socket_name()
         session.last_activity = datetime.now()
         if session.provider == "codex-fork":
             self.codex_fork_runtime_owner[session.id] = session.parent_session_id or session.id
@@ -5192,6 +5215,9 @@ class SessionManager:
                 "attach_supported": True,
                 "attach_transport": "tmux",
                 "tmux_session": session.tmux_session,
+                "tmux_socket_name": session.tmux_socket_name,
+                "tmux_history_limit": self._tmux_session_history_limit(session.tmux_session),
+                "tmux_configured_history_limit": self._tmux_history_limit(),
                 "runtime_mode": "detached_runtime",
                 "runtime_id": f"codex-fork:{session.id}",
                 "runtime_owner": self.codex_fork_runtime_owner.get(session.id),
@@ -5216,6 +5242,9 @@ class SessionManager:
             "attach_supported": True,
             "attach_transport": "tmux",
             "tmux_session": session.tmux_session,
+            "tmux_socket_name": session.tmux_socket_name,
+            "tmux_history_limit": self._tmux_session_history_limit(session.tmux_session),
+            "tmux_configured_history_limit": self._tmux_history_limit(),
             "runtime_mode": "tmux",
         }
 
@@ -5339,7 +5368,7 @@ class SessionManager:
             # If session is completed, wake it up first
             if session.completion_status == CompletionStatus.COMPLETED:
                 proc = await asyncio.create_subprocess_exec(
-                    "tmux", "send-keys", "-t", tmux_session, "Enter",
+                    *self.tmux.tmux_cmd_for_session(tmux_session, "send-keys", "-t", tmux_session, "Enter"),
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
@@ -5348,7 +5377,7 @@ class SessionManager:
 
             # Interrupt any ongoing stream
             proc = await asyncio.create_subprocess_exec(
-                "tmux", "send-keys", "-t", tmux_session, "Escape",
+                *self.tmux.tmux_cmd_for_session(tmux_session, "send-keys", "-t", tmux_session, "Escape"),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -5357,7 +5386,7 @@ class SessionManager:
 
             # Send clear command
             proc = await asyncio.create_subprocess_exec(
-                "tmux", "send-keys", "-t", tmux_session, clear_command,
+                *self.tmux.tmux_cmd_for_session(tmux_session, "send-keys", "-t", tmux_session, clear_command),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -5365,7 +5394,7 @@ class SessionManager:
             await asyncio.sleep(1.0)
 
             proc = await asyncio.create_subprocess_exec(
-                "tmux", "send-keys", "-t", tmux_session, "Enter",
+                *self.tmux.tmux_cmd_for_session(tmux_session, "send-keys", "-t", tmux_session, "Enter"),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -5375,14 +5404,14 @@ class SessionManager:
             # Send new prompt if provided
             if new_prompt:
                 proc = await asyncio.create_subprocess_exec(
-                    "tmux", "send-keys", "-t", tmux_session, new_prompt,
+                    *self.tmux.tmux_cmd_for_session(tmux_session, "send-keys", "-t", tmux_session, new_prompt),
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
                 await proc.communicate()
                 await asyncio.sleep(1.0)
                 proc = await asyncio.create_subprocess_exec(
-                    "tmux", "send-keys", "-t", tmux_session, "Enter",
+                    *self.tmux.tmux_cmd_for_session(tmux_session, "send-keys", "-t", tmux_session, "Enter"),
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
@@ -5524,6 +5553,7 @@ class SessionManager:
                     session.error_message = tmux_error
                     self._save_state()
                 return False, session, tmux_error or "Failed to restore Claude session runtime"
+            session.tmux_socket_name = self._tmux_socket_name()
         elif session.provider in ("codex", "codex-fork"):
             if not resume_id:
                 return False, session, "No Codex resume id is available for this session"
@@ -5555,6 +5585,7 @@ class SessionManager:
                     session.error_message = tmux_error
                     self._save_state()
                 return False, session, tmux_error or "Failed to restore Codex session runtime"
+            session.tmux_socket_name = self._tmux_socket_name()
         elif session.provider == "codex-app":
             thread_id = session.codex_thread_id or resume_id
             if not thread_id:
@@ -6095,14 +6126,14 @@ class SessionManager:
                 # Harness survived the crash — use /exit for a clean shutdown
                 logger.debug(f"Sending /exit to session {session.id} (graceful)")
                 proc = await asyncio.create_subprocess_exec(
-                    "tmux", "send-keys", "-t", session.tmux_session, "Escape",
+                    *self.tmux.tmux_cmd_for_session(session.tmux_session, "send-keys", "-t", session.tmux_session, "Escape"),
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
                 await asyncio.wait_for(proc.communicate(), timeout=5)
                 await asyncio.sleep(0.3)
                 proc = await asyncio.create_subprocess_exec(
-                    "tmux", "send-keys", "-t", session.tmux_session, "/exit", "Enter",
+                    *self.tmux.tmux_cmd_for_session(session.tmux_session, "send-keys", "-t", session.tmux_session, "/exit", "Enter"),
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
@@ -6113,7 +6144,7 @@ class SessionManager:
                 logger.debug(f"Sending C-c twice to session {session.id}")
                 for _ in range(2):
                     proc = await asyncio.create_subprocess_exec(
-                        "tmux", "send-keys", "-t", session.tmux_session, "C-c",
+                        *self.tmux.tmux_cmd_for_session(session.tmux_session, "send-keys", "-t", session.tmux_session, "C-c"),
                         stdout=asyncio.subprocess.PIPE,
                         stderr=asyncio.subprocess.PIPE,
                     )
@@ -6127,7 +6158,7 @@ class SessionManager:
             #    Claude prints: "To resume this conversation, run:\n  claude --resume <uuid>"
             resume_uuid = None
             proc = await asyncio.create_subprocess_exec(
-                "tmux", "capture-pane", "-p", "-t", session.tmux_session, "-S", "-200",
+                *self.tmux.tmux_cmd_for_session(session.tmux_session, "capture-pane", "-p", "-t", session.tmux_session, "-S", "-200"),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -6158,7 +6189,7 @@ class SessionManager:
             if not graceful:
                 logger.debug(f"Sending stty sane to session {session.id}")
                 proc = await asyncio.create_subprocess_exec(
-                    "tmux", "send-keys", "-t", session.tmux_session, "stty sane", "Enter",
+                    *self.tmux.tmux_cmd_for_session(session.tmux_session, "send-keys", "-t", session.tmux_session, "stty sane", "Enter"),
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
@@ -6168,8 +6199,11 @@ class SessionManager:
             # 6. Unset CLAUDECODE to prevent nested-session detection
             #    (Claude Code exports this; it persists in the shell after the process dies)
             proc = await asyncio.create_subprocess_exec(
-                "tmux", "send-keys", "-t", session.tmux_session,
-                "unset CLAUDECODE", "Enter",
+                *self.tmux.tmux_cmd_for_session(
+                    session.tmux_session,
+                    "send-keys", "-t", session.tmux_session,
+                    "unset CLAUDECODE", "Enter",
+                ),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -6180,8 +6214,11 @@ class SessionManager:
             shell_fd_limit = int(tmux_timeouts.get("shell_fd_limit", 65536))
             if shell_fd_limit > 0:
                 proc = await asyncio.create_subprocess_exec(
-                    "tmux", "send-keys", "-t", session.tmux_session,
-                    f"ulimit -n {shell_fd_limit}", "Enter",
+                    *self.tmux.tmux_cmd_for_session(
+                        session.tmux_session,
+                        "send-keys", "-t", session.tmux_session,
+                        f"ulimit -n {shell_fd_limit}", "Enter",
+                    ),
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
@@ -6205,8 +6242,11 @@ class SessionManager:
 
             for color_cmd in color_cmds:
                 proc = await asyncio.create_subprocess_exec(
-                    "tmux", "send-keys", "-t", session.tmux_session,
-                    color_cmd, "Enter",
+                    *self.tmux.tmux_cmd_for_session(
+                        session.tmux_session,
+                        "send-keys", "-t", session.tmux_session,
+                        color_cmd, "Enter",
+                    ),
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
@@ -6226,7 +6266,7 @@ class SessionManager:
 
             logger.debug(f"Sending resume command to session {session.id}: {resume_cmd}")
             proc = await asyncio.create_subprocess_exec(
-                "tmux", "send-keys", "-t", session.tmux_session, resume_cmd, "Enter",
+                *self.tmux.tmux_cmd_for_session(session.tmux_session, "send-keys", "-t", session.tmux_session, resume_cmd, "Enter"),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )

--- a/src/tmux_controller.py
+++ b/src/tmux_controller.py
@@ -21,6 +21,18 @@ class TmuxController:
         self.config = config or {}
         self.last_error_message: Optional[str] = None
 
+        tmux_config = self.config.get("tmux", {}) if isinstance(self.config, dict) else {}
+        raw_socket_name = str(tmux_config.get("socket_name", "") or "").strip()
+        self.socket_name: Optional[str] = raw_socket_name or None
+        self.native_scrollback = self._coerce_bool(
+            tmux_config.get("native_scrollback"),
+            default=bool(self.socket_name),
+        )
+        self.history_limit = self._coerce_positive_int(
+            tmux_config.get("history_limit"),
+            default=100000,
+        )
+
         # Load timeout configuration with fallbacks
         timeouts = self.config.get("timeouts", {})
         tmux_timeouts = timeouts.get("tmux", {})
@@ -37,6 +49,92 @@ class TmuxController:
         self.submit_verify_seconds = tmux_timeouts.get("submit_verify_seconds", 0.6)
         self.submit_retry_seconds = tmux_timeouts.get("submit_retry_seconds", 0.6)
         self.shell_fd_limit = int(tmux_timeouts.get("shell_fd_limit", 65536))
+
+    @staticmethod
+    def _coerce_bool(value: object, default: bool = False) -> bool:
+        """Parse bool config values with common string/int forms."""
+        if value is None:
+            return default
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)):
+            return value != 0
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in {"true", "1", "yes", "on"}:
+                return True
+            if normalized in {"false", "0", "no", "off"}:
+                return False
+        return default
+
+    @staticmethod
+    def _coerce_positive_int(value: object, default: int) -> int:
+        """Parse a positive integer config value."""
+        try:
+            parsed = int(value)
+        except (TypeError, ValueError):
+            return default
+        return parsed if parsed > 0 else default
+
+    @staticmethod
+    def _normalize_session_target(session_name: str) -> str:
+        """Return the tmux session portion of a target that may include window/pane suffixes."""
+        return str(session_name or "").split(":", 1)[0].split(".", 1)[0]
+
+    def tmux_cmd(self, *args: str, socket_name: Optional[str] = "__primary__") -> list[str]:
+        """Build one tmux command using the configured SM socket unless overridden."""
+        effective_socket = self.socket_name if socket_name == "__primary__" else socket_name
+        cmd = ["tmux"]
+        if effective_socket:
+            cmd.extend(["-L", effective_socket])
+        cmd.extend(args)
+        return cmd
+
+    def tmux_cmd_for_session(self, session_name: str, *args: str) -> list[str]:
+        """Build a tmux command for an existing target, falling back for legacy sessions."""
+        return self.tmux_cmd(*args, socket_name=self._resolve_socket_for_session(session_name))
+
+    def _session_exists_on_socket(self, session_name: str, socket_name: Optional[str]) -> bool:
+        target = self._normalize_session_target(session_name)
+        if not target:
+            return False
+        result = subprocess.run(
+            self.tmux_cmd("has-session", "-t", target, socket_name=socket_name),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return result.returncode == 0
+
+    def _resolve_socket_for_session(self, session_name: str) -> Optional[str]:
+        """Resolve which tmux server owns a session, supporting legacy default-server panes."""
+        target = self._normalize_session_target(session_name)
+        if not target:
+            return self.socket_name
+        if self.socket_name and self._session_exists_on_socket(target, self.socket_name):
+            return self.socket_name
+        if self.socket_name and self._session_exists_on_socket(target, None):
+            return None
+        return self.socket_name
+
+    def _ensure_server_options(self) -> None:
+        """Apply SM-owned tmux server options that are safe only on the configured socket."""
+        if not self.socket_name or not self.native_scrollback:
+            return
+        current = self._run_tmux(
+            "show-options",
+            "-gqv",
+            "terminal-overrides",
+            check=False,
+        )
+        if "smcup@:rmcup@" in (current.stdout or ""):
+            return
+        self._run_tmux(
+            "set-option",
+            "-as",
+            "terminal-overrides",
+            ",*:smcup@:rmcup@",
+        )
 
     def _resolve_launch_command(
         self,
@@ -72,9 +170,28 @@ class TmuxController:
         *args: str,
         check: bool = True,
         timeout: Optional[float] = None,
+        socket_name: Optional[str] = "__primary__",
     ) -> subprocess.CompletedProcess:
         """Run a tmux command."""
-        cmd = ["tmux"] + list(args)
+        cmd = self.tmux_cmd(*args, socket_name=socket_name)
+        logger.debug(f"Running tmux command: {' '.join(cmd)}")
+        return subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=check,
+            timeout=timeout,
+        )
+
+    def _run_tmux_for_session(
+        self,
+        session_name: str,
+        *args: str,
+        check: bool = True,
+        timeout: Optional[float] = None,
+    ) -> subprocess.CompletedProcess:
+        """Run a tmux command against an existing target, with legacy fallback."""
+        cmd = self.tmux_cmd_for_session(session_name, *args)
         logger.debug(f"Running tmux command: {' '.join(cmd)}")
         return subprocess.run(
             cmd,
@@ -125,7 +242,8 @@ class TmuxController:
     def _get_pane_in_mode(self, session_name: str) -> Optional[int]:
         """Return tmux pane_in_mode (1 copy-mode, 0 normal) for active pane."""
         try:
-            result = self._run_tmux(
+            result = self._run_tmux_for_session(
+                session_name,
                 "display-message", "-p", "-t", session_name, "#{pane_in_mode}",
                 check=False,
             )
@@ -139,7 +257,8 @@ class TmuxController:
     def get_pane_title(self, session_name: str) -> Optional[str]:
         """Return the active pane title for one tmux session."""
         try:
-            result = self._run_tmux(
+            result = self._run_tmux_for_session(
+                session_name,
                 "display-message", "-p", "-t", session_name, "#{pane_title}",
                 check=False,
             )
@@ -230,7 +349,7 @@ class TmuxController:
         if before != 1:
             return before, before
         try:
-            self._run_tmux("send-keys", "-t", session_name, "-X", "cancel", check=False)
+            self._run_tmux_for_session(session_name, "send-keys", "-t", session_name, "-X", "cancel", check=False)
         except Exception:
             # Non-fatal: we still attempt delivery.
             pass
@@ -241,7 +360,7 @@ class TmuxController:
         """Best-effort clear of partially typed input after a failed send."""
         try:
             subprocess.run(
-                ["tmux", "send-keys", "-t", session_name, "C-u"],
+                self.tmux_cmd_for_session(session_name, "send-keys", "-t", session_name, "C-u"),
                 check=True,
                 capture_output=True,
                 text=True,
@@ -256,7 +375,7 @@ class TmuxController:
         """Async variant of pane mode query."""
         try:
             proc = await asyncio.create_subprocess_exec(
-                "tmux", "display-message", "-p", "-t", session_name, "#{pane_in_mode}",
+                *self.tmux_cmd_for_session(session_name, "display-message", "-p", "-t", session_name, "#{pane_in_mode}"),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -277,7 +396,7 @@ class TmuxController:
             return before, before
         try:
             proc = await asyncio.create_subprocess_exec(
-                "tmux", "send-keys", "-t", session_name, "-X", "cancel",
+                *self.tmux_cmd_for_session(session_name, "send-keys", "-t", session_name, "-X", "cancel"),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -292,7 +411,7 @@ class TmuxController:
         """Best-effort clear of partially typed input after a failed send."""
         try:
             proc = await asyncio.create_subprocess_exec(
-                "tmux", "send-keys", "-t", session_name, "C-u",
+                *self.tmux_cmd_for_session(session_name, "send-keys", "-t", session_name, "C-u"),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -306,7 +425,7 @@ class TmuxController:
         """Capture the full active tmux pane asynchronously."""
         try:
             proc = await asyncio.create_subprocess_exec(
-                "tmux", "capture-pane", "-p", "-J", "-S", "-200", "-t", session_name,
+                *self.tmux_cmd_for_session(session_name, "capture-pane", "-p", "-J", "-S", "-200", "-t", session_name),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -462,7 +581,7 @@ class TmuxController:
             return False
 
         proc = await asyncio.create_subprocess_exec(
-            "tmux", "send-keys", "-t", session_name, "Enter",
+            *self.tmux_cmd_for_session(session_name, "send-keys", "-t", session_name, "Enter"),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -505,7 +624,7 @@ class TmuxController:
             return False
 
         proc = await asyncio.create_subprocess_exec(
-            "tmux", "send-keys", "-t", session_name, "Escape",
+            *self.tmux_cmd_for_session(session_name, "send-keys", "-t", session_name, "Escape"),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -524,8 +643,29 @@ class TmuxController:
 
     def session_exists(self, session_name: str) -> bool:
         """Check if a tmux session exists."""
-        result = self._run_tmux("has-session", "-t", session_name, check=False)
-        return result.returncode == 0
+        if self._session_exists_on_socket(session_name, self.socket_name):
+            return True
+        if self.socket_name and self._session_exists_on_socket(session_name, None):
+            return True
+        return False
+
+    def get_history_limit(self, session_name: str) -> Optional[int]:
+        """Return the active pane history limit for a tmux session."""
+        try:
+            result = self._run_tmux_for_session(
+                session_name,
+                "display-message",
+                "-p",
+                "-t", session_name,
+                "#{history_limit}",
+                check=False,
+            )
+            if result.returncode != 0:
+                return None
+            raw = (result.stdout or "").strip()
+            return int(raw) if raw.isdigit() else None
+        except Exception:
+            return None
 
     def set_status_bar(
         self,
@@ -551,7 +691,8 @@ class TmuxController:
 
         try:
             # Set status-left to show friendly name
-            self._run_tmux(
+            self._run_tmux_for_session(
+                session_name,
                 "set-option",
                 "-t", session_name,
                 "status-left",
@@ -619,13 +760,19 @@ class TmuxController:
         log_path.touch()
 
         try:
-            # Create new detached tmux session
+            # Create bootstrap session, then create provider window after history-limit is set.
             self._run_tmux(
                 "new-session",
                 "-d",
                 "-s", session_name,
                 "-c", str(working_path),
+                "-n", "__sm_bootstrap",
             )
+            self._ensure_server_options()
+            self._run_tmux("set-option", "-t", session_name, "history-limit", str(self.history_limit))
+            self._run_tmux("new-window", "-d", "-t", session_name, "-n", "main", "-c", str(working_path))
+            self._run_tmux("kill-window", "-t", f"{session_name}:__sm_bootstrap")
+            self._run_tmux("select-window", "-t", f"{session_name}:main")
             self._initialize_pane_title(session_name)
 
             # Set up pipe-pane to capture output to log file
@@ -712,13 +859,19 @@ class TmuxController:
         log_path.touch()
 
         try:
-            # Create new detached tmux session
+            # Create bootstrap session, then create provider window after history-limit is set.
             self._run_tmux(
                 "new-session",
                 "-d",
                 "-s", session_name,
                 "-c", str(working_path),
+                "-n", "__sm_bootstrap",
             )
+            self._ensure_server_options()
+            self._run_tmux("set-option", "-t", session_name, "history-limit", str(self.history_limit))
+            self._run_tmux("new-window", "-d", "-t", session_name, "-n", "main", "-c", str(working_path))
+            self._run_tmux("kill-window", "-t", f"{session_name}:__sm_bootstrap")
+            self._run_tmux("select-window", "-t", f"{session_name}:main")
             self._initialize_pane_title(session_name)
 
             # Set up pipe-pane to capture output to log file
@@ -806,7 +959,7 @@ class TmuxController:
             # Use subprocess with list arguments to prevent shell injection
             for chunk in chunks:
                 subprocess.run(
-                    ["tmux", "send-keys", "-t", session_name, "-l", "--", chunk],
+                    self.tmux_cmd_for_session(session_name, "send-keys", "-t", session_name, "-l", "--", chunk),
                     check=True,
                     capture_output=True,
                     text=True,
@@ -815,7 +968,7 @@ class TmuxController:
                 text_injected = True
             time.sleep(settle_delay)
             subprocess.run(
-                ["tmux", "send-keys", "-t", session_name, "Enter"],
+                self.tmux_cmd_for_session(session_name, "send-keys", "-t", session_name, "Enter"),
                 check=True,
                 capture_output=True,
                 text=True,
@@ -879,7 +1032,7 @@ class TmuxController:
 
             for chunk in chunks:
                 proc = await asyncio.create_subprocess_exec(
-                    'tmux', 'send-keys', '-t', session_name, '-l', '--', chunk,
+                    *self.tmux_cmd_for_session(session_name, "send-keys", "-t", session_name, "-l", "--", chunk),
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
@@ -901,7 +1054,7 @@ class TmuxController:
 
             # Send Enter as a separate keystroke
             proc = await asyncio.create_subprocess_exec(
-                'tmux', 'send-keys', '-t', session_name, 'Enter',
+                *self.tmux_cmd_for_session(session_name, "send-keys", "-t", session_name, "Enter"),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -959,7 +1112,7 @@ class TmuxController:
         """
         try:
             proc = await asyncio.create_subprocess_exec(
-                "tmux", "send-keys", "-t", session_name, key,
+                *self.tmux_cmd_for_session(session_name, "send-keys", "-t", session_name, key),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -1060,7 +1213,7 @@ class TmuxController:
             return True  # Already gone
 
         try:
-            self._run_tmux("kill-session", "-t", session_name)
+            self._run_tmux_for_session(session_name, "kill-session", "-t", session_name)
             logger.info(f"Killed session {session_name}")
             return True
 
@@ -1070,10 +1223,23 @@ class TmuxController:
 
     def list_sessions(self) -> list[str]:
         """List all tmux sessions."""
+        sessions: set[str] = set()
         result = self._run_tmux("list-sessions", "-F", "#{session_name}", check=False)
         if result.returncode != 0:
-            return []
-        return [s.strip() for s in result.stdout.strip().split("\n") if s.strip()]
+            result = None
+        if result is not None:
+            sessions.update(s.strip() for s in result.stdout.strip().split("\n") if s.strip())
+        if self.socket_name:
+            legacy = self._run_tmux(
+                "list-sessions",
+                "-F",
+                "#{session_name}",
+                check=False,
+                socket_name=None,
+            )
+            if legacy.returncode == 0:
+                sessions.update(s.strip() for s in legacy.stdout.strip().split("\n") if s.strip())
+        return sorted(sessions)
 
     def capture_pane(self, session_name: str, lines: int = 50) -> Optional[str]:
         """
@@ -1090,7 +1256,8 @@ class TmuxController:
             return None
 
         try:
-            result = self._run_tmux(
+            result = self._run_tmux_for_session(
+                session_name,
                 "capture-pane",
                 "-t", session_name,
                 "-p",  # Print to stdout
@@ -1140,14 +1307,14 @@ class TmuxController:
                 # Custom mode: send /review <text> directly, bypasses menu
                 review_text = f"/review {custom_prompt}"
                 proc = await asyncio.create_subprocess_exec(
-                    'tmux', 'send-keys', '-t', session_name, '--', review_text,
+                    *self.tmux_cmd_for_session(session_name, "send-keys", "-t", session_name, "--", review_text),
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
                 await asyncio.wait_for(proc.wait(), timeout=self.send_keys_timeout_seconds)
                 await asyncio.sleep(self.send_keys_settle_seconds)
                 proc = await asyncio.create_subprocess_exec(
-                    'tmux', 'send-keys', '-t', session_name, 'Enter',
+                    *self.tmux_cmd_for_session(session_name, "send-keys", "-t", session_name, "Enter"),
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
@@ -1157,7 +1324,7 @@ class TmuxController:
 
             # All other modes: send /review + Enter, then navigate menu
             proc = await asyncio.create_subprocess_exec(
-                'tmux', 'send-keys', '-t', session_name, '--', '/review',
+                *self.tmux_cmd_for_session(session_name, "send-keys", "-t", session_name, "--", "/review"),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -1165,7 +1332,7 @@ class TmuxController:
             await asyncio.sleep(self.send_keys_settle_seconds)
 
             proc = await asyncio.create_subprocess_exec(
-                'tmux', 'send-keys', '-t', session_name, 'Enter',
+                *self.tmux_cmd_for_session(session_name, "send-keys", "-t", session_name, "Enter"),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -1177,7 +1344,7 @@ class TmuxController:
             if mode == "branch":
                 # 1st menu item — just press Enter
                 proc = await asyncio.create_subprocess_exec(
-                    'tmux', 'send-keys', '-t', session_name, 'Enter',
+                    *self.tmux_cmd_for_session(session_name, "send-keys", "-t", session_name, "Enter"),
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
@@ -1190,7 +1357,7 @@ class TmuxController:
                 if branch_position and branch_position > 0:
                     for _ in range(branch_position):
                         proc = await asyncio.create_subprocess_exec(
-                            'tmux', 'send-keys', '-t', session_name, 'Down',
+                            *self.tmux_cmd_for_session(session_name, "send-keys", "-t", session_name, "Down"),
                             stdout=asyncio.subprocess.PIPE,
                             stderr=asyncio.subprocess.PIPE,
                         )
@@ -1199,7 +1366,7 @@ class TmuxController:
                 # Confirm branch selection
                 await asyncio.sleep(self.send_keys_settle_seconds)
                 proc = await asyncio.create_subprocess_exec(
-                    'tmux', 'send-keys', '-t', session_name, 'Enter',
+                    *self.tmux_cmd_for_session(session_name, "send-keys", "-t", session_name, "Enter"),
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
@@ -1209,14 +1376,14 @@ class TmuxController:
             elif mode == "uncommitted":
                 # 2nd menu item — Down then Enter
                 proc = await asyncio.create_subprocess_exec(
-                    'tmux', 'send-keys', '-t', session_name, 'Down',
+                    *self.tmux_cmd_for_session(session_name, "send-keys", "-t", session_name, "Down"),
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
                 await asyncio.wait_for(proc.wait(), timeout=self.send_keys_timeout_seconds)
                 await asyncio.sleep(self.send_keys_settle_seconds)
                 proc = await asyncio.create_subprocess_exec(
-                    'tmux', 'send-keys', '-t', session_name, 'Enter',
+                    *self.tmux_cmd_for_session(session_name, "send-keys", "-t", session_name, "Enter"),
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
@@ -1231,14 +1398,14 @@ class TmuxController:
                 # 3rd menu item — Down Down then Enter
                 for _ in range(2):
                     proc = await asyncio.create_subprocess_exec(
-                        'tmux', 'send-keys', '-t', session_name, 'Down',
+                        *self.tmux_cmd_for_session(session_name, "send-keys", "-t", session_name, "Down"),
                         stdout=asyncio.subprocess.PIPE,
                         stderr=asyncio.subprocess.PIPE,
                     )
                     await asyncio.wait_for(proc.wait(), timeout=self.send_keys_timeout_seconds)
                 await asyncio.sleep(self.send_keys_settle_seconds)
                 proc = await asyncio.create_subprocess_exec(
-                    'tmux', 'send-keys', '-t', session_name, 'Enter',
+                    *self.tmux_cmd_for_session(session_name, "send-keys", "-t", session_name, "Enter"),
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
@@ -1249,7 +1416,7 @@ class TmuxController:
 
                 # Select the first commit (most recent)
                 proc = await asyncio.create_subprocess_exec(
-                    'tmux', 'send-keys', '-t', session_name, 'Enter',
+                    *self.tmux_cmd_for_session(session_name, "send-keys", "-t", session_name, "Enter"),
                     stdout=asyncio.subprocess.PIPE,
                     stderr=asyncio.subprocess.PIPE,
                 )
@@ -1285,7 +1452,7 @@ class TmuxController:
         try:
             # Press Enter to open steer input field
             proc = await asyncio.create_subprocess_exec(
-                'tmux', 'send-keys', '-t', session_name, 'Enter',
+                *self.tmux_cmd_for_session(session_name, "send-keys", "-t", session_name, "Enter"),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -1294,7 +1461,7 @@ class TmuxController:
 
             # Send the steer text
             proc = await asyncio.create_subprocess_exec(
-                'tmux', 'send-keys', '-t', session_name, '--', text,
+                *self.tmux_cmd_for_session(session_name, "send-keys", "-t", session_name, "--", text),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -1303,7 +1470,7 @@ class TmuxController:
 
             # Press Enter to submit
             proc = await asyncio.create_subprocess_exec(
-                'tmux', 'send-keys', '-t', session_name, 'Enter',
+                *self.tmux_cmd_for_session(session_name, "send-keys", "-t", session_name, "Enter"),
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
@@ -1338,13 +1505,10 @@ class TmuxController:
             return False
 
         # AppleScript to open new Terminal window and attach to tmux session
-        # Escape session_name for AppleScript (prevent injection)
-        import shlex
-        escaped_session = shlex.quote(session_name)
         script = f'''
         tell application "Terminal"
             activate
-            do script "tmux attach-session -t {escaped_session}"
+            do script "{' '.join(shlex.quote(part) for part in self.tmux_cmd_for_session(session_name, 'attach-session', '-t', session_name))}"
         end tell
         '''
 

--- a/tests/unit/test_cmd_attach_descriptor.py
+++ b/tests/unit/test_cmd_attach_descriptor.py
@@ -47,3 +47,32 @@ def test_cmd_attach_uses_detached_runtime_descriptor(monkeypatch, capsys):
     assert calls == [(["tmux", "attach", "-t", "codex-fork-fork1001"], True)]
     assert "Reattaching to detached codex-fork runtime codex-fork:fork1001" in capsys.readouterr().out
 
+
+def test_cmd_attach_uses_descriptor_tmux_socket(monkeypatch):
+    calls = []
+
+    def _fake_run(args, check):
+        calls.append((args, check))
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+
+    session = {
+        "id": "claude1001",
+        "provider": "claude",
+        "tmux_session": "claude-claude1001",
+        "status": "running",
+    }
+    descriptor = {
+        "session_id": "claude1001",
+        "provider": "claude",
+        "attach_supported": True,
+        "tmux_session": "claude-claude1001",
+        "tmux_socket_name": "session-manager-test",
+    }
+
+    rc = commands.cmd_attach(_AttachClient(session, descriptor), "claude1001")
+
+    assert rc == 0
+    assert calls == [
+        (["tmux", "-L", "session-manager-test", "attach", "-t", "claude-claude1001"], True)
+    ]

--- a/tests/unit/test_cmd_children.py
+++ b/tests/unit/test_cmd_children.py
@@ -180,6 +180,27 @@ class TestGetTmuxSessionActivity:
             timeout=3,
         )
 
+    def test_uses_tmux_socket_when_available(self):
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="1771480032\n", returncode=0)
+            result = _get_tmux_session_activity("codex-abc123", "session-manager-test")
+        assert result == 1771480032
+        mock_run.assert_called_once_with(
+            [
+                "tmux",
+                "-L",
+                "session-manager-test",
+                "display-message",
+                "-p",
+                "-t",
+                "codex-abc123",
+                "#{session_activity}",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+
     def test_returns_none_on_empty_output(self):
         with patch("subprocess.run") as mock_run:
             mock_run.return_value = MagicMock(stdout="", returncode=1)
@@ -276,6 +297,19 @@ class TestCmdChildrenOutput:
         assert "last tool: n/a (no hooks)" in out
         assert "thinking" in out
         assert " | codex | " in out
+
+    def test_running_codex_session_activity_uses_recorded_tmux_socket(self, tmp_path, capsys):
+        child = _child(child_id="bbb00000002", provider="codex", status="running")
+        child["tmux_session"] = "custom-codex-target"
+        child["tmux_socket_name"] = "session-manager-test"
+        client = _make_client([child])
+
+        epoch = int(time.time()) - 120
+        with patch("src.cli.commands._get_tmux_session_activity", return_value=epoch) as mock_activity:
+            rc = cmd_children(client, "parent1", db_path=str(tmp_path / "tool_usage.db"))
+
+        assert rc == 0
+        mock_activity.assert_called_once_with("custom-codex-target", "session-manager-test")
 
     def test_codex_fork_prefers_activity_state_over_raw_status(self, tmp_path, capsys):
         child = _child(

--- a/tests/unit/test_codex_fork_attach_descriptor.py
+++ b/tests/unit/test_codex_fork_attach_descriptor.py
@@ -78,3 +78,30 @@ def test_stopped_codex_fork_attach_descriptor_is_not_attachable(tmp_path):
     assert descriptor is not None
     assert descriptor["attach_supported"] is False
     assert descriptor["runtime_mode"] == "stopped"
+
+
+def test_attach_descriptor_includes_tmux_socket_and_history_limit(tmp_path, monkeypatch):
+    manager = SessionManager(
+        log_dir=str(tmp_path / "logs"),
+        state_file=str(tmp_path / "sessions.json"),
+        config={"tmux": {"socket_name": "session-manager-test", "history_limit": 12345}},
+    )
+    monkeypatch.setattr(manager.tmux, "get_history_limit", lambda _: 12345)
+    session = Session(
+        id="claude1001",
+        name="claude-claude1001",
+        provider="claude",
+        working_dir=str(tmp_path),
+        tmux_session="claude-claude1001",
+        tmux_socket_name="session-manager-test",
+        log_file=str(tmp_path / "logs" / "claude-claude1001.log"),
+        status=SessionStatus.RUNNING,
+    )
+    manager.sessions[session.id] = session
+
+    descriptor = manager.get_attach_descriptor(session.id)
+
+    assert descriptor is not None
+    assert descriptor["tmux_socket_name"] == "session-manager-test"
+    assert descriptor["tmux_history_limit"] == 12345
+    assert descriptor["tmux_configured_history_limit"] == 12345

--- a/tests/unit/test_config_loading.py
+++ b/tests/unit/test_config_loading.py
@@ -29,6 +29,9 @@ class TestTmuxControllerConfig:
             assert controller.claude_init_no_prompt_seconds == 1
             assert controller.send_keys_timeout_seconds == 5
             assert controller.send_keys_settle_seconds == 0.3
+            assert controller.socket_name is None
+            assert controller.native_scrollback is False
+            assert controller.history_limit == 100000
 
     def test_config_values_loaded(self):
         """Verify config values override defaults."""
@@ -52,6 +55,29 @@ class TestTmuxControllerConfig:
             assert controller.claude_init_no_prompt_seconds == 2
             assert controller.send_keys_timeout_seconds == 10
             assert controller.send_keys_settle_seconds == 0.5
+
+    def test_tmux_config_values_loaded(self):
+        """Verify tmux socket/native-scrollback/history values load from config."""
+        config = {
+            "tmux": {
+                "socket_name": "session-manager-test",
+                "native_scrollback": True,
+                "history_limit": 12345,
+            }
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            controller = TmuxController(log_dir=temp_dir, config=config)
+
+            assert controller.socket_name == "session-manager-test"
+            assert controller.native_scrollback is True
+            assert controller.history_limit == 12345
+            assert controller.tmux_cmd("list-sessions") == [
+                "tmux",
+                "-L",
+                "session-manager-test",
+                "list-sessions",
+            ]
 
     def test_partial_config_uses_defaults(self):
         """Verify missing config values fall back to defaults."""

--- a/tests/unit/test_tmux_controller.py
+++ b/tests/unit/test_tmux_controller.py
@@ -10,12 +10,13 @@ def test_set_status_bar_passes_timeout_to_tmux(monkeypatch):
     controller = TmuxController()
     monkeypatch.setattr(controller, "session_exists", lambda _: True)
     run_tmux = MagicMock(return_value=MagicMock(returncode=0))
-    monkeypatch.setattr(controller, "_run_tmux", run_tmux)
+    monkeypatch.setattr(controller, "_run_tmux_for_session", run_tmux)
 
     ok = controller.set_status_bar("claude-test123", "friendly", timeout_seconds=1.0)
 
     assert ok is True
     run_tmux.assert_called_once_with(
+        "claude-test123",
         "set-option",
         "-t",
         "claude-test123",
@@ -32,11 +33,55 @@ def test_set_status_bar_returns_false_on_timeout(monkeypatch):
     def _raise_timeout(*args, **kwargs):
         raise subprocess.TimeoutExpired(cmd=["tmux", "set-option"], timeout=1.0)
 
-    monkeypatch.setattr(controller, "_run_tmux", _raise_timeout)
+    monkeypatch.setattr(controller, "_run_tmux_for_session", _raise_timeout)
 
     ok = controller.set_status_bar("claude-test123", "friendly", timeout_seconds=1.0)
 
     assert ok is False
+
+
+def test_create_session_with_command_bootstraps_history_before_provider_window(tmp_path, monkeypatch):
+    controller = TmuxController(
+        log_dir=str(tmp_path),
+        config={
+            "tmux": {
+                "socket_name": "session-manager-test",
+                "native_scrollback": True,
+                "history_limit": 12345,
+            },
+            "timeouts": {"tmux": {"shell_export_settle_seconds": 0}},
+        },
+    )
+    calls = []
+
+    def _fake_run_tmux(*args, **kwargs):
+        calls.append(args)
+        if args[:3] == ("show-options", "-gqv", "terminal-overrides"):
+            return MagicMock(returncode=0, stdout="")
+        return MagicMock(returncode=0, stdout="")
+
+    monkeypatch.setattr(controller, "session_exists", lambda _: False)
+    monkeypatch.setattr(controller, "_run_tmux", _fake_run_tmux)
+    monkeypatch.setattr("time.sleep", lambda _: None)
+
+    ok = controller.create_session_with_command(
+        "claude-test123",
+        str(tmp_path),
+        str(tmp_path / "claude-test123.log"),
+        command="sh",
+        args=["-lc", "sleep 1"],
+    )
+
+    assert ok is True
+    assert calls[:7] == [
+        ("new-session", "-d", "-s", "claude-test123", "-c", str(tmp_path), "-n", "__sm_bootstrap"),
+        ("show-options", "-gqv", "terminal-overrides"),
+        ("set-option", "-as", "terminal-overrides", ",*:smcup@:rmcup@"),
+        ("set-option", "-t", "claude-test123", "history-limit", "12345"),
+        ("new-window", "-d", "-t", "claude-test123", "-n", "main", "-c", str(tmp_path)),
+        ("kill-window", "-t", "claude-test123:__sm_bootstrap"),
+        ("select-window", "-t", "claude-test123:main"),
+    ]
 
 
 def test_codex_rename_prompt_detection():

--- a/tests/unit/test_watch_tui.py
+++ b/tests/unit/test_watch_tui.py
@@ -17,6 +17,7 @@ from src.cli.watch_tui import (
     _retire_confirmation_matches,
     _resolve_create_provider,
     _session_line,
+    _tmux_attach_command,
     build_restore_rows,
     build_watch_rows,
     can_attach_session,
@@ -31,6 +32,18 @@ def test_retire_confirmation_requires_same_session_before_expiry():
     assert not _retire_confirmation_matches(confirmation, "agent-b", 12.0)
     assert not _retire_confirmation_matches(confirmation, "agent-a", 16.0)
     assert not _retire_confirmation_matches(None, "agent-a", 12.0)
+
+
+def test_tmux_attach_command_includes_socket_when_available():
+    assert _tmux_attach_command("claude-test") == ["tmux", "attach-session", "-t", "claude-test"]
+    assert _tmux_attach_command("claude-test", "session-manager-test") == [
+        "tmux",
+        "-L",
+        "session-manager-test",
+        "attach-session",
+        "-t",
+        "claude-test",
+    ]
 
 
 def _session(


### PR DESCRIPTION
## Summary
- run new SM tmux sessions on an optional configured socket and apply no-alternate-screen terminal overrides on that SM-owned server
- bootstrap new panes with a configured tmux `history-limit` before provider startup, preserving legacy default-server fallback for existing sessions
- propagate tmux socket metadata through attach descriptors, CLI attach/output/tail/clear/children, watch TUI attach, message queue tmux calls, and Termux attach metadata

Fixes #690

## Verification
- `pytest -q` -> 1834 passed, 93 warnings
- `pytest -q tests/unit/test_cmd_children.py tests/unit/test_cmd_tail.py tests/unit/test_cmd_attach_descriptor.py tests/unit/test_cmd_new.py tests/unit/test_cmd_restore.py tests/unit/test_watch_tui.py tests/unit/test_tmux_controller.py tests/unit/test_config_loading.py` -> 127 passed, 87 warnings
- live disposable tmux socket probe -> `pane=34567 main`, `native_scrollback=True`
