### PR TITLE
Revive stopped sessions from tmux client events

### DIFF
--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -458,6 +458,9 @@ class SessionManager:
         normalized_session = str(tmux_session or "").strip()
         normalized_tty = str(tty or "").strip()
         normalized_client_pid = str(client_pid or "").strip()
+        revived_session_id = None
+        if normalized_event in {"client-attached", "client-session-changed"}:
+            revived_session_id = self._revive_stopped_tmux_session(normalized_session)
 
         with self._tmux_client_event_lock:
             self._tmux_client_event_version += 1
@@ -470,6 +473,8 @@ class SessionManager:
                 "version": self._tmux_client_event_version,
                 "received_at": datetime.now(timezone.utc).isoformat(),
             }
+            if revived_session_id:
+                payload["revived_session_id"] = revived_session_id
             self._last_tmux_client_event = payload
             return dict(payload)
 
@@ -480,6 +485,70 @@ class SessionManager:
                 "version": self._tmux_client_event_version,
                 "last_event": dict(self._last_tmux_client_event) if self._last_tmux_client_event else None,
             }
+
+    def _revive_stopped_tmux_session(self, tmux_session: str) -> Optional[str]:
+        """Mark a stopped tmux-backed record active again when tmux reports a live client."""
+        normalized_tmux_session = str(tmux_session or "").strip()
+        if not normalized_tmux_session:
+            return None
+
+        session = next(
+            (
+                candidate
+                for candidate in self.sessions.values()
+                if candidate.tmux_session == normalized_tmux_session
+                and candidate.status == SessionStatus.STOPPED
+                and candidate.provider == "codex-fork"
+            ),
+            None,
+        )
+        if session is None:
+            return None
+
+        try:
+            tmux_exists = self._tmux_session_exists_for_session(session)
+        except Exception:
+            return None
+        if not tmux_exists:
+            return None
+
+        now = datetime.now()
+        session.status = SessionStatus.IDLE
+        session.stopped_at = None
+        session.completed_at = None
+        session.completion_status = None
+        session.completion_message = None
+        session.agent_task_completed_at = None
+        session.error_message = None
+        session.last_activity = now
+        session.tmux_socket_name = self._tmux_socket_name()
+        self._cache_session_node(session)
+
+        if session.provider == "codex-fork":
+            self.codex_fork_runtime_owner[session.id] = session.parent_session_id or session.id
+            self._reset_codex_fork_lifecycle_reducer(session.id)
+            self._start_codex_fork_event_monitor(session, from_eof=False)
+
+        self._save_state()
+        logger.info(
+            "Revived stopped session %s from tmux client event for %s",
+            session.id,
+            normalized_tmux_session,
+        )
+        return session.id
+
+    def _reset_codex_fork_lifecycle_reducer(self, session_id: str) -> None:
+        """Clear in-memory codex-fork reducer state before replaying runtime events."""
+        self.codex_fork_lifecycle.pop(session_id, None)
+        self.codex_fork_turns_in_flight.discard(session_id)
+        self.codex_fork_wait_resume_state.pop(session_id, None)
+        self.codex_fork_wait_kind.pop(session_id, None)
+        self.codex_fork_last_seq.pop(session_id, None)
+        self.codex_fork_session_epoch.pop(session_id, None)
+        self.codex_fork_event_offsets.pop(session_id, None)
+        self.codex_fork_event_buffers.pop(session_id, None)
+        self.codex_fork_provider_cursors.pop(session_id, None)
+        self.codex_event_store.clear_codex_fork_provider_cursor(session_id)
 
     def _tmux_socket_name(self) -> Optional[str]:
         """Return configured tmux socket name, treating partial mocks as legacy default-server."""

