### PR TITLE
[codex] Fix mobile terminal renderer readiness

### DIFF
--- a/android-app/app/src/main/assets/sm_terminal/terminal.html
+++ b/android-app/app/src/main/assets/sm_terminal/terminal.html
@@ -6,27 +6,71 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline';">
   <link rel="stylesheet" href="vendor/xterm.css">
   <style>
-    html, body, #terminal {
+    html, body, #terminal-root, #terminal {
       background: #05080d;
       height: 100%;
       margin: 0;
+      min-height: 100vh;
       overflow: hidden;
       width: 100%;
     }
+    #terminal-root {
+      bottom: 0;
+      left: 0;
+      position: fixed;
+      right: 0;
+      top: 0;
+    }
+    #terminal {
+      bottom: 0;
+      left: 0;
+      position: absolute;
+      right: 0;
+      top: 0;
+    }
     .terminal {
+      box-sizing: border-box;
       height: 100%;
       padding: 8px;
     }
     .xterm .xterm-viewport {
       background-color: transparent;
     }
+    #terminal-status {
+      align-items: center;
+      background: #05080d;
+      bottom: 0;
+      color: #22d3ee;
+      display: flex;
+      font-family: monospace;
+      font-size: 12px;
+      justify-content: center;
+      left: 0;
+      padding: 12px;
+      position: absolute;
+      right: 0;
+      text-align: center;
+      top: 0;
+      z-index: 5;
+    }
+    #terminal-status.error {
+      color: #fb7185;
+    }
+    #terminal-status.hidden {
+      display: none;
+    }
   </style>
 </head>
 <body>
-  <div id="terminal"></div>
+  <div id="terminal-root">
+    <div id="terminal"></div>
+    <div id="terminal-status">Loading terminal renderer...</div>
+  </div>
   <script src="vendor/xterm.js"></script>
   <script src="vendor/addon-fit.js"></script>
   <script>
+    const terminalElement = document.getElementById("terminal");
+    const statusElement = document.getElementById("terminal-status");
     const fitAddon = new FitAddon.FitAddon();
     const term = new Terminal({
       allowProposedApi: false,
@@ -62,13 +106,41 @@
       }
     });
     term.loadAddon(fitAddon);
-    term.open(document.getElementById("terminal"));
 
     let ready = false;
+    let opened = false;
     let lastResize = "";
+    let pendingWrites = [];
+    let openAttempts = 0;
+    let openTimer = null;
+    let lastBackendStatus = "connecting";
 
     function bridge() {
       return window.TerminalBridge;
+    }
+
+    function bridgeCall(method, ...args) {
+      const target = bridge();
+      if (!target || typeof target[method] !== "function") {
+        return;
+      }
+      try {
+        target[method](...args);
+      } catch (_) {
+      }
+    }
+
+    function setRendererStatus(message, isError) {
+      statusElement.textContent = message;
+      statusElement.classList.toggle("error", Boolean(isError));
+      statusElement.classList.toggle("hidden", ready && !isError);
+      bridgeCall("status", message);
+    }
+
+    function reportError(message) {
+      ready = false;
+      setRendererStatus(message, true);
+      bridgeCall("error", message);
     }
 
     function reportResize() {
@@ -77,14 +149,14 @@
         return;
       }
       lastResize = key;
-      if (bridge()) {
-        bridge().resize(term.cols, term.rows);
-      }
+      bridgeCall("resize", term.cols, term.rows);
     }
 
     function reportReady() {
-      if (bridge()) {
-        bridge().ready(term.cols, term.rows);
+      if (!ready) {
+        ready = true;
+        setRendererStatus(`Terminal renderer ready ${term.cols}x${term.rows}`, false);
+        bridgeCall("ready", term.cols, term.rows);
       }
     }
 
@@ -92,43 +164,152 @@
       try {
         fitAddon.fit();
         reportResize();
-      } catch (_) {
+        if (term.cols > 0 && term.rows > 0) {
+          reportReady();
+          flushPendingWrites();
+          term.focus();
+        }
+      } catch (error) {
+        reportError(`Terminal fit failed: ${error && error.message ? error.message : error}`);
       }
     }
 
