### PR TITLE
Emit tmux client events for desktop clients

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -9,7 +9,7 @@ import signal
 import sys
 import threading
 import time
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from pathlib import Path
 from typing import Optional
 
@@ -327,14 +327,14 @@ class SessionManagerApp:
         if self.telegram_bot:
             self.telegram_bot.set_telemetry_logger(self.tool_logger)
 
-        # Create ASGI lifespan — runs post-bind work only after uvicorn
-        # successfully binds the port.  Doomed instances (port already in use)
-        # exit before the lifespan fires, so no Telegram API calls leak.
+        # Create ASGI lifespan. Uvicorn runs lifespan startup before binding the
+        # listening socket, so work here must not mutate global runtime state
+        # that only the bound server should own.
         sm_app = self
 
         @asynccontextmanager
         async def _lifespan(app):
-            await sm_app._post_bind_startup()
+            await sm_app._lifespan_startup()
             yield
 
         # Create FastAPI app
@@ -730,15 +730,13 @@ class SessionManagerApp:
             self._run_telegram_topic_cleanup_loop()
         )
 
-    async def _post_bind_startup(self):
-        """Run side-effect-bearing startup work after uvicorn binds the port.
+    async def _lifespan_startup(self):
+        """Run ASGI lifespan startup work before the app begins serving.
 
-        Called from the ASGI lifespan hook so that doomed instances
-        (port already in use) never reach this code.
+        Uvicorn invokes lifespan startup before binding the real listener, so
+        tmux hook installation and other bound-server ownership work must run
+        elsewhere after ``server.started`` flips true.
         """
-        if self.session_manager.sessions:
-            self.session_manager.tmux.ensure_client_event_hooks()
-
         # Reconcile Telegram topics
         if self.telegram_bot:
             await self._reconcile_telegram_topics()
@@ -746,6 +744,14 @@ class SessionManagerApp:
 
         # Restore monitoring for existing sessions
         await self._restore_monitoring()
+
+    async def _install_tmux_client_hooks_after_bind(self, server: uvicorn.Server) -> None:
+        """Install global tmux client hooks only after uvicorn owns the listener."""
+        while not server.started and not server.should_exit:
+            await asyncio.sleep(0.05)
+
+        if server.started and self.session_manager.sessions:
+            self.session_manager.tmux.ensure_client_event_hooks()
 
     async def _restore_monitoring(self):
         """Restore output monitoring for sessions that were running before restart."""
@@ -940,7 +946,7 @@ class SessionManagerApp:
             logger.info("Telegram bot started")
 
         # NOTE: _reconcile_telegram_topics() and monitoring restoration run
-        # via the ASGI lifespan hook (_post_bind_startup).  The pre-flight
+        # via the ASGI lifespan hook (_lifespan_startup).  The pre-flight
         # socket probe above is the primary guard — it exits doomed instances
         # before any side effects fire.
 
@@ -956,7 +962,15 @@ class SessionManagerApp:
         logger.info(f"Starting server on http://{self.host}:{self.port}")
 
         # Run until shutdown
-        await server.serve()
+        tmux_hook_task = asyncio.create_task(
+            self._install_tmux_client_hooks_after_bind(server)
+        )
+        try:
+            await server.serve()
+        finally:
+            tmux_hook_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await tmux_hook_task
 
     async def stop(self):
         """Stop all components."""

--- a/src/main.py
+++ b/src/main.py
@@ -736,6 +736,9 @@ class SessionManagerApp:
         Called from the ASGI lifespan hook so that doomed instances
         (port already in use) never reach this code.
         """
+        if self.session_manager.sessions:
+            self.session_manager.tmux.ensure_client_event_hooks()
+
         # Reconcile Telegram topics
         if self.telegram_bot:
             await self._reconcile_telegram_topics()

--- a/src/server.py
+++ b/src/server.py
@@ -36,7 +36,7 @@ from cryptography.hazmat.primitives.asymmetric import ec, ed25519, padding, rsa
 from google.auth.transport.requests import Request as GoogleAuthRequest
 from google.oauth2 import id_token as google_id_token
 from fastapi import FastAPI, HTTPException, Body, Request, Query, Response, WebSocket, WebSocketDisconnect
