### PR TITLE
Implement multi-node session placement

### DIFF
--- a/hooks/log_tool_use.sh
+++ b/hooks/log_tool_use.sh
@@ -4,6 +4,8 @@
 
 FALLBACK_DIR="${HOME}/.local/share/claude-sessions"
 FALLBACK_FILE="${FALLBACK_DIR}/tool_usage_fallback.jsonl"
+HOOK_BASE_URL="${SM_HOOK_BASE_URL:-http://localhost:8420}"
+HOOK_URL="${SM_TOOL_USE_HOOK_URL:-${HOOK_BASE_URL%/}/hooks/tool-use}"
 
 INPUT=$(cat)
 
@@ -14,8 +16,13 @@ fi
 
 # Post to server with short timeout, fallback to file
 # Using very short timeouts (0.5s connect, 1s total) to avoid blocking
-if ! curl -s --max-time 1 --connect-timeout 0.5 -X POST http://localhost:8420/hooks/tool-use \
-    -H "Content-Type: application/json" \
+CURL_HEADERS=(-H "Content-Type: application/json")
+if [ -n "$SM_HOOK_SECRET" ]; then
+  CURL_HEADERS+=(-H "X-SM-Hook-Secret: $SM_HOOK_SECRET")
+fi
+
+if ! curl -s --max-time 1 --connect-timeout 0.5 -X POST "$HOOK_URL" \
+    "${CURL_HEADERS[@]}" \
     -d "$INPUT" >/dev/null 2>&1; then
   # Fallback: write to file if server unavailable
   mkdir -p "$FALLBACK_DIR"

--- a/hooks/notify_server.sh
+++ b/hooks/notify_server.sh
@@ -3,8 +3,61 @@
 # Always exits successfully - if the server is down or session not found, log it
 # and return 0 so Claude does not surface a hook failure.
 
-HOOK_URL="${SM_HOOK_URL:-http://localhost:8420/hooks/claude}"
+HOOK_BASE_URL="${SM_HOOK_BASE_URL:-http://localhost:8420}"
+HOOK_URL="${SM_HOOK_URL:-${HOOK_BASE_URL%/}/hooks/claude}"
 HOOK_LOG_PATH="${CLAUDE_HOOK_LOG_PATH:-/tmp/claude-hooks.log}"
