### PR TITLE
Implement secure mobile HTTPS attach

### DIFF
--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/model/ApiModels.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/model/ApiModels.kt
@@ -51,6 +51,10 @@ data class ExternalAccess(
     val sshUsername: String? = null,
     @SerialName("termux_attach_supported")
     val termuxAttachSupported: Boolean = false,
+    @SerialName("mobile_terminal_supported")
+    val mobileTerminalSupported: Boolean = false,
+    @SerialName("mobile_terminal_ws_url")
+    val mobileTerminalWsUrl: String? = null,
 )
 
 @Serializable
@@ -172,6 +176,8 @@ data class ClientSession(
     val attachDescriptor: AttachDescriptor? = null,
     @SerialName("termux_attach")
     val termuxAttach: TermuxAttachMetadata? = null,
+    @SerialName("mobile_terminal")
+    val mobileTerminal: MobileTerminalMetadata? = null,
     @SerialName("primary_action")
     val primaryAction: PrimaryAction? = null,
 )
@@ -217,6 +223,44 @@ data class TermuxAttachMetadata(
     val runtimeMode: String? = null,
     @SerialName("termux_package")
     val termuxPackage: String? = null,
+)
+
+@Serializable
+data class MobileTerminalMetadata(
+    val supported: Boolean = false,
+    val reason: String? = null,
+    val transport: String? = null,
+    @SerialName("ticket_endpoint")
+    val ticketEndpoint: String? = null,
+    @SerialName("ws_url")
+    val wsUrl: String? = null,
+    @SerialName("tmux_session")
+    val tmuxSession: String? = null,
+    @SerialName("tmux_socket_name")
+    val tmuxSocketName: String? = null,
+    @SerialName("runtime_mode")
+    val runtimeMode: String? = null,
+    @SerialName("requires_device_key")
+    val requiresDeviceKey: Boolean = true,
+)
+
+@Serializable
+data class MobileAttachTicketRequest(
+    val mode: String = "terminal",
+)
+
+@Serializable
+data class MobileAttachTicketResponse(
+    @SerialName("ticket_id")
+    val ticketId: String,
+    @SerialName("ticket_secret")
+    val ticketSecret: String,
+    @SerialName("device_key_id")
+    val deviceKeyId: String,
+    @SerialName("ws_url")
+    val wsUrl: String,
+    @SerialName("expires_at")
+    val expiresAt: String,
 )
 
 @Serializable

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/remote/ApiService.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/remote/ApiService.kt
@@ -12,12 +12,15 @@ import li.rajeshgo.sm.data.model.EnsureMaintainerRequest
 import li.rajeshgo.sm.data.model.EnsureMaintainerResponse
 import li.rajeshgo.sm.data.model.KillSessionRequest
 import li.rajeshgo.sm.data.model.KillSessionResponse
+import li.rajeshgo.sm.data.model.MobileAttachTicketRequest
+import li.rajeshgo.sm.data.model.MobileAttachTicketResponse
 import li.rajeshgo.sm.data.model.OutputResponse
 import li.rajeshgo.sm.data.model.RequestStatusResponse
 import li.rajeshgo.sm.data.model.SessionListResponse
 import li.rajeshgo.sm.data.model.ToolCallsResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -43,6 +46,16 @@ interface ApiService {
 
     @GET("client/sessions/{session_id}")
     suspend fun getClientSession(@Path("session_id") sessionId: String): ClientSession
+
+    @POST("client/sessions/{session_id}/attach-ticket")
+    suspend fun createMobileAttachTicket(
+        @Path("session_id") sessionId: String,
+        @Header("X-SM-Device-Key-Id") deviceKeyId: String,
+        @Header("X-SM-Device-Timestamp") timestamp: String,
+        @Header("X-SM-Device-Nonce") nonce: String,
+        @Header("X-SM-Device-Signature") signature: String,
+        @Body request: MobileAttachTicketRequest = MobileAttachTicketRequest(),
+    ): MobileAttachTicketResponse
 
     @POST("client/request-status")
     suspend fun requestStatus(): RequestStatusResponse

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SessionManagerRepository.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SessionManagerRepository.kt
@@ -31,6 +31,7 @@ import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.HttpException
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import java.net.URI
 
 open class SessionManagerRequestException(message: String, cause: Throwable? = null) : IllegalStateException(message, cause)
 class SessionManagerAuthException(message: String, cause: Throwable? = null) : SessionManagerRequestException(message, cause)
@@ -217,6 +218,13 @@ class SessionManagerRepository {
                 signature = proof.signature,
             )
         }.mapFailure(::classifyWriteFailure)
+    }
+
+    fun mobileAttachTicketPath(baseUrl: String, sessionId: String): String {
+        val prefix = runCatching {
+            URI(baseUrl.trim()).rawPath.orEmpty().trimEnd('/')
+        }.getOrDefault("")
+        return "$prefix/client/sessions/$sessionId/attach-ticket"
     }
 
     fun openMobileTerminalSocket(

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SessionManagerRepository.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SessionManagerRepository.kt
@@ -220,11 +220,28 @@ class SessionManagerRepository {
         }.mapFailure(::classifyWriteFailure)
     }
 
