### PR TITLE
Fix codex-fork watch activity projection

### DIFF
--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -6962,54 +6962,58 @@ done
         """Compute activity state for codex-fork sessions from reducer state."""
         if session.status == SessionStatus.STOPPED:
             return ActivityState.STOPPED.value
-        if session.status == SessionStatus.IDLE:
-            return ActivityState.IDLE.value
 
         lifecycle = self.codex_fork_lifecycle.get(session.id)
-        if not lifecycle:
-            return ActivityState.THINKING.value
-
-        state_name = lifecycle.get("state")
-        if state_name == "running":
-            return ActivityState.WORKING.value
-        if state_name == "idle":
-            return ActivityState.IDLE.value
+        state_name = lifecycle.get("state") if lifecycle else None
         if state_name == "waiting_on_approval":
             return ActivityState.WAITING_PERMISSION.value
         if state_name == "waiting_on_user_input":
             return ActivityState.WAITING_INPUT.value
         if state_name in ("shutdown", "error"):
             return ActivityState.STOPPED.value
+        if state_name == "running" and session.status != SessionStatus.IDLE:
+            return ActivityState.WORKING.value
+
+        if self._codex_fork_pane_indicates_working(session):
+            return ActivityState.WORKING.value
+
+        if session.status == SessionStatus.IDLE:
+            return ActivityState.IDLE.value
+
+        if state_name == "running":
+            return ActivityState.WORKING.value
+        if state_name == "idle":
+            return ActivityState.IDLE.value
+        if not lifecycle:
+            return ActivityState.THINKING.value
         return ActivityState.THINKING.value
 
     @staticmethod
-    def _codex_fork_pane_text_indicates_working(pane_text: str) -> bool:
-        """Return True when codex-fork TUI text shows active work not modeled by events."""
-        if not pane_text:
+    def _codex_fork_pane_title_indicates_working(pane_title: str) -> bool:
+        """Return True when the codex-fork pane title has an active spinner prefix."""
+        if not pane_title:
             return False
-        pane_tail = "\n".join(
-            line
-            for line in pane_text.splitlines()[-5:]
-            if line.strip()
-        )
-        markers = (
-            "Working (",
-            "Waiting for background terminal",
-            "background terminal running",
-            "background terminals running",
-        )
-        return any(marker in pane_tail for marker in markers)
+        title = pane_title.strip()
+        first_token, separator, _ = title.partition(" ")
+        if not separator or len(first_token) != 1:
+            return False
+        codepoint = ord(first_token)
+        return 0x2801 <= codepoint <= 0x28FF
 
     def _codex_fork_pane_indicates_working(self, session: Session) -> bool:
         """Use the live codex-fork pane as a bounded correction for idle reducer gaps."""
         if not session.tmux_session:
             return False
-        try:
-            pane_text = self.tmux.capture_pane(session.tmux_session, lines=8)
-        except Exception:
-            logger.debug("Failed to capture codex-fork pane for activity projection", exc_info=True)
-            return False
-        return self._codex_fork_pane_text_indicates_working(pane_text or "")
+        title_getter = getattr(self.tmux, "get_pane_title", None)
+        if callable(title_getter):
+            try:
+                pane_title = title_getter(session.tmux_session)
+            except Exception:
+                logger.debug("Failed to read codex-fork pane title for activity projection", exc_info=True)
+            else:
+                if self._codex_fork_pane_title_indicates_working(pane_title or ""):
+                    return True
+        return False
 
     def _compute_codex_app_activity(self, session: Session) -> str:
         """Compute activity state for codex-app sessions (no tmux/output monitor)."""

--- a/tests/unit/test_codex_activity_state.py
+++ b/tests/unit/test_codex_activity_state.py
@@ -773,11 +773,35 @@ def test_codex_fork_idle_reducer_does_not_capture_pane_on_read_path():
         "cause_event_type": "turn_complete",
         "updated_at": datetime.now().isoformat(),
     }
+    manager.tmux.get_pane_title = MagicMock(return_value=None)
     manager.tmux.capture_pane = MagicMock(
         return_value="• Working (17m 46s • esc to interrupt) · 1 background terminal running · /ps to view"
     )
 
     assert manager.get_activity_state(session.id) == "idle"
+    manager.tmux.capture_pane.assert_not_called()
+
+
+def test_codex_fork_idle_reducer_uses_active_title_spinner_without_capture():
+    manager = _make_manager()
+    session = Session(
+        id="cf-title",
+        name="codex-fork-cf-title",
+        working_dir="/tmp",
+        tmux_session="codex-fork-cf-title",
+        provider="codex-fork",
+        status=SessionStatus.IDLE,
+    )
+    manager.sessions[session.id] = session
+    manager.codex_fork_lifecycle[session.id] = {
+        "state": "idle",
+        "cause_event_type": "turn_complete",
+        "updated_at": datetime.now().isoformat(),
+    }
+    manager.tmux.get_pane_title = MagicMock(return_value=f"{chr(0x283C)} project-title")
+    manager.tmux.capture_pane = MagicMock(return_value="› tab to queue message")
+
+    assert manager.get_activity_state(session.id) == "working"
     manager.tmux.capture_pane.assert_not_called()
 
 
@@ -797,9 +821,11 @@ def test_codex_fork_idle_reducer_remains_idle_without_active_pane_markers():
         "cause_event_type": "turn_complete",
         "updated_at": datetime.now().isoformat(),
     }
+    manager.tmux.get_pane_title = MagicMock(return_value=None)
     manager.tmux.capture_pane = MagicMock(return_value="› tab to queue message")
 
     assert manager.get_activity_state(session.id) == "idle"
+    manager.tmux.capture_pane.assert_not_called()
 
 
 def test_codex_fork_idle_reducer_ignores_stale_background_terminal_scrollback():
@@ -818,6 +844,7 @@ def test_codex_fork_idle_reducer_ignores_stale_background_terminal_scrollback():
         "cause_event_type": "turn_complete",
         "updated_at": datetime.now().isoformat(),
     }
+    manager.tmux.get_pane_title = MagicMock(return_value=None)
     manager.tmux.capture_pane = MagicMock(
         return_value="\n".join(
             [
@@ -832,3 +859,4 @@ def test_codex_fork_idle_reducer_ignores_stale_background_terminal_scrollback():
     )
 
     assert manager.get_activity_state(session.id) == "idle"
+    manager.tmux.capture_pane.assert_not_called()


### PR DESCRIPTION
## Summary
- use the live codex-fork tmux pane title spinner as a bounded activity signal when reducer state is stale or missing
- keep waiting/error/stopped lifecycle states authoritative
- preserve the guard that activity-state reads do not capture pane output

## Verification
- PASS: `./venv/bin/python -m pytest tests/unit/test_codex_activity_state.py`
- PASS: `./venv/bin/python -m pytest tests/unit/test_codex_activity_state.py tests/unit/test_codex_activity_projection.py tests/unit/test_watch_api_309.py tests/unit/test_watch_tui.py` (`87 passed`)
- FULL UNIT SUITE: `./venv/bin/python -m pytest tests/unit` -> `1483 passed, 2 failed, 96 warnings`
  - The 2 failures are pre-existing on `main` and tracked in #760
  - Failing tests: `tests/unit/test_app_artifact_server.py::test_deploy_upload_writes_artifact_and_metadata_for_local_bypass`, `tests/unit/test_app_artifact_server.py::test_deploy_accepts_external_device_bearer_and_public_downloads_work`