### PR TITLE
Add fixture-backed read-only session contracts

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, net::SocketAddr, sync::Arc};
 
 use axum::{
-    extract::{ConnectInfo, Query, Request, State},
+    extract::{ConnectInfo, Path, Query, Request, State},
     http::{
         header::{AUTHORIZATION, COOKIE, HOST},
         HeaderMap, StatusCode,
@@ -52,7 +52,10 @@ pub fn router(state: AppState) -> Router {
         .route("/auth/session", get(auth_session))
         .route("/client/bootstrap", get(client_bootstrap))
         .route("/sessions", get(list_sessions))
+        .route("/sessions/{session_id}", get(get_session))
+        .route("/sessions/{session_id}/output", get(session_output))
         .route("/client/sessions", get(list_client_sessions))
+        .route("/client/sessions/{session_id}", get(get_client_session))
         .fallback(not_found)
         .with_state(Arc::new(state))
 }
@@ -185,6 +188,46 @@ async fn list_client_sessions(
     Ok(Json(SessionsEnvelope::from(sessions)))
 }
 
+async fn get_session(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+    request: Request,
+) -> Result<Json<SessionResponse>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    let Some(session) = state.session_store.get_session(&session_id)? else {
+        return Err(ApiError::NotFound("Session not found"));
+    };
+    Ok(Json(SessionResponse::from(session)))
+}
+
+async fn get_client_session(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+    request: Request,
+) -> Result<Json<ClientSessionResponse>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    let Some(session) = state.session_store.get_session(&session_id)? else {
+        return Err(ApiError::NotFound("Session not found"));
+    };
+    Ok(Json(ClientSessionResponse::from(session)))
+}
+
+async fn session_output(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+    Query(query): Query<SessionOutputQuery>,
+    request: Request,
+) -> Result<Json<SessionOutputResponse>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    if state.session_store.get_session(&session_id)?.is_none() {
+        return Err(ApiError::NotFound("Session not found"));
+    }
+    let output = state
+        .session_store
+        .capture_output(&session_id, query.lines.unwrap_or(50))?;
+    Ok(Json(SessionOutputResponse { session_id, output }))
+}
+
 async fn not_found() -> impl IntoResponse {
     (
         StatusCode::NOT_FOUND,
@@ -195,6 +238,7 @@ async fn not_found() -> impl IntoResponse {
 #[derive(Debug)]
 enum ApiError {
     Internal(anyhow::Error),
+    NotFound(&'static str),
     Auth {
         status: StatusCode,
         detail: &'static str,
@@ -219,6 +263,9 @@ impl IntoResponse for ApiError {
                 Json(json!({ "detail": error.to_string() })),
             )
                 .into_response(),
+            Self::NotFound(detail) => {
+                (StatusCode::NOT_FOUND, Json(json!({ "detail": detail }))).into_response()
+            }
             Self::Auth {
                 status,
                 detail,
@@ -480,6 +527,17 @@ struct HealthCheck {
 struct ListSessionsQuery {
     #[serde(default)]
     include_stopped: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct SessionOutputQuery {
+    lines: Option<usize>,
+}
+
+#[derive(Serialize)]
+struct SessionOutputResponse {
+    session_id: String,
+    output: Option<String>,
 }
 
 #[derive(Serialize)]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
-    env, fs,
+    env, fs, io,
     path::{Path, PathBuf},
 };
 
@@ -45,6 +45,44 @@ impl SessionStore {
             .into_iter()
             .filter(|session| include_stopped || !session.is_stopped())
             .collect())
+    }
+
+    pub fn get_session(&self, session_id: &str) -> Result<Option<SessionRecord>> {
+        let session_id = session_id.trim();
+        if session_id.is_empty() {
+            return Ok(None);
+        }
+        Ok(self
+            .load_snapshot()?
+            .into_sessions()
+            .into_iter()
+            .find(|session| {
+                session.id == session_id || session.aliases.iter().any(|alias| alias == session_id)
+            }))
+    }
+
+    pub fn capture_output(&self, session_id: &str, lines: usize) -> Result<Option<String>> {
+        let Some(session) = self.get_session(session_id)? else {
+            return Ok(None);
+        };
+        let Some(log_file) = session
+            .log_file
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        else {
+            return Ok(None);
+        };
+        let log_file = expand_home(log_file);
+        let content = match fs::read_to_string(&log_file) {
+            Ok(content) => content,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("failed to read session log {}", log_file.display()))
+            }
+        };
+        Ok(Some(tail_lines(&content, lines)))
     }
 
     fn load_snapshot(&self) -> Result<StateSnapshot> {
@@ -287,6 +325,8 @@ pub struct SessionRecord {
     pub node: String,
     #[serde(default = "default_provider")]
     pub provider: String,
+    #[serde(default)]
+    pub log_file: Option<String>,
     #[serde(default)]
     pub provider_resume_id: Option<String>,
     #[serde(default)]
@@ -614,6 +654,22 @@ fn non_empty_or(value: String, fallback: &str) -> String {
     }
 }
 
+fn tail_lines(content: &str, lines: usize) -> String {
+    if lines == 0 {
+        return String::new();
+    }
+    let all_lines = content.lines().collect::<Vec<_>>();
+    if all_lines.is_empty() {
+        return String::new();
+    }
+    let start = all_lines.len().saturating_sub(lines);
+    let mut output = all_lines[start..].join("\n");
+    if content.ends_with('\n') {
+        output.push('\n');
+    }
+    output
+}
+
 fn default_node() -> String {
     "primary".to_owned()
 }
@@ -653,6 +709,7 @@ mod tests {
             tmux_socket_name: None,
             node: "primary".to_owned(),
             provider: "claude".to_owned(),
+            log_file: Some("/tmp/abc12345.log".to_owned()),
             provider_resume_id: None,
             forked_from_session_id: None,
             forked_from_provider_resume_id: None,

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
-    env, fs, io,
+    env, fs,
+    io::{self, Read, Seek, SeekFrom},
     path::{Path, PathBuf},
 };
 
@@ -10,6 +11,9 @@ use serde_json::{json, Value};
 
 const DEFAULT_SESSION_STATE_FILE: &str = "~/.local/share/claude-sessions/sessions.json";
 const LEGACY_TMP_SESSION_STATE_FILE: &str = "/tmp/claude-sessions/sessions.json";
+const OUTPUT_TAIL_BYTES_PER_LINE: u64 = 4096;
+const MIN_OUTPUT_TAIL_BYTES: u64 = 16 * 1024;
+const MAX_OUTPUT_TAIL_BYTES: u64 = 1024 * 1024;
 
 #[derive(Debug, Clone)]
 pub struct SessionStore {
@@ -74,7 +78,7 @@ impl SessionStore {
             return Ok(None);
         };
         let log_file = expand_home(log_file);
-        let content = match fs::read_to_string(&log_file) {
+        let output = match read_tail_lines(&log_file, lines) {
             Ok(content) => content,
             Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(None),
             Err(error) => {
@@ -82,7 +86,7 @@ impl SessionStore {
                     .with_context(|| format!("failed to read session log {}", log_file.display()))
             }
         };
-        Ok(Some(tail_lines(&content, lines)))
+        Ok(Some(output))
     }
 
     fn load_snapshot(&self) -> Result<StateSnapshot> {
@@ -700,6 +704,29 @@ fn tail_lines(content: &str, lines: usize) -> String {
         output.push('\n');
     }
     output
+}
+
+fn read_tail_lines(path: &Path, lines: usize) -> io::Result<String> {
+    if lines == 0 {
+        return Ok(String::new());
+    }
+
+    let mut file = fs::File::open(path)?;
+    let file_len = file.metadata()?.len();
+    if file_len == 0 {
+        return Ok(String::new());
+    }
+
+    let read_len = file_len.min(output_tail_byte_limit(lines));
+    file.seek(SeekFrom::End(-(read_len as i64)))?;
+    let mut bytes = Vec::with_capacity(read_len as usize);
+    file.take(read_len).read_to_end(&mut bytes)?;
+    Ok(tail_lines(&String::from_utf8_lossy(&bytes), lines))
+}
+
+fn output_tail_byte_limit(lines: usize) -> u64 {
+    let requested = (lines as u64).saturating_mul(OUTPUT_TAIL_BYTES_PER_LINE);
+    requested.clamp(MIN_OUTPUT_TAIL_BYTES, MAX_OUTPUT_TAIL_BYTES)
 }
 
 fn default_node() -> String {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -223,6 +223,7 @@ impl StateSnapshot {
             .as_deref()
             .map(str::trim)
             .filter(|value| !value.is_empty())
+            .filter(|session_id| self.session_is_restorable_for_registry(session_id))
         {
             aliases
                 .entry(session_id.to_owned())
@@ -235,12 +236,22 @@ impl StateSnapshot {
             if role.is_empty() || session_id.is_empty() {
                 continue;
             }
+            if !self.session_is_restorable_for_registry(session_id) {
+                continue;
+            }
             aliases
                 .entry(session_id.to_owned())
                 .or_default()
                 .insert(role);
         }
         aliases
+    }
+
+    fn session_is_restorable_for_registry(&self, session_id: &str) -> bool {
+        self.sessions
+            .iter()
+            .find(|session| session.id == session_id)
+            .is_some_and(SessionRecord::is_restorable_for_registry)
     }
 
     fn pending_proposal_map(
@@ -330,6 +341,10 @@ pub struct SessionRecord {
     #[serde(default)]
     pub provider_resume_id: Option<String>,
     #[serde(default)]
+    pub transcript_path: Option<String>,
+    #[serde(default)]
+    pub codex_thread_id: Option<String>,
+    #[serde(default)]
     pub forked_from_session_id: Option<String>,
     #[serde(default)]
     pub forked_from_provider_resume_id: Option<String>,
@@ -402,6 +417,19 @@ pub struct SessionRecord {
 impl SessionRecord {
     fn is_stopped(&self) -> bool {
         normalized_status(&self.status) == "stopped"
+    }
+
+    fn is_restorable_for_registry(&self) -> bool {
+        if !self.is_stopped() {
+            return true;
+        }
+        let has_provider_resume_id = has_text(self.provider_resume_id.as_deref());
+        match self.provider.as_str() {
+            "claude" => has_provider_resume_id || has_text(self.transcript_path.as_deref()),
+            "codex-app" => has_provider_resume_id || has_text(self.codex_thread_id.as_deref()),
+            "codex" | "codex-fork" => has_provider_resume_id,
+            _ => has_provider_resume_id,
+        }
     }
 
     fn cached_display_name(&self) -> Option<String> {
@@ -654,6 +682,10 @@ fn non_empty_or(value: String, fallback: &str) -> String {
     }
 }
 
+fn has_text(value: Option<&str>) -> bool {
+    value.is_some_and(|value| !value.trim().is_empty())
+}
+
 fn tail_lines(content: &str, lines: usize) -> String {
     if lines == 0 {
         return String::new();
@@ -711,6 +743,8 @@ mod tests {
             provider: "claude".to_owned(),
             log_file: Some("/tmp/abc12345.log".to_owned()),
             provider_resume_id: None,
+            transcript_path: None,
+            codex_thread_id: None,
             forked_from_session_id: None,
             forked_from_provider_resume_id: None,
             forked_provider_resume_id: None,
@@ -973,6 +1007,50 @@ mod tests {
             child.pending_adoption_proposals[0].proposer_name.as_deref(),
             Some("maintainer")
         );
+    }
+
+    #[test]
+    fn snapshot_prunes_stale_aliases_but_keeps_restorable_stopped_aliases() {
+        let snapshot = StateSnapshot {
+            sessions: vec![
+                SessionRecord {
+                    id: "dead001".to_owned(),
+                    provider_resume_id: None,
+                    transcript_path: None,
+                    ..session_record("stopped")
+                },
+                SessionRecord {
+                    id: "restore1".to_owned(),
+                    provider_resume_id: Some("resume-id".to_owned()),
+                    ..session_record("stopped")
+                },
+            ],
+            maintainer_session_id: Some("dead001".to_owned()),
+            agent_registrations: vec![
+                AgentRegistrationRecord {
+                    role: "Stale Role".to_owned(),
+                    session_id: "dead001".to_owned(),
+                },
+                AgentRegistrationRecord {
+                    role: "Restorable Role".to_owned(),
+                    session_id: "restore1".to_owned(),
+                },
+            ],
+            adoption_proposals: Vec::new(),
+        };
+
+        let sessions = snapshot.into_sessions();
+        let stale = sessions
+            .iter()
+            .find(|session| session.id == "dead001")
+            .unwrap();
+        let restorable = sessions
+            .iter()
+            .find(|session| session.id == "restore1")
+            .unwrap();
+
+        assert!(stale.aliases.is_empty());
+        assert_eq!(restorable.aliases, vec!["restorable-role"]);
     }
 
     fn unique_temp_path(label: &str) -> PathBuf {

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -373,6 +373,24 @@ async fn client_session_detail_returns_mobile_metadata_for_one_session() {
 }
 
 #[tokio::test]
+async fn session_detail_prunes_stale_role_aliases() {
+    let state_file = write_registry_fixture();
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+
+    let (status, payload) = get_json(app.clone(), "/sessions/stale-role").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(payload, json!({ "detail": "Session not found" }));
+
+    let (status, payload) = get_json(app.clone(), "/client/sessions/stale-role").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(payload, json!({ "detail": "Session not found" }));
+
+    let (status, payload) = get_json(app, "/sessions/reviewer").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["id"], "child001");
+}
+
+#[tokio::test]
 async fn session_output_tails_fixture_log_file() {
     let state_file = write_session_fixture();
     let app = router(AppState::new(config_with_state_file(&state_file)));
@@ -658,6 +676,17 @@ fn write_registry_fixture() -> PathBuf {
                     "status": "running",
                     "created_at": "2026-06-01T00:00:00",
                     "last_activity": "2026-06-01T00:01:00"
+                },
+                {
+                    "id": "deadrole",
+                    "name": "claude-deadrole",
+                    "working_dir": "/repo",
+                    "tmux_session": "claude-deadrole",
+                    "log_file": "/tmp/deadrole.log",
+                    "status": "stopped",
+                    "created_at": "2026-06-01T00:00:00",
+                    "last_activity": "2026-06-01T00:01:00",
+                    "stopped_at": "2026-06-01T00:02:00"
                 }
             ],
             "maintainer_session_id": "em123456",
@@ -666,6 +695,11 @@ fn write_registry_fixture() -> PathBuf {
                     "role": "Reviewer",
                     "session_id": "child001",
                     "created_at": "2026-06-01T00:02:00"
+                },
+                {
+                    "role": "Stale Role",
+                    "session_id": "deadrole",
+                    "created_at": "2026-06-01T00:02:30"
                 }
             ],
             "adoption_proposals": [

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -333,6 +333,61 @@ async fn client_sessions_adds_read_only_mobile_metadata_without_termux() {
 }
 
 #[tokio::test]
+async fn session_detail_returns_one_projected_session() {
+    let state_file = write_session_fixture();
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+
+    let (status, payload) = get_json(app, "/sessions/run12345").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["id"], "run12345");
+    assert_eq!(payload["friendly_name"], "Runner Native");
+    assert_eq!(payload["activity_state"], "working");
+    assert_eq!(payload["provider"], "claude");
+}
+
+#[tokio::test]
+async fn session_detail_returns_404_for_unknown_session() {
+    let state_file = write_session_fixture();
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+
+    let (status, payload) = get_json(app, "/sessions/missing-session").await;
+
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(payload, json!({ "detail": "Session not found" }));
+}
+
+#[tokio::test]
+async fn client_session_detail_returns_mobile_metadata_for_one_session() {
+    let state_file = write_session_fixture();
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+
+    let (status, payload) = get_json(app, "/client/sessions/run12345").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["id"], "run12345");
+    assert_eq!(payload["attach_descriptor"]["attach_supported"], false);
+    assert_eq!(payload["termux_attach"], Value::Null);
+    assert_eq!(payload["mobile_terminal"]["supported"], false);
+    assert_eq!(payload["primary_action"]["type"], "details");
+}
+
+#[tokio::test]
+async fn session_output_tails_fixture_log_file() {
+    let state_file = write_session_fixture();
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+
+    let (status, payload) = get_json(app, "/sessions/run12345/output?lines=2").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["session_id"], "run12345");
+    assert_eq!(
+        payload["output"],
+        "fixture log line 2\nfixture log line 3\n"
+    );
+}
+
+#[tokio::test]
 async fn sessions_missing_state_file_returns_empty_list() {
     let state_file = unique_temp_path();
     let app = router(AppState::new(config_with_state_file(&state_file)));
@@ -516,6 +571,12 @@ fn config_with_state_file_and_auth(state_file: &PathBuf) -> AppConfig {
 
 fn write_session_fixture() -> PathBuf {
     let path = unique_temp_path();
+    let log_file = unique_temp_path();
+    fs::write(
+        &log_file,
+        "fixture log line 1\nfixture log line 2\nfixture log line 3\n",
+    )
+    .unwrap();
     fs::write(
         &path,
         json!({
@@ -528,7 +589,7 @@ fn write_session_fixture() -> PathBuf {
                     "tmux_socket_name": null,
                     "node": "primary",
                     "provider": "claude",
-                    "log_file": "/tmp/run12345.log",
+                    "log_file": log_file.display().to_string(),
                     "status": "running",
                     "created_at": "2026-06-01T00:00:00",
                     "last_activity": "2026-06-01T00:01:00",

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -406,6 +406,50 @@ async fn session_output_tails_fixture_log_file() {
 }
 
 #[tokio::test]
+async fn session_output_tails_large_log_file_from_end() {
+    let state_file = unique_temp_path();
+    let log_file = unique_temp_path();
+    fs::write(
+        &log_file,
+        format!(
+            "{}\nlast retained line\nfinal retained line\n",
+            "x".repeat(2 * 1024 * 1024)
+        ),
+    )
+    .unwrap();
+    fs::write(
+        &state_file,
+        json!({
+            "sessions": [
+                {
+                    "id": "largeout",
+                    "name": "claude-largeout",
+                    "working_dir": "/repo",
+                    "tmux_session": "claude-largeout",
+                    "node": "primary",
+                    "provider": "claude",
+                    "log_file": log_file.display().to_string(),
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00",
+                    "last_activity": "2026-06-01T00:01:00"
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+
+    let (status, payload) = get_json(app, "/sessions/largeout/output?lines=2").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        payload["output"],
+        "last retained line\nfinal retained line\n"
+    );
+}
+
+#[tokio::test]
 async fn sessions_missing_state_file_returns_empty_list() {
     let state_file = unique_temp_path();
     let app = router(AppState::new(config_with_state_file(&state_file)));

--- a/scripts/rust_migration/README.md
+++ b/scripts/rust_migration/README.md
@@ -38,10 +38,12 @@ python -m scripts.rust_migration.contracts \
 Mutating checks never run unless `--include-mutating` is present. Use only
 disposable fixture sessions for checks such as retained mobile/API session stop.
 
-Run the first Rust read-only server slice:
+Run the first Rust read-only server slice with the synthetic fixture config:
 
 ```bash
-cargo run -p sm-server -- --port 8421 --config /tmp/sm-rust-missing-config.yaml
+cargo run -p sm-server -- \
+  --port 8421 \
+  --config scripts/rust_migration/fixtures/read_only/config.yaml
 ```
 
 Then, in another shell, run only the implemented Rust scaffold checks:
@@ -63,17 +65,22 @@ python -m scripts.rust_migration.contracts \
   --check-id http.queue_policy_runs_retired
 ```
 
-Summary-route retirement must be checked with a real fixture session. The
-harness first verifies `GET /sessions/{session_id}` returns 200 so a stale
-fixture or resource-level 404 cannot masquerade as route retirement:
+Fixture-backed checks assert concrete session projection and output behavior:
 
 ```bash
 python -m scripts.rust_migration.contracts \
   --target rust \
   --base-url http://127.0.0.1:8421 \
-  --session-id <fixture-session-id> \
+  --session-id fixture001 \
+  --check-id http.session_detail_fixture \
+  --check-id http.client_session_detail_fixture \
+  --check-id http.session_output_fixture \
   --check-id http.summary_provider_route_retired
 ```
+
+Summary-route retirement must be checked with a real fixture session. The
+harness first verifies `GET /sessions/{session_id}` returns 200 so a stale
+fixture or resource-level 404 cannot masquerade as route retirement.
 
 Omit `--config` to load `config.yaml`; the Rust scaffold also applies the same
 default `.local/android-parity/values.env` overlay for the auth/bootstrap fields

--- a/scripts/rust_migration/contracts.py
+++ b/scripts/rust_migration/contracts.py
@@ -315,7 +315,9 @@ def _run_http_check(
     missing_body_all = [
         expected for expected in check.expected_body_contains_all if expected not in body_text
     ]
-    json_error = _json_expectation_error(body_text, check.expected_json)
+    json_error = _json_expectation_error(
+        body_text, _render_json_expectations(check.expected_json, fixtures)
+    )
     if status in check.expected_status and body_any_ok and not missing_body_all and not json_error:
         return _result(check, "passed", _elapsed_ms(start), f"HTTP {status}")
     if not body_any_ok:
@@ -476,6 +478,27 @@ def _json_summary(value: Any) -> str:
     if isinstance(value, (dict, list)):
         return _json_type_name(value)
     return repr(value)
+
+
+def _render_json_expectations(
+    expectations: tuple[JsonExpectation, ...], fixtures: dict[str, str]
+) -> tuple[JsonExpectation, ...]:
+    return tuple(
+        JsonExpectation(
+            path=expectation.path,
+            value_type=expectation.value_type,
+            equals=_render_template(expectation.equals, fixtures),
+            has_equals=expectation.has_equals,
+            one_of=tuple(_render_template(value, fixtures) for value in expectation.one_of),
+            contains=(
+                str(_render_template(expectation.contains, fixtures))
+                if expectation.contains is not None
+                else None
+            ),
+            absent=expectation.absent,
+        )
+        for expectation in expectations
+    )
 
 
 _TEMPLATE_PATTERN = re.compile(r"\{([A-Za-z_][A-Za-z0-9_]*)\}")

--- a/scripts/rust_migration/contracts_manifest.json
+++ b/scripts/rust_migration/contracts_manifest.json
@@ -331,6 +331,45 @@
       "source": "specs/762_stage5_artifacts/gate_matrix.md:74"
     },
     {
+      "id": "http.session_detail_fixture",
+      "surface": "http",
+      "classification": "retained",
+      "target": "python_and_rust",
+      "safety": "read_only",
+      "method": "GET",
+      "path": "/sessions/{session_id}",
+      "expected_status": [200],
+      "expected_json": [
+        {"path": "/id", "equals": "{session_id}"},
+        {"path": "/friendly_name", "equals": "Fixture Native Title"},
+        {"path": "/activity_state", "equals": "working"},
+        {"path": "/provider", "equals": "claude"}
+      ],
+      "preconditions": ["live_server", "session_id"],
+      "source": "specs/762_stage5_artifacts/gate_matrix.md:69"
+    },
+    {
+      "id": "http.client_session_detail_fixture",
+      "surface": "http",
+      "classification": "retained",
+      "target": "python_and_rust",
+      "safety": "read_only",
+      "method": "GET",
+      "path": "/client/sessions/{session_id}",
+      "expected_status": [200],
+      "expected_json": [
+        {"path": "/id", "equals": "{session_id}"},
+        {"path": "/attach_descriptor", "type": "object"},
+        {"path": "/attach_descriptor/attach_supported", "equals": false},
+        {"path": "/termux_attach", "type": "null"},
+        {"path": "/mobile_terminal", "type": "object"},
+        {"path": "/mobile_terminal/supported", "equals": false},
+        {"path": "/primary_action/type", "equals": "details"}
+      ],
+      "preconditions": ["live_server", "session_id"],
+      "source": "specs/762_stage5_artifacts/gate_matrix.md:64"
+    },
+    {
       "id": "http.session_output",
       "surface": "http",
       "classification": "retained",
@@ -340,6 +379,22 @@
       "path": "/sessions/{session_id}/output?lines=5",
       "expected_status": [200],
       "preconditions": ["live_server", "session_id"],
+      "source": "specs/762_stage2_artifacts/external_client_manifest.md:25"
+    },
+    {
+      "id": "http.session_output_fixture",
+      "surface": "http",
+      "classification": "retained",
+      "target": "python_and_rust",
+      "safety": "read_only",
+      "method": "GET",
+      "path": "/sessions/{session_id}/output?lines=2",
+      "expected_status": [200],
+      "expected_json": [
+        {"path": "/session_id", "equals": "{session_id}"},
+        {"path": "/output", "contains": "fixture line 3"}
+      ],
+      "preconditions": ["live_server", "session_id", "existing_session"],
       "source": "specs/762_stage2_artifacts/external_client_manifest.md:25"
     },
     {

--- a/scripts/rust_migration/fixtures/read_only/config.yaml
+++ b/scripts/rust_migration/fixtures/read_only/config.yaml
@@ -1,0 +1,2 @@
+paths:
+  state_file: "scripts/rust_migration/fixtures/read_only/sessions.json"

--- a/scripts/rust_migration/fixtures/read_only/logs/fixture001.log
+++ b/scripts/rust_migration/fixtures/read_only/logs/fixture001.log
@@ -1,0 +1,3 @@
+fixture line 1
+fixture line 2
+fixture line 3

--- a/scripts/rust_migration/fixtures/read_only/sessions.json
+++ b/scripts/rust_migration/fixtures/read_only/sessions.json
@@ -1,0 +1,38 @@
+{
+  "sessions": [
+    {
+      "id": "fixture001",
+      "name": "claude-fixture001",
+      "working_dir": "/tmp/sm-fixture-workspace",
+      "tmux_session": "claude-fixture001",
+      "tmux_socket_name": "session-manager",
+      "node": "primary",
+      "provider": "claude",
+      "log_file": "scripts/rust_migration/fixtures/read_only/logs/fixture001.log",
+      "status": "running",
+      "created_at": "2026-06-01T00:00:00",
+      "last_activity": "2026-06-01T00:01:00",
+      "friendly_name": "Fixture Friendly",
+      "friendly_name_is_explicit": false,
+      "friendly_name_updated_at_ns": 10,
+      "native_title": "Fixture Native Title",
+      "native_title_updated_at_ns": 20,
+      "current_task": "Read-only fixture task",
+      "tokens_used": 42,
+      "context_monitor_enabled": true
+    },
+    {
+      "id": "fixture-stop",
+      "name": "claude-fixture-stop",
+      "working_dir": "/tmp/sm-fixture-workspace",
+      "tmux_session": "claude-fixture-stop",
+      "node": "primary",
+      "provider": "claude",
+      "log_file": "scripts/rust_migration/fixtures/read_only/logs/fixture001.log",
+      "status": "stopped",
+      "created_at": "2026-06-01T00:00:00",
+      "last_activity": "2026-06-01T00:01:00",
+      "stopped_at": "2026-06-01T00:02:00"
+    }
+  ]
+}

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -177,6 +177,13 @@ def test_manifest_has_json_shape_assertions_for_core_http_surfaces():
         and expectation.equals == "/auth/device/google"
         for expectation in checks["http.client_bootstrap"].expected_json
     )
+    assert checks["http.session_detail_fixture"].expected_json
+    assert any(
+        expectation.path == "/id" and expectation.equals == "{session_id}"
+        for expectation in checks["http.session_detail_fixture"].expected_json
+    )
+    assert checks["http.client_session_detail_fixture"].expected_json
+    assert checks["http.session_output_fixture"].expected_json
 
 
 def test_python_target_does_not_run_rust_only_retirement_checks():
@@ -387,6 +394,50 @@ def test_http_check_renders_request_headers_and_checks_json():
 
     assert result.status == "passed"
     assert seen["host"] == "sm.example.com"
+
+
+def test_http_check_renders_json_expectation_fixture_values():
+    check = ContractCheck(
+        id="http.fixture_json",
+        surface="http",
+        classification="retained",
+        target="python_and_rust",
+        safety="read_only",
+        method="GET",
+        path="/sessions/{session_id}",
+        expected_status=(200,),
+        expected_json=(
+            JsonExpectation(path="/id", equals="{session_id}", has_equals=True),
+            JsonExpectation(path="/output", contains="{expected_line}"),
+        ),
+        preconditions=("live_server", "session_id"),
+        source="test",
+    )
+
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self, _size):
+            return b'{"id":"fixture001","output":"fixture line 3"}'
+
+    with patch(
+        "scripts.rust_migration.contracts.urllib.request.urlopen",
+        return_value=FakeResponse(),
+    ):
+        result = _run_http_check(
+            check,
+            "http://127.0.0.1:8420",
+            {"session_id": "fixture001", "expected_line": "line 3"},
+            1.0,
+        )
+
+    assert result.status == "passed"
 
 
 def test_http_check_reports_json_shape_mismatch():


### PR DESCRIPTION
## Summary
- add synthetic read-only Rust migration fixtures for session state and log output
- add fixture-backed contract manifest checks for session detail, client session detail, and output tailing
- implement matching read-only Rust scaffold routes for `/sessions/{id}`, `/client/sessions/{id}`, and `/sessions/{id}/output`

## Verification
- `cargo fmt`
- `cargo test -p sm-server`
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py`
- `git diff --check`
- `./venv/bin/python -m json.tool scripts/rust_migration/contracts_manifest.json`
- live Rust scaffold contract run: 15 passed, 0 failed, 0 skipped

Fixes #783
