### PR TITLE
[codex] Show humans in roster and recover maintainer registry

### DIFF
--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -188,6 +188,13 @@ class SessionManagerClient:
             return data.get("registrations", [])
         return None
 
+    def list_humans(self) -> Optional[list]:
+        """List configured human recipients."""
+        data, success, _ = self._request("GET", "/humans")
+        if success and data:
+            return data.get("humans", [])
+        return None
+
     def lookup_role(self, role: str) -> dict:
         """Resolve one registry role."""
         role_path = urllib.parse.quote(role, safe="")

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -732,6 +732,19 @@ def _lookup_live_session_fallback(
     return None, False, None
 
 
+def _print_roster_table(headers: tuple[str, ...], rows: list[tuple[str, ...]]) -> None:
+    widths = [
+        max(len(header), *(len(row[idx]) for row in rows))
+        for idx, header in enumerate(headers)
+    ]
+    header_line = "  ".join(header.ljust(widths[idx]) for idx, header in enumerate(headers))
+    divider = "  ".join("-" * widths[idx] for idx in range(len(headers)))
+    print(header_line)
+    print(divider)
+    for row in rows:
+        print("  ".join(value.ljust(widths[idx]) for idx, value in enumerate(row)))
+
+
 def cmd_roster(client: SessionManagerClient) -> int:
     """
     List all live durable registry roles.
@@ -745,32 +758,57 @@ def cmd_roster(client: SessionManagerClient) -> int:
     if registrations is None:
         print(UNAVAILABLE_MESSAGE, file=sys.stderr)
         return 2
-    if not registrations:
-        print("No registered roles.")
+
+    human_lister = getattr(client, "list_humans", None)
+    humans_raw = human_lister() if callable(human_lister) else []
+    if humans_raw is None:
+        print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+        return 2
+    humans = humans_raw if isinstance(humans_raw, list) else []
+
+    if not registrations and not humans:
+        print("No registered roles or humans.")
         return 0
 
-    headers = ("Role", "Session ID", "Name", "Provider", "State")
-    rows = [
-        (
-            str(entry.get("role") or ""),
-            str(entry.get("session_id") or ""),
-            str(entry.get("friendly_name") or ""),
-            str(entry.get("provider") or ""),
-            str(entry.get("activity_state") or entry.get("status") or ""),
-        )
-        for entry in registrations
-    ]
-    widths = [
-        max(len(header), *(len(row[idx]) for row in rows))
-        for idx, header in enumerate(headers)
-    ]
+    if registrations:
+        print("Agents")
+        headers = ("Role", "Session ID", "Name", "Provider", "State")
+        rows = [
+            (
+                str(entry.get("role") or ""),
+                str(entry.get("session_id") or ""),
+                str(entry.get("friendly_name") or ""),
+                str(entry.get("provider") or ""),
+                str(entry.get("activity_state") or entry.get("status") or ""),
+            )
+            for entry in registrations
+        ]
+        _print_roster_table(headers, rows)
 
-    header_line = "  ".join(header.ljust(widths[idx]) for idx, header in enumerate(headers))
-    divider = "  ".join("-" * widths[idx] for idx in range(len(headers)))
-    print(header_line)
-    print(divider)
-    for row in rows:
-        print("  ".join(value.ljust(widths[idx]) for idx, value in enumerate(row)))
+    if humans:
+        if registrations:
+            print()
+        print("Humans")
+        headers = ("Name", "Display", "Aliases", "Default", "Channels")
+        rows = []
+        for entry in humans:
+            recipient = str(entry.get("recipient") or "")
+            aliases = [
+                str(alias)
+                for alias in (entry.get("aliases") or [])
+                if str(alias) and str(alias) != recipient
+            ]
+            channels = [str(channel) for channel in (entry.get("available_channels") or []) if str(channel)]
+            rows.append(
+                (
+                    recipient,
+                    str(entry.get("display_name") or ""),
+                    ",".join(aliases),
+                    str(entry.get("default_channel") or ""),
+                    ",".join(channels),
+                )
+            )
+        _print_roster_table(headers, rows)
     return 0
 
 

--- a/src/human_recipients.py
+++ b/src/human_recipients.py
@@ -150,7 +150,10 @@ class HumanRecipientRegistry:
             return None
         return self._recipients.get(matches[0])
 
+    def list_recipients(self) -> tuple[HumanRecipient, ...]:
+        """Return all configured human recipients in stable display order."""
+        return tuple(self._recipients[name] for name in sorted(self._recipients))
+
     def reserved_names(self) -> set[str]:
         """Return every canonical name and alias reserved by humans."""
         return set(self._alias_map)
-

--- a/src/server.py
+++ b/src/server.py
@@ -1491,6 +1491,18 @@ def create_app(
             email_use=email_channel.use if email_channel else None,
         )
 
+    def _list_human_recipients() -> list[HumanRecipient]:
+        handler = getattr(app.state, "email_handler", None)
+        registry_getter = getattr(handler, "human_registry", None) if handler is not None else None
+        if not callable(registry_getter):
+            return []
+        try:
+            registry = registry_getter()
+            lister = getattr(registry, "list_recipients", None)
+            return list(lister()) if callable(lister) else []
+        except HumanRecipientConfigError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+
     async def _send_human_telegram(identifier: str, request: HumanDeliveryRequest) -> dict[str, Any]:
         human = _lookup_human_or_404(identifier)
         channel = human.channel("telegram")
@@ -6194,6 +6206,16 @@ Provide ONLY the summary, no preamble or questions."""
             success = True
 
         return {"status": "sent" if success else "failed"}
+
+    @app.get("/humans")
+    async def list_human_recipients():
+        """List configured human recipients without exposing addresses or secrets."""
+        return {
+            "humans": [
+                _response_dict(_human_to_response(human))
+                for human in _list_human_recipients()
+            ]
+        }
 
     @app.get("/humans/{identifier}", response_model=HumanRecipientResponse)
     async def lookup_human_recipient(identifier: str):

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -910,8 +910,9 @@ class SessionManager:
         for proposal_data in data.get("adoption_proposals", []):
             proposal = AdoptionProposal.from_dict(proposal_data)
             self.adoption_proposals[proposal.id] = proposal
+        registry_recovered = self._recover_missing_maintainer_registration()
         registry_changed = self._prune_agent_registrations(persist=False)
-        if retired_codex_app_sessions or registry_changed:
+        if retired_codex_app_sessions or registry_recovered or registry_changed:
             self._save_state()
 
     def _rewrite_state_raw(self, sessions_data: list[dict], extra_state: Optional[dict] = None) -> bool:
@@ -2979,14 +2980,62 @@ class SessionManager:
         self.maintainer_session_id = registration.session_id if registration else None
 
     def _get_live_registered_session(self, session_id: str) -> Optional[Session]:
-        """Return the owning session when it is still live for registry purposes."""
+        """Return the owning session when it is still usable for registry purposes."""
         session = self.sessions.get(session_id)
-        if not session or session.status == SessionStatus.STOPPED:
+        if not session or not self._session_is_restorable_for_registry(session):
             return None
         return session
 
+    @staticmethod
+    def _session_is_restorable_for_registry(session: Session) -> bool:
+        """Return whether a stopped session still has enough provider state to restore."""
+        if session.status != SessionStatus.STOPPED:
+            return True
+        if session.provider == "claude":
+            return bool(session.provider_resume_id or session.transcript_path)
+        if session.provider == "codex-app":
+            return bool(session.codex_thread_id or session.provider_resume_id)
+        if session.provider in {"codex", "codex-fork"}:
+            return bool(session.provider_resume_id)
+        return bool(session.provider_resume_id)
+
+    def _recover_missing_maintainer_registration(self) -> bool:
+        """Recover a missing maintainer role when persisted history still points to it."""
+        registration_map = self._get_agent_registration_map()
+        if "maintainer" in registration_map:
+            return False
+
+        candidates = [
+            self.maintainer_session_id,
+            self.agent_role_last_session_ids.get("maintainer"),
+        ]
+        for session_id in candidates:
+            if not session_id:
+                continue
+            session = self.sessions.get(session_id)
+            if not session or not self._session_is_restorable_for_registry(session):
+                continue
+            session_identity = {
+                str(session.friendly_name or "").strip().lower(),
+                str(getattr(session, "role", "") or "").strip().lower(),
+                str(getattr(session, "auto_bootstrapped_role", "") or "").strip().lower(),
+            }
+            if "maintainer" not in session_identity:
+                continue
+
+            registration_map["maintainer"] = AgentRegistration(
+                role="maintainer",
+                session_id=session_id,
+            )
+            self.agent_role_last_session_ids["maintainer"] = session_id
+            self._synchronize_maintainer_alias()
+            logger.info("Recovered missing maintainer registry entry for session %s", session_id)
+            return True
+
+        return False
+
     def _prune_agent_registrations(self, persist: bool = True) -> bool:
-        """Drop registrations whose owning sessions no longer exist or are no longer live."""
+        """Drop registrations whose owning sessions no longer exist or are no longer restorable."""
         registration_map = self._get_agent_registration_map()
         removed = False
         for role, registration in list(registration_map.items()):
@@ -3084,8 +3133,8 @@ class SessionManager:
         registration = registration_map.get(normalized_role)
         if not registration or registration.session_id != session_id:
             return False
-        self.agent_role_last_session_ids[normalized_role] = registration.session_id
         registration_map.pop(normalized_role, None)
+        self.agent_role_last_session_ids.pop(normalized_role, None)
         self._synchronize_maintainer_alias()
         self._save_state()
         return True

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -12,7 +12,7 @@ from fastapi.testclient import TestClient
 
 from src.server import create_app
 from src.email_handler import RegisteredEmailUser
-from src.human_recipients import HumanChannel, HumanRecipient
+from src.human_recipients import HumanChannel, HumanRecipient, HumanRecipientRegistry
 from src.models import Session, SessionStatus, Subagent, SubagentStatus, DeliveryResult
 
 
@@ -359,6 +359,28 @@ class TestHumanRecipientEndpoints:
         assert data["available_channels"] == ["telegram", "email"]
         assert data["telegram_delivery"] == "sender_session_topic"
         assert data["email_use"] == "fallback_only"
+
+    def test_list_humans_redacts_addresses(self, test_client, mock_email_handler):
+        mock_email_handler.human_registry.return_value = HumanRecipientRegistry(
+            {"rajesh": _human_recipient()}
+        )
+
+        response = test_client.get("/humans")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["humans"] == [
+            {
+                "recipient": "rajesh",
+                "display_name": "Human operator",
+                "aliases": ["rajesh", "rajeshgoli", "user"],
+                "default_channel": "telegram",
+                "available_channels": ["telegram", "email"],
+                "telegram_delivery": "sender_session_topic",
+                "email_use": "fallback_only",
+            }
+        ]
+        assert "private@example.com" not in response.text
 
     def test_forced_telegram_posts_to_sender_topic(
         self,

--- a/tests/unit/test_agent_registry.py
+++ b/tests/unit/test_agent_registry.py
@@ -66,6 +66,82 @@ def test_registering_maintainer_updates_compat_field(tmp_path):
     assert manager.get_maintainer_session().id == session.id
 
 
+def test_load_state_recovers_missing_maintainer_registration_from_live_last_holder(tmp_path):
+    session = _session("maint123", tmp_path)
+    session.friendly_name = "maintainer"
+    state_path = tmp_path / "sessions.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "sessions": [session.to_dict()],
+                "maintainer_session_id": None,
+                "agent_registrations": [],
+                "agent_role_last_session_ids": {"maintainer": session.id},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with patch("src.session_manager.TmuxController") as tmux_cls:
+        tmux_cls.return_value.session_exists.return_value = True
+        manager = SessionManager(
+            log_dir=str(tmp_path / "logs"),
+            state_file=str(state_path),
+            config={},
+        )
+
+    registration = manager.lookup_agent_registration("maintainer")
+    assert registration is not None
+    assert registration.session_id == session.id
+    assert manager.maintainer_session_id == session.id
+
+    state_data = json.loads(state_path.read_text())
+    assert state_data["agent_registrations"][0]["role"] == "maintainer"
+    assert state_data["agent_registrations"][0]["session_id"] == session.id
+
+
+def test_load_state_recovers_missing_maintainer_registration_for_restorable_holder(tmp_path):
+    session = _session("maint123", tmp_path)
+    session.friendly_name = "maintainer"
+    session.status = SessionStatus.STOPPED
+    session.provider = "codex-fork"
+    session.provider_resume_id = "resume-maint123"
+    state_path = tmp_path / "sessions.json"
+    state_path.write_text(
+        json.dumps(
+            {
+                "sessions": [session.to_dict()],
+                "maintainer_session_id": None,
+                "agent_registrations": [],
+                "agent_role_last_session_ids": {"maintainer": session.id},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    manager = SessionManager(
+        log_dir=str(tmp_path / "logs"),
+        state_file=str(state_path),
+        config={},
+    )
+
+    registration = manager.lookup_agent_registration("maintainer")
+    assert registration is not None
+    assert registration.session_id == session.id
+
+
+def test_explicit_unregister_clears_last_role_hint(tmp_path):
+    manager = _manager(tmp_path)
+    session = _session("role1234", tmp_path)
+    manager.sessions[session.id] = session
+    manager.register_agent_role(session.id, "reviewer")
+
+    assert manager.unregister_agent_role(session.id, "reviewer") is True
+
+    state_data = json.loads((tmp_path / "sessions.json").read_text())
+    assert "reviewer" not in state_data["agent_role_last_session_ids"]
+
+
 def test_lookup_prunes_stopped_registration(tmp_path):
     manager = _manager(tmp_path)
     session = _session("stop1234", tmp_path)
@@ -276,11 +352,67 @@ def test_cmd_register_lookup_unregister_and_roster(capsys):
     assert cmd_unregister(client, "sess1234", "reviewer") == 0
     assert "Unregistered: reviewer" in capsys.readouterr().out
 
+    client.list_humans.return_value = []
     assert cmd_roster(client) == 0
     roster_output = capsys.readouterr().out
+    assert "Agents" in roster_output
     assert "Role" in roster_output
     assert "reviewer" in roster_output
     assert "sess1234" in roster_output
+
+
+def test_cmd_roster_lists_reachable_humans(capsys):
+    client = Mock()
+    client.list_registry.return_value = []
+    client.list_humans.return_value = [
+        {
+            "recipient": "rajesh",
+            "display_name": "Human operator",
+            "aliases": ["rajesh", "rajeshgoli", "user"],
+            "default_channel": "telegram",
+            "available_channels": ["telegram", "email"],
+        }
+    ]
+
+    assert cmd_roster(client) == 0
+
+    output = capsys.readouterr().out
+    assert "Humans" in output
+    assert "rajesh" in output
+    assert "Human operator" in output
+    assert "rajeshgoli,user" in output
+    assert "telegram,email" in output
+
+
+def test_cmd_roster_lists_roles_and_humans(capsys):
+    client = Mock()
+    client.list_registry.return_value = [
+        {
+            "role": "maintainer",
+            "session_id": "9b134c6e",
+            "friendly_name": "maintainer",
+            "provider": "codex-fork",
+            "activity_state": "working",
+        }
+    ]
+    client.list_humans.return_value = [
+        {
+            "recipient": "rajesh",
+            "display_name": "Human operator",
+            "aliases": ["rajesh", "user"],
+            "default_channel": "telegram",
+            "available_channels": ["telegram", "email"],
+        }
+    ]
+
+    assert cmd_roster(client) == 0
+
+    output = capsys.readouterr().out
+    assert "Agents" in output
+    assert "maintainer" in output
+    assert "9b134c6e" in output
+    assert "Humans" in output
+    assert "rajesh" in output
 
 
 def test_cmd_lookup_human_alias_prints_delivery_guidance(capsys):

--- a/tests/unit/test_client_codex_endpoints.py
+++ b/tests/unit/test_client_codex_endpoints.py
@@ -76,6 +76,15 @@ def test_lookup_human_uses_humans_endpoint():
     req.assert_called_once_with("GET", "/humans/user")
 
 
+def test_list_humans_uses_humans_endpoint():
+    client = _make_client()
+    payload = {"humans": [{"recipient": "rajesh"}]}
+    with patch.object(client, "_request", return_value=(payload, True, False)) as req:
+        result = client.list_humans()
+    assert result == payload["humans"]
+    req.assert_called_once_with("GET", "/humans")
+
+
 def test_send_human_telegram_result_uses_humans_endpoint():
     client = _make_client()
     payload = {"status": "sent", "recipient": "rajesh"}


### PR DESCRIPTION
## Summary

- Add a redacted `/humans` list endpoint and CLI client method so `sm roster` can show configured reachable humans alongside registered agent roles.
- Keep roster semantics tied to actual registry roles while separately showing human recipients and their aliases/default channels.
- Recover a missing `maintainer` registry entry on state load only when persisted maintainer history points to an active or restorable session that identifies as maintainer, and clear last-role hints on explicit unregister.

## Why

The roster follow-up to the human recipient work showed two gaps: configured humans were reachable but invisible to agents, and the maintainer role could resolve through live-name fallback even when the durable role registry was empty. Roster should expose reachable configured humans plus actual registry roles, and maintainer should not depend on fallback behavior when a persisted registry entry can be recovered.

## Validation

- `pytest tests/unit/test_google_auth.py::test_watch_html_is_not_cached_but_hashed_assets_remain_static tests/unit/test_agent_registry.py tests/unit/test_client_codex_endpoints.py tests/integration/test_api_endpoints.py::TestHumanRecipientEndpoints -q`
- `pytest tests/unit/test_agent_registry.py tests/unit/test_client_codex_endpoints.py tests/integration/test_api_endpoints.py tests/unit/test_email_commands.py tests/unit/test_google_auth.py -q`
- `pytest -q`