### PR TITLE
Use retire copy in app lifecycle controls

### DIFF
--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SessionManagerRepository.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SessionManagerRepository.kt
@@ -38,6 +38,8 @@ class SessionManagerAuthException(message: String, cause: Throwable? = null) : S
 class SessionManagerTransientException(message: String, cause: Throwable? = null) : SessionManagerRequestException(message, cause)
 class SessionManagerBackendUnavailableException(message: String, cause: Throwable? = null) : SessionManagerRequestException(message, cause)
 
+const val RETIRE_REQUEST_FAILED_MESSAGE = "Retire request failed"
+
 class SessionManagerRepository {
     private val json = Json { ignoreUnknownKeys = true }
 
@@ -199,7 +201,7 @@ class SessionManagerRepository {
     suspend fun killSession(baseUrl: String, token: String, sessionId: String): Result<Unit> = withContext(Dispatchers.IO) {
         runCatching {
             val response = api(baseUrl, token).killSession(sessionId)
-            check(response.status == "killed") { response.error ?: "Kill request failed" }
+            check(response.status == "killed") { response.error ?: RETIRE_REQUEST_FAILED_MESSAGE }
         }.mapFailure(::classifyWriteFailure)
     }
 

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchModels.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchModels.kt
@@ -25,6 +25,9 @@ data class WatchRepoGroup(
     val children: List<WatchSessionNode>,
 )
 
+const val RETIRE_SESSION_ACTION_LABEL = "Retire"
+const val SIGN_IN_TO_RETIRE_SESSIONS_MESSAGE = "Sign in to retire sessions"
+
 fun sessionDisplayName(session: ClientSession): String {
     return session.friendlyName?.takeIf { it.isNotBlank() } ?: session.name.ifBlank { session.id }
 }

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
@@ -290,7 +290,7 @@ fun WatchScreen(
                             },
                             onKill = { session ->
                                 viewModel.killSession(session.id) { result ->
-                                    toast = result.exceptionOrNull()?.message ?: "Killed ${session.id}"
+                                    toast = result.exceptionOrNull()?.message ?: "Retired ${session.id}"
                                 }
                             },
                         )
@@ -336,7 +336,7 @@ fun WatchScreen(
                             },
                             onKill = { session ->
                                 viewModel.killSession(session.id) { result ->
-                                    toast = result.exceptionOrNull()?.message ?: "Killed ${session.id}"
+                                    toast = result.exceptionOrNull()?.message ?: "Retired ${session.id}"
                                 }
                             },
                         )
