### PR TITLE
Bridge Android terminal drag scrolling

### DIFF
--- a/android-app/app/src/main/assets/sm_terminal/terminal.html
+++ b/android-app/app/src/main/assets/sm_terminal/terminal.html
@@ -212,12 +212,7 @@
       if (scrollHandlersInstalled || !opened) {
         return;
       }
-      const targets = new Set([
-        terminalElement,
-        terminalViewport(),
-        terminalElement.querySelector(".xterm"),
-        terminalElement.querySelector(".xterm-screen"),
-      ].filter(Boolean));
+      const target = terminalElement;
       const onWheel = (event) => {
         if (scrollTerminalByPixels(event.deltaY)) {
           event.preventDefault();
@@ -247,13 +242,11 @@
         lastTouchY = null;
         touchScrollRemainder = 0;
       };
-      targets.forEach((target) => {
-        target.addEventListener("wheel", onWheel, { capture: true, passive: false });
-        target.addEventListener("touchstart", onTouchStart, { capture: true, passive: false });
-        target.addEventListener("touchmove", onTouchMove, { capture: true, passive: false });
-        target.addEventListener("touchend", onTouchEnd, { capture: true, passive: true });
-        target.addEventListener("touchcancel", onTouchEnd, { capture: true, passive: true });
-      });
+      target.addEventListener("wheel", onWheel, { capture: true, passive: false });
+      target.addEventListener("touchstart", onTouchStart, { capture: true, passive: false });
+      target.addEventListener("touchmove", onTouchMove, { capture: true, passive: false });
+      target.addEventListener("touchend", onTouchEnd, { capture: true, passive: true });
+      target.addEventListener("touchcancel", onTouchEnd, { capture: true, passive: true });
       scrollHandlersInstalled = true;
     }
 