+
+extract_transcript_metadata() {
+  local transcript_path="$1"
+  if [ -z "$transcript_path" ] || [ ! -f "$transcript_path" ]; then
+    return 1
+  fi
+
+  local mtime_seconds
+  mtime_seconds=$(stat -f %m "$transcript_path" 2>/dev/null || stat -c %Y "$transcript_path" 2>/dev/null || echo "")
+  local mtime_ns=""
+  if [ -n "$mtime_seconds" ]; then
+    mtime_ns="${mtime_seconds}000000000"
+  fi
+
+  local metadata
+  metadata=$(
+    tail -n 400 "$transcript_path" | jq -cs '
+      def trim_text:
+        tostring | sub("^[[:space:]]+"; "") | sub("[[:space:]]+$"; "");
+      def assistant_text($entry):
+        (($entry.message.content // [])
+          | map(select(type == "object" and .type == "text") | (.text // ""))
+          | join("\n")
+          | trim_text);
+      reverse | reduce .[] as $entry (
+        {sm_last_message: null, sm_native_title: null, assistant_seen: false};
+        (if .sm_native_title == null then
+          if $entry.type == "custom-title" and (($entry.customTitle // "") | trim_text) != "" then
+            .sm_native_title = (($entry.customTitle // "") | trim_text)
+          elif $entry.type == "agent-name" and (($entry.agentName // "") | trim_text) != "" then
+            .sm_native_title = (($entry.agentName // "") | trim_text)
+          else . end
+        else . end)
+        | (if (.assistant_seen | not) and $entry.type == "assistant" then
+          .assistant_seen = true
+          | (assistant_text($entry)) as $text
+          | if $text != "" then .sm_last_message = $text else . end
+        else . end)
+      ) | del(.assistant_seen)
+    ' 2>/dev/null
+  ) || return 1
+
+  if [ -n "$mtime_ns" ]; then
+    echo "$metadata" | jq -c --argjson mtime "$mtime_ns" '. + {sm_transcript_mtime_ns: $mtime}' 2>/dev/null
+  else
+    echo "$metadata"
+  fi
+}
+
+metadata_message() {
+  echo "$1" | jq -r '.sm_last_message // empty' 2>/dev/null
+}
 
 # Claude writes a single JSON line for the hook payload, but it may keep stdin
 # open until the broader turn finishes (for example while background task
@@ -15,6 +68,30 @@ IFS= read -r INPUT || [ -n "$INPUT" ]
 
 if [ -z "$INPUT" ]; then
   exit 0
+fi
+
+# Inline transcript metadata for remote delivery. When the hook is posting to a
+# non-local primary, that primary cannot safely read the node-local transcript.
+if [ -n "$SM_HOOK_BASE_URL" ] || [ -n "$SM_HOOK_URL" ]; then
+  TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null)
+  HOOK_EVENT=$(echo "$INPUT" | jq -r '.hook_event_name // empty' 2>/dev/null)
+  if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
+    METADATA=$(extract_transcript_metadata "$TRANSCRIPT_PATH" || true)
+    if [ "$HOOK_EVENT" = "Stop" ]; then
+      if [ -z "$(metadata_message "$METADATA")" ]; then
+        sleep 0.5
+        METADATA=$(extract_transcript_metadata "$TRANSCRIPT_PATH" || true)
+      fi
+      CURRENT_MESSAGE="$(metadata_message "$METADATA")"
+      if [ -n "$CURRENT_MESSAGE" ] && { [ -z "$SM_LAST_CLAUDE_OUTPUT" ] || [ "$CURRENT_MESSAGE" = "$SM_LAST_CLAUDE_OUTPUT" ]; }; then
+        sleep 0.3
+        METADATA=$(extract_transcript_metadata "$TRANSCRIPT_PATH" || true)
+      fi
+    fi
+    if [ -n "$METADATA" ]; then
+      INPUT=$(jq -c --argjson meta "$METADATA" '. + $meta' <<< "$INPUT" 2>/dev/null || echo "$INPUT")
+    fi
+  fi
 fi
 
 # If CLAUDE_SESSION_MANAGER_ID is set (from environment), inject it into the payload.
@@ -28,8 +105,13 @@ fi
   echo "$(date): Hook called" >> "$HOOK_LOG_PATH"
   echo "$INPUT" >> "$HOOK_LOG_PATH"
 
+  CURL_HEADERS=(-H "Content-Type: application/json")
+  if [ -n "$SM_HOOK_SECRET" ]; then
+    CURL_HEADERS+=(-H "X-SM-Hook-Secret: $SM_HOOK_SECRET")
+  fi
+
   RESPONSE=$(curl -s --max-time 5 --connect-timeout 2 -X POST "$HOOK_URL" \
-    -H "Content-Type: application/json" \
+    "${CURL_HEADERS[@]}" \
     -d "$INPUT" 2>&1)
 
   echo "$RESPONSE" >> "$HOOK_LOG_PATH"

--- a/specs/752_remote_managed_nodes.md
+++ b/specs/752_remote_managed_nodes.md
@@ -98,8 +98,9 @@ single-brain model.
    identically to local ones, including the Stop-hook retry/staleness semantics.
 4. **Attach** (CLI and web/mobile terminal) works against a remote session.
 5. **Teardown / kill / restart** route to the correct node.
-6. Default behavior is **unchanged**: omitting a node places the session on the primary host. Zero
-   behavior change for existing single-host users.
+6. Default behavior is **unchanged unless configured**: with no `nodes.default` override, omitting
+   a node places the session on the primary host. If `nodes.default` is configured, top-level
+   creation uses that node; child sessions still inherit the parent node.
 7. Requesting a non-primary node with an unsupported provider is an **explicit rejection**,
    whether the node was passed directly or inherited from a parent — never a silent primary
    fallback.
@@ -311,10 +312,12 @@ keys only because one drives the CLI API and the other drives hook delivery.
 
 ## API & CLI Changes
 
-- **`node` defaults to `"primary"` on every creation path**, so unlisted/legacy surfaces are
-  unaffected: `POST /sessions`, `/sessions/create`, `/sessions/spawn` (`SpawnChildRequest`),
-  `/sessions/review`, and CLI `sm claude` / `sm codex` / `sm new` / `sm spawn` / `sm dispatch` /
-  `sm review --new` / `sm watch` create / fork / role bootstrap.
+- **`node` resolves consistently**: explicit `node` wins; children inherit their parent; top-level
+  creates use `nodes.default` (which itself defaults to `"primary"`). This applies to
+  `POST /sessions`, `/sessions/create`, `/sessions/spawn` (`SpawnChildRequest`), and CLI
+  `sm claude` / `sm codex` / `sm new` / `sm spawn` / `sm dispatch`. Primary-only/default-only
+  surfaces (`/sessions/review`, `sm review --new`, fork, and existing watch/role bootstrap flows)
+  continue to pass no non-primary node unless explicitly wired in this phase.
 - **Phase 1 exposes `--node`** on `sm claude` and `sm spawn`. Children inherit the parent node via
   `SpawnChildRequest`. Other surfaces accept only `primary` (default).
 - **`sm dispatch --node`:** `--node` is a **reserved** flag in dispatch's phase-1 (known-args)
@@ -417,7 +420,7 @@ the primary, reconciled via git on reconnect. Explicit operator mode, never auto
 - Integration (local "fake remote" via `ssh localhost`): spawn a remote **Claude** session; assert
   it appears, status transitions fire from hooks, last-message/title populate (incl. the retry
   path), attach connects, kill tears down the remote tmux.
-- Regression: full existing suite with `node="primary"` — zero behavior change.
+- Regression: full existing suite with `nodes.default` absent/`primary` — zero behavior change.
 - Liveness: node down → sessions show `node-unreachable` (not `dead`, no cleanup); node returns →
   recovers.
 - Remote **Codex** acceptance is owned by the deferred sub-ticket, not Phase 1.

--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -375,11 +375,18 @@ class SessionManagerClient:
         """Ensure the maintainer service session exists."""
         return self.ensure_role("maintainer", requester_session_id=requester_session_id)
 
-    def ensure_role(self, role: str, requester_session_id: Optional[str] = None) -> dict:
+    def ensure_role(
+        self,
+        role: str,
+        requester_session_id: Optional[str] = None,
+        node: Optional[str] = None,
+    ) -> dict:
         """Ensure one configured auto-bootstrap registry role session exists."""
         payload = {}
         if requester_session_id:
             payload["requester_session_id"] = requester_session_id
+        if node:
+            payload["node"] = node
         role_path = urllib.parse.quote(role, safe="")
         data, status_code, unavailable = self._request_with_status(
             "POST",
@@ -738,6 +745,7 @@ class SessionManagerClient:
         model: Optional[str] = None,
         working_dir: Optional[str] = None,
         provider: Optional[str] = None,
+        node: Optional[str] = None,
         track_seconds: Optional[int] = None,
     ) -> Optional[dict]:
         """
@@ -768,6 +776,8 @@ class SessionManagerClient:
             payload["working_dir"] = working_dir
         if provider:
             payload["provider"] = provider
+        if node:
+            payload["node"] = node
         if track_seconds is not None:
             payload["track_seconds"] = track_seconds
 
@@ -1045,6 +1055,7 @@ class SessionManagerClient:
         working_dir: str,
         provider: Optional[str] = None,
         parent_session_id: Optional[str] = None,
+        node: Optional[str] = None,
     ) -> dict:
         """
         Create a new Claude Code session and preserve API error details.
@@ -1062,6 +1073,8 @@ class SessionManagerClient:
             payload["provider"] = provider
         if parent_session_id is not None:
             payload["parent_session_id"] = parent_session_id
+        if node:
+            payload["node"] = node
         data, status_code, unavailable = self._request_with_status(
             "POST",
             "/sessions",
@@ -1089,6 +1102,7 @@ class SessionManagerClient:
         working_dir: str,
         provider: Optional[str] = None,
         parent_session_id: Optional[str] = None,
+        node: Optional[str] = None,
     ) -> Optional[dict]:
         """
         Create a new Claude Code session.
@@ -1105,8 +1119,24 @@ class SessionManagerClient:
             working_dir,
             provider=provider,
             parent_session_id=parent_session_id,
+            node=node,
         )
         return result.get("data") if result.get("ok") else None
+
+    def list_nodes(self) -> Optional[dict]:
+        data, success, unavailable = self._request("GET", "/nodes")
+        if unavailable or not success:
+            return None
+        return data
+
+    def ping_node(self, node_id: str) -> dict:
+        path = f"/nodes/{urllib.parse.quote(node_id, safe='')}/ping"
+        data, status_code, unavailable = self._request_with_status("POST", path, {})
+        if unavailable:
+            return {"ok": False, "unavailable": True, "status_code": None, "detail": None, "data": None}
+        ok = status_code in (200, 201)
+        detail = data.get("detail") if isinstance(data, dict) else None
+        return {"ok": ok, "unavailable": False, "status_code": status_code, "detail": detail, "data": data}
 
     def get_queue_status(self, session_id: str) -> Optional[dict]:
         """

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -52,10 +52,15 @@ def _tmux_socket_from_descriptor(descriptor: Optional[dict]) -> Optional[str]:
 
 def _attach_tmux_session(tmux_session: str, descriptor: Optional[dict] = None) -> int:
     """Attach the current terminal to a tmux session."""
-    tmux_socket_name = _tmux_socket_from_descriptor(descriptor)
+    attach_command = descriptor.get("attach_command") if isinstance(descriptor, dict) else None
+    if isinstance(attach_command, list) and attach_command:
+        cmd = [str(part) for part in attach_command]
+    else:
+        tmux_socket_name = _tmux_socket_from_descriptor(descriptor)
+        cmd = _tmux_command(["attach", "-t", tmux_session], tmux_socket_name)
     try:
         subprocess.run(
-            _tmux_command(["attach", "-t", tmux_session], tmux_socket_name),
+            cmd,
             check=True,
         )
         return 0
@@ -881,6 +886,45 @@ def cmd_who(client: SessionManagerClient, session_id: str) -> int:
     return 0
 
 
+def cmd_nodes(client: SessionManagerClient) -> int:
+    """List configured execution nodes."""
+    payload = client.list_nodes()
+    if payload is None:
+        print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+        return 2
+    nodes = payload.get("nodes") or []
+    if not nodes:
+        print("No nodes configured.")
+        return 0
+    headers = ("Node", "Primary", "SSH", "API URL", "Hook Base")
+    rows = [
+        (
+            str(node.get("id") or ""),
+            "yes" if node.get("primary") else "",
+            str(node.get("ssh") or ""),
+            str(node.get("api_url") or ""),
+            str(node.get("hook_base_url") or ""),
+        )
+        for node in nodes
+    ]
+    _print_roster_table(headers, rows)
+    return 0
+
+
+def cmd_node_ping(client: SessionManagerClient, node_id: str) -> int:
+    """Ping one configured execution node."""
+    result = client.ping_node(node_id)
+    if result.get("unavailable"):
+        print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+        return 2
+    if not result.get("ok"):
+        print(f"Error: {result.get('detail') or 'ping failed'}", file=sys.stderr)
+        return 1
+    data = result.get("data") or {}
+    print(f"{data.get('node') or node_id}: ok")
+    return 0
+
+
 def cmd_what(client: SessionManagerClient, identifier: str, lines: int, deep: bool = False) -> int:
     """
     Get AI-generated summary of what a session is doing.
@@ -1377,6 +1421,7 @@ def cmd_dispatch(
     no_clear: bool = False,
     delivery_mode: str = "sequential",
     notify_on_stop: bool = True,
+    node: Optional[str] = None,
 ) -> int:
     """Dispatch a template-expanded prompt to a target agent.
 
@@ -1429,16 +1474,53 @@ def cmd_dispatch(
 
     # Resolve target once so clear/send/role-update all operate on same session.
     target_session_id, _ = resolve_session_id(client, agent_id)
+    target_session = None
     if target_session_id is None:
+        if node:
+            ensure_result = client.ensure_role(agent_id, requester_session_id=em_id, node=node)
+            if ensure_result.get("unavailable"):
+                print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+                return 2
+            if not ensure_result.get("ok"):
+                status_code = ensure_result.get("status_code")
+                detail = ensure_result.get("detail")
+                if status_code not in (None, 404):
+                    print(f"Error: {detail or 'Failed to bootstrap role'}", file=sys.stderr)
+                    return 1
+                print(f"Error: Session '{agent_id}' not found", file=sys.stderr)
+                return 1
+            payload = ensure_result.get("data") or {}
+            target_session = payload.get("session") or {}
+            target_session_id = target_session.get("id")
+            if not target_session_id:
+                print(f"Error: Role bootstrap for '{agent_id}' returned no session", file=sys.stderr)
+                return 1
+            if payload.get("created"):
+                boot_name = target_session.get("friendly_name") or target_session.get("name") or target_session_id
+                provider = target_session.get("provider") or "unknown"
+                print(f"Role bootstrapped: {agent_id} -> {boot_name} ({target_session_id}) [{provider}]")
+        else:
+            sessions = client.list_sessions()
+            if sessions is None:
+                print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+                return 2
+            print(f"Error: Session '{agent_id}' not found", file=sys.stderr)
+            return 1
+    else:
         sessions = client.list_sessions()
         if sessions is None:
             print(UNAVAILABLE_MESSAGE, file=sys.stderr)
             return 2
-        print(f"Error: Session '{agent_id}' not found", file=sys.stderr)
-        return 1
+        target_session = next((item for item in sessions if item.get("id") == target_session_id), None)
+        if node and target_session and (target_session.get("node") or "primary") != node:
+            print(
+                f"Error: --node {node} does not match existing target node {target_session.get('node') or 'primary'}",
+                file=sys.stderr,
+            )
+            return 1
 
     # Clear target before dispatch unless opted out (#234).
-    if not no_clear:
+    if target_session_id is not None and not no_clear:
         rc = cmd_clear(client, em_id, target_session_id)
         if rc != 0:
             return rc
@@ -2331,6 +2413,7 @@ def cmd_spawn(
     working_dir: Optional[str] = None,
     json_output: bool = False,
     track_seconds: Optional[int] = None,
+    node: Optional[str] = None,
 ) -> int:
     """
     Spawn a child agent session.
@@ -2381,16 +2464,19 @@ def cmd_spawn(
         return 1
 
     # Spawn child session
-    result = client.spawn_child(
-        parent_session_id=parent_session_id,
-        prompt=prompt,
-        name=name,
-        wait=wait,
-        model=model,
-        working_dir=working_dir,
-        provider=provider,
-        track_seconds=track_seconds,
-    )
+    spawn_kwargs = {
+        "parent_session_id": parent_session_id,
+        "prompt": prompt,
+        "name": name,
+        "wait": wait,
+        "model": model,
+        "working_dir": working_dir,
+        "provider": provider,
+        "track_seconds": track_seconds,
+    }
+    if node:
+        spawn_kwargs["node"] = node
+    result = client.spawn_child(**spawn_kwargs)
 
     if result is None:
         print(UNAVAILABLE_MESSAGE, file=sys.stderr)
@@ -2885,6 +2971,7 @@ def cmd_new(
     working_dir: Optional[str] = None,
     provider: str = "claude",
     parent_session_id: Optional[str] = None,
+    node: Optional[str] = None,
 ) -> int:
     """
     Create a new session (Claude/Codex attach; Codex app is headless).
@@ -2908,30 +2995,34 @@ def cmd_new(
     if working_dir is None:
         working_dir = os.getcwd()
 
-    # Expand and resolve path
-    try:
-        path = Path(working_dir).expanduser().resolve()
-        if not path.exists():
-            print(f"Error: Directory does not exist: {working_dir}", file=sys.stderr)
+    if not node or node == "primary":
+        # Expand and resolve path locally for primary sessions. Remote nodes are
+        # preflighted by the server on the target machine.
+        try:
+            path = Path(working_dir).expanduser().resolve()
+            if not path.exists():
+                print(f"Error: Directory does not exist: {working_dir}", file=sys.stderr)
+                return 1
+            if not path.is_dir():
+                print(f"Error: Not a directory: {working_dir}", file=sys.stderr)
+                return 1
+            working_dir = str(path)
+        except Exception as e:
+            print(f"Error: Invalid path: {e}", file=sys.stderr)
             return 1
-        if not path.is_dir():
-            print(f"Error: Not a directory: {working_dir}", file=sys.stderr)
-            return 1
-        working_dir = str(path)
-    except Exception as e:
-        print(f"Error: Invalid path: {e}", file=sys.stderr)
-        return 1
 
     if provider == "codex-app" and not _print_codex_app_guidance_for_create(client):
         return 1
 
     # Create session via API
     print(f"Creating session in {working_dir}...")
-    result = client.create_session_result(
-        working_dir,
-        provider=provider,
-        parent_session_id=parent_session_id,
-    )
+    create_kwargs = {
+        "provider": provider,
+        "parent_session_id": parent_session_id,
+    }
+    if node:
+        create_kwargs["node"] = node
+    result = client.create_session_result(working_dir, **create_kwargs)
 
     if result.get("unavailable"):
         print(UNAVAILABLE_MESSAGE, file=sys.stderr)
@@ -2971,6 +3062,7 @@ def cmd_codex_2(
     client: SessionManagerClient,
     working_dir: Optional[str] = None,
     parent_session_id: Optional[str] = None,
+    node: Optional[str] = None,
 ) -> int:
     """
     Create a new codex-fork session and immediately attach via attach-descriptor flow.
@@ -2991,25 +3083,28 @@ def cmd_codex_2(
     if working_dir is None:
         working_dir = os.getcwd()
 
-    try:
-        path = Path(working_dir).expanduser().resolve()
-        if not path.exists():
-            print(f"Error: Directory does not exist: {working_dir}", file=sys.stderr)
+    if not node or node == "primary":
+        try:
+            path = Path(working_dir).expanduser().resolve()
+            if not path.exists():
+                print(f"Error: Directory does not exist: {working_dir}", file=sys.stderr)
+                return 1
+            if not path.is_dir():
+                print(f"Error: Not a directory: {working_dir}", file=sys.stderr)
+                return 1
+            working_dir = str(path)
+        except Exception as e:
+            print(f"Error: Invalid path: {e}", file=sys.stderr)
             return 1
-        if not path.is_dir():
-            print(f"Error: Not a directory: {working_dir}", file=sys.stderr)
-            return 1
-        working_dir = str(path)
-    except Exception as e:
-        print(f"Error: Invalid path: {e}", file=sys.stderr)
-        return 1
 
     print(f"Creating codex-fork session in {working_dir}...")
-    result = client.create_session_result(
-        working_dir,
-        provider="codex-fork",
-        parent_session_id=parent_session_id,
-    )
+    create_kwargs = {
+        "provider": "codex-fork",
+        "parent_session_id": parent_session_id,
+    }
+    if node:
+        create_kwargs["node"] = node
+    result = client.create_session_result(working_dir, **create_kwargs)
     if result.get("unavailable"):
         print(UNAVAILABLE_MESSAGE, file=sys.stderr)
         return 2
@@ -3179,8 +3274,11 @@ def cmd_output(client: SessionManagerClient, identifier: str, lines: int) -> int
         print(f"Error: Session has no tmux session", file=sys.stderr)
         return 1
 
-    descriptor = client.get_attach_descriptor(session_id)
-    output = _capture_tmux_pane(tmux_session, lines=lines, descriptor=descriptor)
+    output_payload = client.get_output(session_id, lines=lines, timeout=10)
+    output = output_payload.get("output") if isinstance(output_payload, dict) else None
+    if output is None:
+        descriptor = client.get_attach_descriptor(session_id)
+        output = _capture_tmux_pane(tmux_session, lines=lines, descriptor=descriptor)
 
     if output is None:
         print(f"Error: Failed to capture output from {tmux_session}", file=sys.stderr)
@@ -3773,8 +3871,11 @@ def cmd_tail(
             print("Error: Session has no tmux session", file=sys.stderr)
             return 1
 
-        descriptor = client.get_attach_descriptor(session_id)
-        output = _capture_tmux_pane(tmux_session, lines=n, descriptor=descriptor)
+        output_payload = client.get_output(session_id, lines=n, timeout=10)
+        output = output_payload.get("output") if isinstance(output_payload, dict) else None
+        if output is None:
+            descriptor = client.get_attach_descriptor(session_id)
+            output = _capture_tmux_pane(tmux_session, lines=n, descriptor=descriptor)
         if output is None:
             print(f"Error: Failed to capture output from {tmux_session}", file=sys.stderr)
             return 1
@@ -4977,6 +5078,22 @@ def cmd_clear(
     if not tmux_session:
         print(f"Error: Session {target_session_id} has no tmux session", file=sys.stderr)
         return 1
+
+    if (session.get("node") or "primary") != "primary":
+        success, unavailable = client.clear_session(target_session_id, new_prompt)
+        if unavailable:
+            print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+            return 2
+        if not success:
+            print(f"Error: Failed to clear session {target_session_id}", file=sys.stderr)
+            return 1
+        name = session.get("friendly_name") or session.get("name") or target_session_id
+        if new_prompt:
+            print(f"Cleared {name} ({target_session_id}) and sent new prompt")
+        else:
+            print(f"Cleared {name} ({target_session_id})")
+        return 0
+
     descriptor = client.get_attach_descriptor(target_session_id)
     tmux_socket_name = _tmux_socket_from_descriptor(descriptor) or session.get("tmux_socket_name")
 

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -117,6 +117,47 @@ def _print_codex_app_guidance_for_create(client: SessionManagerClient) -> bool:
     return True
 
 
+def _effective_create_node_for_cli(
+    client: SessionManagerClient,
+    *,
+    node: Optional[str] = None,
+    parent_session_id: Optional[str] = None,
+) -> str:
+    """Best-effort mirror of server-side create node resolution for CLI preflight."""
+    if node:
+        return str(node).strip() or "primary"
+
+    if parent_session_id:
+        sessions_getter = getattr(client, "list_sessions", None)
+        if callable(sessions_getter):
+            sessions = sessions_getter()
+            if isinstance(sessions, list):
+                parent = next((item for item in sessions if item.get("id") == parent_session_id), None)
+                if isinstance(parent, dict):
+                    return str(parent.get("node") or "primary").strip() or "primary"
+
+    nodes_getter = getattr(client, "list_nodes", None)
+    if callable(nodes_getter):
+        payload = nodes_getter()
+        if isinstance(payload, dict):
+            return str(payload.get("default") or "primary").strip() or "primary"
+
+    return "primary"
+
+
+def _should_validate_working_dir_locally(
+    client: SessionManagerClient,
+    *,
+    node: Optional[str] = None,
+    parent_session_id: Optional[str] = None,
+) -> bool:
+    return _effective_create_node_for_cli(
+        client,
+        node=node,
+        parent_session_id=parent_session_id,
+    ) == "primary"
+
+
 def cmd_removed_entrypoint(entrypoint: str) -> int:
     """Return actionable error text for removed legacy commands."""
     normalized = (entrypoint or "").strip().lower()
@@ -2995,7 +3036,7 @@ def cmd_new(
     if working_dir is None:
         working_dir = os.getcwd()
 
-    if not node or node == "primary":
+    if _should_validate_working_dir_locally(client, node=node, parent_session_id=parent_session_id):
         # Expand and resolve path locally for primary sessions. Remote nodes are
         # preflighted by the server on the target machine.
         try:
@@ -3083,7 +3124,7 @@ def cmd_codex_2(
     if working_dir is None:
         working_dir = os.getcwd()
 
-    if not node or node == "primary":
+    if _should_validate_working_dir_locally(client, node=node, parent_session_id=parent_session_id):
         try:
             path = Path(working_dir).expanduser().resolve()
             if not path.exists():

--- a/src/cli/dispatch.py
+++ b/src/cli/dispatch.py
@@ -261,7 +261,7 @@ def parse_dispatch_args(argv: list[str]) -> tuple:
         argv: sys.argv[2:] (everything after 'dispatch')
 
     Returns:
-        Tuple of (agent_id, role, dry_run, no_clear, delivery_mode, notify_on_stop, dynamic_params)
+        Tuple of (agent_id, role, dry_run, no_clear, delivery_mode, notify_on_stop, node, dynamic_params)
 
     Raises:
         SystemExit: On parse errors (via argparse).
@@ -285,6 +285,7 @@ def parse_dispatch_args(argv: list[str]) -> tuple:
     static_parser.add_argument("--no-notify-on-stop", action="store_true", help="Pass through to sm send --no-notify-on-stop")
     static_parser.add_argument("--no-clear", action="store_true",
         help="Skip clearing target session before dispatch (use for follow-up dispatches on same task)")
+    static_parser.add_argument("--node", help="Execution node for dispatch-created/bootstrap targets")
 
     known, remaining = static_parser.parse_known_args(argv)
 
@@ -333,5 +334,6 @@ def parse_dispatch_args(argv: list[str]) -> tuple:
         known.no_clear,
         delivery_mode,
         notify_on_stop,
+        known.node,
         dynamic_params,
     )

--- a/src/cli/formatting.py
+++ b/src/cli/formatting.py
@@ -90,6 +90,9 @@ def format_session_line(
     parts.append(f"[{session_id}]")
     parts.append(f"- {status}")
     parts.append(f"- {time_str}")
+    node = str(session.get("node") or "primary")
+    if node != "primary":
+        parts.append(f"- node={node}")
 
     if show_working_dir:
         working_dir = session.get("working_dir", "")

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -176,7 +176,7 @@ def _handle_dispatch(session_id: Optional[str]) -> int:
     """
     from .dispatch import parse_dispatch_args
 
-    agent_id, role, dry_run, no_clear, delivery_mode, notify_on_stop, dynamic_params = \
+    agent_id, role, dry_run, no_clear, delivery_mode, notify_on_stop, node, dynamic_params = \
         parse_dispatch_args(sys.argv[2:])
 
     # em_id check: required for send mode, placeholder for dry-run
@@ -193,7 +193,7 @@ def _handle_dispatch(session_id: Optional[str]) -> int:
     return commands.cmd_dispatch(
         client, agent_id, role, dynamic_params, em_id,
         dry_run=dry_run, no_clear=no_clear,
-        delivery_mode=delivery_mode, notify_on_stop=notify_on_stop,
+        delivery_mode=delivery_mode, notify_on_stop=notify_on_stop, node=node,
     )
 
 
@@ -236,6 +236,13 @@ def main():
 
     # sm who
     subparsers.add_parser("who", help="List other active sessions in this workspace")
+
+    # sm nodes / sm node ping <node-id>
+    subparsers.add_parser("nodes", help="List configured execution nodes")
+    node_parser = subparsers.add_parser("node", help="Inspect one execution node")
+    node_subparsers = node_parser.add_subparsers(dest="node_command")
+    node_ping_parser = node_subparsers.add_parser("ping", help="Check node reachability")
+    node_ping_parser.add_argument("node_id", help="Execution node ID")
 
     # sm what <session-id>
     what_parser = subparsers.add_parser("what", help="Get summary of what a session is doing")
@@ -477,6 +484,7 @@ def main():
         ),
     )
     spawn_parser.add_argument("--working-dir", help="Override working directory (defaults to parent's directory)")
+    spawn_parser.add_argument("--node", help="Execution node for the child session")
     spawn_parser.add_argument("--json", action="store_true", help="Output JSON")
     spawn_parser.add_argument(
         "--track",
@@ -545,6 +553,7 @@ def main():
         nargs="?",
         help="Working directory (defaults to current directory)"
     )
+    parser_claude.add_argument("--node", help="Execution node for the session")
 
     # sm codex [working_dir]
     parser_codex = subparsers.add_parser(
@@ -556,6 +565,7 @@ def main():
         nargs="?",
         help="Working directory (defaults to current directory)"
     )
+    parser_codex.add_argument("--node", help="Execution node (remote Codex is rejected in Phase 1)")
 
     # sm codex-legacy [working_dir]
     parser_codex_legacy = subparsers.add_parser(
@@ -567,6 +577,7 @@ def main():
         nargs="?",
         help="Working directory (defaults to current directory)"
     )
+    parser_codex_legacy.add_argument("--node", help="Execution node (remote Codex is rejected in Phase 1)")
 
     # sm codex-fork [working_dir]
     parser_codex_fork = subparsers.add_parser(
@@ -579,6 +590,7 @@ def main():
         nargs="?",
         help="Working directory (defaults to current directory)"
     )
+    parser_codex_fork.add_argument("--node", help="Execution node (remote Codex is rejected in Phase 1)")
 
     # sm codex-2 [working_dir]
     parser_codex_2 = subparsers.add_parser(
@@ -590,6 +602,7 @@ def main():
         nargs="?",
         help="Working directory (defaults to current directory)"
     )
+    parser_codex_2.add_argument("--node", help="Execution node (remote Codex is rejected in Phase 1)")
 
     # sm codex-app [working_dir]
     parser_codex_app = subparsers.add_parser(
@@ -601,6 +614,7 @@ def main():
         nargs="?",
         help="Working directory (defaults to current directory)"
     )
+    parser_codex_app.add_argument("--node", help="Execution node (remote Codex is rejected in Phase 1)")
 
     # sm codex-server [working_dir] (removed entrypoint)
     parser_codex_server = subparsers.add_parser(
@@ -623,6 +637,7 @@ def main():
         nargs="?",
         help="Working directory (defaults to current directory)"
     )
+    parser_new.add_argument("--node", help="Execution node for the session")
 
     # sm attach [session]
     parser_attach = subparsers.add_parser(
@@ -913,7 +928,7 @@ def main():
     no_session_needed = [
         "lock", "unlock", "subagent-start", "subagent-stop", "all", "send", "wait", "what",
         "subagents", "children", "kill", "retire", "restore", "unkill", "fork", "new", "claude", "codex", "codex-legacy", "codex-fork", "codex_fork",
-        "codex-2", "codex-app", "codex-server",
+        "codex-2", "codex-app", "codex-server", "nodes", "node",
         "attach", "output", "codex-tui", "codex-fork-info", "codex-rollout-gates", "watch", "tail", "clear", "review", "context-monitor", "remind", "setup", "lookup", "roster", "email", "request-codex-review", None
     ]
     # Commands that require session_id: self-directed managed-session actions
@@ -939,6 +954,13 @@ def main():
         sys.exit(commands.cmd_me(client, session_id))
     elif args.command == "who":
         sys.exit(commands.cmd_who(client, session_id))
+    elif args.command == "nodes":
+        sys.exit(commands.cmd_nodes(client))
+    elif args.command == "node":
+        if args.node_command == "ping":
+            sys.exit(commands.cmd_node_ping(client, args.node_id))
+        print("Error: node subcommand required (ping)", file=sys.stderr)
+        sys.exit(2)
     elif args.command == "what":
         sys.exit(commands.cmd_what(client, args.session_id, args.lines, args.deep))
     elif args.command == "others":
@@ -1194,6 +1216,7 @@ def main():
             args.working_dir,
             args.json,
             getattr(args, "track", None),
+            node=args.node,
         ))
     elif args.command == "children":
         if args.session_id:
@@ -1238,21 +1261,21 @@ def main():
     elif args.command == "clean":
         sys.exit(commands.cmd_clean(client, session_ids=getattr(args, 'session_ids', None)))
     elif args.command == "claude":
-        sys.exit(commands.cmd_new(client, args.working_dir, provider="claude", parent_session_id=session_id))
+        sys.exit(commands.cmd_new(client, args.working_dir, provider="claude", parent_session_id=session_id, node=args.node))
     elif args.command == "codex":
-        sys.exit(commands.cmd_new(client, args.working_dir, provider="codex-fork", parent_session_id=session_id))
+        sys.exit(commands.cmd_new(client, args.working_dir, provider="codex-fork", parent_session_id=session_id, node=args.node))
     elif args.command == "codex-legacy":
-        sys.exit(commands.cmd_new(client, args.working_dir, provider="codex", parent_session_id=session_id))
+        sys.exit(commands.cmd_new(client, args.working_dir, provider="codex", parent_session_id=session_id, node=args.node))
     elif args.command in ("codex-fork", "codex_fork"):
-        sys.exit(commands.cmd_new(client, args.working_dir, provider="codex-fork", parent_session_id=session_id))
+        sys.exit(commands.cmd_new(client, args.working_dir, provider="codex-fork", parent_session_id=session_id, node=args.node))
     elif args.command == "codex-2":
-        sys.exit(commands.cmd_codex_2(client, args.working_dir, parent_session_id=session_id))
+        sys.exit(commands.cmd_codex_2(client, args.working_dir, parent_session_id=session_id, node=args.node))
     elif args.command == "codex-app":
-        sys.exit(commands.cmd_new(client, args.working_dir, provider="codex-app", parent_session_id=session_id))
+        sys.exit(commands.cmd_new(client, args.working_dir, provider="codex-app", parent_session_id=session_id, node=args.node))
     elif args.command == "codex-server":
         sys.exit(commands.cmd_removed_entrypoint("codex-server"))
     elif args.command == "new":
-        sys.exit(commands.cmd_new(client, args.working_dir, provider="claude", parent_session_id=session_id))
+        sys.exit(commands.cmd_new(client, args.working_dir, provider="claude", parent_session_id=session_id, node=args.node))
     elif args.command == "attach":
         sys.exit(commands.cmd_attach(client, args.session))
     elif args.command == "output":

--- a/src/cli/watch_tui.py
+++ b/src/cli/watch_tui.py
@@ -27,6 +27,7 @@ _COLUMN_SPECS = [
     ("ID", 8, 0, "left"),
     ("Parent", 18, 2, "left"),
     ("Role", 8, 1, "left"),
+    ("Node", 8, 1, "left"),
     ("Provider", 10, 1, "left"),
     ("Activity", 11, 1, "left"),
     ("Status", 8, 1, "left"),
@@ -40,6 +41,7 @@ _COLUMN_FLOORS = {
     "ID": 4,
     "Parent": 8,
     "Role": 4,
+    "Node": 4,
     "Provider": 6,
     "Activity": 7,
     "Status": 5,
@@ -50,6 +52,7 @@ _DYNAMIC_COLUMN_CAPS = {
     "ID": 8,
     "Parent": 36,
     "Role": 16,
+    "Node": 12,
     "Provider": 10,
     "Activity": 18,
     "Status": 10,
@@ -62,6 +65,7 @@ _RESTORE_COLUMN_SPECS = [
     ("ID", 8, 0, "left"),
     ("Parent", 18, 2, "left"),
     ("Role", 8, 1, "left"),
+    ("Node", 8, 1, "left"),
     ("Provider", 10, 1, "left"),
     ("Repo", 12, 2, "left"),
     ("Last Active", 11, 1, "left"),
@@ -73,6 +77,7 @@ _RESTORE_COLUMN_FLOORS = {
     "ID": 4,
     "Parent": 8,
     "Role": 4,
+    "Node": 4,
     "Provider": 6,
     "Repo": 6,
     "Last Active": 5,
@@ -83,6 +88,7 @@ _RESTORE_DYNAMIC_COLUMN_CAPS = {
     "ID": 8,
     "Parent": 36,
     "Role": 16,
+    "Node": 12,
     "Provider": 10,
     "Repo": 28,
     "Last Active": 12,
@@ -684,6 +690,7 @@ def build_watch_rows(
             "ID": session.get("id", ""),
             "Parent": _parent_label(session, sessions_by_id),
             "Role": role,
+            "Node": session.get("node") or "primary",
             "Provider": provider,
             "Activity": _state_label(activity_state, spinner_index),
             "Status": status,
@@ -877,6 +884,7 @@ def build_restore_rows(
             "ID": session_id or "",
             "Parent": _parent_label(session, sessions_by_id),
             "Role": session.get("role") or "-",
+            "Node": session.get("node") or "primary",
             "Provider": session.get("provider", "claude"),
             "Repo": repo_label,
             "Last Active": _age_from_iso(session.get("last_activity")),
@@ -1163,6 +1171,8 @@ def _create_watch_session(
         return session, None, "Created session has no tmux target"
     if descriptor and descriptor.get("tmux_socket_name"):
         session["tmux_socket_name"] = descriptor.get("tmux_socket_name")
+    if descriptor and isinstance(descriptor.get("attach_command"), list):
+        session["_attach_command"] = [str(part) for part in descriptor["attach_command"]]
 
     return session, tmux_session, None
 
@@ -1213,6 +1223,8 @@ def _resolve_tmux_attach_target(
         session["tmux_session"] = tmux_session
         if tmux_socket_name:
             session["tmux_socket_name"] = tmux_socket_name
+        if isinstance(descriptor.get("attach_command"), list):
+            session["_attach_command"] = [str(part) for part in descriptor["attach_command"]]
 
     return tmux_session, tmux_socket_name, None
 
@@ -1225,11 +1237,17 @@ def _tmux_attach_command(tmux_session: str, tmux_socket_name: str | None = None)
     return cmd
 
 
-def _attach_tmux(stdscr, tmux_session: str, tmux_socket_name: str | None = None):
+def _attach_tmux(
+    stdscr,
+    tmux_session: str,
+    tmux_socket_name: str | None = None,
+    attach_command: Optional[list[str]] = None,
+):
     curses.def_prog_mode()
     curses.endwin()
     try:
-        subprocess.run(_tmux_attach_command(tmux_session, tmux_socket_name), check=False)
+        command = attach_command if attach_command else _tmux_attach_command(tmux_session, tmux_socket_name)
+        subprocess.run(command, check=False)
     finally:
         curses.reset_prog_mode()
         curses.curs_set(0)
@@ -1719,7 +1737,7 @@ def run_watch_tui(
 
                     selected_session_id = session.get("id") or selected_session_id
                     next_refresh = 0.0
-                    _attach_tmux(stdscr, tmux_session, session.get("tmux_socket_name"))
+                    _attach_tmux(stdscr, tmux_session, session.get("tmux_socket_name"), session.get("_attach_command"))
                     flash_message = f"Created {selected_session_id}"
                     flash_until = time.monotonic() + 2.5
                     next_refresh = 0.0
@@ -1834,7 +1852,7 @@ def run_watch_tui(
                             else:
                                 tmux_session, tmux_socket_name, attach_error = None, None, None
                             if can_attach_session(restored) and tmux_session:
-                                _attach_tmux(stdscr, tmux_session, tmux_socket_name)
+                                _attach_tmux(stdscr, tmux_session, tmux_socket_name, restored.get("_attach_command"))
                                 flash_message = f"Restored {selected_session_id}"
                             else:
                                 flash_message = attach_error or f"Restored {selected_session_id} (headless)"
@@ -1852,7 +1870,7 @@ def run_watch_tui(
                         flash_message = attach_error
                         flash_until = time.monotonic() + 2.5
                         continue
-                    _attach_tmux(stdscr, tmux_session, tmux_socket_name)
+                    _attach_tmux(stdscr, tmux_session, tmux_socket_name, selected.get("_attach_command"))
                     next_refresh = 0.0
         finally:
             if detail_worker:

--- a/src/models.py
+++ b/src/models.py
@@ -57,6 +57,7 @@ class ActivityState(Enum):
     IDLE = "idle"
     WAITING_PERMISSION = "waiting_permission"
     WAITING_INPUT = "waiting_input"
+    NODE_UNREACHABLE = "node-unreachable"
     STOPPED = "stopped"
 
 
@@ -295,6 +296,7 @@ class Session:
     working_dir: str = ""
     tmux_session: str = ""
     tmux_socket_name: Optional[str] = None  # tmux -L socket for managed sessions; None means default server
+    node: str = "primary"  # Execution node; "primary" is the host running SM
     provider: str = "claude"  # "claude", "codex"/"codex-fork" (tmux), or "codex-app" (app-server)
     log_file: str = ""
     status: SessionStatus = SessionStatus.RUNNING
@@ -392,6 +394,7 @@ class Session:
             "working_dir": self.working_dir,
             "tmux_session": self.tmux_session,
             "tmux_socket_name": self.tmux_socket_name,
+            "node": self.node,
             "provider": self.provider,
             "log_file": self.log_file,
             "status": self.status.value,
@@ -490,6 +493,7 @@ class Session:
             working_dir=data["working_dir"],
             tmux_session=data["tmux_session"],
             tmux_socket_name=data.get("tmux_socket_name"),
+            node=data.get("node", "primary") or "primary",
             provider=data.get("provider", "claude"),
             log_file=data["log_file"],
             status=SessionStatus(mapped_status),

--- a/src/node_runner.py
+++ b/src/node_runner.py
@@ -209,8 +209,32 @@ class NodeRunner:
         return result.returncode == 0
 
     def path_is_dir(self, node_id: Optional[str], path: str, timeout: float = 5.0) -> bool:
-        result = self.run(node_id, ["test", "-d", path], check=False, timeout=timeout)
-        return result.returncode == 0
+        return self.resolve_directory(node_id, path, timeout=timeout) is not None
+
+    def resolve_directory(self, node_id: Optional[str], path: str, timeout: float = 5.0) -> Optional[str]:
+        """Return the node-local physical directory path, or None if it is not a directory."""
+        if self.is_primary(node_id):
+            candidate = Path(path).expanduser().resolve()
+            return str(candidate) if candidate.is_dir() else None
+
+        script = """
+path=$1
+case "$path" in
+  "~") path=${HOME:-~} ;;
+  "~/"*) path="${HOME%/}/${path#\\~/}" ;;
+esac
+CDPATH= cd -- "$path" 2>/dev/null && pwd -P
+"""
+        result = self.run(
+            node_id,
+            ["/bin/sh", "-lc", script, "sh", path],
+            check=False,
+            timeout=timeout,
+        )
+        if result.returncode != 0:
+            return None
+        resolved = [line.strip() for line in (result.stdout or "").splitlines() if line.strip()]
+        return resolved[0] if resolved else None
 
     def ensure_file(self, node_id: Optional[str], path: str, timeout: float = 5.0) -> bool:
         parent = str(Path(path).parent)

--- a/src/node_runner.py
+++ b/src/node_runner.py
@@ -1,0 +1,284 @@
+"""Node registry and command routing for local/remote session execution."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shlex
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+PRIMARY_NODE = "primary"
+
+
+@dataclass(frozen=True)
+class NodeConfig:
+    """Configuration for one Session Manager execution node."""
+
+    id: str
+    ssh: Optional[str] = None
+    ssh_proxy_command: Optional[str] = None
+    control_path: Optional[str] = None
+    api_url: Optional[str] = None
+    hook_base_url: Optional[str] = None
+    hook_secret: Optional[str] = None
+    projects_root: Optional[str] = None
+
+    @property
+    def is_primary(self) -> bool:
+        return self.id == PRIMARY_NODE
+
+
+class NodeRegistry:
+    """Validated node registry loaded from config.yaml."""
+
+    def __init__(self, nodes: dict[str, NodeConfig], default_node: str = PRIMARY_NODE):
+        self._nodes = dict(nodes)
+        self._nodes.setdefault(PRIMARY_NODE, NodeConfig(id=PRIMARY_NODE))
+        self.default_node = default_node if default_node in self._nodes else PRIMARY_NODE
+
+    @classmethod
+    def from_config(cls, config: Optional[dict]) -> "NodeRegistry":
+        raw_nodes = (config or {}).get("nodes") or {}
+        if not isinstance(raw_nodes, dict):
+            raw_nodes = {}
+
+        raw_registry = raw_nodes.get("registry") or {}
+        if not isinstance(raw_registry, dict):
+            raw_registry = {}
+
+        nodes: dict[str, NodeConfig] = {PRIMARY_NODE: NodeConfig(id=PRIMARY_NODE)}
+        for raw_id, raw_value in raw_registry.items():
+            node_id = str(raw_id or "").strip()
+            if not node_id:
+                continue
+            value = raw_value if isinstance(raw_value, dict) else {}
+            nodes[node_id] = NodeConfig(
+                id=node_id,
+                ssh=_clean_optional(value.get("ssh")),
+                ssh_proxy_command=_clean_optional(value.get("ssh_proxy_command")),
+                control_path=_expand_user_optional(value.get("control_path")),
+                api_url=_clean_optional(value.get("api_url")),
+                hook_base_url=_clean_optional(value.get("hook_base_url")),
+                hook_secret=_clean_optional(value.get("hook_secret")),
+                projects_root=_clean_optional(value.get("projects_root")),
+            )
+
+        default_node = _clean_optional(raw_nodes.get("default")) or PRIMARY_NODE
+        return cls(nodes=nodes, default_node=default_node)
+
+    def get(self, node_id: Optional[str]) -> Optional[NodeConfig]:
+        normalized = normalize_node_id(node_id)
+        return self._nodes.get(normalized)
+
+    def require(self, node_id: Optional[str]) -> NodeConfig:
+        normalized = normalize_node_id(node_id)
+        node = self._nodes.get(normalized)
+        if node is None:
+            raise ValueError(f"Unknown node: {normalized}")
+        return node
+
+    def has(self, node_id: Optional[str]) -> bool:
+        return normalize_node_id(node_id) in self._nodes
+
+    def ids(self) -> list[str]:
+        return sorted(self._nodes)
+
+    def as_list(self) -> list[dict[str, object]]:
+        return [
+            {
+                "id": node.id,
+                "primary": node.is_primary,
+                "ssh": node.ssh,
+                "api_url": node.api_url,
+                "hook_base_url": node.hook_base_url,
+                "projects_root": node.projects_root,
+            }
+            for node in sorted(self._nodes.values(), key=lambda item: item.id)
+        ]
+
+
+class NodeRunner:
+    """Run commands on the primary host or on a registered SSH node."""
+
+    def __init__(self, registry: NodeRegistry):
+        self.registry = registry
+
+    def is_primary(self, node_id: Optional[str]) -> bool:
+        return normalize_node_id(node_id) == PRIMARY_NODE
+
+    def command(
+        self,
+        node_id: Optional[str],
+        argv: Iterable[object],
+        *,
+        cwd: Optional[str] = None,
+        tty: bool = False,
+    ) -> list[str]:
+        """Return a local argv or ssh-routed argv for one node."""
+        node = self.registry.require(node_id)
+        local_argv = [str(part) for part in argv]
+        if node.is_primary:
+            return local_argv
+
+        if not node.ssh:
+            raise ValueError(f"Remote node {node.id} is missing ssh target")
+
+        remote = shlex.join(local_argv)
+        if cwd:
+            remote = f"cd {shlex.quote(str(cwd))} && {remote}"
+
+        cmd = ["ssh"]
+        if tty:
+            cmd.append("-tt")
+        cmd.extend(self._ssh_options(node))
+        cmd.append(node.ssh)
+        # OpenSSH concatenates post-destination args into a remote command string.
+        # Quote the shell payload so the remote shell passes it as one sh -lc arg.
+        cmd.extend(["/bin/sh", "-lc", shlex.quote(remote)])
+        return cmd
+
+    def attach_command(self, node_id: Optional[str], argv: Iterable[object]) -> list[str]:
+        """Return an argv suitable for Popen under a local PTY."""
+        return self.command(node_id, argv, tty=not self.is_primary(node_id))
+
+    def run(
+        self,
+        node_id: Optional[str],
+        argv: Iterable[object],
+        *,
+        cwd: Optional[str] = None,
+        check: bool = True,
+        timeout: Optional[float] = None,
+        capture_output: bool = True,
+        text: bool = True,
+    ) -> subprocess.CompletedProcess:
+        cmd = self.command(node_id, argv, cwd=cwd)
+        run_kwargs: dict[str, object] = {
+            "check": check,
+            "timeout": timeout,
+            "capture_output": capture_output,
+            "text": text,
+        }
+        if self.is_primary(node_id) and cwd:
+            run_kwargs["cwd"] = cwd
+        return subprocess.run(cmd, **run_kwargs)
+
+    async def run_async(
+        self,
+        node_id: Optional[str],
+        argv: Iterable[object],
+        *,
+        cwd: Optional[str] = None,
+        check: bool = False,
+        timeout: Optional[float] = None,
+    ) -> subprocess.CompletedProcess:
+        cmd = self.command(node_id, argv, cwd=cwd)
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            cwd=cwd if self.is_primary(node_id) and cwd else None,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            raise
+        result = subprocess.CompletedProcess(
+            cmd,
+            proc.returncode,
+            stdout.decode(errors="replace"),
+            stderr.decode(errors="replace"),
+        )
+        if check and result.returncode != 0:
+            raise subprocess.CalledProcessError(
+                result.returncode,
+                cmd,
+                output=result.stdout,
+                stderr=result.stderr,
+            )
+        return result
+
+    def ping(self, node_id: Optional[str], timeout: float = 5.0) -> bool:
+        result = self.run(node_id, ["true"], check=False, timeout=timeout)
+        return result.returncode == 0
+
+    def path_is_dir(self, node_id: Optional[str], path: str, timeout: float = 5.0) -> bool:
+        result = self.run(node_id, ["test", "-d", path], check=False, timeout=timeout)
+        return result.returncode == 0
+
+    def ensure_file(self, node_id: Optional[str], path: str, timeout: float = 5.0) -> bool:
+        parent = str(Path(path).parent)
+        result = self.run(
+            node_id,
+            ["/bin/sh", "-lc", f"mkdir -p {shlex.quote(parent)} && : > {shlex.quote(path)}"],
+            check=False,
+            timeout=timeout,
+        )
+        return result.returncode == 0
+
+    def command_available(
+        self,
+        node_id: Optional[str],
+        command: str,
+        *,
+        cwd: Optional[str] = None,
+        timeout: float = 5.0,
+    ) -> bool:
+        if "/" in command or command.startswith("~"):
+            payload = f"test -f {shlex.quote(command)} && test -x {shlex.quote(command)}"
+        else:
+            payload = f"command -v {shlex.quote(command)} >/dev/null 2>&1"
+        result = self.run(
+            node_id,
+            ["/bin/sh", "-lc", payload],
+            cwd=cwd,
+            check=False,
+            timeout=timeout,
+        )
+        return result.returncode == 0
+
+    def read_text(self, node_id: Optional[str], path: str, timeout: float = 5.0) -> Optional[str]:
+        result = self.run(node_id, ["cat", path], check=False, timeout=timeout)
+        if result.returncode != 0:
+            return None
+        return result.stdout
+
+    def _ssh_options(self, node: NodeConfig) -> list[str]:
+        opts = [
+            "-o",
+            "ControlMaster=auto",
+            "-o",
+            "ControlPersist=600",
+            "-o",
+            "ConnectTimeout=5",
+        ]
+        if node.control_path:
+            opts.extend(["-S", node.control_path])
+        if node.ssh_proxy_command:
+            opts.extend(["-o", f"ProxyCommand={node.ssh_proxy_command}"])
+        return opts
+
+
+def normalize_node_id(value: Optional[str]) -> str:
+    normalized = str(value or "").strip()
+    return normalized or PRIMARY_NODE
+
+
+def _clean_optional(value: object) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _expand_user_optional(value: object) -> Optional[str]:
+    text = _clean_optional(value)
+    if not text:
+        return None
+    return os.path.expanduser(text)

--- a/src/node_runner.py
+++ b/src/node_runner.py
@@ -237,10 +237,24 @@ CDPATH= cd -- "$path" 2>/dev/null && pwd -P
         return resolved[0] if resolved else None
 
     def ensure_file(self, node_id: Optional[str], path: str, timeout: float = 5.0) -> bool:
-        parent = str(Path(path).parent)
+        if self.is_primary(node_id):
+            local_path = Path(path).expanduser()
+            local_path.parent.mkdir(parents=True, exist_ok=True)
+            local_path.touch()
+            return True
+
+        script = """
+path=$1
+case "$path" in
+  "~") path=${HOME:-~} ;;
+  "~/"*) path="${HOME%/}/${path#\\~/}" ;;
+esac
+parent=$(dirname "$path")
+mkdir -p "$parent" && : >> "$path"
+"""
         result = self.run(
             node_id,
-            ["/bin/sh", "-lc", f"mkdir -p {shlex.quote(parent)} && : > {shlex.quote(path)}"],
+            ["/bin/sh", "-lc", script, "sh", path],
             check=False,
             timeout=timeout,
         )
@@ -255,12 +269,21 @@ CDPATH= cd -- "$path" 2>/dev/null && pwd -P
         timeout: float = 5.0,
     ) -> bool:
         if "/" in command or command.startswith("~"):
-            payload = f"test -f {shlex.quote(command)} && test -x {shlex.quote(command)}"
+            payload = """
+path=$1
+case "$path" in
+  "~") path=${HOME:-~} ;;
+  "~/"*) path="${HOME%/}/${path#\\~/}" ;;
+esac
+test -f "$path" && test -x "$path"
+"""
+            argv = ["/bin/sh", "-lc", payload, "sh", command]
         else:
             payload = f"command -v {shlex.quote(command)} >/dev/null 2>&1"
+            argv = ["/bin/sh", "-lc", payload]
         result = self.run(
             node_id,
-            ["/bin/sh", "-lc", payload],
+            argv,
             cwd=cwd,
             check=False,
             timeout=timeout,

--- a/src/output_monitor.py
+++ b/src/output_monitor.py
@@ -4,6 +4,7 @@ import asyncio
 import inspect
 import re
 import logging
+import shlex
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Callable, Awaitable, Optional
@@ -192,9 +193,23 @@ class OutputMonitor:
             self._last_response_sent[session.id] = datetime.now()
 
         # Get initial file position (end of file)
-        log_path = Path(session.log_file)
-        if log_path.exists():
-            self._file_positions[session.id] = log_path.stat().st_size
+        try:
+            initial_size = await asyncio.to_thread(self._current_log_size_for_session, session)
+            self._mark_node_unreachable(session, False)
+        except Exception as exc:
+            initial_size = None
+            if self._is_remote_session(session):
+                logger.warning(
+                    "Node %s unreachable while initializing log monitor for %s: %s",
+                    self._session_node(session),
+                    session.id,
+                    exc,
+                )
+                self._mark_node_unreachable(session, True)
+            else:
+                raise
+        if initial_size is not None:
+            self._file_positions[session.id] = initial_size
 
         task = asyncio.create_task(self._monitor_loop(session))
         self._tasks[session.id] = task
@@ -246,7 +261,6 @@ class OutputMonitor:
 
     async def _monitor_loop(self, session: Session):
         """Main monitoring loop for a session."""
-        log_path = Path(session.log_file)
         check_counter = 0
 
         while True:
@@ -259,10 +273,23 @@ class OutputMonitor:
                     session_exists = True
                     exit_diagnostics = None
                     if self._session_manager:
-                        session_exists = await asyncio.to_thread(
-                            self._session_manager.tmux.session_exists,
-                            session.tmux_session,
-                        )
+                        try:
+                            session_exists = await asyncio.to_thread(
+                                self._session_manager.tmux.session_exists,
+                                session.tmux_session,
+                            )
+                            self._mark_node_unreachable(session, False)
+                        except Exception as exc:
+                            if self._is_remote_session(session):
+                                logger.warning(
+                                    "Node %s unreachable while checking tmux session %s: %s",
+                                    self._session_node(session),
+                                    session.tmux_session,
+                                    exc,
+                                )
+                                self._mark_node_unreachable(session, True)
+                                continue
+                            raise
                         tmux_controller = self._session_manager.tmux
                         get_exit_diagnostics = getattr(
                             tmux_controller,
@@ -275,10 +302,23 @@ class OutputMonitor:
                             is not None
                         )
                         if has_real_diagnostics:
-                            exit_diagnostics = await asyncio.to_thread(
-                                get_exit_diagnostics,
-                                session.tmux_session,
-                            )
+                            try:
+                                exit_diagnostics = await asyncio.to_thread(
+                                    get_exit_diagnostics,
+                                    session.tmux_session,
+                                )
+                                self._mark_node_unreachable(session, False)
+                            except Exception as exc:
+                                if self._is_remote_session(session):
+                                    logger.warning(
+                                        "Node %s unreachable while collecting exit diagnostics for %s: %s",
+                                        self._session_node(session),
+                                        session.tmux_session,
+                                        exc,
+                                    )
+                                    self._mark_node_unreachable(session, True)
+                                    continue
+                                raise
                             if exit_diagnostics.get("pane_dead"):
                                 logger.info(
                                     "Tmux session %s has a dead pane, cleaning up",
@@ -292,11 +332,25 @@ class OutputMonitor:
                         break
 
                 last_pos = self._file_positions.get(session.id, 0)
-                current_size, new_content = await asyncio.to_thread(
-                    self._read_new_log_content,
-                    log_path,
-                    last_pos,
-                )
+                try:
+                    current_size, new_content = await asyncio.to_thread(
+                        self._read_new_log_content_for_session,
+                        session,
+                        last_pos,
+                    )
+                    self._mark_node_unreachable(session, False)
+                except Exception as exc:
+                    if self._is_remote_session(session):
+                        logger.warning(
+                            "Node %s unreachable while reading log for %s: %s",
+                            self._session_node(session),
+                            session.id,
+                            exc,
+                        )
+                        self._mark_node_unreachable(session, True)
+                        await asyncio.sleep(5)
+                        continue
+                    raise
                 if current_size is None:
                     continue
 
@@ -358,6 +412,81 @@ class OutputMonitor:
         with open(log_path, 'r', errors='ignore') as f:
             f.seek(last_pos)
             return current_size, f.read()
+
+    def _session_node(self, session: Session) -> str:
+        return str(getattr(session, "node", None) or "primary").strip() or "primary"
+
+    def _is_remote_session(self, session: Session) -> bool:
+        return self._session_node(session) != "primary"
+
+    def _mark_node_unreachable(self, session: Session, unreachable: bool) -> None:
+        marker = getattr(self._session_manager, "mark_node_unreachable", None) if self._session_manager else None
+        if callable(marker):
+            marker(session.id, unreachable)
+
+    def _current_log_size_for_session(self, session: Session) -> Optional[int]:
+        if not self._is_remote_session(session):
+            log_path = Path(session.log_file)
+            return log_path.stat().st_size if log_path.exists() else None
+
+        runner = getattr(self._session_manager, "node_runner", None) if self._session_manager else None
+        if runner is None:
+            return None
+        result = runner.run(
+            self._session_node(session),
+            [
+                "/bin/sh",
+                "-lc",
+                f"if [ -f {shlex.quote(session.log_file)} ]; then wc -c < {shlex.quote(session.log_file)}; else exit 3; fi",
+            ],
+            check=False,
+            timeout=5,
+        )
+        if result.returncode == 3:
+            return None
+        if result.returncode != 0:
+            raise RuntimeError(result.stderr or f"failed to stat {session.log_file}")
+        text = (result.stdout or "").strip()
+        return int(text) if text.isdigit() else None
+
+    def _read_new_log_content_for_session(self, session: Session, last_pos: int) -> tuple[Optional[int], str]:
+        if not self._is_remote_session(session):
+            return self._read_new_log_content(Path(session.log_file), last_pos)
+
+        runner = getattr(self._session_manager, "node_runner", None) if self._session_manager else None
+        if runner is None:
+            return None, ""
+
+        marker = "__SM_LOG_CONTENT__"
+        log_file = shlex.quote(session.log_file)
+        safe_last_pos = max(0, int(last_pos or 0))
+        script = (
+            f"file={log_file}; "
+            "if [ ! -f \"$file\" ]; then exit 3; fi; "
+            "size=$(wc -c < \"$file\" | tr -d '[:space:]'); "
+            f"printf '%s\\n{marker}\\n' \"$size\"; "
+            f"if [ \"$size\" -gt {safe_last_pos} ]; then "
+            f"tail -c +$(({safe_last_pos} + 1)) \"$file\"; "
+            "fi"
+        )
+        result = runner.run(
+            self._session_node(session),
+            ["/bin/sh", "-lc", script],
+            check=False,
+            timeout=5,
+        )
+        if result.returncode == 3:
+            return None, ""
+        if result.returncode != 0:
+            raise RuntimeError(result.stderr or f"failed to read {session.log_file}")
+        stdout = result.stdout or ""
+        if f"\n{marker}\n" not in stdout:
+            return None, ""
+        size_text, content = stdout.split(f"\n{marker}\n", 1)
+        size_text = size_text.strip()
+        if not size_text.isdigit():
+            return None, ""
+        return int(size_text), content
 
     async def _analyze_content(self, session: Session, content: str):
         """Analyze new content for patterns."""

--- a/src/server.py
+++ b/src/server.py
@@ -538,6 +538,7 @@ class CreateSessionRequest(BaseModel):
     name: Optional[str] = None
     provider: Optional[str] = "claude"
     parent_session_id: Optional[str] = None
+    node: Optional[str] = None
 
 
 class ForkSessionRequest(BaseModel):
@@ -571,6 +572,7 @@ class SessionResponse(BaseModel):
     stopped_at: Optional[str] = None
     tmux_session: str
     tmux_socket_name: Optional[str] = None
+    node: str = "primary"
     provider: Optional[str] = "claude"
     provider_resume_id: Optional[str] = None
     forked_from_session_id: Optional[str] = None
@@ -664,6 +666,7 @@ class MobileTerminalTicket:
     actor_email: str
     session_id: str
     provider: str
+    node: str
     tmux_session: str
     tmux_socket_name: Optional[str]
     device_key_id: str
@@ -962,6 +965,7 @@ class EnsureMaintainerRequest(BaseModel):
 class EnsureRoleRequest(BaseModel):
     """Request to ensure a generic service role session exists."""
     requester_session_id: Optional[str] = None
+    node: Optional[str] = None
 
 
 class RoleRegistrationRequest(BaseModel):
@@ -1069,6 +1073,7 @@ class SpawnChildRequest(BaseModel):
     model: Optional[str] = None
     working_dir: Optional[str] = None
     provider: Optional[str] = None
+    node: Optional[str] = None
     track_seconds: Optional[int] = Field(default=None, gt=0)
 
 
@@ -1449,6 +1454,81 @@ def create_app(
         if isinstance(state, str):
             return state
         return _fallback_activity_state(session)
+
+    def _node_id_for_session(session: Session) -> str:
+        return str(getattr(session, "node", None) or "primary").strip() or "primary"
+
+    def _hook_secret_for_session(session: Session) -> Optional[str]:
+        node_id = _node_id_for_session(session)
+        if node_id == "primary":
+            return None
+        sm = app.state.session_manager
+        if not sm:
+            return None
+        getter = getattr(sm, "get_node_config", None)
+        if not callable(getter):
+            return None
+        node_config = getter(node_id)
+        if isinstance(node_config, dict):
+            raw_secret = node_config.get("hook_secret")
+        else:
+            raw_secret = getattr(node_config, "hook_secret", None)
+        if not isinstance(raw_secret, str):
+            return None
+        secret = raw_secret.strip()
+        return secret or None
+
+    def _verify_remote_hook_secret(payload: dict[str, Any], request: Request) -> Optional[Session]:
+        """Reject spoofed hooks for remote sessions that have a configured hook secret."""
+        session_manager_id = payload.get("session_manager_id") or payload.get("CLAUDE_SESSION_MANAGER_ID")
+        if not session_manager_id:
+            return None
+        sm = app.state.session_manager
+        if not sm:
+            return None
+        session = sm.get_session(session_manager_id)
+        if not session:
+            return None
+        expected_secret = _hook_secret_for_session(session)
+        if not expected_secret:
+            return session
+        actual_secret = request.headers.get("x-sm-hook-secret") or ""
+        if not hmac.compare_digest(actual_secret, expected_secret):
+            raise HTTPException(status_code=403, detail="Invalid hook secret")
+        return session
+
+    def _payload_int(value: Any) -> Optional[int]:
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    def _validate_create_node_provider(
+        provider: str,
+        *,
+        requested_node: Optional[str] = None,
+        parent_session_id: Optional[str] = None,
+    ) -> tuple[Optional[str], Optional[str]]:
+        sm = app.state.session_manager
+        validator = getattr(sm, "validate_create_node_provider", None) if sm else None
+        if callable(validator):
+            result = validator(
+                provider,
+                requested_node=requested_node,
+                parent_session_id=parent_session_id,
+            )
+            if isinstance(result, (tuple, list)) and len(result) == 2:
+                return result[0], result[1]
+        return requested_node or "primary", None
+
+    def _last_create_error(default: str) -> str:
+        sm = app.state.session_manager
+        detail = getattr(sm, "last_create_error", None) if sm else None
+        if isinstance(detail, str) and detail:
+            return detail
+        return default
 
     def _cached_session_name(session: Session) -> str:
         sm = app.state.session_manager
@@ -2183,6 +2263,7 @@ def create_app(
             stopped_at=session.stopped_at.isoformat() if session.stopped_at else None,
             tmux_session=session.tmux_session,
             tmux_socket_name=session.tmux_socket_name,
+            node=getattr(session, "node", "primary"),
             provider=provider,
             provider_resume_id=getattr(session, "provider_resume_id", None),
             forked_from_session_id=getattr(session, "forked_from_session_id", None),
@@ -3040,6 +3121,12 @@ def create_app(
             return {
                 "supported": False,
                 "reason": descriptor.get("message") or "attach not supported",
+                "transport": "termux-ssh-tmux",
+            }
+        if str(descriptor.get("node") or "primary") != "primary":
+            return {
+                "supported": False,
+                "reason": "external SSH attach for remote nodes is not supported; use mobile terminal",
                 "transport": "termux-ssh-tmux",
             }
         if not public_ssh_host or not ssh_username:
@@ -4375,21 +4462,31 @@ def create_app(
         creation_rejection = _codex_app_create_rejection(provider)
         if creation_rejection:
             raise HTTPException(status_code=400, detail=creation_rejection)
+        resolved_node, node_provider_rejection = _validate_create_node_provider(
+            provider,
+            requested_node=request.node,
+            parent_session_id=request.parent_session_id,
+        )
+        if node_provider_rejection:
+            raise HTTPException(status_code=400, detail=node_provider_rejection)
         provider_rejection = app.state.session_manager.get_provider_create_rejection(
             provider,
             working_dir=request.working_dir,
         )
         if provider_rejection:
             raise HTTPException(status_code=503, detail=provider_rejection)
-        session = await app.state.session_manager.create_session(
-            working_dir=request.working_dir,
-            name=request.name,
-            provider=provider,
-            parent_session_id=request.parent_session_id,
-        )
+        create_kwargs = {
+            "working_dir": request.working_dir,
+            "name": request.name,
+            "provider": provider,
+            "parent_session_id": request.parent_session_id,
+        }
+        if request.node:
+            create_kwargs["node"] = resolved_node
+        session = await app.state.session_manager.create_session(**create_kwargs)
 
         if not session:
-            raise HTTPException(status_code=500, detail="Failed to create session")
+            raise HTTPException(status_code=500, detail=_last_create_error("Failed to create session"))
 
         # Start monitoring the session (tmux providers only)
         if app.state.output_monitor and getattr(session, "provider", "claude") != "codex-app":
@@ -4402,6 +4499,7 @@ def create_app(
         working_dir: str,
         provider: str = "claude",
         parent_session_id: Optional[str] = None,
+        node: Optional[str] = None,
     ):
         """
         Create a new Claude Code session.
@@ -4420,21 +4518,31 @@ def create_app(
         creation_rejection = _codex_app_create_rejection(provider)
         if creation_rejection:
             raise HTTPException(status_code=400, detail=creation_rejection)
+        resolved_node, node_provider_rejection = _validate_create_node_provider(
+            provider,
+            requested_node=node,
+            parent_session_id=parent_session_id,
+        )
+        if node_provider_rejection:
+            raise HTTPException(status_code=400, detail=node_provider_rejection)
         provider_rejection = app.state.session_manager.get_provider_create_rejection(
             provider,
             working_dir=working_dir,
         )
         if provider_rejection:
             raise HTTPException(status_code=503, detail=provider_rejection)
-        session = await app.state.session_manager.create_session(
-            working_dir=working_dir,
-            telegram_chat_id=None,  # No Telegram association
-            provider=provider,
-            parent_session_id=parent_session_id,
-        )
+        create_kwargs = {
+            "working_dir": working_dir,
+            "telegram_chat_id": None,  # No Telegram association
+            "provider": provider,
+            "parent_session_id": parent_session_id,
+        }
+        if node:
+            create_kwargs["node"] = resolved_node
+        session = await app.state.session_manager.create_session(**create_kwargs)
 
         if not session:
-            raise HTTPException(status_code=500, detail="Failed to create session")
+            raise HTTPException(status_code=500, detail=_last_create_error("Failed to create session"))
 
         # Start monitoring (tmux providers only)
         if app.state.output_monitor and getattr(session, "provider", "claude") != "codex-app":
@@ -4456,6 +4564,27 @@ def create_app(
                 for s in sessions
             ]
         }
+
+    @app.get("/nodes")
+    async def list_nodes():
+        """List configured execution nodes."""
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
+        return {
+            "default": getattr(app.state.session_manager.node_registry, "default_node", "primary"),
+            "nodes": app.state.session_manager.list_nodes(),
+        }
+
+    @app.post("/nodes/{node_id}/ping")
+    async def ping_node(node_id: str):
+        """Probe one configured execution node."""
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
+        result = app.state.session_manager.ping_node(node_id)
+        if not result.get("ok"):
+            status = 404 if str(result.get("error") or "").startswith("Unknown node") else 503
+            raise HTTPException(status_code=status, detail=result.get("error") or "ping failed")
+        return result
 
     @app.get("/client/sessions")
     async def list_client_sessions(request: Request):
@@ -4731,6 +4860,7 @@ def create_app(
                 actor_email=actor_email,
                 session_id=session.id,
                 provider=str(session.provider or "claude"),
+                node=str(getattr(session, "node", "primary") or "primary"),
                 tmux_session=tmux_session,
                 tmux_socket_name=tmux_socket_name,
                 device_key_id=str(device_config.get("id") or ""),
@@ -4832,11 +4962,16 @@ def create_app(
             )
             return ticket, attach_id
 
-    def _mobile_terminal_tmux_cmd(ticket: MobileTerminalTicket, *args: str) -> list[str]:
+    def _mobile_terminal_tmux_cmd(ticket: MobileTerminalTicket, *args: str, tty: bool = False) -> list[str]:
         cmd = ["tmux"]
         if ticket.tmux_socket_name:
             cmd.extend(["-L", ticket.tmux_socket_name])
         cmd.extend(args)
+        node_id = str(getattr(ticket, "node", "primary") or "primary")
+        if node_id != "primary" and app.state.session_manager:
+            runner = getattr(app.state.session_manager, "node_runner", None)
+            if runner is not None:
+                return runner.attach_command(node_id, cmd) if tty else runner.command(node_id, cmd)
         return cmd
 
     async def _run_mobile_terminal_bridge(websocket: WebSocket, ticket: MobileTerminalTicket, attach_id: str) -> None:
@@ -4953,6 +5088,7 @@ def create_app(
                         "attach-session",
                         "-t",
                         ticket.tmux_session,
+                        tty=True,
                     ),
                     stdin=fd_slave,
                     stdout=fd_slave,
@@ -5752,7 +5888,10 @@ def create_app(
             raise HTTPException(status_code=503, detail="Role bootstrap unavailable")
 
         try:
-            session, created = await ensurer(role)
+            if request.node:
+                session, created = await ensurer(role, node=request.node)
+            else:
+                session, created = await ensurer(role)
         except ValueError as exc:
             detail = str(exc)
             status_code = 404 if "not configured for auto-bootstrap" in detail else 400
@@ -6860,12 +6999,44 @@ Provide ONLY the summary, no preamble or questions."""
         claude_session_id = payload.get("session_id")
         # This will be set by the environment variable we pass when launching Claude
         session_manager_id = payload.get("session_manager_id") or payload.get("CLAUDE_SESSION_MANAGER_ID")
+        target_session_for_hook = None
+        if session_manager_id:
+            target_session_for_hook = _verify_remote_hook_secret(payload, request)
+
+        inline_last_message = str(payload.get("sm_last_message") or "").strip() or None
+        inline_native_title = str(payload.get("sm_native_title") or "").strip() or None
+        inline_native_title_mtime_ns = _payload_int(payload.get("sm_transcript_mtime_ns"))
+        remote_hook_session = bool(
+            target_session_for_hook
+            and _node_id_for_session(target_session_for_hook) != "primary"
+        )
+        use_inline_transcript = bool(
+            remote_hook_session
+            and (
+                inline_last_message is not None
+                or inline_native_title is not None
+                or inline_native_title_mtime_ns is not None
+            )
+        )
 
         # Read transcript metadata in a thread pool to avoid blocking the event loop.
-        last_message = None
-        native_title = None
-        native_title_mtime_ns = None
-        if transcript_path:
+        last_message = inline_last_message if use_inline_transcript else None
+        native_title = inline_native_title if use_inline_transcript else None
+        native_title_mtime_ns = inline_native_title_mtime_ns if use_inline_transcript else None
+        if transcript_path and use_inline_transcript:
+            logger.debug(
+                "Using inline remote transcript metadata for %s from node %s",
+                session_manager_id,
+                _node_id_for_session(target_session_for_hook),
+            )
+        elif transcript_path and remote_hook_session:
+            logger.info(
+                "Remote hook for %s did not include inline transcript metadata; "
+                "skipping primary-local read of node-local path %s",
+                session_manager_id,
+                transcript_path,
+            )
+        elif transcript_path:
             def read_transcript():
                 """
                 Read transcript file synchronously (runs in thread pool).
@@ -6990,7 +7161,7 @@ Provide ONLY the summary, no preamble or questions."""
                         native_title_mtime_ns = None
 
         if session_manager_id and app.state.session_manager:
-            target_session = app.state.session_manager.get_session(session_manager_id)
+            target_session = target_session_for_hook or app.state.session_manager.get_session(session_manager_id)
             if target_session:
                 state_changed = False
                 title_changed = False
@@ -7306,6 +7477,13 @@ Provide ONLY the summary, no preamble or questions."""
         if creation_rejection:
             raise HTTPException(status_code=400, detail=creation_rejection)
         selected_working_dir = request.working_dir or parent_session.working_dir
+        resolved_node, node_provider_rejection = _validate_create_node_provider(
+            selected_provider,
+            requested_node=request.node,
+            parent_session_id=request.parent_session_id,
+        )
+        if node_provider_rejection:
+            raise HTTPException(status_code=400, detail=node_provider_rejection)
         provider_rejection = app.state.session_manager.get_provider_create_rejection(
             selected_provider,
             working_dir=selected_working_dir,
@@ -7313,19 +7491,22 @@ Provide ONLY the summary, no preamble or questions."""
         if provider_rejection:
             raise HTTPException(status_code=503, detail=provider_rejection)
         _validate_requested_friendly_name(request.name)
-        child_session = await app.state.session_manager.spawn_child_session(
-            parent_session_id=request.parent_session_id,
-            prompt=request.prompt,
-            name=request.name,
-            wait=request.wait,
-            model=request.model,
-            working_dir=selected_working_dir,
-            provider=provider,
-            defer_telegram_topic=True,
-        )
+        spawn_kwargs = {
+            "parent_session_id": request.parent_session_id,
+            "prompt": request.prompt,
+            "name": request.name,
+            "wait": request.wait,
+            "model": request.model,
+            "working_dir": selected_working_dir,
+            "provider": provider,
+            "defer_telegram_topic": True,
+        }
+        if request.node:
+            spawn_kwargs["node"] = resolved_node
+        child_session = await app.state.session_manager.spawn_child_session(**spawn_kwargs)
 
         if not child_session:
-            return {"error": "Failed to spawn child session"}
+            return {"error": _last_create_error("Failed to spawn child session")}
 
         spawn_warnings = _register_spawn_monitoring(
             child_session,
@@ -7346,6 +7527,7 @@ Provide ONLY the summary, no preamble or questions."""
             "working_dir": child_session.working_dir,
             "parent_session_id": child_session.parent_session_id,
             "tmux_session": child_session.tmux_session,
+            "node": getattr(child_session, "node", "primary"),
             "provider": getattr(child_session, "provider", "claude"),
             "created_at": child_session.created_at.isoformat(),
         }
@@ -8374,6 +8556,7 @@ Provide ONLY the summary, no preamble or questions."""
 
         # Our session ID (injected by hook script)
         session_manager_id = data.get("session_manager_id")
+        session = _verify_remote_hook_secret(data, request)
 
         # Claude Code's native fields
         claude_session_id = data.get("session_id")  # Claude's internal ID
@@ -8388,8 +8571,7 @@ Provide ONLY the summary, no preamble or questions."""
         agent_id = data.get("agent_id")  # From SubagentStart context
 
         # Get session info if available
-        session = None
-        if session_manager_id and app.state.session_manager:
+        if session is None and session_manager_id and app.state.session_manager:
             session = app.state.session_manager.get_session(session_manager_id)
 
         # Clear stale is_idle on PreToolUse — signals turn has started (sm#183)

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -34,6 +34,7 @@ from .models import (
     SessionStatus,
     TelegramTopicRecord,
 )
+from .node_runner import NodeRegistry, NodeRunner, PRIMARY_NODE, normalize_node_id
 from .tmux_controller import TmuxController
 from .codex_app_server import CodexAppServerSession, CodexAppServerConfig, CodexAppServerError
 from .codex_activity_projection import CodexActivityProjection
@@ -161,8 +162,19 @@ class SessionManager:
             mq_timeouts.get("input_delivery_wait_seconds", 1.0)
         )
 
-        self.tmux = TmuxController(log_dir=log_dir, config=self.config)
         self.sessions: dict[str, Session] = {}
+        self.node_registry = NodeRegistry.from_config(self.config)
+        self.node_runner = NodeRunner(self.node_registry)
+        self._tmux_session_node_cache: dict[str, str] = {}
+        self._node_unreachable_sessions: set[str] = set()
+        self.last_create_error: Optional[str] = None
+        self.tmux = TmuxController(
+            log_dir=log_dir,
+            config=self.config,
+            node_runner=self.node_runner,
+            node_resolver=self._resolve_node_for_tmux_session,
+            runtime_env_resolver=self._runtime_env_for_session_id,
+        )
         self._event_handlers: list[Callable[[NotificationEvent], Awaitable[None]]] = []
         self.codex_sessions: dict[str, CodexAppServerSession] = {}
         self.codex_turns_in_flight: set[str] = set()
@@ -437,6 +449,97 @@ class SessionManager:
         except Exception:
             return None
         return history_limit if isinstance(history_limit, int) else None
+
+    def _cache_session_node(self, session: Session) -> None:
+        if session.tmux_session:
+            self._tmux_session_node_cache[session.tmux_session] = normalize_node_id(session.node)
+
+    def _resolve_node_for_tmux_session(self, tmux_session: str) -> str:
+        target = str(tmux_session or "").split(":", 1)[0].split(".", 1)[0]
+        if target in self._tmux_session_node_cache:
+            return self._tmux_session_node_cache[target]
+        for session in self.sessions.values():
+            if session.tmux_session == target:
+                node = normalize_node_id(getattr(session, "node", PRIMARY_NODE))
+                self._tmux_session_node_cache[target] = node
+                return node
+        return PRIMARY_NODE
+
+    def get_node_config(self, node: Optional[str]) -> Optional[Any]:
+        return self.node_registry.get(node)
+
+    def list_nodes(self) -> list[dict[str, object]]:
+        return self.node_registry.as_list()
+
+    def ping_node(self, node: str) -> dict[str, object]:
+        node_id = normalize_node_id(node)
+        if not self.node_registry.has(node_id):
+            return {"node": node_id, "ok": False, "error": f"Unknown node: {node_id}"}
+        try:
+            ok = self.node_runner.ping(node_id)
+        except Exception as exc:
+            return {"node": node_id, "ok": False, "error": str(exc)}
+        return {"node": node_id, "ok": ok, "error": None if ok else "ping failed"}
+
+    def _resolve_create_node(self, requested_node: Optional[str], parent_session_id: Optional[str]) -> tuple[Optional[str], Optional[str]]:
+        if requested_node:
+            node = normalize_node_id(requested_node)
+        elif parent_session_id and parent_session_id in self.sessions:
+            node = normalize_node_id(getattr(self.sessions[parent_session_id], "node", PRIMARY_NODE))
+        else:
+            node = PRIMARY_NODE
+
+        if not self.node_registry.has(node):
+            return None, f"Unknown node: {node}"
+        return node, None
+
+    @staticmethod
+    def _provider_node_rejection(provider: str, node: str) -> Optional[str]:
+        if normalize_node_id(node) != PRIMARY_NODE and provider != "claude":
+            return f"Remote placement is Claude-only in this phase (provider={provider})"
+        return None
+
+    def validate_create_node_provider(
+        self,
+        provider: str,
+        *,
+        requested_node: Optional[str] = None,
+        parent_session_id: Optional[str] = None,
+    ) -> tuple[Optional[str], Optional[str]]:
+        node, node_error = self._resolve_create_node(requested_node, parent_session_id)
+        if node_error:
+            return node, node_error
+        return node, self._provider_node_rejection(provider, node or PRIMARY_NODE)
+
+    def _runtime_env_for_session(self, session: Session) -> dict[str, str]:
+        node_id = normalize_node_id(getattr(session, "node", PRIMARY_NODE))
+        if node_id == PRIMARY_NODE:
+            return {}
+        node = self.node_registry.get(node_id)
+        if node is None:
+            return {}
+        env: dict[str, str] = {}
+        if node.api_url:
+            env["SM_API_URL"] = node.api_url
+        if node.hook_base_url:
+            env["SM_HOOK_BASE_URL"] = node.hook_base_url.rstrip("/")
+        if node.hook_secret:
+            env["SM_HOOK_SECRET"] = node.hook_secret
+        return env
+
+    def _runtime_env_for_session_id(self, session_id: str) -> dict[str, str]:
+        session = self.sessions.get(session_id)
+        return self._runtime_env_for_session(session) if session else {}
+
+    def mark_node_unreachable(self, session_id: str, unreachable: bool = True) -> None:
+        if unreachable:
+            self._node_unreachable_sessions.add(session_id)
+        else:
+            self._node_unreachable_sessions.discard(session_id)
+
+    def is_session_node_unreachable(self, session_or_id: Session | str) -> bool:
+        session_id = session_or_id.id if isinstance(session_or_id, Session) else str(session_or_id)
+        return session_id in self._node_unreachable_sessions
 
     def _migrate_legacy_state_file_if_needed(self) -> None:
         """Copy a pre-durable temp-backed session registry into the configured path once."""
@@ -791,6 +894,7 @@ class SessionManager:
                 continue
             cleaned_sessions.append(session_data)
             session = Session.from_dict(session_data)
+            self._cache_session_node(session)
             if session.telegram_chat_id and session.telegram_thread_id:
                 key = (session.telegram_chat_id, session.telegram_thread_id)
                 if key not in self.telegram_topic_registry:
@@ -848,7 +952,31 @@ class SessionManager:
                 continue
 
             # Verify tmux session still exists (Claude/Codex CLI)
-            if self.tmux.session_exists(session.tmux_session):
+            try:
+                tmux_exists = self.tmux.session_exists(session.tmux_session)
+            except Exception as exc:
+                if normalize_node_id(getattr(session, "node", PRIMARY_NODE)) != PRIMARY_NODE:
+                    logger.warning(
+                        "Node %s unreachable while restoring session %s; preserving state: %s",
+                        getattr(session, "node", PRIMARY_NODE),
+                        session.name,
+                        exc,
+                    )
+                    if session.telegram_chat_id and session.telegram_thread_id:
+                        self._upsert_telegram_topic_record(
+                            session,
+                            session.telegram_chat_id,
+                            session.telegram_thread_id,
+                            persist=True,
+                            revive_deleted=True,
+                        )
+                    self.sessions[session.id] = session
+                    self.mark_node_unreachable(session.id, True)
+                    if session.provider == "codex-fork":
+                        self.codex_fork_runtime_owner[session.id] = session.parent_session_id or session.id
+                    continue
+                raise
+            if tmux_exists:
                 if session.telegram_chat_id and session.telegram_thread_id:
                     self._upsert_telegram_topic_record(
                         session,
@@ -1019,7 +1147,7 @@ class SessionManager:
             except Exception as e:
                 logger.error(f"Event handler error: {e}")
 
-    async def _get_git_remote_url_async(self, working_dir: str) -> Optional[str]:
+    async def _get_git_remote_url_async(self, working_dir: str, node: Optional[str] = PRIMARY_NODE) -> Optional[str]:
         """
         Get the git remote URL for a working directory (async, non-blocking).
 
@@ -1030,19 +1158,28 @@ class SessionManager:
             Git remote URL or None if not a git repo
         """
         try:
-            working_path = Path(working_dir).expanduser().resolve()
-            proc = await asyncio.create_subprocess_exec(
-                "git", "config", "--get", "remote.origin.url",
-                cwd=working_path,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
+            if normalize_node_id(node) == PRIMARY_NODE:
+                working_path = Path(working_dir).expanduser().resolve()
+                proc = await asyncio.create_subprocess_exec(
+                    "git", "config", "--get", "remote.origin.url",
+                    cwd=working_path,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+                stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=2)
+                if proc.returncode == 0:
+                    return stdout.decode().strip()
+                return None
+            result = await self.node_runner.run_async(
+                node,
+                ["git", "-C", working_dir, "config", "--get", "remote.origin.url"],
+                timeout=5,
             )
-            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=2)
-            if proc.returncode == 0:
-                return stdout.decode().strip()
+            if result.returncode == 0:
+                return (result.stdout or "").strip()
             return None
         except Exception as e:
-            logger.debug(f"Failed to get git remote for {working_dir}: {e}")
+            logger.debug(f"Failed to get git remote for {working_dir} on node {node}: {e}")
             return None
 
     def _get_git_remote_url(self, working_dir: str) -> Optional[str]:
@@ -2624,6 +2761,7 @@ class SessionManager:
         forked_from_session_id: Optional[str] = None,
         forked_from_provider_resume_id: Optional[str] = None,
         forked_by_session_id: Optional[str] = None,
+        node: Optional[str] = None,
     ) -> Optional[Session]:
         """
         Common session creation logic (private method).
@@ -2641,8 +2779,27 @@ class SessionManager:
         Returns:
             Created Session or None on failure
         """
+        self.last_create_error = None
+        resolved_node, node_error = self._resolve_create_node(node, parent_session_id)
+        if node_error:
+            self.last_create_error = node_error
+            logger.error("Rejecting session create in %s: %s", working_dir, node_error)
+            return None
+
+        provider_node_rejection = self._provider_node_rejection(provider, resolved_node or PRIMARY_NODE)
+        if provider_node_rejection:
+            self.last_create_error = provider_node_rejection
+            logger.error(
+                "Rejecting %s session create on node %s: %s",
+                provider,
+                resolved_node,
+                provider_node_rejection,
+            )
+            return None
+
         provider_rejection = self.get_provider_create_rejection(provider, working_dir=working_dir)
         if provider_rejection:
+            self.last_create_error = provider_rejection
             logger.error("Rejecting %s session create in %s: %s", provider, working_dir, provider_rejection)
             return None
 
@@ -2653,9 +2810,11 @@ class SessionManager:
             parent_session_id=parent_session_id,
             spawn_prompt=spawn_prompt,
             spawned_at=datetime.now() if parent_session_id else None,
+            node=resolved_node or PRIMARY_NODE,
             provider=provider,
             model=model,
         )
+        self._cache_session_node(session)
         if forked_from_session_id:
             session.forked_from_session_id = forked_from_session_id
         if forked_from_provider_resume_id:
@@ -2671,7 +2830,10 @@ class SessionManager:
             session.name = name
 
         # Detect git remote URL for repo matching (async to avoid blocking)
-        session.git_remote_url = await self._get_git_remote_url_async(working_dir)
+        if normalize_node_id(getattr(session, "node", PRIMARY_NODE)) == PRIMARY_NODE:
+            session.git_remote_url = await self._get_git_remote_url_async(working_dir)
+        else:
+            session.git_remote_url = await self._get_git_remote_url_async(working_dir, node=session.node)
 
         # Set up log file path and tmux session for CLI providers
         if provider in ("claude", "codex", "codex-fork"):
@@ -2720,19 +2882,28 @@ class SessionManager:
 
             # Create the tmux session with config args
             # NOTE: session.tmux_session is auto-set by __post_init__ to {provider}-{id}
+            tmux_create_kwargs = {
+                "session_id": session.id,
+                "command": command,
+                "args": args,
+                "model": selected_model if model else None,  # Only pass if explicitly set
+                "initial_prompt": initial_prompt,
+            }
+            runtime_env = self._runtime_env_for_session(session)
+            if normalize_node_id(getattr(session, "node", PRIMARY_NODE)) != PRIMARY_NODE:
+                tmux_create_kwargs["node"] = session.node
+            if runtime_env:
+                tmux_create_kwargs["runtime_env"] = runtime_env
             created = await asyncio.to_thread(
                 self.tmux.create_session_with_command,
                 session.tmux_session,
                 working_dir,
                 session.log_file,
-                session_id=session.id,
-                command=command,
-                args=args,
-                model=selected_model if model else None,  # Only pass if explicitly set
-                initial_prompt=initial_prompt,
+                **tmux_create_kwargs,
             )
             if not created:
                 tmux_error = getattr(self.tmux, "last_error_message", None)
+                self.last_create_error = tmux_error or "Failed to create tmux session"
                 if tmux_error:
                     logger.error("Failed to create tmux session for %s: %s", session.name, tmux_error)
                 else:
@@ -2780,6 +2951,7 @@ class SessionManager:
         else:
             session.status = SessionStatus.RUNNING
         self.sessions[session.id] = session
+        self._cache_session_node(session)
         self._sync_session_resume_id(session)
         self._save_state()
 
@@ -2940,6 +3112,7 @@ class SessionManager:
         telegram_chat_id: Optional[int] = None,
         provider: str = "claude",
         parent_session_id: Optional[str] = None,
+        node: Optional[str] = None,
     ) -> Optional[Session]:
         """
         Create a new Claude Code session (async, non-blocking).
@@ -2959,6 +3132,7 @@ class SessionManager:
             telegram_chat_id=telegram_chat_id,
             provider=provider,
             parent_session_id=parent_session_id,
+            node=node,
         )
 
     async def spawn_child_session(
@@ -2970,6 +3144,7 @@ class SessionManager:
         model: Optional[str] = None,
         working_dir: Optional[str] = None,
         provider: Optional[str] = None,
+        node: Optional[str] = None,
         defer_telegram_topic: bool = False,
     ) -> Optional[Session]:
         """
@@ -3013,6 +3188,7 @@ class SessionManager:
             model=model,
             initial_prompt=prompt,
             provider=selected_provider,
+            node=node,
             defer_telegram_topic=defer_telegram_topic,
         )
 
@@ -3572,8 +3748,15 @@ class SessionManager:
         normalized_role = self.normalize_agent_role(role)
         return self._service_role_bootstrap_locks.setdefault(normalized_role, asyncio.Lock())
 
-    def _resolve_service_role_working_dir(self, spec: dict[str, Any]) -> str:
+    def _resolve_service_role_working_dir(
+        self,
+        spec: dict[str, Any],
+        *,
+        node: Optional[str] = PRIMARY_NODE,
+    ) -> str:
         """Resolve one service-role working directory."""
+        if normalize_node_id(node) != PRIMARY_NODE:
+            return str(spec["working_dir"]).strip()
         candidate = Path(str(spec["working_dir"])).expanduser().resolve()
         role = spec["role"]
         if not candidate.exists():
@@ -3605,7 +3788,7 @@ class SessionManager:
             .replace("{role}", role)
         )
 
-    def _provider_entrypoint_available(self, provider: str) -> bool:
+    def _provider_entrypoint_available(self, provider: str, *, node: Optional[str] = PRIMARY_NODE) -> bool:
         """Best-effort preflight for tmux-backed providers used during maintainer bootstrap."""
         if provider == "codex-fork":
             command = self.codex_fork_command
@@ -3625,6 +3808,9 @@ class SessionManager:
             entrypoint = str(command).strip()
         if not entrypoint:
             return False
+
+        if normalize_node_id(node) != PRIMARY_NODE:
+            return self.node_runner.command_available(node, entrypoint)
 
         if "/" in entrypoint or entrypoint.startswith("~"):
             candidate = Path(entrypoint).expanduser()
@@ -3671,7 +3857,7 @@ class SessionManager:
             return None
         return self._get_live_registered_session(registration.session_id)
 
-    async def ensure_role_session(self, role: str) -> tuple[Session, bool]:
+    async def ensure_role_session(self, role: str, node: Optional[str] = None) -> tuple[Session, bool]:
         """Return the live session for one auto-bootstrap service role, spawning it if needed."""
         normalized_role = self.normalize_agent_role(role)
         if not normalized_role:
@@ -3683,19 +3869,45 @@ class SessionManager:
 
         existing = self.get_service_role_session(normalized_role)
         if existing:
+            if node and normalize_node_id(getattr(existing, "node", PRIMARY_NODE)) != normalize_node_id(node):
+                raise ValueError(
+                    f'Role "{normalized_role}" already exists on node '
+                    f'{getattr(existing, "node", PRIMARY_NODE)}; requested node {normalize_node_id(node)}'
+                )
             return existing, False
 
         async with self._get_service_role_bootstrap_lock(normalized_role):
             existing = self.get_service_role_session(normalized_role)
             if existing:
+                if node and normalize_node_id(getattr(existing, "node", PRIMARY_NODE)) != normalize_node_id(node):
+                    raise ValueError(
+                        f'Role "{normalized_role}" already exists on node '
+                        f'{getattr(existing, "node", PRIMARY_NODE)}; requested node {normalize_node_id(node)}'
+                    )
                 return existing, False
 
-            working_dir = self._resolve_service_role_working_dir(spec)
+            resolved_node = normalize_node_id(node) if node else PRIMARY_NODE
+            working_dir = self._resolve_service_role_working_dir(spec, node=resolved_node)
             bootstrap_prompt = self._render_service_role_bootstrap_prompt(spec, working_dir)
             last_error: Optional[str] = None
 
             for provider in spec["preferred_providers"]:
-                if not self._provider_entrypoint_available(provider):
+                provider_node_rejection = self._provider_node_rejection(provider, resolved_node)
+                if provider_node_rejection:
+                    last_error = provider_node_rejection
+                    logger.warning(
+                        "Skipping %s bootstrap provider %s on node %s: %s",
+                        normalized_role,
+                        provider,
+                        resolved_node,
+                        provider_node_rejection,
+                    )
+                    continue
+                if node:
+                    entrypoint_available = self._provider_entrypoint_available(provider, node=resolved_node)
+                else:
+                    entrypoint_available = self._provider_entrypoint_available(provider)
+                if not entrypoint_available:
                     last_error = f"{provider} entrypoint unavailable"
                     logger.warning(
                         "Skipping %s bootstrap provider %s: entrypoint unavailable",
@@ -3704,12 +3916,15 @@ class SessionManager:
                     )
                     continue
 
-                session = await self._create_session_common(
-                    working_dir=working_dir,
-                    friendly_name=spec["friendly_name"],
-                    initial_prompt=bootstrap_prompt,
-                    provider=provider,
-                )
+                create_kwargs = {
+                    "working_dir": working_dir,
+                    "friendly_name": spec["friendly_name"],
+                    "initial_prompt": bootstrap_prompt,
+                    "provider": provider,
+                }
+                if node:
+                    create_kwargs["node"] = resolved_node
+                session = await self._create_session_common(**create_kwargs)
                 if not session:
                     last_error = f"{provider} session creation failed"
                     logger.warning(
@@ -5252,8 +5467,21 @@ class SessionManager:
         """Mark a tmux-backed session stopped when delivery proves the runtime is gone."""
         if session.provider == "codex-app" or not session.tmux_session:
             return False
-        if self.tmux.session_exists(session.tmux_session):
-            return False
+        try:
+            if self.tmux.session_exists(session.tmux_session):
+                self.mark_node_unreachable(session.id, False)
+                return False
+        except Exception as exc:
+            if normalize_node_id(getattr(session, "node", PRIMARY_NODE)) != PRIMARY_NODE:
+                logger.warning(
+                    "Node %s unreachable while checking tmux runtime for %s: %s",
+                    getattr(session, "node", PRIMARY_NODE),
+                    session.id,
+                    exc,
+                )
+                self.mark_node_unreachable(session.id, True)
+                return False
+            raise
 
         diagnostics = None
         get_exit_diagnostics = getattr(self.tmux, "get_session_exit_diagnostics", None)
@@ -5954,11 +6182,14 @@ class SessionManager:
             if not session:
                 return ActivityState.STOPPED.value
 
-        if session.provider == "codex-fork":
-            return self._compute_codex_fork_activity(session)
-
         if session.status == SessionStatus.STOPPED:
             return ActivityState.STOPPED.value
+
+        if self.is_session_node_unreachable(session):
+            return ActivityState.NODE_UNREACHABLE.value
+
+        if session.provider == "codex-fork":
+            return self._compute_codex_fork_activity(session)
 
         if session.provider == "codex-app":
             return self._compute_codex_app_activity(session)
@@ -6090,11 +6321,22 @@ class SessionManager:
                 "runtime_mode": "stopped",
                 "message": "Session is stopped and no live runtime is available for attach.",
             }
+        attach_command = None
+        attach_command_getter = getattr(self.tmux, "attach_command_for_session", None)
+        if callable(attach_command_getter) and session.tmux_session:
+            try:
+                candidate = attach_command_getter(session.tmux_session)
+            except Exception:
+                candidate = None
+            if isinstance(candidate, list):
+                attach_command = [str(part) for part in candidate]
+
         if provider == "codex-fork":
             lifecycle = self.get_codex_fork_lifecycle_state(session_id) or {}
-            return {
+            descriptor = {
                 "session_id": session.id,
                 "provider": provider,
+                "node": getattr(session, "node", PRIMARY_NODE),
                 "attach_supported": True,
                 "attach_transport": "tmux",
                 "tmux_session": session.tmux_session,
@@ -6109,6 +6351,9 @@ class SessionManager:
                 "control_socket_path": str(self._codex_fork_control_socket_path(session)),
                 "event_stream_path": str(self._codex_fork_event_stream_path(session)),
             }
+            if attach_command:
+                descriptor["attach_command"] = attach_command
+            return descriptor
 
         if provider == "codex-app":
             return {
@@ -6119,9 +6364,10 @@ class SessionManager:
                 "message": "provider=codex-app is headless; use watch/status APIs instead of attach.",
             }
 
-        return {
+        descriptor = {
             "session_id": session.id,
             "provider": provider,
+            "node": getattr(session, "node", PRIMARY_NODE),
             "attach_supported": True,
             "attach_transport": "tmux",
             "tmux_session": session.tmux_session,
@@ -6130,6 +6376,9 @@ class SessionManager:
             "tmux_configured_history_limit": self._tmux_history_limit(),
             "runtime_mode": "tmux",
         }
+        if attach_command:
+            descriptor["attach_command"] = attach_command
+        return descriptor
 
     def get_codex_events(self, session_id: str, since_seq: Optional[int] = None, limit: int = 200) -> dict:
         """Read persisted codex event timeline for one session."""
@@ -6384,7 +6633,20 @@ class SessionManager:
                     state="shutdown",
                     cause_event_type="session_killed",
                 )
-            self.tmux.kill_session(session.tmux_session)
+            try:
+                self.tmux.kill_session(session.tmux_session)
+                self.mark_node_unreachable(session.id, False)
+            except Exception as exc:
+                if normalize_node_id(getattr(session, "node", PRIMARY_NODE)) != PRIMARY_NODE:
+                    logger.warning(
+                        "Node %s unreachable while killing session %s: %s",
+                        getattr(session, "node", PRIMARY_NODE),
+                        session.id,
+                        exc,
+                    )
+                    self.mark_node_unreachable(session.id, True)
+                    return False
+                raise
         now = datetime.now()
         session.status = SessionStatus.STOPPED
         session.completion_status = CompletionStatus.KILLED
@@ -6402,10 +6664,23 @@ class SessionManager:
         session = self.sessions.get(session_id)
         if not session:
             return False, None, "Session not found"
-        tmux_runtime_missing = (
-            session.provider != "codex-app"
-            and not self.tmux.session_exists(session.tmux_session)
-        )
+        try:
+            tmux_runtime_missing = (
+                session.provider != "codex-app"
+                and not self.tmux.session_exists(session.tmux_session)
+            )
+            self.mark_node_unreachable(session.id, False)
+        except Exception as exc:
+            if normalize_node_id(getattr(session, "node", PRIMARY_NODE)) != PRIMARY_NODE:
+                logger.warning(
+                    "Node %s unreachable while restoring session %s: %s",
+                    getattr(session, "node", PRIMARY_NODE),
+                    session.id,
+                    exc,
+                )
+                self.mark_node_unreachable(session.id, True)
+                return False, session, f"Node {getattr(session, 'node', PRIMARY_NODE)} unreachable"
+            raise
         if session.status != SessionStatus.STOPPED and not tmux_runtime_missing:
             return False, session, "Session is not stopped"
 
@@ -6430,6 +6705,8 @@ class SessionManager:
                 command=command,
                 args=args,
                 model=session.model,
+                node=session.node,
+                runtime_env=self._runtime_env_for_session(session),
             ):
                 tmux_error = getattr(self.tmux, "last_error_message", None)
                 if tmux_error:
@@ -6438,6 +6715,9 @@ class SessionManager:
                 return False, session, tmux_error or "Failed to restore Claude session runtime"
             session.tmux_socket_name = self._tmux_socket_name()
         elif session.provider in ("codex", "codex-fork"):
+            provider_node_rejection = self._provider_node_rejection(session.provider, session.node)
+            if provider_node_rejection:
+                return False, session, provider_node_rejection
             if not resume_id:
                 return False, session, "No Codex resume id is available for this session"
             if session.provider == "codex":
@@ -6462,6 +6742,8 @@ class SessionManager:
                 session_id=session.id,
                 command=command,
                 args=args,
+                node=session.node,
+                runtime_env=self._runtime_env_for_session(session),
             ):
                 tmux_error = getattr(self.tmux, "last_error_message", None)
                 if tmux_error:
@@ -6809,6 +7091,7 @@ class SessionManager:
             model=model,
             initial_prompt=None,  # No prompt — we send /review instead
             provider="codex",
+            node=PRIMARY_NODE,
         )
 
         if not session:

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -487,7 +487,7 @@ class SessionManager:
         elif parent_session_id and parent_session_id in self.sessions:
             node = normalize_node_id(getattr(self.sessions[parent_session_id], "node", PRIMARY_NODE))
         else:
-            node = PRIMARY_NODE
+            node = normalize_node_id(getattr(self.node_registry, "default_node", PRIMARY_NODE))
 
         if not self.node_registry.has(node):
             return None, f"Unknown node: {node}"

--- a/src/tmux_controller.py
+++ b/src/tmux_controller.py
@@ -478,9 +478,10 @@ class TmuxController:
                 return None, f"Working directory is not a directory: {working_dir}"
             return str(working_path), None
 
-        if not self.node_runner.path_is_dir(node, working_dir):
+        remote_working_path = self.node_runner.resolve_directory(node, working_dir)
+        if not remote_working_path:
             return None, f"Working directory does not exist on node {node}: {working_dir}"
-        return working_dir, None
+        return remote_working_path, None
 
     def _prepare_log_file(self, log_file: str, *, node: Optional[str]) -> tuple[bool, Optional[str]]:
         """Create the session log file on the node where tmux will run."""

--- a/src/tmux_controller.py
+++ b/src/tmux_controller.py
@@ -7,7 +7,9 @@ import shlex
 import shutil
 import subprocess
 from pathlib import Path
-from typing import Optional
+from typing import Callable, Optional
+
+from .node_runner import NodeRegistry, NodeRunner, PRIMARY_NODE, normalize_node_id
 
 logger = logging.getLogger(__name__)
 
@@ -17,11 +19,21 @@ class TmuxController:
 
     SERVER_ANCHOR_SESSION = "__sm_server_anchor"
 
-    def __init__(self, log_dir: str = "/tmp/claude-sessions", config: Optional[dict] = None):
+    def __init__(
+        self,
+        log_dir: str = "/tmp/claude-sessions",
+        config: Optional[dict] = None,
+        node_runner: Optional[NodeRunner] = None,
+        node_resolver: Optional[Callable[[str], str]] = None,
+        runtime_env_resolver: Optional[Callable[[str], dict[str, str]]] = None,
+    ):
         self.log_dir = Path(log_dir)
         self.log_dir.mkdir(parents=True, exist_ok=True)
         self.config = config or {}
         self.last_error_message: Optional[str] = None
+        self.node_runner = node_runner or NodeRunner(NodeRegistry.from_config(self.config))
+        self._node_resolver = node_resolver
+        self._runtime_env_resolver = runtime_env_resolver
 
         tmux_config = self.config.get("tmux", {}) if isinstance(self.config, dict) else {}
         raw_socket_name = str(tmux_config.get("socket_name", "") or "").strip()
@@ -51,6 +63,12 @@ class TmuxController:
         self.submit_verify_seconds = tmux_timeouts.get("submit_verify_seconds", 0.6)
         self.submit_retry_seconds = tmux_timeouts.get("submit_retry_seconds", 0.6)
         self.shell_fd_limit = int(tmux_timeouts.get("shell_fd_limit", 65536))
+
+    def set_node_resolver(self, resolver: Callable[[str], str]) -> None:
+        self._node_resolver = resolver
+
+    def set_runtime_env_resolver(self, resolver: Callable[[str], dict[str, str]]) -> None:
+        self._runtime_env_resolver = resolver
 
     @staticmethod
     def _coerce_bool(value: object, default: bool = False) -> bool:
@@ -83,8 +101,30 @@ class TmuxController:
         """Return the tmux session portion of a target that may include window/pane suffixes."""
         return str(session_name or "").split(":", 1)[0].split(".", 1)[0]
 
-    def tmux_cmd(self, *args: str, socket_name: Optional[str] = "__primary__") -> list[str]:
+    def _node_for_session(self, session_name: str) -> str:
+        target = self._normalize_session_target(session_name)
+        if self._node_resolver:
+            try:
+                return normalize_node_id(self._node_resolver(target))
+            except Exception:
+                logger.debug("Failed to resolve node for tmux session %s", target, exc_info=True)
+        return PRIMARY_NODE
+
+    def tmux_cmd(
+        self,
+        *args: str,
+        socket_name: Optional[str] = "__primary__",
+        node: Optional[str] = PRIMARY_NODE,
+    ) -> list[str]:
         """Build one tmux command using the configured SM socket unless overridden."""
+        return self.node_runner.command(node, self._tmux_argv(*args, socket_name=socket_name))
+
+    def _tmux_argv(
+        self,
+        *args: str,
+        socket_name: Optional[str] = "__primary__",
+    ) -> list[str]:
+        """Build the raw tmux argv before local/SSH node routing."""
         effective_socket = self.socket_name if socket_name == "__primary__" else socket_name
         cmd = ["tmux"]
         if effective_socket:
@@ -94,32 +134,72 @@ class TmuxController:
 
     def tmux_cmd_for_session(self, session_name: str, *args: str) -> list[str]:
         """Build a tmux command for an existing target, falling back for legacy sessions."""
-        return self.tmux_cmd(*args, socket_name=self._resolve_socket_for_session(session_name))
+        node = self._node_for_session(session_name)
+        return self.tmux_cmd(
+            *args,
+            socket_name=self._resolve_socket_for_session(session_name, node=node),
+            node=node,
+        )
 
-    def _session_exists_on_socket(self, session_name: str, socket_name: Optional[str]) -> bool:
+    def attach_command_for_session(self, session_name: str) -> list[str]:
+        """Build an interactive attach command for a session's owning node."""
+        target = self._normalize_session_target(session_name)
+        node = self._node_for_session(target)
+        socket_name = self._resolve_socket_for_session(target, node=node)
+        return self.node_runner.attach_command(
+            node,
+            self._tmux_argv("attach", "-t", target, socket_name=socket_name),
+        )
+
+    def _session_exists_on_socket(
+        self,
+        session_name: str,
+        socket_name: Optional[str],
+        *,
+        node: Optional[str] = PRIMARY_NODE,
+    ) -> bool:
         target = self._normalize_session_target(session_name)
         if not target:
             return False
         result = subprocess.run(
-            self.tmux_cmd("has-session", "-t", target, socket_name=socket_name),
+            self.tmux_cmd("has-session", "-t", target, socket_name=socket_name, node=node),
             capture_output=True,
             text=True,
             check=False,
         )
+        if normalize_node_id(node) != PRIMARY_NODE and result.returncode == 255:
+            detail = (result.stderr or result.stdout or "").strip() or "ssh transport failed"
+            raise RuntimeError(f"Node {normalize_node_id(node)} unreachable: {detail}")
         return result.returncode == 0
 
-    def _resolve_socket_for_session(self, session_name: str) -> Optional[str]:
+    def _session_exists_on_socket_for_node(
+        self,
+        session_name: str,
+        socket_name: Optional[str],
+        *,
+        node: Optional[str] = PRIMARY_NODE,
+    ) -> bool:
+        """Call _session_exists_on_socket with backward compatibility for tests/mocks."""
+        try:
+            return self._session_exists_on_socket(session_name, socket_name, node=node)
+        except TypeError as exc:
+            if "unexpected keyword argument 'node'" not in str(exc):
+                raise
+            return self._session_exists_on_socket(session_name, socket_name)
+
+    def _resolve_socket_for_session(self, session_name: str, *, node: Optional[str] = None) -> Optional[str]:
         """Resolve which tmux server owns a session, supporting legacy default-server panes."""
         target = self._normalize_session_target(session_name)
+        effective_node = normalize_node_id(node or self._node_for_session(target))
         if not target:
             return self.socket_name
-        if self.socket_name and self._session_exists_on_socket(target, self.socket_name):
+        if self.socket_name and self._session_exists_on_socket_for_node(target, self.socket_name, node=effective_node):
             return self.socket_name
-        if self.socket_name and self._session_exists_on_socket(target, None):
+        if self.socket_name and self._session_exists_on_socket_for_node(target, None, node=effective_node):
             return None
         return self.socket_name
 
-    def _ensure_server_options(self) -> None:
+    def _ensure_server_options(self, *, node: Optional[str] = PRIMARY_NODE) -> None:
         """Apply SM-owned tmux server options that are safe only on the configured socket."""
         if not self.socket_name:
             return
@@ -129,6 +209,7 @@ class TmuxController:
             "focus-events",
             "on",
             check=False,
+            node=node,
         )
         if not self.native_scrollback:
             return
@@ -137,6 +218,7 @@ class TmuxController:
             "-gqv",
             "terminal-overrides",
             check=False,
+            node=node,
         )
         if "smcup@:rmcup@" in (current.stdout or ""):
             return
@@ -145,9 +227,10 @@ class TmuxController:
             "-as",
             "terminal-overrides",
             ",*:smcup@:rmcup@",
+            node=node,
         )
 
-    def _ensure_server_anchor(self) -> None:
+    def _ensure_server_anchor(self, *, node: Optional[str] = PRIMARY_NODE) -> None:
         """Start the configured tmux server under a neutral SM-owned session.
 
         tmux server processes keep the argv from the command that first created
@@ -158,7 +241,7 @@ class TmuxController:
         """
         if not self.socket_name:
             return
-        if self._session_exists_on_socket(self.SERVER_ANCHOR_SESSION, self.socket_name):
+        if self._session_exists_on_socket_for_node(self.SERVER_ANCHOR_SESSION, self.socket_name, node=node):
             return
         result = self._run_tmux(
             "new-session",
@@ -171,6 +254,7 @@ class TmuxController:
             str(self.log_dir),
             "sleep 315360000",
             check=False,
+            node=node,
         )
         if result.returncode == 0:
             logger.info(
@@ -181,7 +265,7 @@ class TmuxController:
         elif "duplicate session" not in (result.stderr or "").lower():
             logger.warning("Could not create tmux server anchor: %s", result.stderr)
 
-    def _enable_exit_diagnostics(self, session_name: str) -> None:
+    def _enable_exit_diagnostics(self, session_name: str, *, node: Optional[str] = None) -> None:
         """Keep dead panes around long enough for the monitor to read exit status."""
         try:
             self._run_tmux(
@@ -191,6 +275,7 @@ class TmuxController:
                 "remain-on-exit",
                 "on",
                 check=False,
+                node=node,
             )
             pane_id = (
                 self._run_tmux(
@@ -200,6 +285,7 @@ class TmuxController:
                     session_name,
                     "#{pane_id}",
                     check=False,
+                    node=node,
                 ).stdout
                 or ""
             ).strip()
@@ -211,13 +297,19 @@ class TmuxController:
                     "@sm_main_pane_id",
                     pane_id,
                     check=False,
+                    node=node,
                 )
         except Exception:
             # Exit diagnostics are best-effort. Spawn should not fail if tmux
             # lacks this option or the pane disappeared during setup.
             logger.debug("Could not enable remain-on-exit for %s", session_name, exc_info=True)
 
-    def _list_sessions_on_socket(self, socket_name: Optional[str]) -> list[str]:
+    def _list_sessions_on_socket(
+        self,
+        socket_name: Optional[str],
+        *,
+        node: Optional[str] = PRIMARY_NODE,
+    ) -> list[str]:
         """Return tmux session names on one socket without using fallback resolution."""
         result = self._run_tmux(
             "list-sessions",
@@ -225,6 +317,7 @@ class TmuxController:
             "#{session_name}",
             check=False,
             socket_name=socket_name,
+            node=node,
         )
         if result.returncode != 0:
             return []
@@ -243,10 +336,11 @@ class TmuxController:
         legacy/default-socket mismatch.
         """
         target = self._normalize_session_target(session_name)
-        socket_name = self._resolve_socket_for_session(target)
-        exists = self._session_exists_on_socket(target, socket_name)
+        node = self._node_for_session(target)
+        socket_name = self._resolve_socket_for_session(target, node=node)
+        exists = self._session_exists_on_socket_for_node(target, socket_name, node=node)
         if not exists and self.socket_name:
-            legacy_exists = self._session_exists_on_socket(target, None)
+            legacy_exists = self._session_exists_on_socket_for_node(target, None, node=node)
             if legacy_exists:
                 socket_name = None
                 exists = True
@@ -254,12 +348,13 @@ class TmuxController:
         diagnostics: dict[str, object] = {
             "session_name": target,
             "socket_name": socket_name,
+            "node": node,
             "configured_socket_name": self.socket_name,
             "exists": exists,
             "pane_dead": False,
             "panes": [],
-            "sessions_on_configured_socket": self._list_sessions_on_socket(self.socket_name),
-            "sessions_on_default_socket": self._list_sessions_on_socket(None),
+            "sessions_on_configured_socket": self._list_sessions_on_socket(self.socket_name, node=node),
+            "sessions_on_default_socket": self._list_sessions_on_socket(None, node=node),
         }
 
         if not exists:
@@ -274,6 +369,7 @@ class TmuxController:
                 "@sm_main_pane_id",
                 check=False,
                 socket_name=socket_name,
+                node=node,
             ).stdout
             or ""
         ).strip() or None
@@ -287,6 +383,7 @@ class TmuxController:
             "#{pane_id}\t#{pane_dead}\t#{pane_dead_status}\t#{pane_dead_signal}\t#{pane_current_command}\t#{pane_pid}\t#{pane_tty}\t#{pane_active}\t#{pane_title}",
             check=False,
             socket_name=socket_name,
+            node=node,
         )
         if result.returncode != 0:
             diagnostics["pane_error"] = (result.stderr or "").strip()
@@ -339,13 +436,20 @@ class TmuxController:
         self,
         command: str,
         *,
-        working_path: Path,
+        working_path: Path | str,
+        node: Optional[str] = PRIMARY_NODE,
     ) -> tuple[Optional[str], Optional[str]]:
         """Resolve and validate one CLI launch command before creating tmux state."""
         raw_command = str(command or "").strip()
         if not raw_command:
             return None, "Launch command is empty"
 
+        if normalize_node_id(node) != PRIMARY_NODE:
+            if self.node_runner.command_available(node, raw_command, cwd=str(working_path)):
+                return raw_command, None
+            return None, f"Launch command not found or not executable on node {node}: {raw_command}"
+
+        working_path = Path(str(working_path))
         if raw_command.startswith("~") or "/" in raw_command:
             candidate = Path(raw_command).expanduser()
             if not candidate.is_absolute():
@@ -364,15 +468,42 @@ class TmuxController:
             return None, f"Launch command not found on PATH: {raw_command}"
         return raw_command, None
 
+    def _prepare_working_dir(self, working_dir: str, *, node: Optional[str]) -> tuple[Optional[str], Optional[str]]:
+        """Validate a working directory on the node that will run the session."""
+        if normalize_node_id(node) == PRIMARY_NODE:
+            working_path = Path(working_dir).expanduser().resolve()
+            if not working_path.exists():
+                return None, f"Working directory does not exist: {working_dir}"
+            if not working_path.is_dir():
+                return None, f"Working directory is not a directory: {working_dir}"
+            return str(working_path), None
+
+        if not self.node_runner.path_is_dir(node, working_dir):
+            return None, f"Working directory does not exist on node {node}: {working_dir}"
+        return working_dir, None
+
+    def _prepare_log_file(self, log_file: str, *, node: Optional[str]) -> tuple[bool, Optional[str]]:
+        """Create the session log file on the node where tmux will run."""
+        if normalize_node_id(node) == PRIMARY_NODE:
+            log_path = Path(log_file)
+            log_path.parent.mkdir(parents=True, exist_ok=True)
+            log_path.touch()
+            return True, None
+
+        if self.node_runner.ensure_file(node, log_file):
+            return True, None
+        return False, f"Failed to create log file on node {node}: {log_file}"
+
     def _run_tmux(
         self,
         *args: str,
         check: bool = True,
         timeout: Optional[float] = None,
         socket_name: Optional[str] = "__primary__",
+        node: Optional[str] = PRIMARY_NODE,
     ) -> subprocess.CompletedProcess:
         """Run a tmux command."""
-        cmd = self.tmux_cmd(*args, socket_name=socket_name)
+        cmd = self.tmux_cmd(*args, socket_name=socket_name, node=node)
         logger.debug(f"Running tmux command: {' '.join(cmd)}")
         return subprocess.run(
             cmd,
@@ -388,9 +519,17 @@ class TmuxController:
         *args: str,
         check: bool = True,
         timeout: Optional[float] = None,
+        node: Optional[str] = None,
     ) -> subprocess.CompletedProcess:
         """Run a tmux command against an existing target, with legacy fallback."""
-        cmd = self.tmux_cmd_for_session(session_name, *args)
+        if node is None:
+            cmd = self.tmux_cmd_for_session(session_name, *args)
+        else:
+            cmd = self.tmux_cmd(
+                *args,
+                socket_name=self._resolve_socket_for_session(session_name, node=node),
+                node=node,
+            )
         logger.debug(f"Running tmux command: {' '.join(cmd)}")
         return subprocess.run(
             cmd,
@@ -468,7 +607,7 @@ class TmuxController:
         except Exception:
             return None
 
-    def _initialize_pane_title(self, session_name: str) -> None:
+    def _initialize_pane_title(self, session_name: str, *, node: Optional[str] = None) -> None:
         """Seed a fresh pane with a neutral title before provider-specific updates arrive."""
         try:
             self._run_tmux(
@@ -476,27 +615,37 @@ class TmuxController:
                 "-t", session_name,
                 "-T", session_name,
                 check=False,
+                node=node,
             )
         except Exception:
             # Non-fatal: pane title is best-effort only.
             pass
 
-    def _prepare_managed_shell(self, session_name: str, session_id: Optional[str]) -> None:
+    def _prepare_managed_shell(
+        self,
+        session_name: str,
+        session_id: Optional[str],
+        *,
+        node: Optional[str] = None,
+        runtime_env: Optional[dict[str, str]] = None,
+    ) -> None:
         """Set shell state inherited by Claude/Codex before launching the provider."""
-        if self.shell_fd_limit > 0:
+        def send_shell(command: str) -> None:
+            kwargs = {}
+            if normalize_node_id(node) != PRIMARY_NODE:
+                kwargs["node"] = node
             self._run_tmux(
                 "send-keys",
                 "-t", session_name,
-                f"ulimit -n {self.shell_fd_limit}",
+                command,
                 "Enter",
+                **kwargs,
             )
 
-        self._run_tmux(
-            "send-keys",
-            "-t", session_name,
-            "unset NO_COLOR",
-            "Enter",
-        )
+        if self.shell_fd_limit > 0:
+            send_shell(f"ulimit -n {self.shell_fd_limit}")
+
+        send_shell("unset NO_COLOR")
         color_env = {
             "TERM_PROGRAM": os.environ.get("TERM_PROGRAM"),
             "TERM_PROGRAM_VERSION": os.environ.get("TERM_PROGRAM_VERSION"),
@@ -510,37 +659,24 @@ class TmuxController:
                 color_cmd = f"export {name}={shlex.quote(value)}"
             else:
                 color_cmd = f"unset {name}"
-            self._run_tmux(
-                "send-keys",
-                "-t", session_name,
-                color_cmd,
-                "Enter",
-            )
+            send_shell(color_cmd)
 
         # Claude Code can leave this behind after exits; managed tmux panes are independent
         # launches, so nested-session detection should not apply.
-        self._run_tmux(
-            "send-keys",
-            "-t", session_name,
-            "unset CLAUDECODE",
-            "Enter",
-        )
+        send_shell("unset CLAUDECODE")
         # Workaround for Claude Code bug: ToolSearch infinite loop (issues #20329, #20468, #20982)
-        self._run_tmux(
-            "send-keys",
-            "-t", session_name,
-            "export ENABLE_TOOL_SEARCH=false",
-            "Enter",
-        )
+        send_shell("export ENABLE_TOOL_SEARCH=false")
 
         if session_id:
             # Export session ID so it persists even if user exits and restarts the provider.
-            self._run_tmux(
-                "send-keys",
-                "-t", session_name,
-                f"export CLAUDE_SESSION_MANAGER_ID={session_id}",
-                "Enter",
-            )
+            send_shell(f"export CLAUDE_SESSION_MANAGER_ID={shlex.quote(session_id)}")
+
+        if runtime_env is None and self._runtime_env_resolver and session_id:
+            runtime_env = self._runtime_env_resolver(session_id)
+        for name, value in (runtime_env or {}).items():
+            if value is None:
+                continue
+            send_shell(f"export {name}={shlex.quote(str(value))}")
 
     def _exit_copy_mode_if_needed(self, session_name: str) -> tuple[Optional[int], Optional[int]]:
         """Exit tmux copy-mode on active pane when present."""
@@ -840,13 +976,23 @@ class TmuxController:
         )
         return True
 
-    def session_exists(self, session_name: str) -> bool:
+    def session_exists(self, session_name: str, *, node: Optional[str] = None) -> bool:
         """Check if a tmux session exists."""
-        if self._session_exists_on_socket(session_name, self.socket_name):
+        effective_node = normalize_node_id(node or self._node_for_session(session_name))
+        if self._session_exists_on_socket_for_node(session_name, self.socket_name, node=effective_node):
             return True
-        if self.socket_name and self._session_exists_on_socket(session_name, None):
+        if self.socket_name and self._session_exists_on_socket_for_node(session_name, None, node=effective_node):
             return True
         return False
+
+    def _session_exists_for_node(self, session_name: str, *, node: Optional[str] = None) -> bool:
+        """Call session_exists with backward compatibility for tests/mocks."""
+        try:
+            return self.session_exists(session_name, node=node)
+        except TypeError as exc:
+            if "unexpected keyword argument 'node'" not in str(exc):
+                raise
+            return self.session_exists(session_name)
 
     def get_history_limit(self, session_name: str) -> Optional[int]:
         """Return the active pane history limit for a tmux session."""
@@ -917,6 +1063,8 @@ class TmuxController:
         working_dir: str,
         log_file: str,
         session_id: Optional[str] = None,
+        node: Optional[str] = PRIMARY_NODE,
+        runtime_env: Optional[dict[str, str]] = None,
     ) -> bool:
         """
         Create a new tmux session with Claude Code running inside.
@@ -931,35 +1079,35 @@ class TmuxController:
             True if session created successfully
         """
         self.last_error_message = None
-        if self.session_exists(session_name):
+        if self._session_exists_for_node(session_name, node=node):
             logger.warning(f"Session {session_name} already exists")
             self.last_error_message = f"Tmux session already exists: {session_name}"
             return False
 
-        working_path = Path(working_dir).expanduser().resolve()
-        if not working_path.exists():
-            self.last_error_message = f"Working directory does not exist: {working_dir}"
+        working_path, working_error = self._prepare_working_dir(working_dir, node=node)
+        if working_error:
+            self.last_error_message = working_error
             logger.error(self.last_error_message)
             return False
 
         launch_command, command_error = self._resolve_launch_command(
             "claude",
             working_path=working_path,
+            node=node,
         )
         if command_error:
             self.last_error_message = command_error
             logger.error(command_error)
             return False
 
-        # Ensure log file parent directory exists
-        log_path = Path(log_file)
-        log_path.parent.mkdir(parents=True, exist_ok=True)
-
-        # Touch the log file
-        log_path.touch()
+        log_ready, log_error = self._prepare_log_file(log_file, node=node)
+        if not log_ready:
+            self.last_error_message = log_error
+            logger.error(log_error)
+            return False
 
         try:
-            self._ensure_server_anchor()
+            self._ensure_server_anchor(node=node)
             # Create bootstrap session, then create provider window after history-limit is set.
             self._run_tmux(
                 "new-session",
@@ -967,23 +1115,25 @@ class TmuxController:
                 "-s", session_name,
                 "-c", str(working_path),
                 "-n", "__sm_bootstrap",
+                node=node,
             )
-            self._ensure_server_options()
-            self._run_tmux("set-option", "-t", session_name, "history-limit", str(self.history_limit))
-            self._run_tmux("new-window", "-d", "-t", session_name, "-n", "main", "-c", str(working_path))
-            self._run_tmux("kill-window", "-t", f"{session_name}:__sm_bootstrap")
-            self._run_tmux("select-window", "-t", f"{session_name}:main")
-            self._enable_exit_diagnostics(session_name)
-            self._initialize_pane_title(session_name)
+            self._ensure_server_options(node=node)
+            self._run_tmux("set-option", "-t", session_name, "history-limit", str(self.history_limit), node=node)
+            self._run_tmux("new-window", "-d", "-t", session_name, "-n", "main", "-c", str(working_path), node=node)
+            self._run_tmux("kill-window", "-t", f"{session_name}:__sm_bootstrap", node=node)
+            self._run_tmux("select-window", "-t", f"{session_name}:main", node=node)
+            self._enable_exit_diagnostics(session_name, node=node)
+            self._initialize_pane_title(session_name, node=node)
 
             # Set up pipe-pane to capture output to log file
             self._run_tmux(
                 "pipe-pane",
                 "-t", session_name,
-                f"cat >> {log_file}",
+                f"cat >> {shlex.quote(log_file)}",
+                node=node,
             )
 
-            self._prepare_managed_shell(session_name, session_id)
+            self._prepare_managed_shell(session_name, session_id, node=node, runtime_env=runtime_env)
 
             # Small delay to ensure exports complete
             import time
@@ -995,6 +1145,7 @@ class TmuxController:
                 "-t", session_name,
                 launch_command,
                 "Enter",
+                node=node,
             )
 
             self.last_error_message = None
@@ -1016,6 +1167,8 @@ class TmuxController:
         args: list[str] = None,
         model: Optional[str] = None,
         initial_prompt: Optional[str] = None,
+        node: Optional[str] = PRIMARY_NODE,
+        runtime_env: Optional[dict[str, str]] = None,
     ) -> bool:
         """
         Create a new tmux session with custom Claude Code command.
@@ -1034,33 +1187,35 @@ class TmuxController:
             True if session created successfully
         """
         self.last_error_message = None
-        if self.session_exists(session_name):
+        if self._session_exists_for_node(session_name, node=node):
             logger.warning(f"Session {session_name} already exists")
             self.last_error_message = f"Tmux session already exists: {session_name}"
             return False
 
-        working_path = Path(working_dir).expanduser().resolve()
-        if not working_path.exists():
-            self.last_error_message = f"Working directory does not exist: {working_dir}"
+        working_path, working_error = self._prepare_working_dir(working_dir, node=node)
+        if working_error:
+            self.last_error_message = working_error
             logger.error(self.last_error_message)
             return False
 
         launch_command, command_error = self._resolve_launch_command(
             command,
             working_path=working_path,
+            node=node,
         )
         if command_error:
             self.last_error_message = command_error
             logger.error(command_error)
             return False
 
-        # Ensure log file parent directory exists
-        log_path = Path(log_file)
-        log_path.parent.mkdir(parents=True, exist_ok=True)
-        log_path.touch()
+        log_ready, log_error = self._prepare_log_file(log_file, node=node)
+        if not log_ready:
+            self.last_error_message = log_error
+            logger.error(log_error)
+            return False
 
         try:
-            self._ensure_server_anchor()
+            self._ensure_server_anchor(node=node)
             # Create bootstrap session, then create provider window after history-limit is set.
             self._run_tmux(
                 "new-session",
@@ -1068,23 +1223,25 @@ class TmuxController:
                 "-s", session_name,
                 "-c", str(working_path),
                 "-n", "__sm_bootstrap",
+                node=node,
             )
-            self._ensure_server_options()
-            self._run_tmux("set-option", "-t", session_name, "history-limit", str(self.history_limit))
-            self._run_tmux("new-window", "-d", "-t", session_name, "-n", "main", "-c", str(working_path))
-            self._run_tmux("kill-window", "-t", f"{session_name}:__sm_bootstrap")
-            self._run_tmux("select-window", "-t", f"{session_name}:main")
-            self._enable_exit_diagnostics(session_name)
-            self._initialize_pane_title(session_name)
+            self._ensure_server_options(node=node)
+            self._run_tmux("set-option", "-t", session_name, "history-limit", str(self.history_limit), node=node)
+            self._run_tmux("new-window", "-d", "-t", session_name, "-n", "main", "-c", str(working_path), node=node)
+            self._run_tmux("kill-window", "-t", f"{session_name}:__sm_bootstrap", node=node)
+            self._run_tmux("select-window", "-t", f"{session_name}:main", node=node)
+            self._enable_exit_diagnostics(session_name, node=node)
+            self._initialize_pane_title(session_name, node=node)
 
             # Set up pipe-pane to capture output to log file
             self._run_tmux(
                 "pipe-pane",
                 "-t", session_name,
-                f"cat >> {log_file}",
+                f"cat >> {shlex.quote(log_file)}",
+                node=node,
             )
 
-            self._prepare_managed_shell(session_name, session_id)
+            self._prepare_managed_shell(session_name, session_id, node=node, runtime_env=runtime_env)
 
             # Small delay to ensure exports complete
             import time
@@ -1111,12 +1268,14 @@ class TmuxController:
                 "-t", session_name,
                 "--",
                 launch_command,
+                node=node,
             )
             time.sleep(self._compute_settle_delay_seconds(launch_command))
             self._run_tmux(
                 "send-keys",
                 "-t", session_name,
                 "Enter",
+                node=node,
             )
 
             if initial_prompt:
@@ -1389,7 +1548,8 @@ class TmuxController:
             return False
 
         try:
-            self._run_tmux(
+            self._run_tmux_for_session(
+                session_name,
                 "send-keys",
                 "-t", session_name,
                 key,
@@ -1427,29 +1587,35 @@ class TmuxController:
     def list_sessions(self) -> list[str]:
         """List all tmux sessions."""
         sessions: set[str] = set()
-        result = self._run_tmux("list-sessions", "-F", "#{session_name}", check=False)
-        if result.returncode != 0:
-            result = None
-        if result is not None:
-            sessions.update(
-                s.strip()
-                for s in result.stdout.strip().split("\n")
-                if s.strip() and s.strip() != self.SERVER_ANCHOR_SESSION
-            )
-        if self.socket_name:
-            legacy = self._run_tmux(
+        for node in self.node_runner.registry.ids():
+            result = self._run_tmux(
                 "list-sessions",
                 "-F",
                 "#{session_name}",
                 check=False,
-                socket_name=None,
+                node=node,
             )
-            if legacy.returncode == 0:
+            if result.returncode == 0:
                 sessions.update(
                     s.strip()
-                    for s in legacy.stdout.strip().split("\n")
+                    for s in result.stdout.strip().split("\n")
                     if s.strip() and s.strip() != self.SERVER_ANCHOR_SESSION
                 )
+            if self.socket_name:
+                legacy = self._run_tmux(
+                    "list-sessions",
+                    "-F",
+                    "#{session_name}",
+                    check=False,
+                    socket_name=None,
+                    node=node,
+                )
+                if legacy.returncode == 0:
+                    sessions.update(
+                        s.strip()
+                        for s in legacy.stdout.strip().split("\n")
+                        if s.strip() and s.strip() != self.SERVER_ANCHOR_SESSION
+                    )
         return sorted(sessions)
 
     def capture_pane(self, session_name: str, lines: int = 50) -> Optional[str]:

--- a/src/tmux_controller.py
+++ b/src/tmux_controller.py
@@ -1080,34 +1080,34 @@ class TmuxController:
             True if session created successfully
         """
         self.last_error_message = None
-        if self._session_exists_for_node(session_name, node=node):
-            logger.warning(f"Session {session_name} already exists")
-            self.last_error_message = f"Tmux session already exists: {session_name}"
-            return False
-
-        working_path, working_error = self._prepare_working_dir(working_dir, node=node)
-        if working_error:
-            self.last_error_message = working_error
-            logger.error(self.last_error_message)
-            return False
-
-        launch_command, command_error = self._resolve_launch_command(
-            "claude",
-            working_path=working_path,
-            node=node,
-        )
-        if command_error:
-            self.last_error_message = command_error
-            logger.error(command_error)
-            return False
-
-        log_ready, log_error = self._prepare_log_file(log_file, node=node)
-        if not log_ready:
-            self.last_error_message = log_error
-            logger.error(log_error)
-            return False
-
         try:
+            if self._session_exists_for_node(session_name, node=node):
+                logger.warning(f"Session {session_name} already exists")
+                self.last_error_message = f"Tmux session already exists: {session_name}"
+                return False
+
+            working_path, working_error = self._prepare_working_dir(working_dir, node=node)
+            if working_error:
+                self.last_error_message = working_error
+                logger.error(self.last_error_message)
+                return False
+
+            launch_command, command_error = self._resolve_launch_command(
+                "claude",
+                working_path=working_path,
+                node=node,
+            )
+            if command_error:
+                self.last_error_message = command_error
+                logger.error(command_error)
+                return False
+
+            log_ready, log_error = self._prepare_log_file(log_file, node=node)
+            if not log_ready:
+                self.last_error_message = log_error
+                logger.error(log_error)
+                return False
+
             self._ensure_server_anchor(node=node)
             # Create bootstrap session, then create provider window after history-limit is set.
             self._run_tmux(
@@ -1157,6 +1157,10 @@ class TmuxController:
             self.last_error_message = f"Failed to create tmux session: {e.stderr}"
             logger.error(f"Failed to create session: {e.stderr}")
             return False
+        except RuntimeError as e:
+            self.last_error_message = str(e)
+            logger.error("Failed to create session: %s", e)
+            return False
 
     def create_session_with_command(
         self,
@@ -1188,34 +1192,34 @@ class TmuxController:
             True if session created successfully
         """
         self.last_error_message = None
-        if self._session_exists_for_node(session_name, node=node):
-            logger.warning(f"Session {session_name} already exists")
-            self.last_error_message = f"Tmux session already exists: {session_name}"
-            return False
-
-        working_path, working_error = self._prepare_working_dir(working_dir, node=node)
-        if working_error:
-            self.last_error_message = working_error
-            logger.error(self.last_error_message)
-            return False
-
-        launch_command, command_error = self._resolve_launch_command(
-            command,
-            working_path=working_path,
-            node=node,
-        )
-        if command_error:
-            self.last_error_message = command_error
-            logger.error(command_error)
-            return False
-
-        log_ready, log_error = self._prepare_log_file(log_file, node=node)
-        if not log_ready:
-            self.last_error_message = log_error
-            logger.error(log_error)
-            return False
-
         try:
+            if self._session_exists_for_node(session_name, node=node):
+                logger.warning(f"Session {session_name} already exists")
+                self.last_error_message = f"Tmux session already exists: {session_name}"
+                return False
+
+            working_path, working_error = self._prepare_working_dir(working_dir, node=node)
+            if working_error:
+                self.last_error_message = working_error
+                logger.error(self.last_error_message)
+                return False
+
+            launch_command, command_error = self._resolve_launch_command(
+                command,
+                working_path=working_path,
+                node=node,
+            )
+            if command_error:
+                self.last_error_message = command_error
+                logger.error(command_error)
+                return False
+
+            log_ready, log_error = self._prepare_log_file(log_file, node=node)
+            if not log_ready:
+                self.last_error_message = log_error
+                logger.error(log_error)
+                return False
+
             self._ensure_server_anchor(node=node)
             # Create bootstrap session, then create provider window after history-limit is set.
             self._run_tmux(
@@ -1294,6 +1298,10 @@ class TmuxController:
         except subprocess.CalledProcessError as e:
             self.last_error_message = f"Failed to create tmux session: {e.stderr}"
             logger.error(f"Failed to create session: {e.stderr}")
+            return False
+        except RuntimeError as e:
+            self.last_error_message = str(e)
+            logger.error("Failed to create session: %s", e)
             return False
 
     def send_input(self, session_name: str, text: str) -> bool:

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -7,6 +7,7 @@ import sqlite3
 import time
 from datetime import datetime
 import subprocess
+from types import SimpleNamespace
 from unittest.mock import MagicMock, AsyncMock, patch
 from fastapi.testclient import TestClient
 
@@ -1724,6 +1725,66 @@ class TestHookEndpoints:
 
         data = response.json()
         assert data["status"] == "logged"
+
+    def test_remote_claude_hook_requires_secret(self, test_client, mock_session_manager, sample_session):
+        """Remote Claude hooks with configured node secrets reject spoofed payloads."""
+        sample_session.node = "worker"
+        mock_session_manager.get_session.return_value = sample_session
+        mock_session_manager.get_node_config.return_value = SimpleNamespace(hook_secret="secret123")
+
+        response = test_client.post(
+            "/hooks/claude",
+            json={
+                "hook_event_name": "Stop",
+                "session_manager_id": "test123",
+                "transcript_path": "/remote/transcript.jsonl",
+                "sm_last_message": "done",
+                "sm_transcript_mtime_ns": 123,
+            },
+        )
+        assert response.status_code == 403
+
+        ok_response = test_client.post(
+            "/hooks/claude",
+            headers={"X-SM-Hook-Secret": "secret123"},
+            json={
+                "hook_event_name": "Stop",
+                "session_manager_id": "test123",
+                "transcript_path": "/remote/transcript.jsonl",
+                "sm_last_message": "done",
+                "sm_transcript_mtime_ns": 123,
+            },
+        )
+        assert ok_response.status_code == 200
+
+    def test_remote_tool_use_hook_requires_secret(self, test_client, mock_session_manager, sample_session):
+        """Remote tool-use hooks share the same node secret check."""
+        sample_session.node = "worker"
+        mock_session_manager.get_session.return_value = sample_session
+        mock_session_manager.get_node_config.return_value = SimpleNamespace(hook_secret="secret123")
+
+        response = test_client.post(
+            "/hooks/tool-use",
+            json={
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Read",
+                "tool_input": {"file_path": "/tmp/test.py"},
+                "session_manager_id": "test123",
+            },
+        )
+        assert response.status_code == 403
+
+        ok_response = test_client.post(
+            "/hooks/tool-use",
+            headers={"X-SM-Hook-Secret": "secret123"},
+            json={
+                "hook_event_name": "PreToolUse",
+                "tool_name": "Read",
+                "tool_input": {"file_path": "/tmp/test.py"},
+                "session_manager_id": "test123",
+            },
+        )
+        assert ok_response.status_code == 200
 
 
 class TestSubagentEndpoints:

--- a/tests/unit/test_cmd_attach_descriptor.py
+++ b/tests/unit/test_cmd_attach_descriptor.py
@@ -76,3 +76,45 @@ def test_cmd_attach_uses_descriptor_tmux_socket(monkeypatch):
     assert calls == [
         (["tmux", "-L", "session-manager-test", "attach", "-t", "claude-claude1001"], True)
     ]
+
+
+def test_cmd_attach_uses_descriptor_attach_command(monkeypatch):
+    calls = []
+
+    def _fake_run(args, check):
+        calls.append((args, check))
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+
+    session = {
+        "id": "remote1001",
+        "provider": "claude",
+        "tmux_session": "claude-remote1001",
+        "status": "running",
+        "node": "worker",
+    }
+    descriptor = {
+        "session_id": "remote1001",
+        "provider": "claude",
+        "attach_supported": True,
+        "tmux_session": "claude-remote1001",
+        "node": "worker",
+        "attach_command": [
+            "ssh",
+            "-tt",
+            "worker",
+            "/bin/sh",
+            "-lc",
+            "'tmux attach -t claude-remote1001'",
+        ],
+    }
+
+    rc = commands.cmd_attach(_AttachClient(session, descriptor), "remote1001")
+
+    assert rc == 0
+    assert calls == [
+        (
+            ["ssh", "-tt", "worker", "/bin/sh", "-lc", "'tmux attach -t claude-remote1001'"],
+            True,
+        )
+    ]

--- a/tests/unit/test_cmd_new.py
+++ b/tests/unit/test_cmd_new.py
@@ -69,3 +69,58 @@ def test_cmd_new_surfaces_create_error_detail(tmp_path, capsys):
 
     assert rc == 1
     assert "Configured codex-fork runtime unavailable" in capsys.readouterr().err
+
+
+def test_cmd_new_skips_local_path_validation_for_remote_default():
+    client = MagicMock()
+    client.list_nodes.return_value = {"default": "worker", "nodes": []}
+    client.create_session_result.return_value = {
+        "ok": True,
+        "unavailable": False,
+        "data": {
+            "id": "remote123",
+            "provider": "claude",
+            "tmux_session": "claude-remote123",
+        },
+    }
+
+    with patch("subprocess.run") as run_mock, patch("time.sleep"):
+        rc = cmd_new(client, working_dir="/remote/only/path", provider="claude")
+
+    assert rc == 0
+    client.create_session_result.assert_called_once_with(
+        "/remote/only/path",
+        provider="claude",
+        parent_session_id=None,
+    )
+    run_mock.assert_called_once_with(["tmux", "attach", "-t", "claude-remote123"], check=True)
+
+
+def test_cmd_new_skips_local_path_validation_for_remote_parent():
+    client = MagicMock()
+    client.list_sessions.return_value = [{"id": "parent123", "node": "worker"}]
+    client.create_session_result.return_value = {
+        "ok": True,
+        "unavailable": False,
+        "data": {
+            "id": "child123",
+            "provider": "claude",
+            "tmux_session": "claude-child123",
+        },
+    }
+
+    with patch("subprocess.run") as run_mock, patch("time.sleep"):
+        rc = cmd_new(
+            client,
+            working_dir="/remote/parent/path",
+            provider="claude",
+            parent_session_id="parent123",
+        )
+
+    assert rc == 0
+    client.create_session_result.assert_called_once_with(
+        "/remote/parent/path",
+        provider="claude",
+        parent_session_id="parent123",
+    )
+    run_mock.assert_called_once_with(["tmux", "attach", "-t", "claude-child123"], check=True)

--- a/tests/unit/test_dispatch.py
+++ b/tests/unit/test_dispatch.py
@@ -397,35 +397,35 @@ class TestFullDispatch:
 class TestDeliveryModePassthrough:
     def test_urgent_passthrough(self):
         """--urgent flag produces delivery_mode='urgent'."""
-        _, _, _, _, mode, _, _ = parse_dispatch_args(
+        _, _, _, _, mode, _, _, _ = parse_dispatch_args(
             ["agent1", "--role", "engineer", "--urgent", "--issue", "1", "--spec", "s"]
         )
         assert mode == "urgent"
 
     def test_important_passthrough(self):
         """--important flag produces delivery_mode='important'."""
-        _, _, _, _, mode, _, _ = parse_dispatch_args(
+        _, _, _, _, mode, _, _, _ = parse_dispatch_args(
             ["agent1", "--role", "engineer", "--important", "--issue", "1", "--spec", "s"]
         )
         assert mode == "important"
 
     def test_steer_passthrough(self):
         """--steer flag produces delivery_mode='steer'."""
-        _, _, _, _, mode, _, _ = parse_dispatch_args(
+        _, _, _, _, mode, _, _, _ = parse_dispatch_args(
             ["agent1", "--role", "engineer", "--steer", "--issue", "1", "--spec", "s"]
         )
         assert mode == "steer"
 
     def test_default_sequential(self):
         """No delivery flag defaults to sequential."""
-        _, _, _, _, mode, _, _ = parse_dispatch_args(
+        _, _, _, _, mode, _, _, _ = parse_dispatch_args(
             ["agent1", "--role", "engineer", "--issue", "1", "--spec", "s"]
         )
         assert mode == "sequential"
 
     def test_precedence_urgent_over_important(self):
         """--urgent takes precedence over --important."""
-        _, _, _, _, mode, _, _ = parse_dispatch_args(
+        _, _, _, _, mode, _, _, _ = parse_dispatch_args(
             ["agent1", "--role", "engineer", "--urgent", "--important", "--issue", "1", "--spec", "s"]
         )
         assert mode == "urgent"
@@ -473,35 +473,44 @@ class TestExistingCommandsUnaffected:
 class TestParseDispatchArgs:
     def test_parses_basic_args(self):
         """Parses agent_id, role, and dynamic params."""
-        agent_id, role, dry_run, no_clear, mode, notify, params = parse_dispatch_args(
+        agent_id, role, dry_run, no_clear, mode, notify, node, params = parse_dispatch_args(
             ["my-agent", "--role", "engineer", "--issue", "42", "--spec", "s.md"]
         )
         assert agent_id == "my-agent"
         assert role == "engineer"
         assert dry_run is False
         assert no_clear is False
+        assert node is None
         assert params == {"issue": "42", "spec": "s.md"}
 
     def test_parses_dry_run(self):
         """--dry-run flag is captured."""
-        _, _, dry_run, _, _, _, _ = parse_dispatch_args(
+        _, _, dry_run, _, _, _, _, _ = parse_dispatch_args(
             ["agent1", "--role", "engineer", "--dry-run", "--issue", "1", "--spec", "s"]
         )
         assert dry_run is True
 
     def test_no_notify_on_stop(self):
         """--no-notify-on-stop sets notify_on_stop to False."""
-        _, _, _, _, _, notify, _ = parse_dispatch_args(
+        _, _, _, _, _, notify, _, _ = parse_dispatch_args(
             ["agent1", "--role", "engineer", "--no-notify-on-stop", "--issue", "1", "--spec", "s"]
         )
         assert notify is False
 
     def test_parses_dynamic_equals_syntax(self):
         """Dynamic args support --key=value inline form."""
-        _, _, _, _, _, _, params = parse_dispatch_args(
+        _, _, _, _, _, _, _, params = parse_dispatch_args(
             ["agent1", "--role", "engineer", "--issue=42", "--spec=docs/spec.md"]
         )
         assert params == {"issue": "42", "spec": "docs/spec.md"}
+
+    def test_node_is_reserved_static_flag(self):
+        """--node is parsed as a static dispatch option, not a template parameter."""
+        _, _, _, _, _, _, node, params = parse_dispatch_args(
+            ["agent1", "--role", "engineer", "--node", "worker", "--issue", "42", "--spec", "s.md"]
+        )
+        assert node == "worker"
+        assert params == {"issue": "42", "spec": "s.md"}
 
     def test_rejects_dynamic_missing_value_when_next_is_flag(self, capsys):
         """--key value form rejects when value token is another flag."""
@@ -982,14 +991,14 @@ class TestNoClearFlag:
 
     def test_no_clear_flag_parsed(self):
         """--no-clear flag sets no_clear=True in return tuple."""
-        _, _, _, no_clear, _, _, _ = parse_dispatch_args(
+        _, _, _, no_clear, _, _, _, _ = parse_dispatch_args(
             ["agent1", "--role", "engineer", "--no-clear", "--issue", "1", "--spec", "s"]
         )
         assert no_clear is True
 
     def test_no_clear_defaults_to_false(self):
         """Omitting --no-clear returns no_clear=False."""
-        _, _, _, no_clear, _, _, _ = parse_dispatch_args(
+        _, _, _, no_clear, _, _, _, _ = parse_dispatch_args(
             ["agent1", "--role", "engineer", "--issue", "1", "--spec", "s"]
         )
         assert no_clear is False
@@ -1039,6 +1048,33 @@ class TestNoClearFlag:
         assert exit_code == 0
         mock_clear.assert_not_called()
         mock_client.send_input.assert_called_once()
+
+    def test_existing_target_rejects_node_mismatch(self, sample_config, capsys):
+        """--node cannot migrate an existing dispatch target."""
+        mock_client = self._make_client()
+        mock_client.list_sessions.return_value = [
+            {
+                "id": "agent1",
+                "friendly_name": "eng",
+                "status": "running",
+                "node": "primary",
+            }
+        ]
+
+        with patch("src.cli.commands.os.getcwd", return_value="/tmp"), \
+             patch("src.cli.dispatch.load_template", return_value=sample_config), \
+             patch("src.cli.commands.cmd_clear", return_value=0) as mock_clear:
+            exit_code = cmd_dispatch(
+                mock_client, "agent1", "engineer",
+                {"issue": "42", "spec": "s.md"},
+                em_id="em-abc",
+                node="worker",
+            )
+
+        assert exit_code == 1
+        assert "--node worker does not match existing target node primary" in capsys.readouterr().err
+        mock_clear.assert_not_called()
+        mock_client.send_input.assert_not_called()
 
     def test_dry_run_skips_clear(self, sample_config, capsys):
         """--dry-run skips cmd_clear regardless of no_clear."""

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -28,6 +28,7 @@ class TestSession:
             working_dir="/tmp/workspace",
             tmux_session="claude-test123",
             log_file="/tmp/logs/test.log",
+            node="worker",
             status=SessionStatus.RUNNING,
             created_at=datetime(2024, 1, 15, 10, 30, 0),
             last_activity=datetime(2024, 1, 15, 11, 45, 0),
@@ -73,6 +74,7 @@ class TestSession:
         assert restored.working_dir == original.working_dir
         assert restored.tmux_session == original.tmux_session
         assert restored.log_file == original.log_file
+        assert restored.node == original.node
         assert restored.status == original.status
         assert restored.created_at == original.created_at
         assert restored.last_activity == original.last_activity
@@ -117,6 +119,7 @@ class TestSession:
         assert session.working_dir == ""
         assert session.tmux_session == f"claude-{session.id}"
         assert session.log_file == ""
+        assert session.node == "primary"
         assert session.status == SessionStatus.RUNNING
         assert isinstance(session.created_at, datetime)
         assert isinstance(session.last_activity, datetime)

--- a/tests/unit/test_node_runner.py
+++ b/tests/unit/test_node_runner.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 
 from src.node_runner import NodeRegistry, NodeRunner
 
@@ -54,3 +55,39 @@ def test_remote_attach_allocates_tty():
         "-lc",
         "'tmux attach -t claude-1234'",
     ]
+
+
+def test_remote_resolve_directory_expands_home_relative_path(monkeypatch):
+    registry = NodeRegistry.from_config(
+        {"nodes": {"registry": {"worker": {"ssh": "dev@example"}}}}
+    )
+    runner = NodeRunner(registry)
+    captured = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout="/home/dev/repo\n", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    resolved = runner.resolve_directory("worker", "~/repo")
+
+    assert resolved == "/home/dev/repo"
+    assert "${HOME%/}/${path#\\~/}" in captured["cmd"][-1]
+    assert "sh " in captured["cmd"][-1]
+    assert "~/repo" in captured["cmd"][-1]
+
+
+def test_remote_resolve_directory_returns_none_for_empty_stdout(monkeypatch):
+    registry = NodeRegistry.from_config(
+        {"nodes": {"registry": {"worker": {"ssh": "dev@example"}}}}
+    )
+    runner = NodeRunner(registry)
+
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 0, stdout="", stderr=""),
+    )
+
+    assert runner.resolve_directory("worker", "~/missing") is None

--- a/tests/unit/test_node_runner.py
+++ b/tests/unit/test_node_runner.py
@@ -1,0 +1,56 @@
+import os
+
+from src.node_runner import NodeRegistry, NodeRunner
+
+
+def test_primary_command_is_local_argv():
+    runner = NodeRunner(NodeRegistry.from_config({}))
+
+    assert runner.command("primary", ["tmux", "list-sessions"]) == ["tmux", "list-sessions"]
+
+
+def test_remote_command_uses_controlmaster_and_remote_shell():
+    registry = NodeRegistry.from_config(
+        {
+            "nodes": {
+                "registry": {
+                    "worker": {
+                        "ssh": "dev@example",
+                        "control_path": "~/.ssh/sm-worker",
+                    }
+                }
+            }
+        }
+    )
+    runner = NodeRunner(registry)
+
+    command = runner.command("worker", ["tmux", "has-session", "-t", "claude-1234"])
+
+    assert command[:2] == ["ssh", "-o"]
+    assert "ControlMaster=auto" in command
+    assert "ControlPersist=600" in command
+    assert "-S" in command
+    assert os.path.expanduser("~/.ssh/sm-worker") in command
+    assert command[-4:] == [
+        "dev@example",
+        "/bin/sh",
+        "-lc",
+        "'tmux has-session -t claude-1234'",
+    ]
+
+
+def test_remote_attach_allocates_tty():
+    registry = NodeRegistry.from_config(
+        {"nodes": {"registry": {"worker": {"ssh": "dev@example"}}}}
+    )
+    runner = NodeRunner(registry)
+
+    command = runner.attach_command("worker", ["tmux", "attach", "-t", "claude-1234"])
+
+    assert command[0:2] == ["ssh", "-tt"]
+    assert command[-4:] == [
+        "dev@example",
+        "/bin/sh",
+        "-lc",
+        "'tmux attach -t claude-1234'",
+    ]

--- a/tests/unit/test_node_runner.py
+++ b/tests/unit/test_node_runner.py
@@ -91,3 +91,54 @@ def test_remote_resolve_directory_returns_none_for_empty_stdout(monkeypatch):
     )
 
     assert runner.resolve_directory("worker", "~/missing") is None
+
+
+def test_primary_ensure_file_preserves_existing_content(tmp_path):
+    runner = NodeRunner(NodeRegistry.from_config({}))
+    log_file = tmp_path / "logs" / "session.log"
+    log_file.parent.mkdir()
+    log_file.write_text("existing output\n")
+
+    assert runner.ensure_file("primary", str(log_file)) is True
+    assert log_file.read_text() == "existing output\n"
+
+
+def test_remote_ensure_file_is_non_truncating_and_expands_home(monkeypatch):
+    registry = NodeRegistry.from_config(
+        {"nodes": {"registry": {"worker": {"ssh": "dev@example"}}}}
+    )
+    runner = NodeRunner(registry)
+    captured = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    assert runner.ensure_file("worker", "~/.sm/logs/session.log") is True
+    remote_payload = captured["cmd"][-1]
+    assert "${HOME%/}/${path#\\~/}" in remote_payload
+    assert ": >>" in remote_payload
+    assert ": > " not in remote_payload
+    assert "~/.sm/logs/session.log" in remote_payload
+
+
+def test_remote_command_available_expands_home_relative_path(monkeypatch):
+    registry = NodeRegistry.from_config(
+        {"nodes": {"registry": {"worker": {"ssh": "dev@example"}}}}
+    )
+    runner = NodeRunner(registry)
+    captured = {}
+
+    def _fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", _fake_run)
+
+    assert runner.command_available("worker", "~/bin/claude") is True
+    remote_payload = captured["cmd"][-1]
+    assert "${HOME%/}/${path#\\~/}" in remote_payload
+    assert 'test -f "$path" && test -x "$path"' in remote_payload
+    assert "~/bin/claude" in remote_payload

--- a/tests/unit/test_session_nodes.py
+++ b/tests/unit/test_session_nodes.py
@@ -11,6 +11,36 @@ def _manager(tmp_path):
     )
 
 
+def _manager_default_worker(tmp_path):
+    return SessionManager(
+        state_file=str(tmp_path / "sessions.json"),
+        config={
+            "nodes": {
+                "default": "worker",
+                "registry": {"worker": {"ssh": "dev@example"}},
+            }
+        },
+    )
+
+
+def test_create_node_validation_uses_configured_default_for_top_level_claude(tmp_path):
+    manager = _manager_default_worker(tmp_path)
+
+    node, error = manager.validate_create_node_provider("claude")
+
+    assert node == "worker"
+    assert error is None
+
+
+def test_create_node_validation_rejects_default_remote_codex(tmp_path):
+    manager = _manager_default_worker(tmp_path)
+
+    node, error = manager.validate_create_node_provider("codex-fork")
+
+    assert node == "worker"
+    assert error == "Remote placement is Claude-only in this phase (provider=codex-fork)"
+
+
 def test_create_node_validation_rejects_inherited_remote_codex(tmp_path):
     manager = _manager(tmp_path)
     parent = Session(id="parent1", node="worker")

--- a/tests/unit/test_session_nodes.py
+++ b/tests/unit/test_session_nodes.py
@@ -1,0 +1,116 @@
+import pytest
+
+from src.models import Session, SessionStatus
+from src.session_manager import SessionManager
+
+
+def _manager(tmp_path):
+    return SessionManager(
+        state_file=str(tmp_path / "sessions.json"),
+        config={"nodes": {"registry": {"worker": {"ssh": "dev@example"}}}},
+    )
+
+
+def test_create_node_validation_rejects_inherited_remote_codex(tmp_path):
+    manager = _manager(tmp_path)
+    parent = Session(id="parent1", node="worker")
+    manager.sessions[parent.id] = parent
+
+    node, error = manager.validate_create_node_provider(
+        "codex-fork",
+        parent_session_id=parent.id,
+    )
+
+    assert node == "worker"
+    assert error == "Remote placement is Claude-only in this phase (provider=codex-fork)"
+
+
+def test_create_node_validation_allows_inherited_remote_claude(tmp_path):
+    manager = _manager(tmp_path)
+    parent = Session(id="parent1", node="worker")
+    manager.sessions[parent.id] = parent
+
+    node, error = manager.validate_create_node_provider(
+        "claude",
+        parent_session_id=parent.id,
+    )
+
+    assert node == "worker"
+    assert error is None
+
+
+@pytest.mark.asyncio
+async def test_remote_node_transport_failure_does_not_stop_session(tmp_path):
+    manager = _manager(tmp_path)
+    session = Session(id="remote1", node="worker", provider="claude")
+    session.status = SessionStatus.RUNNING
+    manager.sessions[session.id] = session
+
+    class FailingTmux:
+        def session_exists(self, _tmux_session):
+            raise RuntimeError("Node worker unreachable: ssh transport failed")
+
+    manager.tmux = FailingTmux()
+
+    marked = await manager._mark_tmux_runtime_missing_if_absent(session)
+
+    assert marked is False
+    assert session.status == SessionStatus.RUNNING
+    assert manager.is_session_node_unreachable(session.id)
+
+
+def test_hydrate_preserves_remote_session_when_node_unreachable(tmp_path):
+    manager = _manager(tmp_path)
+    session = Session(id="remote2", node="worker", provider="claude")
+    session.status = SessionStatus.RUNNING
+
+    class FailingTmux:
+        def session_exists(self, _tmux_session):
+            raise RuntimeError("Node worker unreachable: ssh transport failed")
+
+    manager.tmux = FailingTmux()
+
+    manager._hydrate_state_from_data({"sessions": [session.to_dict()]})
+
+    assert "remote2" in manager.sessions
+    assert manager.sessions["remote2"].status == SessionStatus.RUNNING
+    assert manager.is_session_node_unreachable("remote2")
+
+
+def test_kill_remote_session_unreachable_does_not_stop_session(tmp_path):
+    manager = _manager(tmp_path)
+    session = Session(id="remote3", node="worker", provider="claude")
+    session.status = SessionStatus.RUNNING
+    manager.sessions[session.id] = session
+
+    class FailingTmux:
+        def kill_session(self, _tmux_session):
+            raise RuntimeError("Node worker unreachable: ssh transport failed")
+
+    manager.tmux = FailingTmux()
+
+    assert manager.kill_session(session.id) is False
+    assert session.status == SessionStatus.RUNNING
+    assert manager.is_session_node_unreachable(session.id)
+
+
+@pytest.mark.asyncio
+async def test_restore_remote_session_unreachable_returns_error(tmp_path):
+    manager = _manager(tmp_path)
+    session = Session(id="remote4", node="worker", provider="claude")
+    session.status = SessionStatus.RUNNING
+    manager.sessions[session.id] = session
+
+    class FailingTmux:
+        def session_exists(self, _tmux_session):
+            raise RuntimeError("Node worker unreachable: ssh transport failed")
+
+    manager.tmux = FailingTmux()
+
+    success, returned, error = await manager.restore_session(session.id)
+
+    assert success is False
+    assert returned is session
+    assert error == "Node worker unreachable"
+    assert session.status == SessionStatus.RUNNING
+    assert manager.is_session_node_unreachable(session.id)

--- a/tests/unit/test_tmux_controller.py
+++ b/tests/unit/test_tmux_controller.py
@@ -216,6 +216,54 @@ def test_create_session_with_command_enables_exit_diagnostics(tmp_path, monkeypa
     ) in calls
 
 
+def test_create_session_with_command_uses_remote_resolved_working_dir(tmp_path, monkeypatch):
+    controller = TmuxController(
+        log_dir=str(tmp_path),
+        config={"timeouts": {"tmux": {"shell_export_settle_seconds": 0}}},
+    )
+    calls = []
+    resolve_directory = MagicMock(return_value="/home/dev/repo")
+    command_available = MagicMock(return_value=True)
+    ensure_file = MagicMock(return_value=True)
+    monkeypatch.setattr(controller.node_runner, "resolve_directory", resolve_directory)
+    monkeypatch.setattr(controller.node_runner, "command_available", command_available)
+    monkeypatch.setattr(controller.node_runner, "ensure_file", ensure_file)
+
+    def _fake_run_tmux(*args, **kwargs):
+        calls.append(args)
+        if args[:3] == ("display-message", "-p", "-t"):
+            return MagicMock(returncode=0, stdout="%main\n")
+        return MagicMock(returncode=0, stdout="")
+
+    monkeypatch.setattr(controller, "_session_exists_for_node", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(controller, "_run_tmux", _fake_run_tmux)
+    monkeypatch.setattr("time.sleep", lambda _: None)
+
+    ok = controller.create_session_with_command(
+        "claude-remote",
+        "~/repo",
+        "/remote/logs/claude-remote.log",
+        command="claude",
+        node="worker",
+    )
+
+    assert ok is True
+    resolve_directory.assert_called_once_with("worker", "~/repo")
+    command_available.assert_called_once_with("worker", "claude", cwd="/home/dev/repo")
+    ensure_file.assert_called_once_with("worker", "/remote/logs/claude-remote.log")
+    assert (
+        "new-session",
+        "-d",
+        "-s",
+        "claude-remote",
+        "-c",
+        "/home/dev/repo",
+        "-n",
+        "__sm_bootstrap",
+    ) in calls
+    assert ("new-window", "-d", "-t", "claude-remote", "-n", "main", "-c", "/home/dev/repo") in calls
+
+
 def test_get_session_exit_diagnostics_reports_dead_pane(monkeypatch):
     controller = TmuxController(config={"tmux": {"socket_name": "session-manager-test"}})
     monkeypatch.setattr(

--- a/tests/unit/test_tmux_controller.py
+++ b/tests/unit/test_tmux_controller.py
@@ -264,6 +264,45 @@ def test_create_session_with_command_uses_remote_resolved_working_dir(tmp_path, 
     assert ("new-window", "-d", "-t", "claude-remote", "-n", "main", "-c", "/home/dev/repo") in calls
 
 
+def test_create_session_reports_remote_preflight_unreachable(tmp_path, monkeypatch):
+    controller = TmuxController(log_dir=str(tmp_path))
+
+    def _raise_unreachable(*_args, **_kwargs):
+        raise RuntimeError("Node worker unreachable: ssh transport failed")
+
+    monkeypatch.setattr(controller, "_session_exists_for_node", _raise_unreachable)
+
+    ok = controller.create_session(
+        "claude-remote",
+        "/home/dev/repo",
+        str(tmp_path / "claude-remote.log"),
+        node="worker",
+    )
+
+    assert ok is False
+    assert controller.last_error_message == "Node worker unreachable: ssh transport failed"
+
+
+def test_create_session_with_command_reports_remote_preflight_unreachable(tmp_path, monkeypatch):
+    controller = TmuxController(log_dir=str(tmp_path))
+
+    def _raise_unreachable(*_args, **_kwargs):
+        raise RuntimeError("Node worker unreachable: ssh transport failed")
+
+    monkeypatch.setattr(controller, "_session_exists_for_node", _raise_unreachable)
+
+    ok = controller.create_session_with_command(
+        "claude-remote",
+        "/home/dev/repo",
+        str(tmp_path / "claude-remote.log"),
+        command="claude",
+        node="worker",
+    )
+
+    assert ok is False
+    assert controller.last_error_message == "Node worker unreachable: ssh transport failed"
+
+
 def test_get_session_exit_diagnostics_reports_dead_pane(monkeypatch):
     controller = TmuxController(config={"tmux": {"socket_name": "session-manager-test"}})
     monkeypatch.setattr(

--- a/tests/unit/test_watch_tui.py
+++ b/tests/unit/test_watch_tui.py
@@ -77,6 +77,31 @@ def test_resolve_tmux_attach_target_hydrates_descriptor_socket():
     assert calls == ["agent123"]
 
 
+def test_resolve_tmux_attach_target_hydrates_descriptor_attach_command():
+    attach_command = ["ssh", "-tt", "worker", "/bin/sh", "-lc", "'tmux attach-session -t remote-target'"]
+    client = type(
+        "_Client",
+        (),
+        {
+            "get_attach_descriptor": staticmethod(
+                lambda session_id: {
+                    "attach_supported": True,
+                    "tmux_session": "remote-target",
+                    "attach_command": attach_command,
+                }
+            ),
+        },
+    )()
+    session = {"id": "agent123", "provider": "claude", "tmux_session": "stale-target"}
+
+    tmux_session, tmux_socket_name, error = _resolve_tmux_attach_target(client, session)
+
+    assert error is None
+    assert tmux_session == "remote-target"
+    assert tmux_socket_name is None
+    assert session["_attach_command"] == attach_command
+
+
 def test_resolve_tmux_attach_target_falls_back_to_session_without_descriptor():
     client = type("_Client", (), {"get_attach_descriptor": staticmethod(lambda session_id: None)})()
     session = {

--- a/web/sm-watch/src/components/WatchTable.tsx
+++ b/web/sm-watch/src/components/WatchTable.tsx
@@ -23,7 +23,7 @@ interface WatchTableProps {
 }
 
 const GRID_CLASS =
-  'grid min-w-[1180px] grid-cols-[minmax(18rem,2.5fr)_minmax(6rem,0.8fr)_minmax(12rem,1.5fr)_minmax(7rem,0.8fr)_minmax(8rem,0.9fr)_minmax(8rem,0.9fr)_minmax(7rem,0.8fr)_minmax(15rem,2fr)_minmax(4rem,0.55fr)] items-center gap-x-3';
+  'grid min-w-[1260px] grid-cols-[minmax(18rem,2.5fr)_minmax(6rem,0.8fr)_minmax(12rem,1.5fr)_minmax(7rem,0.8fr)_minmax(7rem,0.75fr)_minmax(8rem,0.9fr)_minmax(8rem,0.9fr)_minmax(7rem,0.8fr)_minmax(15rem,2fr)_minmax(4rem,0.55fr)] items-center gap-x-3';
 
 function normalizeChatId(chatId?: number | null): string {
   if (!chatId) {
@@ -66,6 +66,8 @@ function activityTone(activityState?: string): string {
     case 'waiting_input':
     case 'waiting_permission':
       return 'text-amber-300';
+    case 'node-unreachable':
+      return 'text-orange-300';
     case 'stopped':
       return 'text-rose-300';
     default:
@@ -197,6 +199,7 @@ export function WatchTable({
             <div>ID</div>
             <div>Parent</div>
             <div>Role</div>
+            <div>Node</div>
             <div>Provider</div>
             <div>Activity</div>
             <div>Status</div>
@@ -283,6 +286,7 @@ export function WatchTable({
                   <div className="font-mono text-[12px] text-zinc-300">{row.columns.ID}</div>
                   <div className="truncate text-[12px] text-zinc-400">{row.columns.Parent}</div>
                   <div className="truncate text-[12px] text-zinc-300">{row.columns.Role}</div>
+                  <div className="truncate font-mono text-[12px] text-zinc-400">{row.columns.Node}</div>
                   <div className={`truncate text-[12px] font-medium ${providerTone(row.columns.Provider)}`}>{row.columns.Provider}</div>
                   <div className={`truncate text-[12px] font-semibold uppercase tracking-[0.16em] ${activityTone(row.activityState)}`}>
                     {row.columns.Activity}

--- a/web/sm-watch/src/types.ts
+++ b/web/sm-watch/src/types.ts
@@ -6,6 +6,7 @@ export type ActivityState =
   | 'waiting'
   | 'waiting_permission'
   | 'waiting_input'
+  | 'node-unreachable'
   | 'stopped';
 
 export interface AdoptionProposal {
@@ -67,6 +68,7 @@ export interface Session {
   name: string;
   working_dir: string;
   status: SessionStatus;
+  node?: string;
   created_at: string;
   last_activity: string;
   tmux_session: string;

--- a/web/sm-watch/src/watchModel.ts
+++ b/web/sm-watch/src/watchModel.ts
@@ -369,6 +369,7 @@ export function buildWatchRows(
         ID: session.id,
         Parent: parentLabel(session, sessionsById),
         Role: session.role || (session.is_em ? 'em' : '-'),
+        Node: session.node || 'primary',
         Provider: session.provider || 'claude',
         Activity: stateLabel(session.activity_state),
         Status: session.status || '-',


### PR DESCRIPTION
## Summary
- Add first-class Session.node persistence, node registry, and SSH-routed NodeRunner for tmux/session operations
- Route spawn, send/status/kill/attach/output/monitor paths through per-session node resolution while keeping primary behavior unchanged
- Wire remote Claude runtime env, hook/tool-use forwarding with per-node shared-secret auth, inline transcript metadata, and computed node-unreachable overlay
- Expose node APIs/CLI/watch UI surfaces and reserve dispatch --node semantics

## Spec Reference
- specs/752_remote_managed_nodes.md

## Test Plan
- [x] pytest tests/unit -q
- [x] pytest tests/integration/test_api_endpoints.py -q
- [x] pytest tests/regression -q
- [x] npm run lint (web/sm-watch)
- [x] python -m py_compile src/node_runner.py src/models.py src/tmux_controller.py src/session_manager.py src/server.py src/output_monitor.py src/cli/client.py src/cli/dispatch.py src/cli/main.py src/cli/commands.py src/cli/formatting.py src/cli/watch_tui.py
- [x] bash -n hooks/notify_server.sh hooks/log_tool_use.sh
- [x] git diff --check

Fixes #752