### PR TITLE
Implement remote codex-fork transport

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "pydantic>=2.0.0",
     "google-auth>=2.39.0",
     "cryptography>=42.0.0",
+    "websockets>=12.0",
 ]
 
 [project.optional-dependencies]
@@ -46,6 +47,7 @@ dev = [
 [project.scripts]
 claude-session-manager = "src.main:run"
 sm = "src.cli.main:main"
+sm-node-agent = "src.node_agent:main"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ PyYAML>=6.0
 pydantic>=2.0.0
 google-auth>=2.39.0
 cryptography>=42.0.0
+websockets>=12.0
 pytest>=7.0
 pytest-asyncio>=0.21
 pytest-cov>=4.0

--- a/src/codex_event_store.py
+++ b/src/codex_event_store.py
@@ -105,6 +105,27 @@ class CodexEventStore:
                 ON codex_assistant_relays(relayed_at)
                 """
             )
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS codex_fork_provider_cursors (
+                    session_id TEXT PRIMARY KEY,
+                    session_epoch_json TEXT NOT NULL,
+                    seq INTEGER NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+                """
+            )
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS codex_fork_provider_event_positions (
+                    session_id TEXT NOT NULL,
+                    session_epoch_json TEXT NOT NULL,
+                    seq INTEGER NOT NULL,
+                    applied_at TEXT NOT NULL,
+                    PRIMARY KEY (session_id, session_epoch_json, seq)
+                )
+                """
+            )
             conn.commit()
 
     def _start_startup_maintenance(self) -> None:
@@ -375,6 +396,166 @@ class CodexEventStore:
             if not ring:
                 return []
             return list(ring)[-limit:]
+
+    @staticmethod
+    def encode_provider_epoch(value: Any) -> str:
+        """Return a stable string key for a provider session_epoch value."""
+        return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+    @staticmethod
+    def decode_provider_epoch(value: str) -> Any:
+        try:
+            return json.loads(value)
+        except Exception:
+            return value
+
+    def get_codex_fork_provider_cursor(self, session_id: str) -> Optional[dict[str, Any]]:
+        """Return the durable codex-fork provider cursor for one SM session."""
+        with self._lock:
+            conn = self._get_conn()
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT session_epoch_json, seq, updated_at
+                FROM codex_fork_provider_cursors
+                WHERE session_id = ?
+                """,
+                (session_id,),
+            )
+            row = cursor.fetchone()
+            if not row:
+                return None
+            epoch_json, seq, updated_at = row
+            return {
+                "session_id": session_id,
+                "session_epoch": self.decode_provider_epoch(epoch_json),
+                "session_epoch_key": epoch_json,
+                "seq": int(seq),
+                "updated_at": updated_at,
+            }
+
+    def set_codex_fork_provider_cursor(
+        self,
+        session_id: str,
+        *,
+        session_epoch: Any,
+        seq: int,
+        timestamp: Optional[datetime] = None,
+    ) -> dict[str, Any]:
+        """Persist the last applied codex-fork provider `(session_epoch, seq)` cursor."""
+        epoch_json = self.encode_provider_epoch(session_epoch)
+        updated_at = (timestamp or datetime.now(timezone.utc)).astimezone(timezone.utc).isoformat()
+        with self._lock:
+            conn = self._get_conn()
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                INSERT INTO codex_fork_provider_cursors
+                (session_id, session_epoch_json, seq, updated_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(session_id) DO UPDATE SET
+                    session_epoch_json = excluded.session_epoch_json,
+                    seq = excluded.seq,
+                    updated_at = excluded.updated_at
+                """,
+                (session_id, epoch_json, int(seq), updated_at),
+            )
+            conn.commit()
+        return {
+            "session_id": session_id,
+            "session_epoch": session_epoch,
+            "session_epoch_key": epoch_json,
+            "seq": int(seq),
+            "updated_at": updated_at,
+        }
+
+    def claim_codex_fork_provider_event(
+        self,
+        session_id: str,
+        *,
+        session_epoch: Any,
+        seq: int,
+        timestamp: Optional[datetime] = None,
+    ) -> tuple[bool, Optional[dict[str, Any]], Optional[dict[str, Any]]]:
+        """Claim one provider event position before ingesting it.
+
+        Returns `(claimed, previous_cursor, new_cursor)`. Duplicate positions
+        return `claimed=False` and do not advance the cursor.
+        """
+        epoch_json = self.encode_provider_epoch(session_epoch)
+        applied_at = (timestamp or datetime.now(timezone.utc)).astimezone(timezone.utc).isoformat()
+        with self._lock:
+            conn = self._get_conn()
+            cursor = conn.cursor()
+            cursor.execute(
+                """
+                SELECT session_epoch_json, seq, updated_at
+                FROM codex_fork_provider_cursors
+                WHERE session_id = ?
+                """,
+                (session_id,),
+            )
+            row = cursor.fetchone()
+            previous_cursor = None
+            if row:
+                previous_cursor = {
+                    "session_id": session_id,
+                    "session_epoch": self.decode_provider_epoch(row[0]),
+                    "session_epoch_key": row[0],
+                    "seq": int(row[1]),
+                    "updated_at": row[2],
+                }
+                if row[0] == epoch_json and int(seq) <= int(row[1]):
+                    return False, previous_cursor, previous_cursor
+            try:
+                cursor.execute(
+                    """
+                    INSERT INTO codex_fork_provider_event_positions
+                    (session_id, session_epoch_json, seq, applied_at)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    (session_id, epoch_json, int(seq), applied_at),
+                )
+            except sqlite3.IntegrityError:
+                conn.rollback()
+                return False, previous_cursor, previous_cursor
+
+            cursor.execute(
+                """
+                INSERT INTO codex_fork_provider_cursors
+                (session_id, session_epoch_json, seq, updated_at)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(session_id) DO UPDATE SET
+                    session_epoch_json = excluded.session_epoch_json,
+                    seq = excluded.seq,
+                    updated_at = excluded.updated_at
+                """,
+                (session_id, epoch_json, int(seq), applied_at),
+            )
+            conn.commit()
+        new_cursor = {
+            "session_id": session_id,
+            "session_epoch": session_epoch,
+            "session_epoch_key": epoch_json,
+            "seq": int(seq),
+            "updated_at": applied_at,
+        }
+        return True, previous_cursor, new_cursor
+
+    def clear_codex_fork_provider_cursor(self, session_id: str) -> None:
+        """Delete the durable provider cursor for one codex-fork session."""
+        with self._lock:
+            conn = self._get_conn()
+            cursor = conn.cursor()
+            cursor.execute(
+                "DELETE FROM codex_fork_provider_cursors WHERE session_id = ?",
+                (session_id,),
+            )
+            cursor.execute(
+                "DELETE FROM codex_fork_provider_event_positions WHERE session_id = ?",
+                (session_id,),
+            )
+            conn.commit()
 
     def has_assistant_message_relayed(
         self,

--- a/src/codex_event_store.py
+++ b/src/codex_event_store.py
@@ -295,6 +295,22 @@ class CodexEventStore:
                 self._append_ring_event_locked(fallback_event)
                 return fallback_event
 
+    def delete_event(self, session_id: str, seq: int) -> None:
+        """Best-effort delete of one persisted event row by store-local sequence."""
+        with self._lock:
+            conn = self._get_conn()
+            cursor = conn.cursor()
+            cursor.execute(
+                "DELETE FROM codex_session_events WHERE session_id = ? AND seq = ?",
+                (session_id, int(seq)),
+            )
+            conn.commit()
+            ring = self._ring_events.get(session_id)
+            if ring:
+                retained = [event for event in ring if event.get("seq") != int(seq)]
+                ring.clear()
+                ring.extend(retained)
+
     def get_events(self, session_id: str, since_seq: Optional[int] = None, limit: int = 200) -> dict[str, Any]:
         """Read persisted events for a session using sequence cursor semantics."""
         limit = max(1, min(limit, 500))
@@ -469,21 +485,19 @@ class CodexEventStore:
             "updated_at": updated_at,
         }
 
-    def claim_codex_fork_provider_event(
+    def should_ingest_codex_fork_provider_event(
         self,
         session_id: str,
         *,
         session_epoch: Any,
         seq: int,
-        timestamp: Optional[datetime] = None,
-    ) -> tuple[bool, Optional[dict[str, Any]], Optional[dict[str, Any]]]:
-        """Claim one provider event position before ingesting it.
+    ) -> tuple[bool, Optional[dict[str, Any]]]:
+        """Return whether a provider event position has not been applied yet.
 
-        Returns `(claimed, previous_cursor, new_cursor)`. Duplicate positions
-        return `claimed=False` and do not advance the cursor.
+        This is deliberately read-only. The durable cursor is advanced only
+        after event persistence and lifecycle reduction complete.
         """
         epoch_json = self.encode_provider_epoch(session_epoch)
-        applied_at = (timestamp or datetime.now(timezone.utc)).astimezone(timezone.utc).isoformat()
         with self._lock:
             conn = self._get_conn()
             cursor = conn.cursor()
@@ -506,8 +520,53 @@ class CodexEventStore:
                     "updated_at": row[2],
                 }
                 if row[0] == epoch_json and int(seq) <= int(row[1]):
-                    return False, previous_cursor, previous_cursor
+                    return False, previous_cursor
+            cursor.execute(
+                """
+                SELECT 1
+                FROM codex_fork_provider_event_positions
+                WHERE session_id = ? AND session_epoch_json = ? AND seq = ?
+                """,
+                (session_id, epoch_json, int(seq)),
+            )
+            if cursor.fetchone():
+                return False, previous_cursor
+        return True, previous_cursor
+
+    def record_codex_fork_provider_event_applied(
+        self,
+        session_id: str,
+        *,
+        session_epoch: Any,
+        seq: int,
+        timestamp: Optional[datetime] = None,
+    ) -> tuple[Optional[dict[str, Any]], dict[str, Any]]:
+        """Persist one fully applied provider event position and advance the cursor."""
+        epoch_json = self.encode_provider_epoch(session_epoch)
+        applied_at = (timestamp or datetime.now(timezone.utc)).astimezone(timezone.utc).isoformat()
+        with self._lock:
+            conn = self._get_conn()
+            cursor = conn.cursor()
             try:
+                cursor.execute("BEGIN IMMEDIATE")
+                cursor.execute(
+                    """
+                    SELECT session_epoch_json, seq, updated_at
+                    FROM codex_fork_provider_cursors
+                    WHERE session_id = ?
+                    """,
+                    (session_id,),
+                )
+                row = cursor.fetchone()
+                previous_cursor = None
+                if row:
+                    previous_cursor = {
+                        "session_id": session_id,
+                        "session_epoch": self.decode_provider_epoch(row[0]),
+                        "session_epoch_key": row[0],
+                        "seq": int(row[1]),
+                        "updated_at": row[2],
+                    }
                 cursor.execute(
                     """
                     INSERT INTO codex_fork_provider_event_positions
@@ -518,21 +577,52 @@ class CodexEventStore:
                 )
             except sqlite3.IntegrityError:
                 conn.rollback()
-                return False, previous_cursor, previous_cursor
-
-            cursor.execute(
-                """
-                INSERT INTO codex_fork_provider_cursors
-                (session_id, session_epoch_json, seq, updated_at)
-                VALUES (?, ?, ?, ?)
-                ON CONFLICT(session_id) DO UPDATE SET
-                    session_epoch_json = excluded.session_epoch_json,
-                    seq = excluded.seq,
-                    updated_at = excluded.updated_at
-                """,
-                (session_id, epoch_json, int(seq), applied_at),
-            )
-            conn.commit()
+                cursor = conn.cursor()
+                cursor.execute(
+                    """
+                    SELECT session_epoch_json, seq, updated_at
+                    FROM codex_fork_provider_cursors
+                    WHERE session_id = ?
+                    """,
+                    (session_id,),
+                )
+                current = cursor.fetchone()
+                if current:
+                    return previous_cursor, {
+                        "session_id": session_id,
+                        "session_epoch": self.decode_provider_epoch(current[0]),
+                        "session_epoch_key": current[0],
+                        "seq": int(current[1]),
+                        "updated_at": current[2],
+                    }
+                return previous_cursor, {
+                    "session_id": session_id,
+                    "session_epoch": session_epoch,
+                    "session_epoch_key": epoch_json,
+                    "seq": int(seq),
+                    "updated_at": applied_at,
+                }
+            except Exception:
+                conn.rollback()
+                raise
+            else:
+                try:
+                    cursor.execute(
+                        """
+                        INSERT INTO codex_fork_provider_cursors
+                        (session_id, session_epoch_json, seq, updated_at)
+                        VALUES (?, ?, ?, ?)
+                        ON CONFLICT(session_id) DO UPDATE SET
+                            session_epoch_json = excluded.session_epoch_json,
+                            seq = excluded.seq,
+                            updated_at = excluded.updated_at
+                        """,
+                        (session_id, epoch_json, int(seq), applied_at),
+                    )
+                    conn.commit()
+                except Exception:
+                    conn.rollback()
+                    raise
         new_cursor = {
             "session_id": session_id,
             "session_epoch": session_epoch,
@@ -540,6 +630,30 @@ class CodexEventStore:
             "seq": int(seq),
             "updated_at": applied_at,
         }
+        return previous_cursor, new_cursor
+
+    def claim_codex_fork_provider_event(
+        self,
+        session_id: str,
+        *,
+        session_epoch: Any,
+        seq: int,
+        timestamp: Optional[datetime] = None,
+    ) -> tuple[bool, Optional[dict[str, Any]], Optional[dict[str, Any]]]:
+        """Compatibility wrapper: check and immediately mark one provider event applied."""
+        should_ingest, previous_cursor = self.should_ingest_codex_fork_provider_event(
+            session_id,
+            session_epoch=session_epoch,
+            seq=seq,
+        )
+        if not should_ingest:
+            return False, previous_cursor, previous_cursor
+        previous_cursor, new_cursor = self.record_codex_fork_provider_event_applied(
+            session_id,
+            session_epoch=session_epoch,
+            seq=seq,
+            timestamp=timestamp,
+        )
         return True, previous_cursor, new_cursor
 
     def clear_codex_fork_provider_cursor(self, session_id: str) -> None:

