### PR TITLE
[codex] Turn-bound Telegram response relay

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -406,6 +406,7 @@ class SessionManagerApp:
                 user_input.text,
                 bypass_queue=user_input.is_permission_response,
                 delivery_mode=getattr(user_input, 'delivery_mode', 'sequential'),
+                response_relay_source=user_input.source.value,
             )
             if result != DeliveryResult.FAILED:
                 self.output_monitor.update_activity(user_input.session_id)

--- a/src/main.py
+++ b/src/main.py
@@ -25,6 +25,7 @@ from .notifier import Notifier
 from .server import create_app
 from .child_monitor import ChildMonitor
 from .message_queue import MessageQueueManager
+from .response_relay import ResponseRelayLedger
 from .tool_logger import ToolLogger
 from .cli.commands import validate_friendly_name
 from .infra_supervisor import InfrastructureSupervisor
@@ -283,6 +284,14 @@ class SessionManagerApp:
         # Set notifier reference in session manager for sm_send notifications
         self.session_manager.notifier = self.notifier
 
+        response_relay_config = config.get("response_relay", {})
+        self.response_relay_ledger = ResponseRelayLedger(
+            db_path=response_relay_config.get(
+                "db_path",
+                "~/.local/share/claude-sessions/response_relay.db",
+            )
+        )
+
         # Wire up output monitor callbacks
         self.output_monitor.set_event_callback(self._handle_monitor_event)
         self.output_monitor.set_status_callback(self._handle_status_change)
@@ -305,6 +314,7 @@ class SessionManagerApp:
             db_path=sm_send_config.get("db_path", "~/.local/share/claude-sessions/message_queue.db"),
             config=config,  # Pass full config for timeout settings
             notifier=self.notifier,  # Pass notifier for Telegram mirroring
+            response_relay_ledger=self.response_relay_ledger,
         )
         # Pass message queue to session manager
         self.session_manager.message_queue_manager = self.message_queue
@@ -333,6 +343,7 @@ class SessionManagerApp:
             output_monitor=self.output_monitor,
             child_monitor=self.child_monitor,
             email_handler=self.email_handler,
+            response_relay_ledger=self.response_relay_ledger,
             config=config,  # Pass config for server timeout settings
             lifespan=_lifespan,
         )
@@ -971,6 +982,8 @@ class SessionManagerApp:
         # Stop Telegram bot
         if self.telegram_bot:
             await self.telegram_bot.stop()
+
+        self.response_relay_ledger.close()
 
         # Stop Codex app-server sessions
         for codex_session in self.session_manager.codex_sessions.values():

--- a/src/main.py
+++ b/src/main.py
@@ -291,6 +291,7 @@ class SessionManagerApp:
                 "~/.local/share/claude-sessions/response_relay.db",
             )
         )
+        self.session_manager.response_relay_ledger = self.response_relay_ledger
 
         # Wire up output monitor callbacks
         self.output_monitor.set_event_callback(self._handle_monitor_event)

--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -2123,7 +2123,7 @@ class MessageQueueManager:
 
     def _mark_delivered(self, message_id: str) -> datetime:
         """Mark a message as delivered in the database."""
-        delivered_at = datetime.now()
+        delivered_at = datetime.now(timezone.utc)
         self._execute("""
             UPDATE message_queue SET delivered_at = ? WHERE id = ?
         """, (delivered_at.isoformat(), message_id))

--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -59,6 +59,7 @@ class MessageQueueManager:
         db_path: str = "~/.local/share/claude-sessions/message_queue.db",
         config: Optional[dict] = None,
         notifier=None,
+        response_relay_ledger=None,
     ):
         """
         Initialize message queue manager.
@@ -68,9 +69,11 @@ class MessageQueueManager:
             db_path: Path to SQLite database
             config: Optional config dict with sm_send settings
             notifier: Optional Notifier instance for Telegram mirroring
+            response_relay_ledger: Optional durable turn-bound response relay ledger
         """
         self.session_manager = session_manager
         self.notifier = notifier
+        self.response_relay_ledger = response_relay_ledger
         self.db_path = Path(db_path).expanduser()
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -2118,11 +2121,46 @@ class MessageQueueManager:
         """Get the number of pending messages for a session."""
         return len(self.get_pending_messages(session_id))
 
-    def _mark_delivered(self, message_id: str):
+    def _mark_delivered(self, message_id: str) -> datetime:
         """Mark a message as delivered in the database."""
+        delivered_at = datetime.now()
         self._execute("""
             UPDATE message_queue SET delivered_at = ? WHERE id = ?
-        """, (datetime.now().isoformat(), message_id))
+        """, (delivered_at.isoformat(), message_id))
+        return delivered_at
+
+    def _record_response_relay_inbound(self, msg: QueuedMessage, delivered_at: datetime) -> None:
+        """Record a delivered user/operator message as the active response relay turn."""
+        if msg.message_category is not None:
+            return
+        ledger = getattr(self, "response_relay_ledger", None)
+        if ledger is None:
+            return
+        session = self.session_manager.get_session(msg.target_session_id)
+        if not session:
+            return
+        provider = getattr(session, "provider", None) or "claude"
+        source = "sm-send" if msg.from_sm_send else "sm-input"
+        transcript_path = getattr(session, "transcript_path", None)
+        transcript_offset = ledger.capture_transcript_offset(transcript_path)
+        try:
+            ledger.record_inbound_turn(
+                session_id=msg.target_session_id,
+                inbound_id=msg.id,
+                source=source,
+                provider=provider,
+                delivered_at=delivered_at,
+                transcript_path=transcript_path,
+                transcript_offset=transcript_offset,
+                text=msg.text,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to record response relay inbound turn for %s message %s: %s",
+                msg.target_session_id,
+                msg.id,
+                exc,
+            )
 
     def _mark_expired(self, message_id: str):
         """Mark a message as expired (delete it)."""
@@ -2471,7 +2509,8 @@ class MessageQueueManager:
 
                 # Mark messages as delivered
                 for msg in batch:
-                    self._mark_delivered(msg.id)
+                    delivered_at = self._mark_delivered(msg.id)
+                    self._record_response_relay_inbound(msg, delivered_at)
                     logger.info(f"Delivered message {msg.id}")
 
                     if msg.sender_session_id and msg.message_category is None:
@@ -2574,7 +2613,8 @@ class MessageQueueManager:
             if provider == "codex-app":
                 success = await self.session_manager._deliver_urgent(session, msg.text)
                 if success:
-                    self._mark_delivered(msg.id)
+                    delivered_at = self._mark_delivered(msg.id)
+                    self._record_response_relay_inbound(msg, delivered_at)
                     state = self._get_or_create_state(session_id)
                     state.is_idle = False
                     if state.stop_notify_delay_seconds > 0:
@@ -2677,7 +2717,8 @@ class MessageQueueManager:
                 success = await self.session_manager._deliver_direct(session, msg.text)
 
                 if success:
-                    self._mark_delivered(msg.id)
+                    delivered_at = self._mark_delivered(msg.id)
+                    self._record_response_relay_inbound(msg, delivered_at)
                     state = self._get_or_create_state(session_id)
                     state.is_idle = False
                     if state.stop_notify_delay_seconds > 0:

--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -190,7 +190,8 @@ class MessageQueueManager:
                 remind_hard_threshold INTEGER,
                 remind_cancel_on_reply_session_id TEXT,
                 parent_session_id TEXT,
-                message_category TEXT DEFAULT NULL
+                message_category TEXT DEFAULT NULL,
+                response_relay_source TEXT DEFAULT NULL
             )
         """)
         cursor.execute("""
@@ -235,6 +236,9 @@ class MessageQueueManager:
         if "message_category" not in columns:
             cursor.execute("ALTER TABLE message_queue ADD COLUMN message_category TEXT DEFAULT NULL")
             logger.info("Migrated message_queue: added message_category column")
+        if "response_relay_source" not in columns:
+            cursor.execute("ALTER TABLE message_queue ADD COLUMN response_relay_source TEXT DEFAULT NULL")
+            logger.info("Migrated message_queue: added response_relay_source column")
         cursor.execute("PRAGMA table_info(scheduled_reminders)")
         reminder_columns = [col[1] for col in cursor.fetchall()]
         if "recurring_interval_seconds" not in reminder_columns:
@@ -1923,6 +1927,7 @@ class MessageQueueManager:
         remind_cancel_on_reply_session_id: Optional[str] = None,
         parent_session_id: Optional[str] = None,
         message_category: Optional[str] = None,
+        response_relay_source: Optional[str] = None,
         trigger_delivery: bool = True,
     ) -> QueuedMessage:
         """
@@ -1944,6 +1949,7 @@ class MessageQueueManager:
             remind_cancel_on_reply_session_id: Cancel remind when the target replies to this session (#406)
             parent_session_id: EM session to wake periodically after delivery (#225-C)
             message_category: Optional category tag, e.g. 'context_monitor', for scoped cancellation (#241)
+            response_relay_source: Optional source tag for turn-bound response relay, e.g. 'telegram'
             trigger_delivery: If True, queue_message schedules immediate delivery based on mode.
 
         Returns:
@@ -1966,6 +1972,7 @@ class MessageQueueManager:
             remind_cancel_on_reply_session_id=remind_cancel_on_reply_session_id,
             parent_session_id=parent_session_id,
             message_category=message_category,
+            response_relay_source=response_relay_source or ("sm-send" if from_sm_send else None),
         )
 
         # Persist to database
@@ -1974,8 +1981,8 @@ class MessageQueueManager:
             (id, target_session_id, sender_session_id, sender_name, text,
              delivery_mode, from_sm_send, queued_at, timeout_at, notify_on_delivery, notify_after_seconds,
              notify_on_stop, remind_soft_threshold, remind_hard_threshold,
-             remind_cancel_on_reply_session_id, parent_session_id, message_category)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+             remind_cancel_on_reply_session_id, parent_session_id, message_category, response_relay_source)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (
             msg.id,
             msg.target_session_id,
@@ -1994,6 +2001,7 @@ class MessageQueueManager:
             msg.remind_cancel_on_reply_session_id,
             msg.parent_session_id,
             msg.message_category,
+            msg.response_relay_source,
         ))
 
         queue_len = self.get_queue_length(target_session_id)
@@ -2082,7 +2090,8 @@ class MessageQueueManager:
                    delivery_mode, from_sm_send, queued_at, timeout_at, notify_on_delivery,
                    notify_after_seconds, notify_on_stop, delivered_at,
                    remind_soft_threshold, remind_hard_threshold,
-                   remind_cancel_on_reply_session_id, parent_session_id, message_category
+                   remind_cancel_on_reply_session_id, parent_session_id, message_category,
+                   response_relay_source
             FROM message_queue
             WHERE target_session_id = ? AND delivered_at IS NULL
             ORDER BY queued_at ASC
@@ -2109,6 +2118,7 @@ class MessageQueueManager:
                 remind_cancel_on_reply_session_id=row[15],
                 parent_session_id=row[16],
                 message_category=row[17],
+                response_relay_source=row[18],
             )
             # Skip expired messages
             if msg.timeout_at and datetime.now() > msg.timeout_at:
@@ -2133,9 +2143,10 @@ class MessageQueueManager:
         """Record a delivered user/operator message as the active response relay turn."""
         if msg.message_category is not None:
             return
-        # Internal prompts are often uncategorized; only explicit sm send turns
-        # should move the automatic Telegram response boundary.
-        if not msg.from_sm_send:
+        # Internal prompts are often uncategorized; only explicit inbound turn
+        # sources should move the automatic Telegram response boundary.
+        source = msg.response_relay_source or ("sm-send" if msg.from_sm_send else None)
+        if not source:
             return
         ledger = getattr(self, "response_relay_ledger", None)
         if ledger is None:
