### PR TITLE
Add node restore inventory

### DIFF
--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -371,16 +371,52 @@ class SessionManagerClient:
         refresh: bool = False,
     ) -> Optional[list]:
         """List stopped restore candidates from one node's local inventory."""
+        result = self.list_node_restore_sessions_result(node, timeout=timeout, refresh=refresh)
+        if result.get("ok"):
+            return result.get("sessions", [])
+        return None
+
+    def list_node_restore_sessions_result(
+        self,
+        node: str,
+        *,
+        timeout: Optional[float] = None,
+        refresh: bool = False,
+    ) -> dict:
+        """List node restore candidates while preserving API error details."""
         node_path = urllib.parse.quote(str(node), safe="")
         suffix = "?refresh=true" if refresh else ""
-        data, success, _ = self._request(
+        data, status_code, unavailable = self._request_with_status(
             "GET",
             f"/nodes/{node_path}/restore-candidates{suffix}",
             timeout=timeout,
         )
-        if success and data:
-            return data.get("sessions", [])
-        return None
+        if unavailable:
+            return {
+                "ok": False,
+                "unavailable": True,
+                "status_code": None,
+                "data": None,
+                "sessions": [],
+                "detail": None,
+            }
+
+        ok = status_code in (200, 201)
+        detail = None
+        sessions: list = []
+        if isinstance(data, dict):
+            detail = data.get("detail") or data.get("error") or data.get("raw")
+            raw_sessions = data.get("sessions")
+            if isinstance(raw_sessions, list):
+                sessions = raw_sessions
+        return {
+            "ok": ok,
+            "unavailable": False,
+            "status_code": status_code,
+            "data": data,
+            "sessions": sessions if ok else [],
+            "detail": detail,
+        }
 
     def list_registry(self) -> Optional[list]:
         """List all live agent registry entries."""
@@ -1065,8 +1101,12 @@ class SessionManagerClient:
 
     def restore_session_result(self, session_id: str, node: Optional[str] = None) -> dict:
         """Restore a stopped session and preserve API error details."""
-        # Node-scoped restore candidates resolve to session ids before restore.
-        path = f"/sessions/{session_id}/restore"
+        if node and node != "primary":
+            node_path = urllib.parse.quote(str(node), safe="")
+            session_path = urllib.parse.quote(str(session_id), safe="")
+            path = f"/nodes/{node_path}/restore-candidates/{session_path}/restore"
+        else:
+            path = f"/sessions/{session_id}/restore"
         data, status_code, unavailable = self._request_with_status(
             "POST",
             path,

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -342,6 +342,7 @@ def resolve_restore_session_id(
     identifier: str,
     *,
     timeout: Optional[float] = None,
+    node: Optional[str] = None,
 ) -> tuple[Optional[str], Optional[dict], bool, Optional[str]]:
     """
     Resolve a restore target.
@@ -354,6 +355,56 @@ def resolve_restore_session_id(
     """
     if not identifier or not identifier.strip():
         return None, None, False, None
+
+    if node and node != "primary":
+        list_result = None
+        list_with_result = getattr(client, "list_node_restore_sessions_result", None)
+        if callable(list_with_result):
+            try:
+                list_result = list_with_result(node, timeout=timeout)
+            except TypeError:
+                list_result = list_with_result(node)
+        if isinstance(list_result, dict):
+            if list_result.get("unavailable"):
+                return None, None, True, None
+            if not list_result.get("ok"):
+                error = list_result.get("detail") or f"Failed to list restore inventory for node {node}"
+                return None, None, False, str(error)
+            sessions = list_result.get("sessions")
+        else:
+            try:
+                sessions = client.list_node_restore_sessions(node, timeout=timeout)
+            except TypeError:
+                sessions = client.list_node_restore_sessions(node)
+        if sessions is None:
+            return None, None, True, None
+        direct_matches = [
+            s for s in sessions
+            if identifier in (s.get("id"), s.get("source_session_id"))
+        ]
+        if len(direct_matches) == 1:
+            matched = direct_matches[0]
+            return matched["id"], matched, False, None
+        if len(direct_matches) > 1:
+            matched_ids = ", ".join(s["id"] for s in direct_matches)
+            return None, None, False, (
+                f"Multiple node restore candidates match '{identifier}': {matched_ids}. "
+                "Use a session ID."
+            )
+
+        alias_matches = [s for s in sessions if identifier in (s.get("aliases") or [])]
+        name_matches = [s for s in sessions if s.get("friendly_name") == identifier]
+        candidates = alias_matches or name_matches
+        if not candidates:
+            return None, None, False, None
+        if len(candidates) == 1:
+            candidate = candidates[0]
+            return candidate["id"], candidate, False, None
+        candidate_ids = ", ".join(s["id"] for s in candidates)
+        return None, None, False, (
+            f"Multiple node restore candidates match '{identifier}': {candidate_ids}. "
+            "Use a session ID."
+        )
 
     try:
         session = client.get_session(identifier, timeout=timeout)
@@ -2915,7 +2966,12 @@ def cmd_kill(
     return 0
 
 
-def cmd_restore(client: SessionManagerClient, target_identifier: str) -> int:
+def _default_restore_node(client: SessionManagerClient) -> Optional[str]:
+    node = getattr(client, "default_node", None)
+    return node if node and node != "primary" else None
+
+
+def cmd_restore(client: SessionManagerClient, target_identifier: str, node: Optional[str] = None) -> int:
     """
     Restore a stopped session and attach to it when supported.
 
@@ -2928,10 +2984,25 @@ def cmd_restore(client: SessionManagerClient, target_identifier: str) -> int:
         1: Failed
         2: Session manager unavailable
     """
-    target_session_id, _, unavailable, error = resolve_restore_session_id(client, target_identifier)
+    target_node = node if node and node != "primary" else None
+    target_session_id, _, unavailable, error = resolve_restore_session_id(
+        client,
+        target_identifier,
+        node=target_node,
+    )
     if unavailable:
         print(UNAVAILABLE_MESSAGE, file=sys.stderr)
         return 2
+    if target_session_id is None and not target_node and error is None and _default_restore_node(client):
+        target_node = _default_restore_node(client)
+        target_session_id, _, unavailable, error = resolve_restore_session_id(
+            client,
+            target_identifier,
+            node=target_node,
+        )
+        if unavailable:
+            print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+            return 2
     if target_session_id is None:
         if error:
             print(f"Error: {error}", file=sys.stderr)
@@ -2939,7 +3010,7 @@ def cmd_restore(client: SessionManagerClient, target_identifier: str) -> int:
         print(f"Error: Session '{target_identifier}' not found", file=sys.stderr)
         return 1
 
-    result = client.restore_session_result(target_session_id)
+    result = client.restore_session_result(target_session_id, node=target_node)
     if result.get("unavailable"):
         print(UNAVAILABLE_MESSAGE, file=sys.stderr)
         return 2
@@ -2950,7 +3021,8 @@ def cmd_restore(client: SessionManagerClient, target_identifier: str) -> int:
 
     session = result.get("data") or {}
     provider = session.get("provider")
-    print(f"Session restored: {target_session_id}")
+    node_label = f" on node {target_node}" if target_node else ""
+    print(f"Session restored: {target_session_id}{node_label}")
     if provider == "codex-app":
         print("No tmux attach for Codex app sessions.")
         return 0
@@ -3878,6 +3950,7 @@ def cmd_watch(
     restore_mode: bool = False,
     top_level: bool = False,
     restore_sort: str = "retired",
+    restore_node: Optional[str] = None,
 ) -> int:
     """Launch interactive watch dashboard."""
     if os.environ.get("CLAUDE_SESSION_MANAGER_ID"):
@@ -3902,6 +3975,7 @@ def cmd_watch(
         restore_mode=restore_mode,
         top_level=top_level,
         restore_sort=restore_sort,
+        restore_node=restore_node,
     )
 
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -530,6 +530,7 @@ def main():
         help="Restore a stopped session",
     )
     restore_parser.add_argument("session", help="Session ID or friendly name to restore")
+    restore_parser.add_argument("--node", help="Restore from a specific node's local history")
 
     # sm fork [session] [--self] [--name NAME] [--attach] [--json]
     fork_parser = subparsers.add_parser("fork", help="Fork a session into a new SM-owned session")
@@ -755,6 +756,11 @@ def main():
         choices=("retired", "last-active", "name"),
         default="retired",
         help="In --restore mode, initial sort order (default: retired)",
+    )
+    watch_parser.add_argument(
+        "--node",
+        default=None,
+        help="In --restore mode, browse a specific node's local restore history",
     )
 
     # sm tail <session> [-n N] [--raw] [--db-path PATH]
@@ -1254,7 +1260,7 @@ def main():
     elif args.command in ("kill", "retire"):
         sys.exit(commands.cmd_kill(client, session_id, args.session_id))
     elif args.command in ("restore", "unkill"):
-        sys.exit(commands.cmd_restore(client, args.session))
+        sys.exit(commands.cmd_restore(client, args.session, node=args.node))
     elif args.command == "fork":
         sys.exit(
             commands.cmd_fork(
@@ -1309,6 +1315,7 @@ def main():
             restore_mode=args.restore,
             top_level=args.top_level,
             restore_sort=args.sort,
+            restore_node=args.node,
         ))
     elif args.command == "tail":
         sys.exit(commands.cmd_tail(

--- a/src/cli/watch_tui.py
+++ b/src/cli/watch_tui.py
@@ -1340,11 +1340,14 @@ def _render(
     palette: dict[str, int],
     restore_mode: bool = False,
     restore_sort: str = "retired",
+    restore_node: Optional[str] = None,
 ):
     stdscr.erase()
     height, width = stdscr.getmaxyx()
 
-    title = f"sm watch{' --restore' if restore_mode else ''}  {total_sessions} agents - {repo_count} repos"
+    restore_suffix = " --restore" if restore_mode else ""
+    node_suffix = f" --node {restore_node}" if restore_mode and restore_node else ""
+    title = f"sm watch{restore_suffix}{node_suffix}  {total_sessions} agents - {repo_count} repos"
     if filter_text:
         title += f" - filter: {filter_text}"
     stdscr.addnstr(0, 0, title, _render_columns(width, 0), curses.A_BOLD | palette["header"])
@@ -1408,6 +1411,7 @@ def run_watch_tui(
     restore_mode: bool = False,
     top_level: bool = False,
     restore_sort: str = "retired",
+    restore_node: Optional[str] = None,
 ) -> int:
     """Run the sm watch curses UI."""
 
@@ -1438,6 +1442,11 @@ def run_watch_tui(
             collapsed_repo_keys: set[str] = set()
             restore_tree_collapsed = top_level
             restore_sort_mode = restore_sort
+            effective_restore_node = restore_node
+            if restore_mode and not effective_restore_node:
+                default_node = getattr(client, "default_node", None)
+                if default_node and default_node != "primary":
+                    effective_restore_node = default_node
             repo_count = 0
             total_sessions = 0
             spinner_index = 0
@@ -1448,7 +1457,10 @@ def run_watch_tui(
             while True:
                 now = time.monotonic()
                 if now >= next_refresh:
-                    listed = client.list_sessions(include_stopped=restore_mode)
+                    if restore_mode and effective_restore_node:
+                        listed = client.list_node_restore_sessions(effective_restore_node)
+                    else:
+                        listed = client.list_sessions(include_stopped=restore_mode)
                     if listed is None:
                         flash_message = "Session manager unavailable"
                         flash_until = now + 2.5
@@ -1534,6 +1546,7 @@ def run_watch_tui(
                     palette=palette,
                     restore_mode=restore_mode,
                     restore_sort=restore_sort_mode,
+                    restore_node=effective_restore_node,
                 )
 
                 key = stdscr.getch()
@@ -1838,7 +1851,7 @@ def run_watch_tui(
                         flash_until = time.monotonic() + 2.0
                         continue
                     if restore_mode:
-                        result = client.restore_session_result(selected_session_id)
+                        result = client.restore_session_result(selected_session_id, node=effective_restore_node)
                         if result.get("unavailable"):
                             flash_message = "Session manager unavailable"
                         elif result.get("ok"):

--- a/src/codex_fork_remote.py
+++ b/src/codex_fork_remote.py
@@ -110,6 +110,7 @@ class NodeAgentConnection:
         self._event_queues: dict[str, asyncio.Queue[Optional[str]]] = {}
         self._pending_control: dict[str, asyncio.Future[dict[str, Any]]] = {}
         self._pending_register: dict[str, asyncio.Future[None]] = {}
+        self._pending_restore_inventory: dict[str, asyncio.Future[dict[str, Any]]] = {}
         self._registered_paths: dict[str, CodexForkBridgePaths] = {}
 
     def is_healthy(self) -> bool:
@@ -197,6 +198,17 @@ class NodeAgentConnection:
         finally:
             self._pending_control.pop(bridge_request_id, None)
 
+    async def restore_inventory(self, *, timeout: float = 5.0) -> dict[str, Any]:
+        request_id = uuid.uuid4().hex
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[dict[str, Any]] = loop.create_future()
+        self._pending_restore_inventory[request_id] = future
+        try:
+            await self.send({"type": "restore_inventory", "request_id": request_id})
+            return await asyncio.wait_for(future, timeout=timeout)
+        finally:
+            self._pending_restore_inventory.pop(request_id, None)
+
     async def handle_frame(self, frame: dict[str, Any]) -> None:
         frame_type = frame.get("type")
         if frame_type == "event":
@@ -257,6 +269,17 @@ class NodeAgentConnection:
             future.set_exception(RuntimeError("remote control returned no response"))
             return
 
+        if frame_type == "restore_inventory_result":
+            request_id = str(frame.get("request_id") or "").strip()
+            future = self._pending_restore_inventory.get(request_id)
+            if future is None or future.done():
+                return
+            if frame.get("ok") is False:
+                future.set_exception(RuntimeError(str(frame.get("error") or "restore inventory failed")))
+                return
+            future.set_result(frame)
+            return
+
         if frame_type in {"runtime_ready", "pong"}:
             return
 
@@ -268,6 +291,10 @@ class NodeAgentConnection:
             if not future.done():
                 future.set_exception(RuntimeError(f"Node-agent {self.node_id} disconnected"))
         self._pending_control.clear()
+        for future in list(self._pending_restore_inventory.values()):
+            if not future.done():
+                future.set_exception(RuntimeError(f"Node-agent {self.node_id} disconnected"))
+        self._pending_restore_inventory.clear()
         for future in list(self._pending_register.values()):
             if not future.done():
                 future.set_exception(RuntimeError(f"Node-agent {self.node_id} disconnected"))
@@ -352,3 +379,9 @@ class NodeAgentRegistry:
             frame=frame,
             timeout=timeout,
         )
+
+    async def restore_inventory(self, *, node_id: str, timeout: float = 5.0) -> dict[str, Any]:
+        connection = self.get(node_id)
+        if connection is None:
+            raise RuntimeError(f"Node-agent for {node_id} is not connected")
+        return await connection.restore_inventory(timeout=timeout)

--- a/src/node_agent.py
+++ b/src/node_agent.py
@@ -21,6 +21,9 @@ from urllib.parse import urlparse, urlunparse
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_NODE_STATE_FILE = "~/.local/share/claude-sessions/sessions.json"
+LEGACY_NODE_STATE_FILE = "/tmp/claude-sessions/sessions.json"
+
 
 @dataclass
 class ProviderCursor:
@@ -214,6 +217,7 @@ class CodexForkNodeAgent:
         secret: Optional[str],
         poll_interval: float = 0.2,
         log_dir: Optional[str] = None,
+        state_file: Optional[str] = None,
         control_timeout: float = 5.0,
     ):
         self.node_id = node_id
@@ -222,6 +226,11 @@ class CodexForkNodeAgent:
         self.poll_interval = poll_interval
         self.control_timeout = max(0.5, float(control_timeout))
         self.log_dir = Path(log_dir or "~/.local/share/claude-sessions").expanduser().resolve(strict=False)
+        state_file_value = str(state_file).strip() if state_file is not None else ""
+        self.state_file_explicit = bool(state_file_value)
+        self.state_file = Path(state_file_value or DEFAULT_NODE_STATE_FILE).expanduser().resolve(strict=False)
+        self.default_state_file = Path(DEFAULT_NODE_STATE_FILE).expanduser().resolve(strict=False)
+        self.legacy_state_file = Path(LEGACY_NODE_STATE_FILE).resolve(strict=False)
         self.registrations: dict[str, TailRegistration] = {}
 
     async def run_forever(self) -> None:
@@ -273,6 +282,9 @@ class CodexForkNodeAgent:
             return
         if frame_type == "control":
             await self._control(websocket, frame)
+            return
+        if frame_type == "restore_inventory":
+            await self._restore_inventory(websocket, frame)
             return
 
     async def _register(self, websocket: Any, frame: dict[str, Any]) -> None:
@@ -426,6 +438,70 @@ class CodexForkNodeAgent:
             )
         )
 
+    async def _restore_inventory(self, websocket: Any, frame: dict[str, Any]) -> None:
+        request_id = str(frame.get("request_id") or "").strip()
+        if not request_id:
+            return
+        try:
+            state_file = self._restore_inventory_state_file()
+            sessions = self._load_restore_inventory(state_file)
+            payload = {
+                "type": "restore_inventory_result",
+                "request_id": request_id,
+                "ok": True,
+                "node_id": self.node_id,
+                "state_file": str(state_file),
+                "sessions": sessions,
+            }
+        except Exception as exc:
+            payload = {
+                "type": "restore_inventory_result",
+                "request_id": request_id,
+                "ok": False,
+                "node_id": self.node_id,
+                "error": str(exc),
+            }
+        await websocket.send(json.dumps(payload, separators=(",", ":")))
+
+    def _restore_inventory_state_file(self) -> Path:
+        if self.state_file.exists():
+            return self.state_file
+        if (
+            not self.state_file_explicit
+            and self.state_file == self.default_state_file
+            and self.legacy_state_file.exists()
+        ):
+            return self.legacy_state_file
+        return self.state_file
+
+    def _load_restore_inventory(self, state_file: Optional[Path] = None) -> list[dict[str, Any]]:
+        """Return stopped node-local SM session records from the configured state file."""
+        state_path = state_file or self._restore_inventory_state_file()
+        try:
+            with state_path.open("r", encoding="utf-8") as state_handle:
+                payload = json.load(state_handle)
+        except FileNotFoundError:
+            return []
+        if not isinstance(payload, dict):
+            raise ValueError(f"state file {state_path} does not contain a JSON object")
+
+        sessions: list[dict[str, Any]] = []
+        for item in payload.get("sessions", []):
+            if not isinstance(item, dict):
+                continue
+            session_id = str(item.get("id") or "").strip()
+            if not session_id or item.get("status") != "stopped":
+                continue
+            session = dict(item)
+            session["id"] = session_id
+            session["source_session_id"] = session_id
+            session["node"] = self.node_id
+            session["origin_node"] = self.node_id
+            session["restore_source"] = "node_agent"
+            session["activity_state"] = "stopped"
+            sessions.append(session)
+        return sessions
+
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run a Session Manager codex-fork node-agent")
@@ -440,6 +516,14 @@ def build_parser() -> argparse.ArgumentParser:
         "--log-dir",
         default=os.environ.get("SM_NODE_LOG_DIR") or "~/.local/share/claude-sessions",
         help="Node-local base directory for codex-fork event/control artifacts",
+    )
+    parser.add_argument(
+        "--state-file",
+        default=os.environ.get("SM_NODE_STATE_FILE") or None,
+        help=(
+            "Node-local Session Manager state file used for restore inventory "
+            f"(default: {DEFAULT_NODE_STATE_FILE}; falls back to {LEGACY_NODE_STATE_FILE})"
+        ),
     )
     parser.add_argument("--poll-interval", type=float, default=0.2)
     parser.add_argument(
@@ -461,6 +545,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         secret=args.secret,
         poll_interval=args.poll_interval,
         log_dir=args.log_dir,
+        state_file=args.state_file,
         control_timeout=args.control_timeout,
     )
     try:

--- a/src/server.py
+++ b/src/server.py
@@ -4590,6 +4590,38 @@ def create_app(
             raise HTTPException(status_code=status, detail=result.get("error") or "ping failed")
         return result
 
+    @app.get("/nodes/{node_id}/restore-candidates")
+    async def list_node_restore_candidates(node_id: str, refresh: bool = Query(default=False)):
+        """List stopped Session Manager records from one node's local restore inventory."""
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
+        ok, sessions, error = await app.state.session_manager.list_node_restore_candidates(
+            node_id,
+            force_refresh=refresh,
+        )
+        if not ok:
+            status = 404 if str(error or "").startswith("Unknown node") else 503
+            raise HTTPException(status_code=status, detail=error or "Failed to read node restore inventory")
+        return {"node": node_id, "sessions": sessions}
+
+    @app.post("/nodes/{node_id}/restore-candidates/{session_id}/restore", response_model=SessionResponse)
+    async def restore_node_restore_candidate(node_id: str, session_id: str):
+        """Restore a stopped session from one node's local restore inventory."""
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
+        success, restored_session, error = await app.state.session_manager.restore_node_session(node_id, session_id)
+        if not success or not restored_session:
+            detail = error or "Failed to restore node session"
+            status_code = 409 if detail == "Session is not stopped" else 400
+            if detail.startswith("Unknown node") or detail == "Session not found in node restore inventory":
+                status_code = 404
+            raise HTTPException(status_code=status_code, detail=detail)
+
+        if app.state.output_monitor and getattr(restored_session, "provider", "claude") != "codex-app":
+            await app.state.output_monitor.start_monitoring(restored_session)
+
+        return _session_to_response(restored_session)
+
     @app.websocket("/nodes/agent")
     async def node_agent_websocket(websocket: WebSocket):
         """Authenticated node-initiated codex-fork IPC bridge."""

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -173,6 +173,10 @@ class SessionManager:
         self.node_registry = NodeRegistry.from_config(self.config)
         self.node_runner = NodeRunner(self.node_registry)
         self.codex_fork_node_agents = NodeAgentRegistry()
+        self.node_restore_inventory_cache_seconds = float(
+            self.config.get("nodes", {}).get("restore_inventory_cache_seconds", 10.0)
+        )
+        self._node_restore_inventory_cache: dict[str, tuple[float, list[dict[str, Any]]]] = {}
         self._tmux_session_node_cache: dict[str, str] = {}
         self._node_unreachable_sessions: set[str] = set()
         self.last_create_error: Optional[str] = None
@@ -505,6 +509,152 @@ class SessionManager:
         except Exception as exc:
             return {"node": node_id, "ok": False, "error": str(exc)}
         return {"node": node_id, "ok": ok, "error": None if ok else "ping failed"}
+
+    async def list_node_restore_candidates(
+        self,
+        node: str,
+        *,
+        force_refresh: bool = False,
+    ) -> tuple[bool, list[dict[str, Any]], Optional[str]]:
+        """Return stopped restore candidates from one node's local SM state."""
+        node_id = normalize_node_id(node)
+        if not self.node_registry.has(node_id):
+            return False, [], f"Unknown node: {node_id}"
+
+        if node_id == PRIMARY_NODE:
+            return True, [
+                self._node_restore_candidate_from_session(session, node_id)
+                for session in self.list_sessions(include_stopped=True)
+                if session.status == SessionStatus.STOPPED
+                and normalize_node_id(getattr(session, "node", PRIMARY_NODE)) == PRIMARY_NODE
+            ], None
+
+        now = time.monotonic()
+        cached = self._node_restore_inventory_cache.get(node_id)
+        if (
+            not force_refresh
+            and cached is not None
+            and now - cached[0] < max(0.0, self.node_restore_inventory_cache_seconds)
+        ):
+            candidates = [
+                candidate
+                for item in cached[1]
+                if (candidate := self._normalize_node_restore_candidate(node_id, item)) is not None
+            ]
+            return True, candidates, None
+
+        if not self.is_codex_fork_node_agent_healthy(node_id):
+            return False, [], f"node-agent not connected for node {node_id}"
+
+        try:
+            payload = await self.codex_fork_node_agents.restore_inventory(
+                node_id=node_id,
+                timeout=max(0.5, self.codex_fork_control_timeout_seconds),
+            )
+        except Exception as exc:
+            return False, [], str(exc)
+
+        raw_sessions = payload.get("sessions")
+        if not isinstance(raw_sessions, list):
+            return False, [], "node restore inventory response did not include sessions"
+
+        candidates = [
+            candidate
+            for item in raw_sessions
+            if (candidate := self._normalize_node_restore_candidate(node_id, item)) is not None
+        ]
+        self._node_restore_inventory_cache[node_id] = (now, candidates)
+        return True, list(candidates), None
+
+    def _node_restore_candidate_from_session(self, session: Session, node_id: str) -> dict[str, Any]:
+        candidate = session.to_dict()
+        candidate["node"] = node_id
+        candidate["origin_node"] = node_id
+        candidate["source_session_id"] = session.id
+        candidate["restore_source"] = "server_state" if node_id == PRIMARY_NODE else "node_agent"
+        candidate["activity_state"] = ActivityState.STOPPED.value
+        return candidate
+
+    def _normalize_node_restore_candidate(self, node_id: str, item: Any) -> Optional[dict[str, Any]]:
+        if not isinstance(item, dict):
+            return None
+        session_id = str(item.get("source_session_id") or item.get("id") or "").strip()
+        if not session_id or item.get("status") != SessionStatus.STOPPED.value:
+            return None
+
+        current = self.sessions.get(session_id)
+        if current is not None and normalize_node_id(current.node) == node_id:
+            if current.status != SessionStatus.STOPPED:
+                return None
+            return self._node_restore_candidate_from_session(current, node_id)
+        if current is not None and normalize_node_id(current.node) != node_id:
+            return None
+
+        candidate = dict(item)
+        candidate["id"] = session_id
+        candidate["source_session_id"] = session_id
+        candidate["node"] = node_id
+        candidate["origin_node"] = node_id
+        candidate["restore_source"] = "node_agent"
+        candidate["activity_state"] = ActivityState.STOPPED.value
+        return candidate
+
+    async def import_node_restore_candidate(
+        self,
+        node: str,
+        session_id: str,
+        *,
+        force_refresh: bool = False,
+    ) -> tuple[bool, Optional[Session], Optional[str]]:
+        """Import a node-local stopped session record into primary state."""
+        node_id = normalize_node_id(node)
+        raw_session_id = str(session_id or "").strip()
+        if not raw_session_id:
+            return False, None, "Session id is required"
+        if node_id == PRIMARY_NODE:
+            session = self.sessions.get(raw_session_id)
+            if session is None:
+                return False, None, "Session not found"
+            return True, session, None
+
+        existing = self.sessions.get(raw_session_id)
+        if existing is not None:
+            if normalize_node_id(existing.node) != node_id:
+                return False, existing, f"Session id {raw_session_id} already exists on node {existing.node}"
+            if not force_refresh:
+                return True, existing, None
+
+        ok, candidates, error = await self.list_node_restore_candidates(node_id, force_refresh=force_refresh)
+        if not force_refresh and ok and not any(candidate.get("id") == raw_session_id for candidate in candidates):
+            ok, candidates, error = await self.list_node_restore_candidates(node_id, force_refresh=True)
+        if not ok:
+            return False, None, error
+
+        candidate = next((item for item in candidates if item.get("id") == raw_session_id), None)
+        if candidate is None:
+            return False, None, "Session not found in node restore inventory"
+
+        try:
+            session = Session.from_dict(candidate)
+        except Exception as exc:
+            return False, None, f"Invalid node restore candidate: {exc}"
+        session.node = node_id
+        session.status = SessionStatus.STOPPED
+        self.sessions[session.id] = session
+        self._cache_session_node(session)
+        self._save_state()
+        return True, session, None
+
+    async def restore_node_session(self, node: str, session_id: str) -> tuple[bool, Optional[Session], Optional[str]]:
+        """Import a node-local restore candidate if needed, then restore it."""
+        node_id = normalize_node_id(node)
+        ok, session, error = await self.import_node_restore_candidate(node_id, session_id, force_refresh=True)
+        if not ok or session is None:
+            return False, session, error
+        try:
+            return await self.restore_session(session.id)
+        finally:
+            self._node_restore_inventory_cache.pop(node_id, None)
 
     def node_agent_secret_for_node(self, node: str) -> Optional[str]:
         """Return the configured node-agent auth secret for one node."""

--- a/tests/unit/test_cli_parsing.py
+++ b/tests/unit/test_cli_parsing.py
@@ -151,6 +151,7 @@ class TestCliParsing:
         # sm restore
         restore_parser = subparsers.add_parser("restore")
         restore_parser.add_argument("session")
+        restore_parser.add_argument("--node")
 
         # sm fork
         fork_parser = subparsers.add_parser("fork")
@@ -883,6 +884,14 @@ class TestRestoreCommand:
         assert args.command == "restore"
         assert args.session == "engineer-ticket2508"
 
+    def test_restore_command_parses_node(self):
+        parser = TestCliParsing()
+        args = parser._get_parsed_args(["restore", "engineer-ticket2508", "--node", "macbook"])
+
+        assert args.command == "restore"
+        assert args.session == "engineer-ticket2508"
+        assert args.node == "macbook"
+
     def test_main_restore_allowed_without_managed_session(self):
         mock_client = MagicMock()
 
@@ -894,7 +903,7 @@ class TestRestoreCommand:
                             main()
 
         assert exc_info.value.code == 0
-        mock_cmd_restore.assert_called_once_with(mock_client, "dead123")
+        mock_cmd_restore.assert_called_once_with(mock_client, "dead123", node=None)
 
 
 class TestForkCommand:

--- a/tests/unit/test_client_codex_endpoints.py
+++ b/tests/unit/test_client_codex_endpoints.py
@@ -230,6 +230,26 @@ def test_list_sessions_passes_explicit_timeout():
     req.assert_called_once_with("GET", "/sessions?include_stopped=true", timeout=7)
 
 
+def test_list_node_restore_sessions_result_preserves_api_error_detail():
+    client = _make_client()
+    payload = {"detail": "Unknown node: typo"}
+    with patch.object(client, "_request_with_status", return_value=(payload, 404, False)) as req:
+        result = client.list_node_restore_sessions_result("typo", timeout=7)
+    assert result["ok"] is False
+    assert result["unavailable"] is False
+    assert result["status_code"] == 404
+    assert result["detail"] == "Unknown node: typo"
+    req.assert_called_once_with("GET", "/nodes/typo/restore-candidates", timeout=7)
+
+
+def test_list_node_restore_sessions_wraps_successful_result():
+    client = _make_client()
+    payload = {"sessions": [{"id": "abc123", "status": "stopped"}]}
+    with patch.object(client, "_request_with_status", return_value=(payload, 200, False)):
+        result = client.list_node_restore_sessions("macbook")
+    assert result == payload["sessions"]
+
+
 def test_restore_session_uses_explicit_empty_json_body():
     client = _make_client()
     payload = {"id": "abc123", "status": "running"}
@@ -245,16 +265,16 @@ def test_restore_session_uses_explicit_empty_json_body():
     )
 
 
-def test_restore_session_with_node_uses_existing_restore_endpoint():
+def test_restore_session_can_target_node_restore_candidate():
     client = _make_client()
-    payload = {"id": "abc123", "status": "running"}
+    payload = {"id": "abc123", "status": "running", "node": "macbook"}
     with patch.object(client, "_request_with_status", return_value=(payload, 200, False)) as req:
         result = client.restore_session_result("abc123", node="macbook")
     assert result["ok"] is True
     assert result["data"] == payload
     req.assert_called_once_with(
         "POST",
-        "/sessions/abc123/restore",
+        "/nodes/macbook/restore-candidates/abc123/restore",
         {},
         timeout=10,
     )

--- a/tests/unit/test_cmd_restore.py
+++ b/tests/unit/test_cmd_restore.py
@@ -14,13 +14,31 @@ class _RestoreClient:
 
     def list_sessions(self, include_stopped: bool = False):
         assert include_stopped is True
-        return self._sessions
+        return [session for session in self._sessions if not session.get("node_inventory_only")]
 
-    def restore_session_result(self, session_id: str):
+    def list_node_restore_sessions(self, node: str, timeout=None):
+        return [
+            {**session, "node": node, "origin_node": node, "source_session_id": session["id"]}
+            for session in self._sessions
+            if session.get("node") == node
+        ]
+
+    def list_node_restore_sessions_result(self, node: str, timeout=None):
+        return {
+            "ok": True,
+            "unavailable": False,
+            "sessions": self.list_node_restore_sessions(node, timeout=timeout),
+            "detail": None,
+        }
+
+    def restore_session_result(self, session_id: str, node: str | None = None):
         restored = self._restored_by_id.get(session_id)
         if restored is None:
             return {"ok": False, "unavailable": False, "detail": "not found"}
-        return {"ok": True, "unavailable": False, "data": restored}
+        data = dict(restored)
+        if node:
+            data["node"] = node
+        return {"ok": True, "unavailable": False, "data": data}
 
     def get_attach_descriptor(self, session_id: str):
         restored = self._restored_by_id.get(session_id)
@@ -142,3 +160,69 @@ def test_cmd_restore_rejects_ambiguous_stopped_name_matches(capsys):
     assert rc == 1
     stderr = capsys.readouterr().err
     assert "Multiple stopped sessions match 'onboarder': dead123, dead456. Use a session ID." in stderr
+
+
+def test_cmd_restore_uses_explicit_node_inventory(monkeypatch, capsys):
+    monkeypatch.setattr(commands.sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(commands.sys.stdout, "isatty", lambda: False)
+
+    session = {
+        "id": "macdead1",
+        "friendly_name": "old-local",
+        "status": "stopped",
+        "node": "macbook",
+        "node_inventory_only": True,
+    }
+    restored = {
+        "macdead1": {"id": "macdead1", "provider": "codex-fork", "tmux_session": "codex-fork-macdead1"},
+    }
+    client = _RestoreClient([session], restored)
+
+    rc = commands.cmd_restore(client, "old-local", node="macbook")
+
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    assert "Session restored: macdead1 on node macbook" in stdout
+
+
+def test_cmd_restore_falls_back_to_client_default_node(monkeypatch, capsys):
+    monkeypatch.setattr(commands.sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(commands.sys.stdout, "isatty", lambda: False)
+
+    session = {
+        "id": "macdead2",
+        "friendly_name": "old-default",
+        "status": "stopped",
+        "node": "macbook",
+        "node_inventory_only": True,
+    }
+    restored = {
+        "macdead2": {"id": "macdead2", "provider": "claude", "tmux_session": "claude-macdead2"},
+    }
+    client = _RestoreClient([session], restored)
+    client.default_node = "macbook"
+
+    rc = commands.cmd_restore(client, "old-default")
+
+    assert rc == 0
+    stdout = capsys.readouterr().out
+    assert "Session restored: macdead2 on node macbook" in stdout
+
+
+def test_cmd_restore_reports_node_inventory_api_error(monkeypatch, capsys):
+    monkeypatch.setattr(commands.sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr(commands.sys.stdout, "isatty", lambda: False)
+
+    client = _RestoreClient([], {})
+    client.list_node_restore_sessions_result = lambda node, timeout=None: {
+        "ok": False,
+        "unavailable": False,
+        "sessions": [],
+        "detail": f"Unknown node: {node}",
+    }
+
+    rc = commands.cmd_restore(client, "old-local", node="typo")
+
+    assert rc == 1
+    stderr = capsys.readouterr().err
+    assert "Error: Unknown node: typo" in stderr

--- a/tests/unit/test_cmd_watch.py
+++ b/tests/unit/test_cmd_watch.py
@@ -31,6 +31,7 @@ def test_cmd_watch_delegates_to_watch_tui():
         restore_mode=False,
         top_level=False,
         restore_sort="retired",
+        restore_node=None,
     )
 
 
@@ -65,6 +66,7 @@ def test_cmd_watch_delegates_restore_mode_to_watch_tui():
                 restore_mode=True,
                 top_level=True,
                 restore_sort="last-active",
+                restore_node="macbook",
             )
 
     assert rc == 0
@@ -76,4 +78,5 @@ def test_cmd_watch_delegates_restore_mode_to_watch_tui():
         restore_mode=True,
         top_level=True,
         restore_sort="last-active",
+        restore_node="macbook",
     )

--- a/tests/unit/test_remote_codex_fork_transport.py
+++ b/tests/unit/test_remote_codex_fork_transport.py
@@ -5,7 +5,7 @@ import subprocess
 import tempfile
 import time
 from pathlib import Path
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -200,6 +200,294 @@ async def test_node_agent_connection_forwards_control_timeout():
     )
 
     assert await control_task == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_node_agent_connection_requests_restore_inventory():