--- a/src/codex_fork_remote.py
+++ b/src/codex_fork_remote.py
@@ -1,0 +1,353 @@
+"""Primary-side remote codex-fork node-agent connection registry."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import uuid
+from abc import ABC, abstractmethod
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class CodexForkBridgePaths:
+    """Node-local codex-fork artifact paths registered with a node-agent."""
+
+    event_stream_path: str
+    control_socket_path: str
+
+
+class CodexForkTransport(ABC):
+    """Raw codex-fork IPC transport selected by the owning session's node."""
+
+    @abstractmethod
+    async def register_event_stream(self) -> Optional[asyncio.Queue[Optional[str]]]:
+        """Prepare the event source for monitoring and return a queue for remote streams."""
+
+    @abstractmethod
+    async def control_roundtrip(self, request: dict[str, Any]) -> dict[str, Any]:
+        """Perform one codex-fork control protocol request/response round-trip."""
+
+
+class LocalCodexForkTransport(CodexForkTransport):
+    """Primary-local transport using the existing filesystem tail and AF_UNIX socket."""
+
+    def __init__(
+        self,
+        *,
+        socket_path: Path,
+        roundtrip: Callable[[Path, dict[str, Any]], Awaitable[dict[str, Any]]],
+    ):
+        self.socket_path = socket_path
+        self._roundtrip = roundtrip
+
+    async def register_event_stream(self) -> Optional[asyncio.Queue[Optional[str]]]:
+        return None
+
+    async def control_roundtrip(self, request: dict[str, Any]) -> dict[str, Any]:
+        return await self._roundtrip(self.socket_path, request)
+
+
+class RemoteCodexForkTransport(CodexForkTransport):
+    """Remote transport over a node-agent WebSocket."""
+
+    def __init__(
+        self,
+        *,
+        registry: "NodeAgentRegistry",
+        node_id: str,
+        session_id: str,
+        event_stream_path: str,
+        control_socket_path: str,
+        cursor: Optional[dict[str, Any]],
+        control_timeout: float,
+        registration_timeout: float = 5.0,
+    ):
+        self.registry = registry
+        self.node_id = node_id
+        self.session_id = session_id
+        self.event_stream_path = event_stream_path
+        self.control_socket_path = control_socket_path
+        self.cursor = cursor
+        self.control_timeout = control_timeout
+        self.registration_timeout = registration_timeout
+
+    async def register_event_stream(self) -> Optional[asyncio.Queue[Optional[str]]]:
+        return await self.registry.register_session(
+            node_id=self.node_id,
+            session_id=self.session_id,
+            event_stream_path=self.event_stream_path,
+            control_socket_path=self.control_socket_path,
+            cursor=self.cursor,
+            timeout=self.registration_timeout,
+        )
+
+    async def control_roundtrip(self, request: dict[str, Any]) -> dict[str, Any]:
+        return await self.registry.control_roundtrip(
+            node_id=self.node_id,
+            session_id=self.session_id,
+            frame=request,
+            timeout=self.control_timeout,
+        )
+
+
+class NodeAgentConnection:
+    """One live node-initiated WebSocket bridge for codex-fork IPC."""
+
+    def __init__(self, node_id: str, websocket: Any):
+        self.node_id = node_id
+        self.websocket = websocket
+        self.connected = True
+        self._send_lock = asyncio.Lock()
+        self._register_lock = asyncio.Lock()
+        self._event_queues: dict[str, asyncio.Queue[Optional[str]]] = {}
+        self._pending_control: dict[str, asyncio.Future[dict[str, Any]]] = {}
+        self._pending_register: dict[str, asyncio.Future[None]] = {}
+        self._registered_paths: dict[str, CodexForkBridgePaths] = {}
+
+    def is_healthy(self) -> bool:
+        return self.connected
+
+    def event_queue(self, session_id: str) -> asyncio.Queue[Optional[str]]:
+        queue = self._event_queues.get(session_id)
+        if queue is None:
+            queue = asyncio.Queue()
+            self._event_queues[session_id] = queue
+        return queue
+
+    async def send(self, frame: dict[str, Any]) -> None:
+        if not self.connected:
+            raise RuntimeError(f"Node-agent {self.node_id} is not connected")
+        async with self._send_lock:
+            await self.websocket.send_json(frame)
+
+    async def register_session(
+        self,
+        *,
+        session_id: str,
+        event_stream_path: str,
+        control_socket_path: str,
+        cursor: Optional[dict[str, Any]] = None,
+        timeout: float = 5.0,
+    ) -> asyncio.Queue[Optional[str]]:
+        async with self._register_lock:
+            queue = self.event_queue(session_id)
+            paths = CodexForkBridgePaths(
+                event_stream_path=event_stream_path,
+                control_socket_path=control_socket_path,
+            )
+            loop = asyncio.get_running_loop()
+            future: asyncio.Future[None] = loop.create_future()
+            self._pending_register[session_id] = future
+            try:
+                await self.send(
+                    {
+                        "type": "register",
+                        "session_id": session_id,
+                        "event_stream_path": event_stream_path,
+                        "control_socket_path": control_socket_path,
+                        "cursor": cursor,
+                    }
+                )
+                await asyncio.wait_for(future, timeout=timeout)
+                self._registered_paths[session_id] = paths
+            except Exception:
+                self._registered_paths.pop(session_id, None)
+                raise
+            finally:
+                self._pending_register.pop(session_id, None)
+            return queue
+
+    async def unregister_session(self, session_id: str) -> None:
+        self._registered_paths.pop(session_id, None)
+        self._event_queues.pop(session_id, None)
+        if self.connected:
+            with contextlib.suppress(Exception):
+                await self.send({"type": "unregister", "session_id": session_id})
+
+    async def control_roundtrip(
+        self,
+        *,
+        session_id: str,
+        frame: dict[str, Any],
+        timeout: float,
+    ) -> dict[str, Any]:
+        bridge_request_id = uuid.uuid4().hex
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[dict[str, Any]] = loop.create_future()
+        self._pending_control[bridge_request_id] = future
+        try:
+            await self.send(
+                {
+                    "type": "control",
+                    "request_id": bridge_request_id,
+                    "session_id": session_id,
+                    "frame": frame,
+                }
+            )
+            return await asyncio.wait_for(future, timeout=timeout)
+        finally:
+            self._pending_control.pop(bridge_request_id, None)
+
+    async def handle_frame(self, frame: dict[str, Any]) -> None:
+        frame_type = frame.get("type")
+        if frame_type == "event":
+            session_id = str(frame.get("session_id") or "").strip()
+            line = frame.get("line")
+            if not session_id or not isinstance(line, str):
+                logger.debug("Skipping malformed node-agent event frame from %s", self.node_id)
+                return
+            await self.event_queue(session_id).put(line)
+            return
+
+        if frame_type == "event_gap":
+            logger.warning(
+                "Remote codex-fork event gap on node %s session %s: %s",
+                self.node_id,
+                frame.get("session_id"),
+                frame,
+            )
+            return
+
+        if frame_type == "registered":
+            session_id = str(frame.get("session_id") or "").strip()
+            future = self._pending_register.get(session_id)
+            if future is not None and not future.done():
+                future.set_result(None)
+            return
+
+        if frame_type == "register_failed":
+            session_id = str(frame.get("session_id") or "").strip()
+            future = self._pending_register.get(session_id)
+            if future is not None and not future.done():
+                future.set_exception(RuntimeError(str(frame.get("error") or "node-agent registration failed")))
+            return
+
+        if frame_type == "control_result":
+            request_id = str(frame.get("request_id") or "").strip()
+            future = self._pending_control.get(request_id)
+            if future is None or future.done():
+                return
+            if frame.get("ok") is False:
+                error = frame.get("error") or "remote control failed"
+                if isinstance(error, dict):
+                    future.set_result({"ok": False, "error": error})
+                    return
+                future.set_exception(RuntimeError(str(error)))
+                return
+            response = frame.get("response")
+            if isinstance(response, dict):
+                future.set_result(response)
+                return
+            line = frame.get("line")
+            if isinstance(line, str):
+                try:
+                    future.set_result(json.loads(line))
+                except json.JSONDecodeError as exc:
+                    future.set_exception(RuntimeError(f"control socket returned invalid JSON: {exc}"))
+                return
+            future.set_exception(RuntimeError("remote control returned no response"))
+            return
+
+        if frame_type in {"runtime_ready", "pong"}:
+            return
+
+        logger.debug("Ignoring unknown node-agent frame from %s: %s", self.node_id, frame_type)
+
+    async def close(self) -> None:
+        self.connected = False
+        for future in list(self._pending_control.values()):
+            if not future.done():
+                future.set_exception(RuntimeError(f"Node-agent {self.node_id} disconnected"))
+        self._pending_control.clear()
+        for future in list(self._pending_register.values()):
+            if not future.done():
+                future.set_exception(RuntimeError(f"Node-agent {self.node_id} disconnected"))
+        self._pending_register.clear()
+        for queue in list(self._event_queues.values()):
+            await queue.put(None)
+
+
+class NodeAgentRegistry:
+    """Tracks connected node-agent WebSockets and per-session bridges."""
+
+    def __init__(self):
+        self._connections: dict[str, NodeAgentConnection] = {}
+        self._session_nodes: dict[str, str] = {}
+
+    def is_connected(self, node_id: str) -> bool:
+        connection = self._connections.get(node_id)
+        return bool(connection and connection.is_healthy())
+
+    def get(self, node_id: str) -> Optional[NodeAgentConnection]:
+        connection = self._connections.get(node_id)
+        if connection and connection.is_healthy():
+            return connection
+        return None
+
+    async def attach(self, connection: NodeAgentConnection) -> None:
+        previous = self._connections.get(connection.node_id)
+        if previous is not None and previous is not connection:
+            await previous.close()
+        self._connections[connection.node_id] = connection
+
+    async def detach(self, connection: NodeAgentConnection) -> None:
+        current = self._connections.get(connection.node_id)
+        if current is connection:
+            self._connections.pop(connection.node_id, None)
+        await connection.close()
+
+    async def register_session(
+        self,
+        *,
+        node_id: str,
+        session_id: str,
+        event_stream_path: str,
+        control_socket_path: str,
+        cursor: Optional[dict[str, Any]] = None,
+        timeout: float = 5.0,
+    ) -> asyncio.Queue[Optional[str]]:
+        connection = self.get(node_id)
+        if connection is None:
+            raise RuntimeError(f"Node-agent for {node_id} is not connected")
+        queue = await connection.register_session(
+            session_id=session_id,
+            event_stream_path=event_stream_path,
+            control_socket_path=control_socket_path,
+            cursor=cursor,
+            timeout=timeout,
+        )
+        self._session_nodes[session_id] = node_id
+        return queue
+
+    async def unregister_session(self, session_id: str) -> None:
+        node_id = self._session_nodes.pop(session_id, None)
+        if not node_id:
+            return
+        connection = self.get(node_id)
+        if connection is not None:
+            await connection.unregister_session(session_id)
+
+    async def control_roundtrip(
+        self,
+        *,
+        node_id: str,
+        session_id: str,
+        frame: dict[str, Any],
+        timeout: float,
+    ) -> dict[str, Any]:
+        connection = self.get(node_id)
+        if connection is None:
+            raise RuntimeError(f"Node-agent for {node_id} is not connected")
+        return await connection.control_roundtrip(
+            session_id=session_id,
+            frame=frame,
+            timeout=timeout,
+        )

--- a/src/codex_fork_remote.py
+++ b/src/codex_fork_remote.py
@@ -190,6 +190,7 @@ class NodeAgentConnection:
                     "request_id": bridge_request_id,
                     "session_id": session_id,
                     "frame": frame,
+                    "timeout": timeout,
                 }
             )
             return await asyncio.wait_for(future, timeout=timeout)

--- a/src/node_agent.py
+++ b/src/node_agent.py
@@ -1,0 +1,439 @@
+"""Node-local codex-fork IPC bridge agent.
+
+The agent dials the primary Session Manager over WebSocket, tails node-local
+codex-fork event JSONL files, and relays control RPCs to node-local AF_UNIX
+control sockets.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+from urllib.parse import urlparse, urlunparse
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ProviderCursor:
+    session_epoch_key: Optional[str] = None
+    seq: Optional[int] = None
+
+    @classmethod
+    def from_payload(cls, payload: Any) -> "ProviderCursor":
+        if not isinstance(payload, dict):
+            return cls()
+        epoch_value = payload.get("session_epoch")
+        epoch_key = payload.get("session_epoch_key")
+        if not isinstance(epoch_key, str):
+            epoch_key = _epoch_key(epoch_value) if epoch_value is not None else None
+        seq = _coerce_seq(payload.get("seq"))
+        return cls(session_epoch_key=epoch_key, seq=seq)
+
+    def should_send(self, epoch_value: Any, seq: Optional[int]) -> bool:
+        if seq is None:
+            return True
+        epoch_key = _epoch_key(epoch_value)
+        if self.session_epoch_key is not None and epoch_key == self.session_epoch_key:
+            return self.seq is None or seq > self.seq
+        return True
+
+    def note_sent(self, epoch_value: Any, seq: Optional[int]) -> Optional[dict[str, Any]]:
+        if seq is None:
+            return None
+        epoch_key = _epoch_key(epoch_value)
+        gap = None
+        if self.session_epoch_key is not None and epoch_key == self.session_epoch_key:
+            if self.seq is not None and seq > self.seq + 1:
+                gap = {
+                    "previous_seq": self.seq,
+                    "next_seq": seq,
+                    "session_epoch": epoch_value,
+                }
+        self.session_epoch_key = epoch_key
+        self.seq = seq
+        return gap
+
+
+def _epoch_key(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _coerce_seq(value: Any) -> Optional[int]:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str) and value.isdigit():
+        return int(value)
+    return None
+
+
+def _ws_url(primary_url: str) -> str:
+    parsed = urlparse(primary_url)
+    scheme = parsed.scheme
+    if scheme == "http":
+        scheme = "ws"
+    elif scheme == "https":
+        scheme = "wss"
+    elif scheme not in {"ws", "wss"}:
+        raise ValueError(f"Unsupported primary URL scheme: {parsed.scheme}")
+    path = (parsed.path or "").rstrip("/") + "/nodes/agent"
+    return urlunparse((scheme, parsed.netloc, path, "", "", ""))
+
+
+class TailRegistration:
+    def __init__(
+        self,
+        *,
+        websocket: Any,
+        session_id: str,
+        event_stream_path: Path,
+        control_socket_path: Path,
+        cursor: ProviderCursor,
+        poll_interval: float,
+    ):
+        self.websocket = websocket
+        self.session_id = session_id
+        self.event_stream_path = event_stream_path
+        self.control_socket_path = control_socket_path
+        self.cursor = cursor
+        self.poll_interval = poll_interval
+        self.offset = 0
+        self.buffer = ""
+        self.ready_sent = False
+        self.task: Optional[asyncio.Task[Any]] = None
+
+    def start(self) -> None:
+        if self.task is not None and not self.task.done():
+            return
+        self.task = asyncio.create_task(self._tail_loop())
+
+    async def stop(self) -> None:
+        if self.task is None:
+            return
+        self.task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await self.task
+
+    async def _send(self, frame: dict[str, Any]) -> None:
+        await self.websocket.send(json.dumps(frame, separators=(",", ":")))
+
+    async def _tail_loop(self) -> None:
+        while True:
+            await self._report_ready_if_available()
+            if self.event_stream_path.exists():
+                try:
+                    with self.event_stream_path.open("r", encoding="utf-8", errors="ignore") as handle:
+                        handle.seek(self.offset)
+                        chunk = handle.read()
+                        self.offset = handle.tell()
+                except OSError as exc:
+                    logger.warning("Failed reading %s: %s", self.event_stream_path, exc)
+                    chunk = ""
+                if chunk:
+                    await self._process_chunk(chunk)
+            await asyncio.sleep(self.poll_interval)
+
+    def control_ready(self) -> bool:
+        return self.control_socket_path.exists() and self.control_socket_path.is_socket()
+
+    async def _report_ready_if_available(self) -> None:
+        if self.ready_sent:
+            return
+        if not self.event_stream_path.exists() or not self.control_ready():
+            return
+        self.ready_sent = True
+        await self._send(
+            {
+                "type": "runtime_ready",
+                "session_id": self.session_id,
+                "event_stream_path": str(self.event_stream_path),
+                "control_socket_path": str(self.control_socket_path),
+            }
+        )
+
+    async def _process_chunk(self, chunk: str) -> None:
+        self.buffer += chunk
+        lines = self.buffer.splitlines()
+        if self.buffer and not self.buffer.endswith("\n"):
+            self.buffer = lines.pop() if lines else self.buffer
+        else:
+            self.buffer = ""
+
+        for line in lines:
+            raw = line.strip()
+            if not raw:
+                continue
+            epoch_value = None
+            seq = None
+            try:
+                parsed = json.loads(raw)
+            except json.JSONDecodeError:
+                parsed = None
+            if isinstance(parsed, dict):
+                epoch_value = parsed.get("session_epoch")
+                seq = _coerce_seq(parsed.get("seq"))
+            if not self.cursor.should_send(epoch_value, seq):
+                continue
+            gap = self.cursor.note_sent(epoch_value, seq)
+            if gap is not None:
+                await self._send({"type": "event_gap", "session_id": self.session_id, **gap})
+            await self._send({"type": "event", "session_id": self.session_id, "line": raw})
+
+
+class CodexForkNodeAgent:
+    def __init__(
+        self,
+        *,
+        node_id: str,
+        primary_url: str,
+        secret: Optional[str],
+        poll_interval: float = 0.2,
+        log_dir: Optional[str] = None,
+    ):
+        self.node_id = node_id
+        self.primary_url = primary_url
+        self.secret = secret
+        self.poll_interval = poll_interval
+        self.log_dir = Path(log_dir or "~/.local/share/claude-sessions").expanduser().resolve(strict=False)
+        self.registrations: dict[str, TailRegistration] = {}
+
+    async def run_forever(self) -> None:
+        try:
+            import websockets
+        except ImportError as exc:
+            raise RuntimeError("websockets package is required to run the node-agent") from exc
+
+        url = _ws_url(self.primary_url)
+        while True:
+            try:
+                async with websockets.connect(url) as websocket:
+                    await self._run_connection(websocket)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning("node-agent connection failed: %s", exc)
+                await asyncio.sleep(2)
+
+    async def _run_connection(self, websocket: Any) -> None:
+        await websocket.send(
+            json.dumps(
+                {
+                    "type": "hello",
+                    "node_id": self.node_id,
+                    "secret": self.secret,
+                },
+                separators=(",", ":"),
+            )
+        )
+        async for raw_message in websocket:
+            try:
+                frame = json.loads(raw_message)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(frame, dict):
+                continue
+            await self._handle_frame(websocket, frame)
+
+    async def _handle_frame(self, websocket: Any, frame: dict[str, Any]) -> None:
+        frame_type = frame.get("type")
+        if frame_type == "hello_ok":
+            return
+        if frame_type == "register":
+            await self._register(websocket, frame)
+            return
+        if frame_type == "unregister":
+            await self._unregister(str(frame.get("session_id") or ""))
+            return
+        if frame_type == "control":
+            await self._control(websocket, frame)
+            return
+
+    async def _register(self, websocket: Any, frame: dict[str, Any]) -> None:
+        session_id = str(frame.get("session_id") or "").strip()
+        event_stream_path = str(frame.get("event_stream_path") or "").strip()
+        control_socket_path = str(frame.get("control_socket_path") or "").strip()
+        if not session_id or not event_stream_path or not control_socket_path:
+            await self._send_register_failed(websocket, session_id, "session_id, event_stream_path, and control_socket_path are required")
+            return
+        event_path, event_error = self._resolve_under_log_dir(event_stream_path, "event_stream_path")
+        if event_error:
+            await self._send_register_failed(websocket, session_id, event_error)
+            return
+        control_path, control_error = self._resolve_under_log_dir(control_socket_path, "control_socket_path")
+        if control_error:
+            await self._send_register_failed(websocket, session_id, control_error)
+            return
+        await self._unregister(session_id)
+        registration = TailRegistration(
+            websocket=websocket,
+            session_id=session_id,
+            event_stream_path=event_path,
+            control_socket_path=control_path,
+            cursor=ProviderCursor.from_payload(frame.get("cursor")),
+            poll_interval=self.poll_interval,
+        )
+        self.registrations[session_id] = registration
+        registration.start()
+        await websocket.send(
+            json.dumps(
+                {
+                    "type": "registered",
+                    "session_id": session_id,
+                    "event_stream_path": str(event_path),
+                    "control_socket_path": str(control_path),
+                },
+                separators=(",", ":"),
+            )
+        )
+
+    def _resolve_under_log_dir(self, raw_path: str, label: str) -> tuple[Optional[Path], Optional[str]]:
+        path = Path(raw_path).expanduser()
+        if not path.is_absolute():
+            return None, f"{label} must be absolute or ~-relative under node log_dir"
+        resolved = path.resolve(strict=False)
+        if not resolved.is_relative_to(self.log_dir):
+            return None, f"{label} must be under node log_dir {self.log_dir}"
+        return resolved, None
+
+    async def _send_register_failed(self, websocket: Any, session_id: str, error: str) -> None:
+        await websocket.send(
+            json.dumps(
+                {
+                    "type": "register_failed",
+                    "session_id": session_id,
+                    "error": error,
+                },
+                separators=(",", ":"),
+            )
+        )
+
+    async def _unregister(self, session_id: str) -> None:
+        registration = self.registrations.pop(session_id, None)
+        if registration is not None:
+            await registration.stop()
+
+    async def _send_control_error(
+        self,
+        websocket: Any,
+        *,
+        request_id: str,
+        code: str,
+        message: str,
+    ) -> None:
+        await websocket.send(
+            json.dumps(
+                {
+                    "type": "control_result",
+                    "request_id": request_id,
+                    "ok": False,
+                    "error": {"code": code, "message": message},
+                },
+                separators=(",", ":"),
+            )
+        )
+
+    async def _control(self, websocket: Any, frame: dict[str, Any]) -> None:
+        request_id = str(frame.get("request_id") or "").strip()
+        session_id = str(frame.get("session_id") or "").strip()
+        request_frame = frame.get("frame") if isinstance(frame.get("frame"), dict) else None
+        registration = self.registrations.get(session_id)
+        if not request_id or registration is None or request_frame is None:
+            await self._send_control_error(
+                websocket,
+                request_id=request_id,
+                code="not_registered",
+                message="session not registered",
+            )
+            return
+        if not registration.control_ready():
+            await self._send_control_error(
+                websocket,
+                request_id=request_id,
+                code="not_ready",
+                message=f"control socket not ready: {registration.control_socket_path}",
+            )
+            return
+
+        try:
+            reader, writer = await asyncio.open_unix_connection(str(registration.control_socket_path))
+            try:
+                writer.write((json.dumps(request_frame, separators=(",", ":")) + "\n").encode("utf-8"))
+                await writer.drain()
+                line = await reader.readline()
+                if not line:
+                    raise RuntimeError("control socket closed without response")
+            finally:
+                writer.close()
+                with contextlib.suppress(Exception):
+                    await writer.wait_closed()
+        except Exception as exc:
+            await self._send_control_error(
+                websocket,
+                request_id=request_id,
+                code="control_failed",
+                message=str(exc),
+            )
+            return
+
+        await websocket.send(
+            json.dumps(
+                {
+                    "type": "control_result",
+                    "request_id": request_id,
+                    "ok": True,
+                    "line": line.decode("utf-8", errors="replace").rstrip("\n"),
+                },
+                separators=(",", ":"),
+            )
+        )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run a Session Manager codex-fork node-agent")
+    parser.add_argument("--node-id", required=True, help="Node id as configured on the primary")
+    parser.add_argument(
+        "--primary-url",
+        default=os.environ.get("SM_API_URL") or os.environ.get("SM_HOOK_BASE_URL") or "http://localhost:8420",
+        help="Primary Session Manager HTTP(S)/WS URL",
+    )
+    parser.add_argument("--secret", default=os.environ.get("SM_NODE_TOKEN") or os.environ.get("SM_HOOK_SECRET"))
+    parser.add_argument(
+        "--log-dir",
+        default=os.environ.get("SM_NODE_LOG_DIR") or "~/.local/share/claude-sessions",
+        help="Node-local base directory for codex-fork event/control artifacts",
+    )
+    parser.add_argument("--poll-interval", type=float, default=0.2)
+    parser.add_argument("--log-level", default="INFO")
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    logging.basicConfig(level=getattr(logging, str(args.log_level).upper(), logging.INFO))
+    agent = CodexForkNodeAgent(
+        node_id=args.node_id,
+        primary_url=args.primary_url,
+        secret=args.secret,
+        poll_interval=args.poll_interval,
+        log_dir=args.log_dir,
+    )
+    try:
+        asyncio.run(agent.run_forever())
+    except KeyboardInterrupt:
+        return 130
+    except Exception as exc:
+        print(f"node-agent failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/node_agent.py
+++ b/src/node_agent.py
@@ -130,8 +130,14 @@ class TailRegistration:
         if self.task is None:
             return
         self.task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
+        try:
             await self.task
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.warning("Tail task for session %s failed during cleanup", self.session_id, exc_info=True)
+        finally:
+            self.task = None
 
     async def _send(self, frame: dict[str, Any]) -> None:
         await self.websocket.send(json.dumps(frame, separators=(",", ":")))

--- a/src/node_agent.py
+++ b/src/node_agent.py
@@ -75,6 +75,17 @@ def _coerce_seq(value: Any) -> Optional[int]:
     return None
 
 
+def _coerce_timeout(value: Any, default: float) -> float:
+    if isinstance(value, (int, float)) and value > 0:
+        return float(value)
+    if isinstance(value, str):
+        with contextlib.suppress(ValueError):
+            timeout = float(value)
+            if timeout > 0:
+                return timeout
+    return default
+
+
 def _ws_url(primary_url: str) -> str:
     parsed = urlparse(primary_url)
     scheme = parsed.scheme
@@ -197,11 +208,13 @@ class CodexForkNodeAgent:
         secret: Optional[str],
         poll_interval: float = 0.2,
         log_dir: Optional[str] = None,
+        control_timeout: float = 5.0,
     ):
         self.node_id = node_id
         self.primary_url = primary_url
         self.secret = secret
         self.poll_interval = poll_interval
+        self.control_timeout = max(0.5, float(control_timeout))
         self.log_dir = Path(log_dir or "~/.local/share/claude-sessions").expanduser().resolve(strict=False)
         self.registrations: dict[str, TailRegistration] = {}
 
@@ -362,18 +375,30 @@ class CodexForkNodeAgent:
             )
             return
 
+        timeout = max(0.5, _coerce_timeout(frame.get("timeout"), self.control_timeout))
         try:
-            reader, writer = await asyncio.open_unix_connection(str(registration.control_socket_path))
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_unix_connection(str(registration.control_socket_path)),
+                timeout=timeout,
+            )
             try:
                 writer.write((json.dumps(request_frame, separators=(",", ":")) + "\n").encode("utf-8"))
-                await writer.drain()
-                line = await reader.readline()
+                await asyncio.wait_for(writer.drain(), timeout=timeout)
+                line = await asyncio.wait_for(reader.readline(), timeout=timeout)
                 if not line:
                     raise RuntimeError("control socket closed without response")
             finally:
                 writer.close()
                 with contextlib.suppress(Exception):
                     await writer.wait_closed()
+        except TimeoutError:
+            await self._send_control_error(
+                websocket,
+                request_id=request_id,
+                code="control_failed",
+                message=f"control socket timed out after {timeout:.1f}s",
+            )
+            return
         except Exception as exc:
             await self._send_control_error(
                 websocket,
@@ -411,6 +436,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Node-local base directory for codex-fork event/control artifacts",
     )
     parser.add_argument("--poll-interval", type=float, default=0.2)
+    parser.add_argument(
+        "--control-timeout",
+        type=float,
+        default=_coerce_timeout(os.environ.get("SM_NODE_CONTROL_TIMEOUT"), 5.0),
+        help="Seconds to wait for codex-fork control socket connect/write/read operations",
+    )
     parser.add_argument("--log-level", default="INFO")
     return parser
 
@@ -424,6 +455,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         secret=args.secret,
         poll_interval=args.poll_interval,
         log_dir=args.log_dir,
+        control_timeout=args.control_timeout,
     )
     try:
         asyncio.run(agent.run_forever())

--- a/src/node_runner.py
+++ b/src/node_runner.py
@@ -25,7 +25,9 @@ class NodeConfig:
     api_url: Optional[str] = None
     hook_base_url: Optional[str] = None
     hook_secret: Optional[str] = None
+    node_token: Optional[str] = None
     projects_root: Optional[str] = None
+    log_dir: Optional[str] = None
 
     @property
     def is_primary(self) -> bool:
@@ -64,7 +66,9 @@ class NodeRegistry:
                 api_url=_clean_optional(value.get("api_url")),
                 hook_base_url=_clean_optional(value.get("hook_base_url")),
                 hook_secret=_clean_optional(value.get("hook_secret")),
+                node_token=_clean_optional(value.get("node_token")),
                 projects_root=_clean_optional(value.get("projects_root")),
+                log_dir=_clean_optional(value.get("log_dir")),
             )
 
         default_node = _clean_optional(raw_nodes.get("default")) or PRIMARY_NODE
@@ -96,6 +100,7 @@ class NodeRegistry:
                 "api_url": node.api_url,
                 "hook_base_url": node.hook_base_url,
                 "projects_root": node.projects_root,
+                "log_dir": node.log_dir,
             }
             for node in sorted(self._nodes.values(), key=lambda item: item.id)
         ]
@@ -259,6 +264,32 @@ mkdir -p "$parent" && : >> "$path"
             timeout=timeout,
         )
         return result.returncode == 0
+
+    def ensure_directory(self, node_id: Optional[str], path: str, timeout: float = 5.0) -> Optional[str]:
+        """Create a directory on a node and return its node-local physical path."""
+        if self.is_primary(node_id):
+            local_path = Path(path).expanduser()
+            local_path.mkdir(parents=True, exist_ok=True)
+            return str(local_path.resolve())
+
+        script = """
+path=$1
+case "$path" in
+  "~") path=${HOME:-~} ;;
+  "~/"*) path="${HOME%/}/${path#\\~/}" ;;
+esac
+mkdir -p "$path" && CDPATH= cd -- "$path" 2>/dev/null && pwd -P
+"""
+        result = self.run(
+            node_id,
+            ["/bin/sh", "-lc", script, "sh", path],
+            check=False,
+            timeout=timeout,
+        )
+        if result.returncode != 0:
+            return None
+        resolved = [line.strip() for line in (result.stdout or "").splitlines() if line.strip()]
+        return resolved[0] if resolved else None
 
     def command_available(
         self,

--- a/src/server.py
+++ b/src/server.py
@@ -48,6 +48,7 @@ from .codex_provider_policy import (
     REMOVED_CODEX_SERVER_ENTRYPOINT_MESSAGE,
     get_codex_app_policy,
 )
+from .codex_fork_remote import NodeAgentConnection
 from .models import (
     AdoptionProposal,
     CompletionStatus,
@@ -4472,6 +4473,7 @@ def create_app(
         provider_rejection = app.state.session_manager.get_provider_create_rejection(
             provider,
             working_dir=request.working_dir,
+            node=resolved_node or "primary",
         )
         if provider_rejection:
             raise HTTPException(status_code=503, detail=provider_rejection)
@@ -4528,6 +4530,7 @@ def create_app(
         provider_rejection = app.state.session_manager.get_provider_create_rejection(
             provider,
             working_dir=working_dir,
+            node=resolved_node or "primary",
         )
         if provider_rejection:
             raise HTTPException(status_code=503, detail=provider_rejection)
@@ -4585,6 +4588,64 @@ def create_app(
             status = 404 if str(result.get("error") or "").startswith("Unknown node") else 503
             raise HTTPException(status_code=status, detail=result.get("error") or "ping failed")
         return result
+
+    @app.websocket("/nodes/agent")
+    async def node_agent_websocket(websocket: WebSocket):
+        """Authenticated node-initiated codex-fork IPC bridge."""
+        await websocket.accept()
+        sm = app.state.session_manager
+        if not sm:
+            await websocket.send_json({"type": "error", "message": "Session manager not configured"})
+            await websocket.close(code=1011)
+            return
+
+        connection: Optional[NodeAgentConnection] = None
+        try:
+            hello = await asyncio.wait_for(websocket.receive_json(), timeout=5.0)
+            if not isinstance(hello, dict) or hello.get("type") != "hello":
+                await websocket.send_json({"type": "error", "message": "First node-agent frame must be hello"})
+                await websocket.close(code=1008)
+                return
+
+            node_id = str(hello.get("node_id") or "").strip()
+            if not node_id or node_id == "primary":
+                await websocket.send_json({"type": "error", "message": "Invalid node id"})
+                await websocket.close(code=1008)
+                return
+
+            getter = getattr(sm, "node_agent_secret_for_node", None)
+            expected_secret = getter(node_id) if callable(getter) else None
+            supplied_secret = hello.get("secret")
+            if not isinstance(expected_secret, str) or not expected_secret:
+                await websocket.send_json({"type": "error", "message": "Node-agent secret not configured"})
+                await websocket.close(code=1008)
+                return
+            if not isinstance(supplied_secret, str) or not hmac.compare_digest(supplied_secret, expected_secret):
+                await websocket.send_json({"type": "error", "message": "Invalid node-agent secret"})
+                await websocket.close(code=1008)
+                return
+
+            connection = NodeAgentConnection(node_id, websocket)
+            await sm.attach_codex_fork_node_agent(connection)
+            await websocket.send_json({"type": "hello_ok", "node_id": node_id})
+            while True:
+                frame = await websocket.receive_json()
+                if isinstance(frame, dict):
+                    await connection.handle_frame(frame)
+        except WebSocketDisconnect:
+            pass
+        except asyncio.TimeoutError:
+            await websocket.send_json({"type": "error", "message": "Node-agent hello timed out"})
+            await websocket.close(code=1008)
+        except Exception:
+            logger.exception("Node-agent WebSocket failed")
+            with contextlib.suppress(Exception):
+                await websocket.send_json({"type": "error", "message": "Node-agent bridge failed"})
+            with contextlib.suppress(Exception):
+                await websocket.close(code=1011)
+        finally:
+            if connection is not None:
+                await sm.detach_codex_fork_node_agent(connection)
 
     @app.get("/client/sessions")
     async def list_client_sessions(request: Request):
@@ -7487,6 +7548,7 @@ Provide ONLY the summary, no preamble or questions."""
         provider_rejection = app.state.session_manager.get_provider_create_rejection(
             selected_provider,
             working_dir=selected_working_dir,
+            node=resolved_node or "primary",
         )
         if provider_rejection:
             raise HTTPException(status_code=503, detail=provider_rejection)

