### PR TITLE
Add client-local Session Manager defaults

### DIFF
--- a/config/client.yaml.example
+++ b/config/client.yaml.example
@@ -6,3 +6,7 @@
 # Copy to ~/.config/session-manager/client.yaml on machines that should talk to
 # a primary Session Manager server running somewhere else.
 api_url: "http://127.0.0.1:8420"
+
+# Optional: default execution node for top-level `sm claude` / `sm codex`
+# commands from this client. Managed sessions still inherit their parent node.
+# default_node: "macbook"

--- a/config/client.yaml.example
+++ b/config/client.yaml.example
@@ -10,3 +10,7 @@ api_url: "http://127.0.0.1:8420"
 # Optional: default execution node for top-level `sm claude` / `sm codex`
 # commands from this client. Managed sessions still inherit their parent node.
 # default_node: "macbook"
+
+# Optional: node id for this machine. Set this when `default_node` points at
+# this same host so the CLI can attach through local tmux instead of SSH.
+# local_node: "macbook"

--- a/config/client.yaml.example
+++ b/config/client.yaml.example
@@ -1,0 +1,8 @@
+# Shared Session Manager client config.
+#
+# `sm` and GUI clients such as DeskBar resolve the API URL in this order:
+# explicit override, SM_API_URL, this file, localhost fallback.
+#
+# Copy to ~/.config/session-manager/client.yaml on machines that should talk to
+# a primary Session Manager server running somewhere else.
+api_url: "http://127.0.0.1:8420"

--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -143,10 +143,15 @@ def resolve_api_url(api_url: Optional[str] = None) -> str:
     explicit_url = _coerce_api_url(api_url)
     if explicit_url:
         return explicit_url
+    if api_url is not None:
+        raise ClientConfigError("Invalid Session Manager API URL: explicit api_url must be http(s)")
 
-    env_url = _coerce_api_url(os.environ.get("SM_API_URL"))
+    raw_env_url = os.environ.get("SM_API_URL")
+    env_url = _coerce_api_url(raw_env_url)
     if env_url:
         return env_url
+    if raw_env_url is not None:
+        raise ClientConfigError("Invalid Session Manager API URL: SM_API_URL must be http(s)")
 
     config_url = read_client_config_api_url()
     if config_url:
@@ -315,6 +320,25 @@ class SessionManagerClient:
         """List all sessions."""
         path = "/sessions?include_stopped=true" if include_stopped else "/sessions"
         data, success, _ = self._request("GET", path, timeout=timeout)
+        if success and data:
+            return data.get("sessions", [])
+        return None
+
+    def list_node_restore_sessions(
+        self,
+        node: str,
+        *,
+        timeout: Optional[float] = None,
+        refresh: bool = False,
+    ) -> Optional[list]:
+        """List stopped restore candidates from one node's local inventory."""
+        node_path = urllib.parse.quote(str(node), safe="")
+        suffix = "?refresh=true" if refresh else ""
+        data, success, _ = self._request(
+            "GET",
+            f"/nodes/{node_path}/restore-candidates{suffix}",
+            timeout=timeout,
+        )
         if success and data:
             return data.get("sessions", [])
         return None
@@ -1000,11 +1024,17 @@ class SessionManagerClient:
             return None
         return data
 
-    def restore_session_result(self, session_id: str) -> dict:
+    def restore_session_result(self, session_id: str, node: Optional[str] = None) -> dict:
         """Restore a stopped session and preserve API error details."""
+        if node and node != "primary":
+            node_path = urllib.parse.quote(str(node), safe="")
+            session_path = urllib.parse.quote(str(session_id), safe="")
+            path = f"/nodes/{node_path}/restore-candidates/{session_path}/restore"
+        else:
+            path = f"/sessions/{session_id}/restore"
         data, status_code, unavailable = self._request_with_status(
             "POST",
-            f"/sessions/{session_id}/restore",
+            path,
             {},
             timeout=10,
         )

--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -15,6 +15,7 @@ DEFAULT_API_URL = "http://127.0.0.1:8420"
 CLIENT_CONFIG_ENV = "SM_CLIENT_CONFIG"
 CLIENT_CONFIG_SUBPATH = "session-manager/client.yaml"
 DEFAULT_NODE_ENV = "SM_DEFAULT_NODE"
+LOCAL_NODE_ENV = "SM_LOCAL_NODE"
 DEFAULT_API_TIMEOUT = 5.0  # seconds
 DEFAULT_SEND_API_TIMEOUT = 15.0  # seconds
 DEFAULT_MUTATION_API_TIMEOUT = 15.0  # seconds
@@ -138,6 +139,30 @@ def read_client_config_default_node(config_path: Optional[Path] = None) -> Optio
     return None
 
 
+def read_client_config_local_node(config_path: Optional[Path] = None) -> Optional[str]:
+    """Read this client's local execution node id from YAML config, if present."""
+    payload = _read_client_config_payload(config_path)
+    if payload is None:
+        return None
+
+    if "local_node" in payload:
+        local_node = _coerce_node_id(payload.get("local_node"))
+        if not local_node:
+            raise ClientConfigError("Invalid Session Manager client config: local_node must be a non-empty string")
+        return local_node
+
+    client_payload = payload.get("client")
+    if client_payload is not None and not isinstance(client_payload, dict):
+        raise ClientConfigError("Invalid Session Manager client config: client must be a mapping")
+    if isinstance(client_payload, dict) and "local_node" in client_payload:
+        local_node = _coerce_node_id(client_payload.get("local_node"))
+        if not local_node:
+            raise ClientConfigError("Invalid Session Manager client config: client.local_node must be a non-empty string")
+        return local_node
+
+    return None
+
+
 def resolve_api_url(api_url: Optional[str] = None) -> str:
     """Resolve the API URL using explicit arg, env, shared config, then localhost."""
     explicit_url = _coerce_api_url(api_url)
@@ -161,7 +186,7 @@ def resolve_api_url(api_url: Optional[str] = None) -> str:
 
 
 def resolve_default_node(default_node: Optional[str] = None) -> Optional[str]:
-    """Resolve the client-local preferred create node."""
+    """Resolve the preferred top-level create node."""
     explicit_node = _coerce_node_id(default_node)
     if explicit_node:
         return explicit_node
@@ -171,6 +196,19 @@ def resolve_default_node(default_node: Optional[str] = None) -> Optional[str]:
         return env_node
 
     return read_client_config_default_node()
+
+
+def resolve_local_node(local_node: Optional[str] = None) -> Optional[str]:
+    """Resolve the node id that represents this client machine."""
+    explicit_node = _coerce_node_id(local_node)
+    if explicit_node:
+        return explicit_node
+
+    env_node = _coerce_node_id(os.environ.get(LOCAL_NODE_ENV))
+    if env_node:
+        return env_node
+
+    return read_client_config_local_node()
 
 
 def _read_send_api_timeout() -> float:
