### PR TITLE
Send bearer auth on Android terminal WebSocket

### DIFF
--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SessionManagerRepository.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SessionManagerRepository.kt
@@ -246,12 +246,19 @@ class SessionManagerRepository {
 
     fun openMobileTerminalSocket(
         ticket: MobileAttachTicketResponse,
+        accessToken: String,
         listener: WebSocketListener,
     ): WebSocket {
-        val request = Request.Builder()
-            .url(ticket.wsUrl)
-            .build()
-        return httpClient().newWebSocket(request, listener)
+        return httpClient().newWebSocket(mobileTerminalSocketRequest(ticket, accessToken), listener)
+    }
+
+    fun mobileTerminalSocketRequest(ticket: MobileAttachTicketResponse, accessToken: String): Request {
+        val builder = Request.Builder().url(ticket.wsUrl)
+        val token = accessToken.trim()
+        if (token.isNotBlank()) {
+            builder.header("Authorization", "Bearer $token")
+        }
+        return builder.build()
     }
 
     suspend fun requestStatus(baseUrl: String, token: String): Result<RequestStatusResponse> = withContext(Dispatchers.IO) {

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchViewModel.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchViewModel.kt
@@ -288,7 +288,7 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
                 return@launch
             }
             terminalSocket?.close(1000, "new attach")
-            terminalSocket = sessionRepository.openMobileTerminalSocket(ticket, object : WebSocketListener() {
+            terminalSocket = sessionRepository.openMobileTerminalSocket(ticket, accessToken, object : WebSocketListener() {
                 override fun onOpen(webSocket: WebSocket, response: Response) {
                     val frame = JSONObject()
                         .put("type", "auth")

--- a/android-app/app/src/test/java/li/rajeshgo/sm/data/repository/SessionManagerRepositoryTest.kt
+++ b/android-app/app/src/test/java/li/rajeshgo/sm/data/repository/SessionManagerRepositoryTest.kt
@@ -1,6 +1,8 @@
 package li.rajeshgo.sm.data.repository
 
+import li.rajeshgo.sm.data.model.MobileAttachTicketResponse
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Test
 
 class SessionManagerRepositoryTest {
@@ -49,6 +51,33 @@ class SessionManagerRepositoryTest {
                 "abc123",
                 "https://api.example.com/proxy/client/sessions/abc123/attach-ticket",
             ),
+        )
+    }
+
+    @Test
+    fun mobileTerminalSocketRequestIncludesBearerToken() {
+        val repository = SessionManagerRepository()
+        val request = repository.mobileTerminalSocketRequest(ticket(), " smat_token ")
+
+        assertEquals("Bearer smat_token", request.header("Authorization"))
+        assertEquals("https://example.com/client/terminal", request.url.toString())
+    }
+
+    @Test
+    fun mobileTerminalSocketRequestOmitsBlankBearerToken() {
+        val repository = SessionManagerRepository()
+        val request = repository.mobileTerminalSocketRequest(ticket(), " ")
+
+        assertNull(request.header("Authorization"))
+    }
+
+    private fun ticket(): MobileAttachTicketResponse {
+        return MobileAttachTicketResponse(
+            ticketId = "ticket-1",
+            ticketSecret = "secret-1",
+            deviceKeyId = "device-1",
+            wsUrl = "wss://example.com/client/terminal",
+            expiresAt = "2026-05-03T00:00:00Z",
         )
     }
 }


### PR DESCRIPTION
Fixes #725

## Summary
- include the stored device bearer token on Android mobile-terminal WebSocket upgrade requests
- keep the existing signed ticket/device-key auth frame as the terminal-specific authorization layer
- add JVM coverage for WebSocket request header construction

## Verification
- JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.18/libexec/openjdk.jdk/Contents/Home ./gradlew :app:testDebugUnitTest --tests li.rajeshgo.sm.data.repository.SessionManagerRepositoryTest
- JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.18/libexec/openjdk.jdk/Contents/Home ./gradlew :app:testDebugUnitTest
- JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.18/libexec/openjdk.jdk/Contents/Home ./gradlew assembleDebug