### PR TITLE
[#690] Address tmux socket review feedback

### DIFF
--- a/src/cli/watch_tui.py
+++ b/src/cli/watch_tui.py
@@ -1167,6 +1167,34 @@ def _create_watch_session(
     return session, tmux_session, None
 
 
+def _resolve_tmux_attach_target(
+    client,
+    session: dict,
+) -> tuple[Optional[str], Optional[str], Optional[str]]:
+    """Resolve tmux target/socket from the attach descriptor when available."""
+    session_id = session.get("id")
+    descriptor = None
+    descriptor_getter = getattr(client, "get_attach_descriptor", None)
+    if session_id and callable(descriptor_getter):
+        descriptor = descriptor_getter(session_id)
+
+    if descriptor and not descriptor.get("attach_supported", True):
+        message = descriptor.get("message") or "Attach not supported for this session"
+        return None, None, message
+
+    tmux_session = (descriptor or {}).get("tmux_session") or session.get("tmux_session")
+    if not tmux_session:
+        return None, None, "Selected session has no tmux target"
+
+    tmux_socket_name = (descriptor or {}).get("tmux_socket_name") or session.get("tmux_socket_name")
+    if descriptor:
+        session["tmux_session"] = tmux_session
+        if tmux_socket_name:
+            session["tmux_socket_name"] = tmux_socket_name
+
+    return tmux_session, tmux_socket_name, None
+
+
 def _tmux_attach_command(tmux_session: str, tmux_socket_name: str | None = None) -> list[str]:
     cmd = ["tmux"]
     if tmux_socket_name:
@@ -1751,12 +1779,18 @@ def run_watch_tui(
                         elif result.get("ok"):
                             restored = result.get("data") or selected
                             selected_session_id = restored.get("id") or selected_session_id
-                            tmux_session = restored.get("tmux_session")
+                            if can_attach_session(restored):
+                                tmux_session, tmux_socket_name, attach_error = _resolve_tmux_attach_target(
+                                    client,
+                                    restored,
+                                )
+                            else:
+                                tmux_session, tmux_socket_name, attach_error = None, None, None
                             if can_attach_session(restored) and tmux_session:
-                                _attach_tmux(stdscr, tmux_session, restored.get("tmux_socket_name"))
+                                _attach_tmux(stdscr, tmux_session, tmux_socket_name)
                                 flash_message = f"Restored {selected_session_id}"
                             else:
-                                flash_message = f"Restored {selected_session_id} (headless)"
+                                flash_message = attach_error or f"Restored {selected_session_id} (headless)"
                         else:
                             flash_message = str(result.get("detail") or result.get("error") or "Failed to restore session")
                         flash_until = time.monotonic() + 2.5
@@ -1766,12 +1800,12 @@ def run_watch_tui(
                         flash_message = "no terminal (use s to send)"
                         flash_until = time.monotonic() + 2.5
                         continue
-                    tmux_session = selected.get("tmux_session")
-                    if not tmux_session:
-                        flash_message = "Selected session has no tmux target"
+                    tmux_session, tmux_socket_name, attach_error = _resolve_tmux_attach_target(client, selected)
+                    if attach_error:
+                        flash_message = attach_error
                         flash_until = time.monotonic() + 2.5
                         continue
-                    _attach_tmux(stdscr, tmux_session, selected.get("tmux_socket_name"))
+                    _attach_tmux(stdscr, tmux_session, tmux_socket_name)
                     next_refresh = 0.0
         finally:
             if detail_worker:

--- a/src/server.py
+++ b/src/server.py
@@ -512,6 +512,7 @@ class SessionResponse(BaseModel):
     completed_at: Optional[str] = None
     stopped_at: Optional[str] = None
     tmux_session: str
+    tmux_socket_name: Optional[str] = None
     provider: Optional[str] = "claude"
     friendly_name: Optional[str] = None
     telegram_chat_id: Optional[int] = None
@@ -1841,6 +1842,7 @@ def create_app(
             completed_at=session.completed_at.isoformat() if session.completed_at else None,
             stopped_at=session.stopped_at.isoformat() if session.stopped_at else None,
             tmux_session=session.tmux_session,
+            tmux_socket_name=session.tmux_socket_name,
             provider=provider,
             friendly_name=_effective_session_name(
                 session,
@@ -5684,6 +5686,8 @@ Provide ONLY the summary, no preamble or questions."""
                     "last_activity": s.last_activity.isoformat(),
                     "spawned_at": s.spawned_at.isoformat() if s.spawned_at else None,
                     "completed_at": s.completed_at.isoformat() if s.completed_at else None,
+                    "tmux_session": s.tmux_session,
+                    "tmux_socket_name": s.tmux_socket_name,
                     # sm remind: self-reported status (#188)
                     "agent_status_text": s.agent_status_text,
                     "agent_status_at": s.agent_status_at.isoformat() if s.agent_status_at else None,

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -131,6 +131,7 @@ class TestSessionEndpoints:
         assert len(data["sessions"]) == 1
         assert data["sessions"][0]["id"] == "test123"
         assert data["sessions"][0]["friendly_name"] == "Test Session"
+        assert data["sessions"][0]["tmux_socket_name"] is None
         assert data["sessions"][0]["activity_state"] == "working"
         assert data["sessions"][0]["agent_status_text"] == "running tests"
         assert data["sessions"][0]["agent_status_at"] == "2024-01-15T11:05:00"

--- a/tests/unit/test_children_api.py
+++ b/tests/unit/test_children_api.py
@@ -30,6 +30,8 @@ def test_children_endpoint_includes_activity_state(tmp_path):
         provider="codex-fork",
         parent_session_id=parent.id,
         status=SessionStatus.IDLE,
+        tmux_session="codex-fork-child001",
+        tmux_socket_name="session-manager-test",
     )
     manager.sessions[parent.id] = parent
     manager.sessions[child.id] = child
@@ -48,6 +50,8 @@ def test_children_endpoint_includes_activity_state(tmp_path):
     assert payload[0]["id"] == child.id
     assert payload[0]["status"] == "idle"
     assert payload[0]["activity_state"] == "working"
+    assert payload[0]["tmux_session"] == "codex-fork-child001"
+    assert payload[0]["tmux_socket_name"] == "session-manager-test"
 
 
 def test_children_endpoint_hides_terminated_by_default(tmp_path):

--- a/tests/unit/test_codex_fork_runtime_metadata.py
+++ b/tests/unit/test_codex_fork_runtime_metadata.py
@@ -21,7 +21,7 @@ def test_codex_fork_runtime_metadata_uses_config_pin(tmp_path):
 
     metadata = manager.get_codex_fork_runtime_info()
     assert metadata["command"] == "codex-fork-bin"
-    assert metadata["args"] == ["--fast"]
+    assert metadata["args"] == ["--fast", "-c", "check_for_update_on_startup=false"]
     assert metadata["event_schema_version"] == 7
     assert metadata["artifact_release"] == "v1.2.3-sm"
     assert metadata["artifact_ref"] == "f00dbabe1234"

--- a/tests/unit/test_watch_tui.py
+++ b/tests/unit/test_watch_tui.py
@@ -16,6 +16,7 @@ from src.cli.watch_tui import (
     _render_columns,
     _retire_confirmation_matches,
     _resolve_create_provider,
+    _resolve_tmux_attach_target,
     _session_line,
     _tmux_attach_command,
     build_restore_rows,
@@ -44,6 +45,51 @@ def test_tmux_attach_command_includes_socket_when_available():
         "-t",
         "claude-test",
     ]
+
+
+def test_resolve_tmux_attach_target_hydrates_descriptor_socket():
+    calls = []
+
+    client = type(
+        "_Client",
+        (),
+        {
+            "get_attach_descriptor": staticmethod(
+                lambda session_id: calls.append(session_id)
+                or {
+                    "attach_supported": True,
+                    "tmux_session": "descriptor-target",
+                    "tmux_socket_name": "session-manager-test",
+                }
+            ),
+        },
+    )()
+    session = {"id": "agent123", "provider": "codex-fork", "tmux_session": "stale-target"}
+
+    tmux_session, tmux_socket_name, error = _resolve_tmux_attach_target(client, session)
+
+    assert error is None
+    assert tmux_session == "descriptor-target"
+    assert tmux_socket_name == "session-manager-test"
+    assert session["tmux_session"] == "descriptor-target"
+    assert session["tmux_socket_name"] == "session-manager-test"
+    assert calls == ["agent123"]
+
+
+def test_resolve_tmux_attach_target_falls_back_to_session_without_descriptor():
+    client = type("_Client", (), {"get_attach_descriptor": staticmethod(lambda session_id: None)})()
+    session = {
+        "id": "agent123",
+        "provider": "claude",
+        "tmux_session": "session-target",
+        "tmux_socket_name": "session-manager-test",
+    }
+
+    tmux_session, tmux_socket_name, error = _resolve_tmux_attach_target(client, session)
+
+    assert error is None
+    assert tmux_session == "session-target"
+    assert tmux_socket_name == "session-manager-test"
 
 
 def _session(


### PR DESCRIPTION
## Summary
- hydrate `sm watch` attach targets from the attach descriptor before attaching, so existing/restored SM-socket sessions attach with `tmux -L <socket>`
- include `tmux_session` and `tmux_socket_name` in child/session API payloads so `sm children` and watch surfaces can query the correct tmux server
- update the codex-fork runtime metadata test to match the current managed startup-update args behavior already present on `main`

## Review Feedback Addressed
- P1 from PR #694: https://github.com/rajeshgoli/session-manager/pull/694#discussion_r3174796907
- P2 from PR #694: https://github.com/rajeshgoli/session-manager/pull/694#discussion_r3174796912

## Verification
- `pytest -q` -> 1840 passed, 93 warnings
- `pytest -q tests/unit/test_watch_tui.py tests/unit/test_children_api.py tests/unit/test_cmd_children.py tests/integration/test_api_endpoints.py::TestSessionEndpoints::test_list_sessions tests/unit/test_codex_fork_runtime_metadata.py tests/unit/test_google_auth.py::test_watch_html_is_not_cached_but_hashed_assets_remain_static` -> 86 passed, 32 warnings
- `python -m py_compile src/cli/watch_tui.py src/server.py src/cli/commands.py`

Note: full-suite local verification requires the ignored `web/sm-watch/dist/` artifact to be built first; I built it locally for the run and did not include generated assets in this PR.
