### PR TITLE
Expand Rust migration contract assertions

### DIFF
--- a/scripts/rust_migration/README.md
+++ b/scripts/rust_migration/README.md
@@ -17,6 +17,13 @@ credentials, or mutating opt-in are reported as skipped when their preconditions
 are not supplied. Retired surfaces are Rust-target checks; current Python may
 still expose them during the migration window.
 
+HTTP checks can assert more than status codes. Manifest rows may include:
+
+- `request_headers` for host/proof/auth-boundary fixtures.
+- `expected_body_contains_any` / `expected_body_contains_all` for text or SSE frames.
+- `expected_json` JSON-pointer assertions with `type`, `equals`, `contains`, or
+  `absent` checks for response-shape contracts.
+
 Fixture values are supplied explicitly:
 
 ```bash
@@ -49,7 +56,23 @@ python -m scripts.rust_migration.contracts \
   --check-id http.client_bootstrap \
   --check-id http.sessions \
   --check-id http.client_sessions \
-  --check-id http.api_sessions_absent
+  --check-id http.api_sessions_absent \
+  --check-id http.public_watch_operational_data_denied \
+  --check-id http.scheduler_remind_retired \
+  --check-id http.job_watches_retired \
+  --check-id http.queue_policy_runs_retired
+```
+
+Summary-route retirement must be checked with a real fixture session. The
+harness first verifies `GET /sessions/{session_id}` returns 200 so a stale
+fixture or resource-level 404 cannot masquerade as route retirement:
+
+```bash
+python -m scripts.rust_migration.contracts \
+  --target rust \
+  --base-url http://127.0.0.1:8421 \
+  --session-id <fixture-session-id> \
+  --check-id http.summary_provider_route_retired
 ```
 
 Omit `--config` to load `config.yaml`; the Rust scaffold also applies the same

--- a/scripts/rust_migration/contracts.py
+++ b/scripts/rust_migration/contracts.py
@@ -25,6 +25,29 @@ DEFAULT_TIMEOUT_SECONDS = 5.0
 
 
 @dataclass(frozen=True)
+class JsonExpectation:
+    path: str
+    value_type: str | None = None
+    equals: Any = None
+    has_equals: bool = False
+    one_of: tuple[Any, ...] = ()
+    contains: str | None = None
+    absent: bool = False
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, Any]) -> "JsonExpectation":
+        return cls(
+            path=str(raw["path"]),
+            value_type=raw.get("type"),
+            equals=raw.get("equals"),
+            has_equals="equals" in raw,
+            one_of=tuple(raw.get("one_of", [])),
+            contains=raw.get("contains"),
+            absent=bool(raw.get("absent", False)),
+        )
+
+
+@dataclass(frozen=True)
 class ContractCheck:
     id: str
     surface: str
@@ -40,10 +63,13 @@ class ContractCheck:
     expected_exit: tuple[int, ...] = ()
     expected_output_contains_any: tuple[str, ...] = ()
     expected_output_contains_all: tuple[str, ...] = ()
+    request_headers: tuple[tuple[str, str], ...] = ()
     body: Any = None
     read_mode: str = "bytes"
-    read_bytes: int = 1024
+    read_bytes: int = 65536
     expected_body_contains_any: tuple[str, ...] = ()
+    expected_body_contains_all: tuple[str, ...] = ()
+    expected_json: tuple[JsonExpectation, ...] = ()
 
     @classmethod
     def from_dict(cls, raw: dict[str, Any]) -> "ContractCheck":
@@ -66,11 +92,21 @@ class ContractCheck:
             expected_output_contains_all=tuple(
                 str(v) for v in raw.get("expected_output_contains_all", [])
             ),
+            request_headers=tuple(
+                (str(key), str(value))
+                for key, value in raw.get("request_headers", {}).items()
+            ),
             body=raw.get("body"),
             read_mode=str(raw.get("read_mode", "bytes")),
-            read_bytes=int(raw.get("read_bytes", 1024)),
+            read_bytes=int(raw.get("read_bytes", 65536)),
             expected_body_contains_any=tuple(
                 str(v) for v in raw.get("expected_body_contains_any", [])
+            ),
+            expected_body_contains_all=tuple(
+                str(v) for v in raw.get("expected_body_contains_all", [])
+            ),
+            expected_json=tuple(
+                JsonExpectation.from_dict(item) for item in raw.get("expected_json", [])
             ),
         )
 