--- a/android-app/app/src/main/assets/sm_terminal/terminal.html
+++ b/android-app/app/src/main/assets/sm_terminal/terminal.html
@@ -33,7 +33,7 @@
     .terminal {
       box-sizing: border-box;
       height: 100%;
-      padding: 8px;
+      padding: 4px;
     }
     .xterm .xterm-viewport {
       background-color: transparent;
@@ -84,9 +84,9 @@
       cursorStyle: "block",
       disableStdin: false,
       fontFamily: "monospace",
-      fontSize: 13,
+      fontSize: 12,
       letterSpacing: 0,
-      lineHeight: 1.12,
+      lineHeight: 1.06,
       scrollback: 4000,
       theme: {
         background: "#05080d",
@@ -212,21 +212,26 @@
       if (scrollHandlersInstalled || !opened) {
         return;
       }
-      const target = terminalViewport();
-      target.addEventListener("wheel", (event) => {
+      const targets = new Set([
+        terminalElement,
+        terminalViewport(),
+        terminalElement.querySelector(".xterm"),
+        terminalElement.querySelector(".xterm-screen"),
+      ].filter(Boolean));
+      const onWheel = (event) => {
         if (scrollTerminalByPixels(event.deltaY)) {
           event.preventDefault();
         }
-      }, { passive: false });
-      target.addEventListener("touchstart", (event) => {
+      };
+      const onTouchStart = (event) => {
         if (event.touches.length !== 1) {
           lastTouchY = null;
           return;
         }
         lastTouchY = event.touches[0].clientY;
         touchScrollRemainder = 0;
-      }, { passive: false });
-      target.addEventListener("touchmove", (event) => {
+      };
+      const onTouchMove = (event) => {
         if (event.touches.length !== 1 || lastTouchY === null) {
           lastTouchY = null;
           return;
@@ -237,15 +242,18 @@
         if (scrollTerminalByPixels(deltaY)) {
           event.preventDefault();
         }
-      }, { passive: false });
-      target.addEventListener("touchend", () => {
+      };
+      const onTouchEnd = () => {
         lastTouchY = null;
         touchScrollRemainder = 0;
-      }, { passive: true });
-      target.addEventListener("touchcancel", () => {
-        lastTouchY = null;
-        touchScrollRemainder = 0;
-      }, { passive: true });
+      };
+      targets.forEach((target) => {
+        target.addEventListener("wheel", onWheel, { capture: true, passive: false });
+        target.addEventListener("touchstart", onTouchStart, { capture: true, passive: false });
+        target.addEventListener("touchmove", onTouchMove, { capture: true, passive: false });
+        target.addEventListener("touchend", onTouchEnd, { capture: true, passive: true });
+        target.addEventListener("touchcancel", onTouchEnd, { capture: true, passive: true });
+      });
       scrollHandlersInstalled = true;
     }
 
@@ -385,6 +393,19 @@
         setRendererStatus(`Backend ${lastBackendStatus}; waiting for terminal renderer`, false);
       }
       ensureTerminalOpen();
+    };
+
+    window.smScrollPixels = function(deltaPixels) {
+      return scrollTerminalByPixels(Number(deltaPixels) || 0);
+    };
+
+    window.smScrollLines = function(lines) {
+      const parsed = Number(lines) || 0;
+      if (!ready || parsed === 0) {
+        return false;
+      }
+      term.scrollLines(parsed);
+      return true;
     };
 
     window.smCopySelection = function() {

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
@@ -13,6 +13,7 @@ import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.layout.Arrangement
@@ -20,6 +21,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -46,6 +48,7 @@ import androidx.compose.material.icons.rounded.UnfoldMore
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
@@ -69,6 +72,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
@@ -433,16 +437,16 @@ private fun MobileTerminalOverlay(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(14.dp),
-            verticalArrangement = Arrangement.spacedBy(10.dp),
+                .padding(6.dp),
+            verticalArrangement = Arrangement.spacedBy(6.dp),
         ) {
             Surface(
-                shape = RoundedCornerShape(18.dp),
+                shape = RoundedCornerShape(12.dp),
                 color = Panel,
                 border = androidx.compose.foundation.BorderStroke(1.dp, BorderStrong),
             ) {
                 Row(
-                    modifier = Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 10.dp),
+                    modifier = Modifier.fillMaxWidth().padding(horizontal = 10.dp, vertical = 6.dp),
                     horizontalArrangement = Arrangement.SpaceBetween,
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
@@ -465,11 +469,15 @@ private fun MobileTerminalOverlay(
                             style = MaterialTheme.typography.labelSmall,
                             color = if (terminal.rendererError == null) TextMuted else Rose,
                             fontFamily = FontFamily.Monospace,
-                            maxLines = 2,
+                            maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
                         )
                     }
-                    OutlinedButton(onClick = onDetach) {
+                    OutlinedButton(
+                        onClick = onDetach,
+                        modifier = Modifier.height(32.dp),
+                        contentPadding = PaddingValues(horizontal = 10.dp, vertical = 2.dp),
+                    ) {
                         Text("Detach")
                     }
                 }
@@ -485,7 +493,7 @@ private fun MobileTerminalOverlay(
 
             Surface(
                 modifier = Modifier.weight(1f).fillMaxWidth(),
-                shape = RoundedCornerShape(18.dp),
+                shape = RoundedCornerShape(12.dp),
                 color = Color.Black,
                 border = androidx.compose.foundation.BorderStroke(1.dp, BorderStrong),
             ) {
@@ -502,16 +510,32 @@ private fun MobileTerminalOverlay(
                 )
             }
 
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedButton(onClick = onEsc) { Text("Esc") }
-                OutlinedButton(onClick = onCtrlC) { Text("Ctrl-C") }
-                OutlinedButton(onClick = onEnter) { Text("Enter") }
-                OutlinedButton(onClick = { copyRequest += 1 }) { Text("Copy") }
+            Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                OutlinedButton(
+                    onClick = onEsc,
+                    modifier = Modifier.height(32.dp),
+                    contentPadding = PaddingValues(horizontal = 10.dp, vertical = 2.dp),
+                ) { Text("Esc") }
+                OutlinedButton(
+                    onClick = onCtrlC,
+                    modifier = Modifier.height(32.dp),
+                    contentPadding = PaddingValues(horizontal = 10.dp, vertical = 2.dp),
+                ) { Text("Ctrl-C") }
+                OutlinedButton(
+                    onClick = onEnter,
+                    modifier = Modifier.height(32.dp),
+                    contentPadding = PaddingValues(horizontal = 10.dp, vertical = 2.dp),
+                ) { Text("Enter") }
+                OutlinedButton(
+                    onClick = { copyRequest += 1 },
+                    modifier = Modifier.height(32.dp),
+                    contentPadding = PaddingValues(horizontal = 10.dp, vertical = 2.dp),
+                ) { Text("Copy") }
             }
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                horizontalArrangement = Arrangement.spacedBy(6.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 OutlinedTextField(
@@ -520,9 +544,13 @@ private fun MobileTerminalOverlay(
                     modifier = Modifier.weight(1f),
                     label = { Text("Input") },
                     singleLine = false,
-                    maxLines = 4,
+                    maxLines = 2,
                 )
-                Button(onClick = onSend) {
+                Button(
+                    onClick = onSend,
+                    modifier = Modifier.height(42.dp),
+                    contentPadding = ButtonDefaults.ContentPadding,
+                ) {
                     Text("Send")
                 }
             }
@@ -557,7 +585,14 @@ private fun TerminalWebView(
     }
 
     AndroidView(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .pointerInput(Unit) {
+                detectVerticalDragGestures { change, dragAmount ->
+                    change.consume()
+                    webViewRef?.evaluateJavascript("window.smScrollPixels(${-dragAmount});", null)
+                }
+            },
         factory = { context ->
             WebView(context).apply {
                 setBackgroundColor(android.graphics.Color.rgb(5, 8, 13))


### PR DESCRIPTION
## Summary

Fixes #739.

- Route native Compose vertical drag gestures directly into xterm scrollback via `window.smScrollPixels`.
- Register JS scroll handlers on xterm screen/root elements in capture phase instead of only the viewport sibling.
- Make the mobile terminal overlay denser: smaller chrome/padding, tighter controls, smaller terminal font and padding.

## Verification

- `python -m pytest tests/unit/test_android_api_surface.py -q`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home ./gradlew testDebugUnitTest assembleDebug`
- `git diff --check`