### PR TITLE
Resolve registry aliases before sm send

### DIFF
--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -214,7 +214,7 @@ def resolve_session_id_with_status(
     except TypeError:
         session = client.get_session(identifier)
     if session:
-        return identifier, session, False
+        return session.get("id") or identifier, session, False
 
     # Not found by ID, try as friendly name
     try:

--- a/tests/unit/test_cli_parsing.py
+++ b/tests/unit/test_cli_parsing.py
@@ -969,6 +969,26 @@ class TestSessionResolution:
         assert unavailable is False
         mock_client.get_session.assert_called_with("abc123")
 
+    def test_resolve_with_status_returns_server_resolved_session_id(self):
+        """Registry/read aliases must not leak into later mutation endpoints."""
+        mock_client = MagicMock()
+        mock_client.get_session.return_value = {
+            "id": "9b134c6e",
+            "friendly_name": "maintainer",
+            "aliases": ["maintainer"],
+        }
+
+        session_id, session, unavailable = resolve_session_id_with_status(
+            mock_client,
+            "maintainer",
+            timeout=15.0,
+        )
+
+        assert session_id == "9b134c6e"
+        assert session["friendly_name"] == "maintainer"
+        assert unavailable is False
+        mock_client.list_sessions.assert_not_called()
+
     def test_resolve_with_status_preserves_include_stopped_for_legacy_list_sessions(self):
         """Legacy list_sessions fallbacks still honor include_stopped."""
         mock_client = MagicMock()

--- a/tests/unit/test_dispatch.py
+++ b/tests/unit/test_dispatch.py
@@ -727,6 +727,26 @@ class TestCmdSendRemindParams:
         assert call_kwargs["remind_soft_threshold"] is None
         assert call_kwargs["remind_hard_threshold"] is None
 
+    def test_registry_alias_send_uses_resolved_session_id(self, capsys):
+        """A server-resolved registry alias must post to the concrete session ID."""
+        from src.cli.commands import cmd_send
+        mock_client = self._make_client()
+        mock_client.get_session.return_value = {
+            "id": "9b134c6e",
+            "friendly_name": "maintainer",
+            "status": "idle",
+            "provider": "codex-fork",
+            "aliases": ["maintainer"],
+        }
+
+        rc = cmd_send(mock_client, "maintainer", "hello")
+
+        assert rc == 0
+        mock_client.send_input.assert_called_once()
+        assert mock_client.send_input.call_args.args[:2] == ("9b134c6e", "hello")
+        captured = capsys.readouterr()
+        assert "Input sent to maintainer (9b134c6e)" in captured.out
+
     def test_track_sets_reply_cancelled_thresholds(self):
         """--track maps to periodic remind thresholds and reply-cancel metadata."""
         from src.cli.commands import cmd_send


### PR DESCRIPTION
## Summary

- Return the concrete session ID from CLI direct session lookups when the server resolves an alias/registry role.
- Add regressions for `sm send maintainer` using the resolved `9b134c6e` session ID instead of posting to `/sessions/maintainer/input`.

Fixes #720

## Testing

- `/Users/rajesh/Desktop/automation/session-manager/venv/bin/python -m pytest tests/unit/test_cli_parsing.py::TestSessionResolution::test_resolve_with_status_returns_server_resolved_session_id tests/unit/test_dispatch.py::TestCmdSendRemindParams::test_registry_alias_send_uses_resolved_session_id -q`
- `/Users/rajesh/Desktop/automation/session-manager/venv/bin/python -m pytest tests/unit/test_cli_parsing.py tests/unit/test_dispatch.py -q`