@@ -217,6 +255,7 @@ class SessionManagerClient:
         """
         self.api_url = resolve_api_url(api_url)
         self.default_node = resolve_default_node()
+        self.local_node = resolve_local_node()
         self.session_id = os.environ.get("CLAUDE_SESSION_MANAGER_ID")
 
     def _request(self, method: str, path: str, data: Optional[dict] = None, timeout: Optional[int] = None) -> tuple[Optional[dict], bool, bool]:

--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -1,15 +1,19 @@
 """HTTP client for Session Manager API."""
 
 import os
-import sys
+from pathlib import Path
 from typing import Optional
 import urllib.error
 import urllib.parse
 import urllib.request
 import json
 
+import yaml
+
 # Default API endpoint
 DEFAULT_API_URL = "http://127.0.0.1:8420"
+CLIENT_CONFIG_ENV = "SM_CLIENT_CONFIG"
+CLIENT_CONFIG_SUBPATH = "session-manager/client.yaml"
 DEFAULT_API_TIMEOUT = 5.0  # seconds
 DEFAULT_SEND_API_TIMEOUT = 15.0  # seconds
 DEFAULT_MUTATION_API_TIMEOUT = 15.0  # seconds
@@ -29,6 +33,74 @@ def _read_api_timeout() -> float:
 
 
 API_TIMEOUT = _read_api_timeout()
+
+
+def default_client_config_path() -> Path:
+    """Return the default shared SM client config path."""
+    xdg_config_home = os.environ.get("XDG_CONFIG_HOME")
+    if xdg_config_home:
+        return Path(xdg_config_home).expanduser() / CLIENT_CONFIG_SUBPATH
+    return Path.home() / ".config" / CLIENT_CONFIG_SUBPATH
+
+
+def _client_config_path() -> Path:
+    """Return the configured SM client config path."""
+    override = os.environ.get(CLIENT_CONFIG_ENV)
+    if override:
+        return Path(override).expanduser()
+    return default_client_config_path()
+
+
+def _coerce_api_url(value: object) -> Optional[str]:
+    """Normalize a candidate API URL, rejecting empty or non-HTTP values."""
+    if not isinstance(value, str):
+        return None
+    api_url = value.strip().rstrip("/")
+    if api_url.startswith("http://") or api_url.startswith("https://"):
+        return api_url
+    return None
+
+
+def read_client_config_api_url(config_path: Optional[Path] = None) -> Optional[str]:
+    """Read the shared SM client API URL from YAML config, if present."""
+    path = config_path or _client_config_path()
+    try:
+        with path.open() as config_file:
+            payload = yaml.safe_load(config_file) or {}
+    except FileNotFoundError:
+        return None
+    except Exception:
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    api_url = _coerce_api_url(payload.get("api_url"))
+    if api_url:
+        return api_url
+
+    client_payload = payload.get("client")
+    if isinstance(client_payload, dict):
+        return _coerce_api_url(client_payload.get("api_url"))
+
+    return None
+
+
+def resolve_api_url(api_url: Optional[str] = None) -> str:
+    """Resolve the API URL using explicit arg, env, shared config, then localhost."""
+    explicit_url = _coerce_api_url(api_url)
+    if explicit_url:
+        return explicit_url
+
+    env_url = _coerce_api_url(os.environ.get("SM_API_URL"))
+    if env_url:
+        return env_url
+
+    config_url = read_client_config_api_url()
+    if config_url:
+        return config_url
+
+    return DEFAULT_API_URL
 
 
 def _read_send_api_timeout() -> float:
@@ -73,7 +145,7 @@ class SessionManagerClient:
         Args:
             api_url: Base URL for API (default: http://127.0.0.1:8420)
         """
-        self.api_url = api_url or os.environ.get("SM_API_URL", DEFAULT_API_URL)
+        self.api_url = resolve_api_url(api_url)
         self.session_id = os.environ.get("CLAUDE_SESSION_MANAGER_ID")
 
     def _request(self, method: str, path: str, data: Optional[dict] = None, timeout: Optional[int] = None) -> tuple[Optional[dict], bool, bool]:

--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -21,6 +21,10 @@ DEFAULT_MUTATION_API_TIMEOUT = 15.0  # seconds
 KILL_TIMEOUT = 30  # seconds (kill triggers cleanup that may involve network I/O)
 
 
+class ClientConfigError(ValueError):
+    """Raised when a present shared client config cannot be used safely."""
+
+
 def _read_api_timeout() -> float:
     """Return CLI API timeout from env with a sane fallback."""
     raw = os.environ.get("SM_API_TIMEOUT")
@@ -62,27 +66,42 @@ def _coerce_api_url(value: object) -> Optional[str]:
     return None
 
 
-def read_client_config_api_url(config_path: Optional[Path] = None) -> Optional[str]:
-    """Read the shared SM client API URL from YAML config, if present."""
+def _read_client_config_payload(config_path: Optional[Path] = None) -> Optional[dict]:
+    """Read shared client config YAML, ignoring only a missing config file."""
     path = config_path or _client_config_path()
     try:
         with path.open() as config_file:
             payload = yaml.safe_load(config_file) or {}
     except FileNotFoundError:
         return None
-    except Exception:
-        return None
+    except Exception as exc:
+        raise ClientConfigError(f"Invalid Session Manager client config {path}: {exc}") from exc
 
     if not isinstance(payload, dict):
+        raise ClientConfigError(f"Invalid Session Manager client config {path}: expected a YAML mapping")
+    return payload
+
+
+def read_client_config_api_url(config_path: Optional[Path] = None) -> Optional[str]:
+    """Read the shared SM client API URL from YAML config, if present."""
+    payload = _read_client_config_payload(config_path)
+    if payload is None:
         return None
 
-    api_url = _coerce_api_url(payload.get("api_url"))
-    if api_url:
+    if "api_url" in payload:
+        api_url = _coerce_api_url(payload.get("api_url"))
+        if not api_url:
+            raise ClientConfigError("Invalid Session Manager client config: api_url must be http(s)")
         return api_url
 
     client_payload = payload.get("client")
-    if isinstance(client_payload, dict):
-        return _coerce_api_url(client_payload.get("api_url"))
+    if client_payload is not None and not isinstance(client_payload, dict):
+        raise ClientConfigError("Invalid Session Manager client config: client must be a mapping")
+    if isinstance(client_payload, dict) and "api_url" in client_payload:
+        api_url = _coerce_api_url(client_payload.get("api_url"))
+        if not api_url:
+            raise ClientConfigError("Invalid Session Manager client config: client.api_url must be http(s)")
+        return api_url
 
     return None
 
