### PR TITLE
Implement SM-owned Codex-fork session forking

### DIFF
--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -881,6 +881,59 @@ class SessionManagerClient:
         result = self.restore_session_result(session_id)
         return result.get("data") if result.get("ok") else None
 
+    def fork_session_result(
+        self,
+        session_id: str,
+        *,
+        name: Optional[str] = None,
+        requester_session_id: Optional[str] = None,
+        fork_point: str = "current",
+    ) -> dict:
+        """Fork a session and preserve API error details."""
+        payload: dict[str, object] = {"fork_point": fork_point}
+        if name is not None:
+            payload["name"] = name
+        if requester_session_id is not None:
+            payload["requester_session_id"] = requester_session_id
+
+        session_path = urllib.parse.quote(session_id, safe="")
+        data, status_code, unavailable = self._request_with_status(
+            "POST",
+            f"/sessions/{session_path}/fork",
+            payload,
+            timeout=max(MUTATION_API_TIMEOUT, 45.0),
+        )
+        if unavailable:
+            return {"ok": False, "unavailable": True, "status_code": None, "data": None, "detail": None}
+
+        ok = status_code in (200, 201)
+        detail = None
+        if isinstance(data, dict):
+            detail = data.get("detail") or data.get("error") or data.get("raw")
+
+        return {
+            "ok": ok,
+            "unavailable": False,
+            "status_code": status_code,
+            "data": data,
+            "detail": detail,
+        }
+
+    def fork_session(
+        self,
+        session_id: str,
+        *,
+        name: Optional[str] = None,
+        requester_session_id: Optional[str] = None,
+    ) -> Optional[dict]:
+        """Fork a session."""
+        result = self.fork_session_result(
+            session_id,
+            name=name,
+            requester_session_id=requester_session_id,
+        )
+        return result.get("data") if result.get("ok") else None
+
     def send_email_result(
         self,
         *,

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -827,6 +827,13 @@ def cmd_me(client: SessionManagerClient, session_id: str) -> int:
         return 1
 
     print(format_session_line(session, show_working_dir=True))
+    if session.get("forked_from_session_id") or session.get("forked_from_provider_resume_id"):
+        if session.get("forked_from_session_id"):
+            print(f"Forked from: {session.get('forked_from_session_id')}")
+        if session.get("forked_from_provider_resume_id"):
+            print(f"Original provider thread: {session.get('forked_from_provider_resume_id')}")
+        if session.get("forked_provider_resume_id"):
+            print(f"Fork provider thread: {session.get('forked_provider_resume_id')}")
     return 0
 
 
@@ -2776,6 +2783,101 @@ def cmd_restore(client: SessionManagerClient, target_identifier: str) -> int:
         )
         return 0
     return cmd_attach(client, target_session_id)
