### PR TITLE
Prefer idle status for codex-fork activity

### DIFF
--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -5197,12 +5197,13 @@ class SessionManager:
 
     def _compute_codex_fork_activity(self, session: Session) -> str:
         """Compute activity state for codex-fork sessions from reducer state."""
+        if session.status == SessionStatus.STOPPED:
+            return ActivityState.STOPPED.value
+        if session.status == SessionStatus.IDLE:
+            return ActivityState.IDLE.value
+
         lifecycle = self.codex_fork_lifecycle.get(session.id)
         if not lifecycle:
-            if session.status == SessionStatus.STOPPED:
-                return ActivityState.STOPPED.value
-            if session.status == SessionStatus.IDLE:
-                return ActivityState.IDLE.value
             return ActivityState.THINKING.value
 
         state_name = lifecycle.get("state")

--- a/tests/unit/test_children_api.py
+++ b/tests/unit/test_children_api.py
@@ -29,7 +29,7 @@ def test_children_endpoint_includes_activity_state(tmp_path):
         working_dir=str(tmp_path),
         provider="codex-fork",
         parent_session_id=parent.id,
-        status=SessionStatus.IDLE,
+        status=SessionStatus.RUNNING,
         tmux_session="codex-fork-child001",
         tmux_socket_name="session-manager-test",
     )
@@ -48,7 +48,7 @@ def test_children_endpoint_includes_activity_state(tmp_path):
     payload = response.json()["children"]
     assert len(payload) == 1
     assert payload[0]["id"] == child.id
-    assert payload[0]["status"] == "idle"
+    assert payload[0]["status"] == "running"
     assert payload[0]["activity_state"] == "working"
     assert payload[0]["tmux_session"] == "codex-fork-child001"
     assert payload[0]["tmux_socket_name"] == "session-manager-test"

--- a/tests/unit/test_codex_activity_state.py
+++ b/tests/unit/test_codex_activity_state.py
@@ -719,6 +719,44 @@ def test_codex_fork_turn_diff_reasserts_running_after_restart_without_turn_start
     assert manager.get_activity_state(session.id) == "working"
 
 
+def test_codex_fork_idle_status_overrides_stale_running_lifecycle():
+    manager = _make_manager()
+    session = Session(
+        id="cf-stale-idle",
+        name="codex-fork-cf-stale-idle",
+        working_dir="/tmp",
+        provider="codex-fork",
+        status=SessionStatus.IDLE,
+    )
+    manager.sessions[session.id] = session
+    manager.codex_fork_lifecycle[session.id] = {
+        "state": "running",
+        "cause_event_type": "turn_diff",
+        "updated_at": datetime.now().isoformat(),
+    }
+
+    assert manager.get_activity_state(session.id) == "idle"
+
+
+def test_codex_fork_stopped_status_overrides_stale_running_lifecycle():
+    manager = _make_manager()
+    session = Session(
+        id="cf-stale-stopped",
+        name="codex-fork-cf-stale-stopped",
+        working_dir="/tmp",
+        provider="codex-fork",
+        status=SessionStatus.STOPPED,
+    )
+    manager.sessions[session.id] = session
+    manager.codex_fork_lifecycle[session.id] = {
+        "state": "running",
+        "cause_event_type": "turn_diff",
+        "updated_at": datetime.now().isoformat(),
+    }
+
+    assert manager.get_activity_state(session.id) == "stopped"
+
+
 def test_codex_fork_idle_reducer_does_not_capture_pane_on_read_path():
     manager = _make_manager()
     session = Session(


### PR DESCRIPTION
## Summary
- Make canonical `IDLE`/`STOPPED` session status override stale codex-fork lifecycle `running` state when computing activity
- Keep running codex-fork lifecycle projections intact for sessions whose canonical status is still running
- Add regression coverage for stale running lifecycle snapshots and adjust child API coverage to use a running session when expecting `working`

## Verification
- `pytest -q tests/unit/test_codex_activity_state.py tests/unit/test_watch_tui.py tests/unit/test_children_api.py tests/integration/test_api_endpoints.py::TestSessionEndpoints::test_list_sessions`
- `pytest -q`