+    class FakeWebSocket:
+        def __init__(self):
+            self.sent: list[dict] = []
+
+        async def send_json(self, frame: dict):
+            self.sent.append(frame)
+
+    websocket = FakeWebSocket()
+    connection = NodeAgentConnection("worker", websocket)
+
+    inventory_task = asyncio.create_task(connection.restore_inventory(timeout=1.0))
+    await asyncio.sleep(0)
+
+    request = websocket.sent[0]
+    assert request["type"] == "restore_inventory"
+    await connection.handle_frame(
+        {
+            "type": "restore_inventory_result",
+            "request_id": request["request_id"],
+            "ok": True,
+            "node_id": "worker",
+            "sessions": [{"id": "old12345", "status": "stopped"}],
+        }
+    )
+
+    result = await inventory_task
+    assert result["sessions"] == [{"id": "old12345", "status": "stopped"}]
+
+
+@pytest.mark.asyncio
+async def test_node_agent_restore_inventory_reads_stopped_state_records(tmp_path):
+    state_file = tmp_path / "sessions.json"
+    stopped = Session(
+        id="old12345",
+        name="codex-fork-old12345",
+        working_dir=str(tmp_path),
+        tmux_session="codex-fork-old12345",
+        log_file=str(tmp_path / "old12345.log"),
+        provider="codex-fork",
+        status=SessionStatus.STOPPED,
+        provider_resume_id="resume-old12345",
+    )
+    running = Session(
+        id="live1234",
+        name="codex-fork-live1234",
+        working_dir=str(tmp_path),
+        tmux_session="codex-fork-live1234",
+        log_file=str(tmp_path / "live1234.log"),
+        provider="codex-fork",
+        status=SessionStatus.RUNNING,
+    )
+    state_file.write_text(
+        json.dumps(
+            {
+                "sessions": [stopped.to_dict(), running.to_dict()],
+                "agent_registrations": [],
+                "adoption_proposals": [],
+            }
+        )
+    )
+
+    class FakeWebSocket:
+        def __init__(self):
+            self.sent: list[str] = []
+
+        async def send(self, frame: str):
+            self.sent.append(frame)
+
+    websocket = FakeWebSocket()
+    agent = CodexForkNodeAgent(
+        node_id="worker",
+        primary_url="http://primary:8420",
+        secret="node-secret",
+        state_file=str(state_file),
+    )
+
+    await agent._restore_inventory(websocket, {"type": "restore_inventory", "request_id": "req1"})
+
+    payload = json.loads(websocket.sent[0])
+    assert payload["type"] == "restore_inventory_result"
+    assert payload["ok"] is True
+    assert [session["id"] for session in payload["sessions"]] == ["old12345"]
+    candidate = payload["sessions"][0]
+    assert candidate["node"] == "worker"
+    assert candidate["origin_node"] == "worker"
+    assert candidate["source_session_id"] == "old12345"
+    assert candidate["provider_resume_id"] == "resume-old12345"
+
+
+@pytest.mark.asyncio
+async def test_node_agent_restore_inventory_falls_back_to_legacy_state_file(tmp_path):
+    default_state_file = tmp_path / "new" / "sessions.json"
+    legacy_state_file = tmp_path / "legacy" / "sessions.json"
+    legacy_state_file.parent.mkdir(parents=True)
+    stopped = Session(
+        id="legacy123",
+        name="claude-legacy123",
+        working_dir=str(tmp_path),
+        tmux_session="claude-legacy123",
+        log_file=str(tmp_path / "legacy123.log"),
+        provider="claude",
+        status=SessionStatus.STOPPED,
+        provider_resume_id="resume-legacy123",
+    )
+    legacy_state_file.write_text(
+        json.dumps(
+            {
+                "sessions": [stopped.to_dict()],
+                "agent_registrations": [],
+                "adoption_proposals": [],
+            }
+        )
+    )
+
+    class FakeWebSocket:
+        def __init__(self):
+            self.sent: list[str] = []
+
+        async def send(self, frame: str):
+            self.sent.append(frame)
+
+    with (
+        patch("src.node_agent.DEFAULT_NODE_STATE_FILE", str(default_state_file)),
+        patch("src.node_agent.LEGACY_NODE_STATE_FILE", str(legacy_state_file)),
+    ):
+        agent = CodexForkNodeAgent(
+            node_id="worker",
+            primary_url="http://primary:8420",
+            secret="node-secret",
+        )
+
+    websocket = FakeWebSocket()
+    await agent._restore_inventory(websocket, {"type": "restore_inventory", "request_id": "req1"})
+
+    payload = json.loads(websocket.sent[0])
+    assert payload["ok"] is True
+    assert payload["state_file"] == str(legacy_state_file)
+    assert [session["id"] for session in payload["sessions"]] == ["legacy123"]
+    assert payload["sessions"][0]["provider_resume_id"] == "resume-legacy123"
+
+
+@pytest.mark.asyncio
+async def test_session_manager_imports_node_restore_candidate(tmp_path):
+    manager = _manager(tmp_path)
+    stopped = Session(
+        id="importme",
+        name="codex-fork-importme",
+        working_dir=str(tmp_path),
+        tmux_session="codex-fork-importme",
+        log_file=str(tmp_path / "importme.log"),
+        provider="codex-fork",
+        node="worker",
+        status=SessionStatus.STOPPED,
+        provider_resume_id="resume-importme",
+    )
+
+    class InventoryConnection:
+        def is_healthy(self):
+            return True
+
+        async def restore_inventory(self, timeout: float = 5.0):
+            return {
+                "ok": True,
+                "node_id": "worker",
+                "sessions": [stopped.to_dict()],
+            }
+
+    manager.codex_fork_node_agents._connections["worker"] = InventoryConnection()
+
+    ok, candidates, error = await manager.list_node_restore_candidates("worker")
+    assert ok is True
+    assert error is None
+    assert [candidate["id"] for candidate in candidates] == ["importme"]
+
+    ok, imported, error = await manager.import_node_restore_candidate("worker", "importme")
+    assert ok is True
+    assert error is None
+    assert imported is not None
+    assert imported.id == "importme"
+    assert imported.node == "worker"
+    assert imported.provider_resume_id == "resume-importme"
+    assert manager.get_session("importme") is imported
+
+
+@pytest.mark.asyncio
+async def test_session_manager_force_refreshes_node_restore_candidate_import(tmp_path):
+    manager = _manager(tmp_path)
+    stopped = Session(
+        id="staleone",
+        name="codex-fork-staleone",
+        working_dir=str(tmp_path),
+        tmux_session="codex-fork-staleone",
+        log_file=str(tmp_path / "staleone.log"),
+        provider="codex-fork",
+        node="worker",
+        status=SessionStatus.STOPPED,
+    )
+
+    class InventoryConnection:
+        def __init__(self):
+            self.sessions = [stopped.to_dict()]
+            self.calls = 0
+
+        def is_healthy(self):
+            return True
+
+        async def restore_inventory(self, timeout: float = 5.0):
+            self.calls += 1
+            return {
+                "ok": True,
+                "node_id": "worker",
+                "sessions": list(self.sessions),
+            }
+
+    connection = InventoryConnection()
+    manager.codex_fork_node_agents._connections["worker"] = connection
+
+    ok, candidates, error = await manager.list_node_restore_candidates("worker")
+    assert ok is True
+    assert error is None
+    assert [candidate["id"] for candidate in candidates] == ["staleone"]
+    assert connection.calls == 1
+
+    connection.sessions = []
+    ok, imported, error = await manager.import_node_restore_candidate(
+        "worker",
+        "staleone",
+        force_refresh=True,
+    )
+
+    assert ok is False
+    assert imported is None
+    assert error == "Session not found in node restore inventory"
+    assert connection.calls == 2
+    assert manager.get_session("staleone") is None
+
+
+@pytest.mark.asyncio
+async def test_session_manager_revalidates_cached_node_restore_inventory(tmp_path):
+    manager = _manager(tmp_path)
+    stopped = Session(
+        id="cachedlive",
+        name="codex-fork-cachedlive",
+        working_dir=str(tmp_path),
+        tmux_session="codex-fork-cachedlive",
+        log_file=str(tmp_path / "cachedlive.log"),
+        provider="codex-fork",
+        node="worker",
+        status=SessionStatus.STOPPED,
+    )
+
+    class InventoryConnection:
+        def __init__(self):
+            self.calls = 0
+
+        def is_healthy(self):
+            return True
+
+        async def restore_inventory(self, timeout: float = 5.0):
+            self.calls += 1
+            return {
+                "ok": True,
+                "node_id": "worker",
+                "sessions": [stopped.to_dict()],
+            }
+
+    connection = InventoryConnection()
+    manager.codex_fork_node_agents._connections["worker"] = connection
+
+    ok, candidates, error = await manager.list_node_restore_candidates("worker")
+    assert ok is True
+    assert error is None
+    assert [candidate["id"] for candidate in candidates] == ["cachedlive"]
+    assert connection.calls == 1
+
+    running = Session.from_dict(stopped.to_dict())
+    running.status = SessionStatus.RUNNING
+    manager.sessions[running.id] = running
+    ok, candidates, error = await manager.list_node_restore_candidates("worker")
+
+    assert ok is True
+    assert error is None
+    assert candidates == []
+    assert connection.calls == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add node-agent restore inventory support so Studio can read stopped sessions from a node-local Session Manager state file
- expose Studio endpoints for listing node restore candidates and importing/restoring a node-local stopped session
- wire `sm restore --node`, default-node restore fallback, and `sm watch --restore --node` to the richer node inventory
- preserve legacy `/tmp/claude-sessions/sessions.json` inventory fallback when a node has not migrated to the durable state path yet
- force-refresh node inventory before restore mutations so cached browse results cannot import stale candidates
- preserve node inventory API error details so invalid `--node` values report actionable errors
- revalidate cached restore inventory against current server session state and clear the cache after node restore mutations

## Impact
Clients pointed at Studio can browse and restore the local machine's richer stopped-session history through the node-agent instead of being limited to Studio's own server-side stopped-session list.

## Tests
- `/Users/rajesh/Desktop/automation/session-manager/venv/bin/python -m pytest tests/unit/test_remote_codex_fork_transport.py tests/unit/test_client_codex_endpoints.py tests/unit/test_cmd_restore.py tests/unit/test_cmd_watch.py tests/unit/test_cli_parsing.py` (158 passed, 1 warning)
- `/Users/rajesh/Desktop/automation/session-manager/venv/bin/python -m py_compile src/node_agent.py src/codex_fork_remote.py src/session_manager.py src/server.py src/cli/client.py src/cli/commands.py src/cli/main.py src/cli/watch_tui.py