@@ -2150,7 +2161,7 @@ class MessageQueueManager:
             ledger.record_inbound_turn(
                 session_id=msg.target_session_id,
                 inbound_id=msg.id,
-                source="sm-send",
+                source=source,
                 provider=provider,
                 delivered_at=delivered_at,
                 transcript_path=transcript_path,

--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -2133,6 +2133,10 @@ class MessageQueueManager:
         """Record a delivered user/operator message as the active response relay turn."""
         if msg.message_category is not None:
             return
+        # Internal prompts are often uncategorized; only explicit sm send turns
+        # should move the automatic Telegram response boundary.
+        if not msg.from_sm_send:
+            return
         ledger = getattr(self, "response_relay_ledger", None)
         if ledger is None:
             return
@@ -2140,14 +2144,13 @@ class MessageQueueManager:
         if not session:
             return
         provider = getattr(session, "provider", None) or "claude"
-        source = "sm-send" if msg.from_sm_send else "sm-input"
         transcript_path = getattr(session, "transcript_path", None)
         transcript_offset = ledger.capture_transcript_offset(transcript_path)
         try:
             ledger.record_inbound_turn(
                 session_id=msg.target_session_id,
                 inbound_id=msg.id,
-                source=source,
+                source="sm-send",
                 provider=provider,
                 delivered_at=delivered_at,
                 transcript_path=transcript_path,

--- a/src/models.py
+++ b/src/models.py
@@ -586,6 +586,7 @@ class QueuedMessage:
     remind_cancel_on_reply_session_id: Optional[str] = None  # Cancel remind when target sm-sends back to this session (#406)
     parent_session_id: Optional[str] = None  # EM to wake periodically after delivery (#225-C)
     message_category: Optional[str] = None  # e.g. 'context_monitor' for cancellation scoping (#241)
+    response_relay_source: Optional[str] = None  # e.g. 'sm-send' or 'telegram' for turn-bound response relay
 
     def to_dict(self) -> dict:
         """Convert to dictionary for JSON serialization."""
@@ -608,6 +609,7 @@ class QueuedMessage:
             "remind_cancel_on_reply_session_id": self.remind_cancel_on_reply_session_id,
             "parent_session_id": self.parent_session_id,
             "message_category": self.message_category,
+            "response_relay_source": self.response_relay_source,
         }
 
 

--- a/src/response_relay.py
+++ b/src/response_relay.py
@@ -420,17 +420,25 @@ class ResponseRelayLedger:
             self._conn.commit()
 
 
-def _extract_visible_assistant_text(entry: dict) -> str:
+def _extract_visible_message_text(entry: dict) -> str:
     message = entry.get("message") if isinstance(entry.get("message"), dict) else {}
-    content = message.get("content", [])
+    content = message.get("content", entry.get("content", []))
+    if isinstance(content, str):
+        return content.strip()
     texts: list[str] = []
     if isinstance(content, list):
         for item in content:
-            if isinstance(item, dict) and item.get("type") == "text":
+            if isinstance(item, str):
+                texts.append(item)
+            elif isinstance(item, dict) and item.get("type") == "text":
                 text = item.get("text")
                 if isinstance(text, str):
                     texts.append(text)
     return "\n".join(texts).strip()
+
+
+def _extract_visible_assistant_text(entry: dict) -> str:
+    return _extract_visible_message_text(entry)
 
 
 def _assistant_message_id(entry: dict, line_start_offset: int, text: str) -> str:
@@ -444,6 +452,44 @@ def _assistant_message_id(entry: dict, line_start_offset: int, text: str) -> str
         if value:
             return str(value)
     return f"transcript:{line_start_offset}:{_hash_text(text)[:16]}"
+
+
+def find_claude_inbound_turn_boundary_offset(
+    transcript_path: str,
+    turn: InboundTurn,
+) -> Optional[int]:
+    """Find the byte offset immediately after the matching inbound user line."""
+    if not turn.text_hash:
+        return None
+
+    path = Path(transcript_path).expanduser()
+    if not path.exists():
+        return None
+
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        logger.warning("Could not read Claude transcript for inbound boundary %s: %s", transcript_path, exc)
+        return None
+
+    offset = 0
+    matched_offset: Optional[int] = None
+    for raw_line in data.splitlines(keepends=True):
+        offset += len(raw_line)
+        if not raw_line.strip():
+            continue
+        try:
+            entry = json.loads(raw_line.decode("utf-8").strip())
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            logger.debug("Skipping malformed Claude transcript line for inbound boundary: %s", exc)
+            continue
+        if not isinstance(entry, dict) or entry.get("type") != "user":
+            continue
+        text = _extract_visible_message_text(entry)
+        if text and _hash_text(text) == turn.text_hash:
+            matched_offset = offset
+
+    return matched_offset
 
 
 def collect_claude_assistant_outputs_after_turn(

--- a/src/response_relay.py
+++ b/src/response_relay.py
@@ -250,6 +250,28 @@ class ResponseRelayLedger:
             )
             self._conn.commit()
 
+    def replace_inbound_transcript_boundary(
+        self,
+        inbound_id: str,
+        *,
+        transcript_path: str,
+        transcript_offset: Optional[int] = None,
+    ) -> None:
+        """Replace transcript boundary metadata when a session moves to a new transcript."""
+        now = _utc_now().isoformat()
+        with self._lock:
+            self._conn.execute(
+                """
+                UPDATE inbound_turns
+                SET transcript_path = ?,
+                    transcript_offset = ?,
+                    updated_at = ?
+                WHERE inbound_id = ?
+                """,
+                (transcript_path, transcript_offset, now, inbound_id),
+            )
+            self._conn.commit()
+
     def get_latest_active_turn(self, session_id: str) -> Optional[InboundTurn]:
         with self._lock:
             cursor = self._conn.cursor()

--- a/src/response_relay.py
+++ b/src/response_relay.py
@@ -1,0 +1,507 @@
+"""Durable turn-bound assistant response relay state."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import sqlite3
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _coerce_utc(value: Optional[datetime]) -> datetime:
+    if value is None:
+        return _utc_now()
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _parse_datetime(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        normalized = value.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    return _coerce_utc(parsed)
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class InboundTurn:
+    """A user/operator input delivered to one managed session."""
+
+    inbound_id: str
+    session_id: str
+    source: str
+    provider: Optional[str]
+    delivered_at: datetime
+    transcript_path: Optional[str] = None
+    transcript_offset: Optional[int] = None
+    provider_turn_id: Optional[str] = None
+    text_hash: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class ClaudeAssistantOutput:
+    """Visible Claude assistant text parsed from a transcript."""
+
+    assistant_message_id: str
+    text: str
+    completed_at: datetime
+    line_start_offset: int
+    line_number: int
+
+
+class ResponseRelayLedger:
+    """SQLite ledger for inbound turn boundaries and relayed assistant outputs."""
+
+    def __init__(self, db_path: str = "~/.local/share/claude-sessions/response_relay.db"):
+        self.db_path = Path(db_path).expanduser()
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._conn = sqlite3.connect(str(self.db_path), check_same_thread=False)
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute("PRAGMA busy_timeout=5000")
+        self._init_db()
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+    def _init_db(self) -> None:
+        with self._lock:
+            cursor = self._conn.cursor()
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS inbound_turns (
+                    inbound_id TEXT PRIMARY KEY,
+                    session_id TEXT NOT NULL,
+                    source TEXT NOT NULL,
+                    provider TEXT,
+                    delivered_at TEXT NOT NULL,
+                    transcript_path TEXT,
+                    transcript_offset INTEGER,
+                    provider_turn_id TEXT,
+                    text_hash TEXT,
+                    superseded_at TEXT,
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+                """
+            )
+            cursor.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_inbound_turns_active
+                ON inbound_turns(session_id, delivered_at)
+                WHERE superseded_at IS NULL
+                """
+            )
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS assistant_outputs (
+                    session_id TEXT NOT NULL,
+                    inbound_id TEXT NOT NULL,
+                    provider TEXT NOT NULL,
+                    provider_turn_id TEXT,
+                    assistant_message_id TEXT NOT NULL,
+                    completed_at TEXT NOT NULL,
+                    text_hash TEXT NOT NULL,
+                    text_preview TEXT,
+                    relay_claimed_at TEXT,
+                    relayed_at TEXT,
+                    telegram_thread_id INTEGER,
+                    PRIMARY KEY (session_id, inbound_id, provider, assistant_message_id)
+                )
+                """
+            )
+            cursor.execute(
+                """
+                CREATE INDEX IF NOT EXISTS idx_assistant_outputs_relayed
+                ON assistant_outputs(session_id, inbound_id, relayed_at)
+                """
+            )
+            self._conn.commit()
+
+    @staticmethod
+    def capture_transcript_offset(transcript_path: Optional[str]) -> Optional[int]:
+        """Return the current transcript byte size, if a transcript exists."""
+        if not transcript_path:
+            return None
+        try:
+            return Path(transcript_path).expanduser().stat().st_size
+        except FileNotFoundError:
+            return None
+        except OSError as exc:
+            logger.debug("Could not stat transcript %s for relay boundary: %s", transcript_path, exc)
+            return None
+
+    def record_inbound_turn(
+        self,
+        *,
+        session_id: str,
+        inbound_id: str,
+        source: str,
+        provider: Optional[str] = None,
+        delivered_at: Optional[datetime] = None,
+        transcript_path: Optional[str] = None,
+        transcript_offset: Optional[int] = None,
+        provider_turn_id: Optional[str] = None,
+        text: str = "",
+    ) -> InboundTurn:
+        """Persist a delivered input turn and supersede older active turns."""
+        delivered = _coerce_utc(delivered_at)
+        now = _utc_now().isoformat()
+        delivered_iso = delivered.isoformat()
+        text_hash = _hash_text(text) if text else None
+        with self._lock:
+            cursor = self._conn.cursor()
+            cursor.execute(
+                """
+                UPDATE inbound_turns
+                SET superseded_at = ?, updated_at = ?
+                WHERE session_id = ?
+                  AND inbound_id != ?
+                  AND superseded_at IS NULL
+                """,
+                (now, now, session_id, inbound_id),
+            )
+            cursor.execute(
+                """
+                INSERT INTO inbound_turns
+                (inbound_id, session_id, source, provider, delivered_at, transcript_path,
+                 transcript_offset, provider_turn_id, text_hash, superseded_at, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, ?)
+                ON CONFLICT(inbound_id) DO UPDATE SET
+                    session_id = excluded.session_id,
+                    source = excluded.source,
+                    provider = excluded.provider,
+                    delivered_at = excluded.delivered_at,
+                    transcript_path = COALESCE(excluded.transcript_path, inbound_turns.transcript_path),
+                    transcript_offset = COALESCE(excluded.transcript_offset, inbound_turns.transcript_offset),
+                    provider_turn_id = COALESCE(excluded.provider_turn_id, inbound_turns.provider_turn_id),
+                    text_hash = COALESCE(excluded.text_hash, inbound_turns.text_hash),
+                    superseded_at = NULL,
+                    updated_at = excluded.updated_at
+                """,
+                (
+                    inbound_id,
+                    session_id,
+                    source,
+                    provider,
+                    delivered_iso,
+                    transcript_path,
+                    transcript_offset,
+                    provider_turn_id,
+                    text_hash,
+                    now,
+                    now,
+                ),
+            )
+            self._conn.commit()
+        return InboundTurn(
+            inbound_id=inbound_id,
+            session_id=session_id,
+            source=source,
+            provider=provider,
+            delivered_at=delivered,
+            transcript_path=transcript_path,
+            transcript_offset=transcript_offset,
+            provider_turn_id=provider_turn_id,
+            text_hash=text_hash,
+        )
+
+    def update_inbound_boundary(
+        self,
+        inbound_id: str,
+        *,
+        transcript_path: Optional[str] = None,
+        transcript_offset: Optional[int] = None,
+        provider_turn_id: Optional[str] = None,
+    ) -> None:
+        """Fill missing provider boundary metadata without moving the turn."""
+        now = _utc_now().isoformat()
+        with self._lock:
+            self._conn.execute(
+                """
+                UPDATE inbound_turns
+                SET transcript_path = COALESCE(?, transcript_path),
+                    transcript_offset = COALESCE(?, transcript_offset),
+                    provider_turn_id = COALESCE(?, provider_turn_id),
+                    updated_at = ?
+                WHERE inbound_id = ?
+                """,
+                (transcript_path, transcript_offset, provider_turn_id, now, inbound_id),
+            )
+            self._conn.commit()
+
+    def get_latest_active_turn(self, session_id: str) -> Optional[InboundTurn]:
+        with self._lock:
+            cursor = self._conn.cursor()
+            cursor.execute(
+                """
+                SELECT inbound_id, session_id, source, provider, delivered_at,
+                       transcript_path, transcript_offset, provider_turn_id, text_hash
+                FROM inbound_turns
+                WHERE session_id = ?
+                  AND superseded_at IS NULL
+                ORDER BY delivered_at DESC, updated_at DESC
+                LIMIT 1
+                """,
+                (session_id,),
+            )
+            row = cursor.fetchone()
+        if not row:
+            return None
+        delivered_at = _parse_datetime(row[4]) or _utc_now()
+        return InboundTurn(
+            inbound_id=row[0],
+            session_id=row[1],
+            source=row[2],
+            provider=row[3],
+            delivered_at=delivered_at,
+            transcript_path=row[5],
+            transcript_offset=row[6],
+            provider_turn_id=row[7],
+            text_hash=row[8],
+        )
+
+    def claim_assistant_output(
+        self,
+        *,
+        session_id: str,
+        inbound_id: str,
+        provider: str,
+        assistant_message_id: str,
+        text: str,
+        completed_at: Optional[datetime] = None,
+        provider_turn_id: Optional[str] = None,
+        claim_timeout_seconds: int = 120,
+    ) -> bool:
+        """Claim one assistant output for relay, returning False for duplicates."""
+        now = _utc_now()
+        now_iso = now.isoformat()
+        completed_iso = _coerce_utc(completed_at).isoformat()
+        text_hash = _hash_text(text)
+        preview = text[:400]
+        stale_before = now - timedelta(seconds=claim_timeout_seconds)
+        with self._lock:
+            cursor = self._conn.cursor()
+            cursor.execute(
+                """
+                SELECT relayed_at, relay_claimed_at
+                FROM assistant_outputs
+                WHERE session_id = ?
+                  AND inbound_id = ?
+                  AND provider = ?
+                  AND assistant_message_id = ?
+                """,
+                (session_id, inbound_id, provider, assistant_message_id),
+            )
+            row = cursor.fetchone()
+            if row:
+                relayed_at, claimed_at = row
+                if relayed_at:
+                    return False
+                claimed_dt = _parse_datetime(claimed_at)
+                if claimed_dt and claimed_dt > stale_before:
+                    return False
+                cursor.execute(
+                    """
+                    UPDATE assistant_outputs
+                    SET relay_claimed_at = ?,
+                        completed_at = ?,
+                        text_hash = ?,
+                        text_preview = ?,
+                        provider_turn_id = COALESCE(?, provider_turn_id)
+                    WHERE session_id = ?
+                      AND inbound_id = ?
+                      AND provider = ?
+                      AND assistant_message_id = ?
+                    """,
+                    (
+                        now_iso,
+                        completed_iso,
+                        text_hash,
+                        preview,
+                        provider_turn_id,
+                        session_id,
+                        inbound_id,
+                        provider,
+                        assistant_message_id,
+                    ),
+                )
+            else:
+                cursor.execute(
+                    """
+                    INSERT INTO assistant_outputs
+                    (session_id, inbound_id, provider, provider_turn_id, assistant_message_id,
+                     completed_at, text_hash, text_preview, relay_claimed_at, relayed_at, telegram_thread_id)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL)
+                    """,
+                    (
+                        session_id,
+                        inbound_id,
+                        provider,
+                        provider_turn_id,
+                        assistant_message_id,
+                        completed_iso,
+                        text_hash,
+                        preview,
+                        now_iso,
+                    ),
+                )
+            self._conn.commit()
+        return True
+
+    def mark_assistant_output_relayed(
+        self,
+        *,
+        session_id: str,
+        inbound_id: str,
+        provider: str,
+        assistant_message_id: str,
+        telegram_thread_id: Optional[int] = None,
+        relayed_at: Optional[datetime] = None,
+    ) -> None:
+        relay_ts = _coerce_utc(relayed_at).isoformat()
+        with self._lock:
+            self._conn.execute(
+                """
+                UPDATE assistant_outputs
+                SET relayed_at = ?,
+                    telegram_thread_id = ?
+                WHERE session_id = ?
+                  AND inbound_id = ?
+                  AND provider = ?
+                  AND assistant_message_id = ?
+                """,
+                (relay_ts, telegram_thread_id, session_id, inbound_id, provider, assistant_message_id),
+            )
+            self._conn.commit()
+
+    def release_assistant_output_claim(
+        self,
+        *,
+        session_id: str,
+        inbound_id: str,
+        provider: str,
+        assistant_message_id: str,
+    ) -> None:
+        """Release a claim after notifier rejection so a later hook may retry."""
+        with self._lock:
+            self._conn.execute(
+                """
+                UPDATE assistant_outputs
+                SET relay_claimed_at = NULL
+                WHERE session_id = ?
+                  AND inbound_id = ?
+                  AND provider = ?
+                  AND assistant_message_id = ?
+                  AND relayed_at IS NULL
+                """,
+                (session_id, inbound_id, provider, assistant_message_id),
+            )
+            self._conn.commit()
+
+
+def _extract_visible_assistant_text(entry: dict) -> str:
+    message = entry.get("message") if isinstance(entry.get("message"), dict) else {}
+    content = message.get("content", [])
+    texts: list[str] = []
+    if isinstance(content, list):
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "text":
+                text = item.get("text")
+                if isinstance(text, str):
+                    texts.append(text)
+    return "\n".join(texts).strip()
+
+
+def _assistant_message_id(entry: dict, line_start_offset: int, text: str) -> str:
+    message = entry.get("message") if isinstance(entry.get("message"), dict) else {}
+    for value in (
+        entry.get("uuid"),
+        entry.get("message_id"),
+        entry.get("id"),
+        message.get("id"),
+    ):
+        if value:
+            return str(value)
+    return f"transcript:{line_start_offset}:{_hash_text(text)[:16]}"
+
+
+def collect_claude_assistant_outputs_after_turn(
+    transcript_path: str,
+    turn: InboundTurn,
+) -> list[ClaudeAssistantOutput]:
+    """Collect visible assistant messages provably after an inbound turn boundary."""
+    path = Path(transcript_path).expanduser()
+    if not path.exists():
+        return []
+
+    try:
+        data = path.read_bytes()
+    except OSError as exc:
+        logger.warning("Could not read Claude transcript for relay %s: %s", transcript_path, exc)
+        return []
+
+    start_offset = turn.transcript_offset
+    if start_offset is not None:
+        if start_offset > len(data):
+            return []
+        scan_data = data[start_offset:]
+        base_offset = start_offset
+        require_timestamp = False
+    else:
+        scan_data = data
+        base_offset = 0
+        require_timestamp = True
+
+    outputs: list[ClaudeAssistantOutput] = []
+    line_start = 0
+    for line_number, raw_line in enumerate(scan_data.splitlines(), start=1):
+        absolute_offset = base_offset + line_start
+        line_start += len(raw_line) + 1
+        if not raw_line.strip():
+            continue
+        try:
+            entry = json.loads(raw_line.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            logger.debug("Skipping malformed Claude transcript line for relay: %s", exc)
+            continue
+        if not isinstance(entry, dict) or entry.get("type") != "assistant":
+            continue
+
+        completed_at = _parse_datetime(str(entry.get("timestamp")) if entry.get("timestamp") else None)
+        if require_timestamp:
+            if completed_at is None or completed_at < turn.delivered_at:
+                continue
+        text = _extract_visible_assistant_text(entry)
+        if not text:
+            continue
+        outputs.append(
+            ClaudeAssistantOutput(
+                assistant_message_id=_assistant_message_id(entry, absolute_offset, text),
+                text=text,
+                completed_at=completed_at or _utc_now(),
+                line_start_offset=absolute_offset,
+                line_number=line_number,
+            )
+        )
+    return outputs

--- a/src/server.py
+++ b/src/server.py
@@ -6342,11 +6342,37 @@ Provide ONLY the summary, no preamble or questions."""
 
         active_turn = ledger.get_latest_active_turn(session_id)
         if not active_turn:
-            logger.info(
-                "Suppressing Claude response relay for %s: no active inbound turn boundary",
-                session_id,
-            )
-            return True
+            spawn_prompt = getattr(target_session, "spawn_prompt", None)
+            if isinstance(spawn_prompt, str) and spawn_prompt.strip():
+                try:
+                    active_turn = ledger.record_inbound_turn(
+                        session_id=session_id,
+                        inbound_id=f"initial:{session_id}",
+                        source="spawn",
+                        provider="claude",
+                        delivered_at=target_session.spawned_at or target_session.created_at,
+                        transcript_path=transcript_path or target_session.transcript_path,
+                        transcript_offset=None,
+                        text=spawn_prompt,
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to backfill spawn response relay boundary for %s: %s",
+                        session_id,
+                        exc,
+                    )
+                    active_turn = None
+            if active_turn:
+                logger.info(
+                    "Backfilled Claude response relay boundary for spawned session %s",
+                    session_id,
+                )
+            else:
+                logger.info(
+                    "Suppressing Claude response relay for %s: no active inbound turn boundary",
+                    session_id,
+                )
+                return True
 
         hook_replaces_stored_transcript = bool(
             transcript_path

--- a/src/server.py
+++ b/src/server.py
@@ -1357,7 +1357,8 @@ def create_app(
     if notifier is not None:
         setattr(notifier, "session_manager", session_manager)
     if session_manager is not None:
-        setattr(session_manager, "response_relay_ledger", response_relay_ledger)
+        if response_relay_ledger is not None:
+            setattr(session_manager, "response_relay_ledger", response_relay_ledger)
         queue_mgr = getattr(session_manager, "message_queue_manager", None)
         if queue_mgr is not None and response_relay_ledger is not None:
             setattr(queue_mgr, "response_relay_ledger", response_relay_ledger)

--- a/src/server.py
+++ b/src/server.py
@@ -6348,8 +6348,17 @@ Provide ONLY the summary, no preamble or questions."""
             )
             return True
 
