### PR TITLE
Fix watch cache test fixture

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -189,6 +189,11 @@ def _google_auth_config(config: Optional[dict]) -> dict:
     return ((config or {}).get("auth") or {}).get("google") or {}
 
 
+def _watch_frontend_config(config: Optional[dict]) -> dict:
+    """Return normalized watch frontend config block."""
+    return ((config or {}).get("watch_frontend") or {})
+
+
 def _google_auth_requested(config: Optional[dict]) -> bool:
     """Whether operators requested Google auth enforcement."""
     return bool(_google_auth_config(config).get("enabled"))
@@ -3315,7 +3320,12 @@ def create_app(
     def _configure_watch_frontend() -> None:
         """Serve the mobile dashboard if static assets exist in web/sm-watch/dist."""
         project_root = Path(__file__).resolve().parents[1]
-        watch_dist = project_root / "web" / "sm-watch" / "dist"
+        configured_dist = _watch_frontend_config(app.state.config).get("dist_path")
+        watch_dist = (
+            Path(str(configured_dist)).expanduser()
+            if configured_dist
+            else project_root / "web" / "sm-watch" / "dist"
+        )
 
         if not watch_dist.is_dir():
             detail = (

--- a/tests/unit/test_google_auth.py
+++ b/tests/unit/test_google_auth.py
@@ -1,5 +1,6 @@
-from unittest.mock import MagicMock
 import re
+from pathlib import Path
+from unittest.mock import MagicMock
 
 from fastapi.testclient import TestClient
 
@@ -22,6 +23,24 @@ def _auth_config() -> dict:
             }
         }
     }
+
+
+def _auth_config_with_watch_dist(watch_dist: Path) -> dict:
+    config = _auth_config()
+    config["watch_frontend"] = {"dist_path": str(watch_dist)}
+    return config
+
+
+def _write_watch_dist_fixture(tmp_path: Path) -> Path:
+    watch_dist = tmp_path / "sm-watch-dist"
+    assets_dir = watch_dist / "assets"
+    assets_dir.mkdir(parents=True)
+    (watch_dist / "index.html").write_text(
+        '<!doctype html><script type="module" src="/watch/assets/app.abc123.js"></script>',
+        encoding="utf-8",
+    )
+    (assets_dir / "app.abc123.js").write_text("console.log('watch fixture');", encoding="utf-8")
+    return watch_dist
 
 
 def _misconfigured_auth_config() -> dict:
@@ -160,8 +179,14 @@ def test_local_loopback_bypasses_google_auth():
     assert root_response.json() == {"status": "ok", "service": "session-manager"}
 
 
-def test_watch_html_is_not_cached_but_hashed_assets_remain_static():
-    client = TestClient(create_app(session_manager=_session_manager(), config=_auth_config()))
+def test_watch_html_is_not_cached_but_hashed_assets_remain_static(tmp_path):
+    watch_dist = _write_watch_dist_fixture(tmp_path)
+    client = TestClient(
+        create_app(
+            session_manager=_session_manager(),
+            config=_auth_config_with_watch_dist(watch_dist),
+        )
+    )
 
     html_response = client.get("/watch/")
 


### PR DESCRIPTION
## Summary\n- Add a configurable watch frontend dist path for tests and non-default deployments\n- Make the watch cache-header unit test create its own minimal static fixture instead of relying on untracked web/sm-watch/dist output\n\nFixes #716\n\n## Testing\n- /Users/rajesh/Desktop/automation/session-manager/venv/bin/python -m pytest tests/unit/test_google_auth.py::test_watch_html_is_not_cached_but_hashed_assets_remain_static -q\n- /Users/rajesh/Desktop/automation/session-manager/venv/bin/python -m pytest tests/unit/test_google_auth.py -q