@@ -170,6 +206,15 @@ def run_checks(
         if skip_reason:
             results.append(_result(check, "skipped", None, skip_reason))
             continue
+        precondition_failure = _precondition_failure(
+            check,
+            base_url=base_url,
+            fixtures=fixture_values,
+            timeout_seconds=timeout_seconds,
+        )
+        if precondition_failure:
+            results.append(_result(check, "failed", None, precondition_failure))
+            continue
 
         if check.surface == "http":
             results.append(_run_http_check(check, base_url or "", fixture_values, timeout_seconds))
@@ -211,6 +256,32 @@ def _skip_reason(
     return None
 
 
+def _precondition_failure(
+    check: ContractCheck,
+    *,
+    base_url: str | None,
+    fixtures: dict[str, str],
+    timeout_seconds: float,
+) -> str | None:
+    if "existing_session" not in check.preconditions:
+        return None
+    assert base_url is not None
+    session_id = fixtures["session_id"]
+    url = base_url.rstrip("/") + f"/sessions/{session_id}"
+    request = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            status = response.status
+            response.read(1)
+    except urllib.error.HTTPError as exc:
+        status = exc.code
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        return f"session fixture precondition failed: live server unavailable: {exc}"
+    if status == 200:
+        return None
+    return f"session fixture precondition failed: GET /sessions/{{session_id}} returned HTTP {status}"
+
+
 def _run_http_check(
     check: ContractCheck, base_url: str, fixtures: dict[str, str], timeout_seconds: float
 ) -> CheckResult:
@@ -219,7 +290,9 @@ def _run_http_check(
     url = base_url.rstrip("/") + path
     start = time.perf_counter()
     data = None
-    headers = {}
+    headers = {
+        name: str(_render_template(value, fixtures)) for name, value in check.request_headers
+    }
     if check.method not in {"GET", "HEAD"}:
         body = {} if check.body is None else _render_template(check.body, fixtures)
         data = json.dumps(body).encode("utf-8")
@@ -236,18 +309,31 @@ def _run_http_check(
     except (urllib.error.URLError, TimeoutError, OSError) as exc:
         return _result(check, "failed", _elapsed_ms(start), f"live server unavailable: {exc}")
 
-    body_ok = not check.expected_body_contains_any or any(
+    body_any_ok = not check.expected_body_contains_any or any(
         expected in body_text for expected in check.expected_body_contains_any
     )
-    if status in check.expected_status and body_ok:
+    missing_body_all = [
+        expected for expected in check.expected_body_contains_all if expected not in body_text
+    ]
+    json_error = _json_expectation_error(body_text, check.expected_json)
+    if status in check.expected_status and body_any_ok and not missing_body_all and not json_error:
         return _result(check, "passed", _elapsed_ms(start), f"HTTP {status}")
-    if not body_ok:
+    if not body_any_ok:
         return _result(
             check,
             "failed",
             _elapsed_ms(start),
             f"HTTP {status}; body missing one of {list(check.expected_body_contains_any)}",
         )
+    if missing_body_all:
+        return _result(
+            check,
+            "failed",
+            _elapsed_ms(start),
+            f"HTTP {status}; body missing required content {missing_body_all}",
+        )
+    if json_error:
+        return _result(check, "failed", _elapsed_ms(start), f"HTTP {status}; {json_error}")
     return _result(
         check,
         "failed",
@@ -294,6 +380,102 @@ def _read_response_text(response: Any, check: ContractCheck) -> str:
     else:
         raw = response.read(check.read_bytes)
     return raw.decode("utf-8", errors="replace")
+
+
+_MISSING = object()
+
+
+def _json_expectation_error(body_text: str, expectations: tuple[JsonExpectation, ...]) -> str | None:
+    if not expectations:
+        return None
+    try:
+        payload = json.loads(body_text)
+    except json.JSONDecodeError as exc:
+        return f"response is not valid JSON: {exc}"
+
+    for expectation in expectations:
+        value = _json_pointer(payload, expectation.path)
+        if expectation.absent:
+            if value is _MISSING:
+                continue
+            return f"JSON {expectation.path} expected absent, got {_json_summary(value)}"
+        if value is _MISSING:
+            return f"JSON {expectation.path} is missing"
+        if expectation.value_type and not _json_type_matches(value, expectation.value_type):
+            return (
+                f"JSON {expectation.path} expected type {expectation.value_type}, "
+                f"got {_json_type_name(value)}"
+            )
+        if expectation.has_equals and value != expectation.equals:
+            return (
+                f"JSON {expectation.path} expected {expectation.equals!r}, "
+                f"got {value!r}"
+            )
+        if expectation.one_of and value not in expectation.one_of:
+            return (
+                f"JSON {expectation.path} expected one of {list(expectation.one_of)!r}, "
+                f"got {value!r}"
+            )
+        if expectation.contains is not None:
+            if isinstance(value, str):
+                if expectation.contains not in value:
+                    return f"JSON {expectation.path} missing substring {expectation.contains!r}"
+            elif isinstance(value, list):
+                if expectation.contains not in value:
+                    return f"JSON {expectation.path} missing list item {expectation.contains!r}"
+            else:
+                return f"JSON {expectation.path} cannot be checked with contains"
+    return None
+
+
+def _json_pointer(payload: Any, pointer: str) -> Any:
+    if pointer == "":
+        return payload
+    if not pointer.startswith("/"):
+        raise ValueError(f"JSON expectation path must be a JSON pointer: {pointer}")
+    current = payload
+    for raw_part in pointer.lstrip("/").split("/"):
+        part = raw_part.replace("~1", "/").replace("~0", "~")
+        if isinstance(current, dict):
+            if part not in current:
+                return _MISSING
+            current = current[part]
+        elif isinstance(current, list):
+            if not part.isdigit():
+                return _MISSING
+            index = int(part)
+            if index >= len(current):
+                return _MISSING
+            current = current[index]
+        else:
+            return _MISSING
+    return current
+
+
+def _json_type_matches(value: Any, expected_type: str) -> bool:
+    return _json_type_name(value) == expected_type
+
+
+def _json_type_name(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, dict):
+        return "object"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, (int, float)):
+        return "number"
+    return type(value).__name__
+
+
+def _json_summary(value: Any) -> str:
+    if isinstance(value, (dict, list)):
+        return _json_type_name(value)
+    return repr(value)
 
 
 _TEMPLATE_PATTERN = re.compile(r"\{([A-Za-z_][A-Za-z0-9_]*)\}")

--- a/scripts/rust_migration/contracts_manifest.json
+++ b/scripts/rust_migration/contracts_manifest.json
@@ -17,6 +17,9 @@
       "method": "GET",
       "path": "/health",
       "expected_status": [200],
+      "expected_json": [
+        {"path": "/status", "equals": "healthy"}
+      ],
       "preconditions": ["live_server"],
       "source": "specs/762_stage5_artifacts/gate_matrix.md:62"
     },
@@ -29,6 +32,12 @@
       "method": "GET",
       "path": "/health/detailed",
       "expected_status": [200],
+      "expected_json": [
+        {"path": "/status", "one_of": ["healthy", "degraded", "unhealthy"]},
+        {"path": "/checks", "type": "object"},
+        {"path": "/resources", "type": "object"},
+        {"path": "/timestamp", "type": "string"}
+      ],
       "preconditions": ["live_server"],
       "source": "specs/762_stage5_artifacts/gate_matrix.md:62"
     },
@@ -41,6 +50,11 @@
       "method": "GET",
       "path": "/auth/session",
       "expected_status": [200],
+      "expected_json": [
+        {"path": "/enabled", "type": "boolean"},
+        {"path": "/authenticated", "type": "boolean"},
+        {"path": "/bypass", "type": "boolean"}
+      ],
       "preconditions": ["live_server"],
       "source": "specs/762_stage5_artifacts/gate_matrix.md:63"
     },
@@ -53,6 +67,15 @@
       "method": "GET",
       "path": "/client/bootstrap",
       "expected_status": [200],
+      "expected_json": [
+        {"path": "/auth", "type": "object"},
+        {"path": "/auth/session_endpoint", "equals": "/auth/session"},
+        {"path": "/auth/device_auth_endpoint", "equals": "/auth/device/google"},
+        {"path": "/external_access", "type": "object"},
+        {"path": "/external_access/mobile_terminal_supported", "type": "boolean"},
+        {"path": "/session_open_defaults", "type": "object"},
+        {"path": "/session_open_defaults/preferred_action", "type": "string"}
+      ],
       "preconditions": ["live_server"],
       "source": "specs/762_stage5_artifacts/gate_matrix.md:64"
     },
@@ -65,6 +88,9 @@
       "method": "GET",
       "path": "/client/sessions",
       "expected_status": [200],
+      "expected_json": [
+        {"path": "/sessions", "type": "array"}
+      ],
       "preconditions": ["live_server"],
       "source": "specs/762_stage5_artifacts/gate_matrix.md:64"
     },
