### PR TITLE
Capture minimal Rust value baseline

### DIFF
--- a/scripts/rust_migration/README.md
+++ b/scripts/rust_migration/README.md
@@ -2,7 +2,7 @@
 
 These scripts are implementation artifacts for issue #762. They do not reopen
 the migration spec; they turn the converged spec artifacts into executable
-checks and measurable Python baselines.
+checks and minimal value-gate baselines.
 
 ## Contract Harness
 
@@ -58,12 +58,35 @@ that the Python server uses.
 
 ## Baseline Runner
 
-Run a safe local baseline:
+Run a safe local Python baseline:
 
 ```bash
-python -m scripts.rust_migration.baseline --base-url http://127.0.0.1:8420 --repetitions 5 --output /tmp/sm-python-baseline.json
+python -m scripts.rust_migration.baseline \
+  --target python \
+  --base-url http://127.0.0.1:8420 \
+  --repetitions 5 \
+  --output /tmp/sm-python-baseline.json
+```
+
+Run the comparable Rust scaffold subset while `sm-server` is listening:
+
+```bash
+python -m scripts.rust_migration.baseline \
+  --target rust \
+  --base-url http://127.0.0.1:8421 \
+  --check-id http.health \
+  --check-id http.health_detailed \
+  --check-id http.auth_session \
+  --check-id http.client_bootstrap \
+  --check-id http.sessions \
+  --check-id http.client_sessions \
+  --check-id http.api_sessions_absent \
+  --repetitions 5 \
+  --output /tmp/sm-rust-baseline.json
 ```
 
 The report records numeric data where it is safe to measure and marks missing
-instrumentation or unsafe workloads explicitly. Do not commit machine-local
-baseline reports if they contain host-specific or private runtime details.
+instrumentation or unsafe workloads explicitly. Python hardening/config variants
+are owner-waived for the cutover value gate; compare current Python against the
+Rust scaffold/prototype instead. Do not commit machine-local baseline reports if
+they contain host-specific or private runtime details.

--- a/scripts/rust_migration/baseline.py
+++ b/scripts/rust_migration/baseline.py
@@ -1,10 +1,11 @@
-"""Safe Python baseline runner for the Rust migration value gate."""
+"""Minimal baseline runner for the Rust migration value gate."""
 
 from __future__ import annotations
 
 import argparse
 import json
 import platform
+import re
 import statistics
 import subprocess
 import time
@@ -18,11 +19,13 @@ from .contracts import ContractManifest, run_checks
 
 def run_baseline(
     *,
+    target: str,
     base_url: str | None,
     sm_binary: str,
     repetitions: int,
     output: Path | None,
     server_pid: int | None,
+    check_ids: set[str] | None = None,
 ) -> dict[str, Any]:
     start = time.perf_counter()
     manifest = ContractManifest.load()