--- a/src/server.py
+++ b/src/server.py
@@ -1,6 +1,7 @@
 """FastAPI server for hooks and API endpoints."""
 
 import asyncio
+import contextlib
 import fcntl
 from dataclasses import replace
 import inspect
@@ -4600,6 +4601,7 @@ def create_app(
             return
 
         connection: Optional[NodeAgentConnection] = None
+        registration_task: Optional[asyncio.Task[None]] = None
         try:
             hello = await asyncio.wait_for(websocket.receive_json(), timeout=5.0)
             if not isinstance(hello, dict) or hello.get("type") != "hello":
@@ -4628,6 +4630,7 @@ def create_app(
             connection = NodeAgentConnection(node_id, websocket)
             await sm.attach_codex_fork_node_agent(connection)
             await websocket.send_json({"type": "hello_ok", "node_id": node_id})
+            registration_task = asyncio.create_task(sm.register_active_codex_fork_node_agent_sessions(node_id))
             while True:
                 frame = await websocket.receive_json()
                 if isinstance(frame, dict):
@@ -4644,6 +4647,11 @@ def create_app(
             with contextlib.suppress(Exception):
                 await websocket.close(code=1011)
         finally:
+            if registration_task is not None:
+                if not registration_task.done():
+                    registration_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await registration_task
             if connection is not None:
                 await sm.detach_codex_fork_node_agent(connection)
 

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -463,6 +463,18 @@ class SessionManager:
         if session.tmux_session:
             self._tmux_session_node_cache[session.tmux_session] = normalize_node_id(session.node)
 
+    def _tmux_session_exists_for_session(self, session: Session) -> bool:
+        """Check tmux reachability on the node that owns this session."""
+        if not session.tmux_session:
+            return False
+        node_id = normalize_node_id(getattr(session, "node", PRIMARY_NODE))
+        try:
+            return self.tmux.session_exists(session.tmux_session, node=node_id)
+        except TypeError as exc:
+            if "unexpected keyword argument 'node'" not in str(exc):
+                raise
+            return self.tmux.session_exists(session.tmux_session)
+
     def _resolve_node_for_tmux_session(self, tmux_session: str) -> str:
         target = str(tmux_session or "").split(":", 1)[0].split(".", 1)[0]
         if target in self._tmux_session_node_cache:
@@ -1031,7 +1043,7 @@ class SessionManager:
 
             # Verify tmux session still exists (Claude/Codex CLI)
             try:
-                tmux_exists = self.tmux.session_exists(session.tmux_session)
+                tmux_exists = self._tmux_session_exists_for_session(session)
             except Exception as exc:
                 if normalize_node_id(getattr(session, "node", PRIMARY_NODE)) != PRIMARY_NODE:
                     logger.warning(
@@ -1568,7 +1580,7 @@ done
         node_id = normalize_node_id(getattr(session, "node", PRIMARY_NODE))
         if node_id != PRIMARY_NODE:
             try:
-                tmux_exists = bool(session.tmux_session) and self.tmux.session_exists(session.tmux_session)
+                tmux_exists = self._tmux_session_exists_for_session(session)
             except Exception:
                 self.mark_node_unreachable(session.id, True)
                 return False
@@ -1579,7 +1591,7 @@ done
         socket_path = self._codex_fork_control_socket_path(session)
         if not socket_path.exists():
             return False
-        if not session.tmux_session or not self.tmux.session_exists(session.tmux_session):
+        if not self._tmux_session_exists_for_session(session):
             return False
 
         client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
@@ -5582,7 +5594,7 @@ done
                 should_remove = True
             elif session.status == SessionStatus.STOPPED:
                 should_remove = True
-            elif not session.tmux_session or not self.tmux.session_exists(session.tmux_session):
+            elif not self._tmux_session_exists_for_session(session):
                 should_remove = True
 
             if not should_remove:
@@ -5625,7 +5637,7 @@ done
 
         if session.tmux_session:
             try:
-                tmux_exists = self.tmux.session_exists(session.tmux_session)
+                tmux_exists = self._tmux_session_exists_for_session(session)
             except Exception as exc:
                 if node_id != PRIMARY_NODE:
                     self.mark_node_unreachable(session.id, True)
@@ -5716,7 +5728,7 @@ done
                 continue
             node_id = normalize_node_id(getattr(session, "node", PRIMARY_NODE))
             try:
-                tmux_exists = bool(session.tmux_session) and self.tmux.session_exists(session.tmux_session)
+                tmux_exists = self._tmux_session_exists_for_session(session)
             except Exception as exc:
                 if node_id != PRIMARY_NODE:
                     logger.warning(
@@ -5990,7 +6002,7 @@ done
         if session.provider == "codex-app" or not session.tmux_session:
             return False
         try:
-            if self.tmux.session_exists(session.tmux_session):
+            if self._tmux_session_exists_for_session(session):
                 self.mark_node_unreachable(session.id, False)
                 return False
         except Exception as exc:
@@ -7193,7 +7205,7 @@ done
         try:
             tmux_runtime_missing = (
                 session.provider != "codex-app"
-                and not self.tmux.session_exists(session.tmux_session)
+                and not self._tmux_session_exists_for_session(session)
             )
             self.mark_node_unreachable(session.id, False)
         except Exception as exc:

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -3265,10 +3265,19 @@ done
                 )
                 if effective_provider != session.provider:
                     if codex_fork_source_resume_id:
+                        self.last_create_error = fallback_reason or "codex-fork fork create cannot fall back to legacy codex"
                         logger.error(
                             "Rejecting codex-fork fork create for %s because runtime is unavailable: %s",
                             session.id,
                             fallback_reason,
+                        )
+                        return None
+                    if normalize_node_id(getattr(session, "node", PRIMARY_NODE)) != PRIMARY_NODE:
+                        self.last_create_error = fallback_reason or "remote codex-fork cannot fall back to legacy codex"
+                        logger.error(
+                            "Rejecting remote codex-fork create for %s because runtime is unavailable: %s",
+                            session.id,
+                            self.last_create_error,
                         )
                         return None
                     logger.warning(

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -519,7 +519,8 @@ class SessionManager:
 
     async def detach_codex_fork_node_agent(self, connection: NodeAgentConnection) -> None:
         await self.codex_fork_node_agents.detach(connection)
-        self._mark_node_sessions_unreachable(connection.node_id)
+        if not self.codex_fork_node_agents.is_connected(connection.node_id):
+            self._mark_node_sessions_unreachable(connection.node_id)
 
     def _mark_node_sessions_reachable(self, node: str) -> None:
         node_id = normalize_node_id(node)

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -2615,8 +2615,42 @@ done
         event_type = event.get("event_type") or event.get("type")
         if not event_type:
             return None
-        if not self._claim_codex_fork_provider_event(session_id, event):
-            return None
+        provider_position = self._codex_fork_provider_position(event)
+        previous_provider_cursor = None
+        if provider_position is not None:
+            should_ingest, previous_provider_cursor = self._should_ingest_codex_fork_provider_event(
+                session_id,
+                provider_position[0],
+                provider_position[1],
+            )
+            if not should_ingest:
+                return None
+        if provider_position is not None:
+            return self._ingest_claimed_codex_fork_event(
+                session_id=session_id,
+                event=event,
+                event_type=event_type,
+                provider_position=provider_position,
+                previous_provider_cursor=previous_provider_cursor,
+            )
+        return self._ingest_claimed_codex_fork_event(
+            session_id=session_id,
+            event=event,
+            event_type=event_type,
+            provider_position=None,
+            previous_provider_cursor=None,
+        )
+
+    def _ingest_claimed_codex_fork_event(
+        self,
+        *,
+        session_id: str,
+        event: dict[str, Any],
+        event_type: Any,
+        provider_position: Optional[tuple[Any, int]],
+        previous_provider_cursor: Optional[dict[str, Any]],
+    ) -> Optional[dict[str, Any]]:
+        """Apply one non-duplicate codex-fork event and then advance provider cursor."""
         payload = event.get("payload") if isinstance(event.get("payload"), dict) else {}
         provider_session_id = event.get("session_id")
         if not provider_session_id and payload:
@@ -2683,25 +2717,42 @@ done
                 payload_for_reducer = {**payload_for_store, "session_id": event_thread_id}
 
         turn_id = self._codex_fork_turn_id_for_event(event, payload_for_store)
-        self.codex_event_store.append_event(
-            session_id=session_id,
-            event_type=f"codex_fork_{normalized}",
-            turn_id=turn_id,
-            payload={
-                "schema_version": event.get("schema_version"),
-                "seq": seq,
-                "session_epoch": session_epoch,
-                "payload": payload_for_store,
-            },
-        )
-        return self._reduce_codex_fork_lifecycle(
-            session_id=session_id,
-            event_type=normalized,
-            payload=payload_for_reducer,
-            seq=seq,
-            session_epoch=session_epoch,
-            event_timestamp_ns=self._timestamp_to_epoch_ns(event.get("ts")),
-        )
+        stored_event: Optional[dict[str, Any]] = None
+        try:
+            stored_event = self.codex_event_store.append_event(
+                session_id=session_id,
+                event_type=f"codex_fork_{normalized}",
+                turn_id=turn_id,
+                payload={
+                    "schema_version": event.get("schema_version"),
+                    "seq": seq,
+                    "session_epoch": session_epoch,
+                    "payload": payload_for_store,
+                },
+            )
+            if not stored_event.get("persisted"):
+                return None
+            lifecycle = self._reduce_codex_fork_lifecycle(
+                session_id=session_id,
+                event_type=normalized,
+                payload=payload_for_reducer,
+                seq=seq,
+                session_epoch=session_epoch,
+                event_timestamp_ns=self._timestamp_to_epoch_ns(event.get("ts")),
+            )
+            if provider_position is not None:
+                self._record_codex_fork_provider_event_applied(
+                    session_id,
+                    provider_position[0],
+                    provider_position[1],
+                    previous_provider_cursor=previous_provider_cursor,
+                )
+            return lifecycle
+        except Exception:
+            if stored_event and stored_event.get("persisted") and isinstance(stored_event.get("seq"), int):
+                with contextlib.suppress(Exception):
+                    self.codex_event_store.delete_event(session_id, stored_event["seq"])
+            raise
 
     def _sync_session_resume_id(self, session: Session) -> bool:
         """Synchronize one session's provider-native resume identifier."""
@@ -2847,6 +2898,13 @@ done
             return int(seq_raw)
         return None
 
+    def _codex_fork_provider_position(self, event: dict[str, Any]) -> Optional[tuple[Any, int]]:
+        seq = self._codex_fork_event_provider_seq(event)
+        session_epoch = event.get("session_epoch")
+        if seq is None or session_epoch is None:
+            return None
+        return session_epoch, seq
+
     def _get_codex_fork_provider_cursor(self, session_id: str) -> Optional[dict[str, Any]]:
         cursor = self.codex_fork_provider_cursors.get(session_id)
         if cursor is not None:
@@ -2856,19 +2914,35 @@ done
             self.codex_fork_provider_cursors[session_id] = dict(stored)
         return stored
 
-    def _claim_codex_fork_provider_event(self, session_id: str, event: dict[str, Any]) -> bool:
-        """Return True when one codex-fork provider event should be ingested."""
-        seq = self._codex_fork_event_provider_seq(event)
-        if seq is None or event.get("session_epoch") is None:
-            return True
-        session_epoch = event.get("session_epoch")
-        claimed, previous, cursor = self.codex_event_store.claim_codex_fork_provider_event(
+    def _should_ingest_codex_fork_provider_event(
+        self,
+        session_id: str,
+        session_epoch: Any,
+        seq: int,
+    ) -> tuple[bool, Optional[dict[str, Any]]]:
+        """Return whether this provider event has not already been fully applied."""
+        return self.codex_event_store.should_ingest_codex_fork_provider_event(
             session_id,
             session_epoch=session_epoch,
             seq=seq,
         )
-        if not claimed:
-            return False
+
+    def _record_codex_fork_provider_event_applied(
+        self,
+        session_id: str,
+        session_epoch: Any,
+        seq: int,
+        *,
+        previous_provider_cursor: Optional[dict[str, Any]],
+    ) -> None:
+        """Advance the provider cursor after persistence and reducer side effects succeed."""
+        previous, cursor = self.codex_event_store.record_codex_fork_provider_event_applied(
+            session_id,
+            session_epoch=session_epoch,
+            seq=seq,
+        )
+        if previous_provider_cursor is not None:
+            previous = previous_provider_cursor
         if previous is not None and previous.get("session_epoch_key") == cursor.get("session_epoch_key"):
             previous_seq = int(previous.get("seq") or 0)
             if seq > previous_seq + 1:
@@ -2880,7 +2954,6 @@ done
                     seq,
                 )
         self.codex_fork_provider_cursors[session_id] = dict(cursor)
-        return True
 
     def _codex_fork_transport_for_session(self, session: Session) -> CodexForkTransport:
         """Select the raw codex-fork IPC transport for the session's owning node."""

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -35,6 +35,13 @@ from .models import (
     TelegramTopicRecord,
 )
 from .node_runner import NodeRegistry, NodeRunner, PRIMARY_NODE, normalize_node_id
+from .codex_fork_remote import (
+    CodexForkTransport,
+    LocalCodexForkTransport,
+    NodeAgentConnection,
+    NodeAgentRegistry,
+    RemoteCodexForkTransport,
+)
 from .tmux_controller import TmuxController
 from .codex_app_server import CodexAppServerSession, CodexAppServerConfig, CodexAppServerError
 from .codex_activity_projection import CodexActivityProjection
@@ -165,6 +172,7 @@ class SessionManager:
         self.sessions: dict[str, Session] = {}
         self.node_registry = NodeRegistry.from_config(self.config)
         self.node_runner = NodeRunner(self.node_registry)
+        self.codex_fork_node_agents = NodeAgentRegistry()
         self._tmux_session_node_cache: dict[str, str] = {}
         self._node_unreachable_sessions: set[str] = set()
         self.last_create_error: Optional[str] = None
@@ -336,6 +344,7 @@ class SessionManager:
         self.codex_fork_wait_kind: dict[str, str] = {}
         self.codex_fork_last_seq: dict[str, int] = {}
         self.codex_fork_session_epoch: dict[str, Any] = {}
+        self.codex_fork_provider_cursors: dict[str, dict[str, Any]] = {}
         self.codex_fork_control_epoch: dict[str, str] = {}
         self.codex_fork_control_degraded: dict[str, str] = {}
         self.codex_fork_runtime_owner: dict[str, str] = {}
@@ -469,7 +478,11 @@ class SessionManager:
         return self.node_registry.get(node)
 
     def list_nodes(self) -> list[dict[str, object]]:
-        return self.node_registry.as_list()
+        nodes = self.node_registry.as_list()
+        for node in nodes:
+            node_id = str(node.get("id") or PRIMARY_NODE)
+            node["codex_fork_node_agent"] = self.codex_fork_node_agents.is_connected(node_id)
+        return nodes
 
     def ping_node(self, node: str) -> dict[str, object]:
         node_id = normalize_node_id(node)
@@ -480,6 +493,57 @@ class SessionManager:
         except Exception as exc:
             return {"node": node_id, "ok": False, "error": str(exc)}
         return {"node": node_id, "ok": ok, "error": None if ok else "ping failed"}
+
+    def node_agent_secret_for_node(self, node: str) -> Optional[str]:
+        """Return the configured node-agent auth secret for one node."""
+        node_config = self.node_registry.get(node)
+        if node_config is None:
+            return None
+        token = getattr(node_config, "node_token", None) or getattr(node_config, "hook_secret", None)
+        if not isinstance(token, str):
+            return None
+        token = token.strip()
+        return token or None
+
+    def is_codex_fork_node_agent_healthy(self, node: str) -> bool:
+        node_id = normalize_node_id(node)
+        if node_id == PRIMARY_NODE:
+            return True
+        return self.codex_fork_node_agents.is_connected(node_id)
+
+    async def attach_codex_fork_node_agent(self, connection: NodeAgentConnection) -> None:
+        """Register a live node-agent connection and re-register active sessions for that node."""
+        await self.codex_fork_node_agents.attach(connection)
+        self._mark_node_sessions_reachable(connection.node_id)
+        await self._register_active_remote_codex_fork_sessions(connection.node_id)
+
+    async def detach_codex_fork_node_agent(self, connection: NodeAgentConnection) -> None:
+        await self.codex_fork_node_agents.detach(connection)
+        self._mark_node_sessions_unreachable(connection.node_id)
+
+    def _mark_node_sessions_reachable(self, node: str) -> None:
+        node_id = normalize_node_id(node)
+        for session in self.sessions.values():
+            if normalize_node_id(getattr(session, "node", PRIMARY_NODE)) == node_id:
+                self.mark_node_unreachable(session.id, False)
+
+    def _mark_node_sessions_unreachable(self, node: str) -> None:
+        node_id = normalize_node_id(node)
+        for session in self.sessions.values():
+            if normalize_node_id(getattr(session, "node", PRIMARY_NODE)) == node_id:
+                if session.provider == "codex-fork" and session.status != SessionStatus.STOPPED:
+                    self.mark_node_unreachable(session.id, True)
+
+    async def _register_active_remote_codex_fork_sessions(self, node: str) -> None:
+        node_id = normalize_node_id(node)
+        for session in list(self.sessions.values()):
+            if (
+                session.provider == "codex-fork"
+                and session.status != SessionStatus.STOPPED
+                and normalize_node_id(getattr(session, "node", PRIMARY_NODE)) == node_id
+            ):
+                with contextlib.suppress(Exception):
+                    await self._register_codex_fork_remote_bridge(session)
 
     def _resolve_create_node(self, requested_node: Optional[str], parent_session_id: Optional[str]) -> tuple[Optional[str], Optional[str]]:
         if requested_node:
@@ -495,8 +559,15 @@ class SessionManager:
 
     @staticmethod
     def _provider_node_rejection(provider: str, node: str) -> Optional[str]:
-        if normalize_node_id(node) != PRIMARY_NODE and provider != "claude":
-            return f"Remote placement is Claude-only in this phase (provider={provider})"
+        if normalize_node_id(node) != PRIMARY_NODE and provider not in {"claude", "codex-fork"}:
+            return f"Remote placement supports provider=claude or provider=codex-fork in this phase (provider={provider})"
+        return None
+
+    def _codex_fork_remote_capability_rejection(self, provider: str, node: str) -> Optional[str]:
+        if provider != "codex-fork" or normalize_node_id(node) == PRIMARY_NODE:
+            return None
+        if not self.is_codex_fork_node_agent_healthy(node):
+            return f"Remote codex-fork requires a healthy node-agent on node {normalize_node_id(node)}"
         return None
 
     def validate_create_node_provider(
@@ -509,7 +580,10 @@ class SessionManager:
         node, node_error = self._resolve_create_node(requested_node, parent_session_id)
         if node_error:
             return node, node_error
-        return node, self._provider_node_rejection(provider, node or PRIMARY_NODE)
+        provider_rejection = self._provider_node_rejection(provider, node or PRIMARY_NODE)
+        if provider_rejection:
+            return node, provider_rejection
+        return node, self._codex_fork_remote_capability_rejection(provider, node or PRIMARY_NODE)
 
     def _runtime_env_for_session(self, session: Session) -> dict[str, str]:
         node_id = normalize_node_id(getattr(session, "node", PRIMARY_NODE))
@@ -1213,11 +1287,108 @@ class SessionManager:
 
     def _codex_fork_event_stream_path(self, session: Session) -> Path:
         """Return event-stream JSONL path for one codex-fork session."""
-        return self.log_dir / f"{session.id}.codex-fork.events.jsonl"
+        return Path(self._codex_fork_event_stream_path_string(session))
 
     def _codex_fork_control_socket_path(self, session: Session) -> Path:
         """Return control-socket path for one codex-fork session."""
-        return self.log_dir / f"{session.id}.codex-fork.control.sock"
+        return Path(self._codex_fork_control_socket_path_string(session))
+
+    def _codex_fork_node_log_dir(self, session: Session) -> str:
+        node_id = normalize_node_id(getattr(session, "node", PRIMARY_NODE))
+        if node_id == PRIMARY_NODE:
+            return str(self.log_dir)
+        node_config = self.node_registry.get(node_id)
+        configured = getattr(node_config, "log_dir", None) if node_config else None
+        if isinstance(configured, str) and configured.strip():
+            return configured.strip()
+        return "~/.local/share/claude-sessions"
+
+    def _codex_fork_artifact_basename(self, session: Session, suffix: str) -> str:
+        return f"{session.id}.codex-fork.{suffix}"
+
+    def _codex_fork_event_stream_path_string(self, session: Session) -> str:
+        return str(Path(self._codex_fork_node_log_dir(session)) / self._codex_fork_artifact_basename(session, "events.jsonl"))
+
+    def _codex_fork_control_socket_path_string(self, session: Session) -> str:
+        return str(Path(self._codex_fork_node_log_dir(session)) / self._codex_fork_artifact_basename(session, "control.sock"))
+
+    def _codex_fork_artifact_path_strings(self, session: Session) -> tuple[str, str]:
+        return (
+            self._codex_fork_event_stream_path_string(session),
+            self._codex_fork_control_socket_path_string(session),
+        )
+
+    def _prepare_codex_fork_runtime_artifacts(self, session: Session) -> tuple[bool, Optional[str]]:
+        """Prepare event/control artifacts on the node that will run codex-fork."""
+        node_id = normalize_node_id(getattr(session, "node", PRIMARY_NODE))
+        event_stream_path, control_socket_path = self._codex_fork_artifact_path_strings(session)
+        if node_id == PRIMARY_NODE:
+            event_path = Path(event_stream_path)
+            control_path = Path(control_socket_path)
+            event_path.parent.mkdir(parents=True, exist_ok=True)
+            if event_path.exists():
+                event_path.unlink()
+            if control_path.exists():
+                control_path.unlink()
+            return True, None
+
+        script = """
+event_path=$1
+control_path=$2
+for path in "$event_path" "$control_path"; do
+  case "$path" in
+    "~") path=${HOME:-~} ;;
+    "~/"*) path="${HOME%/}/${path#\\~/}" ;;
+  esac
+  parent=$(dirname "$path")
+  mkdir -p "$parent" || exit 1
+done
+case "$event_path" in
+  "~") event_path=${HOME:-~} ;;
+  "~/"*) event_path="${HOME%/}/${event_path#\\~/}" ;;
+esac
+case "$control_path" in
+  "~") control_path=${HOME:-~} ;;
+  "~/"*) control_path="${HOME%/}/${control_path#\\~/}" ;;
+esac
+rm -f "$event_path" "$control_path" && : > "$event_path"
+"""
+        result = self.node_runner.run(
+            node_id,
+            ["/bin/sh", "-lc", script, "sh", event_stream_path, control_socket_path],
+            check=False,
+            timeout=5.0,
+        )
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout or "").strip()
+            return False, detail or f"failed to prepare codex-fork artifacts on node {node_id}"
+        return True, None
+
+    def _unlink_codex_fork_runtime_artifacts(self, session: Session) -> None:
+        """Best-effort removal of codex-fork runtime artifacts on their owning node."""
+        node_id = normalize_node_id(getattr(session, "node", PRIMARY_NODE))
+        event_stream_path, control_socket_path = self._codex_fork_artifact_path_strings(session)
+        if node_id == PRIMARY_NODE:
+            for path in (Path(event_stream_path), Path(control_socket_path)):
+                with contextlib.suppress(FileNotFoundError):
+                    path.unlink()
+            return
+        script = """
+for path in "$@"; do
+  case "$path" in
+    "~") path=${HOME:-~} ;;
+    "~/"*) path="${HOME%/}/${path#\\~/}" ;;
+  esac
+  rm -f "$path"
+done
+"""
+        with contextlib.suppress(Exception):
+            self.node_runner.run(
+                node_id,
+                ["/bin/sh", "-lc", script, "sh", event_stream_path, control_socket_path],
+                check=False,
+                timeout=5.0,
+            )
 
     @staticmethod
     def _resolve_cli_command(
@@ -1267,10 +1438,16 @@ class SessionManager:
         """Return launch command/args, falling back to codex when codex-fork is unavailable."""
         if resume_id and fork_id:
             raise ValueError("resume_id and fork_id are mutually exclusive")
-        _, fork_error = self._resolve_cli_command(
-            self.codex_fork_command,
-            working_dir=session.working_dir,
-        )
+        node_id = normalize_node_id(getattr(session, "node", PRIMARY_NODE))
+        if node_id == PRIMARY_NODE:
+            _, fork_error = self._resolve_cli_command(
+                self.codex_fork_command,
+                working_dir=session.working_dir,
+            )
+        else:
+            fork_error = None
+            if not self.node_runner.command_available(node_id, self.codex_fork_command, cwd=session.working_dir):
+                fork_error = f"Launch command not found or not executable on node {node_id}: {self.codex_fork_command}"
         if fork_error:
             args = list(self.codex_cli_args)
             if resume_id:
@@ -1289,21 +1466,18 @@ class SessionManager:
             args = ["resume", resume_id, *args]
         elif fork_id:
             args = ["fork", fork_id, *args]
-        event_stream_path = self._codex_fork_event_stream_path(session)
-        control_socket_path = self._codex_fork_control_socket_path(session)
-        event_stream_path.parent.mkdir(parents=True, exist_ok=True)
-        if event_stream_path.exists():
-            event_stream_path.unlink()
-        if control_socket_path.exists():
-            control_socket_path.unlink()
+        prepared, prepare_error = self._prepare_codex_fork_runtime_artifacts(session)
+        if not prepared:
+            raise RuntimeError(f"Failed to prepare codex-fork runtime artifacts: {prepare_error}")
+        event_stream_path, control_socket_path = self._codex_fork_artifact_path_strings(session)
         args.extend(
             [
                 "--event-stream",
-                str(event_stream_path),
+                event_stream_path,
                 "--event-schema-version",
                 str(self.codex_fork_event_schema_version),
                 "--control-socket",
-                str(control_socket_path),
+                control_socket_path,
             ]
         )
         return self.codex_fork_command, args, "codex-fork", None
@@ -1313,17 +1487,25 @@ class SessionManager:
         provider: str,
         *,
         working_dir: str,
+        node: Optional[str] = PRIMARY_NODE,
     ) -> Optional[str]:
         """Return a user-facing rejection reason when a fresh provider create cannot proceed."""
         if provider != "codex-fork":
             return None
 
-        _, fork_error = self._resolve_cli_command(
-            self.codex_fork_command,
-            working_dir=working_dir,
-        )
-        if fork_error:
-            return f"Configured codex-fork runtime unavailable: {fork_error}"
+        node_id = normalize_node_id(node)
+        if node_id == PRIMARY_NODE:
+            _, fork_error = self._resolve_cli_command(
+                self.codex_fork_command,
+                working_dir=working_dir,
+            )
+            if fork_error:
+                return f"Configured codex-fork runtime unavailable: {fork_error}"
+        elif not self.node_runner.command_available(node_id, self.codex_fork_command, cwd=working_dir):
+            return (
+                "Configured codex-fork runtime unavailable on "
+                f"node {node_id}: {self.codex_fork_command}"
+            )
         return None
 
     @staticmethod
@@ -1379,6 +1561,17 @@ class SessionManager:
         """Return True when a codex-fork detached runtime still answers on its control socket."""
         if getattr(session, "provider", "") != "codex-fork":
             return False
+        node_id = normalize_node_id(getattr(session, "node", PRIMARY_NODE))
+        if node_id != PRIMARY_NODE:
+            try:
+                tmux_exists = bool(session.tmux_session) and self.tmux.session_exists(session.tmux_session)
+            except Exception:
+                self.mark_node_unreachable(session.id, True)
+                return False
+            return (
+                self.is_codex_fork_node_agent_healthy(node_id)
+                and tmux_exists
+            )
         socket_path = self._codex_fork_control_socket_path(session)
         if not socket_path.exists():
             return False
@@ -2422,6 +2615,8 @@ class SessionManager:
         event_type = event.get("event_type") or event.get("type")
         if not event_type:
             return None
+        if not self._claim_codex_fork_provider_event(session_id, event):
+            return None
         payload = event.get("payload") if isinstance(event.get("payload"), dict) else {}
         provider_session_id = event.get("session_id")
         if not provider_session_id and payload:
@@ -2643,6 +2838,69 @@ class SessionManager:
                 return recovered
         return None
 
+    @staticmethod
+    def _codex_fork_event_provider_seq(event: dict[str, Any]) -> Optional[int]:
+        seq_raw = event.get("seq")
+        if isinstance(seq_raw, int):
+            return seq_raw
+        if isinstance(seq_raw, str) and seq_raw.isdigit():
+            return int(seq_raw)
+        return None
+
+    def _get_codex_fork_provider_cursor(self, session_id: str) -> Optional[dict[str, Any]]:
+        cursor = self.codex_fork_provider_cursors.get(session_id)
+        if cursor is not None:
+            return dict(cursor)
+        stored = self.codex_event_store.get_codex_fork_provider_cursor(session_id)
+        if stored is not None:
+            self.codex_fork_provider_cursors[session_id] = dict(stored)
+        return stored
+
+    def _claim_codex_fork_provider_event(self, session_id: str, event: dict[str, Any]) -> bool:
+        """Return True when one codex-fork provider event should be ingested."""
+        seq = self._codex_fork_event_provider_seq(event)
+        if seq is None or event.get("session_epoch") is None:
+            return True
+        session_epoch = event.get("session_epoch")
+        claimed, previous, cursor = self.codex_event_store.claim_codex_fork_provider_event(
+            session_id,
+            session_epoch=session_epoch,
+            seq=seq,
+        )
+        if not claimed:
+            return False
+        if previous is not None and previous.get("session_epoch_key") == cursor.get("session_epoch_key"):
+            previous_seq = int(previous.get("seq") or 0)
+            if seq > previous_seq + 1:
+                logger.warning(
+                    "Codex-fork provider event gap for %s epoch=%s previous_seq=%s next_seq=%s",
+                    session_id,
+                    session_epoch,
+                    previous_seq,
+                    seq,
+                )
+        self.codex_fork_provider_cursors[session_id] = dict(cursor)
+        return True
+
+    def _codex_fork_transport_for_session(self, session: Session) -> CodexForkTransport:
+        """Select the raw codex-fork IPC transport for the session's owning node."""
+        node_id = normalize_node_id(getattr(session, "node", PRIMARY_NODE))
+        if node_id == PRIMARY_NODE:
+            return LocalCodexForkTransport(
+                socket_path=self._codex_fork_control_socket_path(session),
+                roundtrip=self._codex_fork_control_roundtrip,
+            )
+        event_stream_path, control_socket_path = self._codex_fork_artifact_path_strings(session)
+        return RemoteCodexForkTransport(
+            registry=self.codex_fork_node_agents,
+            node_id=node_id,
+            session_id=session.id,
+            event_stream_path=event_stream_path,
+            control_socket_path=control_socket_path,
+            cursor=self._get_codex_fork_provider_cursor(session.id),
+            control_timeout=max(0.5, self.codex_fork_control_timeout_seconds),
+        )
+
     def get_codex_fork_lifecycle_state(self, session_id: str) -> Optional[dict[str, Any]]:
         """Return current codex-fork lifecycle reducer snapshot."""
         state = self.codex_fork_lifecycle.get(session_id)
@@ -2656,7 +2914,7 @@ class SessionManager:
             return
         if session.provider != "codex-fork":
             return
-        if from_eof:
+        if from_eof and normalize_node_id(getattr(session, "node", PRIMARY_NODE)) == PRIMARY_NODE:
             stream_path = self._codex_fork_event_stream_path(session)
             if stream_path.exists():
                 self.codex_fork_event_offsets[session.id] = stream_path.stat().st_size
@@ -2666,6 +2924,16 @@ class SessionManager:
             return
         task = loop.create_task(self._monitor_codex_fork_event_stream(session.id))
         self.codex_fork_event_monitors[session.id] = task
+
+    async def _register_codex_fork_remote_bridge(self, session: Session) -> asyncio.Queue[Optional[str]]:
+        """Register one remote codex-fork session's node-local artifacts with its node-agent."""
+        node_id = normalize_node_id(getattr(session, "node", PRIMARY_NODE))
+        if node_id == PRIMARY_NODE:
+            raise RuntimeError("codex-fork remote bridge requested for primary session")
+        queue = await self._codex_fork_transport_for_session(session).register_event_stream()
+        if queue is None:
+            raise RuntimeError("remote codex-fork transport did not return an event queue")
+        return queue
 
     async def _stop_codex_fork_event_monitor(self, session_id: str):
         """Stop one codex-fork event monitor task."""
@@ -2677,6 +2945,35 @@ class SessionManager:
             except asyncio.CancelledError:
                 pass
 
+    async def _process_codex_fork_event_line(self, session_id: str, line: str) -> None:
+        raw = line.strip()
+        if not raw:
+            return
+        try:
+            event = json.loads(raw)
+        except json.JSONDecodeError:
+            logger.debug("Skipping non-JSON codex-fork event line for %s", session_id)
+            return
+        if not isinstance(event, dict):
+            logger.debug("Skipping malformed codex-fork event line for %s", session_id)
+            return
+        lifecycle = self.ingest_codex_fork_event(session_id, event)
+        if lifecycle is None:
+            return
+        await self._handle_codex_fork_assistant_relay_event(session_id, event)
+        normalized = self._normalize_codex_fork_event_type(
+            event.get("event_type") or event.get("type")
+        )
+        if normalized == "turn_complete":
+            payload = event.get("payload") if isinstance(event.get("payload"), dict) else {}
+            last_message = payload.get("last_agent_message")
+            if isinstance(last_message, str) and last_message.strip():
+                await self._handle_codex_fork_turn_complete(
+                    session_id=session_id,
+                    last_message=last_message,
+                    event=event,
+                )
+
     async def _monitor_codex_fork_event_stream(self, session_id: str):
         """Tail codex-fork event-stream file and feed reducer."""
         buffer = self.codex_fork_event_buffers.get(session_id, "")
@@ -2684,6 +2981,9 @@ class SessionManager:
             while True:
                 session = self.sessions.get(session_id)
                 if not session or session.provider != "codex-fork":
+                    return
+                if normalize_node_id(getattr(session, "node", PRIMARY_NODE)) != PRIMARY_NODE:
+                    await self._monitor_remote_codex_fork_event_stream(session)
                     return
 
                 stream_path = self._codex_fork_event_stream_path(session)
@@ -2705,31 +3005,7 @@ class SessionManager:
                         self.codex_fork_event_buffers[session_id] = buffer
 
                         for line in lines:
-                            raw = line.strip()
-                            if not raw:
-                                continue
-                            try:
-                                event = json.loads(raw)
-                            except json.JSONDecodeError:
-                                logger.debug("Skipping non-JSON codex-fork event line for %s", session_id)
-                                continue
-                            if not isinstance(event, dict):
-                                logger.debug("Skipping malformed codex-fork event line for %s", session_id)
-                                continue
-                            self.ingest_codex_fork_event(session_id, event)
-                            await self._handle_codex_fork_assistant_relay_event(session_id, event)
-                            normalized = self._normalize_codex_fork_event_type(
-                                event.get("event_type") or event.get("type")
-                            )
-                            if normalized == "turn_complete":
-                                payload = event.get("payload") if isinstance(event.get("payload"), dict) else {}
-                                last_message = payload.get("last_agent_message")
-                                if isinstance(last_message, str) and last_message.strip():
-                                    await self._handle_codex_fork_turn_complete(
-                                        session_id=session_id,
-                                        last_message=last_message,
-                                        event=event,
-                                    )
+                            await self._process_codex_fork_event_line(session_id, line)
 
                 await asyncio.sleep(self.codex_fork_event_poll_interval_seconds)
         except asyncio.CancelledError:
@@ -2744,6 +3020,39 @@ class SessionManager:
         finally:
             self.codex_fork_event_monitors.pop(session_id, None)
             self.codex_fork_event_buffers.pop(session_id, None)
+
+    async def _monitor_remote_codex_fork_event_stream(self, session: Session) -> None:
+        """Consume remote codex-fork event lines delivered by a node-agent."""
+        session_id = session.id
+        while True:
+            current = self.sessions.get(session_id)
+            if not current or current.provider != "codex-fork":
+                return
+            node_id = normalize_node_id(getattr(current, "node", PRIMARY_NODE))
+            if node_id == PRIMARY_NODE:
+                return
+            try:
+                queue = await self._register_codex_fork_remote_bridge(current)
+                self.mark_node_unreachable(session_id, False)
+            except Exception as exc:
+                logger.warning("Remote codex-fork bridge unavailable for %s: %s", session_id, exc)
+                self.mark_node_unreachable(session_id, True)
+                await asyncio.sleep(max(1.0, self.codex_fork_event_poll_interval_seconds))
+                continue
+
+            while True:
+                current = self.sessions.get(session_id)
+                if not current or current.provider != "codex-fork":
+                    return
+                try:
+                    line = await queue.get()
+                except asyncio.CancelledError:
+                    raise
+                if line is None:
+                    self.mark_node_unreachable(session_id, True)
+                    break
+                self.mark_node_unreachable(session_id, False)
+                await self._process_codex_fork_event_line(session_id, line)
 
     async def _create_session_common(
         self,
@@ -2796,8 +3105,22 @@ class SessionManager:
                 provider_node_rejection,
             )
             return None
+        capability_rejection = self._codex_fork_remote_capability_rejection(provider, resolved_node or PRIMARY_NODE)
+        if capability_rejection:
+            self.last_create_error = capability_rejection
+            logger.error(
+                "Rejecting %s session create on node %s: %s",
+                provider,
+                resolved_node,
+                capability_rejection,
+            )
+            return None
 
-        provider_rejection = self.get_provider_create_rejection(provider, working_dir=working_dir)
+        provider_rejection = self.get_provider_create_rejection(
+            provider,
+            working_dir=working_dir,
+            node=resolved_node or PRIMARY_NODE,
+        )
         if provider_rejection:
             self.last_create_error = provider_rejection
             logger.error("Rejecting %s session create in %s: %s", provider, working_dir, provider_rejection)
@@ -2852,10 +3175,15 @@ class SessionManager:
                 default_model = self.codex_default_model
             else:
                 # Codex-fork config with codex fallback when the fork binary is unavailable.
-                command, args, effective_provider, fallback_reason = self._build_codex_fork_launch_spec(
-                    session,
-                    fork_id=codex_fork_source_resume_id,
-                )
+                try:
+                    command, args, effective_provider, fallback_reason = self._build_codex_fork_launch_spec(
+                        session,
+                        fork_id=codex_fork_source_resume_id,
+                    )
+                except RuntimeError as exc:
+                    self.last_create_error = str(exc)
+                    logger.error("Rejecting codex-fork session create for %s: %s", session.id, exc)
+                    return None
                 default_model = (
                     self.codex_fork_default_model
                     if effective_provider == "codex-fork"
@@ -2894,6 +3222,15 @@ class SessionManager:
                 tmux_create_kwargs["node"] = session.node
             if runtime_env:
                 tmux_create_kwargs["runtime_env"] = runtime_env
+            remote_bridge_registered = False
+            if provider == "codex-fork" and normalize_node_id(getattr(session, "node", PRIMARY_NODE)) != PRIMARY_NODE:
+                try:
+                    await self._register_codex_fork_remote_bridge(session)
+                    remote_bridge_registered = True
+                except Exception as exc:
+                    self.last_create_error = str(exc)
+                    logger.error("Rejecting remote codex-fork create for %s: %s", session.id, exc)
+                    return None
             created = await asyncio.to_thread(
                 self.tmux.create_session_with_command,
                 session.tmux_session,
@@ -2908,6 +3245,9 @@ class SessionManager:
                     logger.error("Failed to create tmux session for %s: %s", session.name, tmux_error)
                 else:
                     logger.error(f"Failed to create tmux session for {session.name}")
+                if remote_bridge_registered:
+                    with contextlib.suppress(Exception):
+                        await self.codex_fork_node_agents.unregister_session(session.id)
                 return None
             session.tmux_socket_name = self._tmux_socket_name()
         elif provider == "codex-app":
@@ -3322,7 +3662,11 @@ class SessionManager:
         if not source_resume_id:
             return False, None, "Source session has no provider resume id to fork"
 
-        provider_rejection = self.get_provider_create_rejection("codex-fork", working_dir=source.working_dir)
+        provider_rejection = self.get_provider_create_rejection(
+            "codex-fork",
+            working_dir=source.working_dir,
+            node=getattr(source, "node", PRIMARY_NODE),
+        )
         if provider_rejection:
             return False, None, provider_rejection
 
@@ -3901,6 +4245,17 @@ class SessionManager:
                         provider,
                         resolved_node,
                         provider_node_rejection,
+                    )
+                    continue
+                capability_rejection = self._codex_fork_remote_capability_rejection(provider, resolved_node)
+                if capability_rejection:
+                    last_error = capability_rejection
+                    logger.warning(
+                        "Skipping %s bootstrap provider %s on node %s: %s",
+                        normalized_role,
+                        provider,
+                        resolved_node,
+                        capability_rejection,
                     )
                     continue
                 if node:
@@ -5160,6 +5515,10 @@ class SessionManager:
         """Recreate one codex-fork runtime in place to restore missing bridge artifacts."""
         if session.provider != "codex-fork":
             return False, "session is not codex-fork"
+        node_id = normalize_node_id(getattr(session, "node", PRIMARY_NODE))
+        if node_id != PRIMARY_NODE and not self.is_codex_fork_node_agent_healthy(node_id):
+            self.mark_node_unreachable(session.id, True)
+            return False, f"node-agent not connected for node {node_id}"
 
         resume_id = self.get_session_resume_id(session)
         if not resume_id:
@@ -5176,13 +5535,26 @@ class SessionManager:
         self.codex_fork_control_epoch.pop(session.id, None)
         self.codex_fork_control_degraded.pop(session.id, None)
 
-        if session.tmux_session and self.tmux.session_exists(session.tmux_session):
-            self.tmux.kill_session(session.tmux_session)
+        if session.tmux_session:
+            try:
+                tmux_exists = self.tmux.session_exists(session.tmux_session)
+            except Exception as exc:
+                if node_id != PRIMARY_NODE:
+                    self.mark_node_unreachable(session.id, True)
+                    return False, f"node {node_id} unreachable: {exc}"
+                raise
+            if tmux_exists:
+                self.tmux.kill_session(session.tmux_session)
 
-        command, args, effective_provider, fallback_reason = self._build_codex_fork_launch_spec(
-            session,
-            resume_id=resume_id,
-        )
+        try:
+            command, args, effective_provider, fallback_reason = self._build_codex_fork_launch_spec(
+                session,
+                resume_id=resume_id,
+            )
+        except RuntimeError as exc:
+            return False, str(exc)
+        if effective_provider != session.provider and node_id != PRIMARY_NODE:
+            return False, fallback_reason or "remote codex-fork cannot fall back to legacy codex"
         if effective_provider != session.provider:
             logger.warning(
                 "Falling back from codex-fork to codex while recreating %s: %s",
@@ -5191,15 +5563,36 @@ class SessionManager:
             )
             session.provider = effective_provider
 
+        remote_bridge_registered = False
+        if session.provider == "codex-fork" and node_id != PRIMARY_NODE:
+            try:
+                await self._register_codex_fork_remote_bridge(session)
+                remote_bridge_registered = True
+            except Exception as exc:
+                self.mark_node_unreachable(session.id, True)
+                return False, str(exc)
+
+        tmux_kwargs: dict[str, Any] = {
+            "session_id": session.id,
+            "command": command,
+            "args": args,
+        }
+        runtime_env = self._runtime_env_for_session(session)
+        if node_id != PRIMARY_NODE:
+            tmux_kwargs["node"] = session.node
+        if runtime_env:
+            tmux_kwargs["runtime_env"] = runtime_env
+
         if not self.tmux.create_session_with_command(
             session.tmux_session,
             session.working_dir,
             session.log_file,
-            session_id=session.id,
-            command=command,
-            args=args,
+            **tmux_kwargs,
         ):
             tmux_error = getattr(self.tmux, "last_error_message", None)
+            if remote_bridge_registered:
+                with contextlib.suppress(Exception):
+                    await self.codex_fork_node_agents.unregister_session(session.id)
             session.error_message = f"codex_fork_runtime_artifacts_missing: {reason}"
             if tmux_error:
                 session.error_message = f"{session.error_message} ({tmux_error})"
@@ -5233,7 +5626,41 @@ class SessionManager:
         for session in list(self.sessions.values()):
             if session.provider != "codex-fork" or session.status == SessionStatus.STOPPED:
                 continue
-            if not session.tmux_session or not self.tmux.session_exists(session.tmux_session):
+            node_id = normalize_node_id(getattr(session, "node", PRIMARY_NODE))
+            try:
+                tmux_exists = bool(session.tmux_session) and self.tmux.session_exists(session.tmux_session)
+            except Exception as exc:
+                if node_id != PRIMARY_NODE:
+                    logger.warning(
+                        "Node %s unreachable while maintaining codex-fork artifacts for %s: %s",
+                        node_id,
+                        session.id,
+                        exc,
+                    )
+                    self.mark_node_unreachable(session.id, True)
+                    degraded.append(session.id)
+                    continue
+                raise
+            if not tmux_exists:
+                continue
+            if node_id != PRIMARY_NODE:
+                if not self.is_codex_fork_node_agent_healthy(node_id):
+                    self.mark_node_unreachable(session.id, True)
+                    degraded.append(session.id)
+                    continue
+                try:
+                    await self._register_codex_fork_remote_bridge(session)
+                except Exception as exc:
+                    logger.warning("Remote codex-fork bridge registration failed for %s: %s", session.id, exc)
+                    self.mark_node_unreachable(session.id, True)
+                    degraded.append(session.id)
+                    continue
+                self.mark_node_unreachable(session.id, False)
+                if session.id not in self.codex_fork_event_monitors:
+                    self._start_codex_fork_event_monitor(session, from_eof=True)
+                if session.error_message and session.error_message.startswith("codex_fork_runtime_artifacts_missing:"):
+                    session.error_message = None
+                    self._save_state()
                 continue
 
             missing: list[str] = []
@@ -5338,13 +5765,16 @@ class SessionManager:
             with contextlib.suppress(Exception):
                 await writer.wait_closed()
 
-    async def _refresh_codex_fork_control_epoch(self, session: Session, socket_path: Path) -> tuple[bool, str]:
+    async def _codex_fork_control_roundtrip_for_session(self, session: Session, request: dict[str, Any]) -> dict[str, Any]:
+        return await self._codex_fork_transport_for_session(session).control_roundtrip(request)
+
+    async def _refresh_codex_fork_control_epoch(self, session: Session) -> tuple[bool, str]:
         request = {
             "request_id": uuid.uuid4().hex,
             "command": "get_epoch",
         }
         try:
-            response = await self._codex_fork_control_roundtrip(socket_path, request)
+            response = await self._codex_fork_control_roundtrip_for_session(session, request)
         except Exception as exc:
             return False, f"failed to read control epoch: {exc}"
         if not response.get("ok"):
@@ -5369,13 +5799,17 @@ class SessionManager:
         command: str,
         payload: dict[str, Any],
     ) -> tuple[bool, str]:
-        socket_path = self._codex_fork_control_socket_path(session)
-        if not socket_path.exists():
-            return False, f"control socket not found: {socket_path}"
+        node_id = normalize_node_id(getattr(session, "node", PRIMARY_NODE))
+        if node_id == PRIMARY_NODE:
+            socket_path = self._codex_fork_control_socket_path(session)
+            if not socket_path.exists():
+                return False, f"control socket not found: {socket_path}"
+        elif not self.is_codex_fork_node_agent_healthy(node_id):
+            return False, f"node-agent not connected for node {node_id}"
 
         epoch = self.codex_fork_control_epoch.get(session.id)
         if not epoch:
-            ok, epoch_or_error = await self._refresh_codex_fork_control_epoch(session, socket_path)
+            ok, epoch_or_error = await self._refresh_codex_fork_control_epoch(session)
             if not ok:
                 return False, epoch_or_error
             epoch = epoch_or_error
@@ -5387,7 +5821,7 @@ class SessionManager:
                 "command": command,
                 **payload,
             }
-            return await self._codex_fork_control_roundtrip(socket_path, request)
+            return await self._codex_fork_control_roundtrip_for_session(session, request)
 
         try:
             response = await send_with_epoch(epoch)
@@ -5398,7 +5832,7 @@ class SessionManager:
             error = response.get("error") if isinstance(response.get("error"), dict) else {}
             error_code = error.get("code", "unknown_error")
             if error_code == "stale_epoch":
-                ok, epoch_or_error = await self._refresh_codex_fork_control_epoch(session, socket_path)
+                ok, epoch_or_error = await self._refresh_codex_fork_control_epoch(session)
                 if not ok:
                     return False, epoch_or_error
                 try:
@@ -6333,10 +6767,11 @@ class SessionManager:
 
         if provider == "codex-fork":
             lifecycle = self.get_codex_fork_lifecycle_state(session_id) or {}
+            artifact_node = normalize_node_id(getattr(session, "node", PRIMARY_NODE))
             descriptor = {
                 "session_id": session.id,
                 "provider": provider,
-                "node": getattr(session, "node", PRIMARY_NODE),
+                "node": artifact_node,
                 "attach_supported": True,
                 "attach_transport": "tmux",
                 "tmux_session": session.tmux_session,
@@ -6348,8 +6783,11 @@ class SessionManager:
                 "runtime_owner": self.codex_fork_runtime_owner.get(session.id),
                 "lifecycle_state": lifecycle.get("state", "idle"),
                 "lifecycle_cause": lifecycle.get("cause_event_type"),
-                "control_socket_path": str(self._codex_fork_control_socket_path(session)),
-                "event_stream_path": str(self._codex_fork_event_stream_path(session)),
+                "artifact_paths_node": artifact_node,
+                "artifact_paths_scope": "primary-local" if artifact_node == PRIMARY_NODE else "node-local",
+                "artifact_paths_debug_only": artifact_node != PRIMARY_NODE,
+                "control_socket_path": self._codex_fork_control_socket_path_string(session),
+                "event_stream_path": self._codex_fork_event_stream_path_string(session),
             }
             if attach_command:
                 descriptor["attach_command"] = attach_command
@@ -6622,12 +7060,12 @@ class SessionManager:
                 self.codex_fork_control_epoch.pop(session_id, None)
                 self.codex_fork_control_degraded.pop(session_id, None)
                 self.codex_fork_runtime_owner.pop(session_id, None)
-                event_stream_path = self._codex_fork_event_stream_path(session)
-                control_socket_path = self._codex_fork_control_socket_path(session)
-                if event_stream_path.exists():
-                    event_stream_path.unlink()
-                if control_socket_path.exists():
-                    control_socket_path.unlink()
+                try:
+                    loop = asyncio.get_running_loop()
+                    loop.create_task(self.codex_fork_node_agents.unregister_session(session_id))
+                except RuntimeError:
+                    asyncio.run(self.codex_fork_node_agents.unregister_session(session_id))
+                self._unlink_codex_fork_runtime_artifacts(session)
                 self._set_codex_fork_lifecycle_state(
                     session_id=session_id,
                     state="shutdown",
@@ -6687,7 +7125,7 @@ class SessionManager:
         resume_id = self.get_session_resume_id(session)
         if session.provider != "codex-app" and not session.log_file:
             session.log_file = str(self.log_dir / f"{session.name}.log")
-        if session.provider != "codex-app" and self.tmux.session_exists(session.tmux_session):
+        if session.provider != "codex-app" and not tmux_runtime_missing:
             self.tmux.kill_session(session.tmux_session)
 
         if session.provider == "claude":
@@ -6718,16 +7156,24 @@ class SessionManager:
             provider_node_rejection = self._provider_node_rejection(session.provider, session.node)
             if provider_node_rejection:
                 return False, session, provider_node_rejection
+            capability_rejection = self._codex_fork_remote_capability_rejection(session.provider, session.node)
+            if capability_rejection:
+                return False, session, capability_rejection
             if not resume_id:
                 return False, session, "No Codex resume id is available for this session"
             if session.provider == "codex":
                 command = self.codex_cli_command
                 args = ["resume", resume_id, *self.codex_cli_args]
             else:
-                command, args, effective_provider, fallback_reason = self._build_codex_fork_launch_spec(
-                    session,
-                    resume_id=resume_id,
-                )
+                try:
+                    command, args, effective_provider, fallback_reason = self._build_codex_fork_launch_spec(
+                        session,
+                        resume_id=resume_id,
+                    )
+                except RuntimeError as exc:
+                    return False, session, str(exc)
+                if effective_provider != session.provider and normalize_node_id(session.node) != PRIMARY_NODE:
+                    return False, session, fallback_reason or "remote codex-fork cannot fall back to legacy codex"
                 if effective_provider != session.provider:
                     logger.warning(
                         "Falling back from codex-fork to codex while restoring %s: %s",
@@ -6735,6 +7181,14 @@ class SessionManager:
                         fallback_reason,
                     )
                     session.provider = effective_provider
+            remote_bridge_registered = False
+            if session.provider == "codex-fork" and normalize_node_id(session.node) != PRIMARY_NODE:
+                try:
+                    await self._register_codex_fork_remote_bridge(session)
+                    remote_bridge_registered = True
+                except Exception as exc:
+                    self.mark_node_unreachable(session.id, True)
+                    return False, session, str(exc)
             if not self.tmux.create_session_with_command(
                 session.tmux_session,
                 session.working_dir,
@@ -6746,6 +7200,9 @@ class SessionManager:
                 runtime_env=self._runtime_env_for_session(session),
             ):
                 tmux_error = getattr(self.tmux, "last_error_message", None)
+                if remote_bridge_registered:
+                    with contextlib.suppress(Exception):
+                        await self.codex_fork_node_agents.unregister_session(session.id)
                 if tmux_error:
                     session.error_message = tmux_error
                     self._save_state()

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -3736,10 +3736,11 @@ done
         if not source_resume_id:
             return False, None, "Source session has no provider resume id to fork"
 
+        source_node = normalize_node_id(getattr(source, "node", PRIMARY_NODE))
         provider_rejection = self.get_provider_create_rejection(
             "codex-fork",
             working_dir=source.working_dir,
-            node=getattr(source, "node", PRIMARY_NODE),
+            node=source_node,
         )
         if provider_rejection:
             return False, None, provider_rejection
@@ -3759,6 +3760,7 @@ done
             forked_from_session_id=source.id,
             forked_from_provider_resume_id=source_resume_id,
             forked_by_session_id=forked_by_session_id,
+            node=source_node,
         )
         if fork_session is None:
             return False, None, "Failed to create fork session"

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -512,10 +512,13 @@ class SessionManager:
         return self.codex_fork_node_agents.is_connected(node_id)
 
     async def attach_codex_fork_node_agent(self, connection: NodeAgentConnection) -> None:
-        """Register a live node-agent connection and re-register active sessions for that node."""
+        """Register a live node-agent connection and mark its sessions reachable."""
         await self.codex_fork_node_agents.attach(connection)
         self._mark_node_sessions_reachable(connection.node_id)
-        await self._register_active_remote_codex_fork_sessions(connection.node_id)
+
+    async def register_active_codex_fork_node_agent_sessions(self, node: str) -> None:
+        """Re-register active remote codex-fork sessions for a connected node-agent."""
+        await self._register_active_remote_codex_fork_sessions(node)
 
     async def detach_codex_fork_node_agent(self, connection: NodeAgentConnection) -> None:
         await self.codex_fork_node_agents.detach(connection)

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -2734,6 +2734,8 @@ done
                     "payload": payload_for_store,
                 },
             )
+            if provider_position is not None and not stored_event.get("persisted"):
+                return None
             lifecycle = self._reduce_codex_fork_lifecycle(
                 session_id=session_id,
                 event_type=normalized,

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -2654,7 +2654,7 @@ done
         provider_position: Optional[tuple[Any, int]],
         previous_provider_cursor: Optional[dict[str, Any]],
     ) -> Optional[dict[str, Any]]:
-        """Apply one non-duplicate codex-fork event and then advance provider cursor."""
+        """Apply one non-duplicate codex-fork event and advance the cursor after durable persistence."""
         payload = event.get("payload") if isinstance(event.get("payload"), dict) else {}
         provider_session_id = event.get("session_id")
         if not provider_session_id and payload:
@@ -2734,8 +2734,6 @@ done
                     "payload": payload_for_store,
                 },
             )
