### PR TITLE
Add Rust migration contract and baseline harness

### DIFF
--- a/scripts/rust_migration/README.md
+++ b/scripts/rust_migration/README.md
@@ -1,0 +1,31 @@
+# Rust Migration Harness
+
+These scripts are implementation artifacts for issue #762. They do not reopen
+the migration spec; they turn the converged spec artifacts into executable
+checks and measurable Python baselines.
+
+## Contract Harness
+
+Run the safe Python subset:
+
+```bash
+python -m scripts.rust_migration.contracts --target python --base-url http://127.0.0.1:8420
+```
+
+The harness is manifest driven. Checks that need a live server, a real session,
+credentials, or mutating opt-in are reported as skipped when their preconditions
+are not supplied. Retired surfaces are Rust-target checks; current Python may
+still expose them during the migration window.
+
+## Baseline Runner
+
+Run a safe local baseline:
+
+```bash
+python -m scripts.rust_migration.baseline --base-url http://127.0.0.1:8420 --repetitions 5 --output /tmp/sm-python-baseline.json
+```
+
+The report records numeric data where it is safe to measure and marks missing
+instrumentation or unsafe workloads explicitly. Do not commit machine-local
+baseline reports if they contain host-specific or private runtime details.
+

--- a/scripts/rust_migration/__init__.py
+++ b/scripts/rust_migration/__init__.py
@@ -1,0 +1,2 @@
+"""Rust migration contract and baseline tooling."""
+