@@ -30,12 +33,12 @@ def run_baseline(
     for _ in range(repetitions):
         results = run_checks(
             manifest,
-            target="python",
+            target=target,
             base_url=base_url,
             sm_binary=sm_binary,
             session_id=None,
             fixtures={},
-            check_ids=None,
+            check_ids=check_ids,
             include_mutating=False,
         )
         runs.append([result.to_dict() for result in results])
@@ -43,48 +46,30 @@ def run_baseline(
     report = {
         "schema_version": 1,
         "generated_at": datetime.now(timezone.utc).isoformat(),
-        "target": "python",
+        "target": target,
         "host": {
             "system": platform.system(),
             "machine": platform.machine(),
             "python": platform.python_version(),
         },
         "inputs": {
+            "target": target,
             "base_url": base_url,
             "sm_binary": sm_binary,
             "repetitions": repetitions,
             "server_pid": server_pid,
+            "check_ids": sorted(check_ids) if check_ids else None,
         },
         "memory": _memory_snapshot(server_pid, base_url),
         "latency": _latency_summary(runs),
         "runs": runs,
-        "python_hardening_variants": [
-            {
-                "variant": "disable already-unused integrations by config",
-                "status": "not_measured",
-                "reason": "requires controlled config copy and restart rehearsal",
-            },
-            {
-                "variant": "reduce retained event/log scan windows where compatible",
-                "status": "not_measured",
-                "reason": "requires retained-state workload and compatibility fixture comparison",
-            },
-            {
-                "variant": "defer startup background work not needed for first response",
-                "status": "not_measured",
-                "reason": "requires startup harness and controlled service restart",
-            },
-            {
-                "variant": "remove retired surfaces while isolating optional retained integrations",
-                "status": "not_measured",
-                "reason": "requires feature-gated Python patch or Rust prototype comparison",
-            },
-            {
-                "variant": "reduce logging verbosity or request timing thresholds where compatible",
-                "status": "not_measured",
-                "reason": "requires log/telemetry compatibility comparison",
-            },
-        ],
+        "python_hardening_comparison": {
+            "status": "owner_waived",
+            "reason": (
+                "Owner requested a minimal current-Python versus Rust value baseline "
+                "and no throwaway Python hardening/config variant work."
+            ),
+        },
     }
     report["elapsed_seconds"] = round(time.perf_counter() - start, 3)
     if output:
@@ -159,7 +144,7 @@ def _memory_snapshot(server_pid: int | None, base_url: str | None) -> dict[str, 
             "reason": completed.stderr.strip() or "ps did not return RSS",
         }
     rss_kib = int(completed.stdout.strip().splitlines()[0])
-    return {
+    snapshot = {
         "status": "measured",
         "pid": server_pid,
         "rss_kib": rss_kib,
@@ -169,6 +154,56 @@ def _memory_snapshot(server_pid: int | None, base_url: str | None) -> dict[str, 
             "reason": "USS requires platform-specific tooling not used by the safe stdlib runner",
         },
     }
+    footprint = _darwin_physical_footprint(server_pid)
+    if footprint:
+        snapshot["physical_footprint"] = footprint
+    return snapshot
+
+
+def _darwin_physical_footprint(pid: int) -> dict[str, Any] | None:
+    if platform.system() != "Darwin":
+        return None
+    try:
+        completed = subprocess.run(
+            ["vmmap", "-summary", str(pid)],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        return {"status": "skipped", "reason": str(exc)}
+    if completed.returncode != 0:
+        return {
+            "status": "skipped",
+            "reason": completed.stderr.strip() or "vmmap did not return a summary",
+        }
+    for line in completed.stdout.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("Physical footprint:"):
+            raw_value = stripped.split(":", 1)[1].strip()
+            return {
+                "status": "measured",
+                "raw": raw_value,
+                "mib": _parse_memory_to_mib(raw_value),
+            }
+    return {"status": "skipped", "reason": "vmmap summary omitted physical footprint"}
+
+
+def _parse_memory_to_mib(raw_value: str) -> float | None:
+    match = re.match(r"^([0-9]+(?:\.[0-9]+)?)([KMG])$", raw_value.strip())
+    if not match:
+        return None
+    value = float(match.group(1))
+    unit = match.group(2)
+    if unit == "K":
+        return round(value / 1024, 3)
+    if unit == "M":
+        return round(value, 3)
+    if unit == "G":
+        return round(value * 1024, 3)
+    return None
 
 
 def _port_from_base_url(base_url: str | None) -> int:
@@ -205,10 +240,17 @@ def _discover_server_pid(port: int) -> int | None:
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--target", choices=["python", "rust"], default="python")
     parser.add_argument("--base-url", default="http://127.0.0.1:8420")
     parser.add_argument("--sm-binary", default="sm")
     parser.add_argument("--repetitions", type=int, default=5)
     parser.add_argument("--server-pid", type=int, default=None)
+    parser.add_argument(
+        "--check-id",
+        action="append",
+        default=[],
+        help="Run only the named check; repeat for multiple checks",
+    )
     parser.add_argument("--output", type=Path, default=None)
     return parser
 
@@ -216,11 +258,13 @@ def _build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
     report = run_baseline(
+        target=args.target,
         base_url=args.base_url,
         sm_binary=args.sm_binary,
         repetitions=args.repetitions,
         output=args.output,
         server_pid=args.server_pid,
+        check_ids=set(args.check_id) if args.check_id else None,
     )
     print(json.dumps(report, indent=2, sort_keys=True))
     return 1 if report["latency"]["failed"] else 0

--- a/scripts/rust_migration/baseline.py
+++ b/scripts/rust_migration/baseline.py
@@ -241,7 +241,11 @@ def _discover_server_pid(port: int) -> int | None:
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--target", choices=["python", "rust"], default="python")
-    parser.add_argument("--base-url", default="http://127.0.0.1:8420")
+    parser.add_argument(
+        "--base-url",
+        default=None,
+        help="Server base URL; defaults to http://127.0.0.1:8420 for Python and is required for Rust",
+    )
     parser.add_argument("--sm-binary", default="sm")
     parser.add_argument("--repetitions", type=int, default=5)
     parser.add_argument("--server-pid", type=int, default=None)
@@ -255,11 +259,24 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _resolve_base_url(target: str, base_url: str | None) -> str:
+    if base_url:
+        return base_url
+    if target == "rust":
+        raise ValueError("--base-url is required when --target rust")
+    return "http://127.0.0.1:8420"
+
+
 def main(argv: list[str] | None = None) -> int:
-    args = _build_parser().parse_args(argv)
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        base_url = _resolve_base_url(args.target, args.base_url)
+    except ValueError as exc:
+        parser.error(str(exc))
     report = run_baseline(
         target=args.target,
-        base_url=args.base_url,
+        base_url=base_url,
         sm_binary=args.sm_binary,
         repetitions=args.repetitions,
         output=args.output,

--- a/specs/762_baselines/2026-06-07_minimal_value_baseline.md
+++ b/specs/762_baselines/2026-06-07_minimal_value_baseline.md
@@ -1,0 +1,110 @@
+# Minimal Value Baseline - 2026-06-07
+
+Issue: #779
+
+This is a minimal Rust migration value-gate baseline. It follows the owner
+direction to avoid throwaway Python hardening/config variant work. The comparison
+is current Python as operated versus the existing Rust read-only scaffold.
+
+Raw machine-local JSON was written under `/tmp` and was not committed.
+
+## Commands
+
+Current Python attempt:
+
+```bash
+./venv/bin/python -m scripts.rust_migration.baseline \
+  --target python \
+  --base-url http://127.0.0.1:8420 \
+  --repetitions 5 \
+  --output /tmp/sm-python-min-baseline.json
+```
+
+Rust scaffold:
+
+```bash
+cargo run -p sm-server -- --port 8421 --config config.yaml
+
+./venv/bin/python -m scripts.rust_migration.baseline \
+  --target rust \
+  --base-url http://127.0.0.1:8421 \
+  --check-id http.health \
+  --check-id http.health_detailed \
+  --check-id http.auth_session \
+  --check-id http.client_bootstrap \
+  --check-id http.sessions \
+  --check-id http.client_sessions \
+  --check-id http.api_sessions_absent \
+  --repetitions 5 \
+  --output /tmp/sm-rust-min-baseline.json
+```
+
+## Python Hardening Waiver
+
+Python hardening/config variant comparison is owner-waived for this cutover.
+Python hardening is treated as throwaway work and should not block Rust migration
+baseline or implementation tickets unless the owner later reopens that decision.
+
+## Current Python Result
+
+The live Python service did not complete the safe HTTP baseline. During the run,
+the service stopped listening on `127.0.0.1:8420`; the baseline reported
+connection-refused failures for 16 HTTP checks and 6 fixture-dependent skips.
+CLI help checks still passed because they do not require the server.
+
+Relevant daemon log evidence:
+
+```text
+2026-06-07 14:24:38,333 - __main__ - WARNING - Event loop did not respond within 10s
+2026-06-07 14:24:38,334 - __main__ - ERROR - Event loop is frozen! Killing process for restart...
+```
+
+After launchd restarted the service, startup/restore work continued for minutes
+and the daemon was still not listening on port 8420 when rechecked.
+
+This means the current Python service is unstable under the retained real-state
+environment used for the baseline attempt. The last successful committed safe
+Python reference remains
+`specs/762_baselines/2026-06-06_python_safe_baseline.md`, where the Python
+service measured approximately 200.7 MiB RSS and completed 25 safe checks with
+0 failures.
+
+## Rust Scaffold Result
+
+The Rust read-only scaffold completed the comparable implemented subset with
+0 failures and 0 skips.
+
+| Metric | Value |
+| --- | ---: |
+| Server PID | 65861 |
+| RSS | 8.062 MiB |
+| macOS physical footprint | 3.969 MiB |
+| USS | unknown; not available from stdlib-safe runner |
+| Elapsed baseline run | 0.599s |
+
+Latency summary:
+
+| Check | Count | Median ms | P95 ms | Max ms |
+| --- | ---: | ---: | ---: | ---: |
+| `http.health` | 5 | 0.248 | 8.500 | 10.563 |
+| `http.health_detailed` | 5 | 0.253 | 0.447 | 0.481 |
+| `http.auth_session` | 5 | 0.274 | 0.317 | 0.322 |
+| `http.client_bootstrap` | 5 | 0.287 | 0.304 | 0.306 |
+| `http.sessions` | 5 | 4.273 | 4.279 | 4.280 |
+| `http.client_sessions` | 5 | 4.439 | 4.554 | 4.575 |
+| `http.api_sessions_absent` | 5 | 0.274 | 0.302 | 0.304 |
+
+## Interpretation
+
+This is not a full replacement benchmark; the Rust server is still a read-only
+scaffold. It is enough to justify continuing the Rust port:
+
+- The scaffold is far smaller than the last successful Python RSS reference.
+- The scaffold passes the implemented retained read-only subset.
+- The current Python daemon showed event-loop watchdog restarts during the
+  value-gate attempt, which strengthens the responsiveness/reliability case for
+  moving the retained core out of the current Python runtime.
+
+Do not spend Rust migration time on Python hardening variants. The next useful
+work is more executable contract capture for retained high-priority surfaces,
+especially native mobile/auth/public-edge proof and session lifecycle behavior.

--- a/specs/762_stage5_artifacts/gate_matrix.md
+++ b/specs/762_stage5_artifacts/gate_matrix.md
@@ -6,7 +6,7 @@ Status: converged after three sequential independent reviewer convergence signal
 
 | Gate | Required Evidence | Blocks |
 | --- | --- | --- |
-| value/falsifiability | Python baseline, Rust spike or prototype comparison, and comparison against feasible Python hardening. | Filing runtime replacement tickets. |
+| value/falsifiability | Current Python baseline, Rust spike or prototype comparison, and recorded owner waiver for Python hardening/config variants. | Filing runtime replacement tickets. |
 | contract capture | Retained Stage 2 route/CLI/protocol/schema/client/config/persistence artifacts converted into executable tests against Python; removed surfaces from `cutover_scope.md` converted into retirement/absence tests. | Any Rust route/CLI/protocol implementation claiming compatibility. |
 | internal behavior | Stage 3 ordered recovery and state-transition fixtures pass against Python. | Rust ownership of queue, sessions, tmux, mobile attach, provider events, and external delivery. |
 | threat controls | Stage 4 threat register and secret matrix have tests for auth, route-local secrets, abuse cases, no-secret logging, retained email/GitHub integrations, and Telegram retirement/absence. | Public exposure, mobile terminal, hooks, node agents, queue runner, app upload, retained email/GitHub integrations, and retired Telegram denial/absence fixtures. |
@@ -35,7 +35,7 @@ Baseline measurements must use retained real state where safe plus fixture workl
 - app artifact metadata/latest/hash serving and upload validation.
 - local/auth/proofed watch diagnostics, SSE `/events`, `/events/state`, and denial of public unauthenticated operational watch data.
 
-Feasible Python hardening/config comparisons must include measured or explicitly ruled-out variants for:
+Python hardening/config variant comparisons are owner-waived for the Rust cutover value gate. Do not spend implementation time on throwaway Python-hardening branches unless the owner explicitly reopens that decision. The baseline artifact should record this waiver instead of measuring:
 
 - disabling integrations that are already disabled or unused in the current config.
 - reducing retained event/log scan windows where compatible.
@@ -47,7 +47,7 @@ Feasible Python hardening/config comparisons must include measured or explicitly
 
 These are acceptance targets for the first replacement release:
 
-- Memory: Rust loaded median RSS and USS must be at least 25% lower than the best measured Python-compatible baseline, or at least 100 MiB RSS and 75 MiB USS lower when those absolute thresholds are smaller. Rust idle median RSS and USS must be at least 15% lower, or at least 50 MiB lower when that absolute threshold is smaller. No first-class workload may use more than 5% higher RSS/USS than the Python-compatible baseline without an approved mitigation.
+- Memory: Rust loaded median RSS and USS must be at least 25% lower than the current Python baseline, or at least 100 MiB RSS and 75 MiB USS lower when those absolute thresholds are smaller. Rust idle median RSS and USS must be at least 15% lower, or at least 50 MiB lower when that absolute threshold is smaller. No first-class workload may use more than 5% higher RSS/USS than the Python baseline without an approved mitigation.
 - Latency: p95 latency for first-class mobile attach/auth/bootstrap, hook ingestion, queue wake delivery, and session-control APIs must be no worse than Python by more than 10% unless an explicit mitigation is approved.
 - Startup/recovery: Rust restore/recovery must be no slower than Python by more than 10% for retained state, and must not change recovery ordering contracts.
 - Reliability: contract fixtures must pass with zero known compatibility regressions for first-class mobile, CLI/operator, queue, hooks, session lifecycle, and persistence surfaces.

--- a/specs/762_stage5_artifacts/rollout_plan.md
+++ b/specs/762_stage5_artifacts/rollout_plan.md
@@ -18,7 +18,7 @@ The initial shipping shape should be:
 
 ## Falsifiable Decision Gate
 
-Before implementation tickets that replace runtime ownership are filed, capture current Python baselines for:
+Before implementation tickets that replace runtime ownership are filed, capture a minimal current-Python baseline for:
 
 - idle and loaded RSS/USS memory measured as median and max over three runs.
 - startup and restore time with retained real state.
@@ -26,16 +26,16 @@ Before implementation tickets that replace runtime ownership are filed, capture 
 - retained 30-day usage for commands/endpoints/surfaces from the Stage 2 telemetry report.
 - error and slow-request rates from retained logs.
 
-The baseline artifact must include the same retained-state workload for current Python, feasible Python hardening/config variants, and Rust spike/prototype runs. At minimum, feasible Python alternatives must either be measured or explicitly ruled out: disabling unused integrations by config, reducing retained log/event scan windows, tightening startup background tasks, lowering uvicorn/logging overhead where compatible, and isolating retired Telegram plus retained-but-optional email/node/queue-runner/mobile-terminal work when disabled.
+The baseline artifact must compare the current Python service against a Rust spike/prototype on the same safe retained-state workload. The owner has explicitly waived Python hardening/config variant measurement for this cutover: Python hardening is throwaway work and should not block or consume Rust migration effort. Record the waiver in the baseline artifact instead of measuring variant branches.
 
 The Rust migration should pause or narrow if:
 
-- a Rust spike cannot show at least 25% lower median loaded RSS and USS than the best measured Python-compatible baseline, or at least 100 MiB RSS and 75 MiB USS absolute loaded improvement when that is the smaller threshold. Idle memory should be at least 15% lower or 50 MiB RSS/USS lower when that is the smaller threshold. No first-class workload may use more than 5% higher memory than the Python-compatible baseline without a documented mitigation.
+- a Rust spike cannot show at least 25% lower median loaded RSS and USS than the current Python baseline, or at least 100 MiB RSS and 75 MiB USS absolute loaded improvement when that is the smaller threshold. Idle memory should be at least 15% lower or 50 MiB RSS/USS lower when that absolute threshold is smaller. No first-class workload may use more than 5% higher memory than the Python baseline without a documented mitigation.
 - critical mobile attach, hook, queue, or session-control paths are slower than Python without a documented mitigation.
 - compatibility or state-migration cost exceeds the value of the rewrite for first-class surfaces.
 - rollback cannot be rehearsed from copied real state.
 
-The comparison is against current Python plus feasible Python hardening/config changes, not against an unmaintained strawman.
+The comparison is against current Python as operated for retained workflows. Do not file Python hardening work as part of the Rust value gate unless the owner later reopens that decision.
 
 ## Cutover Sequence
 

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from scripts.rust_migration.baseline import (
     _parse_memory_to_mib,
     _port_from_base_url,
+    _resolve_base_url,
     run_baseline,
 )
 from scripts.rust_migration.contracts import (
@@ -351,6 +352,17 @@ def test_baseline_memory_discovery_uses_selected_base_url_port():
     assert _port_from_base_url("http://127.0.0.1") == 80
     assert _port_from_base_url("https://sm.example.test") == 443
     assert _port_from_base_url(None) == 8420
+
+
+def test_rust_baseline_requires_explicit_base_url():
+    assert _resolve_base_url("python", None) == "http://127.0.0.1:8420"
+    assert _resolve_base_url("rust", "http://127.0.0.1:8421") == "http://127.0.0.1:8421"
+    try:
+        _resolve_base_url("rust", None)
+    except ValueError as exc:
+        assert "--base-url" in str(exc)
+    else:
+        raise AssertionError("expected ValueError")
 
 
 def test_memory_unit_parser_handles_vmmap_units():

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -2,7 +2,11 @@ import subprocess
 import urllib.error
 from unittest.mock import patch
 
-from scripts.rust_migration.baseline import _port_from_base_url
+from scripts.rust_migration.baseline import (
+    _parse_memory_to_mib,
+    _port_from_base_url,
+    run_baseline,
+)
 from scripts.rust_migration.contracts import (
     ContractCheck,
     ContractManifest,
@@ -347,6 +351,31 @@ def test_baseline_memory_discovery_uses_selected_base_url_port():
     assert _port_from_base_url("http://127.0.0.1") == 80
     assert _port_from_base_url("https://sm.example.test") == 443
     assert _port_from_base_url(None) == 8420
+
+
+def test_memory_unit_parser_handles_vmmap_units():
+    assert _parse_memory_to_mib("512K") == 0.5
+    assert _parse_memory_to_mib("87.3M") == 87.3
+    assert _parse_memory_to_mib("1.5G") == 1536.0
+    assert _parse_memory_to_mib("unknown") is None
+
+
+def test_baseline_runner_records_owner_waived_hardening_and_target():
+    report = run_baseline(
+        target="rust",
+        base_url=None,
+        sm_binary="sm",
+        repetitions=1,
+        output=None,
+        server_pid=None,
+        check_ids={"http.health"},
+    )
+
+    assert report["target"] == "rust"
+    assert report["inputs"]["target"] == "rust"
+    assert report["inputs"]["check_ids"] == ["http.health"]
+    assert report["python_hardening_comparison"]["status"] == "owner_waived"
+    assert report["latency"]["skipped"]["http.health"] == "live server URL not supplied"
 
 
 def test_template_rendering_replaces_nested_fixture_values():


### PR DESCRIPTION
Fixes #779
Refs #762

## Summary
- narrow the value-gate docs to current Python vs Rust scaffold, with Python hardening/config variants explicitly owner-waived
- extend the baseline runner with `--target`, `--check-id`, and macOS physical-footprint capture
- add a minimal value baseline artifact comparing the existing Rust scaffold and the current Python service attempt
- document that the Python daemon froze and stopped listening during the safe baseline attempt

## Verification
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py -q
- ./venv/bin/python -m py_compile scripts/rust_migration/baseline.py scripts/rust_migration/contracts.py tests/unit/test_rust_migration_contracts.py
- cargo test -p sm-server
- ./venv/bin/python -m scripts.rust_migration.baseline --target python --base-url http://127.0.0.1:8420 --repetitions 1 --check-id http.health --check-id http.auth_session --output /tmp/sm-python-baseline-smoke.json
- ./venv/bin/python -m scripts.rust_migration.baseline --target rust --base-url http://127.0.0.1:8421 --check-id http.health --check-id http.health_detailed --check-id http.auth_session --check-id http.client_bootstrap --check-id http.sessions --check-id http.client_sessions --check-id http.api_sessions_absent --repetitions 5 --output /tmp/sm-rust-min-baseline.json
- git diff --check

## Notes
The full current-Python baseline attempt failed because the running Python daemon froze and stopped listening on port 8420. The new artifact records this as a value-gate observation instead of spending time on Python hardening.
