### PR TITLE
Add Settings to Android watch overflow menu

### DIFF
--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
@@ -597,6 +597,20 @@ private fun HeaderBar(
                                 )
                             },
                         )
+                        DropdownMenuItem(
+                            text = { Text("Settings") },
+                            onClick = {
+                                menuExpanded = false
+                                onOpenSettings()
+                            },
+                            leadingIcon = {
+                                Icon(
+                                    Icons.Rounded.Settings,
+                                    contentDescription = null,
+                                    tint = TextSecondary,
+                                )
+                            },
+                        )
                     }
                 }
                 SettingsIconButtonWithUpdate(hasUpdate = hasUpdate, onClick = onOpenSettings)


### PR DESCRIPTION
Fixes #723

## Summary
- add a Settings item to the Android watch screen three-dot overflow menu
- keep the existing gear icon entry point unchanged

## Verification
- JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.18/libexec/openjdk.jdk/Contents/Home ./gradlew assembleDebug
- python -m pytest tests/unit/test_android_api_surface.py tests/unit/test_android_analytics_api.py -q