@@ -77,6 +103,9 @@
       "method": "GET",
       "path": "/sessions",
       "expected_status": [200],
+      "expected_json": [
+        {"path": "/sessions", "type": "array"}
+      ],
       "preconditions": ["live_server"],
       "source": "specs/762_stage5_artifacts/gate_matrix.md:69"
     },
@@ -89,6 +118,9 @@
       "method": "GET",
       "path": "/events/state",
       "expected_status": [200],
+      "expected_json": [
+        {"path": "", "type": "object"}
+      ],
       "preconditions": ["live_server"],
       "source": "specs/762_stage5_artifacts/gate_matrix.md:71"
     },
@@ -104,6 +136,7 @@
       "read_mode": "line",
       "read_bytes": 128,
       "expected_body_contains_any": ["event: hello"],
+      "expected_body_contains_all": ["event: hello"],
       "preconditions": ["live_server"],
       "source": "specs/762_stage5_artifacts/gate_matrix.md:71"
     },
@@ -128,6 +161,9 @@
       "method": "GET",
       "path": "/nodes",
       "expected_status": [200],
+      "expected_json": [
+        {"path": "/nodes", "type": "array"}
+      ],
       "preconditions": ["live_server"],
       "source": "specs/762_stage5_artifacts/gate_matrix.md:73"
     },