-    fun mobileAttachTicketPath(baseUrl: String, sessionId: String): String {
+    fun mobileAttachTicketPath(
+        baseUrl: String,
+        sessionId: String,
+        advertisedEndpoint: String? = null,
+    ): String {
+        val advertised = advertisedEndpoint.orEmpty().trim()
+        if (advertised.isNotEmpty()) {
+            val path = runCatching { URI(advertised).rawPath.orEmpty() }.getOrDefault("")
+            return normalizePath(path.ifBlank { advertised.substringBefore('?').substringBefore('#') })
+        }
         val prefix = runCatching {
             URI(baseUrl.trim()).rawPath.orEmpty().trimEnd('/')
         }.getOrDefault("")
         return "$prefix/client/sessions/$sessionId/attach-ticket"
+    }
+
+    private fun normalizePath(path: String): String {
+        val trimmed = path.trim()
+        if (trimmed.isEmpty() || trimmed == "/") {
+            return "/"
+        }
+        return if (trimmed.startsWith("/")) trimmed else "/$trimmed"
     }
 
     fun openMobileTerminalSocket(

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SessionManagerRepository.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SessionManagerRepository.kt
@@ -15,13 +15,18 @@ import li.rajeshgo.sm.data.model.ClientBootstrapResponse
 import li.rajeshgo.sm.data.model.ClientSession
 import li.rajeshgo.sm.data.model.DeviceGoogleAuthResponse
 import li.rajeshgo.sm.data.model.EnsureMaintainerResponse
+import li.rajeshgo.sm.data.model.MobileAttachTicketResponse
 import li.rajeshgo.sm.data.model.RequestStatusResponse
 import li.rajeshgo.sm.data.model.SessionDetail
 import li.rajeshgo.sm.data.model.ToolCallRow
 import li.rajeshgo.sm.data.remote.ApiService
 import li.rajeshgo.sm.data.remote.AuthInterceptor
+import li.rajeshgo.sm.data.security.DeviceProof
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.HttpException
@@ -48,17 +53,20 @@ class SessionManagerRepository {
         val message: String? = null,
     )
 
-    private fun api(baseUrl: String, token: String = ""): ApiService {
-        require(baseUrl.isNotBlank()) { "Server URL is required" }
-        val normalizedBaseUrl = baseUrl.trim().trimEnd('/') + "/"
+    private fun httpClient(token: String = ""): OkHttpClient {
         val logger = HttpLoggingInterceptor().apply { level = HttpLoggingInterceptor.Level.BASIC }
-        val client = OkHttpClient.Builder()
+        return OkHttpClient.Builder()
             .addInterceptor(AuthInterceptor { token })
             .addInterceptor(logger)
             .build()
+    }
+
+    private fun api(baseUrl: String, token: String = ""): ApiService {
+        require(baseUrl.isNotBlank()) { "Server URL is required" }
+        val normalizedBaseUrl = baseUrl.trim().trimEnd('/') + "/"
         return Retrofit.Builder()
             .baseUrl(normalizedBaseUrl)
-            .client(client)
+            .client(httpClient(token))
             .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
             .build()
             .create(ApiService::class.java)
@@ -192,6 +200,33 @@ class SessionManagerRepository {
             val response = api(baseUrl, token).killSession(sessionId)
             check(response.status == "killed") { response.error ?: "Kill request failed" }
         }.mapFailure(::classifyWriteFailure)
+    }
+
+    suspend fun createMobileAttachTicket(
+        baseUrl: String,
+        token: String,
+        sessionId: String,
+        proof: DeviceProof,
+    ): Result<MobileAttachTicketResponse> = withContext(Dispatchers.IO) {
+        runCatching {
+            api(baseUrl, token).createMobileAttachTicket(
+                sessionId = sessionId,
+                deviceKeyId = proof.deviceKeyId,
+                timestamp = proof.timestamp,
+                nonce = proof.nonce,
+                signature = proof.signature,
+            )
+        }.mapFailure(::classifyWriteFailure)
+    }
+
+    fun openMobileTerminalSocket(
+        ticket: MobileAttachTicketResponse,
+        listener: WebSocketListener,
+    ): WebSocket {
+        val request = Request.Builder()
+            .url(ticket.wsUrl)
+            .build()
+        return httpClient().newWebSocket(request, listener)
     }
 
     suspend fun requestStatus(baseUrl: String, token: String): Result<RequestStatusResponse> = withContext(Dispatchers.IO) {

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/security/DeviceKeyManager.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/security/DeviceKeyManager.kt
@@ -1,0 +1,125 @@
+package li.rajeshgo.sm.data.security
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import android.util.Base64
+import java.security.KeyPairGenerator
+import java.security.KeyStore
+import java.security.MessageDigest
+import java.security.PrivateKey
+import java.security.Signature
+import java.security.spec.ECGenParameterSpec
+
+data class DeviceProof(
+    val deviceKeyId: String,
+    val timestamp: String,
+    val nonce: String,
+    val signature: String,
+)
+
+class DeviceKeyManager {
+    private val keyStore: KeyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+
+    fun deviceKeyId(): String {
+        val publicKey = ensureKeyPair().certificate.publicKey.encoded
+        val digest = MessageDigest.getInstance("SHA-256").digest(publicKey)
+        return "android-${digest.take(8).joinToString("") { "%02x".format(it.toInt() and 0xff) }}"
+    }
+
+    fun publicKeyPem(): String {
+        val publicKey = ensureKeyPair().certificate.publicKey.encoded
+        val body = Base64.encodeToString(publicKey, Base64.NO_WRAP)
+            .chunked(64)
+            .joinToString("\n")
+        return "-----BEGIN PUBLIC KEY-----\n$body\n-----END PUBLIC KEY-----"
+    }
+
+    fun signTicketRequest(
+        method: String,
+        path: String,
+        sessionId: String,
+        actorEmail: String,
+    ): DeviceProof {
+        val timestamp = (System.currentTimeMillis() / 1000L).toString()
+        val nonce = randomNonce()
+        val keyId = deviceKeyId()
+        val message = listOf(
+            "SM-MOBILE-TERMINAL-TICKET-V1",
+            method.uppercase(),
+            path,
+            sessionId,
+            actorEmail.lowercase(),
+            keyId,
+            timestamp,
+            nonce,
+        ).joinToString("\n")
+        return DeviceProof(
+            deviceKeyId = keyId,
+            timestamp = timestamp,
+            nonce = nonce,
+            signature = sign(message),
+        )
+    }
+
+    fun signWebSocketAuth(
+        ticketId: String,
+        sessionId: String,
+        actorEmail: String,
+        deviceKeyId: String,
+        nonce: String,
+    ): String {
+        val message = listOf(
+            "SM-MOBILE-TERMINAL-WS-V1",
+            ticketId,
+            sessionId,
+            actorEmail.lowercase(),
+            deviceKeyId,
+            nonce,
+        ).joinToString("\n")
+        return sign(message)
+    }
+
+    private fun sign(message: String): String {
+        val privateKey = ensurePrivateKey()
+        val signer = Signature.getInstance("SHA256withECDSA")
+        signer.initSign(privateKey)
+        signer.update(message.toByteArray(Charsets.UTF_8))
+        return Base64.encodeToString(signer.sign(), Base64.NO_WRAP)
+    }
+
+    private fun ensurePrivateKey(): PrivateKey {
+        ensureKeyPair()
+        return keyStore.getKey(KEY_ALIAS, null) as PrivateKey
+    }
+
+    private fun ensureKeyPair(): KeyStore.PrivateKeyEntry {
+        keyStore.getEntry(KEY_ALIAS, null)?.let { entry ->
+            if (entry is KeyStore.PrivateKeyEntry) {
+                return entry
+            }
+        }
+        val generator = KeyPairGenerator.getInstance(KeyProperties.KEY_ALGORITHM_EC, ANDROID_KEYSTORE)
+        val spec = KeyGenParameterSpec.Builder(
+            KEY_ALIAS,
+            KeyProperties.PURPOSE_SIGN or KeyProperties.PURPOSE_VERIFY,
+        )
+            .setAlgorithmParameterSpec(ECGenParameterSpec("secp256r1"))
+            .setDigests(KeyProperties.DIGEST_SHA256)
+            .setUserAuthenticationRequired(false)
+            .build()
+        generator.initialize(spec)
+        generator.generateKeyPair()
+        return keyStore.getEntry(KEY_ALIAS, null) as KeyStore.PrivateKeyEntry
+    }
+
+    private fun randomNonce(): String {
+        val bytes = ByteArray(18)
+        java.security.SecureRandom().nextBytes(bytes)
+        return Base64.encodeToString(bytes, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
+    }
+
+    private companion object {
+        private const val ANDROID_KEYSTORE = "AndroidKeyStore"
+        private const val KEY_ALIAS = "li.rajeshgo.sm.mobile_terminal_device_key.v1"
+    }
+}

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsScreen.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsScreen.kt
@@ -2,6 +2,7 @@ package li.rajeshgo.sm.ui.settings
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -62,7 +63,7 @@ fun SettingsScreen(
         )
         Spacer(Modifier.height(8.dp))
         Text(
-            text = "Native Android watch client for sm.rajeshgo.li with direct Termux attach.",
+            text = "Native Android watch client for sm.rajeshgo.li with in-app HTTPS terminal attach.",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -118,6 +119,64 @@ fun SettingsScreen(
                 color = Cyan,
                 fontFamily = FontFamily.Monospace,
             )
+        }
+
+        Spacer(Modifier.height(24.dp))
+
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(containerColor = PanelElevated),
+            border = androidx.compose.foundation.BorderStroke(1.dp, BorderStrong),
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(
+                    text = "Mobile HTTPS attach",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = "Register this public key under mobile_terminal.allowed_users in Session Manager config to enable in-app terminal attach.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(10.dp))
+                Text(
+                    text = "Device key id",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    text = state.mobileDeviceKeyId.ifBlank { "unavailable" },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (state.mobileDeviceKeyId.isBlank()) Rose else Cyan,
+                    fontFamily = FontFamily.Monospace,
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = state.mobileDevicePublicKey.ifBlank { state.mobileDeviceKeyError ?: "No key generated yet" },
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (state.mobileDeviceKeyError == null) MaterialTheme.colorScheme.onSurfaceVariant else Rose,
+                    fontFamily = FontFamily.Monospace,
+                )
+                Spacer(Modifier.height(10.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedButton(onClick = viewModel::loadMobileDeviceKey) {
+                        Text("Refresh key")
+                    }
+                    Button(
+                        onClick = {
+                            val clipboard = context.getSystemService(android.content.ClipboardManager::class.java)
+                            val text = "id: ${state.mobileDeviceKeyId}\npublic_key: |\n" +
+                                state.mobileDevicePublicKey.lines().joinToString("\n") { "  $it" }
+                            clipboard?.setPrimaryClip(android.content.ClipData.newPlainText("sm mobile attach key", text))
+                        },
+                        enabled = state.mobileDeviceKeyId.isNotBlank() && state.mobileDevicePublicKey.isNotBlank(),
+                    ) {
+                        Text("Copy config")
+                    }
+                }
+            }
         }
 
         Spacer(Modifier.height(24.dp))
@@ -251,7 +310,7 @@ fun SettingsScreen(
 
         Spacer(Modifier.height(24.dp))
         Text(
-            text = "Attach note: install Termux, allow external apps, complete Cloudflare Access login there, and add your SSH public key once. Password auth is unsupported.",
+            text = "Attach note: HTTPS in-app attach is primary when mobile_terminal is enabled server-side. Termux remains a temporary fallback for sessions without mobile terminal support.",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsViewModel.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsViewModel.kt
@@ -13,6 +13,7 @@ import li.rajeshgo.sm.data.repository.AppUpdateRepository
 import li.rajeshgo.sm.data.repository.AvailableAppUpdate
 import li.rajeshgo.sm.data.repository.SessionManagerRepository
 import li.rajeshgo.sm.data.repository.SettingsRepository
+import li.rajeshgo.sm.data.security.DeviceKeyManager
 
 data class SettingsUiState(
     val serverUrl: String = "",
@@ -22,6 +23,9 @@ data class SettingsUiState(
     val loading: Boolean = false,
     val bootstrap: ClientBootstrapResponse? = null,
     val availableUpdate: AvailableAppUpdate? = null,
+    val mobileDeviceKeyId: String = "",
+    val mobileDevicePublicKey: String = "",
+    val mobileDeviceKeyError: String? = null,
     val updateInstalling: Boolean = false,
     val updateError: String? = null,
     val error: String? = null,
@@ -31,6 +35,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     private val settingsRepository = SettingsRepository(application)
     private val sessionRepository = SessionManagerRepository()
     private val appUpdateRepository = AppUpdateRepository(application, settingsRepository)
+    private val deviceKeyManager = DeviceKeyManager()
 
     private val _uiState = MutableStateFlow(SettingsUiState())
     val uiState: StateFlow<SettingsUiState> = _uiState
@@ -43,6 +48,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                 userName = settingsRepository.userName.first(),
                 isLoggedIn = settingsRepository.isLoggedIn.first(),
             )
+            loadMobileDeviceKey()
             refreshBootstrap()
             refreshUpdate()
         }
@@ -68,6 +74,22 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             }.onFailure { error ->
                 _uiState.value = _uiState.value.copy(error = error.message ?: "Failed to load bootstrap")
             }
+        }
+    }
+
+    fun loadMobileDeviceKey() {
+        runCatching {
+            deviceKeyManager.deviceKeyId() to deviceKeyManager.publicKeyPem()
+        }.onSuccess { (keyId, publicKey) ->
+            _uiState.value = _uiState.value.copy(
+                mobileDeviceKeyId = keyId,
+                mobileDevicePublicKey = publicKey,
+                mobileDeviceKeyError = null,
+            )
+        }.onFailure { error ->
+            _uiState.value = _uiState.value.copy(
+                mobileDeviceKeyError = error.message ?: "Failed to load mobile attach device key",
+            )
         }
     }
 

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -36,6 +37,7 @@ import androidx.compose.material.icons.rounded.UnfoldLess
 import androidx.compose.material.icons.rounded.UnfoldMore
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -46,6 +48,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -120,6 +123,22 @@ fun WatchScreen(
     val lifecycleOwner = LocalLifecycleOwner.current
     var isResumed by remember {
         mutableStateOf(lifecycleOwner.lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED))
+    }
+    val openAttach: (ClientSession) -> Unit = { session ->
+        if (session.mobileTerminal?.supported == true) {
+            viewModel.openMobileTerminal(session) { result ->
+                toast = result.exceptionOrNull()?.message ?: result.getOrNull()
+            }
+        } else {
+            val attach = session.termuxAttach
+            if (attach == null) {
+                toast = "Attach metadata unavailable"
+            } else {
+                launchTermuxAttach(context, attach)
+                    .onSuccess { toast = "Opening Termux for ${sessionDisplayName(session)}" }
+                    .onFailure { error -> toast = error.message ?: "Attach failed" }
+            }
+        }
     }
 
     androidx.compose.runtime.DisposableEffect(lifecycleOwner) {
@@ -229,16 +248,7 @@ fun WatchScreen(
                             expandedSessionIds = state.expandedSessionIds,
                             detailsById = state.detailsBySessionId,
                             onToggleExpanded = { viewModel.toggleExpanded(it) },
-                            onOpenAttach = { session ->
-                                val attach = session.termuxAttach
-                                if (attach == null) {
-                                    toast = "Attach metadata unavailable"
-                                } else {
-                                    launchTermuxAttach(context, attach)
-                                        .onSuccess { toast = "Opening Termux for ${sessionDisplayName(session)}" }
-                                        .onFailure { error -> toast = error.message ?: "Attach failed" }
-                                }
-                            },
+                            onOpenAttach = openAttach,
                             onCopyAttach = { session ->
                                 val command = session.termuxAttach?.let(::termuxAttachCommand)
                                 if (command == null) {
@@ -284,16 +294,7 @@ fun WatchScreen(
                             expandedSessionIds = state.expandedSessionIds,
                             detailsById = state.detailsBySessionId,
                             onToggleExpanded = { viewModel.toggleExpanded(it) },
-                            onOpenAttach = { session ->
-                                val attach = session.termuxAttach
-                                if (attach == null) {
-                                    toast = "Attach metadata unavailable"
-                                } else {
-                                    launchTermuxAttach(context, attach)
-                                        .onSuccess { toast = "Opening Termux for ${sessionDisplayName(session)}" }
-                                        .onFailure { error -> toast = error.message ?: "Attach failed" }
-                                }
-                            },
+                            onOpenAttach = openAttach,
                             onCopyAttach = { session ->
                                 val command = session.termuxAttach?.let(::termuxAttachCommand)
                                 if (command == null) {
@@ -365,6 +366,129 @@ fun WatchScreen(
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurface,
                     )
+                }
+            }
+        }
+
+        state.terminal?.let { terminal ->
+            MobileTerminalOverlay(
+                terminal = terminal,
+                onInputChange = viewModel::updateTerminalInput,
+                onSend = { viewModel.sendTerminalInput(sendEnter = true) },
+                onEsc = { viewModel.sendTerminalKey("esc") },
+                onCtrlC = { viewModel.sendTerminalKey("ctrl-c") },
+                onEnter = { viewModel.sendTerminalKey("enter") },
+                onDetach = viewModel::detachTerminal,
+                onCopy = {
+                    val clipboard = context.getSystemService(android.content.ClipboardManager::class.java)
+                    clipboard?.setPrimaryClip(android.content.ClipData.newPlainText("sm terminal", terminal.output))
+                    toast = "Terminal output copied"
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun MobileTerminalOverlay(
+    terminal: TerminalUiState,
+    onInputChange: (String) -> Unit,
+    onSend: () -> Unit,
+    onEsc: () -> Unit,
+    onCtrlC: () -> Unit,
+    onEnter: () -> Unit,
+    onDetach: () -> Unit,
+    onCopy: () -> Unit,
+) {
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(14.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            Surface(
+                shape = RoundedCornerShape(18.dp),
+                color = Panel,
+                border = androidx.compose.foundation.BorderStroke(1.dp, BorderStrong),
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 10.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = terminal.title,
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.onSurface,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Text(
+                            text = terminal.status,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = if (terminal.error == null) Cyan else Rose,
+                            fontFamily = FontFamily.Monospace,
+                        )
+                    }
+                    OutlinedButton(onClick = onDetach) {
+                        Text("Detach")
+                    }
+                }
+            }
+
+            terminal.error?.let { error ->
+                Text(
+                    text = error,
+                    color = Rose,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+            }
+
+            Surface(
+                modifier = Modifier.weight(1f).fillMaxWidth(),
+                shape = RoundedCornerShape(18.dp),
+                color = Color.Black,
+                border = androidx.compose.foundation.BorderStroke(1.dp, BorderStrong),
+            ) {
+                Text(
+                    text = terminal.output.ifBlank { "Waiting for terminal output..." },
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .verticalScroll(rememberScrollState())
+                        .padding(12.dp),
+                    color = Color(0xFFE7F6F2),
+                    style = MaterialTheme.typography.bodySmall,
+                    fontFamily = FontFamily.Monospace,
+                )
+            }
+
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedButton(onClick = onEsc) { Text("Esc") }
+                OutlinedButton(onClick = onCtrlC) { Text("Ctrl-C") }
+                OutlinedButton(onClick = onEnter) { Text("Enter") }
+                OutlinedButton(onClick = onCopy) { Text("Copy") }
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                OutlinedTextField(
+                    value = terminal.inputDraft,
+                    onValueChange = onInputChange,
+                    modifier = Modifier.weight(1f),
+                    label = { Text("Input") },
+                    singleLine = false,
+                    maxLines = 4,
+                )
+                Button(onClick = onSend) {
+                    Text("Send")
                 }
             }
         }
@@ -639,7 +763,7 @@ private fun SessionRow(
     onOpenTelegram: () -> Unit,
     onKill: () -> Unit,
 ) {
-    val attachSupported = session.termuxAttach?.supported == true
+    val attachSupported = session.mobileTerminal?.supported == true || session.termuxAttach?.supported == true
     Surface(
         modifier = Modifier.padding(start = (depth * 14).dp),
         shape = RoundedCornerShape(22.dp),
@@ -756,7 +880,9 @@ private fun SessionRow(
                         }
                         ActionPill(label = "Kill", icon = Icons.Rounded.UnfoldLess, onClick = onKill, tint = Rose)
                     }
-                    if (session.termuxAttach?.supported == false) {
+                    if (session.mobileTerminal?.supported == false && session.termuxAttach?.supported != true) {
+                        StatusChip(label = session.mobileTerminal.reason ?: "mobile attach unavailable", tint = TextMuted)
+                    } else if (session.termuxAttach?.supported == false && session.mobileTerminal?.supported != true) {
                         StatusChip(label = session.termuxAttach.reason ?: "attach unavailable", tint = TextMuted)
                     }
                 }

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchViewModel.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchViewModel.kt
@@ -73,6 +73,12 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
         }
     }
 
+    override fun onCleared() {
+        terminalSocket?.close(1000, "viewmodel cleared")
+        terminalSocket = null
+        super.onCleared()
+    }
+
     fun refresh(initial: Boolean = false) {
         if (refreshJob?.isActive == true) {
             return
@@ -232,7 +238,7 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
                 onComplete(Result.failure(IllegalStateException("Sign in to attach")))
                 return@launch
             }
-            val path = "/client/sessions/${session.id}/attach-ticket"
+            val path = sessionRepository.mobileAttachTicketPath(serverUrl, session.id)
             _uiState.value = _uiState.value.copy(
                 terminal = TerminalUiState(
                     sessionId = session.id,

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchViewModel.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchViewModel.kt
@@ -242,7 +242,11 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
             }
             val attachToken = UUID.randomUUID().toString()
             terminalAttachToken = attachToken
-            val path = sessionRepository.mobileAttachTicketPath(serverUrl, session.id)
+            val path = sessionRepository.mobileAttachTicketPath(
+                baseUrl = serverUrl,
+                sessionId = session.id,
+                advertisedEndpoint = session.mobileTerminal?.ticketEndpoint,
+            )
             _uiState.value = _uiState.value.copy(
                 terminal = TerminalUiState(
                     sessionId = session.id,

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchViewModel.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchViewModel.kt
@@ -8,6 +8,11 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import org.json.JSONObject
+import java.util.UUID
 import li.rajeshgo.sm.data.model.ClientBootstrapResponse
 import li.rajeshgo.sm.data.model.ClientSession
 import li.rajeshgo.sm.data.model.SessionDetail
@@ -16,6 +21,16 @@ import li.rajeshgo.sm.data.repository.SessionManagerBackendUnavailableException
 import li.rajeshgo.sm.data.repository.SessionManagerRepository
 import li.rajeshgo.sm.data.repository.SessionManagerTransientException
 import li.rajeshgo.sm.data.repository.SettingsRepository
+import li.rajeshgo.sm.data.security.DeviceKeyManager
+
+data class TerminalUiState(
+    val sessionId: String,
+    val title: String,
+    val status: String = "connecting",
+    val output: String = "",
+    val inputDraft: String = "",
+    val error: String? = null,
+)
 
 data class WatchUiState(
     val serverUrl: String = "",
@@ -28,6 +43,7 @@ data class WatchUiState(
     val refreshing: Boolean = false,
     val requestingStatus: Boolean = false,
     val ensuringMaintainer: Boolean = false,
+    val terminal: TerminalUiState? = null,
     val lastSync: String? = null,
     val error: String? = null,
 )
@@ -35,7 +51,9 @@ data class WatchUiState(
 class WatchViewModel(application: Application) : AndroidViewModel(application) {
     private val settingsRepository = SettingsRepository(application)
     private val sessionRepository = SessionManagerRepository()
+    private val deviceKeyManager = DeviceKeyManager()
     private var refreshJob: Job? = null
+    private var terminalSocket: WebSocket? = null
 
     private val _uiState = MutableStateFlow(WatchUiState())
     val uiState: StateFlow<WatchUiState> = _uiState
@@ -203,6 +221,157 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
             }
             onComplete(result)
         }
+    }
+
+    fun openMobileTerminal(session: ClientSession, onComplete: (Result<String>) -> Unit) {
+        viewModelScope.launch {
+            val serverUrl = settingsRepository.serverUrl.first()
+            val accessToken = settingsRepository.accessToken.first()
+            val actorEmail = settingsRepository.userEmail.first()
+            if (serverUrl.isBlank() || accessToken.isBlank() || actorEmail.isBlank()) {
+                onComplete(Result.failure(IllegalStateException("Sign in to attach")))
+                return@launch
+            }
+            val path = "/client/sessions/${session.id}/attach-ticket"
+            _uiState.value = _uiState.value.copy(
+                terminal = TerminalUiState(
+                    sessionId = session.id,
+                    title = sessionDisplayName(session),
+                    status = "requesting ticket",
+                )
+            )
+            val proof = runCatching {
+                deviceKeyManager.signTicketRequest(
+                    method = "POST",
+                    path = path,
+                    sessionId = session.id,
+                    actorEmail = actorEmail,
+                )
+            }.getOrElse { error ->
+                _uiState.value = _uiState.value.copy(terminal = null)
+                onComplete(Result.failure(error))
+                return@launch
+            }
+            val ticketResult = sessionRepository.createMobileAttachTicket(serverUrl, accessToken, session.id, proof)
+            ticketResult.onFailure { error ->
+                _uiState.value = _uiState.value.copy(
+                    terminal = _uiState.value.terminal?.copy(status = "failed", error = error.message)
+                )
+                onComplete(Result.failure(error))
+                return@launch
+            }
+            val ticket = ticketResult.getOrThrow()
+            val wsNonce = UUID.randomUUID().toString()
+            val wsSignature = runCatching {
+                deviceKeyManager.signWebSocketAuth(
+                    ticketId = ticket.ticketId,
+                    sessionId = session.id,
+                    actorEmail = actorEmail,
+                    deviceKeyId = ticket.deviceKeyId,
+                    nonce = wsNonce,
+                )
+            }.getOrElse { error ->
+                _uiState.value = _uiState.value.copy(
+                    terminal = _uiState.value.terminal?.copy(status = "failed", error = error.message)
+                )
+                onComplete(Result.failure(error))
+                return@launch
+            }
+            terminalSocket?.close(1000, "new attach")
+            terminalSocket = sessionRepository.openMobileTerminalSocket(ticket, object : WebSocketListener() {
+                override fun onOpen(webSocket: WebSocket, response: Response) {
+                    val frame = JSONObject()
+                        .put("type", "auth")
+                        .put("ticket_id", ticket.ticketId)
+                        .put("ticket_secret", ticket.ticketSecret)
+                        .put("device_key_id", ticket.deviceKeyId)
+                        .put("nonce", wsNonce)
+                        .put("signature", wsSignature)
+                    webSocket.send(frame.toString())
+                    viewModelScope.launch {
+                        _uiState.value = _uiState.value.copy(
+                            terminal = _uiState.value.terminal?.copy(status = "authenticating", error = null)
+                        )
+                    }
+                }
+
+                override fun onMessage(webSocket: WebSocket, text: String) {
+                    val payload = runCatching { JSONObject(text) }.getOrNull() ?: return
+                    viewModelScope.launch {
+                        val current = _uiState.value.terminal ?: return@launch
+                        when (payload.optString("type")) {
+                            "output" -> _uiState.value = _uiState.value.copy(
+                                terminal = current.copy(
+                                    status = "attached",
+                                    output = if (payload.optString("mode") == "snapshot") {
+                                        payload.optString("data")
+                                    } else {
+                                        current.output + payload.optString("data")
+                                    },
+                                    error = null,
+                                )
+                            )
+                            "status" -> _uiState.value = _uiState.value.copy(
+                                terminal = current.copy(status = payload.optString("state", current.status))
+                            )
+                            "error" -> _uiState.value = _uiState.value.copy(
+                                terminal = current.copy(error = payload.optString("message", "Terminal error"))
+                            )
+                            "exit" -> _uiState.value = _uiState.value.copy(
+                                terminal = current.copy(status = "detached")
+                            )
+                        }
+                    }
+                }
+
+                override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+                    viewModelScope.launch {
+                        _uiState.value = _uiState.value.copy(
+                            terminal = _uiState.value.terminal?.copy(status = "failed", error = t.message ?: "Terminal socket failed")
+                        )
+                    }
+                }
+
+                override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+                    viewModelScope.launch {
+                        _uiState.value = _uiState.value.copy(
+                            terminal = _uiState.value.terminal?.copy(status = "detached")
+                        )
+                    }
+                }
+            })
+            onComplete(Result.success("Opening terminal for ${sessionDisplayName(session)}"))
+        }
+    }
+
+    fun updateTerminalInput(value: String) {
+        _uiState.value = _uiState.value.copy(
+            terminal = _uiState.value.terminal?.copy(inputDraft = value)
+        )
+    }
+
+    fun sendTerminalInput(sendEnter: Boolean = false) {
+        val terminal = _uiState.value.terminal ?: return
+        val text = terminal.inputDraft
+        if (text.isNotEmpty()) {
+            terminalSocket?.send(JSONObject().put("type", "input").put("data", text).toString())
+        }
+        if (sendEnter) {
+            terminalSocket?.send(JSONObject().put("type", "key").put("key", "enter").toString())
+        }
+        _uiState.value = _uiState.value.copy(terminal = terminal.copy(inputDraft = ""))
+    }
+
+    fun sendTerminalKey(key: String) {
+        terminalSocket?.send(JSONObject().put("type", "key").put("key", key).toString())
+    }
+
+    fun detachTerminal() {
+        terminalSocket?.send(JSONObject().put("type", "detach").toString())
+        terminalSocket?.close(1000, "detach")
+        terminalSocket = null
+        _uiState.value = _uiState.value.copy(terminal = null)
+        refresh()
     }
 
     fun requestStatus(onComplete: (Result<String>) -> Unit) {

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchViewModel.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchViewModel.kt
@@ -54,6 +54,7 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
     private val deviceKeyManager = DeviceKeyManager()
     private var refreshJob: Job? = null
     private var terminalSocket: WebSocket? = null
+    private var terminalAttachToken: String? = null
 
     private val _uiState = MutableStateFlow(WatchUiState())
     val uiState: StateFlow<WatchUiState> = _uiState
@@ -74,6 +75,7 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     override fun onCleared() {
+        terminalAttachToken = null
         terminalSocket?.close(1000, "viewmodel cleared")
         terminalSocket = null
         super.onCleared()
@@ -238,6 +240,8 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
                 onComplete(Result.failure(IllegalStateException("Sign in to attach")))
                 return@launch
             }
+            val attachToken = UUID.randomUUID().toString()
+            terminalAttachToken = attachToken
             val path = sessionRepository.mobileAttachTicketPath(serverUrl, session.id)
             _uiState.value = _uiState.value.copy(
                 terminal = TerminalUiState(
@@ -254,15 +258,13 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
                     actorEmail = actorEmail,
                 )
             }.getOrElse { error ->
-                _uiState.value = _uiState.value.copy(terminal = null)
+                clearTerminalIfCurrent(attachToken)
                 onComplete(Result.failure(error))
                 return@launch
             }
             val ticketResult = sessionRepository.createMobileAttachTicket(serverUrl, accessToken, session.id, proof)
             ticketResult.onFailure { error ->
-                _uiState.value = _uiState.value.copy(
-                    terminal = _uiState.value.terminal?.copy(status = "failed", error = error.message)
-                )
+                updateTerminalIfCurrent(attachToken) { it.copy(status = "failed", error = error.message) }
                 onComplete(Result.failure(error))
                 return@launch
             }
@@ -277,9 +279,7 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
                     nonce = wsNonce,
                 )
             }.getOrElse { error ->
-                _uiState.value = _uiState.value.copy(
-                    terminal = _uiState.value.terminal?.copy(status = "failed", error = error.message)
-                )
+                updateTerminalIfCurrent(attachToken) { it.copy(status = "failed", error = error.message) }
                 onComplete(Result.failure(error))
                 return@launch
             }
@@ -295,19 +295,16 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
                         .put("signature", wsSignature)
                     webSocket.send(frame.toString())
                     viewModelScope.launch {
-                        _uiState.value = _uiState.value.copy(
-                            terminal = _uiState.value.terminal?.copy(status = "authenticating", error = null)
-                        )
+                        updateTerminalIfCurrent(attachToken) { it.copy(status = "authenticating", error = null) }
                     }
                 }
 
                 override fun onMessage(webSocket: WebSocket, text: String) {
                     val payload = runCatching { JSONObject(text) }.getOrNull() ?: return
                     viewModelScope.launch {
-                        val current = _uiState.value.terminal ?: return@launch
                         when (payload.optString("type")) {
-                            "output" -> _uiState.value = _uiState.value.copy(
-                                terminal = current.copy(
+                            "output" -> updateTerminalIfCurrent(attachToken) { current ->
+                                current.copy(
                                     status = "attached",
                                     output = if (payload.optString("mode") == "snapshot") {
                                         payload.optString("data")
@@ -316,33 +313,29 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
                                     },
                                     error = null,
                                 )
-                            )
-                            "status" -> _uiState.value = _uiState.value.copy(
-                                terminal = current.copy(status = payload.optString("state", current.status))
-                            )
-                            "error" -> _uiState.value = _uiState.value.copy(
-                                terminal = current.copy(error = payload.optString("message", "Terminal error"))
-                            )
-                            "exit" -> _uiState.value = _uiState.value.copy(
-                                terminal = current.copy(status = "detached")
-                            )
+                            }
+                            "status" -> updateTerminalIfCurrent(attachToken) {
+                                it.copy(status = payload.optString("state", it.status))
+                            }
+                            "error" -> updateTerminalIfCurrent(attachToken) {
+                                it.copy(error = payload.optString("message", "Terminal error"))
+                            }
+                            "exit" -> updateTerminalIfCurrent(attachToken) { it.copy(status = "detached") }
                         }
                     }
                 }
 
                 override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
                     viewModelScope.launch {
-                        _uiState.value = _uiState.value.copy(
-                            terminal = _uiState.value.terminal?.copy(status = "failed", error = t.message ?: "Terminal socket failed")
-                        )
+                        updateTerminalIfCurrent(attachToken) {
+                            it.copy(status = "failed", error = t.message ?: "Terminal socket failed")
+                        }
                     }
                 }
 
                 override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
                     viewModelScope.launch {
-                        _uiState.value = _uiState.value.copy(
-                            terminal = _uiState.value.terminal?.copy(status = "detached")
-                        )
+                        updateTerminalIfCurrent(attachToken) { it.copy(status = "detached") }
                     }
                 }
             })
@@ -373,11 +366,31 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun detachTerminal() {
+        terminalAttachToken = null
         terminalSocket?.send(JSONObject().put("type", "detach").toString())
         terminalSocket?.close(1000, "detach")
         terminalSocket = null
         _uiState.value = _uiState.value.copy(terminal = null)
         refresh()
+    }
+
+    private fun updateTerminalIfCurrent(
+        attachToken: String,
+        transform: (TerminalUiState) -> TerminalUiState,
+    ) {
+        if (terminalAttachToken != attachToken) {
+            return
+        }
+        val current = _uiState.value.terminal ?: return
+        _uiState.value = _uiState.value.copy(terminal = transform(current))
+    }
+
+    private fun clearTerminalIfCurrent(attachToken: String) {
+        if (terminalAttachToken != attachToken) {
+            return
+        }
+        terminalAttachToken = null
+        _uiState.value = _uiState.value.copy(terminal = null)
     }
 
     fun requestStatus(onComplete: (Result<String>) -> Unit) {

--- a/android-app/app/src/test/java/li/rajeshgo/sm/data/repository/SessionManagerRepositoryTest.kt
+++ b/android-app/app/src/test/java/li/rajeshgo/sm/data/repository/SessionManagerRepositoryTest.kt
@@ -1,0 +1,26 @@
+package li.rajeshgo.sm.data.repository
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SessionManagerRepositoryTest {
+    @Test
+    fun mobileAttachTicketPathIncludesBaseUrlPathPrefix() {
+        val repository = SessionManagerRepository()
+
+        assertEquals(
+            "/sm/client/sessions/abc123/attach-ticket",
+            repository.mobileAttachTicketPath("https://example.com/sm/", "abc123"),
+        )
+    }
+
+    @Test
+    fun mobileAttachTicketPathUsesRootWhenBaseUrlHasNoPrefix() {
+        val repository = SessionManagerRepository()
+
+        assertEquals(
+            "/client/sessions/abc123/attach-ticket",
+            repository.mobileAttachTicketPath("https://example.com", "abc123"),
+        )
+    }
+}

--- a/android-app/app/src/test/java/li/rajeshgo/sm/data/repository/SessionManagerRepositoryTest.kt
+++ b/android-app/app/src/test/java/li/rajeshgo/sm/data/repository/SessionManagerRepositoryTest.kt
@@ -23,4 +23,32 @@ class SessionManagerRepositoryTest {
             repository.mobileAttachTicketPath("https://example.com", "abc123"),
         )
     }
+
+    @Test
+    fun mobileAttachTicketPathPrefersAdvertisedTicketEndpoint() {
+        val repository = SessionManagerRepository()
+
+        assertEquals(
+            "/proxy/client/sessions/abc123/attach-ticket",
+            repository.mobileAttachTicketPath(
+                "https://example.com/sm/",
+                "abc123",
+                "/proxy/client/sessions/abc123/attach-ticket",
+            ),
+        )
+    }
+
+    @Test
+    fun mobileAttachTicketPathExtractsPathFromAbsoluteAdvertisedTicketEndpoint() {
+        val repository = SessionManagerRepository()
+
+        assertEquals(
+            "/proxy/client/sessions/abc123/attach-ticket",
+            repository.mobileAttachTicketPath(
+                "https://example.com/sm/",
+                "abc123",
+                "https://api.example.com/proxy/client/sessions/abc123/attach-ticket",
+            ),
+        )
+    }
 }

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -171,6 +171,8 @@ mobile_terminal:
     you:
       email: "you@example.com"
       interactive_shell_access: true
+      # Required for the global emergency disable endpoint.
+      mobile_terminal_owner: true
       registered_device_keys:
         - id: "replace-with-app-device-key-id"
           label: "Your Android device"

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -162,6 +162,31 @@ external_access:
   ssh_username: "your-ssh-user"
   ssh_proxy_command: "cloudflared access ssh --hostname %h"
 
+# Optional Android in-app HTTPS terminal attach. Disabled by default because it
+# exposes an interactive shell path; enable only for explicitly registered users
+# and app-generated device public keys.
+mobile_terminal:
+  enabled: false
+  allowed_users:
+    you:
+      email: "you@example.com"
+      interactive_shell_access: true
+      registered_device_keys:
+        - id: "replace-with-app-device-key-id"
+          label: "Your Android device"
+          public_key: |
+            -----BEGIN PUBLIC KEY-----
+            REPLACE_WITH_APP_SETTINGS_PUBLIC_KEY
+            -----END PUBLIC KEY-----
+          enabled: true
+  ticket_ttl_seconds: 30
+  auth_frame_timeout_seconds: 3
+  max_attach_seconds: 3600
+  max_concurrent_attaches_per_user: 1
+  max_concurrent_attaches_per_session: 1
+  max_concurrent_attaches_global: 4
+  require_tls: true
+
 auth:
   google:
     enabled: false

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -157,6 +157,7 @@ services:
 # Real secrets should stay in a gitignored local env file; these are placeholders.
 external_access:
   public_http_host: "sm.example.com"
+  public_http_path_prefix: ""
   public_ssh_host: "ssh.sm.example.com"
   http_origin_url: "http://127.0.0.1:8420"
   ssh_username: "your-ssh-user"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "PyYAML>=6.0",
     "pydantic>=2.0.0",
     "google-auth>=2.39.0",
+    "cryptography>=42.0.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ aiofiles>=23.0
 PyYAML>=6.0
 pydantic>=2.0.0
 google-auth>=2.39.0
+cryptography>=42.0.0
 pytest>=7.0
 pytest-asyncio>=0.21
 pytest-cov>=4.0

--- a/src/server.py
+++ b/src/server.py
@@ -15,15 +15,19 @@ import base64
 import hashlib
 import hmac
 import re
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional, Dict, Any, Literal
 from urllib.parse import urlencode, urlparse
 
 import httpx
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec, ed25519, padding, rsa
 from google.auth.transport.requests import Request as GoogleAuthRequest
 from google.oauth2 import id_token as google_id_token
-from fastapi import FastAPI, HTTPException, Body, Request, Query, Response
+from fastapi import FastAPI, HTTPException, Body, Request, Query, Response, WebSocket, WebSocketDisconnect
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
@@ -71,6 +75,9 @@ BUG_REPORT_MAX_TEXT_CHARS = 4000
 BUG_REPORT_MAX_CLIENT_STATE_CHARS = 100_000
 BUG_REPORT_MAX_SERVER_STATE_CHARS = 200_000
 DISPLAY_IDENTITY_SYNC_TIMEOUT_SECONDS = 1.0
+MOBILE_TERMINAL_INPUT_MAX_CHARS = 8192
+MOBILE_TERMINAL_TMUX_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_.:@-]+$")
+MOBILE_TERMINAL_SOCKET_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+$")
 DEFAULT_APP_ARTIFACTS_ROOT = Path(__file__).resolve().parents[1] / "data" / "apps"
 DEFAULT_BUG_REPORTS_DB = Path(__file__).resolve().parents[1] / "data" / "bug_reports.db"
 DEFAULT_EMAIL_INBOUND_WEBHOOK_PATH = "/api/email-inbound"
@@ -574,6 +581,37 @@ class DeviceGoogleAuthResponse(BaseModel):
     expires_at: str
     email: str
     name: Optional[str] = None
+
+
+class MobileAttachTicketResponse(BaseModel):
+    """Short-lived, single-use mobile terminal attach ticket."""
+    ticket_id: str
+    ticket_secret: str
+    device_key_id: str
+    ws_url: str
+    expires_at: str
+
+
+class MobileTerminalDisableResponse(BaseModel):
+    """Response for emergency mobile terminal disable controls."""
+    ok: bool = True
+    disabled: bool
+
+
+@dataclass
+class MobileTerminalTicket:
+    ticket_id: str
+    secret_hash: str
+    user_id: str
+    actor_email: str
+    session_id: str
+    provider: str
+    tmux_session: str
+    tmux_socket_name: Optional[str]
+    device_key_id: str
+    created_at: float
+    expires_at: float
+    consumed_at: Optional[float] = None
 
 
 class AppArtifactMetadataResponse(BaseModel):
@@ -1283,6 +1321,12 @@ def create_app(
         setattr(notifier, "session_manager", session_manager)
 
     attach_infra_cache = {"expires_at": 0.0, "issue": None}
+    app.state.mobile_terminal_tickets: dict[str, MobileTerminalTicket] = {}
+    app.state.mobile_terminal_active_attaches: dict[str, dict[str, Any]] = {}
+    app.state.mobile_terminal_lock = asyncio.Lock()
+    app.state.mobile_terminal_secret = secrets.token_bytes(32)
+    app.state.mobile_terminal_runtime_disabled = False
+    app.state.mobile_terminal_revoked_keys: set[tuple[str, str]] = set()
 
     # Wire _app back-reference so _execute_handoff can clear server-side caches (#196)
     if session_manager:
@@ -2025,6 +2069,255 @@ def create_app(
     def _external_access_config() -> dict:
         return (app.state.config or {}).get("external_access") or {}
 
+    def _mobile_terminal_config() -> dict[str, Any]:
+        raw = (app.state.config or {}).get("mobile_terminal") or {}
+        return raw if isinstance(raw, dict) else {}
+
+    def _mobile_terminal_enabled() -> bool:
+        return bool(_mobile_terminal_config().get("enabled")) and not bool(
+            getattr(app.state, "mobile_terminal_runtime_disabled", False)
+        )
+
+    def _mobile_terminal_int(name: str, default: int, minimum: int = 1, maximum: Optional[int] = None) -> int:
+        try:
+            value = int(_mobile_terminal_config().get(name, default))
+        except (TypeError, ValueError):
+            value = default
+        value = max(minimum, value)
+        if maximum is not None:
+            value = min(maximum, value)
+        return value
+
+    def _mobile_terminal_public_http_host() -> Optional[str]:
+        external_access = _external_access_config()
+        host = str(external_access.get("public_http_host") or "").strip()
+        if not host:
+            host = str(_google_auth_config(app.state.config).get("public_host") or "").strip()
+        return host or None
+
+    def _mobile_terminal_ws_url() -> Optional[str]:
+        config_block = _mobile_terminal_config()
+        configured = str(config_block.get("ws_url") or "").strip()
+        if configured:
+            return configured
+        host = _mobile_terminal_public_http_host()
+        if not host:
+            return None
+        scheme = "wss"
+        if host.startswith("localhost") or host.startswith("127.0.0.1") or host.startswith("testserver"):
+            scheme = "ws"
+        return f"{scheme}://{host}/client/terminal"
+
+    def _mobile_terminal_visible_user(actor_email: str) -> Optional[tuple[str, dict[str, Any]]]:
+        allowed_users = _mobile_terminal_config().get("allowed_users") or {}
+        if not isinstance(allowed_users, dict):
+            return None
+        normalized_email = str(actor_email or "").strip().lower()
+        email_local = normalized_email.split("@", 1)[0]
+        for user_id, raw_user_config in allowed_users.items():
+            user_config = raw_user_config if isinstance(raw_user_config, dict) else {}
+            candidates = {
+                str(user_id or "").strip().lower(),
+                str(user_config.get("email") or "").strip().lower(),
+            }
+            aliases = user_config.get("aliases") or []
+            if isinstance(aliases, list):
+                candidates.update(str(alias or "").strip().lower() for alias in aliases)
+            candidates.discard("")
+            if normalized_email in candidates or email_local in candidates:
+                return str(user_id), user_config
+        return None
+
+    def _mobile_terminal_device_config(
+        user_id: str,
+        user_config: dict[str, Any],
+        device_key_id: str,
+    ) -> Optional[dict[str, Any]]:
+        if (user_id, device_key_id) in getattr(app.state, "mobile_terminal_revoked_keys", set()):
+            return None
+        keys = user_config.get("registered_device_keys") or []
+        if not isinstance(keys, list):
+            return None
+        for raw_key in keys:
+            if not isinstance(raw_key, dict):
+                continue
+            if str(raw_key.get("id") or "").strip() != device_key_id:
+                continue
+            if raw_key.get("enabled", True) is False:
+                return None
+            public_key = str(raw_key.get("public_key") or "").strip()
+            if not public_key:
+                return None
+            return raw_key
+        return None
+
+    def _mobile_terminal_signature_bytes(value: str) -> bytes:
+        text = str(value or "").strip()
+        if not text:
+            raise HTTPException(status_code=401, detail="Missing device signature")
+        try:
+            return base64.b64decode(text, validate=True)
+        except Exception:
+            try:
+                return _urlsafe_b64decode(text)
+            except Exception as exc:
+                raise HTTPException(status_code=401, detail="Invalid device signature encoding") from exc
+
+    def _load_mobile_terminal_public_key(public_key_text: str):
+        encoded = public_key_text.strip().encode("utf-8")
+        if public_key_text.strip().startswith("ssh-"):
+            return serialization.load_ssh_public_key(encoded)
+        return serialization.load_pem_public_key(encoded)
+
+    def _verify_mobile_terminal_signature(
+        *,
+        public_key_text: str,
+        signature_text: str,
+        message: str,
+    ) -> None:
+        try:
+            public_key = _load_mobile_terminal_public_key(public_key_text)
+            signature = _mobile_terminal_signature_bytes(signature_text)
+            payload = message.encode("utf-8")
+            if isinstance(public_key, ed25519.Ed25519PublicKey):
+                public_key.verify(signature, payload)
+                return
+            if isinstance(public_key, ec.EllipticCurvePublicKey):
+                public_key.verify(signature, payload, ec.ECDSA(hashes.SHA256()))
+                return
+            if isinstance(public_key, rsa.RSAPublicKey):
+                public_key.verify(signature, payload, padding.PKCS1v15(), hashes.SHA256())
+                return
+        except InvalidSignature as exc:
+            raise HTTPException(status_code=401, detail="Invalid device signature") from exc
+        except HTTPException:
+            raise
+        except Exception as exc:
+            raise HTTPException(status_code=401, detail="Invalid device public key") from exc
+        raise HTTPException(status_code=401, detail="Unsupported device public key type")
+
+    def _mobile_terminal_ticket_message(
+        *,
+        method: str,
+        path: str,
+        session_id: str,
+        actor_email: str,
+        device_key_id: str,
+        timestamp: str,
+        nonce: str,
+    ) -> str:
+        return "\n".join(
+            [
+                "SM-MOBILE-TERMINAL-TICKET-V1",
+                method.upper(),
+                path,
+                session_id,
+                actor_email.lower(),
+                device_key_id,
+                timestamp,
+                nonce,
+            ]
+        )
+
+    def _mobile_terminal_ws_message(
+        *,
+        ticket_id: str,
+        session_id: str,
+        actor_email: str,
+        device_key_id: str,
+        nonce: str,
+    ) -> str:
+        return "\n".join(
+            [
+                "SM-MOBILE-TERMINAL-WS-V1",
+                ticket_id,
+                session_id,
+                actor_email.lower(),
+                device_key_id,
+                nonce,
+            ]
+        )
+
+    def _validate_mobile_terminal_timestamp(timestamp_text: str) -> None:
+        try:
+            timestamp = float(timestamp_text)
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(status_code=401, detail="Invalid device timestamp") from exc
+        max_skew = _mobile_terminal_int("device_signature_max_skew_seconds", 60, minimum=5, maximum=600)
+        if abs(time.time() - timestamp) > max_skew:
+            raise HTTPException(status_code=401, detail="Expired device signature")
+
+    def _hash_mobile_terminal_ticket_secret(secret: str) -> str:
+        return hmac.new(
+            app.state.mobile_terminal_secret,
+            secret.encode("utf-8"),
+            hashlib.sha256,
+        ).hexdigest()
+
+    def _audit_mobile_terminal(event: str, **fields: Any) -> None:
+        safe_fields = {key: value for key, value in fields.items() if value is not None}
+        logger.info("mobile_terminal.%s %s", event, json.dumps(safe_fields, sort_keys=True, default=str))
+
+    def _mobile_terminal_cleanup_expired_tickets(now: Optional[float] = None) -> None:
+        current = now or time.time()
+        tickets = getattr(app.state, "mobile_terminal_tickets", {})
+        for ticket_id, ticket in list(tickets.items()):
+            if ticket.expires_at <= current or ticket.consumed_at is not None:
+                tickets.pop(ticket_id, None)
+
+    def _validate_mobile_terminal_tmux_target(tmux_session: str, tmux_socket_name: Optional[str]) -> None:
+        if not tmux_session or not MOBILE_TERMINAL_TMUX_NAME_PATTERN.fullmatch(tmux_session):
+            raise HTTPException(status_code=403, detail="Unsafe tmux session target")
+        if tmux_socket_name and not MOBILE_TERMINAL_SOCKET_NAME_PATTERN.fullmatch(tmux_socket_name):
+            raise HTTPException(status_code=403, detail="Unsafe tmux socket target")
+
+    def _mobile_terminal_metadata(session: Session, descriptor: Optional[dict[str, Any]]) -> dict[str, Any]:
+        if not _mobile_terminal_enabled():
+            return {
+                "supported": False,
+                "transport": "sm-https-tmux",
+                "reason": "mobile terminal attach is disabled",
+            }
+        ws_url = _mobile_terminal_ws_url()
+        if not ws_url:
+            return {
+                "supported": False,
+                "transport": "sm-https-tmux",
+                "reason": "mobile terminal public HTTPS host is not configured",
+            }
+        if not descriptor:
+            return {
+                "supported": False,
+                "transport": "sm-https-tmux",
+                "reason": "attach descriptor unavailable",
+            }
+        if not descriptor.get("attach_supported", True):
+            return {
+                "supported": False,
+                "transport": "sm-https-tmux",
+                "reason": descriptor.get("message") or "attach not supported",
+            }
+        tmux_session = str(descriptor.get("tmux_session") or getattr(session, "tmux_session", "") or "").strip()
+        tmux_socket_name = str(descriptor.get("tmux_socket_name") or "").strip() or None
+        try:
+            _validate_mobile_terminal_tmux_target(tmux_session, tmux_socket_name)
+        except HTTPException as exc:
+            return {
+                "supported": False,
+                "transport": "sm-https-tmux",
+                "reason": str(exc.detail),
+            }
+        return {
+            "supported": True,
+            "transport": "sm-https-tmux",
+            "ticket_endpoint": f"/client/sessions/{session.id}/attach-ticket",
+            "ws_url": ws_url,
+            "tmux_session": tmux_session,
+            "tmux_socket_name": tmux_socket_name,
+            "runtime_mode": descriptor.get("runtime_mode"),
+            "requires_device_key": True,
+        }
+
     def _app_artifacts_root() -> Path:
         configured = ((app.state.config or {}).get("paths") or {}).get("app_artifacts_dir")
         if configured:
@@ -2117,6 +2410,10 @@ def create_app(
         ssh_username = str(external_access.get("ssh_username") or "").strip()
         google_server_client_id = str(google_auth.get("client_id") or "").strip()
         termux_supported = bool(public_ssh_host and ssh_username and not _termux_attach_infra_issue())
+        mobile_terminal_supported = bool(_mobile_terminal_enabled() and _mobile_terminal_ws_url())
+        preferred_action = "mobile_terminal" if mobile_terminal_supported else (
+            "termux_attach" if termux_supported else "details"
+        )
         return _response_dict(
             ClientBootstrapResponse(
                 auth={
@@ -2133,9 +2430,11 @@ def create_app(
                     "public_ssh_host": public_ssh_host or None,
                     "ssh_username": ssh_username or None,
                     "termux_attach_supported": termux_supported,
+                    "mobile_terminal_supported": mobile_terminal_supported,
+                    "mobile_terminal_ws_url": _mobile_terminal_ws_url() if mobile_terminal_supported else None,
                 },
                 session_open_defaults={
-                    "preferred_action": "termux_attach" if termux_supported else "details",
+                    "preferred_action": preferred_action,
                     "termux_package": "com.termux",
                 },
             )
@@ -2477,7 +2776,16 @@ def create_app(
             metadata["tmux_socket_name"] = tmux_socket_name
         return metadata
 
-    def _mobile_primary_action(termux_attach: dict[str, Any], descriptor: Optional[dict[str, Any]]) -> dict[str, Any]:
+    def _mobile_primary_action(
+        mobile_terminal: dict[str, Any],
+        termux_attach: dict[str, Any],
+        descriptor: Optional[dict[str, Any]],
+    ) -> dict[str, Any]:
+        if mobile_terminal.get("supported"):
+            return {
+                "type": "mobile_terminal",
+                "label": "Attach",
+            }
         if termux_attach.get("supported"):
             return {
                 "type": "termux_attach",
@@ -2504,9 +2812,11 @@ def create_app(
         )
         descriptor = _attach_descriptor(session)
         termux_attach = _termux_attach_metadata(session, descriptor)
+        mobile_terminal = _mobile_terminal_metadata(session, descriptor)
         base["attach_descriptor"] = descriptor
         base["termux_attach"] = termux_attach
-        base["primary_action"] = _mobile_primary_action(termux_attach, descriptor)
+        base["mobile_terminal"] = mobile_terminal
+        base["primary_action"] = _mobile_primary_action(mobile_terminal, termux_attach, descriptor)
         return base
 
     async def _sync_session_display_identity(
@@ -3843,6 +4153,445 @@ def create_app(
             bug_id=created["id"],
             maintainer_notified=maintainer_notified,
         )
+
+    def _mobile_terminal_authorize_ticket_request(
+        request: Request,
+        session: Session,
+        descriptor: Optional[dict[str, Any]],
+        actor_email: str,
+    ) -> tuple[str, dict[str, Any], dict[str, Any]]:
+        if not _mobile_terminal_enabled():
+            _audit_mobile_terminal("ticket_denied", user_id=actor_email, session_id=session.id, reason="disabled")
+            raise HTTPException(status_code=403, detail="Mobile terminal attach is disabled")
+        if session.status == SessionStatus.STOPPED:
+            _audit_mobile_terminal("ticket_denied", user_id=actor_email, session_id=session.id, reason="session_stopped")
+            raise HTTPException(status_code=409, detail="Session is not running")
+        metadata = _mobile_terminal_metadata(session, descriptor)
+        if not metadata.get("supported"):
+            _audit_mobile_terminal(
+                "ticket_denied",
+                user_id=actor_email,
+                session_id=session.id,
+                reason=metadata.get("reason") or "not_supported",
+            )
+            raise HTTPException(status_code=403, detail=metadata.get("reason") or "Attach not supported")
+        user_match = _mobile_terminal_visible_user(actor_email)
+        if user_match is None:
+            _audit_mobile_terminal("ticket_denied", user_id=actor_email, session_id=session.id, reason="user_not_allowed")
+            raise HTTPException(status_code=403, detail="User is not allowed to attach")
+        user_id, user_config = user_match
+        if user_config.get("interactive_shell_access") is not True:
+            _audit_mobile_terminal("ticket_denied", user_id=user_id, session_id=session.id, reason="shell_access_disabled")
+            raise HTTPException(status_code=403, detail="Interactive shell access is not enabled for this user")
+
+        device_key_id = str(request.headers.get("x-sm-device-key-id") or "").strip()
+        timestamp = str(request.headers.get("x-sm-device-timestamp") or "").strip()
+        nonce = str(request.headers.get("x-sm-device-nonce") or "").strip()
+        signature = str(request.headers.get("x-sm-device-signature") or "").strip()
+        if not device_key_id or not timestamp or not nonce or not signature:
+            raise HTTPException(status_code=401, detail="Device key proof is required")
+        _validate_mobile_terminal_timestamp(timestamp)
+        device_config = _mobile_terminal_device_config(user_id, user_config, device_key_id)
+        if device_config is None:
+            _audit_mobile_terminal(
+                "ticket_denied",
+                user_id=user_id,
+                session_id=session.id,
+                device_key_id=device_key_id,
+                reason="device_not_allowed",
+            )
+            raise HTTPException(status_code=401, detail="Device key is not registered")
+        message = _mobile_terminal_ticket_message(
+            method=request.method,
+            path=request.url.path,
+            session_id=session.id,
+            actor_email=actor_email,
+            device_key_id=device_key_id,
+            timestamp=timestamp,
+            nonce=nonce,
+        )
+        _verify_mobile_terminal_signature(
+            public_key_text=str(device_config.get("public_key") or ""),
+            signature_text=signature,
+            message=message,
+        )
+        return user_id, user_config, device_config
+
+    @app.post("/client/sessions/{session_id}/attach-ticket", response_model=MobileAttachTicketResponse)
+    async def create_mobile_attach_ticket(session_id: str, request: Request):
+        """Mint a short-lived, single-use mobile terminal attach ticket."""
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
+        actor_email = _request_actor_email(request)
+        if actor_email is None:
+            raise HTTPException(status_code=401, detail="Authentication required")
+        session = _resolve_session_or_registry_role(session_id)
+        if not session:
+            raise HTTPException(status_code=404, detail="Session not found")
+        descriptor = _attach_descriptor(session)
+        user_id, _user_config, device_config = _mobile_terminal_authorize_ticket_request(
+            request,
+            session,
+            descriptor,
+            actor_email,
+        )
+        metadata = _mobile_terminal_metadata(session, descriptor)
+        tmux_session = str(metadata.get("tmux_session") or "").strip()
+        tmux_socket_name = str(metadata.get("tmux_socket_name") or "").strip() or None
+        _validate_mobile_terminal_tmux_target(tmux_session, tmux_socket_name)
+
+        now = time.time()
+        ttl_seconds = _mobile_terminal_int("ticket_ttl_seconds", 30, minimum=5, maximum=300)
+        async with app.state.mobile_terminal_lock:
+            _mobile_terminal_cleanup_expired_tickets(now)
+            active = list(app.state.mobile_terminal_active_attaches.values())
+            max_global = _mobile_terminal_int("max_concurrent_attaches_global", 4, minimum=1, maximum=64)
+            max_user = _mobile_terminal_int("max_concurrent_attaches_per_user", 1, minimum=1, maximum=16)
+            max_session = _mobile_terminal_int("max_concurrent_attaches_per_session", 1, minimum=1, maximum=16)
+            if len(active) >= max_global:
+                raise HTTPException(status_code=429, detail="Too many active mobile attaches")
+            if sum(1 for item in active if item.get("user_id") == user_id) >= max_user:
+                raise HTTPException(status_code=429, detail="Too many active mobile attaches for user")
+            if sum(1 for item in active if item.get("session_id") == session.id) >= max_session:
+                raise HTTPException(status_code=429, detail="Session already has an active mobile attach")
+
+            ticket_id = f"att_{secrets.token_urlsafe(18)}"
+            ticket_secret = secrets.token_urlsafe(40)
+            expires_at = now + ttl_seconds
+            app.state.mobile_terminal_tickets[ticket_id] = MobileTerminalTicket(
+                ticket_id=ticket_id,
+                secret_hash=_hash_mobile_terminal_ticket_secret(ticket_secret),
+                user_id=user_id,
+                actor_email=actor_email,
+                session_id=session.id,
+                provider=str(session.provider or "claude"),
+                tmux_session=tmux_session,
+                tmux_socket_name=tmux_socket_name,
+                device_key_id=str(device_config.get("id") or ""),
+                created_at=now,
+                expires_at=expires_at,
+            )
+
+        _audit_mobile_terminal(
+            "ticket_minted",
+            user_id=user_id,
+            session_id=session.id,
+            provider=session.provider,
+            device_key_id=device_config.get("id"),
+            remote_addr=request.client.host if request.client else None,
+        )
+        return MobileAttachTicketResponse(
+            ticket_id=ticket_id,
+            ticket_secret=ticket_secret,
+            device_key_id=str(device_config.get("id") or ""),
+            ws_url=metadata["ws_url"],
+            expires_at=datetime.fromtimestamp(expires_at, tz=timezone.utc).isoformat(),
+        )
+
+    async def _consume_mobile_terminal_ticket(auth_frame: dict[str, Any]) -> MobileTerminalTicket:
+        ticket_id = str(auth_frame.get("ticket_id") or "").strip()
+        ticket_secret = str(auth_frame.get("ticket_secret") or "").strip()
+        device_key_id = str(auth_frame.get("device_key_id") or "").strip()
+        nonce = str(auth_frame.get("nonce") or "").strip()
+        signature = str(auth_frame.get("signature") or "").strip()
+        if not ticket_id or not ticket_secret or not device_key_id or not nonce or not signature:
+            raise HTTPException(status_code=401, detail="Invalid terminal auth frame")
+
+        async with app.state.mobile_terminal_lock:
+            _mobile_terminal_cleanup_expired_tickets()
+            ticket = app.state.mobile_terminal_tickets.get(ticket_id)
+            if ticket is None:
+                raise HTTPException(status_code=401, detail="Attach ticket is invalid or expired")
+            if ticket.device_key_id != device_key_id:
+                raise HTTPException(status_code=401, detail="Attach ticket device mismatch")
+            if not hmac.compare_digest(ticket.secret_hash, _hash_mobile_terminal_ticket_secret(ticket_secret)):
+                raise HTTPException(status_code=401, detail="Attach ticket secret mismatch")
+            if ticket.expires_at <= time.time() or ticket.consumed_at is not None:
+                app.state.mobile_terminal_tickets.pop(ticket_id, None)
+                raise HTTPException(status_code=401, detail="Attach ticket is expired or consumed")
+
+            user_match = _mobile_terminal_visible_user(ticket.actor_email)
+            if user_match is None or user_match[0] != ticket.user_id:
+                raise HTTPException(status_code=403, detail="User is no longer allowed to attach")
+            _user_id, user_config = user_match
+            device_config = _mobile_terminal_device_config(ticket.user_id, user_config, device_key_id)
+            if device_config is None:
+                raise HTTPException(status_code=401, detail="Device key is no longer registered")
+            message = _mobile_terminal_ws_message(
+                ticket_id=ticket.ticket_id,
+                session_id=ticket.session_id,
+                actor_email=ticket.actor_email,
+                device_key_id=device_key_id,
+                nonce=nonce,
+            )
+            _verify_mobile_terminal_signature(
+                public_key_text=str(device_config.get("public_key") or ""),
+                signature_text=signature,
+                message=message,
+            )
+
+            session = app.state.session_manager.get_session(ticket.session_id)
+            if not session or session.status == SessionStatus.STOPPED:
+                raise HTTPException(status_code=409, detail="Session is no longer attachable")
+            descriptor = _attach_descriptor(session)
+            metadata = _mobile_terminal_metadata(session, descriptor)
+            if not metadata.get("supported"):
+                raise HTTPException(status_code=403, detail=metadata.get("reason") or "Session is no longer attachable")
+            ticket.consumed_at = time.time()
+            app.state.mobile_terminal_tickets.pop(ticket_id, None)
+            _audit_mobile_terminal(
+                "ticket_consumed",
+                user_id=ticket.user_id,
+                session_id=ticket.session_id,
+                provider=ticket.provider,
+                device_key_id=ticket.device_key_id,
+            )
+            return ticket
+
+    def _mobile_terminal_tmux_cmd(ticket: MobileTerminalTicket, *args: str) -> list[str]:
+        cmd = ["tmux"]
+        if ticket.tmux_socket_name:
+            cmd.extend(["-L", ticket.tmux_socket_name])
+        cmd.extend(args)
+        return cmd
+
+    async def _mobile_terminal_tmux_run(ticket: MobileTerminalTicket, *args: str) -> subprocess.CompletedProcess[str]:
+        return await asyncio.to_thread(
+            subprocess.run,
+            _mobile_terminal_tmux_cmd(ticket, *args),
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=3,
+        )
+
+    async def _run_mobile_terminal_bridge(websocket: WebSocket, ticket: MobileTerminalTicket, attach_id: str) -> None:
+        """Bridge authenticated WebSocket frames to one server-derived tmux target."""
+        max_attach_seconds = _mobile_terminal_int("max_attach_seconds", 3600, minimum=30, maximum=24 * 3600)
+        poll_interval = float(_mobile_terminal_config().get("capture_poll_seconds", 0.5) or 0.5)
+        poll_interval = min(max(poll_interval, 0.2), 2.0)
+        stop_event = asyncio.Event()
+        counters = {"input_bytes": 0, "output_bytes": 0}
+
+        async def send_status(state: str, **extra: Any) -> None:
+            await websocket.send_json({"type": "status", "state": state, **extra})
+
+        async def capture_loop() -> None:
+            last_output: Optional[str] = None
+            while not stop_event.is_set():
+                result = await _mobile_terminal_tmux_run(
+                    ticket,
+                    "capture-pane",
+                    "-p",
+                    "-e",
+                    "-J",
+                    "-t",
+                    ticket.tmux_session,
+                )
+                if result.returncode != 0:
+                    await websocket.send_json({
+                        "type": "error",
+                        "message": "tmux session is no longer attachable",
+                    })
+                    stop_event.set()
+                    return
+                output = result.stdout or ""
+                if output != last_output:
+                    counters["output_bytes"] += len(output.encode("utf-8", errors="ignore"))
+                    await websocket.send_json({
+                        "type": "output",
+                        "mode": "snapshot",
+                        "data": output,
+                    })
+                    last_output = output
+                try:
+                    await asyncio.wait_for(stop_event.wait(), timeout=poll_interval)
+                except asyncio.TimeoutError:
+                    pass
+
+        async def receive_loop() -> None:
+            while not stop_event.is_set():
+                frame = await websocket.receive_json()
+                frame_type = str(frame.get("type") or "").strip().lower()
+                if frame_type == "input":
+                    data = str(frame.get("data") or "")
+                    if len(data) > MOBILE_TERMINAL_INPUT_MAX_CHARS:
+                        await websocket.send_json({"type": "error", "message": "input frame too large"})
+                        stop_event.set()
+                        return
+                    if data:
+                        counters["input_bytes"] += len(data.encode("utf-8", errors="ignore"))
+                        result = await _mobile_terminal_tmux_run(
+                            ticket,
+                            "send-keys",
+                            "-t",
+                            ticket.tmux_session,
+                            "-l",
+                            data,
+                        )
+                        if result.returncode != 0:
+                            await websocket.send_json({"type": "error", "message": "failed to deliver terminal input"})
+                            stop_event.set()
+                            return
+                elif frame_type == "key":
+                    key = str(frame.get("key") or "").strip().lower()
+                    key_map = {
+                        "enter": "Enter",
+                        "esc": "Escape",
+                        "escape": "Escape",
+                        "tab": "Tab",
+                        "backspace": "BSpace",
+                        "ctrl-c": "C-c",
+                        "ctrl-d": "C-d",
+                        "ctrl-z": "C-z",
+                        "ctrl-b": "C-b",
+                    }
+                    tmux_key = key_map.get(key)
+                    if not tmux_key:
+                        await websocket.send_json({"type": "error", "message": f"unsupported key: {key}"})
+                        continue
+                    counters["input_bytes"] += 1
+                    result = await _mobile_terminal_tmux_run(
+                        ticket,
+                        "send-keys",
+                        "-t",
+                        ticket.tmux_session,
+                        tmux_key,
+                    )
+                    if result.returncode != 0:
+                        await websocket.send_json({"type": "error", "message": "failed to deliver terminal key"})
+                        stop_event.set()
+                        return
+                elif frame_type == "resize":
+                    rows = int(frame.get("rows") or 0)
+                    cols = int(frame.get("cols") or 0)
+                    if not (10 <= rows <= 120 and 20 <= cols <= 300):
+                        await websocket.send_json({"type": "error", "message": "ignored invalid resize"})
+                    else:
+                        await websocket.send_json({"type": "status", "state": "resized", "rows": rows, "cols": cols})
+                elif frame_type == "ping":
+                    await websocket.send_json({"type": "status", "state": "pong"})
+                elif frame_type == "detach":
+                    stop_event.set()
+                    return
+                else:
+                    await websocket.send_json({"type": "error", "message": "unsupported terminal frame"})
+
+        await send_status("attached", session_id=ticket.session_id)
+        capture_task = asyncio.create_task(capture_loop())
+        receive_task = asyncio.create_task(receive_loop())
+        timeout_task = asyncio.create_task(asyncio.sleep(max_attach_seconds))
+        try:
+            done, pending = await asyncio.wait(
+                {capture_task, receive_task, timeout_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if timeout_task in done and not stop_event.is_set():
+                await websocket.send_json({"type": "exit", "code": 124, "reason": "max_attach_seconds"})
+            stop_event.set()
+            for task in pending:
+                task.cancel()
+        finally:
+            stop_event.set()
+            for task in (capture_task, receive_task, timeout_task):
+                if not task.done():
+                    task.cancel()
+            active = getattr(app.state, "mobile_terminal_active_attaches", {})
+            active.pop(attach_id, None)
+            _audit_mobile_terminal(
+                "attach_ended",
+                user_id=ticket.user_id,
+                session_id=ticket.session_id,
+                provider=ticket.provider,
+                device_key_id=ticket.device_key_id,
+                duration_seconds=round(time.time() - ticket.created_at, 3),
+                input_bytes=counters["input_bytes"],
+                output_bytes=counters["output_bytes"],
+            )
+
+    @app.websocket("/client/terminal")
+    async def mobile_terminal_websocket(websocket: WebSocket):
+        """Authenticated mobile terminal stream over the public HTTPS origin."""
+        await websocket.accept()
+        if not _mobile_terminal_enabled():
+            await websocket.send_json({"type": "error", "message": "mobile terminal attach is disabled"})
+            await websocket.close(code=1008)
+            return
+        origin = websocket.headers.get("origin")
+        allowed_origins = set(str(item).rstrip("/") for item in (_mobile_terminal_config().get("allowed_origins") or []))
+        public_host = _mobile_terminal_public_http_host()
+        if public_host:
+            allowed_origins.add(f"https://{public_host}")
+        if origin and allowed_origins and origin.rstrip("/") not in allowed_origins:
+            _audit_mobile_terminal("auth_failed", reason="invalid_origin", origin=origin)
+            await websocket.send_json({"type": "error", "message": "invalid origin"})
+            await websocket.close(code=1008)
+            return
+
+        auth_timeout = _mobile_terminal_int("auth_frame_timeout_seconds", 3, minimum=1, maximum=30)
+        try:
+            auth_frame = await asyncio.wait_for(websocket.receive_json(), timeout=auth_timeout)
+            if not isinstance(auth_frame, dict) or auth_frame.get("type") != "auth":
+                raise HTTPException(status_code=401, detail="First terminal frame must be auth")
+            ticket = await _consume_mobile_terminal_ticket(auth_frame)
+            _validate_mobile_terminal_tmux_target(ticket.tmux_session, ticket.tmux_socket_name)
+        except asyncio.TimeoutError:
+            _audit_mobile_terminal("auth_failed", reason="timeout")
+            await websocket.send_json({"type": "error", "message": "terminal auth timed out"})
+            await websocket.close(code=1008)
+            return
+        except HTTPException as exc:
+            _audit_mobile_terminal("auth_failed", reason=exc.detail)
+            await websocket.send_json({"type": "error", "message": str(exc.detail)})
+            await websocket.close(code=1008)
+            return
+        except WebSocketDisconnect:
+            return
+        except Exception as exc:
+            _audit_mobile_terminal("auth_failed", reason=type(exc).__name__)
+            await websocket.send_json({"type": "error", "message": "terminal auth failed"})
+            await websocket.close(code=1008)
+            return
+
+        attach_id = secrets.token_urlsafe(16)
+        async with app.state.mobile_terminal_lock:
+            app.state.mobile_terminal_active_attaches[attach_id] = {
+                "user_id": ticket.user_id,
+                "session_id": ticket.session_id,
+                "provider": ticket.provider,
+                "device_key_id": ticket.device_key_id,
+                "started_at": time.time(),
+            }
+        _audit_mobile_terminal(
+            "attach_started",
+            user_id=ticket.user_id,
+            session_id=ticket.session_id,
+            provider=ticket.provider,
+            device_key_id=ticket.device_key_id,
+        )
+        try:
+            await _run_mobile_terminal_bridge(websocket, ticket, attach_id)
+        except WebSocketDisconnect:
+            app.state.mobile_terminal_active_attaches.pop(attach_id, None)
+        finally:
+            if websocket.client_state.name != "DISCONNECTED":
+                try:
+                    await websocket.close()
+                except Exception:
+                    pass
+
+    @app.post("/client/mobile-terminal/disable", response_model=MobileTerminalDisableResponse)
+    async def disable_mobile_terminal(request: Request):
+        """Emergency runtime kill switch for mobile terminal attach."""
+        actor_email = _request_actor_email(request)
+        if actor_email is None:
+            raise HTTPException(status_code=401, detail="Authentication required")
+        user_match = _mobile_terminal_visible_user(actor_email)
+        if user_match is None or user_match[1].get("interactive_shell_access") is not True:
+            raise HTTPException(status_code=403, detail="User is not allowed to disable mobile terminal attach")
+        app.state.mobile_terminal_runtime_disabled = True
+        _audit_mobile_terminal("runtime_disabled", user_id=user_match[0])
+        return MobileTerminalDisableResponse(disabled=True)
 
     @app.get("/sessions/{session_id}/attach-descriptor")
     async def get_attach_descriptor(session_id: str):

--- a/src/server.py
+++ b/src/server.py
@@ -4,6 +4,7 @@ import asyncio
 import inspect
 import json
 import logging
+import math
 import os
 import secrets
 import shutil
@@ -2096,10 +2097,41 @@ def create_app(
             host = str(_google_auth_config(app.state.config).get("public_host") or "").strip()
         return host or None
 
+    def _normalize_mobile_terminal_path_prefix(value: Optional[str]) -> str:
+        prefix = str(value or "").strip()
+        if not prefix or prefix == "/":
+            return ""
+        if not prefix.startswith("/"):
+            prefix = f"/{prefix}"
+        return prefix.rstrip("/")
+
+    def _mobile_terminal_public_http_path_prefix(path_prefix: Optional[str] = None) -> str:
+        if path_prefix is not None:
+            return _normalize_mobile_terminal_path_prefix(path_prefix)
+        config_block = _mobile_terminal_config()
+        external_access = _external_access_config()
+        return _normalize_mobile_terminal_path_prefix(
+            config_block.get("public_path_prefix")
+            or external_access.get("public_http_path_prefix")
+            or _google_auth_config(app.state.config).get("public_path_prefix")
+        )
+
+    def _request_path_prefix(request: Request, route_suffix: str) -> str:
+        root_path = _normalize_mobile_terminal_path_prefix(request.scope.get("root_path"))
+        if root_path:
+            return root_path
+        path = request.url.path.rstrip("/") or "/"
+        suffix = route_suffix.rstrip("/") or "/"
+        if path == suffix:
+            return ""
+        if path.endswith(suffix):
+            return _normalize_mobile_terminal_path_prefix(path[: -len(suffix)])
+        return ""
+
     def _mobile_terminal_require_tls() -> bool:
         return _mobile_terminal_config().get("require_tls", True) is not False
 
-    def _mobile_terminal_ws_url() -> Optional[str]:
+    def _mobile_terminal_ws_url(path_prefix: Optional[str] = None) -> Optional[str]:
         config_block = _mobile_terminal_config()
         configured = str(config_block.get("ws_url") or "").strip()
         if configured:
@@ -2115,7 +2147,8 @@ def create_app(
             and (host.startswith("localhost") or host.startswith("127.0.0.1") or host.startswith("testserver"))
         ):
             scheme = "ws"
-        return f"{scheme}://{host}/client/terminal"
+        prefix = _mobile_terminal_public_http_path_prefix(path_prefix)
+        return f"{scheme}://{host}{prefix}/client/terminal"
 
     def _mobile_terminal_visible_user(actor_email: str) -> Optional[tuple[str, dict[str, Any]]]:
         allowed_users = _mobile_terminal_config().get("allowed_users") or {}
@@ -2273,6 +2306,8 @@ def create_app(
             timestamp = float(timestamp_text)
         except (TypeError, ValueError) as exc:
             raise HTTPException(status_code=401, detail="Invalid device timestamp") from exc
+        if not math.isfinite(timestamp):
+            raise HTTPException(status_code=401, detail="Invalid device timestamp")
         max_skew = _mobile_terminal_int("device_signature_max_skew_seconds", 60, minimum=5, maximum=600)
         if abs(time.time() - timestamp) > max_skew:
             raise HTTPException(status_code=401, detail="Expired device signature")
@@ -2306,6 +2341,7 @@ def create_app(
         descriptor: Optional[dict[str, Any]],
         *,
         actor_email: Optional[str] = None,
+        path_prefix: Optional[str] = None,
     ) -> dict[str, Any]:
         if not _mobile_terminal_enabled():
             return {
@@ -2313,7 +2349,7 @@ def create_app(
                 "transport": "sm-https-tmux",
                 "reason": "mobile terminal attach is disabled",
             }
-        ws_url = _mobile_terminal_ws_url()
+        ws_url = _mobile_terminal_ws_url(path_prefix=path_prefix)
         if not ws_url:
             return {
                 "supported": False,
@@ -2371,7 +2407,10 @@ def create_app(
         return {
             "supported": True,
             "transport": "sm-https-tmux",
-            "ticket_endpoint": f"/client/sessions/{session.id}/attach-ticket",
+            "ticket_endpoint": (
+                f"{_mobile_terminal_public_http_path_prefix(path_prefix)}"
+                f"/client/sessions/{session.id}/attach-ticket"
+            ),
             "ws_url": ws_url,
             "tmux_session": tmux_session,
             "tmux_socket_name": tmux_socket_name,
@@ -2868,13 +2907,19 @@ def create_app(
         *,
         sync_display_name: bool = True,
         actor_email: Optional[str] = None,
+        path_prefix: Optional[str] = None,
     ) -> dict[str, Any]:
         base = _response_dict(
             _session_to_response(session, sync_display_name=sync_display_name)
         )
         descriptor = _attach_descriptor(session)
         termux_attach = _termux_attach_metadata(session, descriptor)
-        mobile_terminal = _mobile_terminal_metadata(session, descriptor, actor_email=actor_email)
+        mobile_terminal = _mobile_terminal_metadata(
+            session,
+            descriptor,
+            actor_email=actor_email,
+            path_prefix=path_prefix,
+        )
         base["attach_descriptor"] = descriptor
         base["termux_attach"] = termux_attach
         base["mobile_terminal"] = mobile_terminal
@@ -4096,10 +4141,16 @@ def create_app(
             raise HTTPException(status_code=503, detail="Session manager not configured")
 
         actor_email = _request_actor_email(request)
+        path_prefix = _request_path_prefix(request, "/client/sessions") or None
         sessions = app.state.session_manager.list_sessions()
         return {
             "sessions": [
-                _mobile_session_payload(session, sync_display_name=False, actor_email=actor_email)
+                _mobile_session_payload(
+                    session,
+                    sync_display_name=False,
+                    actor_email=actor_email,
+                    path_prefix=path_prefix,
+                )
                 for session in sessions
             ]
         }
@@ -4222,6 +4273,7 @@ def create_app(
         session: Session,
         descriptor: Optional[dict[str, Any]],
         actor_email: str,
+        path_prefix: Optional[str] = None,
     ) -> tuple[str, dict[str, Any], dict[str, Any]]:
         if not _mobile_terminal_enabled():
             _audit_mobile_terminal("ticket_denied", user_id=actor_email, session_id=session.id, reason="disabled")
@@ -4229,7 +4281,12 @@ def create_app(
         if session.status == SessionStatus.STOPPED:
             _audit_mobile_terminal("ticket_denied", user_id=actor_email, session_id=session.id, reason="session_stopped")
             raise HTTPException(status_code=409, detail="Session is not running")
-        metadata = _mobile_terminal_metadata(session, descriptor, actor_email=actor_email)
+        metadata = _mobile_terminal_metadata(
+            session,
+            descriptor,
+            actor_email=actor_email,
+            path_prefix=path_prefix,
+        )
         if not metadata.get("supported"):
             _audit_mobile_terminal(
                 "ticket_denied",
@@ -4292,13 +4349,20 @@ def create_app(
         if not session:
             raise HTTPException(status_code=404, detail="Session not found")
         descriptor = _attach_descriptor(session)
+        path_prefix = _request_path_prefix(request, f"/client/sessions/{session.id}/attach-ticket") or None
         user_id, _user_config, device_config = _mobile_terminal_authorize_ticket_request(
             request,
             session,
             descriptor,
             actor_email,
+            path_prefix=path_prefix,
         )
-        metadata = _mobile_terminal_metadata(session, descriptor, actor_email=actor_email)
+        metadata = _mobile_terminal_metadata(
+            session,
+            descriptor,
+            actor_email=actor_email,
+            path_prefix=path_prefix,
+        )
         tmux_session = str(metadata.get("tmux_session") or "").strip()
         tmux_socket_name = str(metadata.get("tmux_socket_name") or "").strip() or None
         _validate_mobile_terminal_tmux_target(tmux_session, tmux_socket_name)
@@ -4786,7 +4850,11 @@ def create_app(
             raise HTTPException(status_code=404, detail="Session not found")
 
         await _ensure_session_display_identity_synced(session)
-        return _mobile_session_payload(session, actor_email=_request_actor_email(request))
+        return _mobile_session_payload(
+            session,
+            actor_email=_request_actor_email(request),
+            path_prefix=_request_path_prefix(request, f"/client/sessions/{session_id}") or None,
+        )
 
     @app.get("/sessions/{session_id}/codex-events")
     async def get_codex_events(

--- a/src/server.py
+++ b/src/server.py
@@ -2150,6 +2150,10 @@ def create_app(
         prefix = _mobile_terminal_public_http_path_prefix(path_prefix)
         return f"{scheme}://{host}{prefix}/client/terminal"
 
+    def _mobile_terminal_attach_ticket_path(session_id: str, path_prefix: Optional[str] = None) -> str:
+        prefix = _mobile_terminal_public_http_path_prefix(path_prefix)
+        return f"{prefix}/client/sessions/{session_id}/attach-ticket"
+
     def _mobile_terminal_visible_user(actor_email: str) -> Optional[tuple[str, dict[str, Any]]]:
         allowed_users = _mobile_terminal_config().get("allowed_users") or {}
         if not isinstance(allowed_users, dict):
@@ -2407,10 +2411,7 @@ def create_app(
         return {
             "supported": True,
             "transport": "sm-https-tmux",
-            "ticket_endpoint": (
-                f"{_mobile_terminal_public_http_path_prefix(path_prefix)}"
-                f"/client/sessions/{session.id}/attach-ticket"
-            ),
+            "ticket_endpoint": _mobile_terminal_attach_ticket_path(session.id, path_prefix),
             "ws_url": ws_url,
             "tmux_session": tmux_session,
             "tmux_socket_name": tmux_socket_name,
@@ -4323,7 +4324,7 @@ def create_app(
             raise HTTPException(status_code=401, detail="Device key is not registered")
         message = _mobile_terminal_ticket_message(
             method=request.method,
-            path=request.url.path,
+            path=_mobile_terminal_attach_ticket_path(session.id, path_prefix),
             session_id=session.id,
             actor_email=actor_email,
             device_key_id=device_key_id,

--- a/src/server.py
+++ b/src/server.py
@@ -4528,9 +4528,16 @@ def create_app(
         stop_event = asyncio.Event()
         counters = {"input_bytes": 0, "output_bytes": 0}
         active = getattr(app.state, "mobile_terminal_active_attaches", {})
-        if attach_id in active:
-            active[attach_id]["stop_event"] = stop_event
-            active[attach_id]["websocket"] = websocket
+        if attach_id not in active or not _mobile_terminal_enabled():
+            await websocket.send_json({
+                "type": "exit",
+                "code": 1008,
+                "reason": "mobile_terminal_disabled",
+            })
+            await websocket.close(code=1008)
+            return
+        active[attach_id]["stop_event"] = stop_event
+        active[attach_id]["websocket"] = websocket
 
         async def send_status(state: str, **extra: Any) -> None:
             await websocket.send_json({"type": "status", "state": state, **extra})

--- a/src/server.py
+++ b/src/server.py
@@ -2113,7 +2113,8 @@ def create_app(
         if not isinstance(allowed_users, dict):
             return None
         normalized_email = str(actor_email or "").strip().lower()
-        email_local = normalized_email.split("@", 1)[0]
+        if not normalized_email:
+            return None
         for user_id, raw_user_config in allowed_users.items():
             user_config = raw_user_config if isinstance(raw_user_config, dict) else {}
             candidates = {
@@ -2124,9 +2125,22 @@ def create_app(
             if isinstance(aliases, list):
                 candidates.update(str(alias or "").strip().lower() for alias in aliases)
             candidates.discard("")
-            if normalized_email in candidates or email_local in candidates:
+            if normalized_email in candidates:
                 return str(user_id), user_config
         return None
+
+    def _mobile_terminal_user_has_registered_device(user_config: dict[str, Any]) -> bool:
+        keys = user_config.get("registered_device_keys") or []
+        if not isinstance(keys, list):
+            return False
+        for raw_key in keys:
+            if not isinstance(raw_key, dict):
+                continue
+            if raw_key.get("enabled", True) is False:
+                continue
+            if str(raw_key.get("id") or "").strip() and str(raw_key.get("public_key") or "").strip():
+                return True
+        return False
 
     def _mobile_terminal_device_config(
         user_id: str,
@@ -2271,7 +2285,12 @@ def create_app(
         if tmux_socket_name and not MOBILE_TERMINAL_SOCKET_NAME_PATTERN.fullmatch(tmux_socket_name):
             raise HTTPException(status_code=403, detail="Unsafe tmux socket target")
 
-    def _mobile_terminal_metadata(session: Session, descriptor: Optional[dict[str, Any]]) -> dict[str, Any]:
+    def _mobile_terminal_metadata(
+        session: Session,
+        descriptor: Optional[dict[str, Any]],
+        *,
+        actor_email: Optional[str] = None,
+    ) -> dict[str, Any]:
         if not _mobile_terminal_enabled():
             return {
                 "supported": False,
@@ -2284,6 +2303,32 @@ def create_app(
                 "supported": False,
                 "transport": "sm-https-tmux",
                 "reason": "mobile terminal public HTTPS host is not configured",
+            }
+        if actor_email is None:
+            return {
+                "supported": False,
+                "transport": "sm-https-tmux",
+                "reason": "authenticated mobile terminal user is required",
+            }
+        user_match = _mobile_terminal_visible_user(actor_email)
+        if user_match is None:
+            return {
+                "supported": False,
+                "transport": "sm-https-tmux",
+                "reason": "mobile terminal user is not configured",
+            }
+        _user_id, user_config = user_match
+        if user_config.get("interactive_shell_access") is not True:
+            return {
+                "supported": False,
+                "transport": "sm-https-tmux",
+                "reason": "interactive shell access is not enabled",
+            }
+        if not _mobile_terminal_user_has_registered_device(user_config):
+            return {
+                "supported": False,
+                "transport": "sm-https-tmux",
+                "reason": "registered mobile device key is required",
             }
         if not descriptor:
             return {
@@ -2806,13 +2851,14 @@ def create_app(
         session: Session,
         *,
         sync_display_name: bool = True,
+        actor_email: Optional[str] = None,
     ) -> dict[str, Any]:
         base = _response_dict(
             _session_to_response(session, sync_display_name=sync_display_name)
         )
         descriptor = _attach_descriptor(session)
         termux_attach = _termux_attach_metadata(session, descriptor)
-        mobile_terminal = _mobile_terminal_metadata(session, descriptor)
+        mobile_terminal = _mobile_terminal_metadata(session, descriptor, actor_email=actor_email)
         base["attach_descriptor"] = descriptor
         base["termux_attach"] = termux_attach
         base["mobile_terminal"] = mobile_terminal
@@ -4028,15 +4074,16 @@ def create_app(
         }
 
     @app.get("/client/sessions")
-    async def list_client_sessions():
+    async def list_client_sessions(request: Request):
         """List sessions with mobile-friendly attach metadata."""
         if not app.state.session_manager:
             raise HTTPException(status_code=503, detail="Session manager not configured")
 
+        actor_email = _request_actor_email(request)
         sessions = app.state.session_manager.list_sessions()
         return {
             "sessions": [
-                _mobile_session_payload(session, sync_display_name=False)
+                _mobile_session_payload(session, sync_display_name=False, actor_email=actor_email)
                 for session in sessions
             ]
         }
@@ -4166,7 +4213,7 @@ def create_app(
         if session.status == SessionStatus.STOPPED:
             _audit_mobile_terminal("ticket_denied", user_id=actor_email, session_id=session.id, reason="session_stopped")
             raise HTTPException(status_code=409, detail="Session is not running")
-        metadata = _mobile_terminal_metadata(session, descriptor)
+        metadata = _mobile_terminal_metadata(session, descriptor, actor_email=actor_email)
         if not metadata.get("supported"):
             _audit_mobile_terminal(
                 "ticket_denied",
@@ -4235,7 +4282,7 @@ def create_app(
             descriptor,
             actor_email,
         )
-        metadata = _mobile_terminal_metadata(session, descriptor)
+        metadata = _mobile_terminal_metadata(session, descriptor, actor_email=actor_email)
         tmux_session = str(metadata.get("tmux_session") or "").strip()
         tmux_socket_name = str(metadata.get("tmux_socket_name") or "").strip() or None
         _validate_mobile_terminal_tmux_target(tmux_session, tmux_socket_name)
@@ -4297,7 +4344,7 @@ def create_app(
             expires_at=datetime.fromtimestamp(expires_at, tz=timezone.utc).isoformat(),
         )
 
-    async def _consume_mobile_terminal_ticket(auth_frame: dict[str, Any]) -> MobileTerminalTicket:
+    async def _consume_mobile_terminal_ticket(auth_frame: dict[str, Any]) -> tuple[MobileTerminalTicket, str]:
         ticket_id = str(auth_frame.get("ticket_id") or "").strip()
         ticket_secret = str(auth_frame.get("ticket_secret") or "").strip()
         device_key_id = str(auth_frame.get("device_key_id") or "").strip()
@@ -4353,11 +4400,19 @@ def create_app(
             if not session or session.status == SessionStatus.STOPPED:
                 raise HTTPException(status_code=409, detail="Session is no longer attachable")
             descriptor = _attach_descriptor(session)
-            metadata = _mobile_terminal_metadata(session, descriptor)
+            metadata = _mobile_terminal_metadata(session, descriptor, actor_email=ticket.actor_email)
             if not metadata.get("supported"):
                 raise HTTPException(status_code=403, detail=metadata.get("reason") or "Session is no longer attachable")
             ticket.consumed_at = time.time()
             app.state.mobile_terminal_tickets.pop(ticket_id, None)
+            attach_id = secrets.token_urlsafe(16)
+            app.state.mobile_terminal_active_attaches[attach_id] = {
+                "user_id": ticket.user_id,
+                "session_id": ticket.session_id,
+                "provider": ticket.provider,
+                "device_key_id": ticket.device_key_id,
+                "started_at": time.time(),
+            }
             _audit_mobile_terminal(
                 "ticket_consumed",
                 user_id=ticket.user_id,
@@ -4365,7 +4420,7 @@ def create_app(
                 provider=ticket.provider,
                 device_key_id=ticket.device_key_id,
             )
-            return ticket
+            return ticket, attach_id
 
     def _mobile_terminal_tmux_cmd(ticket: MobileTerminalTicket, *args: str) -> list[str]:
         cmd = ["tmux"]
@@ -4548,11 +4603,12 @@ def create_app(
             return
 
         auth_timeout = _mobile_terminal_int("auth_frame_timeout_seconds", 3, minimum=1, maximum=30)
+        attach_id: Optional[str] = None
         try:
             auth_frame = await asyncio.wait_for(websocket.receive_json(), timeout=auth_timeout)
             if not isinstance(auth_frame, dict) or auth_frame.get("type") != "auth":
                 raise HTTPException(status_code=401, detail="First terminal frame must be auth")
-            ticket = await _consume_mobile_terminal_ticket(auth_frame)
+            ticket, attach_id = await _consume_mobile_terminal_ticket(auth_frame)
             _validate_mobile_terminal_tmux_target(ticket.tmux_session, ticket.tmux_socket_name)
         except asyncio.TimeoutError:
             _audit_mobile_terminal("auth_failed", reason="timeout")
@@ -4572,15 +4628,6 @@ def create_app(
             await websocket.close(code=1008)
             return
 
-        attach_id = secrets.token_urlsafe(16)
-        async with app.state.mobile_terminal_lock:
-            app.state.mobile_terminal_active_attaches[attach_id] = {
-                "user_id": ticket.user_id,
-                "session_id": ticket.session_id,
-                "provider": ticket.provider,
-                "device_key_id": ticket.device_key_id,
-                "started_at": time.time(),
-            }
         _audit_mobile_terminal(
             "attach_started",
             user_id=ticket.user_id,
@@ -4591,8 +4638,10 @@ def create_app(
         try:
             await _run_mobile_terminal_bridge(websocket, ticket, attach_id)
         except WebSocketDisconnect:
-            app.state.mobile_terminal_active_attaches.pop(attach_id, None)
+            pass
         finally:
+            if attach_id is not None:
+                app.state.mobile_terminal_active_attaches.pop(attach_id, None)
             if websocket.client_state.name != "DISCONNECTED":
                 try:
                     await websocket.close()
@@ -4655,7 +4704,7 @@ def create_app(
         return _session_to_response(session, sync_display_name=False)
 
     @app.get("/client/sessions/{session_id}")
-    async def get_client_session(session_id: str):
+    async def get_client_session(session_id: str, request: Request):
         """Get one session with mobile-friendly attach metadata."""
         if not app.state.session_manager:
             raise HTTPException(status_code=503, detail="Session manager not configured")
@@ -4665,7 +4714,7 @@ def create_app(
             raise HTTPException(status_code=404, detail="Session not found")
 
         await _ensure_session_display_identity_synced(session)
-        return _mobile_session_payload(session)
+        return _mobile_session_payload(session, actor_email=_request_actor_email(request))
 
     @app.get("/sessions/{session_id}/codex-events")
     async def get_codex_events(

--- a/src/server.py
+++ b/src/server.py
@@ -4245,14 +4245,23 @@ def create_app(
         async with app.state.mobile_terminal_lock:
             _mobile_terminal_cleanup_expired_tickets(now)
             active = list(app.state.mobile_terminal_active_attaches.values())
+            pending = list(app.state.mobile_terminal_tickets.values())
             max_global = _mobile_terminal_int("max_concurrent_attaches_global", 4, minimum=1, maximum=64)
             max_user = _mobile_terminal_int("max_concurrent_attaches_per_user", 1, minimum=1, maximum=16)
             max_session = _mobile_terminal_int("max_concurrent_attaches_per_session", 1, minimum=1, maximum=16)
-            if len(active) >= max_global:
+            if len(active) + len(pending) >= max_global:
                 raise HTTPException(status_code=429, detail="Too many active mobile attaches")
-            if sum(1 for item in active if item.get("user_id") == user_id) >= max_user:
+            if (
+                sum(1 for item in active if item.get("user_id") == user_id)
+                + sum(1 for item in pending if item.user_id == user_id)
+                >= max_user
+            ):
                 raise HTTPException(status_code=429, detail="Too many active mobile attaches for user")
-            if sum(1 for item in active if item.get("session_id") == session.id) >= max_session:
+            if (
+                sum(1 for item in active if item.get("session_id") == session.id)
+                + sum(1 for item in pending if item.session_id == session.id)
+                >= max_session
+            ):
                 raise HTTPException(status_code=429, detail="Session already has an active mobile attach")
 
             ticket_id = f"att_{secrets.token_urlsafe(18)}"
@@ -4309,6 +4318,16 @@ def create_app(
             if ticket.expires_at <= time.time() or ticket.consumed_at is not None:
                 app.state.mobile_terminal_tickets.pop(ticket_id, None)
                 raise HTTPException(status_code=401, detail="Attach ticket is expired or consumed")
+            active = list(app.state.mobile_terminal_active_attaches.values())
+            max_global = _mobile_terminal_int("max_concurrent_attaches_global", 4, minimum=1, maximum=64)
+            max_user = _mobile_terminal_int("max_concurrent_attaches_per_user", 1, minimum=1, maximum=16)
+            max_session = _mobile_terminal_int("max_concurrent_attaches_per_session", 1, minimum=1, maximum=16)
+            if len(active) >= max_global:
+                raise HTTPException(status_code=429, detail="Too many active mobile attaches")
+            if sum(1 for item in active if item.get("user_id") == ticket.user_id) >= max_user:
+                raise HTTPException(status_code=429, detail="Too many active mobile attaches for user")
+            if sum(1 for item in active if item.get("session_id") == ticket.session_id) >= max_session:
+                raise HTTPException(status_code=429, detail="Session already has an active mobile attach")
 
             user_match = _mobile_terminal_visible_user(ticket.actor_email)
             if user_match is None or user_match[0] != ticket.user_id:

--- a/src/server.py
+++ b/src/server.py
@@ -2095,16 +2095,24 @@ def create_app(
             host = str(_google_auth_config(app.state.config).get("public_host") or "").strip()
         return host or None
 
+    def _mobile_terminal_require_tls() -> bool:
+        return _mobile_terminal_config().get("require_tls", True) is not False
+
     def _mobile_terminal_ws_url() -> Optional[str]:
         config_block = _mobile_terminal_config()
         configured = str(config_block.get("ws_url") or "").strip()
         if configured:
+            if _mobile_terminal_require_tls() and not configured.lower().startswith("wss://"):
+                return None
             return configured
         host = _mobile_terminal_public_http_host()
         if not host:
             return None
         scheme = "wss"
-        if host.startswith("localhost") or host.startswith("127.0.0.1") or host.startswith("testserver"):
+        if (
+            not _mobile_terminal_require_tls()
+            and (host.startswith("localhost") or host.startswith("127.0.0.1") or host.startswith("testserver"))
+        ):
             scheme = "ws"
         return f"{scheme}://{host}/client/terminal"
 
@@ -4542,6 +4550,19 @@ def create_app(
                     if not (10 <= rows <= 120 and 20 <= cols <= 300):
                         await websocket.send_json({"type": "error", "message": "ignored invalid resize"})
                     else:
+                        result = await _mobile_terminal_tmux_run(
+                            ticket,
+                            "resize-window",
+                            "-t",
+                            ticket.tmux_session,
+                            "-x",
+                            str(cols),
+                            "-y",
+                            str(rows),
+                        )
+                        if result.returncode != 0:
+                            await websocket.send_json({"type": "error", "message": "failed to resize terminal"})
+                            continue
                         await websocket.send_json({"type": "status", "state": "resized", "rows": rows, "cols": cols})
                 elif frame_type == "ping":
                     await websocket.send_json({"type": "status", "state": "pong"})

--- a/src/server.py
+++ b/src/server.py
@@ -596,6 +596,7 @@ class MobileTerminalDisableResponse(BaseModel):
     """Response for emergency mobile terminal disable controls."""
     ok: bool = True
     disabled: bool
+    active_attaches_terminated: int = 0
 
 
 @dataclass
@@ -2149,6 +2150,13 @@ def create_app(
             if str(raw_key.get("id") or "").strip() and str(raw_key.get("public_key") or "").strip():
                 return True
         return False
+
+    def _mobile_terminal_user_can_disable(user_config: dict[str, Any]) -> bool:
+        return (
+            user_config.get("mobile_terminal_owner") is True
+            or user_config.get("can_disable_mobile_terminal") is True
+            or user_config.get("owner") is True
+        )
 
     def _mobile_terminal_device_config(
         user_id: str,
@@ -4454,6 +4462,10 @@ def create_app(
         poll_interval = min(max(poll_interval, 0.2), 2.0)
         stop_event = asyncio.Event()
         counters = {"input_bytes": 0, "output_bytes": 0}
+        active = getattr(app.state, "mobile_terminal_active_attaches", {})
+        if attach_id in active:
+            active[attach_id]["stop_event"] = stop_event
+            active[attach_id]["websocket"] = websocket
 
         async def send_status(state: str, **extra: Any) -> None:
             await websocket.send_json({"type": "status", "state": state, **extra})
@@ -4676,11 +4688,50 @@ def create_app(
         if actor_email is None:
             raise HTTPException(status_code=401, detail="Authentication required")
         user_match = _mobile_terminal_visible_user(actor_email)
-        if user_match is None or user_match[1].get("interactive_shell_access") is not True:
+        if (
+            user_match is None
+            or user_match[1].get("interactive_shell_access") is not True
+            or not _mobile_terminal_user_can_disable(user_match[1])
+        ):
             raise HTTPException(status_code=403, detail="User is not allowed to disable mobile terminal attach")
-        app.state.mobile_terminal_runtime_disabled = True
-        _audit_mobile_terminal("runtime_disabled", user_id=user_match[0])
-        return MobileTerminalDisableResponse(disabled=True)
+        sockets_to_close: list[WebSocket] = []
+        async with app.state.mobile_terminal_lock:
+            app.state.mobile_terminal_runtime_disabled = True
+            app.state.mobile_terminal_tickets.clear()
+            active_records = list(app.state.mobile_terminal_active_attaches.values())
+            app.state.mobile_terminal_active_attaches.clear()
+
+        for active in active_records:
+            stop_event = active.get("stop_event")
+            if hasattr(stop_event, "set"):
+                stop_event.set()
+            websocket = active.get("websocket")
+            if isinstance(websocket, WebSocket):
+                sockets_to_close.append(websocket)
+
+        for websocket in sockets_to_close:
+            try:
+                await websocket.send_json({
+                    "type": "exit",
+                    "code": 1008,
+                    "reason": "mobile_terminal_disabled",
+                })
+            except Exception:
+                pass
+            try:
+                await websocket.close(code=1008)
+            except Exception:
+                pass
+
+        _audit_mobile_terminal(
+            "runtime_disabled",
+            user_id=user_match[0],
+            active_attaches_terminated=len(active_records),
+        )
+        return MobileTerminalDisableResponse(
+            disabled=True,
+            active_attaches_terminated=len(active_records),
+        )
 
     @app.get("/sessions/{session_id}/attach-descriptor")
     async def get_attach_descriptor(session_id: str):

--- a/tests/unit/test_android_api_surface.py
+++ b/tests/unit/test_android_api_surface.py
@@ -516,6 +516,55 @@ def test_mobile_terminal_websocket_enforces_active_attach_limit_at_consume_time(
         }
 
 
+def test_mobile_terminal_disable_requires_owner_authorization():
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    session = _session()
+    app = create_app(
+        session_manager=_manager(session),
+        config=_mobile_terminal_config(private_key),
+    )
+    client = TestClient(app)
+
+    response = client.post("/client/mobile-terminal/disable")
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "User is not allowed to disable mobile terminal attach"
+    assert app.state.mobile_terminal_runtime_disabled is False
+
+
+def test_mobile_terminal_disable_owner_terminates_active_attaches():
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    session = _session()
+    config = _mobile_terminal_config(private_key)
+    config["mobile_terminal"]["allowed_users"]["local_bypass"]["mobile_terminal_owner"] = True
+    app = create_app(
+        session_manager=_manager(session),
+        config=config,
+    )
+    client = TestClient(app)
+    stop_event = MagicMock()
+    app.state.mobile_terminal_active_attaches["active-1"] = {
+        "user_id": "local_bypass",
+        "session_id": session.id,
+        "provider": session.provider,
+        "device_key_id": "test-device",
+        "started_at": time.time(),
+        "stop_event": stop_event,
+    }
+
+    response = client.post("/client/mobile-terminal/disable")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "ok": True,
+        "disabled": True,
+        "active_attaches_terminated": 1,
+    }
+    assert app.state.mobile_terminal_runtime_disabled is True
+    assert app.state.mobile_terminal_active_attaches == {}
+    stop_event.set.assert_called_once_with()
+
+
 def test_client_sessions_fall_back_to_lan_ssh_on_cloudflare_bad_handshake():
     session = _session()
     app = create_app(

--- a/tests/unit/test_android_api_surface.py
+++ b/tests/unit/test_android_api_surface.py
@@ -643,6 +643,51 @@ def test_mobile_terminal_disable_owner_terminates_active_attaches():
     stop_event.set.assert_called_once_with()
 
 
+def test_mobile_terminal_bridge_aborts_if_disable_cleared_attach_before_start():
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    session = _session()
+    app = create_app(
+        session_manager=_manager(session),
+        config=_mobile_terminal_config(private_key),
+    )
+    client = TestClient(app)
+
+    class ClearOnSetDict(dict):
+        def __setitem__(self, key, value):
+            super().__setitem__(key, value)
+            self.clear()
+
+    app.state.mobile_terminal_active_attaches = ClearOnSetDict()
+    ticket_response = client.post(
+        f"/client/sessions/{session.id}/attach-ticket",
+        json={},
+        headers=_sign_mobile_ticket_headers(private_key, session.id),
+    )
+    assert ticket_response.status_code == 200
+    ticket = ticket_response.json()
+
+    with client.websocket_connect("/client/terminal") as websocket:
+        websocket.send_json(
+            {
+                "type": "auth",
+                "ticket_id": ticket["ticket_id"],
+                "ticket_secret": ticket["ticket_secret"],
+                "device_key_id": "test-device",
+                "nonce": "ws-nonce-1",
+                "signature": _sign_mobile_ws_auth(
+                    private_key,
+                    ticket_id=ticket["ticket_id"],
+                    session_id=session.id,
+                ),
+            }
+        )
+        assert websocket.receive_json() == {
+            "type": "exit",
+            "code": 1008,
+            "reason": "mobile_terminal_disabled",
+        }
+
+
 def test_client_sessions_fall_back_to_lan_ssh_on_cloudflare_bad_handshake():
     session = _session()
     app = create_app(

--- a/tests/unit/test_android_api_surface.py
+++ b/tests/unit/test_android_api_surface.py
@@ -1,5 +1,10 @@
 from unittest.mock import MagicMock
+import base64
+import subprocess
+import time
 
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
 from fastapi.testclient import TestClient
 
 from src.models import Session, SessionStatus
@@ -106,6 +111,8 @@ def test_client_bootstrap_reports_termux_attach_defaults():
             "public_ssh_host": "ssh.sm.rajeshgo.li",
             "ssh_username": "rajesh",
             "termux_attach_supported": True,
+            "mobile_terminal_supported": False,
+            "mobile_terminal_ws_url": None,
         },
         "session_open_defaults": {
             "preferred_action": "termux_attach",
@@ -177,6 +184,179 @@ def test_client_sessions_include_termux_attach_metadata():
         "type": "termux_attach",
         "label": "Attach in Termux",
     }
+
+
+def _mobile_terminal_config(private_key) -> dict:
+    config = _android_config()
+    public_key = private_key.public_key().public_bytes(
+        serialization.Encoding.PEM,
+        serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("utf-8")
+    config["mobile_terminal"] = {
+        "enabled": True,
+        "allowed_users": {
+            "local_bypass": {
+                "interactive_shell_access": True,
+                "registered_device_keys": [
+                    {
+                        "id": "test-device",
+                        "public_key": public_key,
+                        "enabled": True,
+                    }
+                ],
+            }
+        },
+        "ticket_ttl_seconds": 30,
+        "auth_frame_timeout_seconds": 3,
+        "max_concurrent_attaches_per_user": 1,
+        "max_concurrent_attaches_per_session": 1,
+        "max_concurrent_attaches_global": 4,
+    }
+    return config
+
+
+def _sign_mobile_ticket_headers(private_key, session_id: str) -> dict[str, str]:
+    timestamp = str(time.time())
+    nonce = "nonce-1"
+    message = "\n".join(
+        [
+            "SM-MOBILE-TERMINAL-TICKET-V1",
+            "POST",
+            f"/client/sessions/{session_id}/attach-ticket",
+            session_id,
+            "local_bypass",
+            "test-device",
+            timestamp,
+            nonce,
+        ]
+    )
+    signature = private_key.sign(message.encode("utf-8"), ec.ECDSA(hashes.SHA256()))
+    return {
+        "X-SM-Device-Key-Id": "test-device",
+        "X-SM-Device-Timestamp": timestamp,
+        "X-SM-Device-Nonce": nonce,
+        "X-SM-Device-Signature": base64.b64encode(signature).decode("ascii"),
+    }
+
+
+def _sign_mobile_ws_auth(private_key, *, ticket_id: str, session_id: str, nonce: str = "ws-nonce-1") -> str:
+    message = "\n".join(
+        [
+            "SM-MOBILE-TERMINAL-WS-V1",
+            ticket_id,
+            session_id,
+            "local_bypass",
+            "test-device",
+            nonce,
+        ]
+    )
+    signature = private_key.sign(message.encode("utf-8"), ec.ECDSA(hashes.SHA256()))
+    return base64.b64encode(signature).decode("ascii")
+
+
+def test_client_sessions_prefer_mobile_terminal_when_enabled():
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    session = _session()
+    app = create_app(
+        session_manager=_manager(session),
+        config=_mobile_terminal_config(private_key),
+    )
+    client = TestClient(app)
+
+    response = client.get("/client/sessions")
+
+    assert response.status_code == 200
+    payload = response.json()["sessions"][0]
+    assert payload["mobile_terminal"] == {
+        "supported": True,
+        "transport": "sm-https-tmux",
+        "ticket_endpoint": "/client/sessions/fork1001/attach-ticket",
+        "ws_url": "wss://sm.rajeshgo.li/client/terminal",
+        "tmux_session": "codex-fork-fork1001",
+        "tmux_socket_name": None,
+        "runtime_mode": "detached_runtime",
+        "requires_device_key": True,
+    }
+    assert payload["primary_action"] == {
+        "type": "mobile_terminal",
+        "label": "Attach",
+    }
+
+
+def test_mobile_attach_ticket_requires_registered_device_signature():
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    session = _session()
+    app = create_app(
+        session_manager=_manager(session),
+        config=_mobile_terminal_config(private_key),
+    )
+    client = TestClient(app)
+
+    missing = client.post(f"/client/sessions/{session.id}/attach-ticket", json={})
+    assert missing.status_code == 401
+
+    response = client.post(
+        f"/client/sessions/{session.id}/attach-ticket",
+        json={},
+        headers=_sign_mobile_ticket_headers(private_key, session.id),
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ticket_id"].startswith("att_")
+    assert len(payload["ticket_secret"]) >= 40
+    assert payload["device_key_id"] == "test-device"
+    assert payload["ws_url"] == "wss://sm.rajeshgo.li/client/terminal"
+    assert payload["ticket_secret"] not in payload["ws_url"]
+
+
+def test_mobile_terminal_websocket_consumes_ticket_and_bridges_tmux(monkeypatch):
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    session = _session()
+    app = create_app(
+        session_manager=_manager(session),
+        config=_mobile_terminal_config(private_key),
+    )
+    client = TestClient(app)
+
+    ticket_response = client.post(
+        f"/client/sessions/{session.id}/attach-ticket",
+        json={},
+        headers=_sign_mobile_ticket_headers(private_key, session.id),
+    )
+    assert ticket_response.status_code == 200
+    ticket = ticket_response.json()
+
+    def fake_run(args, capture_output, text, check, timeout):
+        if "capture-pane" in args:
+            return subprocess.CompletedProcess(args, 0, stdout="live pane output", stderr="")
+        if "send-keys" in args:
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        return subprocess.CompletedProcess(args, 1, stdout="", stderr="unexpected tmux command")
+
+    monkeypatch.setattr("src.server.subprocess.run", fake_run)
+
+    with client.websocket_connect("/client/terminal") as websocket:
+        websocket.send_json(
+            {
+                "type": "auth",
+                "ticket_id": ticket["ticket_id"],
+                "ticket_secret": ticket["ticket_secret"],
+                "device_key_id": "test-device",
+                "nonce": "ws-nonce-1",
+                "signature": _sign_mobile_ws_auth(
+                    private_key,
+                    ticket_id=ticket["ticket_id"],
+                    session_id=session.id,
+                ),
+            }
+        )
+        assert websocket.receive_json() == {"type": "status", "state": "attached", "session_id": session.id}
+        output = websocket.receive_json()
+        assert output == {"type": "output", "mode": "snapshot", "data": "live pane output"}
+        websocket.send_json({"type": "input", "data": "hello"})
+        websocket.send_json({"type": "key", "key": "enter"})
+        websocket.send_json({"type": "detach"})
 
 
 def test_client_sessions_fall_back_to_lan_ssh_on_cloudflare_bad_handshake():

--- a/tests/unit/test_android_api_surface.py
+++ b/tests/unit/test_android_api_surface.py
@@ -353,6 +353,28 @@ def test_mobile_terminal_metadata_preserves_configured_public_path_prefix():
     assert payload["ws_url"] == "wss://sm.rajeshgo.li/sm/client/terminal"
 
 
+def test_mobile_attach_ticket_signature_uses_advertised_public_path_prefix():
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    session = _session()
+    config = _mobile_terminal_config(private_key)
+    config["external_access"]["public_http_path_prefix"] = "/sm"
+    app = create_app(
+        session_manager=_manager(session),
+        config=config,
+    )
+    client = TestClient(app)
+    advertised_path = client.get("/client/sessions").json()["sessions"][0]["mobile_terminal"]["ticket_endpoint"]
+
+    response = client.post(
+        f"/client/sessions/{session.id}/attach-ticket",
+        json={},
+        headers=_sign_mobile_ticket_headers(private_key, session.id, path=advertised_path),
+    )
+
+    assert response.status_code == 200
+    assert response.json()["ticket_id"].startswith("att_")
+
+
 def test_mobile_terminal_metadata_preserves_request_root_path_prefix():
     private_key = ec.generate_private_key(ec.SECP256R1())
     session = _session()

--- a/tests/unit/test_android_api_surface.py
+++ b/tests/unit/test_android_api_surface.py
@@ -8,7 +8,7 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from fastapi.testclient import TestClient
 
 from src.models import Session, SessionStatus
-from src.server import create_app
+from src.server import _issue_device_access_token, create_app
 
 
 def _android_config() -> dict:
@@ -215,16 +215,22 @@ def _mobile_terminal_config(private_key) -> dict:
     return config
 
 
-def _sign_mobile_ticket_headers(private_key, session_id: str) -> dict[str, str]:
+def _sign_mobile_ticket_headers(
+    private_key,
+    session_id: str,
+    *,
+    actor_email: str = "local_bypass",
+    path: str | None = None,
+) -> dict[str, str]:
     timestamp = str(time.time())
     nonce = "nonce-1"
     message = "\n".join(
         [
             "SM-MOBILE-TERMINAL-TICKET-V1",
             "POST",
-            f"/client/sessions/{session_id}/attach-ticket",
+            path or f"/client/sessions/{session_id}/attach-ticket",
             session_id,
-            "local_bypass",
+            actor_email,
             "test-device",
             timestamp,
             nonce,
@@ -281,6 +287,60 @@ def test_client_sessions_prefer_mobile_terminal_when_enabled():
         "type": "mobile_terminal",
         "label": "Attach",
     }
+
+
+def test_client_sessions_hide_mobile_terminal_action_for_unregistered_actor():
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    session = _session()
+    config = _mobile_terminal_config(private_key)
+    token = _issue_device_access_token(config, email="other@example.com", name="Other")["access_token"]
+    app = create_app(
+        session_manager=_manager(session),
+        config=config,
+    )
+    client = TestClient(app, base_url="https://sm.rajeshgo.li")
+
+    response = client.get(
+        "/client/sessions",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()["sessions"][0]
+    assert payload["mobile_terminal"]["supported"] is False
+    assert payload["mobile_terminal"]["reason"] == "mobile terminal user is not configured"
+    assert payload["primary_action"] == {
+        "type": "termux_attach",
+        "label": "Attach in Termux",
+    }
+
+
+def test_mobile_terminal_user_matching_does_not_accept_email_local_part():
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    session = _session()
+    config = _mobile_terminal_config(private_key)
+    config["mobile_terminal"]["allowed_users"] = {
+        "rajesh": config["mobile_terminal"]["allowed_users"]["local_bypass"],
+    }
+    actor_email = "rajesh@example.invalid"
+    token = _issue_device_access_token(config, email=actor_email, name="Rajesh")["access_token"]
+    app = create_app(
+        session_manager=_manager(session),
+        config=config,
+    )
+    client = TestClient(app, base_url="https://sm.rajeshgo.li")
+
+    response = client.post(
+        f"/client/sessions/{session.id}/attach-ticket",
+        json={},
+        headers={
+            "Authorization": f"Bearer {token}",
+            **_sign_mobile_ticket_headers(private_key, session.id, actor_email=actor_email),
+        },
+    )
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "mobile terminal user is not configured"
 
 
 def test_mobile_attach_ticket_requires_registered_device_signature():
@@ -357,6 +417,51 @@ def test_mobile_terminal_websocket_consumes_ticket_and_bridges_tmux(monkeypatch)
         websocket.send_json({"type": "input", "data": "hello"})
         websocket.send_json({"type": "key", "key": "enter"})
         websocket.send_json({"type": "detach"})
+
+
+def test_mobile_terminal_websocket_enforces_active_attach_limit_at_consume_time():
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    session = _session()
+    app = create_app(
+        session_manager=_manager(session),
+        config=_mobile_terminal_config(private_key),
+    )
+    client = TestClient(app)
+
+    ticket_response = client.post(
+        f"/client/sessions/{session.id}/attach-ticket",
+        json={},
+        headers=_sign_mobile_ticket_headers(private_key, session.id),
+    )
+    assert ticket_response.status_code == 200
+    ticket = ticket_response.json()
+    app.state.mobile_terminal_active_attaches["busy"] = {
+        "user_id": "local_bypass",
+        "session_id": "other-session",
+        "provider": "claude",
+        "device_key_id": "test-device",
+        "started_at": time.time(),
+    }
+
+    with client.websocket_connect("/client/terminal") as websocket:
+        websocket.send_json(
+            {
+                "type": "auth",
+                "ticket_id": ticket["ticket_id"],
+                "ticket_secret": ticket["ticket_secret"],
+                "device_key_id": "test-device",
+                "nonce": "ws-nonce-1",
+                "signature": _sign_mobile_ws_auth(
+                    private_key,
+                    ticket_id=ticket["ticket_id"],
+                    session_id=session.id,
+                ),
+            }
+        )
+        assert websocket.receive_json() == {
+            "type": "error",
+            "message": "Too many active mobile attaches for user",
+        }
 
 
 def test_client_sessions_fall_back_to_lan_ssh_on_cloudflare_bad_handshake():

--- a/tests/unit/test_android_api_surface.py
+++ b/tests/unit/test_android_api_surface.py
@@ -289,6 +289,50 @@ def test_client_sessions_prefer_mobile_terminal_when_enabled():
     }
 
 
+def test_mobile_terminal_require_tls_rejects_configured_plaintext_ws_url():
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    session = _session()
+    config = _mobile_terminal_config(private_key)
+    config["mobile_terminal"]["require_tls"] = True
+    config["mobile_terminal"]["ws_url"] = "ws://localhost:8420/client/terminal"
+    app = create_app(
+        session_manager=_manager(session),
+        config=config,
+    )
+    client = TestClient(app)
+
+    response = client.get("/client/sessions")
+
+    assert response.status_code == 200
+    payload = response.json()["sessions"][0]
+    assert payload["mobile_terminal"]["supported"] is False
+    assert payload["mobile_terminal"]["reason"] == "mobile terminal public HTTPS host is not configured"
+    assert payload["primary_action"] == {
+        "type": "termux_attach",
+        "label": "Attach in Termux",
+    }
+
+
+def test_mobile_terminal_can_allow_plaintext_ws_when_tls_not_required():
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    session = _session()
+    config = _mobile_terminal_config(private_key)
+    config["mobile_terminal"]["require_tls"] = False
+    config["mobile_terminal"]["ws_url"] = "ws://localhost:8420/client/terminal"
+    app = create_app(
+        session_manager=_manager(session),
+        config=config,
+    )
+    client = TestClient(app)
+
+    response = client.get("/client/sessions")
+
+    assert response.status_code == 200
+    payload = response.json()["sessions"][0]
+    assert payload["mobile_terminal"]["supported"] is True
+    assert payload["mobile_terminal"]["ws_url"] == "ws://localhost:8420/client/terminal"
+
+
 def test_client_sessions_hide_mobile_terminal_action_for_unregistered_actor():
     private_key = ec.generate_private_key(ec.SECP256R1())
     session = _session()
@@ -387,10 +431,15 @@ def test_mobile_terminal_websocket_consumes_ticket_and_bridges_tmux(monkeypatch)
     assert ticket_response.status_code == 200
     ticket = ticket_response.json()
 
+    commands = []
+
     def fake_run(args, capture_output, text, check, timeout):
+        commands.append(args)
         if "capture-pane" in args:
             return subprocess.CompletedProcess(args, 0, stdout="live pane output", stderr="")
         if "send-keys" in args:
+            return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
+        if "resize-window" in args:
             return subprocess.CompletedProcess(args, 0, stdout="", stderr="")
         return subprocess.CompletedProcess(args, 1, stdout="", stderr="unexpected tmux command")
 
@@ -416,7 +465,10 @@ def test_mobile_terminal_websocket_consumes_ticket_and_bridges_tmux(monkeypatch)
         assert output == {"type": "output", "mode": "snapshot", "data": "live pane output"}
         websocket.send_json({"type": "input", "data": "hello"})
         websocket.send_json({"type": "key", "key": "enter"})
+        websocket.send_json({"type": "resize", "rows": 32, "cols": 120})
+        assert websocket.receive_json() == {"type": "status", "state": "resized", "rows": 32, "cols": 120}
         websocket.send_json({"type": "detach"})
+    assert any("resize-window" in command for command in commands)
 
 
 def test_mobile_terminal_websocket_enforces_active_attach_limit_at_consume_time():

--- a/tests/unit/test_android_api_surface.py
+++ b/tests/unit/test_android_api_surface.py
@@ -221,8 +221,9 @@ def _sign_mobile_ticket_headers(
     *,
     actor_email: str = "local_bypass",
     path: str | None = None,
+    timestamp: str | None = None,
 ) -> dict[str, str]:
-    timestamp = str(time.time())
+    timestamp = timestamp or str(time.time())
     nonce = "nonce-1"
     message = "\n".join(
         [
@@ -333,6 +334,42 @@ def test_mobile_terminal_can_allow_plaintext_ws_when_tls_not_required():
     assert payload["mobile_terminal"]["ws_url"] == "ws://localhost:8420/client/terminal"
 
 
+def test_mobile_terminal_metadata_preserves_configured_public_path_prefix():
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    session = _session()
+    config = _mobile_terminal_config(private_key)
+    config["external_access"]["public_http_path_prefix"] = "/sm"
+    app = create_app(
+        session_manager=_manager(session),
+        config=config,
+    )
+    client = TestClient(app)
+
+    response = client.get("/client/sessions")
+
+    assert response.status_code == 200
+    payload = response.json()["sessions"][0]["mobile_terminal"]
+    assert payload["ticket_endpoint"] == "/sm/client/sessions/fork1001/attach-ticket"
+    assert payload["ws_url"] == "wss://sm.rajeshgo.li/sm/client/terminal"
+
+
+def test_mobile_terminal_metadata_preserves_request_root_path_prefix():
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    session = _session()
+    app = create_app(
+        session_manager=_manager(session),
+        config=_mobile_terminal_config(private_key),
+    )
+    client = TestClient(app, root_path="/sm")
+
+    response = client.get("/client/sessions")
+
+    assert response.status_code == 200
+    payload = response.json()["sessions"][0]["mobile_terminal"]
+    assert payload["ticket_endpoint"] == "/sm/client/sessions/fork1001/attach-ticket"
+    assert payload["ws_url"] == "wss://sm.rajeshgo.li/sm/client/terminal"
+
+
 def test_client_sessions_hide_mobile_terminal_action_for_unregistered_actor():
     private_key = ec.generate_private_key(ec.SECP256R1())
     session = _session()
@@ -412,6 +449,25 @@ def test_mobile_attach_ticket_requires_registered_device_signature():
     assert payload["device_key_id"] == "test-device"
     assert payload["ws_url"] == "wss://sm.rajeshgo.li/client/terminal"
     assert payload["ticket_secret"] not in payload["ws_url"]
+
+
+def test_mobile_attach_ticket_rejects_non_finite_device_timestamp():
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    session = _session()
+    app = create_app(
+        session_manager=_manager(session),
+        config=_mobile_terminal_config(private_key),
+    )
+    client = TestClient(app)
+
+    response = client.post(
+        f"/client/sessions/{session.id}/attach-ticket",
+        json={},
+        headers=_sign_mobile_ticket_headers(private_key, session.id, timestamp="NaN"),
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "Invalid device timestamp"
 
 
 def test_mobile_terminal_websocket_consumes_ticket_and_bridges_tmux(monkeypatch):


### PR DESCRIPTION
## Summary

Implements the approved #703 secure mobile HTTPS attach spec:

- Adds a disabled-by-default `mobile_terminal` server config with registered device-key authorization.
- Adds short-lived attach tickets and authenticated `/client/terminal` WebSocket bridging to server-derived tmux targets only.
- Adds Android app support for an app-generated Android Keystore ECDSA device key, attach ticket requests, and an in-app terminal surface.
- Keeps Termux attach as fallback when mobile terminal support is not advertised.
- Documents the config shape in `config.yaml.example` and adds focused API/WebSocket regression tests.

## Verification

- `./venv/bin/python -m pytest tests/unit/test_android_api_surface.py tests/unit/test_config_loading.py -q`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17 ./gradlew testDebugUnitTest assembleDebug`