@@ -97,25 +116,24 @@ def _coerce_node_id(value: object) -> Optional[str]:
 
 def read_client_config_default_node(config_path: Optional[Path] = None) -> Optional[str]:
     """Read the preferred top-level create node from YAML config, if present."""
-    path = config_path or _client_config_path()
-    try:
-        with path.open() as config_file:
-            payload = yaml.safe_load(config_file) or {}
-    except FileNotFoundError:
-        return None
-    except Exception:
+    payload = _read_client_config_payload(config_path)
+    if payload is None:
         return None
 
-    if not isinstance(payload, dict):
-        return None
-
-    default_node = _coerce_node_id(payload.get("default_node"))
-    if default_node:
+    if "default_node" in payload:
+        default_node = _coerce_node_id(payload.get("default_node"))
+        if not default_node:
+            raise ClientConfigError("Invalid Session Manager client config: default_node must be a non-empty string")
         return default_node
 
     client_payload = payload.get("client")
-    if isinstance(client_payload, dict):
-        return _coerce_node_id(client_payload.get("default_node"))
+    if client_payload is not None and not isinstance(client_payload, dict):
+        raise ClientConfigError("Invalid Session Manager client config: client must be a mapping")
+    if isinstance(client_payload, dict) and "default_node" in client_payload:
+        default_node = _coerce_node_id(client_payload.get("default_node"))
+        if not default_node:
+            raise ClientConfigError("Invalid Session Manager client config: client.default_node must be a non-empty string")
+        return default_node
 
     return None
 

--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -14,6 +14,7 @@ import yaml
 DEFAULT_API_URL = "http://127.0.0.1:8420"
 CLIENT_CONFIG_ENV = "SM_CLIENT_CONFIG"
 CLIENT_CONFIG_SUBPATH = "session-manager/client.yaml"
+DEFAULT_NODE_ENV = "SM_DEFAULT_NODE"
 DEFAULT_API_TIMEOUT = 5.0  # seconds
 DEFAULT_SEND_API_TIMEOUT = 15.0  # seconds
 DEFAULT_MUTATION_API_TIMEOUT = 15.0  # seconds