--- a/scripts/rust_migration/baseline.py
+++ b/scripts/rust_migration/baseline.py
@@ -1,0 +1,228 @@
+"""Safe Python baseline runner for the Rust migration value gate."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import statistics
+import subprocess
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from .contracts import ContractManifest, run_checks
+
+
+def run_baseline(
+    *,
+    base_url: str | None,
+    sm_binary: str,
+    repetitions: int,
+    output: Path | None,
+    server_pid: int | None,
+) -> dict[str, Any]:
+    start = time.perf_counter()
+    manifest = ContractManifest.load()
+    runs = []
+    for _ in range(repetitions):
+        results = run_checks(
+            manifest,
+            target="python",
+            base_url=base_url,
+            sm_binary=sm_binary,
+            session_id=None,
+            include_mutating=False,
+        )
+        runs.append([result.to_dict() for result in results])
+
+    report = {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "target": "python",
+        "host": {
+            "system": platform.system(),
+            "machine": platform.machine(),
+            "python": platform.python_version(),
+        },
+        "inputs": {
+            "base_url": base_url,
+            "sm_binary": sm_binary,
+            "repetitions": repetitions,
+            "server_pid": server_pid,
+        },
+        "memory": _memory_snapshot(server_pid, base_url),
+        "latency": _latency_summary(runs),
+        "runs": runs,
+        "python_hardening_variants": [
+            {
+                "variant": "disable already-unused integrations by config",
+                "status": "not_measured",
+                "reason": "requires controlled config copy and restart rehearsal",
+            },
+            {
+                "variant": "reduce retained event/log scan windows where compatible",
+                "status": "not_measured",
+                "reason": "requires retained-state workload and compatibility fixture comparison",
+            },
+            {
+                "variant": "defer startup background work not needed for first response",
+                "status": "not_measured",
+                "reason": "requires startup harness and controlled service restart",
+            },
+            {
+                "variant": "remove retired surfaces while isolating optional retained integrations",
+                "status": "not_measured",
+                "reason": "requires feature-gated Python patch or Rust prototype comparison",
+            },
+            {
+                "variant": "reduce logging verbosity or request timing thresholds where compatible",
+                "status": "not_measured",
+                "reason": "requires log/telemetry compatibility comparison",
+            },
+        ],
+    }
+    report["elapsed_seconds"] = round(time.perf_counter() - start, 3)
+    if output:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+    return report
+
+
+def _latency_summary(runs: list[list[dict[str, Any]]]) -> dict[str, Any]:
+    by_id: dict[str, list[float]] = {}
+    skipped: dict[str, str] = {}
+    failed: dict[str, str] = {}
+    for run in runs:
+        for result in run:
+            check_id = result["id"]
+            if result["status"] == "passed" and result["elapsed_ms"] is not None:
+                by_id.setdefault(check_id, []).append(float(result["elapsed_ms"]))
+            elif result["status"] == "skipped":
+                skipped[check_id] = result["detail"]
+            elif result["status"] == "failed":
+                failed[check_id] = result["detail"]
+
+    summaries = {}
+    for check_id, values in by_id.items():
+        ordered = sorted(values)
+        summaries[check_id] = {
+            "count": len(values),
+            "min_ms": ordered[0],
+            "median_ms": statistics.median(ordered),
+            "max_ms": ordered[-1],
+            "p95_ms": _percentile(ordered, 0.95),
+        }
+    return {"summaries": summaries, "skipped": skipped, "failed": failed}
+
+
+def _percentile(sorted_values: list[float], quantile: float) -> float:
+    if not sorted_values:
+        return 0.0
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    index = (len(sorted_values) - 1) * quantile
+    lower = int(index)
+    upper = min(lower + 1, len(sorted_values) - 1)
+    weight = index - lower
+    return round(sorted_values[lower] * (1 - weight) + sorted_values[upper] * weight, 3)
+
+
+def _memory_snapshot(server_pid: int | None, base_url: str | None) -> dict[str, Any]:
+    if server_pid is None:
+        server_pid = _discover_server_pid(_port_from_base_url(base_url))
+    if server_pid is None:
+        return {
+            "status": "skipped",
+            "reason": "server pid not supplied and no process found on selected base-url port",
+        }
+
+    try:
+        completed = subprocess.run(
+            ["ps", "-o", "rss=", "-p", str(server_pid)],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=3,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return {"status": "skipped", "pid": server_pid, "reason": str(exc)}
+    if completed.returncode != 0 or not completed.stdout.strip():
+        return {
+            "status": "skipped",
+            "pid": server_pid,
+            "reason": completed.stderr.strip() or "ps did not return RSS",
+        }
+    rss_kib = int(completed.stdout.strip().splitlines()[0])
+    return {
+        "status": "measured",
+        "pid": server_pid,
+        "rss_kib": rss_kib,
+        "rss_mib": round(rss_kib / 1024, 3),
+        "uss": {
+            "status": "unknown",
+            "reason": "USS requires platform-specific tooling not used by the safe stdlib runner",
+        },
+    }
+
+
+def _port_from_base_url(base_url: str | None) -> int:
+    if not base_url:
+        return 8420
+    parsed = urlparse(base_url)
+    if parsed.port:
+        return parsed.port
+    if parsed.scheme == "https":
+        return 443
+    if parsed.scheme == "http":
+        return 80
+    return 8420
+
+
+def _discover_server_pid(port: int) -> int | None:
+    try:
+        completed = subprocess.run(
+            ["lsof", "-ti", f"tcp:{port}"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=3,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    for line in completed.stdout.splitlines():
+        line = line.strip()
+        if line.isdigit():
+            return int(line)
+    return None
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://127.0.0.1:8420")
+    parser.add_argument("--sm-binary", default="sm")
+    parser.add_argument("--repetitions", type=int, default=5)
+    parser.add_argument("--server-pid", type=int, default=None)
+    parser.add_argument("--output", type=Path, default=None)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    report = run_baseline(
+        base_url=args.base_url,
+        sm_binary=args.sm_binary,
+        repetitions=args.repetitions,
+        output=args.output,
+        server_pid=args.server_pid,
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 1 if report["latency"]["failed"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/rust_migration/contracts.py
+++ b/scripts/rust_migration/contracts.py
@@ -1,0 +1,307 @@
+"""Executable contract harness for the Rust migration.
+
+The harness intentionally starts with a safe, manifest-driven subset. Checks
+that need a live server, session id, credentials, or mutating opt-in are
+reported as skipped until the caller supplies the preconditions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+
+MANIFEST_PATH = Path(__file__).with_name("contracts_manifest.json")
+DEFAULT_TIMEOUT_SECONDS = 5.0
+
+
+@dataclass(frozen=True)
+class ContractCheck:
+    id: str
+    surface: str
+    classification: str
+    target: str
+    safety: str
+    source: str
+    preconditions: tuple[str, ...]
+    method: str | None = None
+    path: str | None = None
+    expected_status: tuple[int, ...] = ()
+    command: tuple[str, ...] = ()
+    expected_exit: tuple[int, ...] = ()
+    expected_output_contains_any: tuple[str, ...] = ()
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "ContractCheck":
+        return cls(
+            id=str(raw["id"]),
+            surface=str(raw["surface"]),
+            classification=str(raw["classification"]),
+            target=str(raw["target"]),
+            safety=str(raw["safety"]),
+            source=str(raw["source"]),
+            preconditions=tuple(raw.get("preconditions", [])),
+            method=raw.get("method"),
+            path=raw.get("path"),
+            expected_status=tuple(int(v) for v in raw.get("expected_status", [])),
+            command=tuple(str(v) for v in raw.get("command", [])),
+            expected_exit=tuple(int(v) for v in raw.get("expected_exit", [])),
+            expected_output_contains_any=tuple(
+                str(v) for v in raw.get("expected_output_contains_any", [])
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class ContractManifest:
+    schema_version: int
+    source_spec: str
+    artifacts: tuple[str, ...]
+    checks: tuple[ContractCheck, ...]
+
+    @classmethod
+    def load(cls, path: Path = MANIFEST_PATH) -> "ContractManifest":
+        raw = json.loads(path.read_text())
+        return cls(
+            schema_version=int(raw["schema_version"]),
+            source_spec=str(raw["source_spec"]),
+            artifacts=tuple(str(v) for v in raw.get("artifacts", [])),
+            checks=tuple(ContractCheck.from_dict(item) for item in raw["checks"]),
+        )
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    id: str
+    status: str
+    classification: str
+    target: str
+    surface: str
+    elapsed_ms: float | None
+    detail: str
+    source: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "status": self.status,
+            "classification": self.classification,
+            "target": self.target,
+            "surface": self.surface,
+            "elapsed_ms": self.elapsed_ms,
+            "detail": self.detail,
+            "source": self.source,
+        }
+
+
+def checks_for_target(
+    checks: Iterable[ContractCheck], target: str, include_mutating: bool
+) -> list[ContractCheck]:
+    selected: list[ContractCheck] = []
+    for check in checks:
+        if check.target == "rust_only" and target != "rust":
+            continue
+        if check.target == "python_only" and target != "python":
+            continue
+        if check.safety == "mutating" and not include_mutating:
+            selected.append(check)
+            continue
+        selected.append(check)
+    return selected
+
+
+def run_checks(
+    manifest: ContractManifest,
+    *,
+    target: str,
+    base_url: str | None,
+    sm_binary: str,
+    session_id: str | None,
+    include_mutating: bool,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+) -> list[CheckResult]:
+    results: list[CheckResult] = []
+    for check in checks_for_target(manifest.checks, target, include_mutating):
+        skip_reason = _skip_reason(
+            check,
+            base_url=base_url,
+            sm_binary=sm_binary,
+            session_id=session_id,
+            include_mutating=include_mutating,
+        )
+        if skip_reason:
+            results.append(_result(check, "skipped", None, skip_reason))
+            continue
+
+        if check.surface == "http":
+            results.append(_run_http_check(check, base_url or "", session_id, timeout_seconds))
+        elif check.surface == "cli":
+            results.append(_run_cli_check(check, sm_binary, timeout_seconds))
+        else:
+            results.append(_result(check, "skipped", None, f"unsupported surface {check.surface}"))
+    return results
+
+
+def summarize(results: Iterable[CheckResult]) -> dict[str, int]:
+    summary = {"passed": 0, "failed": 0, "skipped": 0}
+    for result in results:
+        summary[result.status] = summary.get(result.status, 0) + 1
+    return summary
+
+
+def _skip_reason(
+    check: ContractCheck,
+    *,
+    base_url: str | None,
+    sm_binary: str,
+    session_id: str | None,
+    include_mutating: bool,
+) -> str | None:
+    if "live_server" in check.preconditions and not base_url:
+        return "live server URL not supplied"
+    if "sm_cli" in check.preconditions and not shutil.which(sm_binary):
+        return f"sm CLI not found: {sm_binary}"
+    if "session_id" in check.preconditions and not session_id:
+        return "session id not supplied"
+    if "mutating_opt_in" in check.preconditions and not include_mutating:
+        return "mutating check requires --include-mutating"
+    return None
+
+
+def _run_http_check(
+    check: ContractCheck, base_url: str, session_id: str | None, timeout_seconds: float
+) -> CheckResult:
+    assert check.method and check.path
+    path = check.path
+    if session_id:
+        path = path.replace("{session_id}", session_id)
+    url = base_url.rstrip("/") + path
+    start = time.perf_counter()
+    data = None
+    headers = {}
+    if check.method not in {"GET", "HEAD"}:
+        data = b"{}"
+        headers["Content-Type"] = "application/json"
+    request = urllib.request.Request(url, data=data, headers=headers, method=check.method)
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            status = response.status
+            response.read(1024)
+    except urllib.error.HTTPError as exc:
+        status = exc.code
+    except (urllib.error.URLError, TimeoutError) as exc:
+        return _result(check, "failed", _elapsed_ms(start), f"live server unavailable: {exc}")
+
+    if status in check.expected_status:
+        return _result(check, "passed", _elapsed_ms(start), f"HTTP {status}")
+    return _result(
+        check,
+        "failed",
+        _elapsed_ms(start),
+        f"expected HTTP {list(check.expected_status)}, got {status}",
+    )
+
+
+def _run_cli_check(check: ContractCheck, sm_binary: str, timeout_seconds: float) -> CheckResult:
+    start = time.perf_counter()
+    try:
+        completed = subprocess.run(
+            [sm_binary, *check.command],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout_seconds,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return _result(check, "failed", _elapsed_ms(start), f"timed out after {timeout_seconds}s")
+    output = (completed.stdout + completed.stderr).lower()
+    exit_ok = completed.returncode in check.expected_exit
+    contains_any = not check.expected_output_contains_any or any(
+        needle.lower() in output for needle in check.expected_output_contains_any
+    )
+    if exit_ok and contains_any:
+        return _result(check, "passed", _elapsed_ms(start), f"exit {completed.returncode}")
+
+    detail = f"exit {completed.returncode}; expected {list(check.expected_exit)}"
+    if check.expected_output_contains_any and not contains_any:
+        detail += f"; missing one of {list(check.expected_output_contains_any)}"
+    return _result(check, "failed", _elapsed_ms(start), detail)
+
+
+def _result(
+    check: ContractCheck, status: str, elapsed_ms: float | None, detail: str
+) -> CheckResult:
+    return CheckResult(
+        id=check.id,
+        status=status,
+        classification=check.classification,
+        target=check.target,
+        surface=check.surface,
+        elapsed_ms=elapsed_ms,
+        detail=detail,
+        source=check.source,
+    )
+
+
+def _elapsed_ms(start: float) -> float:
+    return round((time.perf_counter() - start) * 1000, 3)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=MANIFEST_PATH)
+    parser.add_argument("--target", choices=("python", "rust"), default="python")
+    parser.add_argument("--base-url", default=None)
+    parser.add_argument("--sm-binary", default="sm")
+    parser.add_argument("--session-id", default=None)
+    parser.add_argument("--include-mutating", action="store_true")
+    parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--json", action="store_true", help="Emit JSON report")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    manifest = ContractManifest.load(args.manifest)
+    results = run_checks(
+        manifest,
+        target=args.target,
+        base_url=args.base_url,
+        sm_binary=args.sm_binary,
+        session_id=args.session_id,
+        include_mutating=args.include_mutating,
+        timeout_seconds=args.timeout,
+    )
+    summary = summarize(results)
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "schema_version": manifest.schema_version,
+                    "target": args.target,
+                    "summary": summary,
+                    "results": [result.to_dict() for result in results],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    else:
+        for result in results:
+            elapsed = "" if result.elapsed_ms is None else f" ({result.elapsed_ms} ms)"
+            print(f"{result.status.upper():7} {result.id}{elapsed}: {result.detail}")
+        print(f"Summary: {summary}")
+    return 1 if summary.get("failed", 0) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/rust_migration/contracts_manifest.json
+++ b/scripts/rust_migration/contracts_manifest.json
@@ -1,0 +1,188 @@
+{
+  "schema_version": 1,
+  "source_spec": "specs/762_rust_migration_and_ruggedization.md",
+  "artifacts": [
+    "specs/762_stage2_artifacts/route_auth_matrix.md",
+    "specs/762_stage2_artifacts/external_client_manifest.md",
+    "specs/762_stage5_artifacts/cutover_scope.md",
+    "specs/762_stage5_artifacts/gate_matrix.md"
+  ],
+  "checks": [
+    {
+      "id": "http.health",
+      "surface": "http",
+      "classification": "retained",
+      "target": "python_and_rust",
+      "safety": "read_only",
+      "method": "GET",
+      "path": "/health",
+      "expected_status": [200],
+      "preconditions": ["live_server"],
+      "source": "specs/762_stage5_artifacts/gate_matrix.md:62"
+    },
+    {
+      "id": "http.health_detailed",
+      "surface": "http",
+      "classification": "retained",
+      "target": "python_and_rust",
+      "safety": "read_only",
+      "method": "GET",
+      "path": "/health/detailed",
+      "expected_status": [200],
+      "preconditions": ["live_server"],
+      "source": "specs/762_stage5_artifacts/gate_matrix.md:62"
+    },
+    {
+      "id": "http.auth_session",
+      "surface": "http",
+      "classification": "retained",
+      "target": "python_and_rust",
+      "safety": "read_only",
+      "method": "GET",
+      "path": "/auth/session",
+      "expected_status": [200],
+      "preconditions": ["live_server"],
+      "source": "specs/762_stage5_artifacts/gate_matrix.md:63"
+    },
+    {
+      "id": "http.client_bootstrap",
+      "surface": "http",
+      "classification": "retained",
+      "target": "python_and_rust",
+      "safety": "read_only",
+      "method": "GET",
+      "path": "/client/bootstrap",
+      "expected_status": [200],
+      "preconditions": ["live_server"],
+      "source": "specs/762_stage5_artifacts/gate_matrix.md:64"
+    },
+    {
+      "id": "http.client_sessions",
+      "surface": "http",
+      "classification": "retained",
+      "target": "python_and_rust",
+      "safety": "read_only",
+      "method": "GET",
+      "path": "/client/sessions",
+      "expected_status": [200],
+      "preconditions": ["live_server"],
+      "source": "specs/762_stage5_artifacts/gate_matrix.md:64"
+    },
+    {
+      "id": "http.sessions",
+      "surface": "http",
+      "classification": "retained",
+      "target": "python_and_rust",
+      "safety": "read_only",
+      "method": "GET",
+      "path": "/sessions",
+      "expected_status": [200],
+      "preconditions": ["live_server"],
+      "source": "specs/762_stage5_artifacts/gate_matrix.md:69"
+    },
+    {
+      "id": "http.events_state",
+      "surface": "http",
+      "classification": "retained",
+      "target": "python_and_rust",
+      "safety": "read_only",
+      "method": "GET",
+      "path": "/events/state",
+      "expected_status": [200],
+      "preconditions": ["live_server"],
+      "source": "specs/762_stage5_artifacts/gate_matrix.md:71"
+    },
+    {
+      "id": "http.mobile_session_stop",
+      "surface": "http",
+      "classification": "retained",
+      "target": "python_and_rust",
+      "safety": "mutating",
+      "method": "POST",
+      "path": "/sessions/{session_id}/kill",
+      "expected_status": [200],
+      "preconditions": ["live_server", "session_id", "mutating_opt_in"],
+      "source": "specs/762_stage5_artifacts/gate_matrix.md:66"
+    },
+    {
+      "id": "cli.status_help",
+      "surface": "cli",
+      "classification": "retained",
+      "target": "python_and_rust",
+      "safety": "read_only",
+      "command": ["status", "--help"],
+      "expected_exit": [0],
+      "preconditions": ["sm_cli"],
+      "source": "specs/762_stage5_artifacts/gate_matrix.md:69"
+    },
+    {
+      "id": "cli.send_help",
+      "surface": "cli",
+      "classification": "retained",
+      "target": "python_and_rust",
+      "safety": "read_only",
+      "command": ["send", "--help"],
+      "expected_exit": [0],
+      "preconditions": ["sm_cli"],
+      "source": "specs/762_stage2_artifacts/cli_manifest.md:send"
+    },
+    {
+      "id": "cli.tail_raw_help",
+      "surface": "cli",
+      "classification": "retained",
+      "target": "python_and_rust",
+      "safety": "read_only",
+      "command": ["tail", "--help"],
+      "expected_exit": [0],
+      "preconditions": ["sm_cli"],
+      "source": "specs/762_stage5_artifacts/gate_matrix.md:70"
+    },
+    {
+      "id": "cli.retire_help",
+      "surface": "cli",
+      "classification": "retained",
+      "target": "python_and_rust",
+      "safety": "read_only",
+      "command": ["retire", "--help"],
+      "expected_exit": [0],
+      "preconditions": ["sm_cli"],
+      "source": "specs/762_stage5_artifacts/cutover_scope.md:37"
+    },
+    {
+      "id": "cli.what_retired",
+      "surface": "cli",
+      "classification": "retired",
+      "target": "rust_only",
+      "safety": "read_only",
+      "command": ["what", "--help"],
+      "expected_exit": [1, 2],
+      "expected_output_contains_any": ["retired", "not ported", "unknown command"],
+      "preconditions": ["sm_cli"],
+      "source": "specs/762_stage5_artifacts/cutover_scope.md:54"
+    },
+    {
+      "id": "cli.kill_alias_retired",
+      "surface": "cli",
+      "classification": "retired",
+      "target": "rust_only",
+      "safety": "read_only",
+      "command": ["kill", "--help"],
+      "expected_exit": [1, 2],
+      "expected_output_contains_any": ["retired", "not ported", "use sm retire", "unknown command"],
+      "preconditions": ["sm_cli"],
+      "source": "specs/762_stage5_artifacts/cutover_scope.md:55"
+    },
+    {
+      "id": "cli.dispatch_retired",
+      "surface": "cli",
+      "classification": "retired",
+      "target": "rust_only",
+      "safety": "read_only",
+      "command": ["dispatch", "--help"],
+      "expected_exit": [1, 2],
+      "expected_output_contains_any": ["retired", "not ported", "unknown command"],
+      "preconditions": ["sm_cli"],
+      "source": "specs/762_stage5_artifacts/cutover_scope.md:53"
+    }
+  ]
+}

--- a/specs/762_baselines/2026-06-06_python_safe_baseline.md
+++ b/specs/762_baselines/2026-06-06_python_safe_baseline.md
@@ -1,0 +1,81 @@
+# Python Safe Baseline - 2026-06-06
+
+This is the first safe, read-only baseline for the Rust migration value gate.
+It was generated with:
+
+```bash
+./venv/bin/python -m scripts.rust_migration.baseline \
+  --base-url http://127.0.0.1:8420 \
+  --repetitions 5 \
+  --output /tmp/sm-python-baseline-safe.json
+```
+
+The raw machine-local JSON was not committed. This artifact keeps aggregate
+numbers only.
+
+## Environment
+
+| Field | Value |
+| --- | --- |
+| Target | current Python service |
+| Host OS | Darwin |
+| Machine | arm64 |
+| Python | 3.14.5 |
+| Server PID | 3778 |
+| RSS | 203920 KiB / 199.141 MiB |
+| USS | unknown; the safe stdlib runner does not use platform-specific USS tooling |
+
+## Safe Contract Result
+
+| Result | Count |
+| --- | ---: |
+| Passed | 11 |
+| Failed | 0 |
+| Skipped | 1 |
+
+Skipped check:
+
+| Check | Reason |
+| --- | --- |
+| `http.mobile_session_stop` | session id not supplied; this is mutating and requires an explicit test session plus opt-in |
+
+## Latency Summary
+
+Five repetitions against the live local Python service:
+
+| Check | Count | Min ms | Median ms | P95 ms | Max ms |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `http.health` | 5 | 1.914 | 3.858 | 11.487 | 13.246 |
+| `http.health_detailed` | 5 | 168.111 | 444.307 | 645.935 | 691.031 |
+| `http.auth_session` | 5 | 1.045 | 1.232 | 53.694 | 66.707 |
+| `http.client_bootstrap` | 5 | 0.830 | 0.870 | 0.926 | 0.938 |
+| `http.client_sessions` | 5 | 201.032 | 206.959 | 231.113 | 231.235 |
+| `http.sessions` | 5 | 62.043 | 67.372 | 123.851 | 133.677 |
+| `http.events_state` | 5 | 1.052 | 1.352 | 53.733 | 66.066 |
+| `cli.status_help` | 5 | 76.641 | 80.109 | 86.398 | 87.400 |
+| `cli.send_help` | 5 | 72.990 | 76.096 | 81.040 | 81.555 |
+| `cli.tail_raw_help` | 5 | 76.732 | 79.434 | 87.567 | 88.552 |
+| `cli.retire_help` | 5 | 77.814 | 78.537 | 81.323 | 81.463 |
+
+## Python Hardening Variants
+
+These variants remain unmeasured in this safe pass because they require a
+controlled config copy, restart rehearsal, or compatibility fixture comparison:
+
+| Variant | Status | Reason |
+| --- | --- | --- |
+| disable already-unused integrations by config | not measured | requires controlled config copy and restart rehearsal |
+| reduce retained event/log scan windows where compatible | not measured | requires retained-state workload and compatibility fixture comparison |
+| defer startup background work not needed for first response | not measured | requires startup harness and controlled service restart |
+| remove retired surfaces while isolating optional retained integrations | not measured | requires feature-gated Python patch or Rust prototype comparison |
+| reduce logging verbosity or request timing thresholds where compatible | not measured | requires log/telemetry compatibility comparison |
+
+## Remaining Baseline Work
+
+- Capture USS with a platform-specific tool or approved dependency.
+- Add mutating test-session workloads for mobile/session-stop, attach-ticket mint,
+  `sm send`, queue wake delivery, and retained hook paths.
+- Add startup/restore measurements from copied real state.
+- Add provider/Codex event ingestion, node reconnect, SSE stream, and email/human
+  fake-notifier baselines.
+- Run the same report against feasible Python hardening/config variants.

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -1,0 +1,143 @@
+import urllib.error
+from unittest.mock import patch
+
+from scripts.rust_migration.baseline import _port_from_base_url
+from scripts.rust_migration.contracts import (
+    ContractCheck,
+    ContractManifest,
+    _run_http_check,
+    checks_for_target,
+    run_checks,
+    summarize,
+)
+
+
+def test_manifest_preserves_mobile_kill_route_while_retiring_cli_alias():
+    manifest = ContractManifest.load()
+    checks = {check.id: check for check in manifest.checks}
+
+    http_stop = checks["http.mobile_session_stop"]
+    assert http_stop.classification == "retained"
+    assert http_stop.target == "python_and_rust"
+    assert http_stop.path == "/sessions/{session_id}/kill"
+    assert "mutating_opt_in" in http_stop.preconditions
+
+    cli_kill = checks["cli.kill_alias_retired"]
+    assert cli_kill.classification == "retired"
+    assert cli_kill.target == "rust_only"
+    assert cli_kill.command == ("kill", "--help")
+
+
+def test_python_target_does_not_run_rust_only_retirement_checks():
+    manifest = ContractManifest.load()
+    selected = checks_for_target(manifest.checks, target="python", include_mutating=False)
+    ids = {check.id for check in selected}
+
+    assert "cli.kill_alias_retired" not in ids
+    assert "cli.what_retired" not in ids
+    assert "http.mobile_session_stop" in ids
+
+
+def test_mutating_checks_are_reported_as_skipped_without_opt_in():
+    manifest = ContractManifest.load()
+    results = run_checks(
+        manifest,
+        target="python",
+        base_url=None,
+        sm_binary="sm",
+        session_id=None,
+        include_mutating=False,
+    )
+    result_by_id = {result.id: result for result in results}
+
+    assert result_by_id["http.mobile_session_stop"].status == "skipped"
+    assert result_by_id["http.mobile_session_stop"].detail
+
+
+def test_summary_counts_statuses():
+    manifest = ContractManifest.load()
+    results = run_checks(
+        manifest,
+        target="python",
+        base_url=None,
+        sm_binary="definitely-not-an-sm-binary",
+        session_id=None,
+        include_mutating=False,
+    )
+
+    summary = summarize(results)
+    assert summary["failed"] == 0
+    assert summary["skipped"] > 0
+
+
+def test_supplied_live_server_connection_failure_is_failed_not_skipped():
+    check = ContractCheck(
+        id="http.test",
+        surface="http",
+        classification="retained",
+        target="python_and_rust",
+        safety="read_only",
+        method="GET",
+        path="/health",
+        expected_status=(200,),
+        preconditions=("live_server",),
+        source="test",
+    )
+
+    with patch(
+        "scripts.rust_migration.contracts.urllib.request.urlopen",
+        side_effect=urllib.error.URLError("down"),
+    ):
+        result = _run_http_check(check, "http://127.0.0.1:1", None, 0.1)
+
+    assert result.status == "failed"
+    assert "live server unavailable" in result.detail
+
+
+def test_post_checks_send_empty_json_body():
+    check = ContractCheck(
+        id="http.post",
+        surface="http",
+        classification="retained",
+        target="python_and_rust",
+        safety="mutating",
+        method="POST",
+        path="/sessions/{session_id}/kill",
+        expected_status=(200,),
+        preconditions=("live_server", "session_id", "mutating_opt_in"),
+        source="test",
+    )
+    seen = {}
+
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self, _size):
+            return b"{}"
+
+    def fake_urlopen(request, timeout):
+        seen["data"] = request.data
+        seen["content_type"] = request.headers.get("Content-type")
+        seen["url"] = request.full_url
+        return FakeResponse()
+
+    with patch("scripts.rust_migration.contracts.urllib.request.urlopen", fake_urlopen):
+        result = _run_http_check(check, "http://127.0.0.1:8420", "abc123", 1.0)
+
+    assert result.status == "passed"
+    assert seen["data"] == b"{}"
+    assert seen["content_type"] == "application/json"
+    assert seen["url"].endswith("/sessions/abc123/kill")
+
+
+def test_baseline_memory_discovery_uses_selected_base_url_port():
+    assert _port_from_base_url("http://127.0.0.1:8421") == 8421
+    assert _port_from_base_url("http://127.0.0.1") == 80
+    assert _port_from_base_url("https://sm.example.test") == 443
+    assert _port_from_base_url(None) == 8420


### PR DESCRIPTION
## Summary
- Add a manifest-driven Rust migration contract harness under `scripts/rust_migration/`.
- Add a safe Python baseline runner that reuses the contract manifest and records skipped preconditions explicitly.
- Add the first sanitized safe Python baseline artifact under `specs/762_baselines/`.
- Add unit coverage for the key cutover distinction: retained Android/watch HTTP session-stop behavior vs retired `sm kill` CLI alias.

## Verification
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py`
- `./venv/bin/python -m py_compile scripts/rust_migration/contracts.py scripts/rust_migration/baseline.py`
- `./venv/bin/python -m scripts.rust_migration.contracts --target python --base-url http://127.0.0.1:8420 --json`
  - passed 11, failed 0, skipped 1 mutating check requiring session id and opt-in
- `./venv/bin/python -m scripts.rust_migration.baseline --base-url http://127.0.0.1:8420 --repetitions 5 --output /tmp/sm-python-baseline-safe.json`

Fixes #765
Fixes #766
Refs #762