@@ -1176,7 +1176,7 @@ private fun SessionRow(
                         if (telegramLink(session) != null) {
                             ActionPill(label = "TG", icon = Icons.AutoMirrored.Rounded.OpenInNew, onClick = onOpenTelegram, tint = Cyan)
                         }
-                        ActionPill(label = "Kill", icon = Icons.Rounded.UnfoldLess, onClick = onKill, tint = Rose)
+                        ActionPill(label = RETIRE_SESSION_ACTION_LABEL, icon = Icons.Rounded.UnfoldLess, onClick = onKill, tint = Rose)
                     }
                     if (session.mobileTerminal?.supported == false && session.termuxAttach?.supported != true) {
                         StatusChip(label = session.mobileTerminal.reason ?: "mobile attach unavailable", tint = TextMuted)

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchViewModel.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchViewModel.kt
@@ -228,7 +228,7 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
             val serverUrl = settingsRepository.serverUrl.first()
             val accessToken = settingsRepository.accessToken.first()
             val result = if (serverUrl.isBlank() || accessToken.isBlank()) {
-                Result.failure(IllegalStateException("Sign in to kill sessions"))
+                Result.failure(IllegalStateException(SIGN_IN_TO_RETIRE_SESSIONS_MESSAGE))
             } else {
                 sessionRepository.killSession(serverUrl, accessToken, sessionId)
             }

--- a/android-app/app/src/test/java/li/rajeshgo/sm/data/repository/SessionManagerRepositoryTest.kt
+++ b/android-app/app/src/test/java/li/rajeshgo/sm/data/repository/SessionManagerRepositoryTest.kt
@@ -9,6 +9,12 @@ import org.junit.Test
 
 class SessionManagerRepositoryTest {
     @Test
+    fun retireFallbackErrorCopyUsesRetireLanguage() {
+        assertEquals("Retire request failed", RETIRE_REQUEST_FAILED_MESSAGE)
+        assertFalse(RETIRE_REQUEST_FAILED_MESSAGE.contains("kill", ignoreCase = true))
+    }
+
+    @Test
     fun mobileAttachTicketPathIncludesBaseUrlPathPrefix() {
         val repository = SessionManagerRepository()
 

--- a/android-app/app/src/test/java/li/rajeshgo/sm/ui/watch/WatchModelsTest.kt
+++ b/android-app/app/src/test/java/li/rajeshgo/sm/ui/watch/WatchModelsTest.kt
@@ -8,6 +8,14 @@ import org.junit.Test
 
 class WatchModelsTest {
     @Test
+    fun retireSessionCopyUsesRetireLanguage() {
+        assertEquals("Retire", RETIRE_SESSION_ACTION_LABEL)
+        assertEquals("Sign in to retire sessions", SIGN_IN_TO_RETIRE_SESSIONS_MESSAGE)
+        assertFalse(RETIRE_SESSION_ACTION_LABEL.contains("kill", ignoreCase = true))
+        assertFalse(SIGN_IN_TO_RETIRE_SESSIONS_MESSAGE.contains("kill", ignoreCase = true))
+    }
+
+    @Test
     fun projectedStatusTreatsWorkingIdleSessionAsActive() {
         val session = session(status = "idle", activityState = "working")
 

--- a/web/sm-watch/src/App.tsx
+++ b/web/sm-watch/src/App.tsx
@@ -343,14 +343,14 @@ export default function App() {
       const result = await postKill(id);
       if (!result.ok) {
         if (result.httpStatus === 422) {
-          showToast('Kill request rejected by API payload validation.');
+          showToast('Retire request rejected by API payload validation.');
           return;
         }
-        showToast('Kill request failed. Session manager endpoint not reachable.');
+        showToast('Retire request failed. Session manager endpoint not reachable.');
         return;
       }
       if (!result.killed) {
-        showToast(result.error || 'Kill request failed.');
+        showToast(result.error || 'Retire request failed.');
         return;
       }
       setSessions((prev) => prev.filter((session) => session.id !== id));
@@ -364,9 +364,9 @@ export default function App() {
         delete next[id];
         return next;
       });
-      showToast(`Killed ${id}.`);
+      showToast(`Retired ${id}.`);
     } catch {
-      showToast('Kill request failed.');
+      showToast('Retire request failed.');
     }
   };
 

--- a/web/sm-watch/src/components/WatchTable.tsx
+++ b/web/sm-watch/src/components/WatchTable.tsx
@@ -150,7 +150,7 @@ function SessionDetailBlock({
           className="inline-flex items-center gap-2 rounded-full border border-rose-500/30 bg-rose-500/10 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-rose-200 transition hover:border-rose-400/60"
         >
           <Trash2 size={13} />
-          Kill session
+          Retire session
         </button>
         <button
           type="button"


### PR DESCRIPTION
## Summary
- Updates Android watch lifecycle copy from Kill/Killed to Retire/Retired while keeping the existing backend `/kill` API compatibility.
- Updates the web watch app's visible lifecycle labels and toasts to match.
- Adds Android unit assertions for the app-facing retire copy.

## Test Plan
- [x] `JAVA_HOME="$(brew --prefix openjdk@17)/libexec/openjdk.jdk/Contents/Home" ./gradlew test` from `android-app/`
- [x] `JAVA_HOME="$(brew --prefix openjdk@17)/libexec/openjdk.jdk/Contents/Home" ./gradlew assembleRelease` from `android-app/`
- [x] Built APK dex-string check confirms `Retire`, `Retire request failed`, and `Sign in to retire sessions`
- [x] `npm run lint` from `web/sm-watch/`
- [x] `npm run build` from `web/sm-watch/`

Fixes #750
