### PR TITLE
Add multipart parser dependency for app artifact uploads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "google-auth>=2.39.0",
     "cryptography>=42.0.0",
     "websockets>=12.0",
+    "python-multipart>=0.0.9",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ pydantic>=2.0.0
 google-auth>=2.39.0
 cryptography>=42.0.0
 websockets>=12.0
+python-multipart>=0.0.9
 pytest>=7.0
 pytest-asyncio>=0.21
 pytest-cov>=4.0


### PR DESCRIPTION
Fixes #760

## Summary
- add python-multipart as a runtime dependency for FastAPI/Starlette form parsing
- keep app artifact deploy behavior unchanged; this supplies the parser required by request.form()

## Verification
- ./venv/bin/python -m pytest tests/unit/test_app_artifact_server.py -q
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py::test_fixture_precondition_reports_missing_value -q
- ./venv/bin/python -m pytest tests/unit/test_app_artifact_server.py tests/unit/test_rust_migration_contracts.py -q
- ./venv/bin/python -m py_compile src/server.py tests/unit/test_app_artifact_server.py
- git diff --check