@@ -86,6 +87,39 @@ def read_client_config_api_url(config_path: Optional[Path] = None) -> Optional[s
     return None
 
 
+def _coerce_node_id(value: object) -> Optional[str]:
+    """Normalize a candidate node id, rejecting empty values."""
+    if not isinstance(value, str):
+        return None
+    node_id = value.strip()
+    return node_id or None
+
+
+def read_client_config_default_node(config_path: Optional[Path] = None) -> Optional[str]:
+    """Read the preferred top-level create node from YAML config, if present."""
+    path = config_path or _client_config_path()
+    try:
+        with path.open() as config_file:
+            payload = yaml.safe_load(config_file) or {}
+    except FileNotFoundError:
+        return None
+    except Exception:
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    default_node = _coerce_node_id(payload.get("default_node"))
+    if default_node:
+        return default_node
+
+    client_payload = payload.get("client")
+    if isinstance(client_payload, dict):
+        return _coerce_node_id(client_payload.get("default_node"))
+
+    return None
+
+
 def resolve_api_url(api_url: Optional[str] = None) -> str:
     """Resolve the API URL using explicit arg, env, shared config, then localhost."""
     explicit_url = _coerce_api_url(api_url)
@@ -101,6 +135,19 @@ def resolve_api_url(api_url: Optional[str] = None) -> str:
         return config_url
 
     return DEFAULT_API_URL
+
+
+def resolve_default_node(default_node: Optional[str] = None) -> Optional[str]:
+    """Resolve the client-local preferred create node."""
+    explicit_node = _coerce_node_id(default_node)
+    if explicit_node:
+        return explicit_node
+
+    env_node = _coerce_node_id(os.environ.get(DEFAULT_NODE_ENV))
+    if env_node:
+        return env_node
+
+    return read_client_config_default_node()
 
 
 def _read_send_api_timeout() -> float:
@@ -146,6 +193,7 @@ class SessionManagerClient:
             api_url: Base URL for API (default: http://127.0.0.1:8420)
         """
         self.api_url = resolve_api_url(api_url)
+        self.default_node = resolve_default_node()
         self.session_id = os.environ.get("CLAUDE_SESSION_MANAGER_ID")
 
     def _request(self, method: str, path: str, data: Optional[dict] = None, timeout: Optional[int] = None) -> tuple[Optional[dict], bool, bool]:

--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -1026,12 +1026,8 @@ class SessionManagerClient:
 
     def restore_session_result(self, session_id: str, node: Optional[str] = None) -> dict:
         """Restore a stopped session and preserve API error details."""
-        if node and node != "primary":
-            node_path = urllib.parse.quote(str(node), safe="")
-            session_path = urllib.parse.quote(str(session_id), safe="")
-            path = f"/nodes/{node_path}/restore-candidates/{session_path}/restore"
-        else:
-            path = f"/sessions/{session_id}/restore"
+        # Node-scoped restore candidates resolve to session ids before restore.
+        path = f"/sessions/{session_id}/restore"
         data, status_code, unavailable = self._request_with_status(
             "POST",
             path,

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -50,6 +50,23 @@ def _tmux_socket_from_descriptor(descriptor: Optional[dict]) -> Optional[str]:
     return socket_name or None
 
 
+def _localize_attach_descriptor(client: SessionManagerClient, descriptor: Optional[dict]) -> Optional[dict]:
+    """Prefer local tmux attach when this client is running on the session's node."""
+    if not isinstance(descriptor, dict):
+        return descriptor
+    default_node = getattr(client, "default_node", None)
+    if not isinstance(default_node, str) or not default_node.strip():
+        return descriptor
+    descriptor_node = descriptor.get("node")
+    if not isinstance(descriptor_node, str) or descriptor_node.strip() != default_node.strip():
+        return descriptor
+    if "attach_command" not in descriptor:
+        return descriptor
+    localized = dict(descriptor)
+    localized.pop("attach_command", None)
+    return localized
+
+
 def _attach_tmux_session(tmux_session: str, descriptor: Optional[dict] = None) -> int:
     """Attach the current terminal to a tmux session."""
     attach_command = descriptor.get("attach_command") if isinstance(descriptor, dict) else None
@@ -127,6 +144,10 @@ def _effective_create_node_for_cli(
     if node:
         return str(node).strip() or "primary"
 
+    default_node = _client_default_create_node(client, parent_session_id=parent_session_id)
+    if default_node:
+        return default_node
+
     if parent_session_id:
         sessions_getter = getattr(client, "list_sessions", None)
         if callable(sessions_getter):
@@ -143,6 +164,21 @@ def _effective_create_node_for_cli(
             return str(payload.get("default") or "primary").strip() or "primary"
 
     return "primary"
+
+
+def _client_default_create_node(
+    client: SessionManagerClient,
+    *,
+    parent_session_id: Optional[str] = None,
+) -> Optional[str]:
+    """Return a client-local node default for top-level creates only."""
+    if parent_session_id:
+        return None
+    default_node = getattr(client, "default_node", None)
+    if not isinstance(default_node, str):
+        return None
+    default_node = default_node.strip()
+    return default_node or None
 
 
 def _should_validate_working_dir_locally(
@@ -937,11 +973,12 @@ def cmd_nodes(client: SessionManagerClient) -> int:
     if not nodes:
         print("No nodes configured.")
         return 0
-    headers = ("Node", "Primary", "SSH", "API URL", "Hook Base")
+    headers = ("Node", "Primary", "Agent", "SSH", "API URL", "Hook Base")
     rows = [
         (
             str(node.get("id") or ""),
             "yes" if node.get("primary") else "",
+            "yes" if node.get("codex_fork_node_agent") else "",
             str(node.get("ssh") or ""),
             str(node.get("api_url") or ""),
             str(node.get("hook_base_url") or ""),
@@ -3036,6 +3073,8 @@ def cmd_new(
     if working_dir is None:
         working_dir = os.getcwd()
 
+    node = node or _client_default_create_node(client, parent_session_id=parent_session_id)
+
     if _should_validate_working_dir_locally(client, node=node, parent_session_id=parent_session_id):
         # Expand and resolve path locally for primary sessions. Remote nodes are
         # preflighted by the server on the target machine.
@@ -3056,7 +3095,10 @@ def cmd_new(
         return 1
 
     # Create session via API
-    print(f"Creating session in {working_dir}...")
+    if node:
+        print(f"Creating session on node {node} in {working_dir}...")
+    else:
+        print(f"Creating session in {working_dir}...")
     create_kwargs = {
         "provider": provider,
         "parent_session_id": parent_session_id,
@@ -3096,6 +3138,7 @@ def cmd_new(
     time.sleep(1)
 
     descriptor = client.get_attach_descriptor(session_id) if session_id else None
+    descriptor = _localize_attach_descriptor(client, descriptor)
     return _attach_tmux_session(tmux_session, descriptor)
 
 
@@ -3124,6 +3167,8 @@ def cmd_codex_2(
     if working_dir is None:
         working_dir = os.getcwd()
 
+    node = node or _client_default_create_node(client, parent_session_id=parent_session_id)
+
     if _should_validate_working_dir_locally(client, node=node, parent_session_id=parent_session_id):
         try:
             path = Path(working_dir).expanduser().resolve()
@@ -3138,7 +3183,10 @@ def cmd_codex_2(
             print(f"Error: Invalid path: {e}", file=sys.stderr)
             return 1
 
-    print(f"Creating codex-fork session in {working_dir}...")
+    if node:
+        print(f"Creating codex-fork session on node {node} in {working_dir}...")
+    else:
+        print(f"Creating codex-fork session in {working_dir}...")
     create_kwargs = {
         "provider": "codex-fork",
         "parent_session_id": parent_session_id,
@@ -3181,6 +3229,7 @@ def cmd_attach(client: SessionManagerClient, identifier: Optional[str] = None) -
     def _attach_with_descriptor(session: dict) -> int:
         session_id = session.get("id")
         descriptor = client.get_attach_descriptor(session_id) if session_id else None
+        descriptor = _localize_attach_descriptor(client, descriptor)
         if descriptor:
             if not descriptor.get("attach_supported", True):
                 message = descriptor.get("message") or "Attach not supported for this session"

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -54,11 +54,11 @@ def _localize_attach_descriptor(client: SessionManagerClient, descriptor: Option
     """Prefer local tmux attach when this client is running on the session's node."""
     if not isinstance(descriptor, dict):
         return descriptor
-    default_node = getattr(client, "default_node", None)
-    if not isinstance(default_node, str) or not default_node.strip():
+    local_node = getattr(client, "local_node", None)
+    if not isinstance(local_node, str) or not local_node.strip():
         return descriptor
     descriptor_node = descriptor.get("node")
-    if not isinstance(descriptor_node, str) or descriptor_node.strip() != default_node.strip():
+    if not isinstance(descriptor_node, str) or descriptor_node.strip() != local_node.strip():
         return descriptor
     if "attach_command" not in descriptor:
         return descriptor
@@ -181,6 +181,15 @@ def _client_default_create_node(
     return default_node or None
 
 
+def _client_local_node(client: SessionManagerClient) -> Optional[str]:
+    """Return this client's local execution node id, when configured."""
+    local_node = getattr(client, "local_node", None)
+    if not isinstance(local_node, str):
+        return None
+    local_node = local_node.strip()
+    return local_node or None
+
+
 def _should_validate_working_dir_locally(
     client: SessionManagerClient,
     *,
@@ -195,11 +204,8 @@ def _should_validate_working_dir_locally(
     if effective_node == "primary":
         return True
 
-    client_default_node = _client_default_create_node(
-        client,
-        parent_session_id=parent_session_id,
-    )
-    return client_default_node is not None and effective_node == client_default_node
+    client_local_node = _client_local_node(client)
+    return client_local_node is not None and effective_node == client_local_node
 
 
 def cmd_removed_entrypoint(entrypoint: str) -> int:

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -187,11 +187,19 @@ def _should_validate_working_dir_locally(
     node: Optional[str] = None,
     parent_session_id: Optional[str] = None,
 ) -> bool:
-    return _effective_create_node_for_cli(
+    effective_node = _effective_create_node_for_cli(
         client,
         node=node,
         parent_session_id=parent_session_id,
-    ) == "primary"
+    )
+    if effective_node == "primary":
+        return True
+
+    client_default_node = _client_default_create_node(
+        client,
+        parent_session_id=parent_session_id,
+    )
+    return client_default_node is not None and effective_node == client_default_node
 
 
 def cmd_removed_entrypoint(entrypoint: str) -> int:

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -5,7 +5,7 @@ import sys
 import os
 from typing import Optional
 
-from .client import SessionManagerClient
+from .client import ClientConfigError, SessionManagerClient
 from . import commands
 
 
@@ -138,6 +138,15 @@ def _resolve_send_text_argument(text: str, stdin=None) -> str:
     return stdin_text
 
 
+def _create_client_or_exit() -> SessionManagerClient:
+    """Create an API client or exit with a concise config error."""
+    try:
+        return SessionManagerClient()
+    except ClientConfigError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+
 def _handle_send(argv: list[str]) -> int:
     """Handle `sm send` with subcommand-specific parsing and dispatch."""
     args = _parse_send_args(argv)
@@ -155,7 +164,7 @@ def _handle_send(argv: list[str]) -> int:
     elif args.steer:
         delivery_mode = "steer"
 
-    client = SessionManagerClient()
+    client = _create_client_or_exit()
     return commands.cmd_send(
         client,
         args.session_id,
@@ -189,7 +198,7 @@ def _handle_dispatch(session_id: Optional[str]) -> int:
         )
         return 1
 
-    client = SessionManagerClient()
+    client = _create_client_or_exit()
     return commands.cmd_dispatch(
         client, agent_id, role, dynamic_params, em_id,
         dry_run=dry_run, no_clear=no_clear,
@@ -943,7 +952,7 @@ def main():
         sys.exit(2)
 
     # Create client
-    client = SessionManagerClient()
+    client = _create_client_or_exit()
 
     # Dispatch to command handler
     if args.command == "name":

--- a/tests/unit/test_client_codex_endpoints.py
+++ b/tests/unit/test_client_codex_endpoints.py
@@ -243,3 +243,18 @@ def test_restore_session_uses_explicit_empty_json_body():
         {},
         timeout=10,
     )
+
+
+def test_restore_session_with_node_uses_existing_restore_endpoint():
+    client = _make_client()
+    payload = {"id": "abc123", "status": "running"}
+    with patch.object(client, "_request_with_status", return_value=(payload, 200, False)) as req:
+        result = client.restore_session_result("abc123", node="macbook")
+    assert result["ok"] is True
+    assert result["data"] == payload
+    req.assert_called_once_with(
+        "POST",
+        "/sessions/abc123/restore",
+        {},
+        timeout=10,
+    )

--- a/tests/unit/test_client_config.py
+++ b/tests/unit/test_client_config.py
@@ -1,6 +1,9 @@
 from pathlib import Path
 
+import pytest
+
 from src.cli.client import (
+    ClientConfigError,
     DEFAULT_API_URL,
     SessionManagerClient,
     read_client_config_api_url,
@@ -45,6 +48,32 @@ def test_resolve_api_url_falls_back_to_localhost(monkeypatch, tmp_path: Path):
     assert resolve_api_url() == DEFAULT_API_URL
 
 
+def test_present_malformed_client_config_raises(monkeypatch, tmp_path: Path):
+    config_path = tmp_path / "client.yaml"
+    config_path.write_text("api_url: [unterminated\n")
+    monkeypatch.setenv("SM_CLIENT_CONFIG", str(config_path))
+    monkeypatch.delenv("SM_API_URL", raising=False)
+
+    with pytest.raises(ClientConfigError, match="Invalid Session Manager client config"):
+        resolve_api_url()
+
+
+def test_present_non_mapping_client_config_raises(tmp_path: Path):
+    config_path = tmp_path / "client.yaml"
+    config_path.write_text("- api_url: http://primary.example.test:8420\n")
+
+    with pytest.raises(ClientConfigError, match="expected a YAML mapping"):
+        read_client_config_api_url(config_path)
+
+
+def test_invalid_client_config_api_url_raises(tmp_path: Path):
+    config_path = tmp_path / "client.yaml"
+    config_path.write_text("api_url: studio.local:8420\n")
+
+    with pytest.raises(ClientConfigError, match="api_url must be http"):
+        read_client_config_api_url(config_path)
+
+
 def test_read_client_config_default_node_from_top_level_key(tmp_path: Path):
     config_path = tmp_path / "client.yaml"
     config_path.write_text("default_node: macbook\n")
@@ -70,6 +99,14 @@ def test_resolve_default_node_precedence(monkeypatch, tmp_path: Path):
 
     monkeypatch.delenv("SM_DEFAULT_NODE")
     assert resolve_default_node() == "config-node"
+
+
+def test_invalid_client_config_default_node_raises(tmp_path: Path):
+    config_path = tmp_path / "client.yaml"
+    config_path.write_text("default_node: ''\n")
+
+    with pytest.raises(ClientConfigError, match="default_node must be a non-empty string"):
+        read_client_config_default_node(config_path)
 
 
 def test_session_manager_client_uses_shared_config(monkeypatch, tmp_path: Path):

--- a/tests/unit/test_client_config.py
+++ b/tests/unit/test_client_config.py
@@ -40,6 +40,26 @@ def test_resolve_api_url_precedence(monkeypatch, tmp_path: Path):
     assert resolve_api_url() == "http://config.example.test:8420"
 
 
+def test_resolve_api_url_rejects_invalid_explicit_url(monkeypatch, tmp_path: Path):
+    config_path = tmp_path / "client.yaml"
+    config_path.write_text("api_url: http://config.example.test:8420\n")
+    monkeypatch.setenv("SM_CLIENT_CONFIG", str(config_path))
+    monkeypatch.delenv("SM_API_URL", raising=False)
+
+    with pytest.raises(ClientConfigError, match="explicit api_url must be http"):
+        resolve_api_url("config.example.test:8420")
+
+
+def test_resolve_api_url_rejects_invalid_env_url(monkeypatch, tmp_path: Path):
+    config_path = tmp_path / "client.yaml"
+    config_path.write_text("api_url: http://config.example.test:8420\n")
+    monkeypatch.setenv("SM_CLIENT_CONFIG", str(config_path))
+    monkeypatch.setenv("SM_API_URL", "env.example.test:8420")
+
+    with pytest.raises(ClientConfigError, match="SM_API_URL must be http"):
+        resolve_api_url()
+
+
 def test_resolve_api_url_falls_back_to_localhost(monkeypatch, tmp_path: Path):
     config_path = tmp_path / "missing.yaml"
     monkeypatch.setenv("SM_CLIENT_CONFIG", str(config_path))

--- a/tests/unit/test_client_config.py
+++ b/tests/unit/test_client_config.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+from src.cli.client import (
+    DEFAULT_API_URL,
+    SessionManagerClient,
+    read_client_config_api_url,
+    resolve_api_url,
+)
+
+
+def test_read_client_config_api_url_from_top_level_key(tmp_path: Path):
+    config_path = tmp_path / "client.yaml"
+    config_path.write_text('api_url: "http://primary.example.test:8420/"\n')
+
+    assert read_client_config_api_url(config_path) == "http://primary.example.test:8420"
+
+
+def test_read_client_config_api_url_from_client_section(tmp_path: Path):
+    config_path = tmp_path / "client.yaml"
+    config_path.write_text("client:\n  api_url: https://sm.example.test\n")
+
+    assert read_client_config_api_url(config_path) == "https://sm.example.test"
+
+
+def test_resolve_api_url_precedence(monkeypatch, tmp_path: Path):
+    config_path = tmp_path / "client.yaml"
+    config_path.write_text("api_url: http://config.example.test:8420\n")
+    monkeypatch.setenv("SM_CLIENT_CONFIG", str(config_path))
+    monkeypatch.setenv("SM_API_URL", "http://env.example.test:8420")
+
+    assert resolve_api_url("http://explicit.example.test:8420") == "http://explicit.example.test:8420"
+    assert resolve_api_url() == "http://env.example.test:8420"
+
+    monkeypatch.delenv("SM_API_URL")
+    assert resolve_api_url() == "http://config.example.test:8420"
+
+
+def test_resolve_api_url_falls_back_to_localhost(monkeypatch, tmp_path: Path):
+    config_path = tmp_path / "missing.yaml"
+    monkeypatch.setenv("SM_CLIENT_CONFIG", str(config_path))
+    monkeypatch.delenv("SM_API_URL", raising=False)
+
+    assert resolve_api_url() == DEFAULT_API_URL
+
+
+def test_session_manager_client_uses_shared_config(monkeypatch, tmp_path: Path):
+    config_path = tmp_path / "client.yaml"
+    config_path.write_text("api_url: http://config.example.test:8420\n")
+    monkeypatch.setenv("SM_CLIENT_CONFIG", str(config_path))
+    monkeypatch.delenv("SM_API_URL", raising=False)
+
+    client = SessionManagerClient()
+
+    assert client.api_url == "http://config.example.test:8420"

--- a/tests/unit/test_client_config.py
+++ b/tests/unit/test_client_config.py
@@ -8,8 +8,10 @@ from src.cli.client import (
     SessionManagerClient,
     read_client_config_api_url,
     read_client_config_default_node,
+    read_client_config_local_node,
     resolve_api_url,
     resolve_default_node,
+    resolve_local_node,
 )
 
 
@@ -108,6 +110,20 @@ def test_read_client_config_default_node_from_client_section(tmp_path: Path):
     assert read_client_config_default_node(config_path) == "worker"
 
 
+def test_read_client_config_local_node_from_top_level_key(tmp_path: Path):
+    config_path = tmp_path / "client.yaml"
+    config_path.write_text("local_node: macbook\n")
+
+    assert read_client_config_local_node(config_path) == "macbook"
+
+
+def test_read_client_config_local_node_from_client_section(tmp_path: Path):
+    config_path = tmp_path / "client.yaml"
+    config_path.write_text("client:\n  local_node: worker\n")
+
+    assert read_client_config_local_node(config_path) == "worker"
+
+
 def test_resolve_default_node_precedence(monkeypatch, tmp_path: Path):
     config_path = tmp_path / "client.yaml"
     config_path.write_text("default_node: config-node\n")
@@ -121,6 +137,19 @@ def test_resolve_default_node_precedence(monkeypatch, tmp_path: Path):
     assert resolve_default_node() == "config-node"
 
 
+def test_resolve_local_node_precedence(monkeypatch, tmp_path: Path):
+    config_path = tmp_path / "client.yaml"
+    config_path.write_text("local_node: config-node\n")
+    monkeypatch.setenv("SM_CLIENT_CONFIG", str(config_path))
+    monkeypatch.setenv("SM_LOCAL_NODE", "env-node")
+
+    assert resolve_local_node("explicit-node") == "explicit-node"
+    assert resolve_local_node() == "env-node"
+
+    monkeypatch.delenv("SM_LOCAL_NODE")
+    assert resolve_local_node() == "config-node"
+
+
 def test_invalid_client_config_default_node_raises(tmp_path: Path):
     config_path = tmp_path / "client.yaml"
     config_path.write_text("default_node: ''\n")
@@ -129,14 +158,28 @@ def test_invalid_client_config_default_node_raises(tmp_path: Path):
         read_client_config_default_node(config_path)
 
 
+def test_invalid_client_config_local_node_raises(tmp_path: Path):
+    config_path = tmp_path / "client.yaml"
+    config_path.write_text("local_node: ''\n")
+
+    with pytest.raises(ClientConfigError, match="local_node must be a non-empty string"):
+        read_client_config_local_node(config_path)
+
+
 def test_session_manager_client_uses_shared_config(monkeypatch, tmp_path: Path):
     config_path = tmp_path / "client.yaml"
-    config_path.write_text("api_url: http://config.example.test:8420\ndefault_node: macbook\n")
+    config_path.write_text(
+        "api_url: http://config.example.test:8420\n"
+        "default_node: macbook\n"
+        "local_node: macbook\n"
+    )
     monkeypatch.setenv("SM_CLIENT_CONFIG", str(config_path))
     monkeypatch.delenv("SM_API_URL", raising=False)
     monkeypatch.delenv("SM_DEFAULT_NODE", raising=False)
+    monkeypatch.delenv("SM_LOCAL_NODE", raising=False)
 
     client = SessionManagerClient()
 
     assert client.api_url == "http://config.example.test:8420"
     assert client.default_node == "macbook"
+    assert client.local_node == "macbook"

--- a/tests/unit/test_client_config.py
+++ b/tests/unit/test_client_config.py
@@ -4,7 +4,9 @@ from src.cli.client import (
     DEFAULT_API_URL,
     SessionManagerClient,
     read_client_config_api_url,
+    read_client_config_default_node,
     resolve_api_url,
+    resolve_default_node,
 )
 
 
@@ -43,12 +45,41 @@ def test_resolve_api_url_falls_back_to_localhost(monkeypatch, tmp_path: Path):
     assert resolve_api_url() == DEFAULT_API_URL
 
 
+def test_read_client_config_default_node_from_top_level_key(tmp_path: Path):
+    config_path = tmp_path / "client.yaml"
+    config_path.write_text("default_node: macbook\n")
+
+    assert read_client_config_default_node(config_path) == "macbook"
+
+
+def test_read_client_config_default_node_from_client_section(tmp_path: Path):
+    config_path = tmp_path / "client.yaml"
+    config_path.write_text("client:\n  default_node: worker\n")
+
+    assert read_client_config_default_node(config_path) == "worker"
+
+
+def test_resolve_default_node_precedence(monkeypatch, tmp_path: Path):
+    config_path = tmp_path / "client.yaml"
+    config_path.write_text("default_node: config-node\n")
+    monkeypatch.setenv("SM_CLIENT_CONFIG", str(config_path))
+    monkeypatch.setenv("SM_DEFAULT_NODE", "env-node")
+
+    assert resolve_default_node("explicit-node") == "explicit-node"
+    assert resolve_default_node() == "env-node"
+
+    monkeypatch.delenv("SM_DEFAULT_NODE")
+    assert resolve_default_node() == "config-node"
+
+
 def test_session_manager_client_uses_shared_config(monkeypatch, tmp_path: Path):
     config_path = tmp_path / "client.yaml"
-    config_path.write_text("api_url: http://config.example.test:8420\n")
+    config_path.write_text("api_url: http://config.example.test:8420\ndefault_node: macbook\n")
     monkeypatch.setenv("SM_CLIENT_CONFIG", str(config_path))
     monkeypatch.delenv("SM_API_URL", raising=False)
+    monkeypatch.delenv("SM_DEFAULT_NODE", raising=False)
 
     client = SessionManagerClient()
 
     assert client.api_url == "http://config.example.test:8420"
+    assert client.default_node == "macbook"

--- a/tests/unit/test_cmd_attach_descriptor.py
+++ b/tests/unit/test_cmd_attach_descriptor.py
@@ -2,9 +2,10 @@ from src.cli import commands
 
 
 class _AttachClient:
-    def __init__(self, session: dict, descriptor: dict):
+    def __init__(self, session: dict, descriptor: dict, default_node: str | None = None):
         self._session = session
         self._descriptor = descriptor
+        self.default_node = default_node
 
     def get_session(self, session_id: str):
         if session_id == self._session["id"]:
@@ -115,6 +116,49 @@ def test_cmd_attach_uses_descriptor_attach_command(monkeypatch):
     assert calls == [
         (
             ["ssh", "-tt", "worker", "/bin/sh", "-lc", "'tmux attach -t claude-remote1001'"],
+            True,
+        )
+    ]
+
+
+def test_cmd_attach_prefers_local_tmux_when_descriptor_node_matches_client_default(monkeypatch):
+    calls = []
+
+    def _fake_run(args, check):
+        calls.append((args, check))
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+
+    session = {
+        "id": "localnode1",
+        "provider": "codex-fork",
+        "tmux_session": "codex-fork-localnode1",
+        "status": "running",
+        "node": "macbook",
+    }
+    descriptor = {
+        "session_id": "localnode1",
+        "provider": "codex-fork",
+        "attach_supported": True,
+        "tmux_session": "codex-fork-localnode1",
+        "tmux_socket_name": "session-manager-test",
+        "node": "macbook",
+        "attach_command": [
+            "ssh",
+            "-tt",
+            "rajesh@macbook.local",
+            "/bin/sh",
+            "-lc",
+            "'tmux -L session-manager-test attach -t codex-fork-localnode1'",
+        ],
+    }
+
+    rc = commands.cmd_attach(_AttachClient(session, descriptor, default_node="macbook"), "localnode1")
+
+    assert rc == 0
+    assert calls == [
+        (
+            ["tmux", "-L", "session-manager-test", "attach", "-t", "codex-fork-localnode1"],
             True,
         )
     ]

--- a/tests/unit/test_cmd_attach_descriptor.py
+++ b/tests/unit/test_cmd_attach_descriptor.py
@@ -2,10 +2,17 @@ from src.cli import commands
 
 
 class _AttachClient:
-    def __init__(self, session: dict, descriptor: dict, default_node: str | None = None):
+    def __init__(
+        self,
+        session: dict,
+        descriptor: dict,
+        default_node: str | None = None,
+        local_node: str | None = None,
+    ):
         self._session = session
         self._descriptor = descriptor
         self.default_node = default_node
+        self.local_node = local_node
 
     def get_session(self, session_id: str):
         if session_id == self._session["id"]:
@@ -121,7 +128,7 @@ def test_cmd_attach_uses_descriptor_attach_command(monkeypatch):
     ]
 
 
-def test_cmd_attach_prefers_local_tmux_when_descriptor_node_matches_client_default(monkeypatch):
+def test_cmd_attach_keeps_descriptor_attach_command_for_remote_default_node(monkeypatch):
     calls = []
 
     def _fake_run(args, check):
@@ -154,6 +161,59 @@ def test_cmd_attach_prefers_local_tmux_when_descriptor_node_matches_client_defau
     }
 
     rc = commands.cmd_attach(_AttachClient(session, descriptor, default_node="macbook"), "localnode1")
+
+    assert rc == 0
+    assert calls == [
+        (
+            [
+                "ssh",
+                "-tt",
+                "rajesh@macbook.local",
+                "/bin/sh",
+                "-lc",
+                "'tmux -L session-manager-test attach -t codex-fork-localnode1'",
+            ],
+            True,
+        )
+    ]
+
+
+def test_cmd_attach_prefers_local_tmux_when_descriptor_node_matches_client_local_node(monkeypatch):
+    calls = []
+
+    def _fake_run(args, check):
+        calls.append((args, check))
+
+    monkeypatch.setattr("subprocess.run", _fake_run)
+
+    session = {
+        "id": "localnode1",
+        "provider": "codex-fork",
+        "tmux_session": "codex-fork-localnode1",
+        "status": "running",
+        "node": "macbook",
+    }
+    descriptor = {
+        "session_id": "localnode1",
+        "provider": "codex-fork",
+        "attach_supported": True,
+        "tmux_session": "codex-fork-localnode1",
+        "tmux_socket_name": "session-manager-test",
+        "node": "macbook",
+        "attach_command": [
+            "ssh",
+            "-tt",
+            "rajesh@macbook.local",
+            "/bin/sh",
+            "-lc",
+            "'tmux -L session-manager-test attach -t codex-fork-localnode1'",
+        ],
+    }
+
+    rc = commands.cmd_attach(
+        _AttachClient(session, descriptor, default_node="macbook", local_node="macbook"),
+        "localnode1",
+    )
 
     assert rc == 0
     assert calls == [

--- a/tests/unit/test_cmd_new.py
+++ b/tests/unit/test_cmd_new.py
@@ -97,9 +97,10 @@ def test_cmd_new_uses_client_default_node_for_top_level_create(tmp_path):
     run_mock.assert_called_once_with(["tmux", "attach", "-t", "codex-fork-node1234"], check=True)
 
 
-def test_cmd_new_resolves_relative_path_for_client_default_node(monkeypatch, tmp_path):
+def test_cmd_new_resolves_relative_path_for_client_local_node(monkeypatch, tmp_path):
     client = MagicMock()
     client.default_node = "macbook"
+    client.local_node = "macbook"
     client.create_session_result.return_value = {
         "ok": True,
         "unavailable": False,
@@ -122,6 +123,33 @@ def test_cmd_new_resolves_relative_path_for_client_default_node(monkeypatch, tmp
         node="macbook",
     )
     run_mock.assert_called_once_with(["tmux", "attach", "-t", "codex-fork-node5678"], check=True)
+
+
+def test_cmd_new_keeps_relative_path_for_remote_default_node(monkeypatch, tmp_path):
+    client = MagicMock()
+    client.default_node = "worker"
+    client.create_session_result.return_value = {
+        "ok": True,
+        "unavailable": False,
+        "data": {
+            "id": "node9012",
+            "provider": "codex-fork",
+            "tmux_session": "codex-fork-node9012",
+        },
+    }
+    monkeypatch.chdir(tmp_path)
+
+    with patch("subprocess.run") as run_mock, patch("time.sleep"):
+        rc = cmd_new(client, working_dir=".", provider="codex-fork")
+
+    assert rc == 0
+    client.create_session_result.assert_called_once_with(
+        ".",
+        provider="codex-fork",
+        parent_session_id=None,
+        node="worker",
+    )
+    run_mock.assert_called_once_with(["tmux", "attach", "-t", "codex-fork-node9012"], check=True)
 
 
 def test_cmd_new_does_not_override_parent_inherited_node(tmp_path):

--- a/tests/unit/test_cmd_new.py
+++ b/tests/unit/test_cmd_new.py
@@ -71,6 +71,62 @@ def test_cmd_new_surfaces_create_error_detail(tmp_path, capsys):
     assert "Configured codex-fork runtime unavailable" in capsys.readouterr().err
 
 
+def test_cmd_new_uses_client_default_node_for_top_level_create(tmp_path):
+    client = MagicMock()
+    client.default_node = "macbook"
+    client.create_session_result.return_value = {
+        "ok": True,
+        "unavailable": False,
+        "data": {
+            "id": "node1234",
+            "provider": "codex-fork",
+            "tmux_session": "codex-fork-node1234",
+        },
+    }
+
+    with patch("subprocess.run") as run_mock, patch("time.sleep"):
+        rc = cmd_new(client, working_dir=str(tmp_path), provider="codex-fork")
+
+    assert rc == 0
+    client.create_session_result.assert_called_once_with(
+        str(tmp_path),
+        provider="codex-fork",
+        parent_session_id=None,
+        node="macbook",
+    )
+    run_mock.assert_called_once_with(["tmux", "attach", "-t", "codex-fork-node1234"], check=True)
+
+
+def test_cmd_new_does_not_override_parent_inherited_node(tmp_path):
+    client = MagicMock()
+    client.default_node = "macbook"
+    client.create_session_result.return_value = {
+        "ok": True,
+        "unavailable": False,
+        "data": {
+            "id": "child1234",
+            "provider": "codex-fork",
+            "tmux_session": "codex-fork-child1234",
+        },
+    }
+
+    with patch("subprocess.run") as run_mock, patch("time.sleep"):
+        rc = cmd_new(
+            client,
+            working_dir=str(tmp_path),
+            provider="codex-fork",
+            parent_session_id="parent123",
+        )
+
+    assert rc == 0
+    client.create_session_result.assert_called_once_with(
+        str(tmp_path),
+        provider="codex-fork",
+        parent_session_id="parent123",
+    )
+    run_mock.assert_called_once_with(["tmux", "attach", "-t", "codex-fork-child1234"], check=True)
+
+
 def test_cmd_new_skips_local_path_validation_for_remote_default():
     client = MagicMock()
     client.list_nodes.return_value = {"default": "worker", "nodes": []}

--- a/tests/unit/test_cmd_new.py
+++ b/tests/unit/test_cmd_new.py
@@ -97,6 +97,33 @@ def test_cmd_new_uses_client_default_node_for_top_level_create(tmp_path):
     run_mock.assert_called_once_with(["tmux", "attach", "-t", "codex-fork-node1234"], check=True)
 
 
+def test_cmd_new_resolves_relative_path_for_client_default_node(monkeypatch, tmp_path):
+    client = MagicMock()
+    client.default_node = "macbook"
+    client.create_session_result.return_value = {
+        "ok": True,
+        "unavailable": False,
+        "data": {
+            "id": "node5678",
+            "provider": "codex-fork",
+            "tmux_session": "codex-fork-node5678",
+        },
+    }
+    monkeypatch.chdir(tmp_path)
+
+    with patch("subprocess.run") as run_mock, patch("time.sleep"):
+        rc = cmd_new(client, working_dir=".", provider="codex-fork")
+
+    assert rc == 0
+    client.create_session_result.assert_called_once_with(
+        str(tmp_path.resolve()),
+        provider="codex-fork",
+        parent_session_id=None,
+        node="macbook",
+    )
+    run_mock.assert_called_once_with(["tmux", "attach", "-t", "codex-fork-node5678"], check=True)
+
+
 def test_cmd_new_does_not_override_parent_inherited_node(tmp_path):
     client = MagicMock()
     client.default_node = "macbook"


### PR DESCRIPTION
## Summary
- add shared client API URL resolution for `sm`: explicit argument, `SM_API_URL`, `~/.config/session-manager/client.yaml`, then localhost
- fail fast on malformed explicit `api_url`, malformed `SM_API_URL`, and malformed/unreadable/invalid present client config instead of silently falling back
- add client `default_node` resolution via explicit value, `SM_DEFAULT_NODE`, or shared client config for top-level create routing
- add client `local_node` resolution via `SM_LOCAL_NODE` or shared client config for same-machine tmux attach and local path normalization
- use the client default node for top-level `sm claude` / `sm codex` creates while preserving parent-session node inheritance
- normalize relative working directories locally only when the effective create node matches `local_node`
- prefer local tmux attach only when an attach descriptor's node matches `local_node`, preserving SSH for remote default nodes
- expose codex-fork node-agent health in `sm nodes`

## Root Cause
When a thin client points at a primary Session Manager, top-level creates without `--node` are resolved by the primary as `node=primary`. For a demoted local machine acting as a registered node, that sent local paths to the master filesystem and produced false `Working directory does not exist` failures. After placement was corrected, the attach descriptor still used the master-generated SSH command even when the CLI was already running on the target node.

The first version of shared client config also treated present-but-invalid YAML and malformed explicit API URL overrides the same as absent config, which could silently retarget commands to localhost or another configured server. These now raise concise CLI config errors. Client-local node creates also continue local path validation so relative paths are resolved from the caller's cwd before the primary preflights them over SSH. Because `default_node` can be a remote routing preference, `local_node` is now the explicit signal that the CLI is running on that node.

## Impact
Node-local interactive shells can keep `api_url` pointed at the master, set `default_node` to their local node for top-level creates, and set `local_node` to the same node id for local tmux attach/path handling. Managed child sessions still inherit their parent node from the master. Clients that use `default_node` to target a remote worker keep the server-provided SSH attach command.

## Tests
- `./venv/bin/python -m pytest tests/unit/test_client_config.py tests/unit/test_cmd_new.py`
- `./venv/bin/python -m pytest tests/unit/test_cmd_attach_descriptor.py tests/unit/test_client_config.py tests/unit/test_cmd_new.py`
- `./venv/bin/python -m pytest tests/unit/test_client_config.py tests/unit/test_cmd_attach_descriptor.py tests/unit/test_cmd_new.py`
- `/Users/rajesh/Desktop/automation/session-manager/venv/bin/python -m pytest tests/unit/test_client_codex_endpoints.py tests/unit/test_client_config.py tests/unit/test_cmd_attach_descriptor.py tests/unit/test_cmd_new.py`

## Notes
- `.agent-os/workflows/pr_review_workflow.md` was requested but is not present in this checkout or `~/.agent-os`; I followed the repo/GitHub publish workflow instead.