### PR TITLE
[codex] Implement human recipient Telegram delivery

### DIFF
--- a/config/email_send.yaml.example
+++ b/config/email_send.yaml.example
@@ -1,21 +1,37 @@
 resend:
   api_key: "re_PLACEHOLDER"
-  domain: "sm.rajeshgo.li"
+  domain: "sm.example.com"
   # Optional stable mailbox address for friendly-name outbound mail and routed replies.
-  reply_address: "reply@sm.rajeshgo.li"
+  reply_address: "reply@sm.example.com"
   # Legacy fallback when Email Routing receives replies on a different domain.
-  # reply_domain: "rajeshgo.li"
+  # reply_domain: "example.com"
+
+humans:
+  operator:
+    display_name: "Human operator"
+    aliases:
+      - "user"
+      - "owner"
+    default_channel: "telegram"
+    channels:
+      telegram:
+        enabled: true
+        delivery: "sender_session_topic"
+      email:
+        enabled: true
+        address_env: "SM_OPERATOR_EMAIL"
+        use: "fallback_only"
 
 users:
-  rajesh:
-    email: "rajeshgoli@gmail.com"
-    name: "Rajesh"
+  operator:
+    email: "operator@example.com"
+    name: "Human operator"
     aliases:
       - "owner"
 
 email_bridge:
   authorized_senders:
-    - "rajeshgoli@gmail.com"
+    - "operator@example.com"
   # Optional shared secret header enforced on inbound worker delivery.
   # worker_secret: "set-a-random-secret"
   # worker_secret_header: "x-email-worker-secret"

--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -198,6 +198,16 @@ class SessionManagerClient:
         detail = data.get("detail") if isinstance(data, dict) else None
         return {"ok": ok, "unavailable": False, "status_code": status_code, "data": data, "detail": detail}
 
+    def lookup_human(self, identifier: str) -> dict:
+        """Resolve one configured human recipient."""
+        identifier_path = urllib.parse.quote(identifier, safe="")
+        data, status_code, unavailable = self._request_with_status("GET", f"/humans/{identifier_path}")
+        if unavailable:
+            return {"ok": False, "unavailable": True, "status_code": None, "data": None, "detail": None}
+        ok = status_code in (200, 201)
+        detail = data.get("detail") if isinstance(data, dict) else None
+        return {"ok": ok, "unavailable": False, "status_code": status_code, "data": data, "detail": detail}
+
     def register_role(self, session_id: str, role: str) -> dict:
         """Register the current session for one registry role."""
         data, status_code, unavailable = self._request_with_status(
@@ -912,6 +922,63 @@ class SessionManagerClient:
             "data": data,
             "detail": detail,
         }
