### PR TITLE
Add Codex review CLI contract fixtures

### DIFF
--- a/scripts/rust_migration/contracts.py
+++ b/scripts/rust_migration/contracts.py
@@ -39,6 +39,7 @@ class ContractCheck:
     command: tuple[str, ...] = ()
     expected_exit: tuple[int, ...] = ()
     expected_output_contains_any: tuple[str, ...] = ()
+    expected_output_contains_all: tuple[str, ...] = ()
     body: Any = None
     read_mode: str = "bytes"
     read_bytes: int = 1024
@@ -61,6 +62,9 @@ class ContractCheck:
             expected_exit=tuple(int(v) for v in raw.get("expected_exit", [])),
             expected_output_contains_any=tuple(
                 str(v) for v in raw.get("expected_output_contains_any", [])
+            ),
+            expected_output_contains_all=tuple(
+                str(v) for v in raw.get("expected_output_contains_all", [])
             ),
             body=raw.get("body"),
             read_mode=str(raw.get("read_mode", "bytes")),
@@ -229,7 +233,7 @@ def _run_http_check(
     except urllib.error.HTTPError as exc:
         status = exc.code
         body_text = _read_response_text(exc, check)
-    except (urllib.error.URLError, TimeoutError) as exc:
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
         return _result(check, "failed", _elapsed_ms(start), f"live server unavailable: {exc}")
 
     body_ok = not check.expected_body_contains_any or any(
@@ -270,12 +274,17 @@ def _run_cli_check(check: ContractCheck, sm_binary: str, timeout_seconds: float)
     contains_any = not check.expected_output_contains_any or any(
         needle.lower() in output for needle in check.expected_output_contains_any
     )
-    if exit_ok and contains_any:
+    missing_all = [
+        needle for needle in check.expected_output_contains_all if needle.lower() not in output
+    ]
+    if exit_ok and contains_any and not missing_all:
         return _result(check, "passed", _elapsed_ms(start), f"exit {completed.returncode}")
 
     detail = f"exit {completed.returncode}; expected {list(check.expected_exit)}"
     if check.expected_output_contains_any and not contains_any:
         detail += f"; missing one of {list(check.expected_output_contains_any)}"
+    if missing_all:
+        detail += f"; missing required output {missing_all}"
     return _result(check, "failed", _elapsed_ms(start), detail)
 
 

--- a/scripts/rust_migration/contracts_manifest.json
+++ b/scripts/rust_migration/contracts_manifest.json
@@ -350,6 +350,25 @@
       "source": "specs/762_stage5_artifacts/cutover_scope.md:42"
     },
     {
+      "id": "cli.review_help",
+      "surface": "cli",
+      "classification": "retained",
+      "target": "python_and_rust",
+      "safety": "read_only",
+      "command": ["review", "--help"],
+      "expected_exit": [0],
+      "expected_output_contains_all": [
+        "--base",
+        "--uncommitted",
+        "--commit",
+        "--custom",
+        "--new",
+        "--pr"
+      ],
+      "preconditions": ["sm_cli"],
+      "source": "specs/762_stage5_artifacts/cutover_scope.md:32"
+    },
+    {
       "id": "cli.request_codex_review_help",
       "surface": "cli",
       "classification": "retained",
@@ -357,8 +376,15 @@
       "safety": "read_only",
       "command": ["request-codex-review", "--help"],
       "expected_exit": [0],
+      "expected_output_contains_all": [
+        "list",
+        "status",
+        "cancel",
+        "--notify",
+        "--repo"
+      ],
       "preconditions": ["sm_cli"],
-      "source": "specs/762_stage5_artifacts/cutover_scope.md:35"
+      "source": "specs/762_stage5_artifacts/cutover_scope.md:32"
     },
     {
       "id": "cli.codex_help",

--- a/specs/762_stage5_artifacts/cutover_scope.md
+++ b/specs/762_stage5_artifacts/cutover_scope.md
@@ -29,7 +29,7 @@ These surfaces are in scope for the first Rust release:
 | Area | Retained Scope |
 | --- | --- |
 | Core session lifecycle | create/new, spawn, fork, restore, retire, open where local, attach to tmux, output/tail, clear, handoff, parent/child relationships, registry/role/maintainer identity that current agent workflows depend on. |
-| Core CLI | `sm me`, `who`, `status`, `all`, `watch`, `send`, `email`, `wait`, `spawn`, `fork`, `new`, `children`, `retire`, `restore`, `attach`, `output`, `tail`, `clear`, `handoff`, `context-monitor`, `maintainer`, `register`, `unregister`, `lookup`, `roster`, and current Codex provider commands that are active. |
+| Core CLI | `sm me`, `who`, `status`, `all`, `watch`, `send`, `email`, `wait`, `spawn`, `fork`, `new`, `children`, `retire`, `restore`, `attach`, `output`, `tail`, `clear`, `handoff`, `context-monitor`, `maintainer`, `register`, `unregister`, `lookup`, `roster`, `review`, `request-codex-review`, and current Codex provider commands that are active. |
 | Native mobile app | Google/device auth, bootstrap, client session list/detail, mobile terminal attach, request-status, analytics, bug reports, app update/artifact flow, device inventory/revocation. |
 | Mobile terminal | Keep or redesign the current attach-ticket/WebSocket path, but preserve auth, device proof, session binding, quotas, revocation, audit, and fail-closed behavior. Termux is not part of this scope. |
 | Public remote access | Public edge proof is required before operational public traffic reaches origin. Public callers must prove enrolled phone or approved node possession, then pass OAuth/device-bearer or node authorization at origin. |

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -1,3 +1,4 @@
+import subprocess
 import urllib.error
 from unittest.mock import patch
 
@@ -6,6 +7,7 @@ from scripts.rust_migration.contracts import (
     ContractCheck,
     ContractManifest,
     _parse_fixtures,
+    _run_cli_check,
     _run_http_check,
     _render_template,
     checks_for_target,
@@ -28,6 +30,30 @@ def test_manifest_preserves_mobile_kill_route_while_retiring_cli_alias():
     assert cli_kill.classification == "retired"
     assert cli_kill.target == "rust_only"
     assert cli_kill.command == ("kill", "--help")
+
+
+def test_manifest_retains_local_and_durable_codex_review_cli_surfaces():
+    manifest = ContractManifest.load()
+    checks = {check.id: check for check in manifest.checks}
+
+    review = checks["cli.review_help"]
+    assert review.classification == "retained"
+    assert review.target == "python_and_rust"
+    assert review.command == ("review", "--help")
+    assert review.expected_output_contains_all == (
+        "--base",
+        "--uncommitted",
+        "--commit",
+        "--custom",
+        "--new",
+        "--pr",
+    )
+
+    durable = checks["cli.request_codex_review_help"]
+    assert durable.classification == "retained"
+    assert durable.target == "python_and_rust"
+    assert durable.command == ("request-codex-review", "--help")
+    assert "--notify" in durable.expected_output_contains_all
 
 
 def test_python_target_does_not_run_rust_only_retirement_checks():
@@ -97,6 +123,30 @@ def test_supplied_live_server_connection_failure_is_failed_not_skipped():
     assert "live server unavailable" in result.detail
 
 
+def test_supplied_live_server_connection_reset_is_failed_not_crashed():
+    check = ContractCheck(
+        id="http.test",
+        surface="http",
+        classification="retained",
+        target="python_and_rust",
+        safety="read_only",
+        method="GET",
+        path="/health",
+        expected_status=(200,),
+        preconditions=("live_server",),
+        source="test",
+    )
+
+    with patch(
+        "scripts.rust_migration.contracts.urllib.request.urlopen",
+        side_effect=ConnectionResetError("reset by peer"),
+    ):
+        result = _run_http_check(check, "http://127.0.0.1:8420", {}, 0.1)
+
+    assert result.status == "failed"
+    assert "live server unavailable" in result.detail
+
+
 def test_post_checks_send_empty_json_body():
     check = ContractCheck(
         id="http.post",
@@ -137,6 +187,36 @@ def test_post_checks_send_empty_json_body():
     assert seen["data"] == b"{}"
     assert seen["content_type"] == "application/json"
     assert seen["url"].endswith("/sessions/abc123/kill")
+
+
+def test_cli_check_requires_all_expected_output_tokens():
+    check = ContractCheck(
+        id="cli.review",
+        surface="cli",
+        classification="retained",
+        target="python_and_rust",
+        safety="read_only",
+        command=("review", "--help"),
+        expected_exit=(0,),
+        expected_output_contains_all=("--base", "--pr"),
+        preconditions=("sm_cli",),
+        source="test",
+    )
+    completed = subprocess.CompletedProcess(
+        args=["sm", "review", "--help"],
+        returncode=0,
+        stdout="usage: sm review --base\n",
+        stderr="",
+    )
+
+    with patch(
+        "scripts.rust_migration.contracts.subprocess.run",
+        return_value=completed,
+    ):
+        result = _run_cli_check(check, "sm", 1.0)
+
+    assert result.status == "failed"
+    assert "--pr" in result.detail
 
 
 def test_line_mode_http_check_reads_one_streaming_line():


### PR DESCRIPTION
Fixes #775
Refs #762

## Summary
- add `expected_output_contains_all` to the Rust migration contract harness for stronger CLI help contracts
- add retained fixtures for `sm review --help` and durable `sm request-codex-review --help`
- make connection resets from live HTTP checks report as failed contract results instead of crashing the runner
- clarify Stage 5 cutover scope that `review` and `request-codex-review` are retained core CLI surfaces

## Verification
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py -q
- ./venv/bin/python -m scripts.rust_migration.contracts --target python --check-id cli.review_help --check-id cli.request_codex_review_help --json
- ./venv/bin/python -m py_compile scripts/rust_migration/contracts.py tests/unit/test_rust_migration_contracts.py
- ./venv/bin/python -m json.tool scripts/rust_migration/contracts_manifest.json >/tmp/contracts_manifest.pretty
- git diff --check