### PR TITLE
Fix sm send positional validation

### DIFF
--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -30,6 +30,7 @@ from ..codex_provider_policy import (
 # Claude Code (Node.js TUI in raw mode) treats a rapid character burst as pasted
 # text; Enter must arrive as a separate event after the paste mode ends.
 _SEND_KEYS_SETTLE_SECONDS = 0.3
+_SM_ID_TOKEN_RE = re.compile(r"^[0-9a-fA-F]{8}$")
 
 
 def _tmux_command(args: list[str], tmux_socket_name: Optional[str] = None) -> list[str]:
@@ -1646,6 +1647,11 @@ def cmd_send(
             print(f"Error: {detail_message}", file=sys.stderr)
             return 1
 
+    redundant_address_error = _redundant_send_address_error(client, identifier, session_id, text)
+    if redundant_address_error:
+        print(redundant_address_error, file=sys.stderr)
+        return 1
+
     # Self-sends are commonly used as delayed wakeups; do not advertise or request
     # stop-notify because it would wake the same agent on its next stop hook.
     effective_notify_on_stop = notify_on_stop and sender_session_id != session_id
@@ -1702,6 +1708,36 @@ def cmd_send(
         print(f"  Options: {', '.join(extras)}")
 
     return 0
+
+
+def _redundant_send_address_error(
+    client: SessionManagerClient,
+    identifier: str,
+    session_id: str,
+    text: str,
+) -> Optional[str]:
+    """Return an error when the message is the same target's sm-id."""
+    token = str(text or "").strip()
+    if token != text or not _SM_ID_TOKEN_RE.fullmatch(token):
+        return None
+
+    try:
+        token_session = client.get_session(token, timeout=SEND_API_TIMEOUT)
+    except TypeError:
+        token_session = client.get_session(token)
+    if not token_session:
+        return None
+
+    token_session_id = token_session.get("id") or token
+    if token_session_id != session_id:
+        return None
+
+    name = token_session.get("friendly_name") or token_session.get("name") or identifier
+    return (
+        f"Error: message text '{token}' is the sm-id for {name} ({session_id}). "
+        "sm send accepts one recipient followed by one message; pass either the "
+        f"friendly name or the sm-id, not both. Example: sm send {identifier} \"<message>\""
+    )
 
 
 def _try_send_human_telegram(

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -9,6 +9,15 @@ from .client import SessionManagerClient
 from . import commands
 
 
+SEND_HELP_EPILOG = (
+    "Flag placement: send options may appear before the recipient, between the "
+    "recipient and message, or after the message. The message is exactly one "
+    "shell argument. Pass one recipient only; "
+    "if you copied '<friendly-name> [<sm-id>]' from list output, use either the "
+    "friendly name or the sm-id, not both."
+)
+
+
 def _looks_like_int_token(token: str) -> bool:
     """Return True when one argv token can be parsed as an integer."""
     try:
@@ -60,6 +69,77 @@ def _normalize_optional_track_args(argv: list[str]) -> list[str]:
     return normalized
 
 
+def _add_send_arguments(send_parser: argparse.ArgumentParser) -> None:
+    """Register arguments shared by the top-level and send-specific parsers."""
+    send_parser.add_argument("session_id", help="Target session ID, friendly name, human alias, or comma-delimited list")
+    send_parser.add_argument("text", help="Text to send")
+    send_parser.add_argument("--sequential", action="store_true", help="Wait for idle before sending (default)")
+    send_parser.add_argument("--important", action="store_true", help="Inject immediately, queue behind current work")
+    send_parser.add_argument("--urgent", action="store_true", help="Interrupt immediately")
+    send_parser.add_argument("--wait", type=int, metavar="SECONDS", help="Notify sender N seconds after delivery if recipient is idle")
+    send_parser.add_argument("--steer", action="store_true", help="Inject via Enter-based mid-turn steering (for Codex reviews)")
+    send_parser.add_argument("--no-notify-on-stop", action="store_true", help="Don't notify sender when receiver's Stop hook fires")
+    send_parser.add_argument(
+        "--track",
+        action="store_const",
+        const=300,
+        default=None,
+        help="Track the recipient with periodic remind until it replies (default: 300s; explicit seconds also supported)",
+    )
+    send_parser.add_argument("--track-seconds", dest="track", type=int, metavar="SECONDS", help=argparse.SUPPRESS)
+
+
+def _build_send_parser() -> argparse.ArgumentParser:
+    """Build the standalone parser used for `sm send` execution and tests."""
+    parser = argparse.ArgumentParser(
+        prog="sm send",
+        description="Send input to a session or Telegram to a human recipient",
+        epilog=SEND_HELP_EPILOG,
+    )
+    _add_send_arguments(parser)
+    return parser
+
+
+def _parse_send_args(argv: list[str]) -> argparse.Namespace:
+    """Parse `sm send` args with send-specific errors for extra positionals."""
+    parser = _build_send_parser()
+    normalized = _normalize_optional_track_args(["send", *argv])[1:]
+    args, extras = parser.parse_known_args(normalized)
+    if extras:
+        optionish = [token for token in extras if token.startswith("-")]
+        if optionish:
+            parser.error(f"unrecognized arguments: {' '.join(extras)}")
+        parser.error(
+            "unexpected extra positional argument(s): "
+            f"{' '.join(extras)}. sm send accepts exactly one recipient "
+            "followed by one message; pass either the friendly name or the sm-id, not both."
+        )
+    return args
+
+
+def _handle_send(argv: list[str]) -> int:
+    """Handle `sm send` with subcommand-specific parsing and dispatch."""
+    args = _parse_send_args(argv)
+    delivery_mode = "sequential"
+    if args.urgent:
+        delivery_mode = "urgent"
+    elif args.important:
+        delivery_mode = "important"
+    elif args.steer:
+        delivery_mode = "steer"
+
+    client = SessionManagerClient()
+    return commands.cmd_send(
+        client,
+        args.session_id,
+        args.text,
+        delivery_mode,
+        wait_seconds=getattr(args, "wait", None),
+        notify_on_stop=not getattr(args, "no_notify_on_stop", False),
+        track_seconds=getattr(args, "track", None),
+    )
+
+
 def _handle_dispatch(session_id: Optional[str]) -> int:
     """Handle 'sm dispatch' with two-phase argument parsing.
 
@@ -98,6 +178,8 @@ def main():
     if len(sys.argv) >= 2 and sys.argv[1] == "dispatch":
         session_id = os.environ.get("CLAUDE_SESSION_MANAGER_ID")
         sys.exit(_handle_dispatch(session_id))
+    if len(sys.argv) >= 2 and sys.argv[1] == "send":
+        sys.exit(_handle_send(sys.argv[2:]))
 
     parser = argparse.ArgumentParser(
         prog="sm",
@@ -178,23 +260,13 @@ def main():
     subagents_parser.add_argument("session_id", help="Session ID")
 
     # sm send <session-id|human> "<text>"
-    send_parser = subparsers.add_parser("send", help="Send input to a session or Telegram to a human recipient")
-    send_parser.add_argument("session_id", help="Target session ID, friendly name, human alias, or comma-delimited list")
-    send_parser.add_argument("text", help="Text to send")
-    send_parser.add_argument("--sequential", action="store_true", help="Wait for idle before sending (default)")
-    send_parser.add_argument("--important", action="store_true", help="Inject immediately, queue behind current work")
-    send_parser.add_argument("--urgent", action="store_true", help="Interrupt immediately")
-    send_parser.add_argument("--wait", type=int, metavar="SECONDS", help="Notify sender N seconds after delivery if recipient is idle")
-    send_parser.add_argument("--steer", action="store_true", help="Inject via Enter-based mid-turn steering (for Codex reviews)")
-    send_parser.add_argument("--no-notify-on-stop", action="store_true", help="Don't notify sender when receiver's Stop hook fires")
-    send_parser.add_argument(
-        "--track",
-        action="store_const",
-        const=300,
-        default=None,
-        help="Track the recipient with periodic remind until it replies (default: 300s; explicit seconds also supported)",
+    send_parser = subparsers.add_parser(
+        "send",
+        help="Send input to a session or Telegram to a human recipient",
+        description="Send input to a session or Telegram to a human recipient",
+        epilog=SEND_HELP_EPILOG,
     )
-    send_parser.add_argument("--track-seconds", dest="track", type=int, metavar="SECONDS", help=argparse.SUPPRESS)
+    _add_send_arguments(send_parser)
 
     # sm telegram <human> "<text>" / sm tg <human> "<text>"
     telegram_parser = subparsers.add_parser(

--- a/tests/unit/test_cli_parsing.py
+++ b/tests/unit/test_cli_parsing.py
@@ -7,7 +7,7 @@ import os
 from unittest.mock import MagicMock, patch
 from io import StringIO
 
-from src.cli.main import main, _normalize_optional_track_args
+from src.cli.main import main, _build_send_parser, _normalize_optional_track_args, _parse_send_args
 from src.cli.commands import (
     parse_duration,
     resolve_session_id,
@@ -283,6 +283,47 @@ class TestSendCommand:
         assert args.track is None
         assert args.session_id == "target123"
         assert args.text == "--track=420"
+
+    def test_send_options_may_follow_message(self):
+        """sm send target text --urgent is accepted and documented behavior."""
+        args = _parse_send_args(["target123", "Test", "--urgent"])
+
+        assert args.session_id == "target123"
+        assert args.text == "Test"
+        assert args.urgent is True
+
+    def test_send_options_may_appear_between_recipient_and_message(self):
+        """sm send target --urgent text remains a valid call shape."""
+        args = _parse_send_args(["target123", "--urgent", "Test"])
+
+        assert args.session_id == "target123"
+        assert args.text == "Test"
+        assert args.urgent is True
+
+    def test_send_extra_positionals_get_send_specific_error(self, capsys):
+        """Extra recipient-like tokens fail under sm send usage, not global usage."""
+        with pytest.raises(SystemExit) as exc_info:
+            _parse_send_args(["em-proximity-3324", "69c4f382", "--urgent", "hello"])
+
+        assert exc_info.value.code == 2
+        captured = capsys.readouterr()
+        assert "usage: sm send" in captured.err
+        assert "unexpected extra positional argument(s): hello" in captured.err
+        assert "pass either the friendly name or the sm-id, not both" in captured.err
+
+    def test_send_help_documents_flag_position_and_one_recipient(self, capsys):
+        """sm send -h documents option placement and the one-recipient rule."""
+        parser = _build_send_parser()
+
+        with pytest.raises(SystemExit) as exc_info:
+            parser.parse_args(["-h"])
+
+        assert exc_info.value.code == 0
+        captured = capsys.readouterr()
+        help_text = " ".join(captured.out.split())
+        assert "Flag placement:" in captured.out
+        assert "before the recipient, between the recipient and message, or after the message" in help_text
+        assert "use either the friendly name or the sm-id, not both" in help_text
 
 
 class TestEmailCommand:

--- a/tests/unit/test_email_commands.py
+++ b/tests/unit/test_email_commands.py
@@ -361,6 +361,58 @@ def test_cmd_send_uses_extended_timeout_for_resolution_and_delivery(capsys):
     assert "Input sent to worker (live123)" in capsys.readouterr().out
 
 
+def test_cmd_send_rejects_redundant_friendly_name_plus_sm_id(capsys):
+    client = Mock()
+    client.session_id = "sender123"
+    target_session = {
+        "id": "69c4f382",
+        "friendly_name": "em-proximity-3324",
+        "status": "idle",
+        "provider": "claude",
+    }
+
+    def get_session(session_id, timeout=None):
+        if session_id == "69c4f382":
+            return target_session
+        return None
+
+    client.get_session.side_effect = get_session
+    client.list_sessions.return_value = [target_session]
+
+    rc = cmd_send(client, "em-proximity-3324", "69c4f382")
+
+    assert rc == 1
+    client.send_input.assert_not_called()
+    captured = capsys.readouterr()
+    assert "message text '69c4f382' is the sm-id for em-proximity-3324" in captured.err
+    assert "pass either the friendly name or the sm-id, not both" in captured.err
+
+
+def test_cmd_send_allows_unknown_id_shaped_message(capsys):
+    client = Mock()
+    client.session_id = "sender123"
+
+    def get_session(session_id, timeout=None):
+        if session_id == "live123":
+            return {
+                "id": "live123",
+                "friendly_name": "worker",
+                "status": "running",
+                "provider": "claude",
+            }
+        return None
+
+    client.get_session.side_effect = get_session
+    client.send_input.return_value = (True, False)
+
+    rc = cmd_send(client, "live123", "deadbeef")
+
+    assert rc == 0
+    client.send_input.assert_called_once()
+    assert client.send_input.call_args.args[:2] == ("live123", "deadbeef")
+    assert "Input sent to worker (live123)" in capsys.readouterr().out
+
+
 def test_cmd_send_multiple_recipients_uses_batch_endpoint(capsys):
     client = Mock()
     client.session_id = "sender123"


### PR DESCRIPTION
## Summary

- Add a send-specific parser path so extra positional tokens produce `sm send` usage and a clear one-recipient error instead of a top-level parser error.
- Document that `sm send` options may appear before the recipient, between recipient and message, or after the message.
- Reject `sm send <friendly-name> <same-sm-id>` after resolution before delivery, preventing the sm-id from being sent as the body.

Fixes #715

## Tests

- `/Users/rajesh/Desktop/automation/session-manager/venv/bin/python -m pytest tests/unit/test_cli_parsing.py::TestSendCommand tests/unit/test_email_commands.py tests/unit/test_dispatch.py::TestExistingCommandsUnaffected -q`
- `/Users/rajesh/Desktop/automation/session-manager/venv/bin/python -m pytest tests/unit -q` (`1334 passed`; required ignored `web/sm-watch/dist` fixture copied into the fresh worktree)
- Manual: `/Users/rajesh/Desktop/automation/session-manager/venv/bin/python -m src.cli.main send fake-target 12345678 --urgent hello` exits 2 with `usage: sm send` and an unexpected-extra-positional message.

## Note

A fresh worktree without `web/sm-watch/dist` fails `tests/unit/test_google_auth.py::test_watch_html_is_not_cached_but_hashed_assets_remain_static` on current `origin/main`; tracked separately as #716.