+
+    def send_human_telegram_result(
+        self,
+        *,
+        requester_session_id: Optional[str],
+        recipient: str,
+        text: str,
+    ) -> dict:
+        """Send a configured human recipient message through Telegram."""
+        recipient_path = urllib.parse.quote(recipient, safe="")
+        payload = {
+            "requester_session_id": requester_session_id,
+            "text": text,
+        }
+        data, status_code, unavailable = self._request_with_status(
+            "POST",
+            f"/humans/{recipient_path}/telegram",
+            payload,
+            timeout=15,
+        )
+        if unavailable:
+            return {"ok": False, "unavailable": True, "status_code": None, "data": None, "detail": None}
+        ok = status_code in (200, 201)
+        detail = data.get("detail") if isinstance(data, dict) else None
+        return {"ok": ok, "unavailable": False, "status_code": status_code, "data": data, "detail": detail}
+
+    def send_human_email_result(
+        self,
+        *,
+        requester_session_id: Optional[str],
+        recipient: str,
+        text: str,
+        subject: Optional[str] = None,
+        body_markdown: bool = False,
+        auto_subject: bool = True,
+    ) -> dict:
+        """Send explicit email fallback to a configured human recipient."""
+        recipient_path = urllib.parse.quote(recipient, safe="")
+        payload: dict[str, object] = {
+            "requester_session_id": requester_session_id,
+            "text": text,
+            "body_markdown": body_markdown,
+            "auto_subject": auto_subject,
+        }
+        if subject is not None:
+            payload["subject"] = subject
+        data, status_code, unavailable = self._request_with_status(
+            "POST",
+            f"/humans/{recipient_path}/email",
+            payload,
+            timeout=15,
+        )
+        if unavailable:
+            return {"ok": False, "unavailable": True, "status_code": None, "data": None, "detail": None}
+        ok = status_code in (200, 201)
+        detail = data.get("detail") if isinstance(data, dict) else None
+        return {"ok": ok, "unavailable": False, "status_code": status_code, "data": data, "detail": detail}
 
     def create_session_result(
         self,

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -1975,37 +1975,59 @@ def cmd_email(
         print(f"Error: {exc}", file=sys.stderr)
         return 1
 
-    if len(recipients) == 1 and not cc and body_text is not None and body_html is None:
-        human_result = _lookup_human_result(client, recipients[0])
-        if human_result is not None:
-            if human_result.get("unavailable"):
+    human_targets: dict[str, dict] = {}
+    for target in recipients + cc:
+        human_result = _lookup_human_result(client, target)
+        if human_result is None:
+            continue
+        if human_result.get("unavailable"):
+            print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+            return 2
+        if human_result.get("ok"):
+            human_targets[target] = human_result
+            continue
+        if human_result.get("status_code") not in (None, 404):
+            print(f"Error: {human_result.get('detail') or 'Human recipient lookup failed'}", file=sys.stderr)
+            return 1
+
+    if human_targets:
+        if len(recipients) != 1 or cc:
+            print(
+                "Error: sm email to human recipients supports exactly one recipient and no --cc",
+                file=sys.stderr,
+            )
+            return 1
+        if body_text is None or body_html is not None:
+            print(
+                "Error: sm email to human recipients supports plain text or markdown bodies only",
+                file=sys.stderr,
+            )
+            return 1
+
+        sender = getattr(client, "send_human_email_result", None)
+        if callable(sender):
+            result = sender(
+                requester_session_id=sender_session_id,
+                recipient=recipients[0],
+                text=body_text,
+                subject=subject,
+                body_markdown=body_markdown,
+                auto_subject=not bool(str(subject or "").strip()),
+            )
+            if result.get("unavailable"):
                 print(UNAVAILABLE_MESSAGE, file=sys.stderr)
                 return 2
-            if human_result.get("ok"):
-                sender = getattr(client, "send_human_email_result", None)
-                if callable(sender):
-                    result = sender(
-                        requester_session_id=sender_session_id,
-                        recipient=recipients[0],
-                        text=body_text,
-                        subject=subject,
-                        body_markdown=body_markdown,
-                        auto_subject=not bool(str(subject or "").strip()),
-                    )
-                    if result.get("unavailable"):
-                        print(UNAVAILABLE_MESSAGE, file=sys.stderr)
-                        return 2
-                    if not result.get("ok"):
-                        print(f"Error: {result.get('detail') or 'Failed to send email'}", file=sys.stderr)
-                        return 1
-                    payload = result.get("data") or {}
-                    print(f"Email sent to {payload.get('recipient') or recipients[0]}")
-                    if payload.get("subject"):
-                        print(f"  Subject: {payload['subject']}")
-                    return 0
-            elif human_result.get("status_code") not in (None, 404):
-                print(f"Error: {human_result.get('detail') or 'Human recipient lookup failed'}", file=sys.stderr)
+            if not result.get("ok"):
+                print(f"Error: {result.get('detail') or 'Failed to send email'}", file=sys.stderr)
                 return 1
+            payload = result.get("data") or {}
+            print(f"Email sent to {payload.get('recipient') or recipients[0]}")
+            if payload.get("subject"):
+                print(f"  Subject: {payload['subject']}")
+            return 0
+
+        print("Error: Human email delivery is not supported by this Session Manager server", file=sys.stderr)
+        return 1
 
     if not str(subject or "").strip():
         print("Error: --subject is required for non-human registered email", file=sys.stderr)

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -1563,37 +1563,34 @@ def cmd_send(
         )
     identifier = identifiers[0]
 
-    # Exact session IDs stay first. Human aliases come before friendly-name and
-    # role fallback because configured human aliases are reserved identifiers.
-    try:
-        exact_session = client.get_session(identifier, timeout=SEND_API_TIMEOUT)
-    except TypeError:
-        exact_session = client.get_session(identifier)
-    if exact_session:
-        session_id, session, resolve_unavailable = identifier, exact_session, False
-    else:
+    # Resolve live session IDs, aliases, and friendly names before human aliases
+    # so legacy sessions created before alias reservation cannot be rerouted.
+    session_id, session, resolve_unavailable = resolve_session_id_with_status(
+        client,
+        identifier,
+        timeout=SEND_API_TIMEOUT,
+    )
+    if resolve_unavailable:
+        print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+        return 2
+    if session_id is None:
         human_send_rc = _try_send_human_telegram(
             client,
             identifier,
             text,
             sender_session_id=sender_session_id,
             delivery_mode=delivery_mode,
+            timeout_seconds=timeout_seconds,
+            notify_on_delivery=notify_on_delivery,
             notify_after_seconds=effective_notify_after,
+            remind_soft_threshold=remind_soft_threshold,
+            remind_hard_threshold=remind_hard_threshold,
+            parent_session_id=parent_session_id,
             track_seconds=track_seconds,
         )
         if human_send_rc is not None:
             return human_send_rc
 
-        # Resolve identifier to session ID and get session details
-        session_id, session, resolve_unavailable = resolve_session_id_with_status(
-            client,
-            identifier,
-            timeout=SEND_API_TIMEOUT,
-        )
-    if resolve_unavailable:
-        print(UNAVAILABLE_MESSAGE, file=sys.stderr)
-        return 2
-    if session_id is None:
         ensure_result = client.ensure_role(identifier, requester_session_id=sender_session_id)
         if ensure_result.get("unavailable"):
             print(UNAVAILABLE_MESSAGE, file=sys.stderr)
@@ -1714,7 +1711,12 @@ def _try_send_human_telegram(
     *,
     sender_session_id: Optional[str],
     delivery_mode: str,
+    timeout_seconds: Optional[int],
+    notify_on_delivery: bool,
     notify_after_seconds: Optional[int],
+    remind_soft_threshold: Optional[int],
+    remind_hard_threshold: Optional[int],
+    parent_session_id: Optional[str],
     track_seconds: Optional[int],
 ) -> Optional[int]:
     """Send to a configured human recipient, returning None when not a human."""
@@ -1733,9 +1735,18 @@ def _try_send_human_telegram(
     if not sender_session_id:
         print("Error: human Telegram delivery requires a managed sender session", file=sys.stderr)
         return 2
-    if delivery_mode != "sequential" or notify_after_seconds or track_seconds is not None:
+    if (
+        delivery_mode != "sequential"
+        or timeout_seconds is not None
+        or notify_on_delivery
+        or notify_after_seconds is not None
+        or remind_soft_threshold is not None
+        or remind_hard_threshold is not None
+        or parent_session_id is not None
+        or track_seconds is not None
+    ):
         print(
-            "Error: human Telegram delivery only supports plain sequential sends without --wait/--track/--urgent",
+            "Error: human Telegram delivery only supports plain sequential sends without delivery modifiers",
             file=sys.stderr,
         )
         return 1

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -595,14 +595,25 @@ def cmd_unregister(client: SessionManagerClient, session_id: Optional[str], role
 
 def cmd_lookup(client: SessionManagerClient, role: str) -> int:
     """
-    Resolve a durable registry role or live session identifier to a session ID.
-
-    Prints only the session ID on stdout so it can be used in command substitution.
+    Resolve a human recipient, durable registry role, or live session identifier.
     """
     normalized_role = (role or "").strip()
     if not normalized_role:
         print("Error: role is required", file=sys.stderr)
         return 1
+
+    human_result = _lookup_human_result(client, normalized_role)
+    if human_result is not None:
+        if human_result.get("unavailable"):
+            print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+            return 2
+        if human_result.get("ok"):
+            _print_human_lookup(human_result.get("data") or {})
+            return 0
+        if human_result.get("status_code") not in (None, 404):
+            detail = human_result.get("detail") or "Human recipient lookup failed"
+            print(f"Error: {detail}", file=sys.stderr)
+            return 1
 
     result = client.lookup_role(normalized_role)
     if result.get("unavailable"):
@@ -635,6 +646,32 @@ def cmd_lookup(client: SessionManagerClient, role: str) -> int:
         return 1
     print(session_id)
     return 0
+
+
+def _lookup_human_result(client: SessionManagerClient, identifier: str) -> Optional[dict]:
+    """Return a human lookup result when the client supports the endpoint."""
+    lookup = getattr(client, "lookup_human", None)
+    if not callable(lookup):
+        return None
+    result = lookup(identifier)
+    return result if isinstance(result, dict) else None
+
+
+def _print_human_lookup(payload: dict) -> None:
+    """Print human-recipient lookup details for operator-facing discovery."""
+    recipient = payload.get("recipient") or "<unknown>"
+    aliases = [alias for alias in payload.get("aliases") or [] if alias != recipient]
+    print(f"Human recipient: {recipient}")
+    if aliases:
+        print(f"Aliases: {', '.join(aliases)}")
+    print(f"Default delivery: {payload.get('default_channel') or 'unknown'}")
+    channels = payload.get("available_channels") or []
+    if channels:
+        print(f"Available delivery: {', '.join(channels)}")
+    if "telegram" in channels:
+        print("Telegram delivery posts into the sending agent's SM-managed Telegram thread.")
+    if "email" in channels:
+        print("Email is available as fallback/explicit only; use email sparingly.")
 
 
 def _lookup_ambiguous_match_error(identifier: str, matches: list[dict]) -> str:
@@ -1526,12 +1563,33 @@ def cmd_send(
         )
     identifier = identifiers[0]
 
-    # Resolve identifier to session ID and get session details
-    session_id, session, resolve_unavailable = resolve_session_id_with_status(
-        client,
-        identifier,
-        timeout=SEND_API_TIMEOUT,
-    )
+    # Exact session IDs stay first. Human aliases come before friendly-name and
+    # role fallback because configured human aliases are reserved identifiers.
+    try:
+        exact_session = client.get_session(identifier, timeout=SEND_API_TIMEOUT)
+    except TypeError:
+        exact_session = client.get_session(identifier)
+    if exact_session:
+        session_id, session, resolve_unavailable = identifier, exact_session, False
+    else:
+        human_send_rc = _try_send_human_telegram(
+            client,
+            identifier,
+            text,
+            sender_session_id=sender_session_id,
+            delivery_mode=delivery_mode,
+            notify_after_seconds=effective_notify_after,
+            track_seconds=track_seconds,
+        )
+        if human_send_rc is not None:
+            return human_send_rc
+
+        # Resolve identifier to session ID and get session details
+        session_id, session, resolve_unavailable = resolve_session_id_with_status(
+            client,
+            identifier,
+            timeout=SEND_API_TIMEOUT,
+        )
     if resolve_unavailable:
         print(UNAVAILABLE_MESSAGE, file=sys.stderr)
         return 2
@@ -1581,7 +1639,7 @@ def cmd_send(
                 payload = email_result.get("data") or {}
                 recipients = payload.get("to") or []
                 recipient_summary = ", ".join(
-                    f"{item.get('username')} <{item.get('email')}>"
+                    str(item.get("username") or identifier)
                     for item in recipients
                     if isinstance(item, dict)
                 ) or identifier
@@ -1649,6 +1707,63 @@ def cmd_send(
     return 0
 
 
+def _try_send_human_telegram(
+    client: SessionManagerClient,
+    identifier: str,
+    text: str,
+    *,
+    sender_session_id: Optional[str],
+    delivery_mode: str,
+    notify_after_seconds: Optional[int],
+    track_seconds: Optional[int],
+) -> Optional[int]:
+    """Send to a configured human recipient, returning None when not a human."""
+    human_result = _lookup_human_result(client, identifier)
+    if human_result is None:
+        return None
+    if human_result.get("unavailable"):
+        print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+        return 2
+    if not human_result.get("ok"):
+        if human_result.get("status_code") in (None, 404):
+            return None
+        detail = human_result.get("detail") or "Human recipient lookup failed"
+        print(f"Error: {detail}", file=sys.stderr)
+        return 1
+    if not sender_session_id:
+        print("Error: human Telegram delivery requires a managed sender session", file=sys.stderr)
+        return 2
+    if delivery_mode != "sequential" or notify_after_seconds or track_seconds is not None:
+        print(
+            "Error: human Telegram delivery only supports plain sequential sends without --wait/--track/--urgent",
+            file=sys.stderr,
+        )
+        return 1
+
+    sender = getattr(client, "send_human_telegram_result", None)
+    if not callable(sender):
+        return None
+    result = sender(
+        requester_session_id=sender_session_id,
+        recipient=identifier,
+        text=text,
+    )
+    if not isinstance(result, dict):
+        print("Error: Failed to send Telegram message", file=sys.stderr)
+        return 1
+    if result.get("unavailable"):
+        print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+        return 2
+    if not result.get("ok"):
+        print(f"Error: {result.get('detail') or 'Failed to send Telegram message'}", file=sys.stderr)
+        return 1
+
+    payload = result.get("data") or {}
+    print(f"Telegram sent to {payload.get('recipient') or identifier}")
+    print(f"Thread: {payload.get('thread') or 'sender session topic'}")
+    return 0
+
+
 def _cmd_send_batch(
     client: SessionManagerClient,
     identifiers: list[str],
@@ -1705,6 +1820,11 @@ def _cmd_send_batch(
             print(f"Email sent to {recipient_summary}")
             continue
 
+        if item.get("delivery_kind") == "human_telegram" and status == "delivered":
+            print(f"Telegram sent to {item.get('target_name') or item.get('identifier')}")
+            print("Thread: sender session topic")
+            continue
+
         if status in {"delivered", "queued"}:
             had_session_success = True
             target_name = item.get("target_name") or item.get("session_id") or item.get("identifier")
@@ -1739,10 +1859,7 @@ def _cmd_send_batch(
 def _email_result_summary(item: dict) -> str:
     """Format one batch email result for CLI output."""
     username = item.get("email_username")
-    email = item.get("email_address")
-    if username and email:
-        return f"{username} <{email}>"
-    return email or item.get("identifier") or "<unknown>"
+    return username or item.get("identifier") or "<unknown>"
 
 
 def _send_option_labels(
@@ -1831,7 +1948,7 @@ def cmd_email(
     *,
     sender_session_id: Optional[str],
     recipients_raw: str,
-    subject: str,
+    subject: Optional[str] = None,
     body: Optional[str] = None,
     text_file: Optional[str] = None,
     html_file: Optional[str] = None,
@@ -1847,9 +1964,6 @@ def cmd_email(
     if not recipients:
         print("Error: at least one recipient is required", file=sys.stderr)
         return 1
-    if not str(subject or "").strip():
-        print("Error: --subject is required", file=sys.stderr)
-        return 1
 
     try:
         body_text, body_html, body_markdown = _load_email_body(
@@ -1859,6 +1973,42 @@ def cmd_email(
         )
     except (OSError, ValueError) as exc:
         print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    if len(recipients) == 1 and not cc and body_text is not None and body_html is None:
+        human_result = _lookup_human_result(client, recipients[0])
+        if human_result is not None:
+            if human_result.get("unavailable"):
+                print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+                return 2
+            if human_result.get("ok"):
+                sender = getattr(client, "send_human_email_result", None)
+                if callable(sender):
+                    result = sender(
+                        requester_session_id=sender_session_id,
+                        recipient=recipients[0],
+                        text=body_text,
+                        subject=subject,
+                        body_markdown=body_markdown,
+                        auto_subject=not bool(str(subject or "").strip()),
+                    )
+                    if result.get("unavailable"):
+                        print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+                        return 2
+                    if not result.get("ok"):
+                        print(f"Error: {result.get('detail') or 'Failed to send email'}", file=sys.stderr)
+                        return 1
+                    payload = result.get("data") or {}
+                    print(f"Email sent to {payload.get('recipient') or recipients[0]}")
+                    if payload.get("subject"):
+                        print(f"  Subject: {payload['subject']}")
+                    return 0
+            elif human_result.get("status_code") not in (None, 404):
+                print(f"Error: {human_result.get('detail') or 'Human recipient lookup failed'}", file=sys.stderr)
+                return 1
+
+    if not str(subject or "").strip():
+        print("Error: --subject is required for non-human registered email", file=sys.stderr)
         return 1
 
     result = client.send_email_result(
@@ -1880,13 +2030,45 @@ def cmd_email(
     payload = result.get("data") or {}
     to_entries = payload.get("to") or []
     to_summary = ", ".join(
-        f"{entry.get('username')} <{entry.get('email')}>"
+        str(entry.get("username") or "recipient")
         for entry in to_entries
         if isinstance(entry, dict)
     ) or ", ".join(recipients)
     print(f"Email sent to {to_summary}")
     if payload.get("subject"):
         print(f"  Subject: {payload['subject']}")
+    return 0
+
+
+def cmd_telegram(
+    client: SessionManagerClient,
+    *,
+    sender_session_id: Optional[str],
+    recipient: str,
+    text: str,
+) -> int:
+    """Send a configured human recipient message through Telegram."""
+    if not sender_session_id:
+        print("Error: sm telegram requires a managed session (CLAUDE_SESSION_MANAGER_ID not set)", file=sys.stderr)
+        return 2
+    sender = getattr(client, "send_human_telegram_result", None)
+    if not callable(sender):
+        print("Error: Telegram human delivery is not available", file=sys.stderr)
+        return 1
+    result = sender(
+        requester_session_id=sender_session_id,
+        recipient=recipient,
+        text=text,
+    )
+    if result.get("unavailable"):
+        print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+        return 2
+    if not result.get("ok"):
+        print(f"Error: {result.get('detail') or 'Failed to send Telegram message'}", file=sys.stderr)
+        return 1
+    payload = result.get("data") or {}
+    print(f"Telegram sent to {payload.get('recipient') or recipient}")
+    print(f"Thread: {payload.get('thread') or 'sender session topic'}")
     return 0
 
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -177,10 +177,10 @@ def main():
     subagents_parser = subparsers.add_parser("subagents", help="List subagents spawned by a session")
     subagents_parser.add_argument("session_id", help="Session ID")
 
-    # sm send <session-id> "<text>"
-    send_parser = subparsers.add_parser("send", help="Send input to a session")
-    send_parser.add_argument("session_id", help="Target session ID, friendly name, alias, or comma-delimited list")
-    send_parser.add_argument("text", help="Text to send to the session")
+    # sm send <session-id|human> "<text>"
+    send_parser = subparsers.add_parser("send", help="Send input to a session or Telegram to a human recipient")
+    send_parser.add_argument("session_id", help="Target session ID, friendly name, human alias, or comma-delimited list")
+    send_parser.add_argument("text", help="Text to send")
     send_parser.add_argument("--sequential", action="store_true", help="Wait for idle before sending (default)")
     send_parser.add_argument("--important", action="store_true", help="Inject immediately, queue behind current work")
     send_parser.add_argument("--urgent", action="store_true", help="Interrupt immediately")
@@ -196,10 +196,20 @@ def main():
     )
     send_parser.add_argument("--track-seconds", dest="track", type=int, metavar="SECONDS", help=argparse.SUPPRESS)
 
-    # sm email <user[,user2]> --subject "..." [--body ... | --text file | --html file]
-    email_parser = subparsers.add_parser("email", help="Send a routed email to registered user(s)")
-    email_parser.add_argument("recipients", help="Registered user(s), comma-separated")
-    email_parser.add_argument("--subject", required=True, help="Email subject line")
+    # sm telegram <human> "<text>" / sm tg <human> "<text>"
+    telegram_parser = subparsers.add_parser(
+        "telegram",
+        aliases=["tg"],
+        help="Send a Telegram message to a configured human recipient",
+    )
+    telegram_parser.add_argument("recipient", help="Configured human recipient or alias")
+    telegram_parser.add_argument("text", help="Text to post into this session's Telegram topic")
+
+    # sm email <human> "<text>" OR sm email <user[,user2]> --subject "..." [--body ... | --text file | --html file]
+    email_parser = subparsers.add_parser("email", help="Send explicit email fallback to a human recipient or registered user")
+    email_parser.add_argument("recipients", help="Human/registered user(s), comma-separated")
+    email_parser.add_argument("message", nargs="?", help="Inline plain-text body")
+    email_parser.add_argument("--subject", help="Email subject line")
     email_parser.add_argument("--body", help="Inline plain-text body")
     email_parser.add_argument("--text", help="Text/Markdown file for the body")
     email_parser.add_argument("--html", help="HTML file for the body")
@@ -727,14 +737,14 @@ def main():
         help="Registry role to release",
     )
 
-    # sm lookup <role>
+    # sm lookup <role|human>
     lookup_parser = subparsers.add_parser(
         "lookup",
-        help="Resolve a durable agent registry role to its session ID",
+        help="Resolve a human recipient, durable registry role, or live session",
     )
     lookup_parser.add_argument(
         "role",
-        help="Registry role to resolve",
+        help="Human alias, registry role, or session name to resolve",
     )
 
     # sm roster
@@ -869,13 +879,26 @@ def main():
             wait_seconds=wait_seconds, notify_on_stop=notify_on_stop,
             track_seconds=getattr(args, "track", None),
         ))
+    elif args.command in ("telegram", "tg"):
+        sys.exit(commands.cmd_telegram(
+            client,
+            sender_session_id=session_id,
+            recipient=args.recipient,
+            text=args.text,
+        ))
     elif args.command == "email":
+        inline_body = getattr(args, "body", None)
+        if inline_body is not None and getattr(args, "message", None) is not None:
+            print("Error: use either positional message or --body, not both", file=sys.stderr)
+            sys.exit(1)
+        if inline_body is None:
+            inline_body = getattr(args, "message", None)
         sys.exit(commands.cmd_email(
             client,
             sender_session_id=session_id,
             recipients_raw=args.recipients,
             subject=args.subject,
-            body=getattr(args, "body", None),
+            body=inline_body,
             text_file=getattr(args, "text", None),
             html_file=getattr(args, "html", None),
             cc_raw=getattr(args, "cc", None),

--- a/src/email_handler.py
+++ b/src/email_handler.py
@@ -179,10 +179,7 @@ class EmailHandler:
 
     def lookup_user(self, identifier: str) -> Optional[RegisteredEmailUser]:
         """Resolve one registered user by username or alias."""
-        configured_user = self._lookup_configured_user(identifier)
-        if configured_user is not None:
-            return configured_user
-        return self._lookup_human_email_user(identifier)
+        return self._lookup_configured_user(identifier)
 
     def _lookup_configured_user(self, identifier: str) -> Optional[RegisteredEmailUser]:
         """Resolve one legacy registered email user by username or alias."""
@@ -213,6 +210,10 @@ class EmailHandler:
     def human_reserved_names(self) -> set[str]:
         """Return every configured human canonical name and alias."""
         return self.human_registry().reserved_names()
+
+    def lookup_human_email_user(self, identifier: str) -> Optional[RegisteredEmailUser]:
+        """Resolve an email-enabled human recipient for explicit human email delivery."""
+        return self._lookup_human_email_user(identifier)
 
     def _lookup_human_email_user(self, identifier: str) -> Optional[RegisteredEmailUser]:
         """Resolve an email-enabled human recipient into the email send model."""
@@ -580,6 +581,36 @@ class EmailHandler:
         auto_subject: bool = False,
     ) -> dict[str, Any]:
         """Send a reply-routable email from one managed session to registered user(s)."""
+        to_users = self.resolve_users(to_identifiers)
+        cc_users = self.resolve_users(cc_identifiers or []) if cc_identifiers else []
+        return await self.send_agent_email_to_resolved_users(
+            sender_session_id=sender_session_id,
+            sender_name=sender_name,
+            sender_provider=sender_provider,
+            to_users=to_users,
+            cc_users=cc_users,
+            subject=subject,
+            body_text=body_text,
+            body_html=body_html,
+            body_markdown=body_markdown,
+            auto_subject=auto_subject,
+        )
+
+    async def send_agent_email_to_resolved_users(
+        self,
+        *,
+        sender_session_id: str,
+        sender_name: str,
+        sender_provider: str,
+        to_users: list[RegisteredEmailUser],
+        cc_users: Optional[list[RegisteredEmailUser]] = None,
+        subject: Optional[str] = None,
+        body_text: Optional[str] = None,
+        body_html: Optional[str] = None,
+        body_markdown: bool = False,
+        auto_subject: bool = False,
+    ) -> dict[str, Any]:
+        """Send a reply-routable email to pre-resolved users."""
         if not self.bridge_is_available():
             raise RuntimeError(f"Email bridge config is unavailable at {self.bridge_config}")
 
@@ -593,8 +624,9 @@ class EmailHandler:
         if not text_payload and not html_payload:
             raise ValueError("Email body is required")
 
-        to_users = self.resolve_users(to_identifiers)
-        cc_users = self.resolve_users(cc_identifiers or []) if cc_identifiers else []
+        cc_users = cc_users or []
+        if not to_users:
+            raise LookupError("No registered email users were provided")
 
         if body_markdown and text_payload and not html_payload:
             html_payload = self.render_markdown_to_html(text_payload)

--- a/src/email_handler.py
+++ b/src/email_handler.py
@@ -16,6 +16,8 @@ from typing import Any, Optional
 import httpx
 import yaml
 
+from .human_recipients import HumanRecipient, HumanRecipientConfigError, HumanRecipientRegistry
+
 logger = logging.getLogger(__name__)
 
 # Path to existing email automation
@@ -177,6 +179,13 @@ class EmailHandler:
 
     def lookup_user(self, identifier: str) -> Optional[RegisteredEmailUser]:
         """Resolve one registered user by username or alias."""
+        configured_user = self._lookup_configured_user(identifier)
+        if configured_user is not None:
+            return configured_user
+        return self._lookup_human_email_user(identifier)
+
+    def _lookup_configured_user(self, identifier: str) -> Optional[RegisteredEmailUser]:
+        """Resolve one legacy registered email user by username or alias."""
         needle = str(identifier or "").strip().lower()
         if not needle:
             return None
@@ -192,6 +201,45 @@ class EmailHandler:
             if needle in resolved.aliases:
                 return resolved
         return None
+
+    def human_registry(self) -> HumanRecipientRegistry:
+        """Return the configured human recipient registry."""
+        return HumanRecipientRegistry.from_config(self._load_bridge_config())
+
+    def lookup_human(self, identifier: str) -> Optional[HumanRecipient]:
+        """Resolve one configured human recipient by canonical name or alias."""
+        return self.human_registry().lookup(identifier)
+
+    def human_reserved_names(self) -> set[str]:
+        """Return every configured human canonical name and alias."""
+        return self.human_registry().reserved_names()
+
+    def _lookup_human_email_user(self, identifier: str) -> Optional[RegisteredEmailUser]:
+        """Resolve an email-enabled human recipient into the email send model."""
+        try:
+            human = self.lookup_human(identifier)
+        except HumanRecipientConfigError:
+            raise
+        if human is None:
+            return None
+        channel = human.channel("email")
+        if channel is None:
+            return None
+
+        email_address = channel.resolved_address()
+        if not email_address:
+            canonical_user = self._lookup_configured_user(human.name)
+            if canonical_user is not None:
+                email_address = canonical_user.email
+        if not email_address:
+            return None
+
+        return RegisteredEmailUser(
+            username=human.name,
+            email=email_address,
+            display_name=human.display_name,
+            aliases=human.aliases,
+        )
 
     def resolve_users(self, identifiers: list[str]) -> list[RegisteredEmailUser]:
         """Resolve a list of usernames/aliases into distinct registered users."""

--- a/src/human_recipients.py
+++ b/src/human_recipients.py
@@ -1,0 +1,156 @@
+"""File-driven human recipient registry."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+class HumanRecipientConfigError(ValueError):
+    """Raised when the human recipient registry is ambiguous or malformed."""
+
+
+@dataclass(frozen=True)
+class HumanChannel:
+    """One configured delivery channel for a human recipient."""
+
+    name: str
+    enabled: bool = False
+    delivery: Optional[str] = None
+    address: Optional[str] = None
+    address_env: Optional[str] = None
+    use: Optional[str] = None
+
+    def resolved_address(self) -> Optional[str]:
+        """Return the configured email address without requiring it in source config."""
+        if self.address:
+            return self.address
+        if self.address_env:
+            value = os.environ.get(self.address_env)
+            if value:
+                return value.strip() or None
+        return None
+
+
+@dataclass(frozen=True)
+class HumanRecipient:
+    """A canonical human/operator recipient and its aliases."""
+
+    name: str
+    display_name: str
+    aliases: tuple[str, ...]
+    default_channel: str
+    channels: dict[str, HumanChannel]
+
+    @property
+    def available_channels(self) -> tuple[str, ...]:
+        """Return enabled channel names in config order."""
+        return tuple(name for name, channel in self.channels.items() if channel.enabled)
+
+    def channel(self, name: str) -> Optional[HumanChannel]:
+        """Return an enabled channel by name."""
+        channel = self.channels.get(name)
+        if not channel or not channel.enabled:
+            return None
+        return channel
+
+
+class HumanRecipientRegistry:
+    """Resolve configured human/operator aliases."""
+
+    def __init__(self, recipients: dict[str, HumanRecipient]):
+        self._recipients = recipients
+        alias_map: dict[str, list[str]] = {}
+        for recipient in recipients.values():
+            for alias in recipient.aliases:
+                alias_map.setdefault(alias, []).append(recipient.name)
+        self._alias_map = alias_map
+
+    @classmethod
+    def from_config(cls, config: Any) -> "HumanRecipientRegistry":
+        """Build a registry from a mapping containing a top-level humans key."""
+        if not isinstance(config, dict):
+            return cls({})
+        raw_humans = config.get("humans") or {}
+        if not isinstance(raw_humans, dict):
+            return cls({})
+
+        recipients: dict[str, HumanRecipient] = {}
+        for raw_name, raw_spec in raw_humans.items():
+            recipient = cls._normalize_human(raw_name, raw_spec)
+            if recipient is not None:
+                recipients[recipient.name] = recipient
+        return cls(recipients)
+
+    @staticmethod
+    def _normalize_human(raw_name: Any, raw_spec: Any) -> Optional[HumanRecipient]:
+        canonical = str(raw_name or "").strip().lower()
+        if not canonical or not isinstance(raw_spec, dict):
+            return None
+
+        display_name = str(
+            raw_spec.get("display_name") or raw_spec.get("name") or canonical
+        ).strip() or canonical
+        default_channel = str(raw_spec.get("default_channel") or "telegram").strip().lower()
+
+        aliases: list[str] = [canonical]
+        raw_aliases = raw_spec.get("aliases") or []
+        if isinstance(raw_aliases, str):
+            raw_aliases = [raw_aliases]
+        aliases.extend(str(alias).strip().lower() for alias in raw_aliases if str(alias).strip())
+        normalized_aliases = tuple(dict.fromkeys(alias for alias in aliases if alias))
+
+        channels = HumanRecipientRegistry._normalize_channels(raw_spec.get("channels") or {})
+        return HumanRecipient(
+            name=canonical,
+            display_name=display_name,
+            aliases=normalized_aliases,
+            default_channel=default_channel,
+            channels=channels,
+        )
+
+    @staticmethod
+    def _normalize_channels(raw_channels: Any) -> dict[str, HumanChannel]:
+        if not isinstance(raw_channels, dict):
+            return {}
+
+        channels: dict[str, HumanChannel] = {}
+        for raw_name, raw_spec in raw_channels.items():
+            name = str(raw_name or "").strip().lower()
+            if not name:
+                continue
+            if isinstance(raw_spec, bool):
+                channels[name] = HumanChannel(name=name, enabled=raw_spec)
+                continue
+            if not isinstance(raw_spec, dict):
+                continue
+            channels[name] = HumanChannel(
+                name=name,
+                enabled=bool(raw_spec.get("enabled", False)),
+                delivery=str(raw_spec.get("delivery") or "").strip().lower() or None,
+                address=str(raw_spec.get("address") or "").strip() or None,
+                address_env=str(raw_spec.get("address_env") or "").strip() or None,
+                use=str(raw_spec.get("use") or "").strip().lower() or None,
+            )
+        return channels
+
+    def lookup(self, identifier: str) -> Optional[HumanRecipient]:
+        """Resolve one alias to a human recipient."""
+        needle = str(identifier or "").strip().lower()
+        if not needle:
+            return None
+        matches = self._alias_map.get(needle, [])
+        if len(matches) > 1:
+            raise HumanRecipientConfigError(
+                f'Human recipient alias "{identifier}" is configured for multiple humans: '
+                + ", ".join(sorted(matches))
+            )
+        if not matches:
+            return None
+        return self._recipients.get(matches[0])
+
+    def reserved_names(self) -> set[str]:
+        """Return every canonical name and alias reserved by humans."""
+        return set(self._alias_map)
+

--- a/src/notifier.py
+++ b/src/notifier.py
@@ -224,6 +224,48 @@ class Notifier:
 
         return msg_id is not None
 
+    async def send_human_message_to_session_topic(
+        self,
+        *,
+        session: Session,
+        recipient_name: str,
+        message: str,
+    ) -> tuple[bool, Optional[str]]:
+        """Post an agent-to-human message into the sender session's Telegram topic."""
+        if not self.telegram:
+            return False, "Telegram is not configured"
+        if not session.telegram_chat_id:
+            return False, "Sender session has no Telegram chat configured"
+
+        if not session.telegram_thread_id:
+            session_manager = getattr(self, "session_manager", None)
+            ensure_topic = getattr(session_manager, "_ensure_telegram_topic", None) if session_manager else None
+            if callable(ensure_topic) and getattr(session, "status", None) != SessionStatus.STOPPED:
+                try:
+                    await ensure_topic(session)
+                except Exception as exc:
+                    logger.warning(
+                        "Failed to ensure Telegram topic for human recipient send from %s: %s",
+                        session.id,
+                        exc,
+                    )
+            if not session.telegram_thread_id:
+                return False, "Sender session has no SM-managed Telegram topic"
+
+        body = str(message or "").strip()
+        if not body:
+            return False, "Message body is required"
+        recipient = str(recipient_name or "human").strip() or "human"
+        payload = f"To {recipient}:\n{body}"
+
+        msg_id = await self.telegram.send_notification(
+            chat_id=session.telegram_chat_id,
+            message=payload,
+            session_id=session.id,
+            message_thread_id=session.telegram_thread_id,
+        )
+        return (msg_id is not None), None if msg_id is not None else "Telegram send failed"
+
     async def _notify_email(self, event: NotificationEvent, message: str) -> bool:
         """Send notification via Email."""
         if not self.email:

--- a/src/server.py
+++ b/src/server.py
@@ -51,6 +51,7 @@ from .models import (
 from .cli.commands import validate_friendly_name
 from .cli.dispatch import get_auto_remind_config
 from .bug_report_store import BugReportStore
+from .human_recipients import HumanRecipient, HumanRecipientConfigError
 from .mobile_analytics import MobileAnalyticsBuilder
 
 logger = logging.getLogger(__name__)
@@ -648,7 +649,7 @@ class SendInputBatchResult(BaseModel):
     """Per-recipient result returned by batch send."""
     identifier: str
     status: Literal["delivered", "queued", "emailed", "failed"]
-    delivery_kind: Literal["session", "email", "none"]
+    delivery_kind: Literal["session", "email", "human_telegram", "none"]
     session_id: Optional[str] = None
     target_name: Optional[str] = None
     provider: Optional[str] = None
@@ -896,6 +897,26 @@ class SendEmailRequest(BaseModel):
     body_html: Optional[str] = None
     body_markdown: bool = False
     auto_subject: bool = False
+
+
+class HumanRecipientResponse(BaseModel):
+    """Lookup response for one configured human recipient."""
+    recipient: str
+    display_name: str
+    aliases: list[str]
+    default_channel: str
+    available_channels: list[str]
+    telegram_delivery: Optional[str] = None
+    email_use: Optional[str] = None
+
+
+class HumanDeliveryRequest(BaseModel):
+    """Request to deliver a message to one human recipient."""
+    requester_session_id: Optional[str] = None
+    text: str
+    subject: Optional[str] = None
+    body_markdown: bool = False
+    auto_subject: bool = True
 
 
 class InboundEmailRequest(BaseModel):
@@ -1378,12 +1399,115 @@ def create_app(
         valid, error = validate_friendly_name(name)
         if not valid:
             raise HTTPException(status_code=400, detail=f"Invalid name: {error}")
+        validator = getattr(app.state.session_manager, "validate_reserved_human_name", None)
+        if callable(validator):
+            identity_error = validator(name)
+            if isinstance(identity_error, str) and identity_error:
+                raise HTTPException(status_code=400, detail=identity_error)
 
     def _email_handler_or_503():
         handler = getattr(app.state, "email_handler", None)
         if handler is None:
             raise HTTPException(status_code=503, detail="Email bridge not configured")
         return handler
+
+    def _lookup_human_optional(identifier: str) -> Optional[HumanRecipient]:
+        handler = getattr(app.state, "email_handler", None)
+        lookup = getattr(handler, "lookup_human", None) if handler is not None else None
+        if not callable(lookup):
+            return None
+        try:
+            return lookup(identifier)
+        except HumanRecipientConfigError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    def _lookup_human_or_404(identifier: str) -> HumanRecipient:
+        human = _lookup_human_optional(identifier)
+        if human is None:
+            raise HTTPException(status_code=404, detail="Human recipient not configured")
+        return human
+
+    def _human_to_response(human: HumanRecipient) -> HumanRecipientResponse:
+        telegram_channel = human.channel("telegram")
+        email_channel = human.channel("email")
+        return HumanRecipientResponse(
+            recipient=human.name,
+            display_name=human.display_name,
+            aliases=list(human.aliases),
+            default_channel=human.default_channel,
+            available_channels=list(human.available_channels),
+            telegram_delivery=telegram_channel.delivery if telegram_channel else None,
+            email_use=email_channel.use if email_channel else None,
+        )
+
+    async def _send_human_telegram(identifier: str, request: HumanDeliveryRequest) -> dict[str, Any]:
+        human = _lookup_human_or_404(identifier)
+        channel = human.channel("telegram")
+        if channel is None:
+            raise HTTPException(status_code=400, detail=f'Human recipient "{human.name}" has no enabled Telegram channel')
+        if channel.delivery not in (None, "sender_session_topic"):
+            raise HTTPException(status_code=400, detail=f'Unsupported Telegram delivery "{channel.delivery}"')
+        if not request.requester_session_id:
+            raise HTTPException(status_code=400, detail="Managed sender session is required for Telegram delivery")
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
+
+        sender_session = app.state.session_manager.get_session(request.requester_session_id)
+        if not sender_session:
+            raise HTTPException(status_code=404, detail="Sender session not found")
+
+        notifier = getattr(app.state, "notifier", None)
+        sender = getattr(notifier, "send_human_message_to_session_topic", None) if notifier else None
+        if not callable(sender):
+            raise HTTPException(status_code=503, detail="Telegram delivery is not configured")
+        ok, detail = await sender(
+            session=sender_session,
+            recipient_name=human.name,
+            message=request.text,
+        )
+        if not ok:
+            status_code = 503 if detail == "Telegram is not configured" else 409
+            raise HTTPException(status_code=status_code, detail=detail or "Telegram delivery failed")
+        return {
+            "status": "sent",
+            "recipient": human.name,
+            "channel": "telegram",
+            "thread": "sender session topic",
+            "sender_session_id": sender_session.id,
+        }
+
+    async def _send_human_email(identifier: str, request: HumanDeliveryRequest) -> dict[str, Any]:
+        human = _lookup_human_or_404(identifier)
+        channel = human.channel("email")
+        if channel is None:
+            raise HTTPException(status_code=400, detail=f'Human recipient "{human.name}" has no enabled email channel')
+
+        handler = _email_handler_or_503()
+        lookup_user = getattr(handler, "lookup_user", None)
+        try:
+            resolved_email_user = lookup_user(identifier) if callable(lookup_user) else None
+        except HumanRecipientConfigError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        if resolved_email_user is None:
+            raise HTTPException(status_code=400, detail=f'Human recipient "{human.name}" has no resolved email address')
+
+        email_payload = await _send_registered_email(
+            SendEmailRequest(
+                requester_session_id=request.requester_session_id,
+                recipients=[identifier],
+                subject=request.subject,
+                body_text=request.text,
+                body_markdown=request.body_markdown,
+                auto_subject=request.auto_subject,
+            )
+        )
+        return {
+            "status": "sent",
+            "recipient": human.name,
+            "channel": "email",
+            "subject": email_payload.get("subject"),
+            "to": [{"username": human.name}],
+        }
 
     def _normalize_identifier_list(values: list[str]) -> list[str]:
         identifiers: list[str] = []
@@ -1425,11 +1549,12 @@ def create_app(
         )
 
     def _resolve_live_send_target(identifier: str) -> Optional[Session]:
-        session = _resolve_session_or_registry_role(identifier)
-        if session is not None:
-            return session
         if not app.state.session_manager:
             return None
+
+        session = app.state.session_manager.get_session(identifier)
+        if session is not None:
+            return session
 
         lister = getattr(app.state.session_manager, "list_sessions", None)
         alias_getter = getattr(app.state.session_manager, "get_session_aliases", None)
@@ -1447,6 +1572,12 @@ def create_app(
         for candidate in sessions or []:
             if _effective_session_name(candidate, sync_native_title=False) == identifier:
                 return candidate
+
+        getter = getattr(app.state.session_manager, "lookup_agent_registration", None)
+        if callable(getter):
+            registration = getter(identifier)
+            if registration is not None:
+                return app.state.session_manager.get_session(registration.session_id)
         return None
 
     async def _send_registered_email(request: SendEmailRequest) -> dict[str, Any]:
@@ -1534,8 +1665,38 @@ def create_app(
         request: SendInputBatchRequest,
     ) -> SendInputBatchResult:
         """Resolve and deliver one batch send target."""
-        session = _resolve_live_send_target(identifier)
+        session = app.state.session_manager.get_session(identifier) if app.state.session_manager else None
         bootstrapped = False
+
+        if session is None:
+            human = _lookup_human_optional(identifier)
+            if human is not None:
+                try:
+                    payload = await _send_human_telegram(
+                        identifier,
+                        HumanDeliveryRequest(
+                            requester_session_id=request.sender_session_id,
+                            text=request.text,
+                        ),
+                    )
+                except HTTPException as exc:
+                    return SendInputBatchResult(
+                        identifier=identifier,
+                        status="failed",
+                        delivery_kind="none",
+                        target_name=human.name,
+                        detail=_detail_text(exc.detail),
+                    )
+                return SendInputBatchResult(
+                    identifier=identifier,
+                    status="delivered",
+                    delivery_kind="human_telegram",
+                    target_name=payload.get("recipient") or human.name,
+                    detail="Telegram sent to sender session topic",
+                )
+
+        if session is None:
+            session = _resolve_live_send_target(identifier)
 
         if session is None and app.state.session_manager:
             ensurer = getattr(app.state.session_manager, "ensure_role_session", None)
@@ -4455,6 +4616,14 @@ def create_app(
 
         session = app.state.session_manager.get_session(session_id)
         if not session:
+            if _lookup_human_optional(session_id) is not None:
+                return await _send_human_telegram(
+                    session_id,
+                    HumanDeliveryRequest(
+                        requester_session_id=request.sender_session_id,
+                        text=request.text,
+                    ),
+                )
             raise HTTPException(status_code=404, detail="Session not found")
         return await _deliver_send_input_to_session(session, request)
 
@@ -4993,6 +5162,21 @@ Provide ONLY the summary, no preamble or questions."""
             success = True
 
         return {"status": "sent" if success else "failed"}
+
+    @app.get("/humans/{identifier}", response_model=HumanRecipientResponse)
+    async def lookup_human_recipient(identifier: str):
+        """Resolve one configured human recipient."""
+        return _human_to_response(_lookup_human_or_404(identifier))
+
+    @app.post("/humans/{identifier}/telegram")
+    async def send_human_telegram(identifier: str, request: HumanDeliveryRequest):
+        """Send a human recipient message through the sender session Telegram topic."""
+        return await _send_human_telegram(identifier, request)
+
+    @app.post("/humans/{identifier}/email")
+    async def send_human_email(identifier: str, request: HumanDeliveryRequest):
+        """Send an explicit email fallback to a configured human recipient."""
+        return await _send_human_email(identifier, request)
 
     @app.post("/email/send")
     async def send_registered_email(request: SendEmailRequest):

--- a/src/server.py
+++ b/src/server.py
@@ -1575,7 +1575,6 @@ def create_app(
             and request.timeout_seconds is None
             and request.notify_on_delivery is False
             and request.notify_after_seconds is None
-            and request.notify_on_stop is False
             and request.remind_soft_threshold is None
             and request.remind_hard_threshold is None
             and request.remind_cancel_on_reply_session_id is None

--- a/src/server.py
+++ b/src/server.py
@@ -1485,7 +1485,7 @@ def create_app(
         handler = _email_handler_or_503()
         lookup_user = getattr(handler, "lookup_user", None)
         try:
-            resolved_email_user = lookup_user(identifier) if callable(lookup_user) else None
+            resolved_email_user = lookup_user(human.name) if callable(lookup_user) else None
         except HumanRecipientConfigError as exc:
             raise HTTPException(status_code=409, detail=str(exc)) from exc
         if resolved_email_user is None:
@@ -1494,7 +1494,7 @@ def create_app(
         email_payload = await _send_registered_email(
             SendEmailRequest(
                 requester_session_id=request.requester_session_id,
-                recipients=[identifier],
+                recipients=[human.name],
                 subject=request.subject,
                 body_text=request.text,
                 body_markdown=request.body_markdown,

--- a/src/server.py
+++ b/src/server.py
@@ -1483,7 +1483,7 @@ def create_app(
             raise HTTPException(status_code=400, detail=f'Human recipient "{human.name}" has no enabled email channel')
 
         handler = _email_handler_or_503()
-        lookup_user = getattr(handler, "lookup_user", None)
+        lookup_user = getattr(handler, "lookup_human_email_user", None)
         try:
             resolved_email_user = lookup_user(human.name) if callable(lookup_user) else None
         except HumanRecipientConfigError as exc:
@@ -1491,16 +1491,37 @@ def create_app(
         if resolved_email_user is None:
             raise HTTPException(status_code=400, detail=f'Human recipient "{human.name}" has no resolved email address')
 
-        email_payload = await _send_registered_email(
-            SendEmailRequest(
-                requester_session_id=request.requester_session_id,
-                recipients=[human.name],
+        if not getattr(handler, "bridge_is_available", lambda: False)():
+            raise HTTPException(status_code=503, detail="Email bridge is unavailable")
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
+        if not request.requester_session_id:
+            raise HTTPException(status_code=400, detail="Managed sender session is required for email delivery")
+
+        sender_session = app.state.session_manager.get_session(request.requester_session_id)
+        if not sender_session:
+            raise HTTPException(status_code=404, detail="Sender session not found")
+
+        sender = getattr(handler, "send_agent_email_to_resolved_users", None)
+        if not callable(sender):
+            raise HTTPException(status_code=503, detail="Explicit human email delivery is not configured")
+        try:
+            email_payload = await sender(
+                sender_session_id=sender_session.id,
+                sender_name=_effective_session_name(sender_session),
+                sender_provider=getattr(sender_session, "provider", "claude"),
+                to_users=[resolved_email_user],
+                cc_users=[],
                 subject=request.subject,
                 body_text=request.text,
+                body_html=None,
                 body_markdown=request.body_markdown,
                 auto_subject=request.auto_subject,
             )
-        )
+        except LookupError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except (RuntimeError, ValueError) as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
         return {
             "status": "sent",
             "recipient": human.name,
@@ -1546,6 +1567,19 @@ def create_app(
             and request.remind_soft_threshold is None
             and request.remind_hard_threshold is None
             and request.remind_cancel_on_reply_session_id is None
+        )
+
+    def _send_request_supports_human_telegram(request: SendInputRequest) -> bool:
+        return (
+            request.delivery_mode == "sequential"
+            and request.timeout_seconds is None
+            and request.notify_on_delivery is False
+            and request.notify_after_seconds is None
+            and request.notify_on_stop is False
+            and request.remind_soft_threshold is None
+            and request.remind_hard_threshold is None
+            and request.remind_cancel_on_reply_session_id is None
+            and request.parent_session_id is None
         )
 
     def _resolve_live_send_target(identifier: str) -> Optional[Session]:
@@ -1597,6 +1631,17 @@ def create_app(
         cc = _normalize_identifier_list(request.cc)
         if not recipients:
             raise HTTPException(status_code=400, detail="At least one email recipient is required")
+
+        for identifier in recipients + cc:
+            human = _lookup_human_optional(identifier)
+            if human is not None:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f'Human recipient "{human.name}" must use explicit human email delivery; '
+                        "generic email routing is not allowed"
+                    ),
+                )
 
         try:
             return await handler.send_agent_email(
@@ -1671,6 +1716,14 @@ def create_app(
         if session is None:
             human = _lookup_human_optional(identifier)
             if human is not None:
+                if not _send_request_supports_human_telegram(request):
+                    return SendInputBatchResult(
+                        identifier=identifier,
+                        status="failed",
+                        delivery_kind="none",
+                        target_name=human.name,
+                        detail="human Telegram delivery only supports plain sequential sends without --wait/--track/--urgent",
+                    )
                 try:
                     payload = await _send_human_telegram(
                         identifier,
@@ -4617,6 +4670,11 @@ def create_app(
         session = app.state.session_manager.get_session(session_id)
         if not session:
             if _lookup_human_optional(session_id) is not None:
+                if not _send_request_supports_human_telegram(request):
+                    raise HTTPException(
+                        status_code=400,
+                        detail="human Telegram delivery only supports plain sequential sends without --wait/--track/--urgent",
+                    )
                 return await _send_human_telegram(
                     session_id,
                     HumanDeliveryRequest(

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -3934,9 +3934,9 @@ class SessionManager:
 
     def _load_human_recipient_config(self) -> dict[str, Any]:
         """Load human recipient config from config.yaml and the email bridge config."""
-        merged: dict[str, Any] = {}
+        humans: dict[str, Any] = {}
         if isinstance(self.config.get("humans"), dict):
-            merged["humans"] = self.config["humans"]
+            self._merge_human_recipient_entries(humans, self.config["humans"])
 
         bridge_config = (self.config.get("email") or {}).get("bridge_config")
         bridge_path = Path(str(bridge_config or DEFAULT_EMAIL_BRIDGE_CONFIG_PATH)).expanduser()
@@ -3947,8 +3947,64 @@ class SessionManager:
                 logger.warning("Failed to load human recipient config from %s: %s", bridge_path, exc)
                 bridge_data = {}
             if isinstance(bridge_data, dict) and isinstance(bridge_data.get("humans"), dict):
-                merged["humans"] = bridge_data["humans"]
+                self._merge_human_recipient_entries(humans, bridge_data["humans"])
+
+        merged: dict[str, Any] = {}
+        if humans:
+            merged["humans"] = humans
         return merged
+
+    @staticmethod
+    def _merge_human_recipient_entries(target: dict[str, Any], source: dict[str, Any]) -> None:
+        """Merge human recipient entries while preserving aliases from earlier sources."""
+        for raw_name, raw_spec in source.items():
+            name = str(raw_name or "").strip().lower()
+            if not name or not isinstance(raw_spec, dict):
+                continue
+
+            incoming = dict(raw_spec)
+            existing = target.get(name)
+            if not isinstance(existing, dict):
+                target[name] = incoming
+                continue
+
+            aliases = SessionManager._merged_human_aliases(existing.get("aliases"), incoming.get("aliases"))
+            channels = SessionManager._merged_human_channels(existing.get("channels"), incoming.get("channels"))
+
+            merged_spec = dict(existing)
+            merged_spec.update(incoming)
+            if aliases:
+                merged_spec["aliases"] = aliases
+            if channels:
+                merged_spec["channels"] = channels
+            target[name] = merged_spec
+
+    @staticmethod
+    def _merged_human_aliases(*alias_values: Any) -> list[str]:
+        aliases: list[str] = []
+        seen: set[str] = set()
+        for value in alias_values:
+            if isinstance(value, str):
+                values = [value]
+            elif isinstance(value, list):
+                values = value
+            else:
+                values = []
+            for alias in values:
+                normalized = str(alias or "").strip().lower()
+                if normalized and normalized not in seen:
+                    aliases.append(normalized)
+                    seen.add(normalized)
+        return aliases
+
+    @staticmethod
+    def _merged_human_channels(existing: Any, incoming: Any) -> dict[str, Any]:
+        channels: dict[str, Any] = {}
+        if isinstance(existing, dict):
+            channels.update(existing)
+        if isinstance(incoming, dict):
+            channels.update(incoming)
+        return channels
 
     def human_recipient_registry(self) -> HumanRecipientRegistry:
         """Return the configured human recipient registry."""

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -18,6 +18,9 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional, Callable, Awaitable, Any
 
+import yaml
+
+from .human_recipients import HumanRecipientConfigError, HumanRecipientRegistry
 from .models import (
     AgentRegistration,
     ActivityState,
@@ -51,6 +54,7 @@ DEFAULT_LOG_DIR = "/tmp/claude-sessions"
 DEFAULT_SESSION_STATE_FILE = "~/.local/share/claude-sessions/sessions.json"
 LEGACY_TMP_SESSION_STATE_FILE = "/tmp/claude-sessions/sessions.json"
 CODEX_FORK_DISABLE_STARTUP_UPDATE_ARGS = ["-c", "check_for_update_on_startup=false"]
+DEFAULT_EMAIL_BRIDGE_CONFIG_PATH = Path(__file__).resolve().parents[1] / "config" / "email_send.yaml"
 
 DEFAULT_MAINTAINER_BOOTSTRAP_PROMPT = textwrap.dedent(
     """
@@ -3026,6 +3030,9 @@ class SessionManager:
         normalized_role = self.normalize_agent_role(role)
         if not normalized_role:
             raise ValueError("Role cannot be empty")
+        reserved_error = self.validate_reserved_human_name(normalized_role)
+        if reserved_error:
+            raise ValueError(reserved_error)
 
         session = self.sessions.get(session_id)
         if not session:
@@ -3919,6 +3926,48 @@ class SessionManager:
         if normalized_name in reserved_aliases and normalized_name != primary_alias:
             return f'Name "{friendly_name}" is reserved for registry identity "{normalized_name}"'
 
+        human_error = self.validate_reserved_human_name(friendly_name)
+        if human_error:
+            return human_error
+
+        return None
+
+    def _load_human_recipient_config(self) -> dict[str, Any]:
+        """Load human recipient config from config.yaml and the email bridge config."""
+        merged: dict[str, Any] = {}
+        if isinstance(self.config.get("humans"), dict):
+            merged["humans"] = self.config["humans"]
+
+        bridge_config = (self.config.get("email") or {}).get("bridge_config")
+        bridge_path = Path(str(bridge_config or DEFAULT_EMAIL_BRIDGE_CONFIG_PATH)).expanduser()
+        if bridge_path.exists():
+            try:
+                bridge_data = yaml.safe_load(bridge_path.read_text(encoding="utf-8")) or {}
+            except Exception as exc:
+                logger.warning("Failed to load human recipient config from %s: %s", bridge_path, exc)
+                bridge_data = {}
+            if isinstance(bridge_data, dict) and isinstance(bridge_data.get("humans"), dict):
+                merged["humans"] = bridge_data["humans"]
+        return merged
+
+    def human_recipient_registry(self) -> HumanRecipientRegistry:
+        """Return the configured human recipient registry."""
+        return HumanRecipientRegistry.from_config(self._load_human_recipient_config())
+
+    def human_reserved_names(self) -> set[str]:
+        """Return every configured human recipient canonical name and alias."""
+        try:
+            return self.human_recipient_registry().reserved_names()
+        except HumanRecipientConfigError:
+            raise
+
+    def validate_reserved_human_name(self, name: str) -> Optional[str]:
+        """Return an error when a name is reserved for a configured human recipient."""
+        normalized_name = self.normalize_agent_role(name)
+        if not normalized_name:
+            return None
+        if normalized_name in self.human_reserved_names():
+            return f'Name "{name}" is reserved for configured human recipient "{normalized_name}"'
         return None
 
     def list_sessions(self, include_stopped: bool = False) -> list[Session]:

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -453,12 +453,25 @@ class TestHumanRecipientEndpoints:
         sample_session,
     ):
         mock_email_handler.lookup_human.return_value = _human_recipient()
-        mock_email_handler.lookup_user.return_value = RegisteredEmailUser(
-            username="rajesh",
-            email="private@example.com",
-            display_name="Human operator",
-            aliases=("rajesh", "user"),
-        )
+
+        def lookup_user(identifier: str):
+            if identifier == "user":
+                return RegisteredEmailUser(
+                    username="other-user",
+                    email="wrong@example.com",
+                    display_name="Wrong recipient",
+                    aliases=("user",),
+                )
+            if identifier == "rajesh":
+                return RegisteredEmailUser(
+                    username="rajesh",
+                    email="private@example.com",
+                    display_name="Human operator",
+                    aliases=("rajesh", "user"),
+                )
+            return None
+
+        mock_email_handler.lookup_user.side_effect = lookup_user
         mock_session_manager.get_session.return_value = sample_session
         mock_email_handler.send_agent_email = AsyncMock(
             return_value={
@@ -478,6 +491,10 @@ class TestHumanRecipientEndpoints:
         assert data["recipient"] == "rajesh"
         assert data["channel"] == "email"
         assert "private@example.com" not in json.dumps(data)
+        assert "wrong@example.com" not in json.dumps(data)
+        mock_email_handler.lookup_user.assert_called_once_with("rajesh")
+        mock_email_handler.send_agent_email.assert_awaited_once()
+        assert mock_email_handler.send_agent_email.await_args.kwargs["to_identifiers"] == ["rajesh"]
 
     def test_human_telegram_missing_sender_topic_fails_clearly(
         self,

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -447,6 +447,57 @@ class TestHumanRecipientEndpoints:
             message="default route",
         )
 
+    def test_send_input_batch_allows_default_notify_on_stop_for_human_telegram(
+        self,
+        mock_session_manager,
+        mock_output_monitor,
+        mock_email_handler,
+    ):
+        sender_session = Session(
+            id="sender123",
+            name="sender-session",
+            working_dir="/tmp/sender",
+            tmux_session="claude-sender123",
+            log_file="/tmp/sender.log",
+            status=SessionStatus.RUNNING,
+            telegram_chat_id=12345,
+            telegram_thread_id=67890,
+        )
+        mock_email_handler.lookup_human.return_value = _human_recipient()
+        mock_session_manager.get_session.side_effect = lambda session_id: {
+            "sender123": sender_session,
+        }.get(session_id)
+        notifier = MagicMock()
+        notifier.send_human_message_to_session_topic = AsyncMock(return_value=(True, None))
+        app = create_app(
+            session_manager=mock_session_manager,
+            notifier=notifier,
+            output_monitor=mock_output_monitor,
+            email_handler=mock_email_handler,
+            config={},
+        )
+        client = TestClient(app)
+
+        response = client.post(
+            "/sessions/input-batch",
+            json={
+                "recipients": ["user"],
+                "text": "default cli route",
+                "sender_session_id": "sender123",
+                "notify_on_stop": True,
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["ok"] is True
+        assert data["results"][0]["delivery_kind"] == "human_telegram"
+        notifier.send_human_message_to_session_topic.assert_awaited_once_with(
+            session=sender_session,
+            recipient_name="rajesh",
+            message="default cli route",
+        )
+
     def test_send_input_batch_rejects_urgent_human_telegram(
         self,
         mock_session_manager,

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -58,7 +58,9 @@ def mock_email_handler():
     mock.bridge_session_id_header.return_value = "x-email-session-id"
     mock.normalize_explicit_session_id.side_effect = lambda value: value.strip().lower() if value else None
     mock.send_agent_email = AsyncMock(return_value={"to": [], "cc": [], "subject": "test"})
+    mock.send_agent_email_to_resolved_users = AsyncMock(return_value={"to": [], "cc": [], "subject": "test"})
     mock.lookup_human.return_value = None
+    mock.lookup_human_email_user.return_value = None
     mock.lookup_user.return_value = None
     mock.is_authorized_sender.return_value = True
     mock.extract_routed_session_id.return_value = None
@@ -445,6 +447,55 @@ class TestHumanRecipientEndpoints:
             message="default route",
         )
 
+    def test_send_input_batch_rejects_urgent_human_telegram(
+        self,
+        mock_session_manager,
+        mock_output_monitor,
+        mock_email_handler,
+    ):
+        sender_session = Session(
+            id="sender123",
+            name="sender-session",
+            working_dir="/tmp/sender",
+            tmux_session="claude-sender123",
+            log_file="/tmp/sender.log",
+            status=SessionStatus.RUNNING,
+            telegram_chat_id=12345,
+            telegram_thread_id=67890,
+        )
+        mock_email_handler.lookup_human.return_value = _human_recipient()
+        mock_session_manager.get_session.side_effect = lambda session_id: {
+            "sender123": sender_session,
+        }.get(session_id)
+        notifier = MagicMock()
+        notifier.send_human_message_to_session_topic = AsyncMock(return_value=(True, None))
+        app = create_app(
+            session_manager=mock_session_manager,
+            notifier=notifier,
+            output_monitor=mock_output_monitor,
+            email_handler=mock_email_handler,
+            config={},
+        )
+        client = TestClient(app)
+
+        response = client.post(
+            "/sessions/input-batch",
+            json={
+                "recipients": ["user"],
+                "text": "urgent route",
+                "sender_session_id": "sender123",
+                "delivery_mode": "urgent",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["ok"] is False
+        assert data["results"][0]["status"] == "failed"
+        assert data["results"][0]["delivery_kind"] == "none"
+        assert "human Telegram delivery only supports plain sequential sends" in data["results"][0]["detail"]
+        notifier.send_human_message_to_session_topic.assert_not_awaited()
+
     def test_explicit_human_email_redacts_address(
         self,
         test_client,
@@ -471,9 +522,9 @@ class TestHumanRecipientEndpoints:
                 )
             return None
 
-        mock_email_handler.lookup_user.side_effect = lookup_user
+        mock_email_handler.lookup_human_email_user.side_effect = lookup_user
         mock_session_manager.get_session.return_value = sample_session
-        mock_email_handler.send_agent_email = AsyncMock(
+        mock_email_handler.send_agent_email_to_resolved_users = AsyncMock(
             return_value={
                 "to": [{"username": "rajesh", "email": "private@example.com"}],
                 "cc": [],
@@ -492,9 +543,33 @@ class TestHumanRecipientEndpoints:
         assert data["channel"] == "email"
         assert "private@example.com" not in json.dumps(data)
         assert "wrong@example.com" not in json.dumps(data)
-        mock_email_handler.lookup_user.assert_called_once_with("rajesh")
-        mock_email_handler.send_agent_email.assert_awaited_once()
-        assert mock_email_handler.send_agent_email.await_args.kwargs["to_identifiers"] == ["rajesh"]
+        mock_email_handler.lookup_human_email_user.assert_called_once_with("rajesh")
+        mock_email_handler.send_agent_email_to_resolved_users.assert_awaited_once()
+        assert mock_email_handler.send_agent_email_to_resolved_users.await_args.kwargs["to_users"][0].username == "rajesh"
+
+    def test_generic_email_rejects_human_alias(
+        self,
+        test_client,
+        mock_session_manager,
+        mock_email_handler,
+        sample_session,
+    ):
+        mock_session_manager.get_session.return_value = sample_session
+        mock_email_handler.lookup_human.return_value = _human_recipient()
+
+        response = test_client.post(
+            "/email/send",
+            json={
+                "requester_session_id": "test123",
+                "recipients": ["user"],
+                "subject": "Wrong path",
+                "body_html": "<p>Hello</p>",
+            },
+        )
+
+        assert response.status_code == 400
+        assert "generic email routing is not allowed" in response.json()["detail"]
+        mock_email_handler.send_agent_email.assert_not_awaited()
 
     def test_human_telegram_missing_sender_topic_fails_clearly(
         self,

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -11,6 +11,8 @@ from unittest.mock import MagicMock, AsyncMock, patch
 from fastapi.testclient import TestClient
 
 from src.server import create_app
+from src.email_handler import RegisteredEmailUser
+from src.human_recipients import HumanChannel, HumanRecipient
 from src.models import Session, SessionStatus, Subagent, SubagentStatus, DeliveryResult
 
 
@@ -56,11 +58,35 @@ def mock_email_handler():
     mock.bridge_session_id_header.return_value = "x-email-session-id"
     mock.normalize_explicit_session_id.side_effect = lambda value: value.strip().lower() if value else None
     mock.send_agent_email = AsyncMock(return_value={"to": [], "cc": [], "subject": "test"})
+    mock.lookup_human.return_value = None
+    mock.lookup_user.return_value = None
     mock.is_authorized_sender.return_value = True
     mock.extract_routed_session_id.return_value = None
     mock.extract_subject_from_raw_email.return_value = None
     mock.extract_reply_message_body.side_effect = lambda value: value
     return mock
+
+
+def _human_recipient() -> HumanRecipient:
+    return HumanRecipient(
+        name="rajesh",
+        display_name="Human operator",
+        aliases=("rajesh", "rajeshgoli", "user"),
+        default_channel="telegram",
+        channels={
+            "telegram": HumanChannel(
+                name="telegram",
+                enabled=True,
+                delivery="sender_session_topic",
+            ),
+            "email": HumanChannel(
+                name="email",
+                enabled=True,
+                address="private@example.com",
+                use="fallback_only",
+            ),
+        },
+    )
 
 
 @pytest.fixture
@@ -313,6 +339,228 @@ class TestSessionEndpoints:
             text="[sm] user requests status, please update now using sm status",
             delivery_mode="important",
         )
+
+
+class TestHumanRecipientEndpoints:
+    """Tests for human-recipient lookup and delivery."""
+
+    def test_lookup_human_alias(self, test_client, mock_email_handler):
+        mock_email_handler.lookup_human.return_value = _human_recipient()
+
+        response = test_client.get("/humans/rajeshgoli")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["recipient"] == "rajesh"
+        assert data["aliases"] == ["rajesh", "rajeshgoli", "user"]
+        assert data["default_channel"] == "telegram"
+        assert data["available_channels"] == ["telegram", "email"]
+        assert data["telegram_delivery"] == "sender_session_topic"
+        assert data["email_use"] == "fallback_only"
+
+    def test_forced_telegram_posts_to_sender_topic(
+        self,
+        mock_session_manager,
+        mock_output_monitor,
+        mock_email_handler,
+        sample_session,
+    ):
+        sample_session.telegram_chat_id = 12345
+        sample_session.telegram_thread_id = 67890
+        mock_email_handler.lookup_human.return_value = _human_recipient()
+        mock_session_manager.get_session.return_value = sample_session
+        notifier = MagicMock()
+        notifier.send_human_message_to_session_topic = AsyncMock(return_value=(True, None))
+        app = create_app(
+            session_manager=mock_session_manager,
+            notifier=notifier,
+            output_monitor=mock_output_monitor,
+            email_handler=mock_email_handler,
+            config={},
+        )
+        client = TestClient(app)
+
+        response = client.post(
+            "/humans/user/telegram",
+            json={"requester_session_id": "test123", "text": "hello human"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["channel"] == "telegram"
+        assert response.json()["thread"] == "sender session topic"
+        notifier.send_human_message_to_session_topic.assert_awaited_once_with(
+            session=sample_session,
+            recipient_name="rajesh",
+            message="hello human",
+        )
+
+    def test_send_input_batch_defaults_human_to_telegram(
+        self,
+        mock_session_manager,
+        mock_output_monitor,
+        mock_email_handler,
+    ):
+        sender_session = Session(
+            id="sender123",
+            name="sender-session",
+            working_dir="/tmp/sender",
+            tmux_session="claude-sender123",
+            log_file="/tmp/sender.log",
+            status=SessionStatus.RUNNING,
+            telegram_chat_id=12345,
+            telegram_thread_id=67890,
+        )
+        mock_email_handler.lookup_human.return_value = _human_recipient()
+        mock_session_manager.get_session.side_effect = lambda session_id: {
+            "sender123": sender_session,
+        }.get(session_id)
+        notifier = MagicMock()
+        notifier.send_human_message_to_session_topic = AsyncMock(return_value=(True, None))
+        app = create_app(
+            session_manager=mock_session_manager,
+            notifier=notifier,
+            output_monitor=mock_output_monitor,
+            email_handler=mock_email_handler,
+            config={},
+        )
+        client = TestClient(app)
+
+        response = client.post(
+            "/sessions/input-batch",
+            json={
+                "recipients": ["user"],
+                "text": "default route",
+                "sender_session_id": "sender123",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["ok"] is True
+        assert data["results"][0]["delivery_kind"] == "human_telegram"
+        assert data["results"][0]["target_name"] == "rajesh"
+        notifier.send_human_message_to_session_topic.assert_awaited_once_with(
+            session=sender_session,
+            recipient_name="rajesh",
+            message="default route",
+        )
+
+    def test_explicit_human_email_redacts_address(
+        self,
+        test_client,
+        mock_session_manager,
+        mock_email_handler,
+        sample_session,
+    ):
+        mock_email_handler.lookup_human.return_value = _human_recipient()
+        mock_email_handler.lookup_user.return_value = RegisteredEmailUser(
+            username="rajesh",
+            email="private@example.com",
+            display_name="Human operator",
+            aliases=("rajesh", "user"),
+        )
+        mock_session_manager.get_session.return_value = sample_session
+        mock_email_handler.send_agent_email = AsyncMock(
+            return_value={
+                "to": [{"username": "rajesh", "email": "private@example.com"}],
+                "cc": [],
+                "subject": "Fallback",
+            }
+        )
+
+        response = test_client.post(
+            "/humans/user/email",
+            json={"requester_session_id": "test123", "text": "email fallback", "subject": "Fallback"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["recipient"] == "rajesh"
+        assert data["channel"] == "email"
+        assert "private@example.com" not in json.dumps(data)
+
+    def test_human_telegram_missing_sender_topic_fails_clearly(
+        self,
+        mock_session_manager,
+        mock_output_monitor,
+        mock_email_handler,
+        sample_session,
+    ):
+        mock_email_handler.lookup_human.return_value = _human_recipient()
+        mock_session_manager.get_session.return_value = sample_session
+        notifier = MagicMock()
+        notifier.send_human_message_to_session_topic = AsyncMock(
+            return_value=(False, "Sender session has no SM-managed Telegram topic")
+        )
+        app = create_app(
+            session_manager=mock_session_manager,
+            notifier=notifier,
+            output_monitor=mock_output_monitor,
+            email_handler=mock_email_handler,
+            config={},
+        )
+        client = TestClient(app)
+
+        response = client.post(
+            "/humans/user/telegram",
+            json={"requester_session_id": "test123", "text": "hello"},
+        )
+
+        assert response.status_code == 409
+        assert "SM-managed Telegram topic" in response.json()["detail"]
+
+    def test_human_telegram_missing_config_fails_clearly(
+        self,
+        test_client,
+        mock_session_manager,
+        mock_email_handler,
+        sample_session,
+    ):
+        mock_email_handler.lookup_human.return_value = _human_recipient()
+        mock_session_manager.get_session.return_value = sample_session
+
+        response = test_client.post(
+            "/humans/user/telegram",
+            json={"requester_session_id": "test123", "text": "hello"},
+        )
+
+        assert response.status_code == 503
+        assert "Telegram delivery is not configured" in response.json()["detail"]
+
+    def test_spawn_rejects_reserved_human_alias(
+        self,
+        test_client,
+        mock_session_manager,
+        sample_session,
+    ):
+        mock_session_manager.get_session.return_value = sample_session
+        mock_session_manager.validate_reserved_human_name.return_value = (
+            'Name "user" is reserved for configured human recipient "user"'
+        )
+
+        response = test_client.post(
+            "/sessions/spawn",
+            json={"parent_session_id": "test123", "prompt": "hello", "name": "user"},
+        )
+
+        assert response.status_code == 400
+        assert "reserved for configured human recipient" in response.json()["detail"]
+
+    def test_name_rejects_reserved_human_alias(
+        self,
+        test_client,
+        mock_session_manager,
+        sample_session,
+    ):
+        mock_session_manager.get_session.return_value = sample_session
+        mock_session_manager.validate_friendly_name_update.return_value = (
+            'Name "user" is reserved for configured human recipient "user"'
+        )
+
+        response = test_client.patch("/sessions/test123", json={"friendly_name": "user"})
+
+        assert response.status_code == 400
+        assert "reserved for configured human recipient" in response.json()["detail"]
 
 
 class TestEmailBridgeEndpoints:

--- a/tests/unit/test_agent_registry.py
+++ b/tests/unit/test_agent_registry.py
@@ -341,6 +341,56 @@ humans:
     )
 
 
+def test_human_reserved_names_merge_main_and_bridge_config(tmp_path):
+    bridge_config = tmp_path / "email_send.yaml"
+    bridge_config.write_text(
+        """
+humans:
+  rajesh:
+    aliases: [bridge-user]
+    default_channel: telegram
+    channels:
+      email:
+        enabled: true
+        use: fallback_only
+""",
+        encoding="utf-8",
+    )
+    manager = SessionManager(
+        log_dir=str(tmp_path / "logs"),
+        state_file=str(tmp_path / "sessions.json"),
+        config={
+            "humans": {
+                "rajesh": {
+                    "aliases": ["main-user"],
+                    "default_channel": "telegram",
+                    "channels": {
+                        "telegram": {
+                            "enabled": True,
+                            "delivery": "sender_session_topic",
+                        },
+                    },
+                },
+                "operator": {
+                    "aliases": ["main-operator"],
+                    "default_channel": "telegram",
+                    "channels": {
+                        "telegram": {
+                            "enabled": True,
+                            "delivery": "sender_session_topic",
+                        },
+                    },
+                },
+            },
+            "email": {"bridge_config": str(bridge_config)},
+        },
+    )
+
+    reserved_names = manager.human_reserved_names()
+
+    assert {"rajesh", "main-user", "bridge-user", "operator", "main-operator"}.issubset(reserved_names)
+
+
 def test_cmd_lookup_falls_back_to_exact_session_name(capsys):
     client = Mock()
     client.lookup_role.return_value = {

--- a/tests/unit/test_agent_registry.py
+++ b/tests/unit/test_agent_registry.py
@@ -283,6 +283,64 @@ def test_cmd_register_lookup_unregister_and_roster(capsys):
     assert "sess1234" in roster_output
 
 
+def test_cmd_lookup_human_alias_prints_delivery_guidance(capsys):
+    client = Mock()
+    client.lookup_human.return_value = {
+        "ok": True,
+        "unavailable": False,
+        "data": {
+            "recipient": "rajesh",
+            "display_name": "Human operator",
+            "aliases": ["rajesh", "rajeshgoli", "user"],
+            "default_channel": "telegram",
+            "available_channels": ["telegram", "email"],
+            "telegram_delivery": "sender_session_topic",
+            "email_use": "fallback_only",
+        },
+    }
+
+    assert cmd_lookup(client, "user") == 0
+
+    output = capsys.readouterr().out
+    assert "Human recipient: rajesh" in output
+    assert "Aliases: rajeshgoli, user" in output
+    assert "Default delivery: telegram" in output
+    assert "Telegram delivery posts into the sending agent's SM-managed Telegram thread." in output
+    assert "Email is available as fallback/explicit only; use email sparingly." in output
+    client.lookup_role.assert_not_called()
+
+
+def test_human_aliases_are_reserved_for_register_and_name(tmp_path):
+    bridge_config = tmp_path / "email_send.yaml"
+    bridge_config.write_text(
+        """
+humans:
+  rajesh:
+    aliases: [rajeshgoli, user]
+    default_channel: telegram
+    channels:
+      telegram:
+        enabled: true
+        delivery: sender_session_topic
+""",
+        encoding="utf-8",
+    )
+    manager = SessionManager(
+        log_dir=str(tmp_path / "logs"),
+        state_file=str(tmp_path / "sessions.json"),
+        config={"email": {"bridge_config": str(bridge_config)}},
+    )
+    session = _session("human001", tmp_path)
+    manager.sessions[session.id] = session
+
+    with pytest.raises(ValueError, match='Name "user" is reserved'):
+        manager.register_agent_role(session.id, "user")
+
+    assert manager.validate_friendly_name_update(session.id, "user") == (
+        'Name "user" is reserved for configured human recipient "user"'
+    )
+
+
 def test_cmd_lookup_falls_back_to_exact_session_name(capsys):
     client = Mock()
     client.lookup_role.return_value = {

--- a/tests/unit/test_cli_parsing.py
+++ b/tests/unit/test_cli_parsing.py
@@ -49,11 +49,17 @@ class TestCliParsing:
         # sm email
         email_parser = subparsers.add_parser("email")
         email_parser.add_argument("recipients")
-        email_parser.add_argument("--subject", required=True)
+        email_parser.add_argument("message", nargs="?")
+        email_parser.add_argument("--subject")
         email_parser.add_argument("--body")
         email_parser.add_argument("--text")
         email_parser.add_argument("--html")
         email_parser.add_argument("--cc")
+
+        # sm telegram / tg
+        telegram_parser = subparsers.add_parser("telegram", aliases=["tg"])
+        telegram_parser.add_argument("recipient")
+        telegram_parser.add_argument("text")
 
         # sm spawn
         spawn_parser = subparsers.add_parser("spawn")
@@ -290,6 +296,7 @@ class TestEmailCommand:
 
         assert args.command == "email"
         assert args.recipients == "rajesh,architect"
+        assert args.message is None
         assert args.subject == "Spec ready"
         assert args.body == "See attached"
         assert args.text is None
@@ -303,6 +310,35 @@ class TestEmailCommand:
 
         assert args.text == "docs/summary.md"
         assert args.cc == "architect"
+
+    def test_email_command_parses_positional_message(self):
+        parser = TestCliParsing()
+        args = parser._get_parsed_args(["email", "rajesh", "Use the fallback path"])
+
+        assert args.command == "email"
+        assert args.recipients == "rajesh"
+        assert args.message == "Use the fallback path"
+        assert args.subject is None
+
+
+class TestTelegramCommand:
+    """Tests for 'sm telegram' command parsing."""
+
+    def test_telegram_command_parses(self):
+        parser = TestCliParsing()
+        args = parser._get_parsed_args(["telegram", "rajesh", "hello"])
+
+        assert args.command == "telegram"
+        assert args.recipient == "rajesh"
+        assert args.text == "hello"
+
+    def test_tg_alias_parses(self):
+        parser = TestCliParsing()
+        args = parser._get_parsed_args(["tg", "user", "hello"])
+
+        assert args.command == "tg"
+        assert args.recipient == "user"
+        assert args.text == "hello"
 
 
 class TestSpawnCommand:

--- a/tests/unit/test_client_codex_endpoints.py
+++ b/tests/unit/test_client_codex_endpoints.py
@@ -66,6 +66,35 @@ def test_send_input_batch_result_uses_batch_endpoint():
     )
 
 
+def test_lookup_human_uses_humans_endpoint():
+    client = _make_client()
+    payload = {"recipient": "rajesh"}
+    with patch.object(client, "_request_with_status", return_value=(payload, 200, False)) as req:
+        result = client.lookup_human("user")
+    assert result["ok"] is True
+    assert result["data"] == payload
+    req.assert_called_once_with("GET", "/humans/user")
+
+
+def test_send_human_telegram_result_uses_humans_endpoint():
+    client = _make_client()
+    payload = {"status": "sent", "recipient": "rajesh"}
+    with patch.object(client, "_request_with_status", return_value=(payload, 200, False)) as req:
+        result = client.send_human_telegram_result(
+            requester_session_id="sender123",
+            recipient="user",
+            text="hello",
+        )
+    assert result["ok"] is True
+    assert result["data"] == payload
+    req.assert_called_once_with(
+        "POST",
+        "/humans/user/telegram",
+        {"requester_session_id": "sender123", "text": "hello"},
+        timeout=15,
+    )
+
+
 def test_update_friendly_name_uses_mutation_timeout():
     client = _make_client()
     with patch.object(client, "_request", return_value=({}, True, False)) as req:

--- a/tests/unit/test_email_commands.py
+++ b/tests/unit/test_email_commands.py
@@ -79,6 +79,7 @@ def test_cmd_send_human_alias_defaults_to_telegram(capsys):
     client = Mock()
     client.session_id = "sender123"
     client.get_session.return_value = None
+    client.list_sessions.return_value = []
     client.lookup_human.return_value = {
         "ok": True,
         "unavailable": False,
@@ -103,6 +104,63 @@ def test_cmd_send_human_alias_defaults_to_telegram(capsys):
     output = capsys.readouterr().out
     assert "Telegram sent to rajesh" in output
     assert "Thread: sender session topic" in output
+
+
+@pytest.mark.parametrize(
+    "session_identity",
+    [
+        {"friendly_name": "user"},
+        {"friendly_name": "historical-user", "aliases": ["user"]},
+    ],
+)
+def test_cmd_send_prefers_live_session_identity_over_human_alias(
+    session_identity: dict,
+    capsys,
+):
+    client = Mock()
+    client.session_id = "sender123"
+    client.get_session.return_value = None
+    client.list_sessions.return_value = [
+        {
+            "id": "live-user",
+            "status": "idle",
+            "provider": "claude",
+            **session_identity,
+        }
+    ]
+    client.lookup_human.return_value = {
+        "ok": True,
+        "unavailable": False,
+        "data": _human_lookup_payload(),
+    }
+    client.send_input.return_value = (True, False)
+
+    rc = cmd_send(client, "user", "message for existing session")
+
+    assert rc == 0
+    client.lookup_human.assert_not_called()
+    client.send_human_telegram_result.assert_not_called()
+    client.ensure_role.assert_not_called()
+    client.send_email_result.assert_not_called()
+    client.send_input.assert_called_once_with(
+        "live-user",
+        "message for existing session",
+        sender_session_id="sender123",
+        delivery_mode="sequential",
+        from_sm_send=True,
+        timeout_seconds=None,
+        notify_on_delivery=False,
+        notify_after_seconds=None,
+        notify_on_stop=True,
+        remind_soft_threshold=None,
+        remind_hard_threshold=None,
+        remind_cancel_on_reply_session_id=None,
+        parent_session_id=None,
+        timeout=SEND_API_TIMEOUT,
+    )
+    output = capsys.readouterr().out
+    expected_name = session_identity["friendly_name"]
+    assert f"Input sent to {expected_name} (live-user)" in output
 
 
 def test_cmd_telegram_forces_human_telegram(capsys):

--- a/tests/unit/test_email_commands.py
+++ b/tests/unit/test_email_commands.py
@@ -169,6 +169,58 @@ def test_cmd_email_human_uses_explicit_email_endpoint_and_redacts_address(capsys
     assert "private@example.com" not in output
 
 
+def test_cmd_email_human_with_cc_rejects_before_registered_email(capsys):
+    client = Mock()
+    client.lookup_human.side_effect = lambda identifier: (
+        {
+            "ok": True,
+            "unavailable": False,
+            "data": _human_lookup_payload(),
+        }
+        if identifier == "rajeshgoli"
+        else {"ok": False, "unavailable": False, "status_code": 404}
+    )
+
+    rc = cmd_email(
+        client,
+        sender_session_id="sender123",
+        recipients_raw="rajeshgoli",
+        subject="Fallback",
+        body="explicit fallback",
+        cc_raw="architect",
+    )
+
+    assert rc == 1
+    client.send_human_email_result.assert_not_called()
+    client.send_email_result.assert_not_called()
+    assert "supports exactly one recipient and no --cc" in capsys.readouterr().err
+
+
+def test_cmd_email_human_html_rejects_before_registered_email(tmp_path, capsys):
+    html_path = tmp_path / "body.html"
+    html_path.write_text("<p>explicit fallback</p>", encoding="utf-8")
+
+    client = Mock()
+    client.lookup_human.return_value = {
+        "ok": True,
+        "unavailable": False,
+        "data": _human_lookup_payload(),
+    }
+
+    rc = cmd_email(
+        client,
+        sender_session_id="sender123",
+        recipients_raw="rajeshgoli",
+        subject="Fallback",
+        html_file=str(html_path),
+    )
+
+    assert rc == 1
+    client.send_human_email_result.assert_not_called()
+    client.send_email_result.assert_not_called()
+    assert "supports plain text or markdown bodies only" in capsys.readouterr().err
+
+
 @pytest.mark.parametrize(
     ("delivery_mode", "expected_snippet"),
     [

--- a/tests/unit/test_email_commands.py
+++ b/tests/unit/test_email_commands.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from src.cli.client import SEND_API_TIMEOUT
-from src.cli.commands import cmd_email, cmd_send
+from src.cli.commands import cmd_email, cmd_send, cmd_telegram
 
 
 def test_cmd_send_falls_back_to_registered_user_email(capsys):
@@ -39,7 +39,9 @@ def test_cmd_send_falls_back_to_registered_user_email(capsys):
         body_text="Deployment done",
         auto_subject=True,
     )
-    assert "Email sent to rajesh <rajesh@example.com>" in capsys.readouterr().out
+    output = capsys.readouterr().out
+    assert "Email sent to rajesh" in output
+    assert "rajesh@example.com" not in output
 
 
 def test_cmd_send_email_fallback_rejects_track(capsys):
@@ -59,6 +61,112 @@ def test_cmd_send_email_fallback_rejects_track(capsys):
     assert rc == 1
     client.send_email_result.assert_not_called()
     assert "email fallback only supports plain sequential sends" in capsys.readouterr().err
+
+
+def _human_lookup_payload() -> dict:
+    return {
+        "recipient": "rajesh",
+        "display_name": "Human operator",
+        "aliases": ["rajesh", "rajeshgoli", "user"],
+        "default_channel": "telegram",
+        "available_channels": ["telegram", "email"],
+        "telegram_delivery": "sender_session_topic",
+        "email_use": "fallback_only",
+    }
+
+
+def test_cmd_send_human_alias_defaults_to_telegram(capsys):
+    client = Mock()
+    client.session_id = "sender123"
+    client.get_session.return_value = None
+    client.lookup_human.return_value = {
+        "ok": True,
+        "unavailable": False,
+        "data": _human_lookup_payload(),
+    }
+    client.send_human_telegram_result.return_value = {
+        "ok": True,
+        "unavailable": False,
+        "data": {"recipient": "rajesh", "thread": "sender session topic"},
+    }
+
+    rc = cmd_send(client, "user", "status for the human")
+
+    assert rc == 0
+    client.send_human_telegram_result.assert_called_once_with(
+        requester_session_id="sender123",
+        recipient="user",
+        text="status for the human",
+    )
+    client.ensure_role.assert_not_called()
+    client.send_email_result.assert_not_called()
+    output = capsys.readouterr().out
+    assert "Telegram sent to rajesh" in output
+    assert "Thread: sender session topic" in output
+
+
+def test_cmd_telegram_forces_human_telegram(capsys):
+    client = Mock()
+    client.send_human_telegram_result.return_value = {
+        "ok": True,
+        "unavailable": False,
+        "data": {"recipient": "rajesh", "thread": "sender session topic"},
+    }
+
+    rc = cmd_telegram(
+        client,
+        sender_session_id="sender123",
+        recipient="rajeshgoli",
+        text="forced telegram",
+    )
+
+    assert rc == 0
+    client.send_human_telegram_result.assert_called_once_with(
+        requester_session_id="sender123",
+        recipient="rajeshgoli",
+        text="forced telegram",
+    )
+    output = capsys.readouterr().out
+    assert "Telegram sent to rajesh" in output
+
+
+def test_cmd_email_human_uses_explicit_email_endpoint_and_redacts_address(capsys):
+    client = Mock()
+    client.lookup_human.return_value = {
+        "ok": True,
+        "unavailable": False,
+        "data": _human_lookup_payload(),
+    }
+    client.send_human_email_result.return_value = {
+        "ok": True,
+        "unavailable": False,
+        "data": {
+            "recipient": "rajesh",
+            "subject": "Auto subject",
+            "to": [{"username": "rajesh", "email": "private@example.com"}],
+        },
+    }
+
+    rc = cmd_email(
+        client,
+        sender_session_id="sender123",
+        recipients_raw="rajeshgoli",
+        body="explicit fallback",
+    )
+
+    assert rc == 0
+    client.send_human_email_result.assert_called_once_with(
+        requester_session_id="sender123",
+        recipient="rajeshgoli",
+        text="explicit fallback",
+        subject=None,
+        body_markdown=False,
+        auto_subject=True,
+    )
+    client.send_email_result.assert_not_called()
+    output = capsys.readouterr().out
+    assert "Email sent to rajesh" in output
+    assert "private@example.com" not in output
 
 
 @pytest.mark.parametrize(
@@ -192,7 +300,8 @@ def test_cmd_send_multiple_recipients_uses_batch_endpoint(capsys):
     )
     output = capsys.readouterr().out
     assert "Input sent to spec-owner-3004 (owner123)" in output
-    assert "Email sent to orchestrator <orch@example.com>" in output
+    assert "Email sent to orchestrator" in output
+    assert "orch@example.com" not in output
 
 
 def test_cmd_send_multiple_recipients_returns_nonzero_on_partial_failure(capsys):
@@ -261,7 +370,9 @@ def test_cmd_email_reads_markdown_file_and_calls_api(tmp_path, capsys):
     assert kwargs["subject"] == "Reading list"
     assert kwargs["body_text"] == body_path.read_text(encoding="utf-8")
     assert kwargs["body_markdown"] is True
-    assert "Email sent to rajesh <rajesh@example.com>" in capsys.readouterr().out
+    output = capsys.readouterr().out
+    assert "Email sent to rajesh" in output
+    assert "rajesh@example.com" not in output
 
 
 def test_cmd_email_treats_stdin_as_markdown(capsys):
@@ -291,4 +402,6 @@ def test_cmd_email_treats_stdin_as_markdown(capsys):
     kwargs = client.send_email_result.call_args.kwargs
     assert kwargs["body_text"] == "# Heading\n\n## Subhead\n"
     assert kwargs["body_markdown"] is True
-    assert "Email sent to rajesh <rajesh@example.com>" in capsys.readouterr().out
+    output = capsys.readouterr().out
+    assert "Email sent to rajesh" in output
+    assert "rajesh@example.com" not in output

--- a/tests/unit/test_email_handler.py
+++ b/tests/unit/test_email_handler.py
@@ -78,7 +78,7 @@ def test_lookup_human_alias_and_email_channel_via_legacy_user(tmp_path):
     handler = EmailHandler(bridge_config=str(config_path))
 
     human = handler.lookup_human("user")
-    email_user = handler.lookup_user("rajeshgoli")
+    email_user = handler.lookup_human_email_user("rajeshgoli")
 
     assert human is not None
     assert human.name == "rajesh"
@@ -86,6 +86,30 @@ def test_lookup_human_alias_and_email_channel_via_legacy_user(tmp_path):
     assert email_user is not None
     assert email_user.username == "rajesh"
     assert email_user.email == "rajesh@example.com"
+    assert handler.lookup_user("rajeshgoli") is None
+
+
+def test_generic_resolve_users_does_not_accept_human_alias(tmp_path):
+    config_path = tmp_path / "email_send.yaml"
+    _write_bridge_config(config_path)
+    with config_path.open("a", encoding="utf-8") as handle:
+        handle.write(
+            "\n"
+            "humans:\n"
+            "  rajesh:\n"
+            "    display_name: Human operator\n"
+            "    aliases: [rajeshgoli, user]\n"
+            "    default_channel: telegram\n"
+            "    channels:\n"
+            "      email:\n"
+            "        enabled: true\n"
+            "        address: private@example.com\n"
+            "        use: fallback_only\n"
+        )
+    handler = EmailHandler(bridge_config=str(config_path))
+
+    with pytest.raises(LookupError, match="rajeshgoli"):
+        handler.resolve_users(["rajeshgoli"])
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_email_handler.py
+++ b/tests/unit/test_email_handler.py
@@ -56,6 +56,38 @@ def test_lookup_user_and_authorized_sender(tmp_path):
     assert handler.normalize_explicit_session_id("reply@sm.rajeshgo.li") is None
 
 
+def test_lookup_human_alias_and_email_channel_via_legacy_user(tmp_path):
+    config_path = tmp_path / "email_send.yaml"
+    _write_bridge_config(config_path)
+    with config_path.open("a", encoding="utf-8") as handle:
+        handle.write(
+            "\n"
+            "humans:\n"
+            "  rajesh:\n"
+            "    display_name: Human operator\n"
+            "    aliases: [rajeshgoli, user]\n"
+            "    default_channel: telegram\n"
+            "    channels:\n"
+            "      telegram:\n"
+            "        enabled: true\n"
+            "        delivery: sender_session_topic\n"
+            "      email:\n"
+            "        enabled: true\n"
+            "        use: fallback_only\n"
+        )
+    handler = EmailHandler(bridge_config=str(config_path))
+
+    human = handler.lookup_human("user")
+    email_user = handler.lookup_user("rajeshgoli")
+
+    assert human is not None
+    assert human.name == "rajesh"
+    assert human.available_channels == ("telegram", "email")
+    assert email_user is not None
+    assert email_user.username == "rajesh"
+    assert email_user.email == "rajesh@example.com"
+
+
 @pytest.mark.asyncio
 async def test_send_agent_email_builds_resend_payload(tmp_path):
     config_path = tmp_path / "email_send.yaml"


### PR DESCRIPTION
## Summary
- Add configured human recipient lookup with reserved aliases for `rajesh`, `rajeshgoli`, and `user` style recipients.
- Route default and forced human sends through the sender session's SM-managed Telegram topic, with explicit email fallback preserved.
- Redact email addresses from CLI/API success output and example config, and cover missing Telegram/topic/config failure paths.

Fixes #707

## Validation
- `pytest -q` -> `1897 passed, 93 warnings`
- `git diff --check`