-        effective_transcript_path = active_turn.transcript_path or transcript_path
-        boundary_offset = active_turn.transcript_offset
+        hook_replaces_stored_transcript = bool(
+            transcript_path
+            and active_turn.transcript_path
+            and transcript_path != active_turn.transcript_path
+        )
+        effective_transcript_path = (
+            transcript_path
+            if hook_replaces_stored_transcript
+            else active_turn.transcript_path or transcript_path
+        )
+        boundary_offset = None if hook_replaces_stored_transcript else active_turn.transcript_offset
         if effective_transcript_path and boundary_offset is None:
             boundary_offset = find_claude_inbound_turn_boundary_offset(
                 effective_transcript_path,
@@ -6357,7 +6366,18 @@ Provide ONLY the summary, no preamble or questions."""
             )
         should_update_path = bool(transcript_path and not active_turn.transcript_path)
         should_update_offset = boundary_offset is not None and active_turn.transcript_offset is None
-        if should_update_path or should_update_offset:
+        if hook_replaces_stored_transcript:
+            ledger.replace_inbound_transcript_boundary(
+                active_turn.inbound_id,
+                transcript_path=transcript_path,
+                transcript_offset=boundary_offset,
+            )
+            active_turn = replace(
+                active_turn,
+                transcript_path=transcript_path,
+                transcript_offset=boundary_offset,
+            )
+        elif should_update_path or should_update_offset:
             ledger.update_inbound_boundary(
                 active_turn.inbound_id,
                 transcript_path=transcript_path if should_update_path else None,

--- a/src/server.py
+++ b/src/server.py
@@ -58,6 +58,10 @@ from .cli.dispatch import get_auto_remind_config
 from .bug_report_store import BugReportStore
 from .human_recipients import HumanRecipient, HumanRecipientConfigError
 from .mobile_analytics import MobileAnalyticsBuilder
+from .response_relay import (
+    ResponseRelayLedger,
+    collect_claude_assistant_outputs_after_turn,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1293,6 +1297,7 @@ def create_app(
     config: Optional[dict] = None,
     lifespan=None,
     email_handler=None,
+    response_relay_ledger: Optional[ResponseRelayLedger] = None,
 ) -> FastAPI:
     """
     Create the FastAPI application.
@@ -1305,6 +1310,7 @@ def create_app(
         config: Configuration dictionary
         lifespan: Optional ASGI lifespan context manager
         email_handler: EmailHandler instance
+        response_relay_ledger: Durable turn-bound response relay ledger
 
     Returns:
         Configured FastAPI app
@@ -1341,12 +1347,17 @@ def create_app(
     app.state.output_monitor = output_monitor
     app.state.child_monitor = child_monitor
     app.state.email_handler = email_handler
+    app.state.response_relay_ledger = response_relay_ledger
     app.state.bug_report_store = None
     app.state.infra_supervisor = None
     app.state.last_claude_output = {}  # Store last output per session from hooks
     app.state.pending_stop_notifications = set()  # Sessions where Stop hook had empty transcript
     if notifier is not None:
         setattr(notifier, "session_manager", session_manager)
+    if session_manager is not None:
+        queue_mgr = getattr(session_manager, "message_queue_manager", None)
+        if queue_mgr is not None and response_relay_ledger is not None:
+            setattr(queue_mgr, "response_relay_ledger", response_relay_ledger)
 
     attach_infra_cache = {"expires_at": 0.0, "issue": None}
     app.state.mobile_terminal_tickets: dict[str, MobileTerminalTicket] = {}
@@ -6240,6 +6251,192 @@ Provide ONLY the summary, no preamble or questions."""
             methods=["POST"],
         )
 
+    def _resolve_claude_hook_session(
+        session_manager_id: Optional[str],
+        transcript_path: Optional[str],
+        claude_session_id: Optional[str],
+    ) -> Optional[Session]:
+        """Resolve a Claude hook to its managed session without transcript probing."""
+        if not app.state.session_manager:
+            return None
+        if session_manager_id:
+            target_session = app.state.session_manager.get_session(session_manager_id)
+            if target_session:
+                logger.info(f"Matched hook to session {session_manager_id} via environment variable")
+                return target_session
+        if transcript_path:
+            for session in app.state.session_manager.list_sessions():
+                if session.transcript_path == transcript_path:
+                    logger.info(f"Matched hook to session {session.id} via existing transcript path")
+                    return session
+        if claude_session_id:
+            target_session = app.state.session_manager.get_session(claude_session_id)
+            if target_session:
+                logger.info(f"Matched hook to session {claude_session_id} via claude_session_id")
+                return target_session
+        return None
+
+    async def _emit_review_complete_if_needed(target_session: Session, last_message: str) -> None:
+        """Preserve existing Claude review-complete side effects after response relay."""
+        if not target_session.review_config:
+            return
+        try:
+            from .review_parser import parse_tui_output, parse_github_review
+
+            review_config = target_session.review_config
+            review_result = None
+            if review_config.mode == "pr" and review_config.pr_repo and review_config.pr_number:
+                from .github_reviews import fetch_latest_codex_review
+
+                codex_review = await asyncio.to_thread(
+                    fetch_latest_codex_review,
+                    review_config.pr_repo,
+                    review_config.pr_number,
+                )
+                if codex_review:
+                    review_result = await asyncio.to_thread(
+                        parse_github_review,
+                        review_config.pr_repo,
+                        review_config.pr_number,
+                        codex_review,
+                    )
+            else:
+                review_result = parse_tui_output(last_message)
+
+            if review_result and review_result.findings:
+                review_event = NotificationEvent(
+                    session_id=target_session.id,
+                    event_type="review_complete",
+                    message="Review complete",
+                    context="",
+                    urgent=False,
+                )
+                review_event.review_result = review_result
+                await app.state.notifier.notify(review_event, target_session)
+        except Exception as e:
+            logger.warning(f"Failed to emit review_complete notification: {e}")
+
+    async def _relay_claude_response_for_turn(
+        *,
+        session_id: str,
+        transcript_path: Optional[str],
+        hook_event: str,
+    ) -> bool:
+        """Relay a Claude response only when it belongs to the active inbound turn."""
+        ledger = getattr(app.state, "response_relay_ledger", None)
+        if ledger is None or not app.state.notifier or not app.state.session_manager:
+            return False
+
+        target_session = app.state.session_manager.get_session(session_id)
+        if not target_session:
+            return True
+        if not target_session.telegram_chat_id:
+            return True
+
+        active_turn = ledger.get_latest_active_turn(session_id)
+        if not active_turn:
+            logger.info(
+                "Suppressing Claude response relay for %s: no active inbound turn boundary",
+                session_id,
+            )
+            return True
+
+        effective_transcript_path = active_turn.transcript_path or transcript_path
+        if transcript_path and not active_turn.transcript_path:
+            ledger.update_inbound_boundary(active_turn.inbound_id, transcript_path=transcript_path)
+        if not effective_transcript_path:
+            app.state.pending_stop_notifications.add(session_id)
+            logger.info(
+                "Deferring Claude response relay for %s: no transcript path for inbound %s",
+                session_id,
+                active_turn.inbound_id,
+            )
+            return True
+
+        outputs = collect_claude_assistant_outputs_after_turn(effective_transcript_path, active_turn)
+        if hook_event == "Stop":
+            retry_delay = EMPTY_TRANSCRIPT_RETRY_DELAY_SECONDS if not outputs else TRANSCRIPT_RETRY_DELAY_SECONDS
+            await asyncio.sleep(retry_delay)
+            retry_outputs = collect_claude_assistant_outputs_after_turn(effective_transcript_path, active_turn)
+            if retry_outputs:
+                outputs = retry_outputs
+
+        if not outputs:
+            app.state.pending_stop_notifications.add(session_id)
+            logger.info(
+                "Deferring Claude response relay for %s inbound %s: no post-boundary assistant output",
+                session_id,
+                active_turn.inbound_id,
+            )
+            return True
+
+        candidate = outputs[-1]
+        claimed = ledger.claim_assistant_output(
+            session_id=session_id,
+            inbound_id=active_turn.inbound_id,
+            provider="claude",
+            assistant_message_id=candidate.assistant_message_id,
+            text=candidate.text,
+            completed_at=candidate.completed_at,
+            provider_turn_id=active_turn.provider_turn_id,
+        )
+        if not claimed:
+            app.state.pending_stop_notifications.discard(session_id)
+            logger.info(
+                "Skipping duplicate Claude response relay for %s inbound %s message %s",
+                session_id,
+                active_turn.inbound_id,
+                candidate.assistant_message_id,
+            )
+            return True
+
+        app.state.last_claude_output["latest"] = candidate.text
+        app.state.last_claude_output[session_id] = candidate.text
+        app.state.pending_stop_notifications.discard(session_id)
+
+        event = NotificationEvent(
+            session_id=target_session.id,
+            event_type="response",
+            message="Claude responded",
+            context=candidate.text,
+            urgent=False,
+        )
+        if app.state.output_monitor:
+            app.state.output_monitor.mark_response_sent(target_session.id)
+
+        async def _notify_response_event():
+            try:
+                accepted = await app.state.notifier.notify(event, target_session)
+            except Exception as exc:
+                accepted = False
+                logger.warning(
+                    "Failed to send turn-bound Claude response notification for %s: %s",
+                    target_session.id,
+                    exc,
+                )
+
+            if accepted:
+                ledger.mark_assistant_output_relayed(
+                    session_id=session_id,
+                    inbound_id=active_turn.inbound_id,
+                    provider="claude",
+                    assistant_message_id=candidate.assistant_message_id,
+                    telegram_thread_id=target_session.telegram_thread_id,
+                )
+                target_session.last_activity = datetime.now()
+                await _save_session_manager_state(app.state.session_manager)
+                await _emit_review_complete_if_needed(target_session, candidate.text)
+            else:
+                ledger.release_assistant_output_claim(
+                    session_id=session_id,
+                    inbound_id=active_turn.inbound_id,
+                    provider="claude",
+                    assistant_message_id=candidate.assistant_message_id,
+                )
+
+        asyncio.create_task(_notify_response_event())
+        return True
+
     @app.post("/hooks/claude")
     async def claude_hook(request: Request):
         """
@@ -6527,7 +6724,15 @@ Provide ONLY the summary, no preamble or questions."""
                     elif prompt_state_changed:
                         await _save_session_manager_state(app.state.session_manager)
 
-        if hook_event == "Stop" and not last_message and session_manager_id:
+        relay_handled = False
+        if hook_event == "Stop" and session_manager_id:
+            relay_handled = await _relay_claude_response_for_turn(
+                session_id=session_manager_id,
+                transcript_path=transcript_path,
+                hook_event=hook_event,
+            )
+
+        if hook_event == "Stop" and not last_message and session_manager_id and not relay_handled:
             # Transcript was empty/whitespace-only at Stop time (race condition:
             # file not flushed yet). Track this so we can send a deferred
             # notification when the idle_prompt Notification hook arrives with
@@ -6535,40 +6740,16 @@ Provide ONLY the summary, no preamble or questions."""
             app.state.pending_stop_notifications.add(session_manager_id)
             logger.info(f"Stop hook for {session_manager_id} had empty transcript, deferring notification")
 
-        if hook_event == "Stop" and last_message:
+        if hook_event == "Stop" and last_message and not relay_handled:
             # Send immediate notification to Telegram
             app.state.pending_stop_notifications.discard(session_manager_id)
             if app.state.notifier and app.state.session_manager:
                 # Try to find the session this hook belongs to
-                target_session = None
-
-                # First try: match by session_manager_id (set when session manager launches Claude)
-                # This is the most reliable - set via CLAUDE_SESSION_MANAGER_ID env var
-                if session_manager_id:
-                    target_session = app.state.session_manager.get_session(session_manager_id)
-                    if target_session:
-                        logger.info(f"Matched hook to session {session_manager_id} via environment variable")
-
-                # If we have a reliable match, don't try other methods
-                if target_session:
-                    pass  # Use this session
-                else:
-                    # Second try: match by transcript path - but only if it hasn't been set yet
-                    # (to avoid matching wrong session if transcript paths get reused)
-                    if transcript_path:
-                        sessions = app.state.session_manager.list_sessions()
-                        for session in sessions:
-                            # Only match if session has this transcript path already recorded
-                            if session.transcript_path == transcript_path:
-                                target_session = session
-                                logger.info(f"Matched hook to session {session.id} via existing transcript path")
-                                break
-
-                    # Third try: match by claude_session_id (if provided)
-                    if not target_session and claude_session_id:
-                        target_session = app.state.session_manager.get_session(claude_session_id)
-                        if target_session:
-                            logger.info(f"Matched hook to session {claude_session_id} via claude_session_id")
+                target_session = _resolve_claude_hook_session(
+                    session_manager_id,
+                    transcript_path,
+                    claude_session_id,
+                )
 
                 # If we found a matching session, send the notification
                 if target_session and target_session.telegram_chat_id:
@@ -6604,44 +6785,7 @@ Provide ONLY the summary, no preamble or questions."""
 
                     asyncio.create_task(_notify_response_event())
 
-                    # If session has a review_config, emit review_complete notification
-                    if target_session.review_config:
-                        try:
-                            from .review_parser import parse_tui_output, parse_github_review
-                            review_config = target_session.review_config
-
-                            review_result = None
-                            if review_config.mode == "pr" and review_config.pr_repo and review_config.pr_number:
-                                # PR mode: fetch from GitHub (async)
-                                from .github_reviews import fetch_latest_codex_review
-                                codex_review = await asyncio.to_thread(
-                                    fetch_latest_codex_review,
-                                    review_config.pr_repo,
-                                    review_config.pr_number,
-                                )
-                                if codex_review:
-                                    review_result = await asyncio.to_thread(
-                                        parse_github_review,
-                                        review_config.pr_repo,
-                                        review_config.pr_number,
-                                        codex_review,
-                                    )
-                            else:
-                                # TUI mode: parse from last message
-                                review_result = parse_tui_output(last_message)
-
-                            if review_result and review_result.findings:
-                                review_event = NotificationEvent(
-                                    session_id=target_session.id,
-                                    event_type="review_complete",
-                                    message="Review complete",
-                                    context="",
-                                    urgent=False,
-                                )
-                                review_event.review_result = review_result
-                                await app.state.notifier.notify(review_event, target_session)
-                        except Exception as e:
-                            logger.warning(f"Failed to emit review_complete notification: {e}")
+                    await _emit_review_complete_if_needed(target_session, last_message)
                 else:
                     # Couldn't find matching session
                     logger.warning(
@@ -6660,6 +6804,16 @@ Provide ONLY the summary, no preamble or questions."""
             # preceding Stop hook had an empty transcript (race condition).
             if notification_type == "idle_prompt":
                 sid = session_manager_id
+                relay_handled = False
+                if sid:
+                    relay_handled = await _relay_claude_response_for_turn(
+                        session_id=sid,
+                        transcript_path=transcript_path,
+                        hook_event=hook_event,
+                    )
+                if relay_handled:
+                    return {"status": "received", "hook_event": hook_event}
+
                 if sid and sid in app.state.pending_stop_notifications and last_message:
                     app.state.pending_stop_notifications.discard(sid)
                     logger.info(f"Sending deferred response notification for {sid} (idle_prompt had content)")

--- a/src/server.py
+++ b/src/server.py
@@ -6329,7 +6329,7 @@ Provide ONLY the summary, no preamble or questions."""
 
         target_session = app.state.session_manager.get_session(session_id)
         if not target_session:
-            return True
+            return False
         if not target_session.telegram_chat_id:
             return True
 

--- a/src/server.py
+++ b/src/server.py
@@ -1357,6 +1357,7 @@ def create_app(
     if notifier is not None:
         setattr(notifier, "session_manager", session_manager)
     if session_manager is not None:
+        setattr(session_manager, "response_relay_ledger", response_relay_ledger)
         queue_mgr = getattr(session_manager, "message_queue_manager", None)
         if queue_mgr is not None and response_relay_ledger is not None:
             setattr(queue_mgr, "response_relay_ledger", response_relay_ledger)

--- a/src/server.py
+++ b/src/server.py
@@ -6426,7 +6426,6 @@ Provide ONLY the summary, no preamble or questions."""
                 )
                 target_session.last_activity = datetime.now()
                 await _save_session_manager_state(app.state.session_manager)
-                await _emit_review_complete_if_needed(target_session, candidate.text)
             else:
                 ledger.release_assistant_output_claim(
                     session_id=session_id,
@@ -6434,6 +6433,7 @@ Provide ONLY the summary, no preamble or questions."""
                     provider="claude",
                     assistant_message_id=candidate.assistant_message_id,
                 )
+            await _emit_review_complete_if_needed(target_session, candidate.text)
 
         asyncio.create_task(_notify_response_event())
         return True

--- a/src/server.py
+++ b/src/server.py
@@ -1,6 +1,7 @@
 """FastAPI server for hooks and API endpoints."""
 
 import asyncio
+from dataclasses import replace
 import inspect
 import json
 import logging
@@ -61,6 +62,7 @@ from .mobile_analytics import MobileAnalyticsBuilder
 from .response_relay import (
     ResponseRelayLedger,
     collect_claude_assistant_outputs_after_turn,
+    find_claude_inbound_turn_boundary_offset,
 )
 
 logger = logging.getLogger(__name__)
@@ -6343,8 +6345,25 @@ Provide ONLY the summary, no preamble or questions."""
             return True
 
         effective_transcript_path = active_turn.transcript_path or transcript_path
-        if transcript_path and not active_turn.transcript_path:
-            ledger.update_inbound_boundary(active_turn.inbound_id, transcript_path=transcript_path)
+        boundary_offset = active_turn.transcript_offset
+        if effective_transcript_path and boundary_offset is None:
+            boundary_offset = find_claude_inbound_turn_boundary_offset(
+                effective_transcript_path,
+                active_turn,
+            )
+        should_update_path = bool(transcript_path and not active_turn.transcript_path)
+        should_update_offset = boundary_offset is not None and active_turn.transcript_offset is None
+        if should_update_path or should_update_offset:
+            ledger.update_inbound_boundary(
+                active_turn.inbound_id,
+                transcript_path=transcript_path if should_update_path else None,
+                transcript_offset=boundary_offset if should_update_offset else None,
+            )
+            active_turn = replace(
+                active_turn,
+                transcript_path=active_turn.transcript_path or transcript_path,
+                transcript_offset=boundary_offset,
+            )
         if not effective_transcript_path:
             app.state.pending_stop_notifications.add(session_id)
             logger.info(

--- a/src/server.py
+++ b/src/server.py
@@ -1645,6 +1645,9 @@ def create_app(
             and request.parent_session_id is None
         )
 
+    def _response_relay_source_for_send_request(request: SendInputRequest) -> str:
+        return "sm-send" if request.from_sm_send else "api"
+
     def _resolve_live_send_target(identifier: str) -> Optional[Session]:
         if not app.state.session_manager:
             return None
@@ -1747,6 +1750,7 @@ def create_app(
             remind_hard_threshold=request.remind_hard_threshold,
             remind_cancel_on_reply_session_id=request.remind_cancel_on_reply_session_id,
             parent_session_id=request.parent_session_id,
+            response_relay_source=_response_relay_source_for_send_request(request),
         )
 
         if result == DeliveryResult.FAILED:

--- a/src/server.py
+++ b/src/server.py
@@ -1983,6 +1983,7 @@ def create_app(
             sender_session_id=None,
             delivery_mode="sequential",
             from_sm_send=False,
+            response_relay_source="email",
         )
         if result == DeliveryResult.FAILED:
             raise HTTPException(status_code=500, detail="Failed to deliver inbound email to session")

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -390,6 +390,7 @@ class SessionManager:
 
         # Message queue manager (set by main app)
         self.message_queue_manager = None
+        self.response_relay_ledger = None
         queue_runner_config = dict(self.config)
         if "queue_runner" not in queue_runner_config and self.state_file != self.default_state_file:
             queue_runner_config["queue_runner"] = {
@@ -4077,6 +4078,12 @@ class SessionManager:
                 )
             self._save_state()
 
+    def _get_response_relay_ledger(self):
+        ledger = None
+        if self.message_queue_manager:
+            ledger = getattr(self.message_queue_manager, "response_relay_ledger", None)
+        return ledger or getattr(self, "response_relay_ledger", None)
+
     def _record_initial_response_relay_inbound(
         self,
         *,
@@ -4086,9 +4093,9 @@ class SessionManager:
         delivered_at: datetime,
     ) -> None:
         """Record a Claude prompt injected at session launch as the first relay turn."""
-        if not text.strip() or not self.message_queue_manager:
+        if not text.strip():
             return
-        ledger = getattr(self.message_queue_manager, "response_relay_ledger", None)
+        ledger = self._get_response_relay_ledger()
         if ledger is None:
             return
         try:
@@ -4118,9 +4125,9 @@ class SessionManager:
         delivered_at: datetime,
     ) -> None:
         """Record a direct user/operator input turn that bypassed the message queue."""
-        if not source or not self.message_queue_manager:
+        if not source or not text.strip():
             return
-        ledger = getattr(self.message_queue_manager, "response_relay_ledger", None)
+        ledger = self._get_response_relay_ledger()
         if ledger is None:
             return
         transcript_path = getattr(session, "transcript_path", None)
@@ -4376,8 +4383,15 @@ class SessionManager:
         # Fallback: send immediately (no queue manager or unknown mode)
         success = await self._deliver_direct(session, formatted_text)
         if success:
+            delivered_at = datetime.now(timezone.utc)
             session.last_activity = datetime.now()
             session.status = SessionStatus.RUNNING
+            self._record_direct_response_relay_inbound(
+                session=session,
+                text=formatted_text,
+                source=response_relay_source or ("sm-send" if from_sm_send else None),
+                delivered_at=delivered_at,
+            )
             _clear_completed_state()
             self._save_state()
 

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -2678,6 +2678,14 @@ class SessionManager:
         self._sync_session_resume_id(session)
         self._save_state()
 
+        if provider == "claude" and initial_prompt:
+            self._record_initial_response_relay_inbound(
+                session=session,
+                text=initial_prompt,
+                source="spawn" if spawn_prompt else "initial",
+                delivered_at=session.spawned_at or session.created_at,
+            )
+
         if provider == "codex-fork":
             self.codex_fork_runtime_owner[session.id] = parent_session_id or session.id
             self._set_codex_fork_lifecycle_state(
@@ -4068,6 +4076,38 @@ class SessionManager:
                     revive_deleted=True,
                 )
             self._save_state()
+
+    def _record_initial_response_relay_inbound(
+        self,
+        *,
+        session: Session,
+        text: str,
+        source: str,
+        delivered_at: datetime,
+    ) -> None:
+        """Record a Claude prompt injected at session launch as the first relay turn."""
+        if not text.strip() or not self.message_queue_manager:
+            return
+        ledger = getattr(self.message_queue_manager, "response_relay_ledger", None)
+        if ledger is None:
+            return
+        try:
+            ledger.record_inbound_turn(
+                session_id=session.id,
+                inbound_id=f"initial:{session.id}",
+                source=source,
+                provider="claude",
+                delivered_at=delivered_at,
+                transcript_path=getattr(session, "transcript_path", None),
+                transcript_offset=None,
+                text=text,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to record initial response relay inbound turn for %s: %s",
+                session.id,
+                exc,
+            )
 
     def _record_direct_response_relay_inbound(
         self,

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -4069,6 +4069,40 @@ class SessionManager:
                 )
             self._save_state()
 
+    def _record_direct_response_relay_inbound(
+        self,
+        *,
+        session: Session,
+        text: str,
+        source: Optional[str],
+        delivered_at: datetime,
+    ) -> None:
+        """Record a direct user/operator input turn that bypassed the message queue."""
+        if not source or not self.message_queue_manager:
+            return
+        ledger = getattr(self.message_queue_manager, "response_relay_ledger", None)
+        if ledger is None:
+            return
+        transcript_path = getattr(session, "transcript_path", None)
+        transcript_offset = ledger.capture_transcript_offset(transcript_path)
+        try:
+            ledger.record_inbound_turn(
+                session_id=session.id,
+                inbound_id=f"direct:{session.id}:{uuid.uuid4().hex}",
+                source=source,
+                provider=getattr(session, "provider", None) or "claude",
+                delivered_at=delivered_at,
+                transcript_path=transcript_path,
+                transcript_offset=transcript_offset,
+                text=text,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Failed to record direct response relay inbound turn for %s: %s",
+                session.id,
+                exc,
+            )
+
     async def send_input(
         self,
         session_id: str,
@@ -4135,7 +4169,14 @@ class SessionManager:
             logger.info(f"Bypassing queue for direct send to {session_id}: {text}")
             success = await self._deliver_direct(session, text)
             if success:
-                session.last_activity = datetime.now()
+                delivered_at = datetime.now(timezone.utc)
+                session.last_activity = delivered_at
+                self._record_direct_response_relay_inbound(
+                    session=session,
+                    text=text,
+                    source=response_relay_source,
+                    delivered_at=delivered_at,
+                )
                 _clear_completed_state()
             return DeliveryResult.DELIVERED if success else DeliveryResult.FAILED
 

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -4085,6 +4085,7 @@ class SessionManager:
         remind_hard_threshold: Optional[int] = None,
         remind_cancel_on_reply_session_id: Optional[str] = None,
         parent_session_id: Optional[str] = None,
+        response_relay_source: Optional[str] = None,
     ) -> DeliveryResult:
         """
         Send input to a session with optional sender metadata and delivery mode.
@@ -4103,6 +4104,7 @@ class SessionManager:
             remind_soft_threshold: Seconds after delivery before soft remind fires (#188)
             remind_hard_threshold: Seconds after delivery before hard remind fires (#188)
             remind_cancel_on_reply_session_id: Cancel remind when target replies to this session (#406)
+            response_relay_source: Explicit user/operator source for turn-bound response relay
 
         Returns:
             DeliveryResult indicating whether message was DELIVERED, QUEUED, or FAILED
@@ -4183,6 +4185,12 @@ class SessionManager:
                 sender_state.last_outgoing_sm_send_target = session_id
                 sender_state.last_outgoing_sm_send_at = datetime.now()
 
+        response_relay_kwargs = (
+            {"response_relay_source": response_relay_source}
+            if response_relay_source
+            else {}
+        )
+
         # Handle steer delivery mode — direct Enter-based injection, bypasses queue
         if delivery_mode == "steer":
             if session.provider not in ("codex", "codex-fork"):
@@ -4216,6 +4224,7 @@ class SessionManager:
                     remind_cancel_on_reply_session_id=remind_cancel_on_reply_session_id,
                     parent_session_id=parent_session_id,
                     trigger_delivery=False,
+                    **response_relay_kwargs,
                 )
                 # Record outgoing sm send for deferred stop notification suppression (#182)
                 # Placed after queue_message to ensure message was persisted first.
@@ -4248,6 +4257,7 @@ class SessionManager:
                     remind_cancel_on_reply_session_id=remind_cancel_on_reply_session_id,
                     parent_session_id=parent_session_id,
                     trigger_delivery=False,
+                    **response_relay_kwargs,
                 )
                 # Record outgoing sm send for deferred stop notification suppression (#182)
                 _record_outgoing_sm_send_target()
@@ -4276,6 +4286,7 @@ class SessionManager:
                     remind_hard_threshold=remind_hard_threshold,
                     remind_cancel_on_reply_session_id=remind_cancel_on_reply_session_id,
                     parent_session_id=parent_session_id,
+                    **response_relay_kwargs,
                 )
                 _record_outgoing_sm_send_target()
                 _clear_completed_state()

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -4170,7 +4170,7 @@ class SessionManager:
             success = await self._deliver_direct(session, text)
             if success:
                 delivered_at = datetime.now(timezone.utc)
-                session.last_activity = delivered_at
+                session.last_activity = datetime.now()
                 self._record_direct_response_relay_inbound(
                     session=session,
                     text=text,

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -796,6 +796,7 @@ class TestEmailBridgeEndpoints:
             sender_session_id=None,
             delivery_mode="sequential",
             from_sm_send=False,
+            response_relay_source="email",
         )
         mock_output_monitor.start_monitoring.assert_awaited_once_with(restored)
         mock_email_handler.extract_reply_message_body.assert_called_once_with("please continue")
@@ -892,6 +893,7 @@ class TestEmailBridgeEndpoints:
             sender_session_id=None,
             delivery_mode="sequential",
             from_sm_send=False,
+            response_relay_source="email",
         )
 
     def test_inbound_email_ignores_explicit_session_header_without_worker_secret(
@@ -989,6 +991,7 @@ class TestEmailBridgeEndpoints:
             sender_session_id=None,
             delivery_mode="sequential",
             from_sm_send=False,
+            response_relay_source="email",
         )
         mock_email_handler.extract_routed_session_id.assert_called_once_with(body)
 
@@ -1048,6 +1051,7 @@ class TestEmailBridgeEndpoints:
             sender_session_id=None,
             delivery_mode="sequential",
             from_sm_send=False,
+            response_relay_source="email",
         )
 
     def test_get_session_not_found(self, test_client, mock_session_manager):

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -1386,6 +1386,8 @@ class TestEmailBridgeEndpoints:
         data = response.json()
         assert data["status"] == "delivered"
         assert data["session_id"] == "test123"
+        mock_session_manager.send_input.assert_awaited_once()
+        assert mock_session_manager.send_input.await_args.kwargs["response_relay_source"] == "api"
 
     def test_send_input_codex_app_with_pending_structured_request_returns_409(self, test_client, mock_session_manager):
         """POST /sessions/{id}/input is blocked for codex-app when structured requests are pending."""

--- a/tests/regression/test_issue_706_turn_bound_telegram_response_relay.py
+++ b/tests/regression/test_issue_706_turn_bound_telegram_response_relay.py
@@ -345,3 +345,43 @@ async def test_message_queue_records_inbound_boundary_only_after_delivery(tmp_pa
         (msg.id,),
     )
     assert delivered_rows[0][0].endswith("+00:00")
+
+
+@pytest.mark.asyncio
+async def test_message_queue_ignores_internal_uncategorized_prompts(tmp_path):
+    transcript = tmp_path / "internal-prompt.jsonl"
+    transcript.write_text(_assistant_line("existing old output", uuid="old"))
+    session = _session(transcript)
+    manager = MagicMock()
+    manager.get_session.return_value = session
+    manager._deliver_direct = AsyncMock(return_value=True)
+    manager._save_state = MagicMock()
+    ledger = ResponseRelayLedger(str(tmp_path / "relay.db"))
+    mq = MessageQueueManager(
+        manager,
+        db_path=str(tmp_path / "message_queue.db"),
+        response_relay_ledger=ledger,
+    )
+
+    user_msg = mq.queue_message(
+        session.id,
+        "real user turn",
+        from_sm_send=True,
+        trigger_delivery=False,
+    )
+    await mq._try_deliver_messages(session.id)
+    assert ledger.get_latest_active_turn(session.id).inbound_id == user_msg.id
+
+    internal_msg = mq.queue_message(
+        session.id,
+        "[sm info] Uncommitted changes in worktree(s):\n- /tmp/worktree",
+        delivery_mode="important",
+        trigger_delivery=False,
+    )
+    await mq._try_deliver_messages(session.id, important_only=True)
+
+    assert mq.was_message_delivered(internal_msg.id)
+    active_turn = ledger.get_latest_active_turn(session.id)
+    assert active_turn is not None
+    assert active_turn.inbound_id == user_msg.id
+    assert active_turn.source == "sm-send"

--- a/tests/regression/test_issue_706_turn_bound_telegram_response_relay.py
+++ b/tests/regression/test_issue_706_turn_bound_telegram_response_relay.py
@@ -1,0 +1,320 @@
+"""Regression tests for sm#706 turn-bound Telegram response relay."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.message_queue import MessageQueueManager
+from src.models import Session, SessionStatus
+from src.response_relay import ResponseRelayLedger
+from src.server import create_app
+
+
+def _assistant_line(text: str, *, timestamp: str | None = None, uuid: str | None = None) -> str:
+    entry = {
+        "type": "assistant",
+        "message": {
+            "id": uuid or f"msg-{abs(hash(text))}",
+            "content": [{"type": "text", "text": text}],
+        },
+    }
+    if timestamp:
+        entry["timestamp"] = timestamp
+    if uuid:
+        entry["uuid"] = uuid
+    return json.dumps(entry) + "\n"
+
+
+def _record_inbound(
+    ledger: ResponseRelayLedger,
+    session: Session,
+    inbound_id: str,
+    transcript_path,
+    *,
+    source: str = "sm-send",
+) -> None:
+    ledger.record_inbound_turn(
+        session_id=session.id,
+        inbound_id=inbound_id,
+        source=source,
+        provider=session.provider,
+        delivered_at=datetime(2026, 5, 2, 22, 24, 19, tzinfo=timezone.utc),
+        transcript_path=str(transcript_path),
+        transcript_offset=transcript_path.stat().st_size,
+        text="This is way too complex of an explanation",
+    )
+
+
+def _make_app(tmp_path, session: Session, ledger: ResponseRelayLedger):
+    manager = MagicMock()
+    manager.get_session.side_effect = lambda sid: session if sid == session.id else None
+    manager.list_sessions.return_value = [session]
+    manager._sync_session_resume_id = MagicMock()
+    manager._save_state = MagicMock()
+    manager.update_session_status = MagicMock()
+    queue = MagicMock()
+    queue.delivery_states = {session.id: SimpleNamespace(is_idle=True)}
+    queue.mark_session_idle = MagicMock()
+    queue._restore_user_input_after_response = AsyncMock()
+    manager.message_queue_manager = queue
+
+    notifier = MagicMock()
+    notifier.notify = AsyncMock(return_value=True)
+    output_monitor = MagicMock()
+    app = create_app(
+        session_manager=manager,
+        notifier=notifier,
+        output_monitor=output_monitor,
+        response_relay_ledger=ledger,
+        config={},
+    )
+    return app, TestClient(app), notifier, output_monitor
+
+
+def _session(transcript_path) -> Session:
+    return Session(
+        id="3401-consultant",
+        name="claude-3401-consultant",
+        working_dir="/tmp",
+        tmux_session="claude-3401-consultant",
+        log_file="/tmp/3401.log",
+        status=SessionStatus.RUNNING,
+        telegram_chat_id=123,
+        telegram_thread_id=456,
+        transcript_path=str(transcript_path),
+        provider="claude",
+    )
+
+
+def test_3401_timeline_suppresses_d13_then_relays_current_turn(tmp_path):
+    transcript = tmp_path / "3401-consultant.jsonl"
+    transcript.write_text(
+        _assistant_line(
+            "D13 previous assistant response",
+            timestamp="2026-05-02T22:23:00Z",
+            uuid="old-d13",
+        )
+    )
+    session = _session(transcript)
+    ledger = ResponseRelayLedger(str(tmp_path / "relay.db"))
+    _record_inbound(ledger, session, "inbound-3401", transcript)
+    app, client, notifier, _ = _make_app(tmp_path, session, ledger)
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        response = client.post(
+            "/hooks/claude",
+            json={
+                "hook_event_name": "Stop",
+                "session_manager_id": session.id,
+                "transcript_path": str(transcript),
+            },
+        )
+
+    assert response.status_code == 200
+    notifier.notify.assert_not_awaited()
+    assert session.id in app.state.pending_stop_notifications
+
+    transcript.write_text(
+        transcript.read_text()
+        + _assistant_line(
+            "You're right - the correct current-turn answer",
+            timestamp="2026-05-02T22:26:27Z",
+            uuid="current-answer",
+        )
+    )
+
+    response = client.post(
+        "/hooks/claude",
+        json={
+            "hook_event_name": "Notification",
+            "notification_type": "idle_prompt",
+            "session_manager_id": session.id,
+            "transcript_path": str(transcript),
+        },
+    )
+
+    assert response.status_code == 200
+    notifier.notify.assert_awaited_once()
+    event = notifier.notify.await_args.args[0]
+    assert event.context.startswith("You're right")
+    assert "D13" not in event.context
+    assert session.id not in app.state.pending_stop_notifications
+
+
+def test_restart_dedupe_suppresses_replayed_hook(tmp_path):
+    transcript = tmp_path / "restart.jsonl"
+    transcript.write_text(_assistant_line("old answer", uuid="old"))
+    session = _session(transcript)
+    ledger_path = tmp_path / "relay.db"
+    ledger = ResponseRelayLedger(str(ledger_path))
+    _record_inbound(ledger, session, "inbound-restart", transcript)
+    transcript.write_text(transcript.read_text() + _assistant_line("fresh answer", uuid="fresh"))
+
+    app, client, notifier, _ = _make_app(tmp_path, session, ledger)
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        response = client.post(
+            "/hooks/claude",
+            json={
+                "hook_event_name": "Stop",
+                "session_manager_id": session.id,
+                "transcript_path": str(transcript),
+            },
+        )
+    assert response.status_code == 200
+    notifier.notify.assert_awaited_once()
+
+    restarted_ledger = ResponseRelayLedger(str(ledger_path))
+    _, restarted_client, restarted_notifier, _ = _make_app(tmp_path, session, restarted_ledger)
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        response = restarted_client.post(
+            "/hooks/claude",
+            json={
+                "hook_event_name": "Stop",
+                "session_manager_id": session.id,
+                "transcript_path": str(transcript),
+            },
+        )
+
+    assert response.status_code == 200
+    restarted_notifier.notify.assert_not_awaited()
+
+
+def test_deferred_transcript_lag_waits_for_post_boundary_output(tmp_path):
+    transcript = tmp_path / "lag.jsonl"
+    transcript.write_text("")
+    session = _session(transcript)
+    ledger = ResponseRelayLedger(str(tmp_path / "relay.db"))
+    _record_inbound(ledger, session, "inbound-lag", transcript)
+    app, client, notifier, _ = _make_app(tmp_path, session, ledger)
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        response = client.post(
+            "/hooks/claude",
+            json={
+                "hook_event_name": "Stop",
+                "session_manager_id": session.id,
+                "transcript_path": str(transcript),
+            },
+        )
+
+    assert response.status_code == 200
+    notifier.notify.assert_not_awaited()
+    assert session.id in app.state.pending_stop_notifications
+
+    transcript.write_text(_assistant_line("response after transcript lag", uuid="lag-answer"))
+    response = client.post(
+        "/hooks/claude",
+        json={
+            "hook_event_name": "Notification",
+            "notification_type": "idle_prompt",
+            "session_manager_id": session.id,
+            "transcript_path": str(transcript),
+        },
+    )
+
+    assert response.status_code == 200
+    notifier.notify.assert_awaited_once()
+    assert notifier.notify.await_args.args[0].context == "response after transcript lag"
+
+
+def test_long_chunk_group_is_deduped_as_one_output(tmp_path):
+    transcript = tmp_path / "long.jsonl"
+    transcript.write_text(_assistant_line("old", uuid="old"))
+    session = _session(transcript)
+    ledger = ResponseRelayLedger(str(tmp_path / "relay.db"))
+    _record_inbound(ledger, session, "inbound-long", transcript)
+    long_answer = "chunk-group " + ("x" * 9000)
+    transcript.write_text(transcript.read_text() + _assistant_line(long_answer, uuid="long-answer"))
+    _, client, notifier, _ = _make_app(tmp_path, session, ledger)
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        for _ in range(3):
+            response = client.post(
+                "/hooks/claude",
+                json={
+                    "hook_event_name": "Stop",
+                    "session_manager_id": session.id,
+                    "transcript_path": str(transcript),
+                },
+            )
+            assert response.status_code == 200
+
+    notifier.notify.assert_awaited_once()
+    assert notifier.notify.await_args.args[0].context == long_answer
+
+
+def test_newer_inbound_supersedes_late_output_for_previous_turn(tmp_path):
+    transcript = tmp_path / "multi-turn.jsonl"
+    transcript.write_text(_assistant_line("old", uuid="old"))
+    session = _session(transcript)
+    ledger = ResponseRelayLedger(str(tmp_path / "relay.db"))
+    _record_inbound(ledger, session, "turn-1", transcript)
+    transcript.write_text(transcript.read_text() + _assistant_line("late turn one answer", uuid="turn-1-answer"))
+    _record_inbound(ledger, session, "turn-2", transcript)
+    _, client, notifier, _ = _make_app(tmp_path, session, ledger)
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        response = client.post(
+            "/hooks/claude",
+            json={
+                "hook_event_name": "Stop",
+                "session_manager_id": session.id,
+                "transcript_path": str(transcript),
+            },
+        )
+
+    assert response.status_code == 200
+    notifier.notify.assert_not_awaited()
+
+    transcript.write_text(transcript.read_text() + _assistant_line("turn two answer", uuid="turn-2-answer"))
+    response = client.post(
+        "/hooks/claude",
+        json={
+            "hook_event_name": "Notification",
+            "notification_type": "idle_prompt",
+            "session_manager_id": session.id,
+            "transcript_path": str(transcript),
+        },
+    )
+
+    assert response.status_code == 200
+    notifier.notify.assert_awaited_once()
+    assert notifier.notify.await_args.args[0].context == "turn two answer"
+
+
+@pytest.mark.asyncio
+async def test_message_queue_records_inbound_boundary_only_after_delivery(tmp_path):
+    transcript = tmp_path / "delivery.jsonl"
+    transcript.write_text(_assistant_line("existing old output", uuid="old"))
+    session = _session(transcript)
+    manager = MagicMock()
+    manager.get_session.return_value = session
+    manager._deliver_direct = AsyncMock(return_value=True)
+    manager._save_state = MagicMock()
+    ledger = ResponseRelayLedger(str(tmp_path / "relay.db"))
+    mq = MessageQueueManager(
+        manager,
+        db_path=str(tmp_path / "message_queue.db"),
+        response_relay_ledger=ledger,
+    )
+
+    msg = mq.queue_message(
+        session.id,
+        "new user turn",
+        from_sm_send=True,
+        trigger_delivery=False,
+    )
+    assert ledger.get_latest_active_turn(session.id) is None
+
+    await mq._try_deliver_messages(session.id)
+
+    active_turn = ledger.get_latest_active_turn(session.id)
+    assert active_turn is not None
+    assert active_turn.inbound_id == msg.id
+    assert active_turn.transcript_offset == transcript.stat().st_size

--- a/tests/regression/test_issue_706_turn_bound_telegram_response_relay.py
+++ b/tests/regression/test_issue_706_turn_bound_telegram_response_relay.py
@@ -424,6 +424,37 @@ async def test_message_queue_records_telegram_inbound_boundary(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_message_queue_records_email_inbound_boundary(tmp_path):
+    transcript = tmp_path / "email.jsonl"
+    transcript.write_text(_assistant_line("existing old output", uuid="old"))
+    session = _session(transcript)
+    manager = MagicMock()
+    manager.get_session.return_value = session
+    manager._deliver_direct = AsyncMock(return_value=True)
+    manager._save_state = MagicMock()
+    ledger = ResponseRelayLedger(str(tmp_path / "relay.db"))
+    mq = MessageQueueManager(
+        manager,
+        db_path=str(tmp_path / "message_queue.db"),
+        response_relay_ledger=ledger,
+    )
+
+    msg = mq.queue_message(
+        session.id,
+        "{sm email from user@example.com}\nemail user turn",
+        response_relay_source="email",
+        trigger_delivery=False,
+    )
+
+    await mq._try_deliver_messages(session.id)
+
+    active_turn = ledger.get_latest_active_turn(session.id)
+    assert active_turn is not None
+    assert active_turn.inbound_id == msg.id
+    assert active_turn.source == "email"
+
+
+@pytest.mark.asyncio
 async def test_bypass_queue_telegram_permission_response_records_boundary(tmp_path):
     transcript = tmp_path / "permission-response.jsonl"
     transcript.write_text(_assistant_line("existing old output", uuid="old"))
@@ -446,6 +477,7 @@ async def test_bypass_queue_telegram_permission_response_records_boundary(tmp_pa
     )
 
     assert result.value == "delivered"
+    assert session.last_activity.tzinfo is None
     active_turn = ledger.get_latest_active_turn(session.id)
     assert active_turn is not None
     assert active_turn.inbound_id.startswith(f"direct:{session.id}:")

--- a/tests/regression/test_issue_706_turn_bound_telegram_response_relay.py
+++ b/tests/regression/test_issue_706_turn_bound_telegram_response_relay.py
@@ -11,7 +11,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from src.message_queue import MessageQueueManager
-from src.models import Session, SessionStatus
+from src.models import ReviewConfig, Session, SessionStatus
 from src.response_relay import ResponseRelayLedger
 from src.server import create_app
 from src.session_manager import SessionManager
@@ -270,6 +270,38 @@ def test_long_chunk_group_is_deduped_as_one_output(tmp_path):
 
     notifier.notify.assert_awaited_once()
     assert notifier.notify.await_args.args[0].context == long_answer
+
+
+def test_review_complete_emits_when_response_notify_is_rejected(tmp_path):
+    transcript = tmp_path / "review-complete.jsonl"
+    transcript.write_text(_assistant_line("old", uuid="old"))
+    session = _session(transcript)
+    session.review_config = ReviewConfig(mode="branch", base_branch="main")
+    ledger = ResponseRelayLedger(str(tmp_path / "relay.db"))
+    _record_inbound(ledger, session, "inbound-review", transcript)
+    review_text = "[P2] Keep review completion\nReview findings remain available."
+    transcript.write_text(transcript.read_text() + _assistant_line(review_text, uuid="review-answer"))
+    _, client, notifier, _ = _make_app(tmp_path, session, ledger)
+    notifier.notify.side_effect = [False, True]
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        response = client.post(
+            "/hooks/claude",
+            json={
+                "hook_event_name": "Stop",
+                "session_manager_id": session.id,
+                "transcript_path": str(transcript),
+            },
+        )
+
+    assert response.status_code == 200
+    assert notifier.notify.await_count == 2
+    response_event = notifier.notify.await_args_list[0].args[0]
+    review_event = notifier.notify.await_args_list[1].args[0]
+    assert response_event.event_type == "response"
+    assert review_event.event_type == "review_complete"
+    assert review_event.review_result is not None
+    assert review_event.review_result.findings[0].title == "Keep review completion"
 
 
 def test_newer_inbound_supersedes_late_output_for_previous_turn(tmp_path):

--- a/tests/regression/test_issue_706_turn_bound_telegram_response_relay.py
+++ b/tests/regression/test_issue_706_turn_bound_telegram_response_relay.py
@@ -617,6 +617,71 @@ def test_api_input_records_default_inbound_boundary(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_session_create_initial_prompt_records_relay_boundary(tmp_path):
+    manager = SessionManager(
+        log_dir=str(tmp_path / "logs"),
+        state_file=str(tmp_path / "sessions.json"),
+    )
+    manager.tmux = MagicMock()
+    manager.tmux.create_session_with_command.return_value = True
+    manager._get_git_remote_url_async = AsyncMock(return_value=None)
+    manager._ensure_telegram_topic = AsyncMock()
+    ledger = ResponseRelayLedger(str(tmp_path / "relay.db"))
+    manager.message_queue_manager = SimpleNamespace(response_relay_ledger=ledger)
+
+    session = await manager._create_session_common(
+        working_dir=str(tmp_path),
+        parent_session_id="parent-session",
+        spawn_prompt="first spawned turn",
+        initial_prompt="first spawned turn",
+        provider="claude",
+    )
+
+    assert session is not None
+    active_turn = ledger.get_latest_active_turn(session.id)
+    assert active_turn is not None
+    assert active_turn.inbound_id == f"initial:{session.id}"
+    assert active_turn.source == "spawn"
+    assert active_turn.provider == "claude"
+    assert active_turn.text_hash is not None
+
+
+def test_stop_hook_backfills_spawn_prompt_boundary_for_first_turn(tmp_path):
+    prompt = "first spawned turn"
+    transcript = tmp_path / "spawn-first-turn.jsonl"
+    transcript.write_text(
+        _user_line(prompt, uuid="spawn-user")
+        + _assistant_line("spawn first answer", uuid="spawn-answer")
+    )
+    session = _session(transcript)
+    session.spawn_prompt = prompt
+    session.spawned_at = datetime(2026, 5, 2, 22, 24, 18)
+    ledger = ResponseRelayLedger(str(tmp_path / "relay.db"))
+    app, client, notifier, _ = _make_app(tmp_path, session, ledger)
+
+    assert ledger.get_latest_active_turn(session.id) is None
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        response = client.post(
+            "/hooks/claude",
+            json={
+                "hook_event_name": "Stop",
+                "session_manager_id": session.id,
+                "transcript_path": str(transcript),
+            },
+        )
+
+    assert response.status_code == 200
+    notifier.notify.assert_awaited_once()
+    assert notifier.notify.await_args.args[0].context == "spawn first answer"
+    active_turn = ledger.get_latest_active_turn(session.id)
+    assert active_turn is not None
+    assert active_turn.inbound_id == f"initial:{session.id}"
+    assert active_turn.source == "spawn"
+    assert active_turn.transcript_offset is not None
+    assert active_turn.transcript_offset < transcript.stat().st_size
+
+
+@pytest.mark.asyncio
 async def test_bypass_queue_telegram_permission_response_records_boundary(tmp_path):
     transcript = tmp_path / "permission-response.jsonl"
     transcript.write_text(_assistant_line("existing old output", uuid="old"))

--- a/tests/regression/test_issue_706_turn_bound_telegram_response_relay.py
+++ b/tests/regression/test_issue_706_turn_bound_telegram_response_relay.py
@@ -710,3 +710,65 @@ async def test_bypass_queue_telegram_permission_response_records_boundary(tmp_pa
     assert active_turn.inbound_id.startswith(f"direct:{session.id}:")
     assert active_turn.source == "telegram"
     assert active_turn.transcript_offset == transcript.stat().st_size
+
+
+@pytest.mark.asyncio
+async def test_direct_fallback_without_queue_records_boundary(tmp_path):
+    transcript = tmp_path / "direct-no-queue.jsonl"
+    transcript.write_text(_assistant_line("existing old output", uuid="old"))
+    manager = SessionManager(
+        log_dir=str(tmp_path / "logs"),
+        state_file=str(tmp_path / "sessions.json"),
+    )
+    session = _session(transcript)
+    manager.sessions[session.id] = session
+    ledger = ResponseRelayLedger(str(tmp_path / "relay.db"))
+    manager.response_relay_ledger = ledger
+    manager.message_queue_manager = None
+    manager._deliver_direct = AsyncMock(return_value=True)
+    manager._save_state = MagicMock()
+
+    result = await manager.send_input(
+        session.id,
+        "direct api user turn",
+        response_relay_source="api",
+    )
+
+    assert result.value == "delivered"
+    manager._deliver_direct.assert_awaited_once_with(session, "direct api user turn")
+    active_turn = ledger.get_latest_active_turn(session.id)
+    assert active_turn is not None
+    assert active_turn.inbound_id.startswith(f"direct:{session.id}:")
+    assert active_turn.source == "api"
+    assert active_turn.transcript_offset == transcript.stat().st_size
+
+
+@pytest.mark.asyncio
+async def test_direct_fallback_mode_fallthrough_records_sm_send_boundary(tmp_path):
+    transcript = tmp_path / "direct-fallthrough.jsonl"
+    transcript.write_text(_assistant_line("existing old output", uuid="old"))
+    manager = SessionManager(
+        log_dir=str(tmp_path / "logs"),
+        state_file=str(tmp_path / "sessions.json"),
+    )
+    session = _session(transcript)
+    manager.sessions[session.id] = session
+    ledger = ResponseRelayLedger(str(tmp_path / "relay.db"))
+    manager.message_queue_manager = SimpleNamespace(response_relay_ledger=ledger)
+    manager._deliver_direct = AsyncMock(return_value=True)
+    manager._save_state = MagicMock()
+
+    result = await manager.send_input(
+        session.id,
+        "fallthrough user turn",
+        delivery_mode="custom-direct",
+        from_sm_send=True,
+    )
+
+    assert result.value == "delivered"
+    manager._deliver_direct.assert_awaited_once_with(session, "fallthrough user turn")
+    active_turn = ledger.get_latest_active_turn(session.id)
+    assert active_turn is not None
+    assert active_turn.inbound_id.startswith(f"direct:{session.id}:")
+    assert active_turn.source == "sm-send"
+    assert active_turn.transcript_offset == transcript.stat().st_size

--- a/tests/regression/test_issue_706_turn_bound_telegram_response_relay.py
+++ b/tests/regression/test_issue_706_turn_bound_telegram_response_relay.py
@@ -340,6 +340,7 @@ async def test_message_queue_records_inbound_boundary_only_after_delivery(tmp_pa
     assert active_turn is not None
     assert active_turn.inbound_id == msg.id
     assert active_turn.transcript_offset == transcript.stat().st_size
+    assert active_turn.source == "sm-send"
     delivered_rows = mq._execute_query(
         "SELECT delivered_at FROM message_queue WHERE id = ?",
         (msg.id,),
@@ -385,3 +386,37 @@ async def test_message_queue_ignores_internal_uncategorized_prompts(tmp_path):
     assert active_turn is not None
     assert active_turn.inbound_id == user_msg.id
     assert active_turn.source == "sm-send"
+
+
+@pytest.mark.asyncio
+async def test_message_queue_records_telegram_inbound_boundary(tmp_path):
+    transcript = tmp_path / "telegram.jsonl"
+    transcript.write_text(_assistant_line("existing old output", uuid="old"))
+    session = _session(transcript)
+    manager = MagicMock()
+    manager.get_session.return_value = session
+    manager._deliver_direct = AsyncMock(return_value=True)
+    manager._save_state = MagicMock()
+    ledger = ResponseRelayLedger(str(tmp_path / "relay.db"))
+    mq = MessageQueueManager(
+        manager,
+        db_path=str(tmp_path / "message_queue.db"),
+        response_relay_ledger=ledger,
+    )
+
+    msg = mq.queue_message(
+        session.id,
+        "telegram user turn",
+        response_relay_source="telegram",
+        trigger_delivery=False,
+    )
+
+    pending = mq.get_pending_messages(session.id)
+    assert pending[0].response_relay_source == "telegram"
+
+    await mq._try_deliver_messages(session.id)
+
+    active_turn = ledger.get_latest_active_turn(session.id)
+    assert active_turn is not None
+    assert active_turn.inbound_id == msg.id
+    assert active_turn.source == "telegram"

--- a/tests/regression/test_issue_706_turn_bound_telegram_response_relay.py
+++ b/tests/regression/test_issue_706_turn_bound_telegram_response_relay.py
@@ -32,6 +32,21 @@ def _assistant_line(text: str, *, timestamp: str | None = None, uuid: str | None
     return json.dumps(entry) + "\n"
 
 
+def _user_line(text: str, *, timestamp: str | None = None, uuid: str | None = None) -> str:
+    entry = {
+        "type": "user",
+        "message": {
+            "id": uuid or f"user-{abs(hash(text))}",
+            "content": [{"type": "text", "text": text}],
+        },
+    }
+    if timestamp:
+        entry["timestamp"] = timestamp
+    if uuid:
+        entry["uuid"] = uuid
+    return json.dumps(entry) + "\n"
+
+
 def _record_inbound(
     ledger: ResponseRelayLedger,
     session: Session,
@@ -222,6 +237,43 @@ def test_deferred_transcript_lag_waits_for_post_boundary_output(tmp_path):
     assert response.status_code == 200
     notifier.notify.assert_awaited_once()
     assert notifier.notify.await_args.args[0].context == "response after transcript lag"
+
+
+def test_missing_transcript_path_binds_offset_from_inbound_user_line(tmp_path):
+    transcript = tmp_path / "late-boundary.jsonl"
+    user_text = "the first input before transcript discovery"
+    prefix = _assistant_line("old answer before the turn", uuid="old") + _user_line(user_text, uuid="user-current")
+    transcript.write_text(prefix + _assistant_line("current answer without timestamp", uuid="answer-current"))
+    session = _session(transcript)
+    session.transcript_path = None
+    ledger = ResponseRelayLedger(str(tmp_path / "relay.db"))
+    ledger.record_inbound_turn(
+        session_id=session.id,
+        inbound_id="inbound-late-boundary",
+        source="telegram",
+        provider=session.provider,
+        delivered_at=datetime(2026, 5, 2, 22, 24, 19, tzinfo=timezone.utc),
+        text=user_text,
+    )
+    _, client, notifier, _ = _make_app(tmp_path, session, ledger)
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        response = client.post(
+            "/hooks/claude",
+            json={
+                "hook_event_name": "Stop",
+                "session_manager_id": session.id,
+                "transcript_path": str(transcript),
+            },
+        )
+
+    assert response.status_code == 200
+    notifier.notify.assert_awaited_once()
+    assert notifier.notify.await_args.args[0].context == "current answer without timestamp"
+    active_turn = ledger.get_latest_active_turn(session.id)
+    assert active_turn is not None
+    assert active_turn.transcript_path == str(transcript)
+    assert active_turn.transcript_offset == len(prefix.encode("utf-8"))
 
 
 def test_unresolved_session_manager_id_uses_legacy_transcript_match(tmp_path):

--- a/tests/regression/test_issue_706_turn_bound_telegram_response_relay.py
+++ b/tests/regression/test_issue_706_turn_bound_telegram_response_relay.py
@@ -223,6 +223,28 @@ def test_deferred_transcript_lag_waits_for_post_boundary_output(tmp_path):
     assert notifier.notify.await_args.args[0].context == "response after transcript lag"
 
 
+def test_unresolved_session_manager_id_uses_legacy_transcript_match(tmp_path):
+    transcript = tmp_path / "fallback.jsonl"
+    transcript.write_text(_assistant_line("fallback matched answer", uuid="fallback-answer"))
+    session = _session(transcript)
+    ledger = ResponseRelayLedger(str(tmp_path / "relay.db"))
+    _, client, notifier, _ = _make_app(tmp_path, session, ledger)
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        response = client.post(
+            "/hooks/claude",
+            json={
+                "hook_event_name": "Stop",
+                "session_manager_id": "stale-missing-session",
+                "transcript_path": str(transcript),
+            },
+        )
+
+    assert response.status_code == 200
+    notifier.notify.assert_awaited_once()
+    assert notifier.notify.await_args.args[0].context == "fallback matched answer"
+
+
 def test_long_chunk_group_is_deduped_as_one_output(tmp_path):
     transcript = tmp_path / "long.jsonl"
     transcript.write_text(_assistant_line("old", uuid="old"))
@@ -318,3 +340,8 @@ async def test_message_queue_records_inbound_boundary_only_after_delivery(tmp_pa
     assert active_turn is not None
     assert active_turn.inbound_id == msg.id
     assert active_turn.transcript_offset == transcript.stat().st_size
+    delivered_rows = mq._execute_query(
+        "SELECT delivered_at FROM message_queue WHERE id = ?",
+        (msg.id,),
+    )
+    assert delivered_rows[0][0].endswith("+00:00")

--- a/tests/regression/test_issue_706_turn_bound_telegram_response_relay.py
+++ b/tests/regression/test_issue_706_turn_bound_telegram_response_relay.py
@@ -276,6 +276,46 @@ def test_missing_transcript_path_binds_offset_from_inbound_user_line(tmp_path):
     assert active_turn.transcript_offset == len(prefix.encode("utf-8"))
 
 
+def test_hook_transcript_path_replaces_stale_turn_path(tmp_path):
+    stale_transcript = tmp_path / "stale-transcript.jsonl"
+    stale_transcript.write_text(_assistant_line("old stale file answer", uuid="old-stale"))
+    current_transcript = tmp_path / "current-transcript.jsonl"
+    user_text = "input after transcript rotation"
+    prefix = _assistant_line("older current file answer", uuid="old-current") + _user_line(user_text, uuid="user-rotated")
+    current_transcript.write_text(prefix + _assistant_line("answer in rotated transcript", uuid="answer-rotated"))
+    session = _session(stale_transcript)
+    ledger = ResponseRelayLedger(str(tmp_path / "relay.db"))
+    ledger.record_inbound_turn(
+        session_id=session.id,
+        inbound_id="inbound-stale-path",
+        source="telegram",
+        provider=session.provider,
+        delivered_at=datetime(2026, 5, 2, 22, 24, 19, tzinfo=timezone.utc),
+        transcript_path=str(stale_transcript),
+        transcript_offset=stale_transcript.stat().st_size,
+        text=user_text,
+    )
+    _, client, notifier, _ = _make_app(tmp_path, session, ledger)
+
+    with patch("asyncio.sleep", new_callable=AsyncMock):
+        response = client.post(
+            "/hooks/claude",
+            json={
+                "hook_event_name": "Stop",
+                "session_manager_id": session.id,
+                "transcript_path": str(current_transcript),
+            },
+        )
+
+    assert response.status_code == 200
+    notifier.notify.assert_awaited_once()
+    assert notifier.notify.await_args.args[0].context == "answer in rotated transcript"
+    active_turn = ledger.get_latest_active_turn(session.id)
+    assert active_turn is not None
+    assert active_turn.transcript_path == str(current_transcript)
+    assert active_turn.transcript_offset == len(prefix.encode("utf-8"))
+
+
 def test_unresolved_session_manager_id_uses_legacy_transcript_match(tmp_path):
     transcript = tmp_path / "fallback.jsonl"
     transcript.write_text(_assistant_line("fallback matched answer", uuid="fallback-answer"))

--- a/tests/regression/test_issue_706_turn_bound_telegram_response_relay.py
+++ b/tests/regression/test_issue_706_turn_bound_telegram_response_relay.py
@@ -14,6 +14,7 @@ from src.message_queue import MessageQueueManager
 from src.models import Session, SessionStatus
 from src.response_relay import ResponseRelayLedger
 from src.server import create_app
+from src.session_manager import SessionManager
 
 
 def _assistant_line(text: str, *, timestamp: str | None = None, uuid: str | None = None) -> str:
@@ -420,3 +421,33 @@ async def test_message_queue_records_telegram_inbound_boundary(tmp_path):
     assert active_turn is not None
     assert active_turn.inbound_id == msg.id
     assert active_turn.source == "telegram"
+
+
+@pytest.mark.asyncio
+async def test_bypass_queue_telegram_permission_response_records_boundary(tmp_path):
+    transcript = tmp_path / "permission-response.jsonl"
+    transcript.write_text(_assistant_line("existing old output", uuid="old"))
+    manager = SessionManager(
+        log_dir=str(tmp_path / "logs"),
+        state_file=str(tmp_path / "sessions.json"),
+    )
+    session = _session(transcript)
+    manager.sessions[session.id] = session
+    ledger = ResponseRelayLedger(str(tmp_path / "relay.db"))
+    manager.message_queue_manager = SimpleNamespace(response_relay_ledger=ledger)
+    manager._deliver_direct = AsyncMock(return_value=True)
+    manager._save_state = MagicMock()
+
+    result = await manager.send_input(
+        session.id,
+        "yes, allow the command",
+        bypass_queue=True,
+        response_relay_source="telegram",
+    )
+
+    assert result.value == "delivered"
+    active_turn = ledger.get_latest_active_turn(session.id)
+    assert active_turn is not None
+    assert active_turn.inbound_id.startswith(f"direct:{session.id}:")
+    assert active_turn.source == "telegram"
+    assert active_turn.transcript_offset == transcript.stat().st_size

--- a/tests/regression/test_issue_706_turn_bound_telegram_response_relay.py
+++ b/tests/regression/test_issue_706_turn_bound_telegram_response_relay.py
@@ -538,6 +538,44 @@ async def test_message_queue_records_email_inbound_boundary(tmp_path):
     assert active_turn.source == "email"
 
 
+def test_api_input_records_default_inbound_boundary(tmp_path):
+    transcript = tmp_path / "api-input.jsonl"
+    transcript.write_text(_assistant_line("existing old output", uuid="old"))
+    manager = SessionManager(
+        log_dir=str(tmp_path / "logs"),
+        state_file=str(tmp_path / "sessions.json"),
+    )
+    session = _session(transcript)
+    session.status = SessionStatus.IDLE
+    manager.sessions[session.id] = session
+    ledger = ResponseRelayLedger(str(tmp_path / "relay.db"))
+    mq = MessageQueueManager(
+        manager,
+        db_path=str(tmp_path / "message_queue.db"),
+        response_relay_ledger=ledger,
+    )
+    manager.message_queue_manager = mq
+    manager._deliver_direct = AsyncMock(return_value=True)
+    manager._save_state = MagicMock()
+    app = create_app(
+        session_manager=manager,
+        notifier=MagicMock(),
+        output_monitor=MagicMock(),
+        response_relay_ledger=ledger,
+        config={},
+    )
+    client = TestClient(app)
+
+    response = client.post(f"/sessions/{session.id}/input", json={"text": "api user turn"})
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "delivered"
+    active_turn = ledger.get_latest_active_turn(session.id)
+    assert active_turn is not None
+    assert active_turn.source == "api"
+    assert active_turn.transcript_offset == transcript.stat().st_size
+
+
 @pytest.mark.asyncio
 async def test_bypass_queue_telegram_permission_response_records_boundary(tmp_path):
     transcript = tmp_path / "permission-response.jsonl"

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -275,6 +275,7 @@ class TestQueuedMessage:
             notify_on_delivery=True,
             notify_after_seconds=60,
             delivered_at=None,
+            response_relay_source="telegram",
         )
 
         as_dict = original.to_dict()
@@ -289,6 +290,7 @@ class TestQueuedMessage:
         assert as_dict["notify_on_delivery"] is True
         assert as_dict["notify_after_seconds"] == 60
         assert as_dict["delivered_at"] is None
+        assert as_dict["response_relay_source"] == "telegram"
 
     def test_queued_message_defaults(self):
         """QueuedMessage has correct defaults."""
@@ -306,6 +308,7 @@ class TestQueuedMessage:
         assert msg.notify_on_delivery is False
         assert msg.notify_after_seconds is None
         assert msg.delivered_at is None
+        assert msg.response_relay_source is None
 
     def test_is_expired_not_implemented(self):
         """Expiration is handled by MessageQueueManager, not model."""


### PR DESCRIPTION
## Summary
- Add a SQLite-backed response relay ledger for delivered inbound turns and assistant output dedupe.
- Record Claude/SM message boundaries at actual queued-message delivery, including transcript offsets when available.
- Change Claude Stop/idle response relay to scan only post-boundary assistant output, defer transcript lag, and mark outputs relayed only after notifier acceptance.
- Add regression coverage for stale output suppression, deferred transcript lag, restart dedupe, long output/chunk-group dedupe, multiple inbound turns, actual delivery boundary recording, and the 3401-consultant timeline.

## Root Cause
Claude response relay scanned the transcript backwards for the latest assistant text and compared it to volatile in-memory `last_claude_output`. After restarts, delayed transcript writes, or missing cache state, older assistant output could look eligible for Telegram.

## Validation
- `python -m pytest tests/regression/test_issue_706_turn_bound_telegram_response_relay.py tests/regression/test_issue_184_stale_transcript_retry.py tests/regression/test_issue_230_empty_transcript_retry.py tests/unit/test_message_queue.py -q` -> 115 passed
- `python -m pytest -q` -> 1862 passed
- Built ignored local watch assets first for `/watch/` tests: `(cd web/sm-watch && npm install && npm run build)`

## Coordination
#705 has adjacent Codex assistant relay work. This PR avoids taking over the Codex collector and leaves a provider-agnostic ledger path for Codex relay integration to use after #705 lands.

Fixes #706