-    term.onData((data) => {
-      if (bridge()) {
-        bridge().input(data);
+    function viewportDimensions() {
+      const width = window.innerWidth
+        || document.documentElement.clientWidth
+        || document.body.clientWidth
+        || 0;
+      const height = window.innerHeight
+        || document.documentElement.clientHeight
+        || document.body.clientHeight
+        || 0;
+      return { width, height };
+    }
+
+    function applyViewportSize() {
+      const dimensions = viewportDimensions();
+      if (dimensions.width > 0) {
+        terminalElement.style.width = `${dimensions.width}px`;
       }
-    });
+      if (dimensions.height > 0) {
+        terminalElement.style.height = `${dimensions.height}px`;
+      }
+      return dimensions;
+    }
 
-    term.onResize(() => reportResize());
+    function hasLayout() {
+      const dimensions = applyViewportSize();
+      const rect = terminalElement.getBoundingClientRect();
+      const width = rect.width || dimensions.width;
+      const height = rect.height || dimensions.height;
+      return width >= 40 && height >= 40;
+    }
 
-    window.addEventListener("resize", fitAndReport);
+    function scheduleOpenRetry() {
+      if (openTimer !== null) {
+        return;
+      }
+      openTimer = window.setTimeout(() => {
+        openTimer = null;
+        ensureTerminalOpen();
+      }, 250);
+    }
 
-    window.smFocus = function() {
-      term.focus();
-    };
+    function ensureTerminalOpen() {
+      if (!hasLayout()) {
+        openAttempts += 1;
+        if (openAttempts === 1 || openAttempts % 4 === 0) {
+          setRendererStatus(`Waiting for terminal layout (${lastBackendStatus}, attempt ${openAttempts})`, false);
+        }
+        scheduleOpenRetry();
+        return;
+      }
+      try {
+        if (openTimer !== null) {
+          window.clearTimeout(openTimer);
+          openTimer = null;
+        }
+        if (!opened) {
+          term.open(terminalElement);
+          opened = true;
+        }
+        fitAndReport();
+      } catch (error) {
+        reportError(`Terminal open failed: ${error && error.message ? error.message : error}`);
+      }
+    }
 
-    window.smWriteBase64 = function(payload) {
+    function bytesFromBase64(payload) {
       const binary = atob(payload);
       const bytes = new Uint8Array(binary.length);
       for (let i = 0; i < binary.length; i += 1) {
         bytes[i] = binary.charCodeAt(i);
       }
-      term.write(bytes);
+      return bytes;
+    }
+
+    function writeFrame(frame) {
+      try {
+        const data = frame.encoding === "base64" ? bytesFromBase64(frame.payload) : frame.payload;
+        const byteCount = frame.encoding === "base64" ? data.length : frame.payload.length;
+        term.write(data, () => {
+          bridgeCall("written", String(frame.sequence), byteCount);
+        });
+      } catch (error) {
+        reportError(`Terminal write failed: ${error && error.message ? error.message : error}`);
+      }
+    }
+
+    function flushPendingWrites() {
+      if (!ready || pendingWrites.length === 0) {
+        return;
+      }
+      const writes = pendingWrites;
+      pendingWrites = [];
+      writes.forEach(writeFrame);
+    }
+
+    function queueOrWrite(frame) {
+      if (!ready) {
+        pendingWrites.push(frame);
+        setRendererStatus(`Queued ${pendingWrites.length} terminal frames while renderer initializes`, false);
+        ensureTerminalOpen();
+        return;
+      }
+      writeFrame(frame);
+    }
+
+    term.onData((data) => {
+      bridgeCall("input", data);
+    });
+
+    term.onResize(() => reportResize());
+
+    window.addEventListener("resize", () => {
+      applyViewportSize();
+      fitAndReport();
+    });
+
+    window.smFocus = function() {
+      if (ready) {
+        term.focus();
+      }
     };
 
-    window.smWriteText = function(text) {
-      term.write(text);
+    window.smWriteBase64 = function(sequence, payload) {
+      queueOrWrite({ sequence: Number(sequence) || 0, payload, encoding: "base64" });
+    };
+
+    window.smWriteText = function(sequence, text) {
+      queueOrWrite({ sequence: Number(sequence) || 0, payload: text, encoding: "text" });
     };
 
     window.smSetStatus = function(status) {
-      if (!ready) {
-        ready = true;
-        fitAndReport();
-        reportReady();
+      lastBackendStatus = status || lastBackendStatus;
+      if (!ready && !statusElement.classList.contains("error")) {
+        setRendererStatus(`Backend ${lastBackendStatus}; waiting for terminal renderer`, false);
       }
+      ensureTerminalOpen();
     };
 
     window.smCopySelection = function() {
@@ -144,17 +325,13 @@
         }
         text = lines.join("\n").trimEnd();
       }
-      if (bridge()) {
-        bridge().copy(text);
-      }
+      bridgeCall("copy", text);
     };
 
-    setTimeout(() => {
-      ready = true;
-      fitAndReport();
-      reportReady();
-      term.focus();
-    }, 80);
+    window.requestAnimationFrame(() => {
+      applyViewportSize();
+      ensureTerminalOpen();
+    });
   </script>
 </body>
 </html>

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
@@ -391,6 +391,10 @@ fun WatchScreen(
                 onEnter = { viewModel.sendTerminalKey("enter") },
                 onTerminalInput = viewModel::sendTerminalData,
                 onTerminalResize = viewModel::resizeTerminal,
+                onRendererStatus = viewModel::markTerminalRendererStatus,
+                onRendererReady = viewModel::markTerminalRendererReady,
+                onRendererError = viewModel::markTerminalRendererError,
+                onRendererWritten = viewModel::markTerminalRendererWritten,
                 onDetach = viewModel::detachTerminal,
                 onCopy = { selectedText ->
                     val clipboard = context.getSystemService(android.content.ClipboardManager::class.java)
@@ -413,6 +417,10 @@ private fun MobileTerminalOverlay(
     onEnter: () -> Unit,
     onTerminalInput: (String) -> Unit,
     onTerminalResize: (cols: Int, rows: Int) -> Unit,
+    onRendererStatus: (String) -> Unit,
+    onRendererReady: (cols: Int, rows: Int) -> Unit,
+    onRendererError: (String) -> Unit,
+    onRendererWritten: (sequence: Long, bytes: Int) -> Unit,
     onDetach: () -> Unit,
     onCopy: (String) -> Unit,
 ) {
@@ -452,6 +460,14 @@ private fun MobileTerminalOverlay(
                             color = if (terminal.error == null) Cyan else Rose,
                             fontFamily = FontFamily.Monospace,
                         )
+                        Text(
+                            text = terminalDiagnostics(terminal),
+                            style = MaterialTheme.typography.labelSmall,
+                            color = if (terminal.rendererError == null) TextMuted else Rose,
+                            fontFamily = FontFamily.Monospace,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                        )
                     }
                     OutlinedButton(onClick = onDetach) {
                         Text("Detach")
@@ -478,6 +494,10 @@ private fun MobileTerminalOverlay(
                     copyRequest = copyRequest,
                     onInput = onTerminalInput,
                     onResize = onTerminalResize,
+                    onRendererStatus = onRendererStatus,
+                    onRendererReady = onRendererReady,
+                    onRendererError = onRendererError,
+                    onRendererWritten = onRendererWritten,
                     onCopyText = onCopy,
                 )
             }
@@ -518,6 +538,10 @@ private fun TerminalWebView(
     copyRequest: Long,
     onInput: (String) -> Unit,
     onResize: (cols: Int, rows: Int) -> Unit,
+    onRendererStatus: (String) -> Unit,
+    onRendererReady: (cols: Int, rows: Int) -> Unit,
+    onRendererError: (String) -> Unit,
+    onRendererWritten: (sequence: Long, bytes: Int) -> Unit,
     onCopyText: (String) -> Unit,
 ) {
     var deliveredSequence by remember { mutableStateOf(0L) }
@@ -563,10 +587,13 @@ private fun TerminalWebView(
                         onInput = onInput,
                         onResize = onResize,
                         onCopyText = onCopyText,
+                        onStatus = onRendererStatus,
                         onReady = { cols, rows ->
                             terminalReady = true
-                            onResize(cols, rows)
+                            onRendererReady(cols, rows)
                         },
+                        onError = onRendererError,
+                        onWritten = onRendererWritten,
                     ),
                     "TerminalBridge",
                 )
@@ -581,9 +608,9 @@ private fun TerminalWebView(
                     .filter { it.sequence > deliveredSequence }
                     .forEach { frame ->
                         if (frame.encoding == "base64") {
-                            webView.evaluateJavascript("window.smWriteBase64(${jsString(frame.data)});", null)
+                            webView.evaluateJavascript("window.smWriteBase64(${frame.sequence}, ${jsString(frame.data)});", null)
                         } else {
-                            webView.evaluateJavascript("window.smWriteText(${jsString(frame.data)});", null)
+                            webView.evaluateJavascript("window.smWriteText(${frame.sequence}, ${jsString(frame.data)});", null)
                         }
                         deliveredSequence = frame.sequence
                     }
@@ -597,6 +624,27 @@ private fun TerminalWebView(
             }
         },
     )
+}
+
+private fun terminalDiagnostics(terminal: TerminalUiState): String {
+    val frameSummary = "${terminal.outputFrameCount} frames/${formatDiagnosticBytes(terminal.outputByteCount)}"
+    val ackSummary = if (terminal.rendererLastAckSequence > 0) {
+        "ack ${terminal.rendererLastAckSequence}/${terminal.outputSequence}"
+    } else {
+        "ack -/${terminal.outputSequence}"
+    }
+    val rendererMessage = terminal.rendererError ?: terminal.rendererStatus
+    return "$rendererMessage • $frameSummary • $ackSummary"
+}
+
+private fun formatDiagnosticBytes(bytes: Long): String {
+    if (bytes < 1024) {
+        return "${bytes}B"
+    }
+    if (bytes < 1024 * 1024) {
+        return "${bytes / 1024}KiB"
+    }
+    return "${bytes / (1024 * 1024)}MiB"
 }
 
 private const val TERMINAL_ASSET_HOST = "sm-terminal.local"
@@ -650,7 +698,10 @@ private class TerminalJavascriptBridge(
     private val onInput: (String) -> Unit,
     private val onResize: (cols: Int, rows: Int) -> Unit,
     private val onCopyText: (String) -> Unit,
+    private val onStatus: (String) -> Unit,
     private val onReady: (cols: Int, rows: Int) -> Unit,
+    private val onError: (String) -> Unit,
+    private val onWritten: (sequence: Long, bytes: Int) -> Unit,
 ) {
     private val mainHandler = Handler(Looper.getMainLooper())
 
@@ -670,8 +721,24 @@ private class TerminalJavascriptBridge(
     }
 
     @JavascriptInterface
+    fun status(message: String) {
+        mainHandler.post { onStatus(message) }
+    }
+
+    @JavascriptInterface
     fun ready(cols: Int, rows: Int) {
         mainHandler.post { onReady(cols, rows) }
+    }
+
+    @JavascriptInterface
+    fun error(message: String) {
+        mainHandler.post { onError(message) }
+    }
+
+    @JavascriptInterface
+    fun written(sequence: String, bytes: Int) {
+        val parsedSequence = sequence.toLongOrNull() ?: 0L
+        mainHandler.post { onWritten(parsedSequence, bytes) }
     }
 }
 

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchViewModel.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchViewModel.kt
@@ -27,6 +27,11 @@ data class TerminalUiState(
     val sessionId: String,
     val title: String,
     val status: String = "connecting",
+    val rendererStatus: String = "renderer loading",
+    val rendererLastAckSequence: Long = 0L,
+    val rendererError: String? = null,
+    val outputFrameCount: Int = 0,
+    val outputByteCount: Long = 0L,
     val outputFrames: List<TerminalOutputFrame> = emptyList(),
     val outputSequence: Long = 0L,
     val copyBuffer: String = "",
@@ -320,6 +325,7 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
                                 val encoding = payload.optString("encoding", "text")
                                 val mode = payload.optString("mode")
                                 val sequence = current.outputSequence + 1
+                                val byteCount = terminalOutputByteCount(data, encoding)
                                 current.copy(
                                     status = "attached",
                                     outputFrames = (
@@ -330,6 +336,8 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
                                         )
                                     ).takeLast(500),
                                     outputSequence = sequence,
+                                    outputFrameCount = current.outputFrameCount + 1,
+                                    outputByteCount = current.outputByteCount + byteCount,
                                     copyBuffer = if (encoding == "base64") {
                                         current.copyBuffer
                                     } else if (mode == "snapshot") {
@@ -372,6 +380,43 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
     fun updateTerminalInput(value: String) {
         _uiState.value = _uiState.value.copy(
             terminal = _uiState.value.terminal?.copy(inputDraft = value)
+        )
+    }
+
+    fun markTerminalRendererStatus(message: String) {
+        _uiState.value = _uiState.value.copy(
+            terminal = _uiState.value.terminal?.copy(rendererStatus = message)
+        )
+    }
+
+    fun markTerminalRendererReady(cols: Int, rows: Int) {
+        resizeTerminal(cols, rows)
+        _uiState.value = _uiState.value.copy(
+            terminal = _uiState.value.terminal?.copy(
+                rendererStatus = "renderer ready ${cols}x${rows}",
+                rendererError = null,
+            )
+        )
+    }
+
+    fun markTerminalRendererError(message: String) {
+        _uiState.value = _uiState.value.copy(
+            terminal = _uiState.value.terminal?.copy(
+                rendererStatus = "renderer error",
+                rendererError = message,
+            )
+        )
+    }
+
+    fun markTerminalRendererWritten(sequence: Long, bytes: Int) {
+        _uiState.value = _uiState.value.copy(
+            terminal = _uiState.value.terminal?.let { terminal ->
+                terminal.copy(
+                    rendererStatus = "renderer wrote frame $sequence (${bytes}B)",
+                    rendererLastAckSequence = maxOf(terminal.rendererLastAckSequence, sequence),
+                    rendererError = null,
+                )
+            }
         )
     }
 
@@ -439,6 +484,15 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
         }
         terminalAttachToken = null
         _uiState.value = _uiState.value.copy(terminal = null)
+    }
+
+    private fun terminalOutputByteCount(data: String, encoding: String): Long {
+        return if (encoding == "base64") {
+            val padding = data.takeLastWhile { it == '=' }.length
+            ((data.length * 3) / 4 - padding).coerceAtLeast(0).toLong()
+        } else {
+            data.length.toLong()
+        }
     }
 
     fun requestStatus(onComplete: (Result<String>) -> Unit) {

--- a/tests/unit/test_android_terminal_renderer_asset.py
+++ b/tests/unit/test_android_terminal_renderer_asset.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+
+TERMINAL_ASSET = (
+    Path(__file__).resolve().parents[2]
+    / "android-app"
+    / "app"
+    / "src"
+    / "main"
+    / "assets"
+    / "sm_terminal"
+    / "terminal.html"
+)
+
+
+def test_terminal_asset_waits_for_layout_before_reporting_ready():
+    source = TERMINAL_ASSET.read_text()
+
+    assert "function hasLayout()" in source
+    assert "getBoundingClientRect()" in source
+    assert "function viewportDimensions()" in source
+    assert "terminalElement.style.width" in source
+    assert "window.setTimeout" in source
+    assert "window.requestAnimationFrame(() =>" in source
+    assert "bridgeCall(\"ready\", term.cols, term.rows)" in source
+
+
+def test_terminal_asset_queues_output_until_renderer_is_ready():
+    source = TERMINAL_ASSET.read_text()
+
+    assert "let pendingWrites = [];" in source
+    assert "pendingWrites.push(frame)" in source
+    assert "flushPendingWrites()" in source
+    assert "window.smWriteBase64 = function(sequence, payload)" in source
+    assert "window.smWriteText = function(sequence, text)" in source
+
+
+def test_terminal_asset_reports_write_acks_and_renderer_errors():
+    source = TERMINAL_ASSET.read_text()
+
+    assert "bridgeCall(\"written\", String(frame.sequence), byteCount)" in source
+    assert "bridgeCall(\"error\", message)" in source
+    assert "Terminal write failed" in source


### PR DESCRIPTION
## Summary

Fixes #731.

The backend was accepting the mobile attach WebSocket and streaming PTY output, but the Android in-app terminal could still show a blank surface. This changes the terminal renderer so xterm is not opened or marked ready until its WebView container has real dimensions, queues output frames until that renderer-ready signal, and reports renderer status/write acknowledgements back to the Compose header.

## User Impact

If the terminal renderer initializes correctly, output is written after xterm is ready instead of being drained into a zero-size/early page. If it fails again, the terminal header now shows renderer state, frame count, streamed byte count, and last acknowledged write frame instead of a silent blank screen.

## Validation

- `python -m pytest tests/unit/test_android_terminal_renderer_asset.py -q`
- `JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.18/libexec/openjdk.jdk/Contents/Home ./gradlew testDebugUnitTest assembleDebug`
- Deployed hotfix APK artifact `335e38b6` with `./scripts/deploy_android_app.sh`