@@ -140,6 +176,9 @@
       "method": "GET",
       "path": "/queue-jobs",
       "expected_status": [200],
+      "expected_json": [
+        {"path": "/jobs", "type": "array"}
+      ],
       "preconditions": ["live_server"],
       "source": "specs/762_stage5_artifacts/gate_matrix.md:72"
     },
@@ -152,6 +191,9 @@
       "method": "GET",
       "path": "/codex-review-requests",
       "expected_status": [200],
+      "expected_json": [
+        {"path": "/requests", "type": "array"}
+      ],
       "preconditions": ["live_server"],
       "source": "specs/762_stage5_artifacts/gate_matrix.md:72"
     },
@@ -164,8 +206,76 @@
       "method": "GET",
       "path": "/api/sessions",
       "expected_status": [404],
+      "expected_json": [
+        {"path": "/detail", "type": "string"}
+      ],
       "preconditions": ["live_server"],
       "source": "specs/762_stage2_artifacts/external_client_manifest.md:42"
+    },
+    {
+      "id": "http.public_watch_operational_data_denied",
+      "surface": "http",
+      "classification": "retired",
+      "target": "rust_only",
+      "safety": "read_only",
+      "method": "GET",
+      "path": "/watch",
+      "request_headers": {"Host": "sm.example.com"},
+      "expected_status": [401, 403, 404],
+      "preconditions": ["live_server"],
+      "source": "specs/762_stage5_artifacts/cutover_scope.md:58"
+    },
+    {
+      "id": "http.summary_provider_route_retired",
+      "surface": "http",
+      "classification": "retired",
+      "target": "rust_only",
+      "safety": "read_only",
+      "method": "GET",
+      "path": "/sessions/{session_id}/summary",
+      "expected_status": [404, 410],
+      "expected_json": [
+        {"path": "/detail", "type": "string"}
+      ],
+      "preconditions": ["live_server", "session_id", "existing_session"],
+      "source": "specs/762_stage5_artifacts/cutover_scope.md:62"
+    },
+    {
+      "id": "http.scheduler_remind_retired",
+      "surface": "http",
+      "classification": "retired",
+      "target": "rust_only",
+      "safety": "read_only",
+      "method": "POST",
+      "path": "/scheduler/remind",
+      "body": {},
+      "expected_status": [404, 410],
+      "preconditions": ["live_server"],
+      "source": "specs/762_stage5_artifacts/cutover_scope.md:60"
+    },
+    {
+      "id": "http.job_watches_retired",
+      "surface": "http",
+      "classification": "retired",
+      "target": "rust_only",
+      "safety": "read_only",
+      "method": "GET",
+      "path": "/job-watches",
+      "expected_status": [404, 410],
+      "preconditions": ["live_server"],
+      "source": "specs/762_stage5_artifacts/cutover_scope.md:59"
+    },
+    {
+      "id": "http.queue_policy_runs_retired",
+      "surface": "http",
+      "classification": "retired",
+      "target": "rust_only",
+      "safety": "read_only",
+      "method": "GET",
+      "path": "/queue-policy-runs",
+      "expected_status": [404, 410],
+      "preconditions": ["live_server"],
+      "source": "specs/762_stage5_artifacts/cutover_scope.md:61"
     },
     {
       "id": "http.email_inbound_validation_failure",

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -11,6 +11,8 @@ from scripts.rust_migration.baseline import (
 from scripts.rust_migration.contracts import (
     ContractCheck,
     ContractManifest,
+    JsonExpectation,
+    _json_expectation_error,
     _parse_fixtures,
     _run_cli_check,
     _run_http_check,
@@ -141,6 +143,42 @@ def test_manifest_covers_rust_only_retired_cli_surfaces():
         assert "removed" in check.expected_output_contains_any
 
 
+def test_manifest_covers_rust_only_retired_http_surfaces():
+    manifest = ContractManifest.load()
+    checks = {check.id: check for check in manifest.checks}
+    retired_ids = {
+        "http.public_watch_operational_data_denied",
+        "http.summary_provider_route_retired",
+        "http.scheduler_remind_retired",
+        "http.job_watches_retired",
+        "http.queue_policy_runs_retired",
+    }
+
+    missing = retired_ids - set(checks)
+    assert not missing
+    for check_id in retired_ids:
+        check = checks[check_id]
+        assert check.classification == "retired"
+        assert check.target == "rust_only"
+        assert 404 in check.expected_status
+    assert "session_id" in checks["http.summary_provider_route_retired"].preconditions
+
+
+def test_manifest_has_json_shape_assertions_for_core_http_surfaces():
+    manifest = ContractManifest.load()
+    checks = {check.id: check for check in manifest.checks}
+
+    assert checks["http.health"].expected_json
+    assert checks["http.health"].expected_json[0].path == "/status"
+    assert checks["http.health"].expected_json[0].equals == "healthy"
+    assert checks["http.client_bootstrap"].expected_json
+    assert any(
+        expectation.path == "/auth/device_auth_endpoint"
+        and expectation.equals == "/auth/device/google"
+        for expectation in checks["http.client_bootstrap"].expected_json
+    )
+
+
 def test_python_target_does_not_run_rust_only_retirement_checks():
     manifest = ContractManifest.load()
     selected = checks_for_target(manifest.checks, target="python", include_mutating=False)
@@ -150,6 +188,8 @@ def test_python_target_does_not_run_rust_only_retirement_checks():
     assert "cli.what_retired" not in ids
     assert "cli.telegram_alias_retired" not in ids
     assert "cli.codex_server_retired" not in ids
+    assert "http.public_watch_operational_data_denied" not in ids
+    assert "http.summary_provider_route_retired" not in ids
     assert "http.mobile_session_stop" in ids
     assert "http.api_sessions_absent" in ids
 
@@ -168,6 +208,32 @@ def test_mutating_checks_are_reported_as_skipped_without_opt_in():
 
     assert result_by_id["http.mobile_session_stop"].status == "skipped"
     assert result_by_id["http.mobile_session_stop"].detail
+
+
+def test_existing_session_precondition_fails_for_stale_session_fixture():
+    manifest = ContractManifest.load()
+    not_found = urllib.error.HTTPError(
+        url="http://127.0.0.1:8421/sessions/stale",
+        code=404,
+        msg="not found",
+        hdrs=None,
+        fp=None,
+    )
+
+    with patch("scripts.rust_migration.contracts.urllib.request.urlopen", side_effect=not_found):
+        results = run_checks(
+            manifest,
+            target="rust",
+            base_url="http://127.0.0.1:8421",
+            sm_binary="sm",
+            session_id="stale",
+            check_ids={"http.summary_provider_route_retired"},
+            include_mutating=False,
+        )
+
+    assert len(results) == 1
+    assert results[0].status == "failed"
+    assert "session fixture precondition failed" in results[0].detail
 
 
 def test_summary_counts_statuses():
@@ -274,6 +340,107 @@ def test_post_checks_send_empty_json_body():
     assert seen["data"] == b"{}"
     assert seen["content_type"] == "application/json"
     assert seen["url"].endswith("/sessions/abc123/kill")
+
+
+def test_http_check_renders_request_headers_and_checks_json():
+    check = ContractCheck(
+        id="http.header_json",
+        surface="http",
+        classification="retained",
+        target="python_and_rust",
+        safety="read_only",
+        method="GET",
+        path="/sessions",
+        expected_status=(200,),
+        request_headers=(("Host", "{public_host}"),),
+        expected_json=(
+            JsonExpectation(path="/sessions", value_type="array"),
+        ),
+        preconditions=("live_server",),
+        source="test",
+    )
+    seen = {}
+
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self, _size):
+            return b'{"sessions":[]}'
+
+    def fake_urlopen(request, timeout):
+        seen["host"] = request.headers.get("Host")
+        return FakeResponse()
+
+    with patch("scripts.rust_migration.contracts.urllib.request.urlopen", fake_urlopen):
+        result = _run_http_check(
+            check,
+            "http://127.0.0.1:8420",
+            {"public_host": "sm.example.com"},
+            1.0,
+        )
+
+    assert result.status == "passed"
+    assert seen["host"] == "sm.example.com"
+
+
+def test_http_check_reports_json_shape_mismatch():
+    check = ContractCheck(
+        id="http.json",
+        surface="http",
+        classification="retained",
+        target="python_and_rust",
+        safety="read_only",
+        method="GET",
+        path="/sessions",
+        expected_status=(200,),
+        expected_json=(
+            JsonExpectation(path="/sessions", value_type="array"),
+        ),
+        preconditions=("live_server",),
+        source="test",
+    )
+
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self, _size):
+            return b'{"sessions":{}}'
+
+    with patch(
+        "scripts.rust_migration.contracts.urllib.request.urlopen",
+        return_value=FakeResponse(),
+    ):
+        result = _run_http_check(check, "http://127.0.0.1:8420", {}, 1.0)
+
+    assert result.status == "failed"
+    assert "expected type array" in result.detail
+
+
+def test_json_expectations_support_absent_equals_and_contains():
+    expectations = (
+        JsonExpectation(path="/auth/session_endpoint", equals="/auth/session", has_equals=True),
+        JsonExpectation(path="/status", one_of=("healthy", "degraded", "unhealthy")),
+        JsonExpectation(path="/external_access/ssh_proxy_command", absent=True),
+        JsonExpectation(path="/values", contains="mobile"),
+    )
+    body = (
+        '{"auth":{"session_endpoint":"/auth/session"},"status":"degraded",'
+        '"external_access":{},"values":["mobile"]}'
+    )
+
+    assert _json_expectation_error(body, expectations) is None
 
 
 def test_cli_check_requires_all_expected_output_tokens():


### PR DESCRIPTION
## Summary\n- add JSON-pointer, body-all, and request-header assertions to the Rust migration contract harness\n- add response-shape checks for retained core HTTP surfaces\n- add Rust-only retirement fixtures for public watch data, summary provider route, reminders, job watches, and queue policy runs\n- document the new manifest assertion fields and Rust scaffold check set\n\nFixes #781\n\n## Verification\n- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py\n- cargo test -p sm-server\n- ./venv/bin/python -m json.tool scripts/rust_migration/contracts_manifest.json >/tmp/contracts_manifest.pretty.json\n- live Rust scaffold subset passed 12 checks against http://127.0.0.1:8421