--- a/tests/unit/test_tmux_client_event_revival.py
+++ b/tests/unit/test_tmux_client_event_revival.py
@@ -1,0 +1,158 @@
+import json
+from datetime import datetime
+from unittest.mock import Mock
+
+from src.models import Session, SessionStatus
+
+
+def test_tmux_client_event_revives_stopped_tmux_backed_session(
+    session_manager,
+    mock_tmux,
+    temp_state_file,
+):
+    mock_tmux.socket_name = "session-manager"
+    mock_tmux.session_exists.return_value = True
+    stopped_at = datetime(2026, 6, 5, 15, 28, 53)
+    session = Session(
+        id="e7f61918",
+        name="codex-fork-e7f61918",
+        working_dir="/Users/rajesh/projects/fractal-algo-rust",
+        tmux_session="codex-fork-e7f61918",
+        provider="codex-fork",
+        status=SessionStatus.STOPPED,
+        stopped_at=stopped_at,
+        completed_at=stopped_at,
+        error_message="marked stopped",
+    )
+    session_manager.sessions[session.id] = session
+
+    payload = session_manager.record_tmux_client_event(
+        event="client-attached",
+        tmux_session="codex-fork-e7f61918",
+        tty="/dev/ttys001",
+        client_pid="2675",
+    )
+
+    assert payload["revived_session_id"] == "e7f61918"
+    assert session.status == SessionStatus.IDLE
+    assert session.stopped_at is None
+    assert session.completed_at is None
+    assert session.error_message is None
+    assert session.tmux_socket_name == "session-manager"
+
+    saved = json.loads(temp_state_file.read_text())
+    saved_session = next(item for item in saved["sessions"] if item["id"] == "e7f61918")
+    assert saved_session["status"] == "idle"
+    assert saved_session["stopped_at"] is None
+
+
+def test_tmux_client_detach_does_not_revive_stopped_session(
+    session_manager,
+    mock_tmux,
+):
+    mock_tmux.session_exists.return_value = True
+    session = Session(
+        id="e7f61918",
+        name="codex-fork-e7f61918",
+        working_dir="/Users/rajesh/projects/fractal-algo-rust",
+        tmux_session="codex-fork-e7f61918",
+        provider="codex-fork",
+        status=SessionStatus.STOPPED,
+        stopped_at=datetime(2026, 6, 5, 15, 28, 53),
+    )
+    session_manager.sessions[session.id] = session
+
+    payload = session_manager.record_tmux_client_event(
+        event="client-detached",
+        tmux_session="codex-fork-e7f61918",
+        tty="/dev/ttys001",
+        client_pid="2675",
+    )
+
+    assert "revived_session_id" not in payload
+    assert session.status == SessionStatus.STOPPED
+
+
+def test_tmux_client_event_does_not_revive_non_codex_fork_session(
+    session_manager,
+    mock_tmux,
+):
+    mock_tmux.session_exists.return_value = True
+    session = Session(
+        id="claude-live",
+        name="claude-live",
+        working_dir="/Users/rajesh/projects/fractal-algo-rust",
+        tmux_session="claude-live",
+        provider="claude",
+        status=SessionStatus.STOPPED,
+        stopped_at=datetime(2026, 6, 5, 15, 28, 53),
+    )
+    session_manager.sessions[session.id] = session
+
+    payload = session_manager.record_tmux_client_event(
+        event="client-attached",
+        tmux_session="claude-live",
+        tty="/dev/ttys002",
+        client_pid="2676",
+    )
+
+    assert "revived_session_id" not in payload
+    assert session.status == SessionStatus.STOPPED
+
+
+def test_tmux_client_event_replays_codex_fork_history_on_revival(
+    session_manager,
+    mock_tmux,
+    monkeypatch,
+):
+    mock_tmux.session_exists.return_value = True
+    session = Session(
+        id="e7f61918",
+        name="codex-fork-e7f61918",
+        working_dir="/Users/rajesh/projects/fractal-algo-rust",
+        tmux_session="codex-fork-e7f61918",
+        provider="codex-fork",
+        status=SessionStatus.STOPPED,
+        stopped_at=datetime(2026, 6, 5, 15, 28, 53),
+    )
+    session_manager.sessions[session.id] = session
+    session_manager.codex_fork_lifecycle[session.id] = {"state": "shutdown", "seq": 99}
+    session_manager.codex_fork_turns_in_flight.add(session.id)
+    session_manager.codex_fork_wait_resume_state[session.id] = "running"
+    session_manager.codex_fork_wait_kind[session.id] = "approval"
+    session_manager.codex_fork_last_seq[session.id] = 99
+    session_manager.codex_fork_session_epoch[session.id] = "old-epoch"
+    session_manager.codex_fork_event_offsets[session.id] = 1234
+    session_manager.codex_fork_event_buffers[session.id] = "{\"partial\":"
+    session_manager.codex_fork_provider_cursors[session.id] = {
+        "session_epoch": "old-epoch",
+        "session_epoch_key": "s:old-epoch",
+        "seq": 99,
+    }
+    session_manager.codex_event_store.record_codex_fork_provider_event_applied(
+        session.id,
+        session_epoch="old-epoch",
+        seq=99,
+    )
+    start_monitor = Mock()
+    monkeypatch.setattr(session_manager, "_start_codex_fork_event_monitor", start_monitor)
+
+    payload = session_manager.record_tmux_client_event(
+        event="client-attached",
+        tmux_session="codex-fork-e7f61918",
+        tty="/dev/ttys001",
+        client_pid="2675",
+    )
+
+    assert payload["revived_session_id"] == "e7f61918"
+    assert session_manager.codex_fork_lifecycle.get(session.id) is None
+    assert session.id not in session_manager.codex_fork_turns_in_flight
+    assert session.id not in session_manager.codex_fork_wait_resume_state
+    assert session.id not in session_manager.codex_fork_wait_kind
+    assert session.id not in session_manager.codex_fork_last_seq
+    assert session.id not in session_manager.codex_fork_session_epoch
+    assert session.id not in session_manager.codex_fork_event_offsets
+    assert session.id not in session_manager.codex_fork_event_buffers
+    assert session.id not in session_manager.codex_fork_provider_cursors
+    assert session_manager.codex_event_store.get_codex_fork_provider_cursor(session.id) is None
+    start_monitor.assert_called_once_with(session, from_eof=False)


### PR DESCRIPTION
## Summary
- revive stopped tmux-backed sessions when a desktop client attaches or changes into their tmux session
- clear stopped/completed/error fields and restart codex-fork monitoring for revived sessions
- include revived_session_id in tmux client event payloads for downstream clients such as DeskBar

## Tests
- venv/bin/python -m pytest tests/unit/test_tmux_client_event_revival.py tests/unit/test_tmux_controller.py tests/unit/test_main_tmux_hooks.py tests/integration/test_api_endpoints.py -q