-from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, FileResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, FileResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 from starlette.requests import ClientDisconnect
@@ -1421,6 +1421,20 @@ def create_app(
     app.state.mobile_terminal_secret = secrets.token_bytes(32)
     app.state.mobile_terminal_runtime_disabled = False
     app.state.mobile_terminal_revoked_keys: set[tuple[str, str]] = set()
+    app.state.event_stream_subscribers: set[asyncio.Queue[dict[str, Any]]] = set()
+
+    async def _broadcast_event_stream_event(event: dict[str, Any]) -> None:
+        subscribers = list(app.state.event_stream_subscribers)
+        for queue in subscribers:
+            try:
+                queue.put_nowait(event)
+            except asyncio.QueueFull:
+                with contextlib.suppress(KeyError):
+                    app.state.event_stream_subscribers.remove(queue)
+
+    def _event_stream_payload(event_type: str, data: dict[str, Any]) -> str:
+        rendered_data = json.dumps(data, separators=(",", ":"))
+        return f"event: {event_type}\ndata: {rendered_data}\n\n"
 
     # Wire _app back-reference so _execute_handoff can clear server-side caches (#196)
     if session_manager:
@@ -3621,6 +3635,93 @@ def create_app(
         if _google_auth_requested(app.state.config) and not _is_local_bypass_request(request, app.state.config):
             return RedirectResponse(url="/watch/", status_code=302)
         return {"status": "ok", "service": "session-manager"}
+
+    @app.get("/events/state")
+    async def event_state():
+        """Return lightweight event versions for desktop clients."""
+        sm = app.state.session_manager
+        state_getter = getattr(sm, "tmux_client_event_state", None) if sm else None
+        tmux_state = state_getter() if callable(state_getter) else {"version": 0, "last_event": None}
+        if not isinstance(tmux_state, dict):
+            tmux_state = {"version": 0, "last_event": None}
+        return {
+            "tmux_client_event_version": int(tmux_state.get("version") or 0),
+            "last_tmux_client_event": tmux_state.get("last_event"),
+        }
+
+    @app.get("/events")
+    async def event_stream(request: Request):
+        """Server-sent event stream for low-latency desktop UI invalidations."""
+        queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=32)
+        app.state.event_stream_subscribers.add(queue)
+
+        async def stream():
+            try:
+                yield _event_stream_payload("hello", await event_state())
+                while True:
+                    if await request.is_disconnected():
+                        break
+                    try:
+                        event = await asyncio.wait_for(queue.get(), timeout=15.0)
+                    except asyncio.TimeoutError:
+                        yield ": keepalive\n\n"
+                        continue
+
+                    event_type = str(event.get("type") or "message")
+                    yield _event_stream_payload(event_type, event)
+            finally:
+                with contextlib.suppress(KeyError):
+                    app.state.event_stream_subscribers.remove(queue)
+
+        return StreamingResponse(
+            stream(),
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
+
+    @app.post("/hooks/tmux-client")
+    async def tmux_client_hook(
+        request: Request,
+        event: str = Query(...),
+        session: Optional[str] = Query(default=None),
+        client_session: Optional[str] = Query(default=None),
+        tty: Optional[str] = Query(default=None),
+        client_pid: Optional[str] = Query(default=None),
+    ):
+        """Receive best-effort local tmux client attach/detach hook notifications."""
+        if not _is_local_bypass_request(request, app.state.config):
+            raise HTTPException(status_code=403, detail="tmux client hooks must originate locally")
+
+        event_name = str(event or "").strip()
+        if event_name not in {"client-attached", "client-detached", "client-session-changed"}:
+            raise HTTPException(status_code=400, detail="unsupported tmux client event")
+
+        sm = app.state.session_manager
+        recorder = getattr(sm, "record_tmux_client_event", None) if sm else None
+        payload = None
+        if callable(recorder):
+            payload = recorder(
+                event=event_name,
+                tmux_session=session or client_session,
+                tty=tty,
+                client_pid=client_pid,
+            )
+        if not isinstance(payload, dict):
+            payload = {
+                "type": "tmux_client_event",
+                "event": event_name,
+                "tmux_session": session or client_session,
+                "tty": tty,
+                "client_pid": client_pid,
+                "version": 0,
+                "received_at": datetime.now(timezone.utc).isoformat(),
+            }
+
+        await _broadcast_event_stream_event(payload)
+        return {
+            "status": "ok",
+            "tmux_client_event_version": int(payload.get("version") or 0),
+        }
 
     @app.get("/auth/session")
     async def auth_session(request: Request):

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -442,8 +442,6 @@ class SessionManager:
 
         # Load existing sessions from state file
         self._load_state()
-        if self.sessions:
-            self.tmux.ensure_client_event_hooks()
         if self.sync_codex_native_titles_from_index(persist=False):
             self._save_state()
 

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -179,6 +179,9 @@ class SessionManager:
         self._node_restore_inventory_cache: dict[str, tuple[float, list[dict[str, Any]]]] = {}
         self._tmux_session_node_cache: dict[str, str] = {}
         self._node_unreachable_sessions: set[str] = set()
+        self._tmux_client_event_lock = threading.Lock()
+        self._tmux_client_event_version = 0
+        self._last_tmux_client_event: Optional[dict[str, Any]] = None
         self.last_create_error: Optional[str] = None
         self.tmux = TmuxController(
             log_dir=log_dir,
@@ -439,8 +442,46 @@ class SessionManager:
 
         # Load existing sessions from state file
         self._load_state()
+        if self.sessions:
+            self.tmux.ensure_client_event_hooks()
         if self.sync_codex_native_titles_from_index(persist=False):
             self._save_state()
+
+    def record_tmux_client_event(
+        self,
+        *,
+        event: str,
+        tmux_session: Optional[str] = None,
+        tty: Optional[str] = None,
+        client_pid: Optional[str] = None,
+    ) -> dict[str, Any]:
+        """Record a tmux client attach/detach event and return the new event state."""
+        normalized_event = str(event or "").strip()
+        normalized_session = str(tmux_session or "").strip()
+        normalized_tty = str(tty or "").strip()
+        normalized_client_pid = str(client_pid or "").strip()
+
+        with self._tmux_client_event_lock:
+            self._tmux_client_event_version += 1
+            payload = {
+                "type": "tmux_client_event",
+                "event": normalized_event,
+                "tmux_session": normalized_session or None,
+                "tty": normalized_tty or None,
+                "client_pid": normalized_client_pid or None,
+                "version": self._tmux_client_event_version,
+                "received_at": datetime.now(timezone.utc).isoformat(),
+            }
+            self._last_tmux_client_event = payload
+            return dict(payload)
+
+    def tmux_client_event_state(self) -> dict[str, Any]:
+        """Return current tmux attach/detach event state for lightweight clients."""
+        with self._tmux_client_event_lock:
+            return {
+                "version": self._tmux_client_event_version,
+                "last_event": dict(self._last_tmux_client_event) if self._last_tmux_client_event else None,
+            }
 
     def _tmux_socket_name(self) -> Optional[str]:
         """Return configured tmux socket name, treating partial mocks as legacy default-server."""

--- a/src/tmux_controller.py
+++ b/src/tmux_controller.py
@@ -211,6 +211,7 @@ class TmuxController:
             check=False,
             node=node,
         )
+        self.ensure_client_event_hooks(node=node)
         if not self.native_scrollback:
             return
         current = self._run_tmux(
@@ -229,6 +230,66 @@ class TmuxController:
             ",*:smcup@:rmcup@",
             node=node,
         )
+
+    def ensure_client_event_hooks(self, *, node: Optional[str] = PRIMARY_NODE) -> None:
+        """Install tmux client event hooks when SM owns a named tmux socket."""
+        if not self.socket_name:
+            return
+        self._ensure_client_event_hooks(node=node)
+
+    def _ensure_client_event_hooks(self, *, node: Optional[str] = PRIMARY_NODE) -> None:
+        """Install cheap tmux client attach/detach hooks for local SM eventing."""
+        if normalize_node_id(node) != PRIMARY_NODE:
+            return
+
+        endpoint = self._tmux_client_hook_endpoint()
+        for event_name in ("client-attached", "client-detached", "client-session-changed"):
+            self._run_tmux(
+                "set-hook",
+                "-g",
+                f"{event_name}[90]",
+                self._tmux_client_event_hook_command(event_name, endpoint),
+                check=False,
+                node=node,
+            )
+
+    def _tmux_client_hook_endpoint(self) -> str:
+        tmux_config = self.config.get("tmux", {}) if isinstance(self.config, dict) else {}
+        configured_url = str(tmux_config.get("client_event_hook_url") or "").strip()
+        if configured_url:
+            return configured_url
+
+        server_config = self.config.get("server", {}) if isinstance(self.config, dict) else {}
+        try:
+            port = int(server_config.get("port", 8420))
+        except (TypeError, ValueError):
+            port = 8420
+        return f"http://127.0.0.1:{port}/hooks/tmux-client"
+
+    @staticmethod
+    def _tmux_client_event_hook_command(event_name: str, endpoint: str) -> str:
+        curl_args = [
+            "curl",
+            "-fsS",
+            "-m",
+            "1",
+            "-X",
+            "POST",
+            "-G",
+            "--data-urlencode",
+            f"event={event_name}",
+            "--data-urlencode",
+            "session=#{hook_session_name}",
+            "--data-urlencode",
+            "client_session=#{client_session}",
+            "--data-urlencode",
+            "tty=#{client_tty}",
+            "--data-urlencode",
+            "client_pid=#{client_pid}",
+            endpoint,
+        ]
+        shell_command = " ".join(shlex.quote(part) for part in curl_args)
+        return "run-shell -b " + shlex.quote(f"{shell_command} >/dev/null 2>&1 || true")
 
     def _ensure_server_anchor(self, *, node: Optional[str] = PRIMARY_NODE) -> None:
         """Start the configured tmux server under a neutral SM-owned session.

--- a/tests/integration/test_api_endpoints.py
+++ b/tests/integration/test_api_endpoints.py
@@ -140,6 +140,55 @@ class TestHealthEndpoints:
         data = response.json()
         assert data["status"] == "healthy"
 
+    def test_event_state_defaults_without_recorder(self, test_client):
+        """GET /events/state returns a stable default payload for desktop clients."""
+        response = test_client.get("/events/state")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["tmux_client_event_version"] == 0
+        assert data["last_tmux_client_event"] is None
+
+    def test_tmux_client_hook_records_event(self, test_client, mock_session_manager):
+        """POST /hooks/tmux-client records a local tmux attach/detach event."""
+        mock_session_manager.record_tmux_client_event.return_value = {
+            "type": "tmux_client_event",
+            "event": "client-attached",
+            "tmux_session": "codex-fork-abc12345",
+            "tty": "/dev/ttys001",
+            "client_pid": "123",
+            "version": 7,
+            "received_at": "2026-06-05T00:00:00+00:00",
+        }
+
+        response = test_client.post(
+            "/hooks/tmux-client",
+            params={
+                "event": "client-attached",
+                "session": "codex-fork-abc12345",
+                "tty": "/dev/ttys001",
+                "client_pid": "123",
+            },
+        )
+
+        assert response.status_code == 200
+        assert response.json()["tmux_client_event_version"] == 7
+        mock_session_manager.record_tmux_client_event.assert_called_once_with(
+            event="client-attached",
+            tmux_session="codex-fork-abc12345",
+            tty="/dev/ttys001",
+            client_pid="123",
+        )
+
+    def test_tmux_client_hook_rejects_unknown_event(self, test_client):
+        """POST /hooks/tmux-client accepts only tmux client hook events."""
+        response = test_client.post(
+            "/hooks/tmux-client",
+            params={"event": "pane-exited"},
+        )
+
+        assert response.status_code == 400
+
 
 class TestSessionEndpoints:
     """Tests for session CRUD endpoints."""

--- a/tests/unit/test_main_tmux_hooks.py
+++ b/tests/unit/test_main_tmux_hooks.py
@@ -1,0 +1,42 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from src.main import SessionManagerApp
+
+
+@pytest.mark.asyncio
+async def test_tmux_client_hooks_wait_for_uvicorn_started():
+    app = SessionManagerApp.__new__(SessionManagerApp)
+    ensure_hooks = Mock()
+    app.session_manager = SimpleNamespace(
+        sessions={"session-1": object()},
+        tmux=SimpleNamespace(ensure_client_event_hooks=ensure_hooks),
+    )
+    server = SimpleNamespace(started=False, should_exit=False)
+
+    task = asyncio.create_task(app._install_tmux_client_hooks_after_bind(server))
+    await asyncio.sleep(0)
+
+    ensure_hooks.assert_not_called()
+    server.started = True
+    await asyncio.wait_for(task, timeout=1)
+
+    ensure_hooks.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_tmux_client_hooks_skip_when_server_exits_before_bind():
+    app = SessionManagerApp.__new__(SessionManagerApp)
+    ensure_hooks = Mock()
+    app.session_manager = SimpleNamespace(
+        sessions={"session-1": object()},
+        tmux=SimpleNamespace(ensure_client_event_hooks=ensure_hooks),
+    )
+    server = SimpleNamespace(started=False, should_exit=True)
+
+    await app._install_tmux_client_hooks_after_bind(server)
+
+    ensure_hooks.assert_not_called()

--- a/tests/unit/test_tmux_controller.py
+++ b/tests/unit/test_tmux_controller.py
@@ -74,7 +74,7 @@ def test_create_session_with_command_bootstraps_history_before_provider_window(t
     )
 
     assert ok is True
-    assert calls[:9] == [
+    assert calls[:12] == [
         (
             "new-session",
             "-d",
@@ -88,6 +88,33 @@ def test_create_session_with_command_bootstraps_history_before_provider_window(t
         ),
         ("new-session", "-d", "-s", "claude-test123", "-c", str(tmp_path), "-n", "__sm_bootstrap"),
         ("set-option", "-g", "focus-events", "on"),
+        (
+            "set-hook",
+            "-g",
+            "client-attached[90]",
+            TmuxController._tmux_client_event_hook_command(
+                "client-attached",
+                "http://127.0.0.1:8420/hooks/tmux-client",
+            ),
+        ),
+        (
+            "set-hook",
+            "-g",
+            "client-detached[90]",
+            TmuxController._tmux_client_event_hook_command(
+                "client-detached",
+                "http://127.0.0.1:8420/hooks/tmux-client",
+            ),
+        ),
+        (
+            "set-hook",
+            "-g",
+            "client-session-changed[90]",
+            TmuxController._tmux_client_event_hook_command(
+                "client-session-changed",
+                "http://127.0.0.1:8420/hooks/tmux-client",
+            ),
+        ),
         ("show-options", "-gqv", "terminal-overrides"),
         ("set-option", "-as", "terminal-overrides", ",*:smcup@:rmcup@"),
         ("set-option", "-t", "claude-test123", "history-limit", "12345"),
@@ -170,8 +197,24 @@ def test_create_session_with_command_enables_focus_events_without_native_scrollb
 
     assert ok is True
     assert ("set-option", "-g", "focus-events", "on") in calls
+    assert any(call[:3] == ("set-hook", "-g", "client-attached[90]") for call in calls)
+    assert any(call[:3] == ("set-hook", "-g", "client-detached[90]") for call in calls)
     assert ("show-options", "-gqv", "terminal-overrides") not in calls
     assert ("set-option", "-as", "terminal-overrides", ",*:smcup@:rmcup@") not in calls
+
+
+def test_client_event_hook_command_posts_tmux_formats():
+    command = TmuxController._tmux_client_event_hook_command(
+        "client-attached",
+        "http://127.0.0.1:8420/hooks/tmux-client",
+    )
+
+    assert command.startswith("run-shell -b ")
+    assert "client-attached" in command
+    assert "session=#{hook_session_name}" in command
+    assert "tty=#{client_tty}" in command
+    assert "client_pid=#{client_pid}" in command
+    assert "/hooks/tmux-client" in command
 
 
 def test_create_session_with_command_enables_exit_diagnostics(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary\n- add lightweight SSE endpoints for desktop UI invalidation\n- record and broadcast tmux client attach/detach/session-change events\n- install indexed tmux hooks on the local SM socket, including startup coverage for existing sessions\n\n## Verification\n- /Users/rajesh/projects/session-manager/venv/bin/python -m pytest tests/unit/test_tmux_controller.py tests/integration/test_api_endpoints.py -q