+
+
+def cmd_fork(
+    client: SessionManagerClient,
+    current_session_id: Optional[str],
+    target_identifier: Optional[str],
+    *,
+    self_target: bool = False,
+    name: Optional[str] = None,
+    attach: bool = False,
+    json_output: bool = False,
+) -> int:
+    """
+    Fork a provider-native session into a new SM-owned session.
+
+    Exit codes:
+        0: Success
+        1: Invalid target or fork failed
+        2: Session manager unavailable
+    """
+    if self_target and target_identifier:
+        print("Error: use either a session target or --self, not both", file=sys.stderr)
+        return 1
+    if self_target:
+        if not current_session_id:
+            print("Error: CLAUDE_SESSION_MANAGER_ID not set (required for --self)", file=sys.stderr)
+            return 2
+        target_session_id, source_session, unavailable = resolve_session_id_with_status(
+            client,
+            current_session_id,
+            include_stopped=True,
+        )
+        error = None
+    else:
+        if not target_identifier:
+            print("Error: sm fork requires a session target or --self", file=sys.stderr)
+            return 1
+        target_session_id, source_session, unavailable = resolve_session_id_with_status(
+            client,
+            target_identifier,
+            include_stopped=True,
+        )
+        error = None
+
+    if unavailable:
+        print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+        return 2
+    if not target_session_id:
+        missing_identifier = current_session_id if self_target else target_identifier
+        print(f"Error: Session '{missing_identifier}' not found", file=sys.stderr)
+        return 1
+
+    result = client.fork_session_result(
+        target_session_id,
+        name=name,
+        requester_session_id=current_session_id,
+    )
+    if result.get("unavailable"):
+        print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+        return 2
+    if not result.get("ok"):
+        detail = result.get("detail") or error or "Failed to fork session"
+        print(f"Error: {detail}", file=sys.stderr)
+        return 1
+
+    data = result.get("data") or {}
+    source = data.get("source_session") if isinstance(data.get("source_session"), dict) else (source_session or {})
+    fork_session = data.get("fork_session") if isinstance(data.get("fork_session"), dict) else {}
+    fork_session_id = fork_session.get("id")
+    if json_output:
+        payload = {
+            "source_session_id": source.get("id") or target_session_id,
+            "source_provider_resume_id": data.get("source_provider_resume_id"),
+            "fork_session_id": fork_session_id,
+            "fork_provider_resume_id": data.get("fork_provider_resume_id"),
+            "provider": fork_session.get("provider") or source.get("provider"),
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        source_name = source.get("friendly_name") or source.get("name") or target_session_id
+        fork_name = fork_session.get("friendly_name") or fork_session.get("name") or fork_session_id
+        print(f"Forked {source_name} ({target_session_id})")
+        print(f"Original provider thread: {data.get('source_provider_resume_id') or 'unknown'}")
+        print(f"Fork session: {fork_name} ({fork_session_id or 'unknown'})")
+        print(f"Fork provider thread: {data.get('fork_provider_resume_id') or 'unknown'}")
+
+    if attach and fork_session_id:
+        if not sys.stdin.isatty() or not sys.stdout.isatty():
+            print(
+                f"Automatic attach skipped: current shell is not interactive. "
+                f"Run `sm attach {fork_session_id}` from an interactive terminal."
+            )
+            return 0
+        return cmd_attach(client, fork_session_id)
+    return 0
 
 
 def cmd_new(

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -514,6 +514,14 @@ def main():
     )
     restore_parser.add_argument("session", help="Session ID or friendly name to restore")
 
+    # sm fork [session] [--self] [--name NAME] [--attach] [--json]
+    fork_parser = subparsers.add_parser("fork", help="Fork a session into a new SM-owned session")
+    fork_parser.add_argument("session", nargs="?", help="Session ID or friendly name to fork")
+    fork_parser.add_argument("--self", action="store_true", help="Fork the current managed session")
+    fork_parser.add_argument("--name", help="Friendly name for the fork session")
+    fork_parser.add_argument("--attach", action="store_true", help="Attach to the fork after it is confirmed")
+    fork_parser.add_argument("--json", action="store_true", help="Output JSON")
+
     # sm clean [--session-id ID ...]
     clean_parser = subparsers.add_parser(
         "clean",
@@ -904,7 +912,7 @@ def main():
     # Commands that don't need session_id: lock, unlock, hooks, all, send, wait, what, subagents, children, kill/retire, restore, new, attach, output, clear
     no_session_needed = [
         "lock", "unlock", "subagent-start", "subagent-stop", "all", "send", "wait", "what",
-        "subagents", "children", "kill", "retire", "restore", "unkill", "new", "claude", "codex", "codex-legacy", "codex-fork", "codex_fork",
+        "subagents", "children", "kill", "retire", "restore", "unkill", "fork", "new", "claude", "codex", "codex-legacy", "codex-fork", "codex_fork",
         "codex-2", "codex-app", "codex-server",
         "attach", "output", "codex-tui", "codex-fork-info", "codex-rollout-gates", "watch", "tail", "clear", "review", "context-monitor", "remind", "setup", "lookup", "roster", "email", "request-codex-review", None
     ]
@@ -1215,6 +1223,18 @@ def main():
         sys.exit(commands.cmd_kill(client, session_id, args.session_id))
     elif args.command in ("restore", "unkill"):
         sys.exit(commands.cmd_restore(client, args.session))
+    elif args.command == "fork":
+        sys.exit(
+            commands.cmd_fork(
+                client,
+                session_id,
+                args.session,
+                self_target=args.self,
+                name=args.name,
+                attach=args.attach,
+                json_output=args.json,
+            )
+        )
     elif args.command == "clean":
         sys.exit(commands.cmd_clean(client, session_ids=getattr(args, 'session_ids', None)))
     elif args.command == "claude":

--- a/src/cli/watch_tui.py
+++ b/src/cli/watch_tui.py
@@ -1167,6 +1167,28 @@ def _create_watch_session(
     return session, tmux_session, None
 
 
+def _fork_watch_session(
+    client,
+    session_id: str,
+) -> tuple[Optional[dict], Optional[dict], Optional[str]]:
+    """Fork a session from sm watch and return (source, fork, error)."""
+    fork_result = client.fork_session_result(
+        session_id,
+        requester_session_id=getattr(client, "session_id", None),
+    )
+    if fork_result.get("unavailable"):
+        return None, None, "Session manager unavailable"
+    if not fork_result.get("ok"):
+        return None, None, fork_result.get("detail") or "Failed to fork session"
+
+    data = fork_result.get("data") or {}
+    source = data.get("source_session")
+    fork_session = data.get("fork_session")
+    if not isinstance(source, dict) or not isinstance(fork_session, dict):
+        return None, None, "Failed to fork session"
+    return source, fork_session, None
+
+
 def _resolve_tmux_attach_target(
     client,
     session: dict,
@@ -1355,7 +1377,7 @@ def _render(
     if restore_mode:
         footer = f"j/k: move  Enter: restore+attach  o: sort={restore_sort}  R: hide repo  U: show repos  Tab: expand/collapse  E: expand all  C: collapse all  /: search  r: refresh  q: quit"
     else:
-        footer = "j/k: move  +: create  Enter: attach  s: send  K,K: retire  n: rename  A/X: adopt  Tab: details  /: filter  r: refresh  q: quit"
+        footer = "j/k: move  +: create  F: fork  Enter: attach  s: send  K,K: retire  n: rename  A/X: adopt  Tab: details  /: filter  r: refresh  q: quit"
     stdscr.addnstr(height - 1, 0, footer, _render_columns(width, 0, reserve_last_cell=True))
     stdscr.refresh()
 
@@ -1596,7 +1618,7 @@ def run_watch_tui(
                     next_refresh = 0.0
                     continue
 
-                if restore_mode and key in (ord("s"), ord("+"), ord("K"), ord("n"), ord("A"), ord("X")):
+                if restore_mode and key in (ord("s"), ord("+"), ord("F"), ord("K"), ord("n"), ord("A"), ord("X")):
                     flash_message = "Not available in restore mode"
                     flash_until = time.monotonic() + 2.0
                     continue
@@ -1624,6 +1646,31 @@ def run_watch_tui(
                         flash_message = "Session manager unavailable"
                     else:
                         flash_message = "Failed to send"
+                    flash_until = time.monotonic() + 2.5
+                    next_refresh = 0.0
+                    continue
+
+                if key in (ord("F"),):
+                    if not selected_session_id:
+                        flash_message = "No session selected"
+                        flash_until = time.monotonic() + 2.0
+                        continue
+                    source, fork_session, error = _fork_watch_session(client, selected_session_id)
+                    if error:
+                        flash_message = error
+                        flash_until = time.monotonic() + 2.5
+                        next_refresh = 0.0
+                        continue
+                    fork_session_id = fork_session.get("id") if fork_session else None
+                    if not fork_session_id:
+                        flash_message = "Failed to fork session"
+                        flash_until = time.monotonic() + 2.5
+                        next_refresh = 0.0
+                        continue
+                    source_name = (source or {}).get("friendly_name") or (source or {}).get("name") or selected_session_id
+                    fork_name = fork_session.get("friendly_name") or fork_session.get("name") or fork_session_id
+                    selected_session_id = fork_session_id
+                    flash_message = f"Forked {source_name} ({source.get('id') if source else ''}) -> {fork_name} ({fork_session_id})"
                     flash_until = time.monotonic() + 2.5
                     next_refresh = 0.0
                     continue

--- a/src/models.py
+++ b/src/models.py
@@ -306,6 +306,11 @@ class Session:
     transcript_path: Optional[str] = None  # Claude's transcript file path
     provider_resume_id: Optional[str] = None  # Provider-native conversation/thread/session id for restore
     model: Optional[str] = None  # Explicit provider model passed at launch; replayed on restore
+    forked_from_session_id: Optional[str] = None  # SM session id this session was forked from
+    forked_from_provider_resume_id: Optional[str] = None  # Source provider resume id captured before fork
+    forked_provider_resume_id: Optional[str] = None  # Provider resume id produced by the fork
+    forked_at: Optional[datetime] = None  # When SM confirmed or detected the fork
+    forked_by_session_id: Optional[str] = None  # Session that requested the fork, if known
     friendly_name: Optional[str] = None  # Session Manager label for display
     friendly_name_is_explicit: bool = False  # True when sm name / PATCH explicitly set the label
     friendly_name_updated_at_ns: Optional[int] = None  # Last SM-side friendly-name update time
@@ -398,6 +403,11 @@ class Session:
             "transcript_path": self.transcript_path,
             "provider_resume_id": self.provider_resume_id,
             "model": self.model,
+            "forked_from_session_id": self.forked_from_session_id,
+            "forked_from_provider_resume_id": self.forked_from_provider_resume_id,
+            "forked_provider_resume_id": self.forked_provider_resume_id,
+            "forked_at": self.forked_at.isoformat() if self.forked_at else None,
+            "forked_by_session_id": self.forked_by_session_id,
             "friendly_name": self.friendly_name,
             "friendly_name_is_explicit": self.friendly_name_is_explicit,
             "friendly_name_updated_at_ns": self.friendly_name_updated_at_ns,
@@ -491,6 +501,11 @@ class Session:
             transcript_path=data.get("transcript_path"),
             provider_resume_id=data.get("provider_resume_id"),
             model=data.get("model"),
+            forked_from_session_id=data.get("forked_from_session_id"),
+            forked_from_provider_resume_id=data.get("forked_from_provider_resume_id"),
+            forked_provider_resume_id=data.get("forked_provider_resume_id"),
+            forked_at=datetime.fromisoformat(data["forked_at"]) if data.get("forked_at") else None,
+            forked_by_session_id=data.get("forked_by_session_id"),
             friendly_name=data.get("friendly_name"),
             friendly_name_is_explicit=bool(data.get("friendly_name_is_explicit", False)),
             friendly_name_updated_at_ns=data.get("friendly_name_updated_at_ns"),

--- a/src/server.py
+++ b/src/server.py
@@ -540,6 +540,14 @@ class CreateSessionRequest(BaseModel):
     parent_session_id: Optional[str] = None
 
 
+class ForkSessionRequest(BaseModel):
+    """Request to fork a provider-native session under a new SM session."""
+    name: Optional[str] = None
+    attach: bool = False
+    fork_point: str = "current"
+    requester_session_id: Optional[str] = None
+
+
 class AdoptionProposalResponse(BaseModel):
     """Response payload for a pending or resolved adoption proposal."""
     id: str
@@ -564,6 +572,12 @@ class SessionResponse(BaseModel):
     tmux_session: str
     tmux_socket_name: Optional[str] = None
     provider: Optional[str] = "claude"
+    provider_resume_id: Optional[str] = None
+    forked_from_session_id: Optional[str] = None
+    forked_from_provider_resume_id: Optional[str] = None
+    forked_provider_resume_id: Optional[str] = None
+    forked_at: Optional[str] = None
+    forked_by_session_id: Optional[str] = None
     friendly_name: Optional[str] = None
     telegram_chat_id: Optional[int] = None
     telegram_thread_id: Optional[int] = None
@@ -2170,6 +2184,12 @@ def create_app(
             tmux_session=session.tmux_session,
             tmux_socket_name=session.tmux_socket_name,
             provider=provider,
+            provider_resume_id=getattr(session, "provider_resume_id", None),
+            forked_from_session_id=getattr(session, "forked_from_session_id", None),
+            forked_from_provider_resume_id=getattr(session, "forked_from_provider_resume_id", None),
+            forked_provider_resume_id=getattr(session, "forked_provider_resume_id", None),
+            forked_at=session.forked_at.isoformat() if getattr(session, "forked_at", None) else None,
+            forked_by_session_id=getattr(session, "forked_by_session_id", None),
             friendly_name=_effective_session_name(
                 session,
                 sync_native_title=sync_display_name,
@@ -5338,6 +5358,43 @@ def create_app(
             if s.context_monitor_enabled
         ]
         return {"monitored": monitored}
+
+    @app.post("/sessions/{session_id}/fork")
+    async def fork_session(session_id: str, request: ForkSessionRequest):
+        """Fork a provider-native session into a new SM-owned session."""
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
+
+        source = _resolve_session_or_registry_role(session_id)
+        if not source:
+            raise HTTPException(status_code=404, detail="Session not found")
+
+        success, forked_session, error = await app.state.session_manager.fork_session(
+            source.id,
+            name=request.name,
+            fork_point=request.fork_point,
+            forked_by_session_id=request.requester_session_id,
+        )
+        if not success or not forked_session:
+            detail = error or "Failed to fork session"
+            if detail == "Session not found":
+                status_code = 404
+            elif "runtime unavailable" in detail.lower() or "launch command" in detail.lower():
+                status_code = 503
+            else:
+                status_code = 400
+            raise HTTPException(status_code=status_code, detail=detail)
+
+        if app.state.output_monitor and getattr(forked_session, "provider", "claude") != "codex-app":
+            await app.state.output_monitor.start_monitoring(forked_session)
+
+        return {
+            "source_session": _response_dict(_session_to_response(source, sync_display_name=False)),
+            "fork_session": _response_dict(_session_to_response(forked_session, sync_display_name=False)),
+            "source_provider_resume_id": getattr(forked_session, "forked_from_provider_resume_id", None),
+            "fork_provider_resume_id": getattr(forked_session, "forked_provider_resume_id", None)
+            or getattr(forked_session, "provider_resume_id", None),
+        }
 
     @app.get("/sessions/{session_id}", response_model=SessionResponse)
     async def get_session(session_id: str):

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -299,6 +299,9 @@ class SessionManager:
         self.codex_fork_control_timeout_seconds = float(
             codex_fork_config.get("control_timeout_seconds", 5.0)
         )
+        self.codex_fork_fork_timeout_seconds = float(
+            codex_fork_config.get("fork_timeout_seconds", 30.0)
+        )
         self.codex_fork_control_tmux_fallback_enabled = _coerce_rollout_flag(
             codex_fork_config.get("control_tmux_fallback_enabled"),
             default=True,
@@ -1122,8 +1125,11 @@ class SessionManager:
         session: Session,
         *,
         resume_id: Optional[str] = None,
+        fork_id: Optional[str] = None,
     ) -> tuple[str, list[str], str, Optional[str]]:
         """Return launch command/args, falling back to codex when codex-fork is unavailable."""
+        if resume_id and fork_id:
+            raise ValueError("resume_id and fork_id are mutually exclusive")
         _, fork_error = self._resolve_cli_command(
             self.codex_fork_command,
             working_dir=session.working_dir,
@@ -1132,6 +1138,8 @@ class SessionManager:
             args = list(self.codex_cli_args)
             if resume_id:
                 args = ["resume", resume_id, *args]
+            elif fork_id:
+                args = ["fork", fork_id, *args]
             return (
                 self.codex_cli_command,
                 args,
@@ -1142,6 +1150,8 @@ class SessionManager:
         args = list(self.codex_fork_args)
         if resume_id:
             args = ["resume", resume_id, *args]
+        elif fork_id:
+            args = ["fork", fork_id, *args]
         event_stream_path = self._codex_fork_event_stream_path(session)
         control_socket_path = self._codex_fork_control_socket_path(session)
         event_stream_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1626,6 +1636,63 @@ class SessionManager:
         if not thread_id or thread_id.lower() in {"unknown", "none", "null"}:
             return None
         return thread_id
+
+    def _extract_codex_fork_thread_started(
+        self,
+        event_type: Any,
+        payload: dict[str, Any],
+    ) -> tuple[Optional[str], Optional[str]]:
+        """Return (thread_id, forked_from_id) for codex-fork thread/started events."""
+        raw_event_type = str(event_type or "").strip()
+        normalized_event_type = self._normalize_codex_fork_event_type(raw_event_type.replace("/", "_"))
+        if raw_event_type not in {"thread/started", "thread_started"} and normalized_event_type != "thread_started":
+            return None, None
+
+        thread_payload = payload.get("thread") if isinstance(payload.get("thread"), dict) else payload
+        thread_id = self._normalize_codex_thread_id(
+            thread_payload.get("id")
+            or thread_payload.get("thread_id")
+            or payload.get("thread_id")
+            or payload.get("session_id")
+        )
+        forked_from_id = self._normalize_codex_thread_id(
+            thread_payload.get("forkedFromId")
+            or thread_payload.get("forked_from_id")
+            or payload.get("forkedFromId")
+            or payload.get("forked_from_id")
+        )
+        return thread_id, forked_from_id
+
+    @staticmethod
+    def _epoch_ns_to_naive_utc(value: Optional[int]) -> datetime:
+        if value is None:
+            return datetime.now()
+        return datetime.fromtimestamp(value / 1_000_000_000, tz=timezone.utc).replace(tzinfo=None)
+
+    def _record_codex_fork_lineage_from_thread_started(
+        self,
+        session: Session,
+        *,
+        thread_id: str,
+        forked_from_id: str,
+        previous_provider_resume_id: Optional[str],
+        event_timestamp_ns: Optional[int],
+    ) -> bool:
+        """Persist lineage for a codex-fork thread/started fork event before rebinding."""
+        changed = False
+        if session.forked_from_provider_resume_id != forked_from_id:
+            session.forked_from_provider_resume_id = forked_from_id
+            changed = True
+        if session.forked_provider_resume_id != thread_id:
+            session.forked_provider_resume_id = thread_id
+            changed = True
+        if session.forked_at is None:
+            session.forked_at = self._epoch_ns_to_naive_utc(event_timestamp_ns)
+            changed = True
+        if not session.forked_from_session_id and previous_provider_resume_id == forked_from_id:
+            session.forked_from_session_id = session.id
+            changed = True
+        return changed
 
     def _read_codex_session_index(self) -> dict[str, tuple[str, Optional[int]]]:
         """Read Codex's local thread index keyed by provider resume/thread id."""
@@ -2222,11 +2289,27 @@ class SessionManager:
         provider_session_id = event.get("session_id")
         if not provider_session_id and payload:
             provider_session_id = payload.get("session_id")
+        thread_started_id, forked_from_id = self._extract_codex_fork_thread_started(event_type, payload)
+        if thread_started_id:
+            provider_session_id = thread_started_id
         if isinstance(provider_session_id, str) and provider_session_id.strip() and provider_session_id != "unknown":
             session = self.sessions.get(session_id)
-            if session and session.provider in ("codex", "codex-fork") and session.provider_resume_id != provider_session_id:
-                session.provider_resume_id = provider_session_id
-                self._save_state()
+            if session and session.provider in ("codex", "codex-fork"):
+                changed = False
+                previous_provider_resume_id = session.provider_resume_id
+                if thread_started_id and forked_from_id:
+                    changed = self._record_codex_fork_lineage_from_thread_started(
+                        session,
+                        thread_id=thread_started_id,
+                        forked_from_id=forked_from_id,
+                        previous_provider_resume_id=previous_provider_resume_id,
+                        event_timestamp_ns=self._timestamp_to_epoch_ns(event.get("ts")),
+                    )
+                if session.provider_resume_id != provider_session_id:
+                    session.provider_resume_id = provider_session_id
+                    changed = True
+                if changed:
+                    self._save_state()
         seq_raw = event.get("seq")
         seq = int(seq_raw) if isinstance(seq_raw, int) or (isinstance(seq_raw, str) and seq_raw.isdigit()) else None
         session_epoch = event.get("session_epoch")
@@ -2537,6 +2620,10 @@ class SessionManager:
         initial_prompt: Optional[str] = None,
         provider: str = "claude",
         defer_telegram_topic: bool = False,
+        codex_fork_source_resume_id: Optional[str] = None,
+        forked_from_session_id: Optional[str] = None,
+        forked_from_provider_resume_id: Optional[str] = None,
+        forked_by_session_id: Optional[str] = None,
     ) -> Optional[Session]:
         """
         Common session creation logic (private method).
@@ -2569,6 +2656,12 @@ class SessionManager:
             provider=provider,
             model=model,
         )
+        if forked_from_session_id:
+            session.forked_from_session_id = forked_from_session_id
+        if forked_from_provider_resume_id:
+            session.forked_from_provider_resume_id = forked_from_provider_resume_id
+        if forked_by_session_id:
+            session.forked_by_session_id = forked_by_session_id
 
         if friendly_name:
             self.set_session_friendly_name(session, friendly_name, explicit=True)
@@ -2597,13 +2690,23 @@ class SessionManager:
                 default_model = self.codex_default_model
             else:
                 # Codex-fork config with codex fallback when the fork binary is unavailable.
-                command, args, effective_provider, fallback_reason = self._build_codex_fork_launch_spec(session)
+                command, args, effective_provider, fallback_reason = self._build_codex_fork_launch_spec(
+                    session,
+                    fork_id=codex_fork_source_resume_id,
+                )
                 default_model = (
                     self.codex_fork_default_model
                     if effective_provider == "codex-fork"
                     else self.codex_default_model
                 )
                 if effective_provider != session.provider:
+                    if codex_fork_source_resume_id:
+                        logger.error(
+                            "Rejecting codex-fork fork create for %s because runtime is unavailable: %s",
+                            session.id,
+                            fallback_reason,
+                        )
+                        return None
                     logger.warning(
                         "Falling back from codex-fork to codex for %s: %s",
                         session.id,
@@ -2929,6 +3032,164 @@ class SessionManager:
     def get_session(self, session_id: str) -> Optional[Session]:
         """Get a session by ID."""
         return self.sessions.get(session_id)
+
+    def _default_fork_friendly_name(self, source: Session) -> str:
+        """Derive a short explicit name for a fork session."""
+        base = self.get_effective_session_name(source) or source.name or source.id
+        safe_base = re.sub(r"[^a-zA-Z0-9_-]+", "-", base).strip("-") or source.id
+        suffix = uuid.uuid4().hex[:4]
+        max_base_len = max(1, 32 - len("-fork-") - len(suffix))
+        return f"{safe_base[:max_base_len]}-fork-{suffix}"
+
+    def _validate_fork_friendly_name(self, name: Optional[str]) -> Optional[str]:
+        if not name:
+            return None
+        if not self._is_safe_provider_native_rename_name(name):
+            return "Fork name must be 1-32 characters of letters, numbers, underscore, or hyphen"
+        normalized_name = self.normalize_agent_role(name)
+        reserved_aliases = {"maintainer"}
+        registration_map = self._get_agent_registration_map()
+        self._prune_agent_registrations(persist=True)
+        reserved_aliases.update(registration_map.keys())
+        if normalized_name in reserved_aliases:
+            return f'Name "{name}" is reserved for registry identity "{normalized_name}"'
+        return self.validate_reserved_human_name(name)
+
+    async def _wait_for_codex_fork_result(
+        self,
+        fork_session: Session,
+        source_resume_id: str,
+    ) -> tuple[bool, Optional[str], Optional[str]]:
+        """Wait for codex-fork to report the native fork thread id."""
+        stream_path = self._codex_fork_event_stream_path(fork_session)
+        deadline = time.monotonic() + max(0.1, self.codex_fork_fork_timeout_seconds)
+        offset = 0
+        buffer = ""
+        poll_interval = max(0.05, min(0.5, self.codex_fork_event_poll_interval_seconds))
+
+        while time.monotonic() < deadline:
+            if (
+                fork_session.provider_resume_id
+                and fork_session.forked_provider_resume_id == fork_session.provider_resume_id
+                and fork_session.forked_from_provider_resume_id == source_resume_id
+            ):
+                return True, fork_session.provider_resume_id, None
+
+            if stream_path.exists():
+                with open(stream_path, "r", encoding="utf-8", errors="ignore") as handle:
+                    handle.seek(offset)
+                    chunk = handle.read()
+                    offset = handle.tell()
+                if chunk:
+                    buffer += chunk
+                    lines = buffer.splitlines()
+                    if buffer and not buffer.endswith("\n"):
+                        buffer = lines.pop() if lines else buffer
+                    else:
+                        buffer = ""
+
+                    for line in lines:
+                        raw = line.strip()
+                        if not raw:
+                            continue
+                        try:
+                            event = json.loads(raw)
+                        except json.JSONDecodeError:
+                            continue
+                        if not isinstance(event, dict):
+                            continue
+                        payload = event.get("payload") if isinstance(event.get("payload"), dict) else {}
+                        event_type = event.get("event_type") or event.get("type")
+                        thread_id, forked_from_id = self._extract_codex_fork_thread_started(event_type, payload)
+                        if not thread_id or not forked_from_id:
+                            continue
+                        if forked_from_id != source_resume_id:
+                            return (
+                                False,
+                                None,
+                                "Provider fork result did not match the source thread "
+                                f"({forked_from_id} != {source_resume_id})",
+                            )
+                        self._record_codex_fork_lineage_from_thread_started(
+                            fork_session,
+                            thread_id=thread_id,
+                            forked_from_id=forked_from_id,
+                            previous_provider_resume_id=fork_session.provider_resume_id,
+                            event_timestamp_ns=self._timestamp_to_epoch_ns(event.get("ts")),
+                        )
+                        fork_session.provider_resume_id = thread_id
+                        self._save_state()
+                        return True, thread_id, None
+
+            await asyncio.sleep(poll_interval)
+
+        return False, None, "Timed out waiting for provider fork confirmation"
+
+    async def fork_session(
+        self,
+        source_id: str,
+        *,
+        name: Optional[str] = None,
+        fork_point: str = "current",
+        forked_by_session_id: Optional[str] = None,
+    ) -> tuple[bool, Optional[Session], Optional[str]]:
+        """Create an SM-owned provider-native fork session."""
+        source = self.sessions.get(source_id)
+        if source is None:
+            return False, None, "Session not found"
+        if fork_point != "current":
+            return False, None, "Only fork_point=current is supported"
+        if source.provider != "codex-fork":
+            return False, None, f"Session forking is not supported for provider={source.provider} yet."
+
+        source_resume_id = self.get_session_resume_id(source)
+        if not source_resume_id:
+            return False, None, "Source session has no provider resume id to fork"
+
+        provider_rejection = self.get_provider_create_rejection("codex-fork", working_dir=source.working_dir)
+        if provider_rejection:
+            return False, None, provider_rejection
+
+        fork_name = name or self._default_fork_friendly_name(source)
+        name_error = self._validate_fork_friendly_name(fork_name)
+        if name_error:
+            return False, None, name_error
+
+        fork_session = await self._create_session_common(
+            working_dir=source.working_dir,
+            friendly_name=fork_name,
+            model=source.model,
+            provider="codex-fork",
+            defer_telegram_topic=True,
+            codex_fork_source_resume_id=source_resume_id,
+            forked_from_session_id=source.id,
+            forked_from_provider_resume_id=source_resume_id,
+            forked_by_session_id=forked_by_session_id,
+        )
+        if fork_session is None:
+            return False, None, "Failed to create fork session"
+
+        success, fork_resume_id, error = await self._wait_for_codex_fork_result(
+            fork_session,
+            source_resume_id,
+        )
+        if not success or not fork_resume_id:
+            with contextlib.suppress(Exception):
+                self.kill_session(fork_session.id)
+            fork_session.error_message = error or "Failed to confirm provider fork"
+            if fork_session.status != SessionStatus.STOPPED:
+                fork_session.status = SessionStatus.STOPPED
+                fork_session.stopped_at = datetime.now()
+                fork_session.completed_at = fork_session.stopped_at
+            self._save_state()
+            return False, fork_session, fork_session.error_message
+
+        fork_session.provider_resume_id = fork_resume_id
+        fork_session.forked_provider_resume_id = fork_resume_id
+        if fork_session.forked_at is None:
+            fork_session.forked_at = datetime.now()
+        self._save_state()
+        return True, fork_session, None
 
     def get_session_by_name(self, name: str) -> Optional[Session]:
         """Get a session by name."""

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -1338,6 +1338,59 @@ class TestEmailBridgeEndpoints:
         assert "Configured codex-fork runtime unavailable" in response.json()["detail"]
         mock_session_manager.create_session.assert_not_called()
 
+    def test_fork_session(self, test_client, mock_session_manager, sample_session, mock_output_monitor):
+        """POST /sessions/{id}/fork returns source and fork session payloads."""
+        sample_session.provider = "codex-fork"
+        sample_session.provider_resume_id = "thread-source"
+        forked_session = Session(
+            id="fork1234",
+            name="codex-fork-fork1234",
+            working_dir=sample_session.working_dir,
+            tmux_session="codex-fork-fork1234",
+            log_file="/tmp/fork.log",
+            provider="codex-fork",
+            provider_resume_id="thread-fork",
+            forked_from_session_id=sample_session.id,
+            forked_from_provider_resume_id="thread-source",
+            forked_provider_resume_id="thread-fork",
+            forked_by_session_id="caller123",
+            friendly_name="test-fork",
+        )
+        mock_session_manager.get_session.return_value = sample_session
+        mock_session_manager.fork_session = AsyncMock(return_value=(True, forked_session, None))
+        mock_session_manager.get_activity_state.return_value = "idle"
+
+        response = test_client.post(
+            "/sessions/test123/fork",
+            json={"name": "test-fork", "requester_session_id": "caller123"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["source_provider_resume_id"] == "thread-source"
+        assert data["fork_provider_resume_id"] == "thread-fork"
+        assert data["fork_session"]["id"] == "fork1234"
+        assert data["fork_session"]["forked_from_session_id"] == "test123"
+        mock_session_manager.fork_session.assert_awaited_once_with(
+            "test123",
+            name="test-fork",
+            fork_point="current",
+            forked_by_session_id="caller123",
+        )
+        mock_output_monitor.start_monitoring.assert_awaited_once_with(forked_session)
+
+    def test_fork_session_surfaces_provider_error(self, test_client, mock_session_manager, sample_session):
+        """POST /sessions/{id}/fork returns clear provider errors."""
+        mock_session_manager.get_session.return_value = sample_session
+        mock_session_manager.fork_session = AsyncMock(
+            return_value=(False, None, "Session forking is not supported for provider=claude yet.")
+        )
+
+        response = test_client.post("/sessions/test123/fork", json={})
+
+        assert response.status_code == 400
+        assert "not supported" in response.json()["detail"]
+
     def test_kill_session(self, test_client, mock_session_manager, sample_session, mock_output_monitor):
         """DELETE /sessions/{id} kills session."""
         mock_session_manager.get_session.return_value = sample_session

--- a/tests/unit/test_cli_parsing.py
+++ b/tests/unit/test_cli_parsing.py
@@ -152,6 +152,14 @@ class TestCliParsing:
         restore_parser = subparsers.add_parser("restore")
         restore_parser.add_argument("session")
 
+        # sm fork
+        fork_parser = subparsers.add_parser("fork")
+        fork_parser.add_argument("session", nargs="?")
+        fork_parser.add_argument("--self", action="store_true")
+        fork_parser.add_argument("--name")
+        fork_parser.add_argument("--attach", action="store_true")
+        fork_parser.add_argument("--json", action="store_true")
+
         # sm output
         output_parser = subparsers.add_parser("output")
         output_parser.add_argument("session")
@@ -887,6 +895,49 @@ class TestRestoreCommand:
 
         assert exc_info.value.code == 0
         mock_cmd_restore.assert_called_once_with(mock_client, "dead123")
+
+
+class TestForkCommand:
+    """Tests for fork command parsing."""
+
+    def test_fork_command_parses_target_and_flags(self):
+        parser = TestCliParsing()
+        args = parser._get_parsed_args(["fork", "maintainer", "--name", "maintainer-fork", "--attach", "--json"])
+
+        assert args.command == "fork"
+        assert args.session == "maintainer"
+        assert args.name == "maintainer-fork"
+        assert args.attach is True
+        assert args.json is True
+
+    def test_fork_command_parses_self(self):
+        parser = TestCliParsing()
+        args = parser._get_parsed_args(["fork", "--self"])
+
+        assert args.command == "fork"
+        assert args.session is None
+        assert args.self is True
+
+    def test_main_fork_allowed_without_managed_session_for_target(self):
+        mock_client = MagicMock()
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(sys, "argv", ["sm", "fork", "dead123"]):
+                with patch("src.cli.main.SessionManagerClient", return_value=mock_client):
+                    with patch("src.cli.main.commands.cmd_fork", return_value=0) as mock_cmd_fork:
+                        with pytest.raises(SystemExit) as exc_info:
+                            main()
+
+        assert exc_info.value.code == 0
+        mock_cmd_fork.assert_called_once_with(
+            mock_client,
+            None,
+            "dead123",
+            self_target=False,
+            name=None,
+            attach=False,
+            json_output=False,
+        )
 
 
 class TestSessionResolution:

--- a/tests/unit/test_cmd_fork.py
+++ b/tests/unit/test_cmd_fork.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from src.cli import commands
+
+
+class _ForkClient:
+    def __init__(self, sessions: list[dict], result: dict):
+        self._sessions = sessions
+        self._result = result
+        self.calls: list[dict] = []
+
+    def get_session(self, session_id: str, timeout=None):
+        for session in self._sessions:
+            if session_id == session["id"]:
+                return session
+        return None
+
+    def list_sessions(self, include_stopped: bool = False, timeout=None):
+        assert include_stopped is True
+        return self._sessions
+
+    def fork_session_result(self, session_id: str, *, name=None, requester_session_id=None):
+        self.calls.append(
+            {
+                "session_id": session_id,
+                "name": name,
+                "requester_session_id": requester_session_id,
+            }
+        )
+        return self._result
+
+
+def _success_payload():
+    return {
+        "ok": True,
+        "unavailable": False,
+        "data": {
+            "source_provider_resume_id": "thread-source",
+            "fork_provider_resume_id": "thread-fork",
+            "source_session": {
+                "id": "source01",
+                "name": "codex-fork-source01",
+                "friendly_name": "maintainer",
+                "provider": "codex-fork",
+            },
+            "fork_session": {
+                "id": "fork01",
+                "name": "codex-fork-fork01",
+                "friendly_name": "maintainer-fork",
+                "provider": "codex-fork",
+            },
+        },
+    }
+
+
+def test_cmd_fork_target_prints_source_and_fork_identities(capsys):
+    client = _ForkClient(
+        [{"id": "source01", "friendly_name": "maintainer"}],
+        _success_payload(),
+    )
+
+    rc = commands.cmd_fork(
+        client,
+        "caller01",
+        "maintainer",
+        name="maintainer-fork",
+    )
+
+    assert rc == 0
+    assert client.calls == [
+        {
+            "session_id": "source01",
+            "name": "maintainer-fork",
+            "requester_session_id": "caller01",
+        }
+    ]
+    stdout = capsys.readouterr().out
+    assert "Forked maintainer (source01)" in stdout
+    assert "Original provider thread: thread-source" in stdout
+    assert "Fork session: maintainer-fork (fork01)" in stdout
+    assert "Fork provider thread: thread-fork" in stdout
+
+
+def test_cmd_fork_json_output(capsys):
+    client = _ForkClient(
+        [{"id": "source01", "friendly_name": "maintainer"}],
+        _success_payload(),
+    )
+
+    rc = commands.cmd_fork(
+        client,
+        "caller01",
+        "source01",
+        json_output=True,
+    )
+
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    assert '"source_session_id": "source01"' in stdout
+    assert '"fork_session_id": "fork01"' in stdout
+    assert '"fork_provider_resume_id": "thread-fork"' in stdout
+
+
+def test_cmd_fork_self_requires_current_session(capsys):
+    client = _ForkClient([], _success_payload())
+
+    rc = commands.cmd_fork(client, None, None, self_target=True)
+
+    assert rc == 2
+    stderr = capsys.readouterr().err
+    assert "CLAUDE_SESSION_MANAGER_ID not set" in stderr
+
+
+def test_cmd_fork_rejects_target_and_self(capsys):
+    client = _ForkClient([], _success_payload())
+
+    rc = commands.cmd_fork(client, "caller01", "source01", self_target=True)
+
+    assert rc == 1
+    stderr = capsys.readouterr().err
+    assert "use either a session target or --self" in stderr
+
+
+def test_cmd_fork_surfaces_api_error(capsys):
+    client = _ForkClient(
+        [{"id": "source01", "friendly_name": "maintainer"}],
+        {"ok": False, "unavailable": False, "detail": "Session forking is not supported"},
+    )
+
+    rc = commands.cmd_fork(client, "caller01", "source01")
+
+    assert rc == 1
+    stderr = capsys.readouterr().err
+    assert "Session forking is not supported" in stderr

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -35,6 +35,12 @@ class TestSession:
             telegram_thread_id=789,
             error_message="test error",
             transcript_path="/tmp/transcripts/test.jsonl",
+            provider_resume_id="provider-thread-source",
+            forked_from_session_id="source123",
+            forked_from_provider_resume_id="provider-thread-source",
+            forked_provider_resume_id="provider-thread-fork",
+            forked_at=datetime(2024, 1, 15, 10, 45, 0),
+            forked_by_session_id="caller123",
             friendly_name="My Test Session",
             friendly_name_is_explicit=True,
             friendly_name_updated_at_ns=123456789,
@@ -74,6 +80,12 @@ class TestSession:
         assert restored.telegram_thread_id == original.telegram_thread_id
         assert restored.error_message == original.error_message
         assert restored.transcript_path == original.transcript_path
+        assert restored.provider_resume_id == original.provider_resume_id
+        assert restored.forked_from_session_id == original.forked_from_session_id
+        assert restored.forked_from_provider_resume_id == original.forked_from_provider_resume_id
+        assert restored.forked_provider_resume_id == original.forked_provider_resume_id
+        assert restored.forked_at == original.forked_at
+        assert restored.forked_by_session_id == original.forked_by_session_id
         assert restored.friendly_name == original.friendly_name
         assert restored.friendly_name_is_explicit == original.friendly_name_is_explicit
         assert restored.friendly_name_updated_at_ns == original.friendly_name_updated_at_ns
@@ -111,6 +123,11 @@ class TestSession:
         assert session.telegram_chat_id is None
         assert session.telegram_thread_id is None
         assert session.error_message is None
+        assert session.forked_from_session_id is None
+        assert session.forked_from_provider_resume_id is None
+        assert session.forked_provider_resume_id is None
+        assert session.forked_at is None
+        assert session.forked_by_session_id is None
         assert session.friendly_name is None
         assert session.current_task is None
         assert session.subagents == []

--- a/tests/unit/test_session_forking.py
+++ b/tests/unit/test_session_forking.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.models import Session
+from src.session_manager import SessionManager
+
+
+class _FakeTmux:
+    def __init__(self):
+        self.created: list[dict] = []
+        self.last_error_message = None
+
+    def session_exists(self, session_name: str) -> bool:
+        return False
+
+    def create_session_with_command(
+        self,
+        session_name: str,
+        working_dir: str,
+        log_file: str,
+        *,
+        session_id: str | None = None,
+        command: str = "claude",
+        args: list[str] | None = None,
+        model: str | None = None,
+        initial_prompt: str | None = None,
+    ) -> bool:
+        self.created.append(
+            {
+                "session_name": session_name,
+                "working_dir": working_dir,
+                "log_file": log_file,
+                "session_id": session_id,
+                "command": command,
+                "args": args or [],
+                "model": model,
+                "initial_prompt": initial_prompt,
+            }
+        )
+        return True
+
+    def kill_session(self, session_name: str) -> bool:
+        return True
+
+    async def rename_codex_thread_async(self, session_name: str, friendly_name: str) -> bool:
+        return True
+
+
+def _manager(tmp_path) -> SessionManager:
+    manager = SessionManager(
+        log_dir=str(tmp_path / "logs"),
+        state_file=str(tmp_path / "sessions.json"),
+        config={
+            "codex": {"command": sys.executable, "args": []},
+            "codex_fork": {
+                "command": sys.executable,
+                "args": [],
+                "event_schema_version": 2,
+                "fork_timeout_seconds": 0.1,
+            },
+        },
+    )
+    manager.tmux = _FakeTmux()
+    manager._get_git_remote_url_async = AsyncMock(return_value=None)
+    manager.queue_provider_native_rename = AsyncMock(return_value=True)
+    manager._schedule_telegram_topic_ensure = lambda session, explicit_chat_id=None: None
+    return manager
+
+
+@pytest.mark.asyncio
+async def test_fork_session_launches_codex_fork_and_preserves_source_resume_id(tmp_path):
+    manager = _manager(tmp_path)
+    source = Session(
+        id="source01",
+        name="codex-fork-source01",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        provider_resume_id="thread-source",
+        model="gpt-test",
+    )
+    manager.sessions[source.id] = source
+
+    async def _confirm(fork_session: Session, source_resume_id: str):
+        assert source_resume_id == "thread-source"
+        fork_session.provider_resume_id = "thread-fork"
+        fork_session.forked_provider_resume_id = "thread-fork"
+        fork_session.forked_at = datetime(2026, 5, 14, 12, 0, 0)
+        return True, "thread-fork", None
+
+    manager._wait_for_codex_fork_result = _confirm
+
+    ok, fork_session, error = await manager.fork_session(
+        source.id,
+        name="source-fork",
+        forked_by_session_id="caller01",
+    )
+
+    assert ok is True
+    assert error is None
+    assert fork_session is not None
+    assert source.provider_resume_id == "thread-source"
+    assert fork_session.provider == "codex-fork"
+    assert fork_session.provider_resume_id == "thread-fork"
+    assert fork_session.forked_from_session_id == source.id
+    assert fork_session.forked_from_provider_resume_id == "thread-source"
+    assert fork_session.forked_provider_resume_id == "thread-fork"
+    assert fork_session.forked_by_session_id == "caller01"
+    assert fork_session.friendly_name == "source-fork"
+
+    created = manager.tmux.created[-1]
+    assert created["command"] == sys.executable
+    assert created["args"][:2] == ["fork", "thread-source"]
+    assert "--event-stream" in created["args"]
+    assert "--control-socket" in created["args"]
+
+
+@pytest.mark.asyncio
+async def test_fork_session_rejects_unsupported_provider(tmp_path):
+    manager = _manager(tmp_path)
+    manager.sessions["claude01"] = Session(
+        id="claude01",
+        working_dir=str(tmp_path),
+        provider="claude",
+        provider_resume_id="claude-thread",
+    )
+
+    ok, fork_session, error = await manager.fork_session("claude01")
+
+    assert ok is False
+    assert fork_session is None
+    assert error == "Session forking is not supported for provider=claude yet."
+
+
+@pytest.mark.asyncio
+async def test_fork_session_rejects_missing_resume_id(tmp_path):
+    manager = _manager(tmp_path)
+    manager.sessions["source01"] = Session(
+        id="source01",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+    )
+
+    ok, fork_session, error = await manager.fork_session("source01")
+
+    assert ok is False
+    assert fork_session is None
+    assert error == "Source session has no provider resume id to fork"
+
+
+@pytest.mark.asyncio
+async def test_wait_for_codex_fork_result_binds_matching_thread_started_event(tmp_path):
+    manager = _manager(tmp_path)
+    fork_session = Session(
+        id="fork01",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        forked_from_session_id="source01",
+        forked_from_provider_resume_id="thread-source",
+    )
+    event_path = manager._codex_fork_event_stream_path(fork_session)
+    event_path.parent.mkdir(parents=True, exist_ok=True)
+    event_path.write_text(
+        json.dumps(
+            {
+                "event_type": "thread/started",
+                "ts": "2026-05-14T12:00:00Z",
+                "payload": {
+                    "thread": {
+                        "id": "thread-fork",
+                        "forkedFromId": "thread-source",
+                    }
+                },
+            }
+        )
+        + "\n"
+    )
+
+    ok, fork_resume_id, error = await manager._wait_for_codex_fork_result(
+        fork_session,
+        "thread-source",
+    )
+
+    assert ok is True
+    assert error is None
+    assert fork_resume_id == "thread-fork"
+    assert fork_session.provider_resume_id == "thread-fork"
+    assert fork_session.forked_provider_resume_id == "thread-fork"
+    assert fork_session.forked_at is not None
+
+
+def test_ingest_codex_fork_manual_fork_preserves_previous_resume_id(tmp_path):
+    manager = _manager(tmp_path)
+    session = Session(
+        id="livefork",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        provider_resume_id="thread-source",
+    )
+    manager.sessions[session.id] = session
+
+    manager.ingest_codex_fork_event(
+        session.id,
+        {
+            "event_type": "thread/started",
+            "ts": "2026-05-14T12:00:00Z",
+            "payload": {
+                "thread": {
+                    "id": "thread-fork",
+                    "forkedFromId": "thread-source",
+                }
+            },
+        },
+    )
+
+    assert session.provider_resume_id == "thread-fork"
+    assert session.forked_from_session_id == session.id
+    assert session.forked_from_provider_resume_id == "thread-source"
+    assert session.forked_provider_resume_id == "thread-fork"
+    assert session.forked_at is not None

--- a/tests/unit/test_watch_tui.py
+++ b/tests/unit/test_watch_tui.py
@@ -10,6 +10,7 @@ from src.cli.watch_tui import (
     DetailSnapshot,
     _arm_retire_confirmation,
     _create_watch_session,
+    _fork_watch_session,
     _compute_column_widths,
     _default_create_working_dir,
     _normalize_create_working_dir,
@@ -90,6 +91,43 @@ def test_resolve_tmux_attach_target_falls_back_to_session_without_descriptor():
     assert error is None
     assert tmux_session == "session-target"
     assert tmux_socket_name == "session-manager-test"
+
+
+def test_fork_watch_session_returns_source_and_fork():
+    class _Client:
+        session_id = "caller01"
+
+        def fork_session_result(self, session_id, *, requester_session_id=None):
+            assert session_id == "source01"
+            assert requester_session_id == "caller01"
+            return {
+                "ok": True,
+                "unavailable": False,
+                "data": {
+                    "source_session": {"id": "source01", "friendly_name": "source"},
+                    "fork_session": {"id": "fork01", "friendly_name": "source-fork"},
+                },
+            }
+
+    source, fork_session, error = _fork_watch_session(_Client(), "source01")
+
+    assert error is None
+    assert source["id"] == "source01"
+    assert fork_session["id"] == "fork01"
+
+
+def test_fork_watch_session_surfaces_api_error():
+    class _Client:
+        session_id = "caller01"
+
+        def fork_session_result(self, session_id, *, requester_session_id=None):
+            return {"ok": False, "unavailable": False, "detail": "unsupported provider"}
+
+    source, fork_session, error = _fork_watch_session(_Client(), "source01")
+
+    assert source is None
+    assert fork_session is None
+    assert error == "unsupported provider"
 
 
 def _session(


### PR DESCRIPTION
## Summary
- Add durable fork lineage fields and fork-aware Codex-fork event ingestion.
- Add `POST /sessions/{id}/fork`, `sm fork`, and `sm watch` `F` support for SM-owned Codex-fork forks.
- Launch forks with native `codex fork <source-thread-id>` in a new managed tmux session, leaving the source provider resume id unchanged.

## Spec Reference
- `specs/744_session_forking.md`

## Test Plan
- [x] `./venv/bin/python -m pytest tests/unit/test_session_forking.py tests/unit/test_cmd_fork.py tests/unit/test_watch_tui.py tests/unit/test_cli_parsing.py tests/integration/test_api_endpoints.py -q`
- [x] `./venv/bin/python -m pytest tests/ -q`
- [x] `./venv/bin/python -m src.cli.main fork --help`

## Notes
- Live `sm fork --self` cannot be exercised against the running service until this PR is merged and Session Manager is restarted, because the current service does not yet expose `/sessions/{id}/fork`.

Fixes #744