### PR TITLE
Fix Android mobile terminal asset loading

### DIFF
--- a/android-app/app/src/main/assets/sm_terminal/terminal.html
+++ b/android-app/app/src/main/assets/sm_terminal/terminal.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';">
   <link rel="stylesheet" href="vendor/xterm.css">
   <style>
     html, body, #terminal {

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
@@ -5,6 +5,7 @@ import android.os.Handler
 import android.os.Looper
 import android.webkit.JavascriptInterface
 import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
 import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -82,6 +83,7 @@ import kotlin.coroutines.coroutineContext
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import org.json.JSONObject
+import java.io.ByteArrayInputStream
 import li.rajeshgo.sm.data.model.ClientSession
 import li.rajeshgo.sm.data.model.SessionDetail
 import li.rajeshgo.sm.ui.navigation.AppBottomNav
@@ -538,14 +540,22 @@ private fun TerminalWebView(
                 settings.javaScriptEnabled = true
                 settings.domStorageEnabled = false
                 settings.allowContentAccess = false
-                settings.allowFileAccess = true
+                settings.allowFileAccess = false
                 settings.allowFileAccessFromFileURLs = false
                 settings.allowUniversalAccessFromFileURLs = false
                 settings.cacheMode = WebSettings.LOAD_NO_CACHE
-                settings.blockNetworkLoads = true
+                settings.blockNetworkLoads = false
                 webViewClient = object : WebViewClient() {
                     override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
-                        return true
+                        val url = request?.url ?: return true
+                        return url.scheme != "https" || url.host != TERMINAL_ASSET_HOST
+                    }
+
+                    override fun shouldInterceptRequest(
+                        view: WebView?,
+                        request: WebResourceRequest?,
+                    ): WebResourceResponse {
+                        return terminalAssetResponse(context, request?.url)
                     }
                 }
                 addJavascriptInterface(
@@ -560,7 +570,7 @@ private fun TerminalWebView(
                     ),
                     "TerminalBridge",
                 )
-                loadUrl("file:///android_asset/sm_terminal/terminal.html")
+                loadUrl(TERMINAL_ASSET_URL)
                 webViewRef = this
             }
         },
@@ -586,6 +596,53 @@ private fun TerminalWebView(
                 webView.evaluateJavascript("window.smCopySelection();", null)
             }
         },
+    )
+}
+
+private const val TERMINAL_ASSET_HOST = "sm-terminal.local"
+private const val TERMINAL_ASSET_URL = "https://$TERMINAL_ASSET_HOST/terminal.html"
+
+private fun terminalAssetResponse(context: android.content.Context, uri: Uri?): WebResourceResponse {
+    if (uri?.scheme != "https" || uri.host != TERMINAL_ASSET_HOST) {
+        return blockedTerminalAssetResponse()
+    }
+    val assetPath = when (uri.path) {
+        "/terminal.html" -> "sm_terminal/terminal.html"
+        "/vendor/xterm.css" -> "sm_terminal/vendor/xterm.css"
+        "/vendor/xterm.js" -> "sm_terminal/vendor/xterm.js"
+        "/vendor/addon-fit.js" -> "sm_terminal/vendor/addon-fit.js"
+        else -> return blockedTerminalAssetResponse()
+    }
+    val mimeType = when {
+        assetPath.endsWith(".html") -> "text/html"
+        assetPath.endsWith(".css") -> "text/css"
+        assetPath.endsWith(".js") -> "application/javascript"
+        else -> "application/octet-stream"
+    }
+    return try {
+        WebResourceResponse(mimeType, "UTF-8", context.assets.open(assetPath)).apply {
+            setResponseHeaders(mapOf("Cache-Control" to "no-store"))
+        }
+    } catch (_: Exception) {
+        WebResourceResponse(
+            "text/plain",
+            "UTF-8",
+            404,
+            "Not Found",
+            mapOf("Cache-Control" to "no-store"),
+            ByteArrayInputStream(ByteArray(0)),
+        )
+    }
+}
+
+private fun blockedTerminalAssetResponse(): WebResourceResponse {
+    return WebResourceResponse(
+        "text/plain",
+        "UTF-8",
+        403,
+        "Forbidden",
+        mapOf("Cache-Control" to "no-store"),
+        ByteArrayInputStream(ByteArray(0)),
     )
 }
 


### PR DESCRIPTION
## Summary\n- serve the bundled xterm terminal page through an intercepted private HTTPS origin instead of file:// android_asset URLs\n- keep WebView file/content access disabled and add CSP for the renderer shell\n- deploy hotfix APK artifact 7b4ec339 for immediate validation\n\nFixes #731.\n\n## Validation\n- python -m pytest tests/unit/test_android_api_surface.py -q\n- JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.18/libexec/openjdk.jdk/Contents/Home ./gradlew testDebugUnitTest assembleDebug\n