-            if not stored_event.get("persisted"):
-                return None
             lifecycle = self._reduce_codex_fork_lifecycle(
                 session_id=session_id,
                 event_type=normalized,
@@ -2744,7 +2742,7 @@ done
                 session_epoch=session_epoch,
                 event_timestamp_ns=self._timestamp_to_epoch_ns(event.get("ts")),
             )
-            if provider_position is not None:
+            if provider_position is not None and stored_event.get("persisted"):
                 self._record_codex_fork_provider_event_applied(
                     session_id,
                     provider_position[0],

--- a/tests/unit/test_codex_event_store.py
+++ b/tests/unit/test_codex_event_store.py
@@ -265,3 +265,73 @@ def test_startup_maintenance_failure_requeues_pending_overflow_sessions(tmp_path
         store._run_startup_maintenance()
 
     assert store._pop_pending_overflow_prune_sessions() == ["sess-pending"]
+
+
+def test_codex_fork_provider_claim_drops_duplicates_and_old_same_epoch_seq(tmp_path):
+    store = CodexEventStore(db_path=str(tmp_path / "codex_events.db"), startup_maintenance=False)
+
+    claimed, previous, cursor = store.claim_codex_fork_provider_event(
+        "fork1",
+        session_epoch={"pid": 1},
+        seq=3,
+    )
+    assert claimed is True
+    assert previous is None
+    assert cursor["seq"] == 3
+
+    claimed, previous, cursor = store.claim_codex_fork_provider_event(
+        "fork1",
+        session_epoch={"pid": 1},
+        seq=2,
+    )
+    assert claimed is False
+    assert previous["seq"] == 3
+    assert cursor["seq"] == 3
+
+    claimed, previous, cursor = store.claim_codex_fork_provider_event(
+        "fork1",
+        session_epoch={"pid": 1},
+        seq=3,
+    )
+    assert claimed is False
+    assert previous["seq"] == 3
+    assert cursor["seq"] == 3
+
+    claimed, previous, cursor = store.claim_codex_fork_provider_event(
+        "fork1",
+        session_epoch={"pid": 1},
+        seq=4,
+    )
+    assert claimed is True
+    assert previous["seq"] == 3
+    assert cursor["seq"] == 4
+
+    claimed, previous, cursor = store.claim_codex_fork_provider_event(
+        "fork1",
+        session_epoch={"pid": 2},
+        seq=1,
+    )
+    assert claimed is True
+    assert previous["seq"] == 4
+    assert cursor["session_epoch"] == {"pid": 2}
+    assert cursor["seq"] == 1
+
+
+def test_codex_fork_provider_cursor_persists_across_store_instances(tmp_path):
+    db_path = tmp_path / "codex_events.db"
+    first = CodexEventStore(db_path=str(db_path), startup_maintenance=False)
+
+    first.claim_codex_fork_provider_event("fork2", session_epoch="epoch-a", seq=9)
+    second = CodexEventStore(db_path=str(db_path), startup_maintenance=False)
+
+    cursor = second.get_codex_fork_provider_cursor("fork2")
+    assert cursor["session_epoch"] == "epoch-a"
+    assert cursor["seq"] == 9
+
+    claimed, _, cursor = second.claim_codex_fork_provider_event(
+        "fork2",
+        session_epoch="epoch-a",
+        seq=8,
+    )
+    assert claimed is False
+    assert cursor["seq"] == 9

--- a/tests/unit/test_codex_fork_control_client.py
+++ b/tests/unit/test_codex_fork_control_client.py
@@ -83,6 +83,57 @@ async def test_deliver_direct_uses_control_socket_primary_path(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_remote_control_bridge_handles_submit_message_stale_epoch_retry(tmp_path):
+    manager = SessionManager(log_dir=str(tmp_path), state_file=str(tmp_path / "state.json"))
+    session = Session(
+        id="cfctl_remote1",
+        name="codex-fork-cfctl_remote1",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        node="worker",
+        status=SessionStatus.RUNNING,
+    )
+    manager.sessions[session.id] = session
+
+    class HealthyConnection:
+        def is_healthy(self):
+            return True
+
+    manager.codex_fork_node_agents._connections["worker"] = HealthyConnection()
+    manager.codex_fork_node_agents.control_roundtrip = AsyncMock(
+        side_effect=[
+            {"ok": True, "result": {"epoch": "epoch-1"}},
+            {
+                "ok": False,
+                "epoch": "epoch-1",
+                "error": {"code": "stale_epoch", "message": "epoch changed"},
+            },
+            {"ok": True, "result": {"epoch": "epoch-2"}},
+            {"ok": True, "epoch": "epoch-2", "result": {"status": "accepted"}},
+        ]
+    )
+
+    success, reason = await manager._send_codex_fork_control_command(
+        session=session,
+        command="submit_message",
+        payload={"message": "hello remote"},
+    )
+
+    assert success is True
+    assert reason == ""
+    frames = [call.kwargs["frame"] for call in manager.codex_fork_node_agents.control_roundtrip.await_args_list]
+    assert [frame["command"] for frame in frames] == [
+        "get_epoch",
+        "submit_message",
+        "get_epoch",
+        "submit_message",
+    ]
+    assert frames[1]["expected_epoch"] == "epoch-1"
+    assert frames[1]["message"] == "hello remote"
+    assert frames[3]["expected_epoch"] == "epoch-2"
+
+
+@pytest.mark.asyncio
 async def test_provider_native_rename_uses_control_socket_primary_path(tmp_path):
     with tempfile.TemporaryDirectory(dir="/tmp", prefix="cfctl-rename-") as short_dir:
         short_root = Path(short_dir)

--- a/tests/unit/test_codex_fork_runtime_maintenance.py
+++ b/tests/unit/test_codex_fork_runtime_maintenance.py
@@ -216,6 +216,65 @@ async def test_maintain_codex_fork_runtime_artifacts_marks_unhealable_session_de
     assert session.error_message.startswith("codex_fork_runtime_artifacts_missing: event_stream, control_socket")
 
 
+def test_remote_codex_fork_runtime_reachable_checks_tmux_on_session_node(tmp_path):
+    manager = SessionManager(
+        log_dir=str(tmp_path),
+        state_file=str(tmp_path / "state.json"),
+        config={"nodes": {"registry": {"worker": {"ssh": "dev@example", "node_token": "secret"}}}},
+    )
+    session = Session(
+        id="remotereachable",
+        name="codex-fork-remotereachable",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        node="worker",
+        status=SessionStatus.RUNNING,
+        log_file=str(tmp_path / "remotereachable.log"),
+        provider_resume_id="resume-remotereachable",
+    )
+    manager.tmux.session_exists = Mock(return_value=True)
+
+    class HealthyConnection:
+        def is_healthy(self):
+            return True
+
+    manager.codex_fork_node_agents._connections["worker"] = HealthyConnection()
+
+    assert manager._codex_fork_runtime_reachable(session) is True
+    manager.tmux.session_exists.assert_called_once_with(session.tmux_session, node="worker")
+
+
+def test_hydrate_stopped_remote_codex_fork_heals_using_remote_tmux_node(tmp_path):
+    manager = SessionManager(
+        log_dir=str(tmp_path),
+        state_file=str(tmp_path / "state.json"),
+        config={"nodes": {"registry": {"worker": {"ssh": "dev@example", "node_token": "secret"}}}},
+    )
+    session = Session(
+        id="remoteheal",
+        name="codex-fork-remoteheal",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        node="worker",
+        status=SessionStatus.STOPPED,
+        log_file=str(tmp_path / "remoteheal.log"),
+        provider_resume_id="resume-remoteheal",
+    )
+    manager.tmux.session_exists = Mock(return_value=True)
+
+    class HealthyConnection:
+        def is_healthy(self):
+            return True
+
+    manager.codex_fork_node_agents._connections["worker"] = HealthyConnection()
+
+    manager._hydrate_state_from_data({"sessions": [session.to_dict()]})
+
+    assert manager.sessions[session.id].status == SessionStatus.IDLE
+    assert manager.codex_fork_runtime_owner[session.id] == session.id
+    manager.tmux.session_exists.assert_called_once_with(session.tmux_session, node="worker")
+
+
 @pytest.mark.asyncio
 async def test_maintain_remote_codex_fork_marks_node_unreachable_when_agent_missing(tmp_path):
     manager = SessionManager(
@@ -245,6 +304,7 @@ async def test_maintain_remote_codex_fork_marks_node_unreachable_when_agent_miss
     assert manager.is_session_node_unreachable(session.id)
     manager.tmux.create_session_with_command.assert_not_called()
     manager._start_codex_fork_event_monitor.assert_not_called()
+    manager.tmux.session_exists.assert_called_once_with(session.tmux_session, node="worker")
 
 
 @pytest.mark.asyncio
@@ -283,6 +343,7 @@ async def test_maintain_remote_codex_fork_registers_healthy_bridge_without_prima
     assert not manager.is_session_node_unreachable(session.id)
     manager._register_codex_fork_remote_bridge.assert_awaited_once_with(session)
     manager._start_codex_fork_event_monitor.assert_called_once_with(session, from_eof=True)
+    manager.tmux.session_exists.assert_called_once_with(session.tmux_session, node="worker")
 
 
 def test_kill_session_removes_codex_fork_event_stream(tmp_path):

--- a/tests/unit/test_codex_fork_runtime_maintenance.py
+++ b/tests/unit/test_codex_fork_runtime_maintenance.py
@@ -216,6 +216,75 @@ async def test_maintain_codex_fork_runtime_artifacts_marks_unhealable_session_de
     assert session.error_message.startswith("codex_fork_runtime_artifacts_missing: event_stream, control_socket")
 
 
+@pytest.mark.asyncio
+async def test_maintain_remote_codex_fork_marks_node_unreachable_when_agent_missing(tmp_path):
+    manager = SessionManager(
+        log_dir=str(tmp_path),
+        state_file=str(tmp_path / "state.json"),
+        config={"nodes": {"registry": {"worker": {"ssh": "dev@example", "node_token": "secret"}}}},
+    )
+    session = Session(
+        id="remoteagentmissing",
+        name="codex-fork-remoteagentmissing",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        node="worker",
+        status=SessionStatus.RUNNING,
+        log_file=str(tmp_path / "remoteagentmissing.log"),
+        provider_resume_id="resume-remoteagentmissing",
+    )
+    manager.sessions[session.id] = session
+    manager.tmux.session_exists = Mock(return_value=True)
+    manager.tmux.create_session_with_command = Mock(return_value=True)
+    manager._start_codex_fork_event_monitor = Mock()
+
+    result = await manager.maintain_codex_fork_runtime_artifacts()
+
+    assert result["healed"] == []
+    assert result["degraded"] == [session.id]
+    assert manager.is_session_node_unreachable(session.id)
+    manager.tmux.create_session_with_command.assert_not_called()
+    manager._start_codex_fork_event_monitor.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_maintain_remote_codex_fork_registers_healthy_bridge_without_primary_path_checks(tmp_path):
+    manager = SessionManager(
+        log_dir=str(tmp_path),
+        state_file=str(tmp_path / "state.json"),
+        config={"nodes": {"registry": {"worker": {"ssh": "dev@example", "node_token": "secret"}}}},
+    )
+    session = Session(
+        id="remotehealthy",
+        name="codex-fork-remotehealthy",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        node="worker",
+        status=SessionStatus.RUNNING,
+        log_file=str(tmp_path / "remotehealthy.log"),
+        provider_resume_id="resume-remotehealthy",
+    )
+    manager.sessions[session.id] = session
+    manager.mark_node_unreachable(session.id, True)
+    manager.tmux.session_exists = Mock(return_value=True)
+    manager._register_codex_fork_remote_bridge = AsyncMock()
+    manager._start_codex_fork_event_monitor = Mock()
+
+    class HealthyConnection:
+        def is_healthy(self):
+            return True
+
+    manager.codex_fork_node_agents._connections["worker"] = HealthyConnection()
+
+    result = await manager.maintain_codex_fork_runtime_artifacts()
+
+    assert result["healed"] == []
+    assert result["degraded"] == []
+    assert not manager.is_session_node_unreachable(session.id)
+    manager._register_codex_fork_remote_bridge.assert_awaited_once_with(session)
+    manager._start_codex_fork_event_monitor.assert_called_once_with(session, from_eof=True)
+
+
 def test_kill_session_removes_codex_fork_event_stream(tmp_path):
     manager = SessionManager(log_dir=str(tmp_path), state_file=str(tmp_path / "state.json"))
     session = Session(

--- a/tests/unit/test_codex_observability_ingestion.py
+++ b/tests/unit/test_codex_observability_ingestion.py
@@ -252,6 +252,42 @@ def test_codex_fork_raw_function_call_ingestion_logs_tool_event(tmp_path):
     assert session.last_tool_call is not None
 
 
+def test_codex_fork_provider_seq_guard_drops_replay_before_event_append(tmp_path):
+    manager = SessionManager(log_dir=str(tmp_path), state_file=str(tmp_path / "state.json"))
+    session = Session(
+        id="forkdedupe1",
+        name="codex-fork-forkdedupe1",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        status=SessionStatus.RUNNING,
+    )
+    manager.sessions[session.id] = session
+
+    first_event = {
+        "schema_version": 2,
+        "event_type": "turn_started",
+        "session_id": "thread-dedupe",
+        "seq": 3,
+        "session_epoch": {"pid": 111},
+        "payload": {"turn_id": "turn-dedupe"},
+    }
+    duplicate_event = dict(first_event)
+    older_event = {**first_event, "seq": 2, "payload": {"turn_id": "turn-old"}}
+
+    assert manager.ingest_codex_fork_event(session.id, first_event) is not None
+    initial_events = manager.codex_event_store.get_events(session.id, limit=10)["events"]
+    assert manager.ingest_codex_fork_event(session.id, duplicate_event) is None
+    assert manager.ingest_codex_fork_event(session.id, older_event) is None
+
+    stored_events = manager.codex_event_store.get_events(session.id, limit=10)["events"]
+    assert len(stored_events) == len(initial_events)
+    provider_events = [
+        event for event in stored_events if event["event_type"] == "codex_fork_turn_started"
+    ]
+    assert len(provider_events) == 1
+    assert provider_events[0]["payload_preview"]["seq"] == 3
+
+
 @pytest.mark.asyncio
 async def test_codex_fork_turn_complete_updates_last_message_and_notifies(tmp_path):
     manager = SessionManager(log_dir=str(tmp_path), state_file=str(tmp_path / "state.json"))

--- a/tests/unit/test_codex_observability_ingestion.py
+++ b/tests/unit/test_codex_observability_ingestion.py
@@ -288,6 +288,74 @@ def test_codex_fork_provider_seq_guard_drops_replay_before_event_append(tmp_path
     assert provider_events[0]["payload_preview"]["seq"] == 3
 
 
+def test_codex_fork_provider_cursor_not_advanced_when_append_not_persisted(tmp_path):
+    manager = SessionManager(log_dir=str(tmp_path), state_file=str(tmp_path / "state.json"))
+    session = Session(
+        id="forkappendfail1",
+        name="codex-fork-forkappendfail1",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        status=SessionStatus.RUNNING,
+    )
+    manager.sessions[session.id] = session
+    event = {
+        "schema_version": 2,
+        "event_type": "turn_started",
+        "session_id": "thread-appendfail",
+        "seq": 3,
+        "session_epoch": {"pid": 222},
+        "payload": {"turn_id": "turn-appendfail"},
+    }
+
+    with patch.object(
+        manager.codex_event_store,
+        "append_event",
+        return_value={"session_id": session.id, "seq": None, "persisted": False},
+    ):
+        assert manager.ingest_codex_fork_event(session.id, event) is None
+
+    assert manager.codex_event_store.get_codex_fork_provider_cursor(session.id) is None
+    assert manager.ingest_codex_fork_event(session.id, event) is not None
+    cursor = manager.codex_event_store.get_codex_fork_provider_cursor(session.id)
+    assert cursor["seq"] == 3
+    stored_events = manager.codex_event_store.get_events(session.id, limit=10)["events"]
+    provider_events = [item for item in stored_events if item["event_type"] == "codex_fork_turn_started"]
+    assert len(provider_events) == 1
+
+
+def test_codex_fork_provider_cursor_and_event_row_rollback_when_reducer_fails(tmp_path):
+    manager = SessionManager(log_dir=str(tmp_path), state_file=str(tmp_path / "state.json"))
+    session = Session(
+        id="forkreducefail1",
+        name="codex-fork-forkreducefail1",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        status=SessionStatus.RUNNING,
+    )
+    manager.sessions[session.id] = session
+    event = {
+        "schema_version": 2,
+        "event_type": "turn_started",
+        "session_id": "thread-reducefail",
+        "seq": 4,
+        "session_epoch": {"pid": 333},
+        "payload": {"turn_id": "turn-reducefail"},
+    }
+
+    with patch.object(manager, "_reduce_codex_fork_lifecycle", side_effect=RuntimeError("forced reducer failure")):
+        with pytest.raises(RuntimeError, match="forced reducer failure"):
+            manager.ingest_codex_fork_event(session.id, event)
+
+    assert manager.codex_event_store.get_codex_fork_provider_cursor(session.id) is None
+    assert manager.codex_event_store.get_events(session.id, limit=10)["events"] == []
+    assert manager.ingest_codex_fork_event(session.id, event) is not None
+    cursor = manager.codex_event_store.get_codex_fork_provider_cursor(session.id)
+    assert cursor["seq"] == 4
+    stored_events = manager.codex_event_store.get_events(session.id, limit=10)["events"]
+    provider_events = [item for item in stored_events if item["event_type"] == "codex_fork_turn_started"]
+    assert len(provider_events) == 1
+
+
 @pytest.mark.asyncio
 async def test_codex_fork_turn_complete_updates_last_message_and_notifies(tmp_path):
     manager = SessionManager(log_dir=str(tmp_path), state_file=str(tmp_path / "state.json"))

--- a/tests/unit/test_codex_observability_ingestion.py
+++ b/tests/unit/test_codex_observability_ingestion.py
@@ -312,7 +312,7 @@ def test_codex_fork_provider_cursor_not_advanced_when_append_not_persisted(tmp_p
         "append_event",
         return_value={"session_id": session.id, "seq": None, "persisted": False},
     ):
-        assert manager.ingest_codex_fork_event(session.id, event) is None
+        assert manager.ingest_codex_fork_event(session.id, event) is not None
 
     assert manager.codex_event_store.get_codex_fork_provider_cursor(session.id) is None
     assert manager.ingest_codex_fork_event(session.id, event) is not None
@@ -321,6 +321,47 @@ def test_codex_fork_provider_cursor_not_advanced_when_append_not_persisted(tmp_p
     stored_events = manager.codex_event_store.get_events(session.id, limit=10)["events"]
     provider_events = [item for item in stored_events if item["event_type"] == "codex_fork_turn_started"]
     assert len(provider_events) == 1
+
+
+@pytest.mark.asyncio
+async def test_codex_fork_process_line_continues_when_append_not_persisted(tmp_path):
+    manager = SessionManager(log_dir=str(tmp_path), state_file=str(tmp_path / "state.json"))
+    session = Session(
+        id="forkfallback1",
+        name="codex-fork-forkfallback1",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        status=SessionStatus.RUNNING,
+    )
+    manager.sessions[session.id] = session
+    manager._handle_codex_fork_assistant_relay_event = AsyncMock()
+    manager._handle_codex_fork_turn_complete = AsyncMock()
+    event = {
+        "schema_version": 2,
+        "event_type": "turn_complete",
+        "session_id": "thread-fallback",
+        "seq": 5,
+        "session_epoch": {"pid": 444},
+        "payload": {
+            "turn_id": "turn-fallback",
+            "last_agent_message": "done despite persistence fallback",
+        },
+    }
+
+    with patch.object(
+        manager.codex_event_store,
+        "append_event",
+        return_value={"session_id": session.id, "seq": None, "persisted": False},
+    ):
+        await manager._process_codex_fork_event_line(session.id, json.dumps(event))
+
+    assert manager.codex_event_store.get_codex_fork_provider_cursor(session.id) is None
+    manager._handle_codex_fork_assistant_relay_event.assert_awaited_once_with(session.id, event)
+    manager._handle_codex_fork_turn_complete.assert_awaited_once_with(
+        session_id=session.id,
+        last_message="done despite persistence fallback",
+        event=event,
+    )
 
 
 def test_codex_fork_provider_cursor_and_event_row_rollback_when_reducer_fails(tmp_path):

--- a/tests/unit/test_codex_observability_ingestion.py
+++ b/tests/unit/test_codex_observability_ingestion.py
@@ -312,7 +312,7 @@ def test_codex_fork_provider_cursor_not_advanced_when_append_not_persisted(tmp_p
         "append_event",
         return_value={"session_id": session.id, "seq": None, "persisted": False},
     ):
-        assert manager.ingest_codex_fork_event(session.id, event) is not None
+        assert manager.ingest_codex_fork_event(session.id, event) is None
 
     assert manager.codex_event_store.get_codex_fork_provider_cursor(session.id) is None
     assert manager.ingest_codex_fork_event(session.id, event) is not None
@@ -324,7 +324,7 @@ def test_codex_fork_provider_cursor_not_advanced_when_append_not_persisted(tmp_p
 
 
 @pytest.mark.asyncio
-async def test_codex_fork_process_line_continues_when_append_not_persisted(tmp_path):
+async def test_codex_fork_process_line_continues_for_unpositioned_fallback_event(tmp_path):
     manager = SessionManager(log_dir=str(tmp_path), state_file=str(tmp_path / "state.json"))
     session = Session(
         id="forkfallback1",
@@ -340,8 +340,6 @@ async def test_codex_fork_process_line_continues_when_append_not_persisted(tmp_p
         "schema_version": 2,
         "event_type": "turn_complete",
         "session_id": "thread-fallback",
-        "seq": 5,
-        "session_epoch": {"pid": 444},
         "payload": {
             "turn_id": "turn-fallback",
             "last_agent_message": "done despite persistence fallback",
@@ -362,6 +360,43 @@ async def test_codex_fork_process_line_continues_when_append_not_persisted(tmp_p
         last_message="done despite persistence fallback",
         event=event,
     )
+
+
+@pytest.mark.asyncio
+async def test_codex_fork_process_line_skips_provider_event_when_append_not_persisted(tmp_path):
+    manager = SessionManager(log_dir=str(tmp_path), state_file=str(tmp_path / "state.json"))
+    session = Session(
+        id="forkfallback2",
+        name="codex-fork-forkfallback2",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        status=SessionStatus.RUNNING,
+    )
+    manager.sessions[session.id] = session
+    manager._handle_codex_fork_assistant_relay_event = AsyncMock()
+    manager._handle_codex_fork_turn_complete = AsyncMock()
+    event = {
+        "schema_version": 2,
+        "event_type": "turn_complete",
+        "session_id": "thread-provider-fallback",
+        "seq": 6,
+        "session_epoch": {"pid": 555},
+        "payload": {
+            "turn_id": "turn-provider-fallback",
+            "last_agent_message": "must wait for durable checkpoint",
+        },
+    }
+
+    with patch.object(
+        manager.codex_event_store,
+        "append_event",
+        return_value={"session_id": session.id, "seq": None, "persisted": False},
+    ):
+        await manager._process_codex_fork_event_line(session.id, json.dumps(event))
+
+    assert manager.codex_event_store.get_codex_fork_provider_cursor(session.id) is None
+    manager._handle_codex_fork_assistant_relay_event.assert_not_awaited()
+    manager._handle_codex_fork_turn_complete.assert_not_awaited()
 
 
 def test_codex_fork_provider_cursor_and_event_row_rollback_when_reducer_fails(tmp_path):

--- a/tests/unit/test_remote_codex_fork_transport.py
+++ b/tests/unit/test_remote_codex_fork_transport.py
@@ -3,6 +3,7 @@ import json
 import shutil
 import subprocess
 import tempfile
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock
 
@@ -44,6 +45,39 @@ def test_node_agent_websocket_authenticates_and_marks_node_healthy(tmp_path):
         assert manager.is_codex_fork_node_agent_healthy("worker") is True
 
     assert manager.is_codex_fork_node_agent_healthy("worker") is False
+
+
+def test_node_agent_websocket_reregisters_active_sessions_after_hello_ok(tmp_path):
+    manager = _manager(tmp_path)
+    session = Session(
+        id="active-remote",
+        name="codex-fork-active-remote",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        node="worker",
+        status=SessionStatus.RUNNING,
+    )
+    manager.sessions[session.id] = session
+    client = TestClient(create_app(session_manager=manager))
+
+    with client.websocket_connect("/nodes/agent") as websocket:
+        websocket.send_json({"type": "hello", "node_id": "worker", "secret": "node-secret"})
+        assert websocket.receive_json() == {"type": "hello_ok", "node_id": "worker"}
+
+        frame = websocket.receive_json()
+        assert frame["type"] == "register"
+        assert frame["session_id"] == session.id
+        assert frame["event_stream_path"] == "/tmp/worker-sm/active-remote.codex-fork.events.jsonl"
+        assert frame["control_socket_path"] == "/tmp/worker-sm/active-remote.codex-fork.control.sock"
+
+        websocket.send_json({"type": "registered", "session_id": session.id})
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline:
+            if manager.codex_fork_node_agents._session_nodes.get(session.id) == "worker":
+                break
+            time.sleep(0.01)
+
+        assert manager.codex_fork_node_agents._session_nodes.get(session.id) == "worker"
 
 
 def test_node_agent_websocket_rejects_invalid_secret(tmp_path):

--- a/tests/unit/test_remote_codex_fork_transport.py
+++ b/tests/unit/test_remote_codex_fork_transport.py
@@ -438,3 +438,27 @@ async def test_restore_remote_codex_fork_registers_bridge_before_launch_and_uses
     control_socket_path = args[args.index("--control-socket") + 1]
     assert event_stream_path == "/tmp/worker-sm/restoreremote1.codex-fork.events.jsonl"
     assert control_socket_path == "/tmp/worker-sm/restoreremote1.codex-fork.control.sock"
+
+
+@pytest.mark.asyncio
+async def test_remote_codex_fork_create_rejects_legacy_codex_fallback(tmp_path):
+    manager = _manager(tmp_path)
+
+    class HealthyConnection:
+        def is_healthy(self):
+            return True
+
+    manager.codex_fork_node_agents._connections["worker"] = HealthyConnection()
+    manager.node_runner.command_available = Mock(side_effect=[True, False])
+    manager.tmux.create_session_with_command = Mock(return_value=True)
+
+    session = await manager.create_session(
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        node="worker",
+    )
+
+    assert session is None
+    assert manager.last_create_error is not None
+    assert "falling back to codex" in manager.last_create_error
+    manager.tmux.create_session_with_command.assert_not_called()

--- a/tests/unit/test_remote_codex_fork_transport.py
+++ b/tests/unit/test_remote_codex_fork_transport.py
@@ -380,6 +380,59 @@ async def test_node_agent_control_timeout_closes_unresponsive_socket():
     assert "timed out" in frame["error"]["message"]
 
 
+@pytest.mark.asyncio
+async def test_node_agent_reregister_suppresses_stale_tail_task_failure(tmp_path):
+    class FakeWebSocket:
+        def __init__(self):
+            self.sent: list[str] = []
+
+        async def send(self, frame: str):
+            self.sent.append(frame)
+
+    async def failed_tail():
+        raise RuntimeError("stale websocket closed")
+
+    log_dir = tmp_path / "node-log"
+    log_dir.mkdir()
+    event_path = log_dir / "session1.codex-fork.events.jsonl"
+    control_path = log_dir / "session1.codex-fork.control.sock"
+    websocket = FakeWebSocket()
+    stale_registration = TailRegistration(
+        websocket=websocket,
+        session_id="session1",
+        event_stream_path=event_path,
+        control_socket_path=control_path,
+        cursor=ProviderCursor(),
+        poll_interval=0.01,
+    )
+    stale_registration.task = asyncio.create_task(failed_tail())
+    await asyncio.sleep(0)
+
+    agent = CodexForkNodeAgent(
+        node_id="worker",
+        primary_url="http://primary",
+        secret="secret",
+        log_dir=str(log_dir),
+    )
+    agent.registrations["session1"] = stale_registration
+
+    await agent._register(
+        websocket,
+        {
+            "type": "register",
+            "session_id": "session1",
+            "event_stream_path": str(event_path),
+            "control_socket_path": str(control_path),
+        },
+    )
+    await agent._unregister("session1")
+
+    frame = json.loads(websocket.sent[-1])
+    assert frame["type"] == "registered"
+    assert frame["session_id"] == "session1"
+    assert stale_registration.task is None
+
+
 def test_codex_fork_transport_selection_by_node(tmp_path):
     manager = _manager(tmp_path)
     local_session = Session(

--- a/tests/unit/test_remote_codex_fork_transport.py
+++ b/tests/unit/test_remote_codex_fork_transport.py
@@ -1,0 +1,304 @@
+import asyncio
+import json
+import subprocess
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.codex_fork_remote import LocalCodexForkTransport, NodeAgentConnection, RemoteCodexForkTransport
+from src.models import Session, SessionStatus
+from src.node_agent import CodexForkNodeAgent, ProviderCursor, TailRegistration
+from src.server import create_app
+from src.session_manager import SessionManager
+
+
+def _manager(tmp_path):
+    return SessionManager(
+        log_dir=str(tmp_path / "logs"),
+        state_file=str(tmp_path / "state.json"),
+        config={
+            "nodes": {
+                "registry": {
+                    "worker": {
+                        "ssh": "dev@example",
+                        "node_token": "node-secret",
+                        "log_dir": "/tmp/worker-sm",
+                    }
+                }
+            }
+        },
+    )
+
+
+def test_node_agent_websocket_authenticates_and_marks_node_healthy(tmp_path):
+    manager = _manager(tmp_path)
+    client = TestClient(create_app(session_manager=manager))
+
+    with client.websocket_connect("/nodes/agent") as websocket:
+        websocket.send_json({"type": "hello", "node_id": "worker", "secret": "node-secret"})
+        assert websocket.receive_json() == {"type": "hello_ok", "node_id": "worker"}
+        assert manager.is_codex_fork_node_agent_healthy("worker") is True
+
+    assert manager.is_codex_fork_node_agent_healthy("worker") is False
+
+
+def test_node_agent_websocket_rejects_invalid_secret(tmp_path):
+    manager = _manager(tmp_path)
+    client = TestClient(create_app(session_manager=manager))
+
+    with client.websocket_connect("/nodes/agent") as websocket:
+        websocket.send_json({"type": "hello", "node_id": "worker", "secret": "wrong"})
+        assert websocket.receive_json() == {"type": "error", "message": "Invalid node-agent secret"}
+
+    assert manager.is_codex_fork_node_agent_healthy("worker") is False
+
+
+@pytest.mark.asyncio
+async def test_node_agent_connection_waits_for_registered_ack_before_returning_queue():
+    class FakeWebSocket:
+        def __init__(self):
+            self.sent: list[dict] = []
+
+        async def send_json(self, frame: dict):
+            self.sent.append(frame)
+
+    websocket = FakeWebSocket()
+    connection = NodeAgentConnection("worker", websocket)
+
+    register_task = asyncio.create_task(
+        connection.register_session(
+            session_id="session1",
+            event_stream_path="/tmp/session1.events.jsonl",
+            control_socket_path="/tmp/session1.control.sock",
+            timeout=1.0,
+        )
+    )
+    await asyncio.sleep(0)
+
+    assert websocket.sent == [
+        {
+            "type": "register",
+            "session_id": "session1",
+            "event_stream_path": "/tmp/session1.events.jsonl",
+            "control_socket_path": "/tmp/session1.control.sock",
+            "cursor": None,
+        }
+    ]
+    assert register_task.done() is False
+
+    await connection.handle_frame({"type": "registered", "session_id": "session1"})
+    queue = await register_task
+
+    assert queue is connection.event_queue("session1")
+
+
+@pytest.mark.asyncio
+async def test_node_agent_connection_surfaces_register_failure():
+    class FakeWebSocket:
+        def __init__(self):
+            self.sent: list[dict] = []
+
+        async def send_json(self, frame: dict):
+            self.sent.append(frame)
+
+    websocket = FakeWebSocket()
+    connection = NodeAgentConnection("worker", websocket)
+
+    register_task = asyncio.create_task(
+        connection.register_session(
+            session_id="session1",
+            event_stream_path="/tmp/session1.events.jsonl",
+            control_socket_path="/tmp/session1.control.sock",
+            timeout=1.0,
+        )
+    )
+    await asyncio.sleep(0)
+
+    await connection.handle_frame(
+        {
+            "type": "register_failed",
+            "session_id": "session1",
+            "error": "event_stream_path must be under node log_dir /tmp/worker-sm",
+        }
+    )
+
+    with pytest.raises(RuntimeError, match="under node log_dir"):
+        await register_task
+
+
+@pytest.mark.asyncio
+async def test_node_agent_rejects_registered_paths_outside_log_dir(tmp_path):
+    class FakeWebSocket:
+        def __init__(self):
+            self.sent: list[str] = []
+
+        async def send(self, frame: str):
+            self.sent.append(frame)
+
+    log_dir = tmp_path / "node-log"
+    websocket = FakeWebSocket()
+    agent = CodexForkNodeAgent(
+        node_id="worker",
+        primary_url="http://primary",
+        secret="secret",
+        log_dir=str(log_dir),
+    )
+
+    await agent._register(
+        websocket,
+        {
+            "type": "register",
+            "session_id": "session1",
+            "event_stream_path": str(tmp_path / "outside.events.jsonl"),
+            "control_socket_path": str(log_dir / "session1.control.sock"),
+        },
+    )
+
+    assert "session1" not in agent.registrations
+    frame = json.loads(websocket.sent[-1])
+    assert frame["type"] == "register_failed"
+    assert frame["session_id"] == "session1"
+    assert "under node log_dir" in frame["error"]
+
+
+@pytest.mark.asyncio
+async def test_node_agent_control_before_socket_ready_returns_not_ready(tmp_path):
+    class FakeWebSocket:
+        def __init__(self):
+            self.sent: list[str] = []
+
+        async def send(self, frame: str):
+            self.sent.append(frame)
+
+    log_dir = tmp_path / "node-log"
+    log_dir.mkdir()
+    event_path = log_dir / "session1.codex-fork.events.jsonl"
+    control_path = log_dir / "session1.codex-fork.control.sock"
+    websocket = FakeWebSocket()
+    agent = CodexForkNodeAgent(
+        node_id="worker",
+        primary_url="http://primary",
+        secret="secret",
+        log_dir=str(log_dir),
+    )
+
+    await agent._register(
+        websocket,
+        {
+            "type": "register",
+            "session_id": "session1",
+            "event_stream_path": str(event_path),
+            "control_socket_path": str(control_path),
+        },
+    )
+    await agent._control(
+        websocket,
+        {
+            "type": "control",
+            "request_id": "request1",
+            "session_id": "session1",
+            "frame": {"command": "get_epoch"},
+        },
+    )
+    await agent._unregister("session1")
+
+    frame = json.loads(websocket.sent[-1])
+    assert frame["type"] == "control_result"
+    assert frame["ok"] is False
+    assert frame["error"]["code"] == "not_ready"
+    assert "control socket not ready" in frame["error"]["message"]
+
+
+def test_codex_fork_transport_selection_by_node(tmp_path):
+    manager = _manager(tmp_path)
+    local_session = Session(
+        id="localtransport",
+        name="codex-fork-localtransport",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        node="primary",
+    )
+    remote_session = Session(
+        id="remotetransport",
+        name="codex-fork-remotetransport",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        node="worker",
+    )
+
+    assert isinstance(manager._codex_fork_transport_for_session(local_session), LocalCodexForkTransport)
+    assert isinstance(manager._codex_fork_transport_for_session(remote_session), RemoteCodexForkTransport)
+
+
+@pytest.mark.asyncio
+async def test_node_agent_buffers_partial_event_lines(tmp_path):
+    class FakeWebSocket:
+        def __init__(self):
+            self.sent: list[str] = []
+
+        async def send(self, frame: str):
+            self.sent.append(frame)
+
+    registration = TailRegistration(
+        websocket=FakeWebSocket(),
+        session_id="session1",
+        event_stream_path=tmp_path / "session1.events.jsonl",
+        control_socket_path=tmp_path / "session1.control.sock",
+        cursor=ProviderCursor(),
+        poll_interval=0.01,
+    )
+
+    await registration._process_chunk('{"session_epoch":"epoch1",')
+    assert registration.websocket.sent == []
+
+    await registration._process_chunk('"seq":1,"event_type":"turn_started"}\n')
+    assert [json.loads(frame)["type"] for frame in registration.websocket.sent] == ["event"]
+    event_frame = json.loads(registration.websocket.sent[0])
+    assert event_frame["session_id"] == "session1"
+    assert json.loads(event_frame["line"])["seq"] == 1
+
+
+@pytest.mark.asyncio
+async def test_restore_remote_codex_fork_registers_bridge_before_launch_and_uses_node_paths(tmp_path):
+    manager = _manager(tmp_path)
+    session = Session(
+        id="restoreremote1",
+        name="codex-fork-restoreremote1",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        node="worker",
+        status=SessionStatus.STOPPED,
+        provider_resume_id="resume-restoreremote1",
+    )
+    manager.sessions[session.id] = session
+
+    class HealthyConnection:
+        def is_healthy(self):
+            return True
+
+    manager.codex_fork_node_agents._connections["worker"] = HealthyConnection()
+    manager.node_runner.command_available = Mock(return_value=True)
+    manager.node_runner.run = Mock(
+        return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+    )
+    manager._register_codex_fork_remote_bridge = AsyncMock()
+    manager._start_codex_fork_event_monitor = Mock()
+    manager.tmux.session_exists = Mock(return_value=False)
+    manager.tmux.create_session_with_command = Mock(return_value=True)
+
+    success, restored, error = await manager.restore_session(session.id)
+
+    assert success is True
+    assert restored is session
+    assert error is None
+    manager._register_codex_fork_remote_bridge.assert_awaited_once_with(session)
+    manager._start_codex_fork_event_monitor.assert_called_once_with(session)
+    manager.tmux.create_session_with_command.assert_called_once()
+    _, kwargs = manager.tmux.create_session_with_command.call_args
+    assert kwargs["node"] == "worker"
+    args = kwargs["args"]
+    event_stream_path = args[args.index("--event-stream") + 1]
+    control_socket_path = args[args.index("--control-socket") + 1]
+    assert event_stream_path == "/tmp/worker-sm/restoreremote1.codex-fork.events.jsonl"
+    assert control_socket_path == "/tmp/worker-sm/restoreremote1.codex-fork.control.sock"

--- a/tests/unit/test_remote_codex_fork_transport.py
+++ b/tests/unit/test_remote_codex_fork_transport.py
@@ -128,6 +128,33 @@ async def test_node_agent_connection_surfaces_register_failure():
 
 
 @pytest.mark.asyncio
+async def test_stale_node_agent_detach_does_not_mark_reconnected_sessions_unreachable(tmp_path):
+    class FakeWebSocket:
+        async def send_json(self, frame: dict):
+            return None
+
+    manager = _manager(tmp_path)
+    session = Session(
+        id="reconnect1",
+        name="codex-fork-reconnect1",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        node="worker",
+        status=SessionStatus.RUNNING,
+    )
+    manager.sessions[session.id] = session
+    old_connection = NodeAgentConnection("worker", FakeWebSocket())
+    new_connection = NodeAgentConnection("worker", FakeWebSocket())
+
+    await manager.attach_codex_fork_node_agent(old_connection)
+    await manager.attach_codex_fork_node_agent(new_connection)
+    await manager.detach_codex_fork_node_agent(old_connection)
+
+    assert manager.is_codex_fork_node_agent_healthy("worker") is True
+    assert manager.is_session_node_unreachable(session.id) is False
+
+
+@pytest.mark.asyncio
 async def test_node_agent_rejects_registered_paths_outside_log_dir(tmp_path):
     class FakeWebSocket:
         def __init__(self):

--- a/tests/unit/test_remote_codex_fork_transport.py
+++ b/tests/unit/test_remote_codex_fork_transport.py
@@ -1,6 +1,9 @@
 import asyncio
 import json
+import shutil
 import subprocess
+import tempfile
+from pathlib import Path
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -128,6 +131,44 @@ async def test_node_agent_connection_surfaces_register_failure():
 
 
 @pytest.mark.asyncio
+async def test_node_agent_connection_forwards_control_timeout():
+    class FakeWebSocket:
+        def __init__(self):
+            self.sent: list[dict] = []
+
+        async def send_json(self, frame: dict):
+            self.sent.append(frame)
+
+    websocket = FakeWebSocket()
+    connection = NodeAgentConnection("worker", websocket)
+
+    control_task = asyncio.create_task(
+        connection.control_roundtrip(
+            session_id="session1",
+            frame={"command": "get_epoch"},
+            timeout=0.75,
+        )
+    )
+    await asyncio.sleep(0)
+
+    request = websocket.sent[0]
+    assert request["type"] == "control"
+    assert request["session_id"] == "session1"
+    assert request["timeout"] == 0.75
+
+    await connection.handle_frame(
+        {
+            "type": "control_result",
+            "request_id": request["request_id"],
+            "ok": True,
+            "line": '{"ok":true}',
+        }
+    )
+
+    assert await control_task == {"ok": True}
+
+
+@pytest.mark.asyncio
 async def test_stale_node_agent_detach_does_not_mark_reconnected_sessions_unreachable(tmp_path):
     class FakeWebSocket:
         async def send_json(self, frame: dict):
@@ -235,6 +276,74 @@ async def test_node_agent_control_before_socket_ready_returns_not_ready(tmp_path
     assert frame["ok"] is False
     assert frame["error"]["code"] == "not_ready"
     assert "control socket not ready" in frame["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_node_agent_control_timeout_closes_unresponsive_socket():
+    class FakeWebSocket:
+        def __init__(self):
+            self.sent: list[str] = []
+
+        async def send(self, frame: str):
+            self.sent.append(frame)
+
+    log_dir = Path(tempfile.mkdtemp(prefix="smna-", dir="/tmp"))
+    event_path = log_dir / "session1.codex-fork.events.jsonl"
+    control_path = log_dir / "s.sock"
+    client_closed = asyncio.Event()
+
+    async def handle_control(reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+        try:
+            await reader.readline()
+            if await reader.read() == b"":
+                client_closed.set()
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    server = await asyncio.start_unix_server(handle_control, path=str(control_path))
+    websocket = FakeWebSocket()
+    agent = CodexForkNodeAgent(
+        node_id="worker",
+        primary_url="http://primary",
+        secret="secret",
+        log_dir=str(log_dir),
+        control_timeout=0.05,
+    )
+    agent.registrations["session1"] = TailRegistration(
+        websocket=websocket,
+        session_id="session1",
+        event_stream_path=event_path,
+        control_socket_path=control_path,
+        cursor=ProviderCursor(),
+        poll_interval=0.01,
+    )
+
+    try:
+        await asyncio.wait_for(
+            agent._control(
+                websocket,
+                {
+                    "type": "control",
+                    "request_id": "request1",
+                    "session_id": "session1",
+                    "frame": {"command": "get_epoch"},
+                    "timeout": 0.05,
+                },
+            ),
+            timeout=2.0,
+        )
+        await asyncio.wait_for(client_closed.wait(), timeout=1.0)
+    finally:
+        server.close()
+        await server.wait_closed()
+        shutil.rmtree(log_dir, ignore_errors=True)
+
+    frame = json.loads(websocket.sent[-1])
+    assert frame["type"] == "control_result"
+    assert frame["ok"] is False
+    assert frame["error"]["code"] == "control_failed"
+    assert "timed out" in frame["error"]["message"]
 
 
 def test_codex_fork_transport_selection_by_node(tmp_path):

--- a/tests/unit/test_session_forking.py
+++ b/tests/unit/test_session_forking.py
@@ -121,6 +121,48 @@ async def test_fork_session_launches_codex_fork_and_preserves_source_resume_id(t
 
 
 @pytest.mark.asyncio
+async def test_fork_session_creates_native_fork_on_source_node(tmp_path):
+    manager = _manager(tmp_path)
+    source = Session(
+        id="source01",
+        name="codex-fork-source01",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        provider_resume_id="thread-source",
+        model="gpt-test",
+        node="worker",
+    )
+    manager.sessions[source.id] = source
+    create_kwargs = {}
+    manager.get_provider_create_rejection = lambda *args, **kwargs: None
+
+    async def _create_session_common(**kwargs):
+        create_kwargs.update(kwargs)
+        return Session(
+            working_dir=kwargs["working_dir"],
+            provider=kwargs["provider"],
+            model=kwargs["model"],
+            node=kwargs["node"],
+            friendly_name=kwargs["friendly_name"],
+        )
+
+    async def _confirm(fork_session: Session, source_resume_id: str):
+        assert source_resume_id == "thread-source"
+        return True, "thread-fork", None
+
+    manager._create_session_common = _create_session_common
+    manager._wait_for_codex_fork_result = _confirm
+
+    ok, fork_session, error = await manager.fork_session(source.id, name="source-fork")
+
+    assert ok is True
+    assert error is None
+    assert fork_session is not None
+    assert create_kwargs["node"] == "worker"
+    assert fork_session.node == "worker"
+
+
+@pytest.mark.asyncio
 async def test_fork_session_rejects_unsupported_provider(tmp_path):
     manager = _manager(tmp_path)
     manager.sessions["claude01"] = Session(

--- a/tests/unit/test_session_nodes.py
+++ b/tests/unit/test_session_nodes.py
@@ -7,7 +7,7 @@ from src.session_manager import SessionManager
 def _manager(tmp_path):
     return SessionManager(
         state_file=str(tmp_path / "sessions.json"),
-        config={"nodes": {"registry": {"worker": {"ssh": "dev@example"}}}},
+        config={"nodes": {"registry": {"worker": {"ssh": "dev@example", "log_dir": "/tmp/worker-sm"}}}},
     )
 
 
@@ -17,7 +17,7 @@ def _manager_default_worker(tmp_path):
         config={
             "nodes": {
                 "default": "worker",
-                "registry": {"worker": {"ssh": "dev@example"}},
+                "registry": {"worker": {"ssh": "dev@example", "node_token": "node-secret"}},
             }
         },
     )
@@ -32,16 +32,16 @@ def test_create_node_validation_uses_configured_default_for_top_level_claude(tmp
     assert error is None
 
 
-def test_create_node_validation_rejects_default_remote_codex(tmp_path):
+def test_create_node_validation_rejects_default_remote_codex_fork_without_node_agent(tmp_path):
     manager = _manager_default_worker(tmp_path)
 
     node, error = manager.validate_create_node_provider("codex-fork")
 
     assert node == "worker"
-    assert error == "Remote placement is Claude-only in this phase (provider=codex-fork)"
+    assert error == "Remote codex-fork requires a healthy node-agent on node worker"
 
 
-def test_create_node_validation_rejects_inherited_remote_codex(tmp_path):
+def test_create_node_validation_rejects_inherited_remote_codex_fork_without_node_agent(tmp_path):
     manager = _manager(tmp_path)
     parent = Session(id="parent1", node="worker")
     manager.sessions[parent.id] = parent
@@ -52,7 +52,40 @@ def test_create_node_validation_rejects_inherited_remote_codex(tmp_path):
     )
 
     assert node == "worker"
-    assert error == "Remote placement is Claude-only in this phase (provider=codex-fork)"
+    assert error == "Remote codex-fork requires a healthy node-agent on node worker"
+
+
+def test_create_node_validation_allows_remote_codex_fork_with_healthy_node_agent(tmp_path):
+    manager = _manager(tmp_path)
+
+    class HealthyConnection:
+        def is_healthy(self):
+            return True
+
+    manager.codex_fork_node_agents._connections["worker"] = HealthyConnection()
+
+    node, error = manager.validate_create_node_provider("codex-fork", requested_node="worker")
+
+    assert node == "worker"
+    assert error is None
+
+
+def test_create_node_validation_still_rejects_legacy_remote_codex(tmp_path):
+    manager = _manager(tmp_path)
+
+    node, error = manager.validate_create_node_provider("codex", requested_node="worker")
+
+    assert node == "worker"
+    assert error == "Remote placement supports provider=claude or provider=codex-fork in this phase (provider=codex)"
+
+
+def test_node_config_surfaces_remote_codex_fork_artifact_log_dir(tmp_path):
+    manager = _manager(tmp_path)
+
+    worker = next(node for node in manager.list_nodes() if node["id"] == "worker")
+
+    assert worker["log_dir"] == "/tmp/worker-sm"
+    assert worker["codex_fork_node_agent"] is False
 
 
 def test_create_node_validation_allows_inherited_remote_claude(tmp_path):


### PR DESCRIPTION
## Summary
- Add a node-initiated authenticated WebSocket node-agent for remote codex-fork events and control RPCs.
- Add primary-side local/remote CodexForkTransport wiring, remote launch/restore gates, node-local artifact preparation, and node unreachable projection.
- Add durable provider `(session_epoch, seq)` idempotency cursoring before codex event persistence and lifecycle reduction.
- Cover remote bridge auth, ordering, replay dedupe, stale-epoch submit_message, not-ready control, path confinement, and attach/debug path behavior.

## Validation
- `./venv/bin/python -m pytest tests/unit/test_remote_codex_fork_transport.py tests/unit/test_codex_fork_control_client.py tests/unit/test_codex_fork_runtime_maintenance.py -q`
- `./venv/bin/python -m pytest tests/ -v`

Fixes #754