### PR TITLE
Add Rust shadow comparison mode

### DIFF
--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -10,6 +10,7 @@ pub struct AppConfig {
     pub google_auth: GoogleAuthConfig,
     pub external_access: ExternalAccessConfig,
     pub mobile_terminal: MobileTerminalConfig,
+    pub rust_shadow: RustShadowConfig,
 }
 
 impl AppConfig {
@@ -129,6 +130,12 @@ pub struct MobileTerminalConfig {
     pub ws_url: Option<String>,
 }
 
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct RustShadowConfig {
+    #[serde(default)]
+    pub secret: Option<String>,
+}
+
 #[derive(Debug, Default, Deserialize)]
 struct RawConfig {
     #[serde(default)]
@@ -139,6 +146,8 @@ struct RawConfig {
     external_access: ExternalAccessConfig,
     #[serde(default)]
     mobile_terminal: MobileTerminalConfig,
+    #[serde(default)]
+    rust_shadow: RustShadowConfig,
 }
 
 impl From<RawConfig> for AppConfig {
@@ -148,6 +157,7 @@ impl From<RawConfig> for AppConfig {
             google_auth: raw.auth.google,
             external_access: raw.external_access,
             mobile_terminal: raw.mobile_terminal,
+            rust_shadow: raw.rust_shadow,
         }
     }
 }

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -1,6 +1,7 @@
 use std::{collections::BTreeMap, convert::Infallible, net::SocketAddr, sync::Arc, time::Duration};
 
 use axum::{
+    body::to_bytes,
     extract::{ConnectInfo, Path, Query, Request, State},
     http::{
         header::{AUTHORIZATION, COOKIE, HOST},
@@ -32,6 +33,7 @@ use crate::sessions::{
 
 const SESSION_COOKIE_NAME: &str = "sm_auth";
 const SESSION_COOKIE_MAX_AGE_SECONDS: i64 = 60 * 60 * 24 * 14;
+const SHADOW_ENVELOPE_MAX_BYTES: usize = 1024 * 1024;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -267,8 +269,18 @@ async fn session_output(
 
 async fn shadow_http(
     State(state): State<Arc<AppState>>,
-    Json(envelope): Json<ShadowHttpEnvelope>,
+    request: Request,
 ) -> Result<Json<ShadowHttpResult>, ApiError> {
+    let headers = request.headers().clone();
+    let peer_addr = request
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|value| value.0);
+    ensure_shadow_allowed(&state.config, &headers, peer_addr)?;
+    let body = to_bytes(request.into_body(), SHADOW_ENVELOPE_MAX_BYTES)
+        .await
+        .map_err(|error| anyhow::anyhow!("failed to read shadow envelope: {error}"))?;
+    let envelope: ShadowHttpEnvelope = serde_json::from_slice(&body)?;
     Ok(Json(shadow_compare(&state, envelope)?))
 }
 
@@ -585,6 +597,47 @@ fn is_retained_write_surface(method: &str, path: &str) -> bool {
         return matches!(method, "POST" | "DELETE");
     }
     false
+}
+
+fn ensure_shadow_allowed(
+    config: &AppConfig,
+    headers: &HeaderMap,
+    peer_addr: Option<SocketAddr>,
+) -> Result<(), ApiError> {
+    if peer_addr
+        .map(|addr| addr.ip().is_loopback())
+        .unwrap_or(false)
+    {
+        return Ok(());
+    }
+
+    let expected = trimmed(&config.rust_shadow.secret);
+    let provided = headers
+        .get("x-sm-rust-shadow-secret")
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if let (Some(expected), Some(provided)) = (expected, provided) {
+        if constant_time_eq(expected.as_bytes(), provided.as_bytes()) {
+            return Ok(());
+        }
+    }
+
+    Err(ApiError::Auth {
+        status: StatusCode::FORBIDDEN,
+        detail: "Rust shadow endpoint requires local peer or shadow secret",
+        login_url: None,
+    })
+}
+
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    left.iter()
+        .zip(right.iter())
+        .fold(0u8, |acc, (left, right)| acc | (left ^ right))
+        == 0
 }
 
 fn query_bool(query_string: &str, key: &str) -> bool {

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -439,9 +439,13 @@ fn shadow_predict_read(
                 support_status: "implemented_read_status_only",
             }));
         }
-        "/auth/session" => Some(serde_json::to_vec(&shadow_auth_session_response(
-            &state.config,
-        ))?),
+        "/auth/session" => {
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::OK.as_u16(),
+                body_sha256: None,
+                support_status: "implemented_read_status_only",
+            }));
+        }
         "/client/bootstrap" => Some(serde_json::to_vec(&shadow_client_bootstrap_response(
             &state.config,
         ))?),
@@ -480,6 +484,10 @@ fn shadow_predict_session_read(
     path: &str,
     query_string: &str,
 ) -> anyhow::Result<Option<ShadowPrediction>> {
+    if is_static_sessions_path(path) {
+        return Ok(None);
+    }
+
     if let Some(session_id) = path
         .strip_prefix("/client/sessions/")
         .filter(|value| !value.contains('/'))
@@ -549,25 +557,6 @@ fn shadow_predict_session_read(
     Ok(None)
 }
 
-fn shadow_auth_session_response(config: &AppConfig) -> AuthSessionResponse {
-    let auth = &config.google_auth;
-    if !auth.requested() {
-        return AuthSessionResponse::disabled_bypass();
-    }
-    if !auth.ready() {
-        return AuthSessionResponse::misconfigured();
-    }
-    AuthSessionResponse {
-        enabled: true,
-        authenticated: false,
-        bypass: false,
-        email: None,
-        name: None,
-        auth_type: None,
-        error: None,
-    }
-}
-
 fn shadow_client_bootstrap_response(config: &AppConfig) -> ClientBootstrapResponse {
     let auth = &config.google_auth;
     let external = &config.external_access;
@@ -594,6 +583,17 @@ fn shadow_client_bootstrap_response(config: &AppConfig) -> ClientBootstrapRespon
             preferred_action: "details",
         },
     }
+}
+
+fn is_static_sessions_path(path: &str) -> bool {
+    matches!(
+        path,
+        "/sessions/context-monitor"
+            | "/sessions/create"
+            | "/sessions/input-batch"
+            | "/sessions/spawn"
+            | "/sessions/review"
+    )
 }
 
 fn is_retained_write_surface(method: &str, path: &str) -> bool {

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -356,6 +356,25 @@ fn shadow_compare(
         });
     }
 
+    if is_auth_denial_status(python_status) && is_protected_read_surface(&method, &path) {
+        return Ok(ShadowHttpResult {
+            schema_version: 1,
+            method,
+            path,
+            support_status: "python_auth_denial",
+            comparison: "status_match",
+            would_write: false,
+            python_status,
+            predicted_status: Some(python_status),
+            predicted_body_sha256: None,
+            body_sha256_match: None,
+            detail: Some(
+                "Python rejected the protected read before handler execution; shadow mode preserves the denial without reading state"
+                    .to_owned(),
+            ),
+        });
+    }
+
     let Some(prediction) =
         shadow_predict_read(state, &method, &path, &envelope.request.query_string)?
     else {
@@ -599,28 +618,52 @@ fn is_retained_write_surface(method: &str, path: &str) -> bool {
     false
 }
 
+fn is_auth_denial_status(status: u16) -> bool {
+    matches!(status, 401 | 403 | 503)
+}
+
+fn is_protected_read_surface(method: &str, path: &str) -> bool {
+    if method != "GET" {
+        return false;
+    }
+    path == "/events"
+        || path == "/events/state"
+        || path == "/sessions"
+        || path == "/client/sessions"
+        || path.starts_with("/sessions/")
+        || path.starts_with("/client/sessions/")
+}
+
 fn ensure_shadow_allowed(
     config: &AppConfig,
     headers: &HeaderMap,
     peer_addr: Option<SocketAddr>,
 ) -> Result<(), ApiError> {
-    if peer_addr
-        .map(|addr| addr.ip().is_loopback())
-        .unwrap_or(false)
-    {
-        return Ok(());
-    }
-
     let expected = trimmed(&config.rust_shadow.secret);
     let provided = headers
         .get("x-sm-rust-shadow-secret")
         .and_then(|value| value.to_str().ok())
         .map(str::trim)
         .filter(|value| !value.is_empty());
-    if let (Some(expected), Some(provided)) = (expected, provided) {
-        if constant_time_eq(expected.as_bytes(), provided.as_bytes()) {
+    if let Some(expected) = expected {
+        if provided
+            .map(|provided| constant_time_eq(expected.as_bytes(), provided.as_bytes()))
+            .unwrap_or(false)
+        {
             return Ok(());
         }
+        return Err(ApiError::Auth {
+            status: StatusCode::FORBIDDEN,
+            detail: "Rust shadow endpoint requires local peer or shadow secret",
+            login_url: None,
+        });
+    }
+
+    if peer_addr
+        .map(|addr| addr.ip().is_loopback())
+        .unwrap_or(false)
+    {
+        return Ok(());
     }
 
     Err(ApiError::Auth {

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -10,7 +10,7 @@ use axum::{
         sse::{Event, KeepAlive, Sse},
         IntoResponse, Response,
     },
-    routing::get,
+    routing::{get, post},
     Json, Router,
 };
 use base64::{
@@ -57,6 +57,7 @@ pub fn router(state: AppState) -> Router {
         .route("/client/bootstrap", get(client_bootstrap))
         .route("/events/state", get(events_state))
         .route("/events", get(events_stream))
+        .route("/__shadow/http", post(shadow_http))
         .route("/sessions", get(list_sessions))
         .route("/sessions/{session_id}", get(get_session))
         .route("/sessions/{session_id}/output", get(session_output))
@@ -264,11 +265,352 @@ async fn session_output(
     Ok(Json(SessionOutputResponse { session_id, output }))
 }
 
+async fn shadow_http(
+    State(state): State<Arc<AppState>>,
+    Json(envelope): Json<ShadowHttpEnvelope>,
+) -> Result<Json<ShadowHttpResult>, ApiError> {
+    Ok(Json(shadow_compare(&state, envelope)?))
+}
+
 async fn not_found() -> impl IntoResponse {
     (
         StatusCode::NOT_FOUND,
         Json(json!({ "detail": "Not Found" })),
     )
+}
+
+#[derive(Debug, Deserialize)]
+struct ShadowHttpEnvelope {
+    request: ShadowRequestEnvelope,
+    python_response: ShadowPythonResponse,
+}
+
+#[derive(Debug, Deserialize)]
+struct ShadowRequestEnvelope {
+    method: String,
+    path: String,
+    #[serde(default)]
+    query_string: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ShadowPythonResponse {
+    status: u16,
+    body_sha256: String,
+}
+
+#[derive(Serialize)]
+struct ShadowHttpResult {
+    schema_version: u8,
+    method: String,
+    path: String,
+    support_status: &'static str,
+    comparison: &'static str,
+    would_write: bool,
+    python_status: u16,
+    predicted_status: Option<u16>,
+    predicted_body_sha256: Option<String>,
+    body_sha256_match: Option<bool>,
+    detail: Option<String>,
+}
+
+struct ShadowPrediction {
+    status: u16,
+    body_sha256: Option<String>,
+    support_status: &'static str,
+}
+
+fn shadow_compare(
+    state: &AppState,
+    envelope: ShadowHttpEnvelope,
+) -> anyhow::Result<ShadowHttpResult> {
+    let method = envelope.request.method.trim().to_uppercase();
+    let path = envelope.request.path.trim().to_owned();
+    let python_status = envelope.python_response.status;
+
+    if is_retained_write_surface(&method, &path) {
+        return Ok(ShadowHttpResult {
+            schema_version: 1,
+            method,
+            path,
+            support_status: "unsupported_retained_write",
+            comparison: "not_compared",
+            would_write: false,
+            python_status,
+            predicted_status: None,
+            predicted_body_sha256: None,
+            body_sha256_match: None,
+            detail: Some("Rust shadow mode never performs retained write side effects".to_owned()),
+        });
+    }
+
+    let Some(prediction) =
+        shadow_predict_read(state, &method, &path, &envelope.request.query_string)?
+    else {
+        return Ok(ShadowHttpResult {
+            schema_version: 1,
+            method,
+            path,
+            support_status: "unsupported",
+            comparison: "not_compared",
+            would_write: false,
+            python_status,
+            predicted_status: None,
+            predicted_body_sha256: None,
+            body_sha256_match: None,
+            detail: Some("No side-effect-free Rust prediction exists for this surface".to_owned()),
+        });
+    };
+
+    let status_matches = prediction.status == python_status;
+    let body_matches = prediction
+        .body_sha256
+        .as_ref()
+        .map(|value| value == &envelope.python_response.body_sha256);
+    let comparison = match (status_matches, body_matches) {
+        (true, Some(true)) => "match",
+        (true, None) => "status_match",
+        (false, _) => "status_mismatch",
+        (true, Some(false)) => "body_mismatch",
+    };
+
+    Ok(ShadowHttpResult {
+        schema_version: 1,
+        method,
+        path,
+        support_status: prediction.support_status,
+        comparison,
+        would_write: false,
+        python_status,
+        predicted_status: Some(prediction.status),
+        predicted_body_sha256: prediction.body_sha256,
+        body_sha256_match: body_matches,
+        detail: None,
+    })
+}
+
+fn shadow_predict_read(
+    state: &AppState,
+    method: &str,
+    path: &str,
+    query_string: &str,
+) -> anyhow::Result<Option<ShadowPrediction>> {
+    if method != "GET" {
+        return Ok(None);
+    }
+
+    let body = match path {
+        "/health" => Some(serde_json::to_vec(&json!({ "status": "healthy" }))?),
+        "/health/detailed" => {
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::OK.as_u16(),
+                body_sha256: None,
+                support_status: "implemented_read_status_only",
+            }));
+        }
+        "/auth/session" => Some(serde_json::to_vec(&shadow_auth_session_response(
+            &state.config,
+        ))?),
+        "/client/bootstrap" => Some(serde_json::to_vec(&shadow_client_bootstrap_response(
+            &state.config,
+        ))?),
+        "/events/state" => Some(serde_json::to_vec(&event_state_payload())?),
+        "/sessions" => {
+            let include_stopped = query_bool(query_string, "include_stopped");
+            let sessions = state
+                .session_store
+                .list_sessions(include_stopped)?
+                .into_iter()
+                .map(SessionResponse::from)
+                .collect::<Vec<_>>();
+            Some(serde_json::to_vec(&SessionsEnvelope::from(sessions))?)
+        }
+        "/client/sessions" => {
+            let sessions = state
+                .session_store
+                .list_sessions(false)?
+                .into_iter()
+                .map(ClientSessionResponse::from)
+                .collect::<Vec<_>>();
+            Some(serde_json::to_vec(&SessionsEnvelope::from(sessions))?)
+        }
+        _ => return shadow_predict_session_read(state, path, query_string),
+    };
+
+    Ok(body.map(|body| ShadowPrediction {
+        status: StatusCode::OK.as_u16(),
+        body_sha256: Some(sha256_hex(&body)),
+        support_status: "implemented_read",
+    }))
+}
+
+fn shadow_predict_session_read(
+    state: &AppState,
+    path: &str,
+    query_string: &str,
+) -> anyhow::Result<Option<ShadowPrediction>> {
+    if let Some(session_id) = path
+        .strip_prefix("/client/sessions/")
+        .filter(|value| !value.contains('/'))
+    {
+        let Some(session) = state.session_store.get_session(session_id)? else {
+            let body = serde_json::to_vec(&json!({ "detail": "Session not found" }))?;
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::NOT_FOUND.as_u16(),
+                body_sha256: Some(sha256_hex(&body)),
+                support_status: "implemented_read",
+            }));
+        };
+        let body = serde_json::to_vec(&ClientSessionResponse::from(session))?;
+        return Ok(Some(ShadowPrediction {
+            status: StatusCode::OK.as_u16(),
+            body_sha256: Some(sha256_hex(&body)),
+            support_status: "implemented_read",
+        }));
+    }
+
+    if let Some(session_id) = path
+        .strip_prefix("/sessions/")
+        .and_then(|value| value.strip_suffix("/output"))
+    {
+        let Some(_) = state.session_store.get_session(session_id)? else {
+            let body = serde_json::to_vec(&json!({ "detail": "Session not found" }))?;
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::NOT_FOUND.as_u16(),
+                body_sha256: Some(sha256_hex(&body)),
+                support_status: "implemented_read",
+            }));
+        };
+        let output = state
+            .session_store
+            .capture_output(session_id, query_usize(query_string, "lines").unwrap_or(50))?;
+        let body = serde_json::to_vec(&SessionOutputResponse {
+            session_id: session_id.to_owned(),
+            output,
+        })?;
+        return Ok(Some(ShadowPrediction {
+            status: StatusCode::OK.as_u16(),
+            body_sha256: Some(sha256_hex(&body)),
+            support_status: "implemented_read",
+        }));
+    }
+
+    if let Some(session_id) = path
+        .strip_prefix("/sessions/")
+        .filter(|value| !value.contains('/'))
+    {
+        let Some(session) = state.session_store.get_session(session_id)? else {
+            let body = serde_json::to_vec(&json!({ "detail": "Session not found" }))?;
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::NOT_FOUND.as_u16(),
+                body_sha256: Some(sha256_hex(&body)),
+                support_status: "implemented_read",
+            }));
+        };
+        let body = serde_json::to_vec(&SessionResponse::from(session))?;
+        return Ok(Some(ShadowPrediction {
+            status: StatusCode::OK.as_u16(),
+            body_sha256: Some(sha256_hex(&body)),
+            support_status: "implemented_read",
+        }));
+    }
+
+    Ok(None)
+}
+
+fn shadow_auth_session_response(config: &AppConfig) -> AuthSessionResponse {
+    let auth = &config.google_auth;
+    if !auth.requested() {
+        return AuthSessionResponse::disabled_bypass();
+    }
+    if !auth.ready() {
+        return AuthSessionResponse::misconfigured();
+    }
+    AuthSessionResponse {
+        enabled: true,
+        authenticated: false,
+        bypass: false,
+        email: None,
+        name: None,
+        auth_type: None,
+        error: None,
+    }
+}
+
+fn shadow_client_bootstrap_response(config: &AppConfig) -> ClientBootstrapResponse {
+    let auth = &config.google_auth;
+    let external = &config.external_access;
+
+    ClientBootstrapResponse {
+        auth: BootstrapAuth {
+            mode_name: "browser_session_cookie",
+            session_endpoint: "/auth/session",
+            login_endpoint: "/auth/google/login",
+            logout_endpoint: "/auth/logout",
+            device_auth_endpoint: "/auth/device/google",
+            device_auth_token_type: "Bearer",
+            google_server_client_id: trimmed(&auth.client_id),
+        },
+        external_access: BootstrapExternalAccess {
+            public_http_host: trimmed(&external.public_http_host),
+            public_ssh_host: trimmed(&external.public_ssh_host),
+            ssh_username: trimmed(&external.ssh_username),
+            termux_attach_supported: false,
+            mobile_terminal_supported: false,
+            mobile_terminal_ws_url: None,
+        },
+        session_open_defaults: SessionOpenDefaults {
+            preferred_action: "details",
+        },
+    }
+}
+
+fn is_retained_write_surface(method: &str, path: &str) -> bool {
+    if method == "POST" && (path == "/sessions" || path == "/sessions/input-batch") {
+        return true;
+    }
+    if path.starts_with("/sessions/") {
+        return matches!(method, "POST" | "PUT" | "PATCH" | "DELETE");
+    }
+    if method == "POST" && path == "/codex-review-requests" {
+        return true;
+    }
+    if path.starts_with("/codex-review-requests/") {
+        return matches!(method, "POST" | "DELETE");
+    }
+    if method == "POST" && path == "/queue-jobs" {
+        return true;
+    }
+    if path.starts_with("/queue-jobs/") {
+        return matches!(method, "POST" | "DELETE");
+    }
+    false
+}
+
+fn query_bool(query_string: &str, key: &str) -> bool {
+    query_value(query_string, key)
+        .map(|value| matches!(value, "1" | "true" | "True" | "TRUE" | "yes" | "on"))
+        .unwrap_or(false)
+}
+
+fn query_usize(query_string: &str, key: &str) -> Option<usize> {
+    query_value(query_string, key).and_then(|value| value.parse().ok())
+}
+
+fn query_value<'a>(query_string: &'a str, key: &str) -> Option<&'a str> {
+    query_string.split('&').find_map(|part| {
+        let (name, value) = part.split_once('=').unwrap_or((part, ""));
+        if name == key {
+            Some(value)
+        } else {
+            None
+        }
+    })
+}
+
+fn sha256_hex(value: &[u8]) -> String {
+    let digest = Sha256::digest(value);
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
 }
 
 #[derive(Debug)]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -41,6 +41,23 @@ async fn get_response(app: axum::Router, uri: &str) -> (StatusCode, HeaderMap, V
     (status, headers, body.to_vec())
 }
 
+async fn post_json(app: axum::Router, uri: &str, payload: Value) -> (StatusCode, Value) {
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&payload).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    (status, serde_json::from_slice(&body).unwrap())
+}
+
 async fn get_json_with_host(app: axum::Router, uri: &str, host: &str) -> (StatusCode, Value) {
     get_json_with_host_and_peer(app, uri, host, None).await
 }
@@ -124,6 +141,101 @@ async fn auth_session_reports_disabled_bypass_when_google_auth_not_requested() {
             "name": null
         })
     );
+}
+
+#[tokio::test]
+async fn shadow_http_reports_match_for_stable_read_only_route() {
+    let app = router(AppState::new(AppConfig::default()));
+    let python_body = serde_json::to_vec(&json!({ "status": "healthy" })).unwrap();
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/health",
+                "query_string": "",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 200,
+                "body_sha256": sha256_hex(&python_body)
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read");
+    assert_eq!(payload["comparison"], "match");
+    assert_eq!(payload["would_write"], false);
+    assert_eq!(payload["predicted_status"], 200);
+    assert_eq!(payload["body_sha256_match"], true);
+}
+
+#[tokio::test]
+async fn shadow_http_reports_body_mismatch_for_stable_read_only_route() {
+    let app = router(AppState::new(AppConfig::default()));
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/health",
+                "query_string": "",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 200,
+                "body_sha256": sha256_hex(b"different")
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read");
+    assert_eq!(payload["comparison"], "body_mismatch");
+    assert_eq!(payload["body_sha256_match"], false);
+}
+
+#[tokio::test]
+async fn shadow_http_classifies_core_writes_without_side_effects() {
+    let app = router(AppState::new(AppConfig::default()));
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "POST",
+                "path": "/sessions",
+                "query_string": "",
+                "headers": {},
+                "body_sha256": sha256_hex(b"{\"working_dir\":\"~\"}")
+            },
+            "python_response": {
+                "status": 200,
+                "body_sha256": sha256_hex(b"{\"id\":\"python-owned\"}")
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "unsupported_retained_write");
+    assert_eq!(payload["comparison"], "not_compared");
+    assert_eq!(payload["would_write"], false);
+    assert!(payload["detail"]
+        .as_str()
+        .unwrap()
+        .contains("never performs retained write side effects"));
 }
 
 #[tokio::test]
@@ -893,6 +1005,11 @@ fn hmac_sha256_urlsafe(key: &[u8], value: &[u8]) -> String {
     let mut mac = Hmac::<Sha256>::new_from_slice(key).unwrap();
     mac.update(value);
     URL_SAFE_NO_PAD.encode(mac.finalize().into_bytes())
+}
+
+fn sha256_hex(value: &[u8]) -> String {
+    let digest = Sha256::digest(value);
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
 }
 
 fn hmac_sha1_urlsafe(key: &[u8], value: &[u8]) -> String {

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -396,6 +396,76 @@ async fn shadow_http_preserves_python_auth_denial_for_protected_reads() {
 }
 
 #[tokio::test]
+async fn shadow_http_treats_auth_session_as_status_only() {
+    let app = router(AppState::new(AppConfig {
+        google_auth: GoogleAuthConfig {
+            enabled: true,
+            public_host: Some("sm.example.com".to_owned()),
+            client_id: Some("web-client".to_owned()),
+            client_secret: Some("web-secret".to_owned()),
+            redirect_uri: Some("https://sm.example.com/auth/google/callback".to_owned()),
+            allowlist_emails: vec!["user@example.com".to_owned()],
+            session_cookie_secret: Some("cookie-secret".to_owned()),
+            ..GoogleAuthConfig::default()
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/auth/session",
+                "query_string": "",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 200,
+                "body_sha256": sha256_hex(b"{\"authenticated\":true}")
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read_status_only");
+    assert_eq!(payload["comparison"], "status_match");
+    assert_eq!(payload["predicted_body_sha256"], Value::Null);
+}
+
+#[tokio::test]
+async fn shadow_http_does_not_treat_static_sessions_route_as_session_id() {
+    let app = router(AppState::new(AppConfig::default()));
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/sessions/context-monitor",
+                "query_string": "",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 200,
+                "body_sha256": sha256_hex(b"{\"enabled\":true}")
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "unsupported");
+    assert_eq!(payload["comparison"], "not_compared");
+    assert_eq!(payload["predicted_status"], Value::Null);
+}
+
+#[tokio::test]
 async fn auth_session_reports_local_bypass_for_localhost_when_auth_is_misconfigured() {
     let app = router(AppState::new(AppConfig {
         google_auth: GoogleAuthConfig {

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -12,6 +12,7 @@ use hmac::{Hmac, Mac};
 use serde_json::{json, Value};
 use sha1::{Digest, Sha1};
 use sha2::Sha256;
+use sm_server::config::RustShadowConfig;
 use sm_server::{
     config::{AppConfig, ExternalAccessConfig, GoogleAuthConfig, PathsConfig},
     http::{router, AppState},
@@ -42,17 +43,37 @@ async fn get_response(app: axum::Router, uri: &str) -> (StatusCode, HeaderMap, V
 }
 
 async fn post_json(app: axum::Router, uri: &str, payload: Value) -> (StatusCode, Value) {
-    let response = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri(uri)
-                .header("content-type", "application/json")
-                .body(Body::from(serde_json::to_vec(&payload).unwrap()))
-                .unwrap(),
-        )
-        .await
+    post_json_with_headers_and_peer(
+        app,
+        uri,
+        payload,
+        &[],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await
+}
+
+async fn post_json_with_headers_and_peer(
+    app: axum::Router,
+    uri: &str,
+    payload: Value,
+    headers: &[(&str, &str)],
+    peer_addr: Option<SocketAddr>,
+) -> (StatusCode, Value) {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json");
+    for (name, value) in headers {
+        builder = builder.header(*name, *value);
+    }
+    let mut request = builder
+        .body(Body::from(serde_json::to_vec(&payload).unwrap()))
         .unwrap();
+    if let Some(peer_addr) = peer_addr {
+        request.extensions_mut().insert(ConnectInfo(peer_addr));
+    }
+    let response = app.oneshot(request).await.unwrap();
     let status = response.status();
     let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     (status, serde_json::from_slice(&body).unwrap())
@@ -236,6 +257,74 @@ async fn shadow_http_classifies_core_writes_without_side_effects() {
         .as_str()
         .unwrap()
         .contains("never performs retained write side effects"));
+}
+
+#[tokio::test]
+async fn shadow_http_rejects_remote_without_shadow_secret() {
+    let app = router(AppState::new(AppConfig::default()));
+    let python_body = serde_json::to_vec(&json!({ "status": "healthy" })).unwrap();
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/health",
+                "query_string": "",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 200,
+                "body_sha256": sha256_hex(&python_body)
+            }
+        }),
+        &[],
+        Some(SocketAddr::from(([203, 0, 113, 10], 49152))),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(
+        payload["detail"],
+        "Rust shadow endpoint requires local peer or shadow secret"
+    );
+}
+
+#[tokio::test]
+async fn shadow_http_allows_remote_with_configured_shadow_secret() {
+    let app = router(AppState::new(AppConfig {
+        rust_shadow: RustShadowConfig {
+            secret: Some("shared-shadow-secret".to_owned()),
+        },
+        ..AppConfig::default()
+    }));
+    let python_body = serde_json::to_vec(&json!({ "status": "healthy" })).unwrap();
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/health",
+                "query_string": "",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 200,
+                "body_sha256": sha256_hex(&python_body)
+            }
+        }),
+        &[("x-sm-rust-shadow-secret", "shared-shadow-secret")],
+        Some(SocketAddr::from(([203, 0, 113, 10], 49152))),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["comparison"], "match");
 }
 
 #[tokio::test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -328,6 +328,74 @@ async fn shadow_http_allows_remote_with_configured_shadow_secret() {
 }
 
 #[tokio::test]
+async fn shadow_http_requires_configured_secret_even_from_loopback() {
+    let app = router(AppState::new(AppConfig {
+        rust_shadow: RustShadowConfig {
+            secret: Some("shared-shadow-secret".to_owned()),
+        },
+        ..AppConfig::default()
+    }));
+    let python_body = serde_json::to_vec(&json!({ "status": "healthy" })).unwrap();
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/health",
+                "query_string": "",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 200,
+                "body_sha256": sha256_hex(&python_body)
+            }
+        }),
+        &[],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(
+        payload["detail"],
+        "Rust shadow endpoint requires local peer or shadow secret"
+    );
+}
+
+#[tokio::test]
+async fn shadow_http_preserves_python_auth_denial_for_protected_reads() {
+    let app = router(AppState::new(AppConfig::default()));
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/sessions",
+                "query_string": "",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 401,
+                "body_sha256": sha256_hex(b"{\"detail\":\"Authentication required\"}")
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "python_auth_denial");
+    assert_eq!(payload["comparison"], "status_match");
+    assert_eq!(payload["predicted_status"], 401);
+    assert_eq!(payload["predicted_body_sha256"], Value::Null);
+}
+
+#[tokio::test]
 async fn auth_session_reports_local_bypass_for_localhost_when_auth_is_misconfigured() {
     let app = router(AppState::new(AppConfig {
         google_auth: GoogleAuthConfig {

--- a/scripts/rust_migration/README.md
+++ b/scripts/rust_migration/README.md
@@ -157,10 +157,11 @@ hash, Rust comparison result, Rust support status, latency, and any shadow
 transport error. Raw bodies, cookies, bearer tokens, worker secrets, hook
 secrets, and device signatures are not written to the ledger.
 
-The Rust shadow endpoint accepts loopback callers by default. If Rust is behind
-a proxy or bound on a non-local interface, configure the same `rust_shadow.secret`
-for Python and Rust so the comparator rejects unauthenticated remote envelopes
-before reading state.
+The Rust shadow endpoint accepts loopback callers by default only when no
+`rust_shadow.secret` is configured. If Rust is behind a proxy, tunnel, or bound
+on a non-local interface, configure the same `rust_shadow.secret` for Python and
+Rust. Once configured, the secret is required even from loopback so local proxies
+cannot bypass it.
 
 Current Rust shadow support is intentionally side-effect-free:
 

--- a/scripts/rust_migration/README.md
+++ b/scripts/rust_migration/README.md
@@ -145,6 +145,8 @@ Enable Python shadowing in local config only:
 rust_shadow:
   enabled: true
   endpoint: "http://127.0.0.1:8421/__shadow/http"
+  # Required when Rust is not reached over loopback, optional for localhost.
+  secret: "local-dev-shared-secret"
   ledger_path: "~/.local/share/claude-sessions/rust_shadow.jsonl"
   timeout_seconds: 0.5
   max_body_bytes: 65536
@@ -154,6 +156,11 @@ The ledger is JSONL. Each row includes method/path/query, Python status and body
 hash, Rust comparison result, Rust support status, latency, and any shadow
 transport error. Raw bodies, cookies, bearer tokens, worker secrets, hook
 secrets, and device signatures are not written to the ledger.
+
+The Rust shadow endpoint accepts loopback callers by default. If Rust is behind
+a proxy or bound on a non-local interface, configure the same `rust_shadow.secret`
+for Python and Rust so the comparator rejects unauthenticated remote envelopes
+before reading state.
 
 Current Rust shadow support is intentionally side-effect-free:
 

--- a/scripts/rust_migration/README.md
+++ b/scripts/rust_migration/README.md
@@ -124,3 +124,45 @@ instrumentation or unsafe workloads explicitly. Python hardening/config variants
 are owner-waived for the cutover value gate; compare current Python against the
 Rust scaffold/prototype instead. Do not commit machine-local baseline reports if
 they contain host-specific or private runtime details.
+
+## Shadow Comparison Mode
+
+Shadow mode lets Python stay authoritative while Rust observes bounded
+request/response envelopes and reports whether it would match, mismatch, or
+currently lacks a side-effect-free implementation. It is disabled by default.
+
+Start Rust on the shadow port:
+
+```bash
+cargo run -p sm-server -- \
+  --port 8421 \
+  --config scripts/rust_migration/fixtures/read_only/config.yaml
+```
+
+Enable Python shadowing in local config only:
+
+```yaml
+rust_shadow:
+  enabled: true
+  endpoint: "http://127.0.0.1:8421/__shadow/http"
+  ledger_path: "~/.local/share/claude-sessions/rust_shadow.jsonl"
+  timeout_seconds: 0.5
+  max_body_bytes: 65536
+```
+
+The ledger is JSONL. Each row includes method/path/query, Python status and body
+hash, Rust comparison result, Rust support status, latency, and any shadow
+transport error. Raw bodies, cookies, bearer tokens, worker secrets, hook
+secrets, and device signatures are not written to the ledger.
+
+Current Rust shadow support is intentionally side-effect-free:
+
+- stable read-only routes can return `comparison: "match"` or a mismatch.
+- volatile reads such as detailed health may return `status_match`.
+- retained writes such as session create/input/kill return
+  `support_status: "unsupported_retained_write"` and `would_write: false` until
+  native Rust runtime ownership is implemented.
+
+For a cutover trial, run shadow mode for the agreed observation window and treat
+unexplained mismatches on retained core surfaces as blockers before Rust becomes
+the writer.

--- a/src/rust_shadow.py
+++ b/src/rust_shadow.py
@@ -62,6 +62,7 @@ class RustShadowMiddleware:
         shadow_config = (config or {}).get("rust_shadow") or {}
         self.enabled = bool(shadow_config.get("enabled", False))
         self.endpoint = str(shadow_config.get("endpoint") or DEFAULT_SHADOW_ENDPOINT)
+        self.secret = str(shadow_config.get("secret") or "")
         self.ledger_path = Path(
             str(shadow_config.get("ledger_path") or DEFAULT_LEDGER_PATH)
         ).expanduser()
@@ -188,8 +189,11 @@ class RustShadowMiddleware:
             "python_body_sha256": envelope["python_response"]["body_sha256"],
         }
         try:
+            headers = {}
+            if self.secret:
+                headers["x-sm-rust-shadow-secret"] = self.secret
             async with httpx.AsyncClient(timeout=self.timeout_seconds) as client:
-                response = await client.post(self.endpoint, json=envelope)
+                response = await client.post(self.endpoint, json=envelope, headers=headers)
             record["rust_http_status"] = response.status_code
             try:
                 record["rust_result"] = response.json()

--- a/src/rust_shadow.py
+++ b/src/rust_shadow.py
@@ -1,0 +1,314 @@
+"""Opt-in Rust shadow comparison support for the migration cutover."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+import httpx
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SHADOW_ENDPOINT = "http://127.0.0.1:8421/__shadow/http"
+DEFAULT_LEDGER_PATH = "~/.local/share/claude-sessions/rust_shadow.jsonl"
+DEFAULT_MAX_BODY_BYTES = 64 * 1024
+DEFAULT_TIMEOUT_SECONDS = 0.5
+
+SENSITIVE_HEADER_NAMES = {
+    "authorization",
+    "cookie",
+    "set-cookie",
+    "x-email-worker-secret",
+    "x-sm-device-signature",
+    "x-sm-hook-secret",
+    "x-sm-node-token",
+}
+
+SAFE_HEADER_NAMES = {
+    "accept",
+    "content-type",
+    "host",
+    "user-agent",
+    "x-forwarded-host",
+    "x-forwarded-proto",
+    "x-sm-shadow-mode",
+}
+
+BODY_CONTENT_TYPE_PREFIXES = (
+    "application/json",
+    "application/x-www-form-urlencoded",
+    "text/",
+)
+
+
+class RustShadowMiddleware:
+    """Mirror completed Python HTTP requests to Rust without changing authority.
+
+    Python remains the only writer. The Rust side receives a bounded, sanitized
+    request/response envelope at a dedicated shadow endpoint and returns a
+    comparison classification. This middleware records only hashes and metadata
+    in the local ledger, not raw request or response bodies.
+    """
+
+    def __init__(self, app: ASGIApp, config: Optional[dict[str, Any]] = None):
+        self.app = app
+        shadow_config = (config or {}).get("rust_shadow") or {}
+        self.enabled = bool(shadow_config.get("enabled", False))
+        self.endpoint = str(shadow_config.get("endpoint") or DEFAULT_SHADOW_ENDPOINT)
+        self.ledger_path = Path(
+            str(shadow_config.get("ledger_path") or DEFAULT_LEDGER_PATH)
+        ).expanduser()
+        self.timeout_seconds = float(
+            shadow_config.get("timeout_seconds", DEFAULT_TIMEOUT_SECONDS)
+        )
+        self.max_body_bytes = int(
+            shadow_config.get("max_body_bytes", DEFAULT_MAX_BODY_BYTES)
+        )
+        self.await_completion_for_tests = bool(
+            shadow_config.get("await_completion_for_tests", False)
+        )
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if not self.enabled or scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        method = str(scope.get("method") or "").upper()
+        path = str(scope.get("path") or "")
+        query_string = _decode_bytes(scope.get("query_string", b""))
+        request_headers = _headers_from_scope(scope)
+        request_capture = _CaptureBuffer(self.max_body_bytes)
+        response_capture = _CaptureBuffer(self.max_body_bytes)
+        response_status: Optional[int] = None
+        response_headers: dict[str, str] = {}
+
+        async def receive_wrapper() -> Message:
+            message = await receive()
+            if message["type"] == "http.request":
+                request_capture.append(message.get("body", b""))
+            return message
+
+        async def send_wrapper(message: Message) -> None:
+            nonlocal response_status, response_headers
+            if message["type"] == "http.response.start":
+                response_status = int(message["status"])
+                response_headers = _headers_from_message(message)
+            elif message["type"] == "http.response.body":
+                response_capture.append(message.get("body", b""))
+
+            await send(message)
+
+            if message["type"] == "http.response.body" and not message.get(
+                "more_body", False
+            ):
+                envelope = self._build_envelope(
+                    method=method,
+                    path=path,
+                    query_string=query_string,
+                    request_headers=request_headers,
+                    request_capture=request_capture,
+                    response_status=response_status,
+                    response_headers=response_headers,
+                    response_capture=response_capture,
+                )
+                if envelope is not None:
+                    await self._dispatch_shadow(envelope)
+
+        await self.app(scope, receive_wrapper, send_wrapper)
+
+    def _build_envelope(
+        self,
+        *,
+        method: str,
+        path: str,
+        query_string: str,
+        request_headers: dict[str, str],
+        request_capture: "_CaptureBuffer",
+        response_status: Optional[int],
+        response_headers: dict[str, str],
+        response_capture: "_CaptureBuffer",
+    ) -> Optional[dict[str, Any]]:
+        if response_status is None or not _is_shadowable_http(
+            method=method,
+            path=path,
+            request_headers=request_headers,
+            response_headers=response_headers,
+        ):
+            return None
+
+        body_content_type = request_headers.get("content-type", "")
+        include_request_body = _is_shadowable_body_content_type(body_content_type)
+        request_body = request_capture.bytes if include_request_body else b""
+
+        return {
+            "schema_version": 1,
+            "observed_at": _now_iso(),
+            "request": {
+                "method": method,
+                "path": path,
+                "query_string": query_string,
+                "headers": _sanitize_headers(request_headers),
+                "body_sha256": request_capture.sha256_hex,
+                "body_base64": base64.b64encode(request_body).decode("ascii")
+                if request_body and not request_capture.truncated
+                else None,
+                "body_truncated": request_capture.truncated,
+                "body_omitted": not include_request_body or request_capture.truncated,
+            },
+            "python_response": {
+                "status": response_status,
+                "headers": _sanitize_headers(response_headers),
+                "body_sha256": response_capture.sha256_hex,
+                "body_truncated": response_capture.truncated,
+            },
+        }
+
+    async def _dispatch_shadow(self, envelope: dict[str, Any]) -> None:
+        if self.await_completion_for_tests:
+            await self._post_and_record(envelope)
+            return
+        asyncio.create_task(self._post_and_record(envelope))
+
+    async def _post_and_record(self, envelope: dict[str, Any]) -> None:
+        started_at = asyncio.get_running_loop().time()
+        record: dict[str, Any] = {
+            "schema_version": 1,
+            "observed_at": envelope["observed_at"],
+            "method": envelope["request"]["method"],
+            "path": envelope["request"]["path"],
+            "query_string": envelope["request"]["query_string"],
+            "python_status": envelope["python_response"]["status"],
+            "python_body_sha256": envelope["python_response"]["body_sha256"],
+        }
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout_seconds) as client:
+                response = await client.post(self.endpoint, json=envelope)
+            record["rust_http_status"] = response.status_code
+            try:
+                record["rust_result"] = response.json()
+            except ValueError:
+                record["rust_result"] = {
+                    "comparison": "shadow_endpoint_non_json",
+                    "body_preview": response.text[:200],
+                }
+        except Exception as exc:  # pragma: no cover - exact transport errors vary
+            logger.debug("Rust shadow request failed: %s", exc)
+            record["shadow_error"] = type(exc).__name__
+            record["shadow_error_message"] = str(exc)[:200]
+        finally:
+            elapsed_ms = (asyncio.get_running_loop().time() - started_at) * 1000
+            record["shadow_elapsed_ms"] = round(elapsed_ms, 3)
+            await asyncio.to_thread(self._append_ledger, record)
+
+    def _append_ledger(self, record: dict[str, Any]) -> None:
+        self.ledger_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.ledger_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, sort_keys=True, separators=(",", ":")))
+            handle.write("\n")
+
+
+class _CaptureBuffer:
+    def __init__(self, max_bytes: int):
+        self.max_bytes = max(0, max_bytes)
+        self._buffer = bytearray()
+        self._hasher = hashlib.sha256()
+        self.truncated = False
+
+    @property
+    def bytes(self) -> bytes:
+        return bytes(self._buffer)
+
+    @property
+    def sha256_hex(self) -> str:
+        return self._hasher.hexdigest()
+
+    def append(self, chunk: bytes) -> None:
+        self._hasher.update(chunk)
+        if not chunk or self.max_bytes == 0:
+            self.truncated = self.truncated or bool(chunk)
+            return
+        remaining = self.max_bytes - len(self._buffer)
+        if remaining <= 0:
+            self.truncated = True
+            return
+        self._buffer.extend(chunk[:remaining])
+        if len(chunk) > remaining:
+            self.truncated = True
+
+
+def _is_shadowable_http(
+    *,
+    method: str,
+    path: str,
+    request_headers: dict[str, str],
+    response_headers: dict[str, str],
+) -> bool:
+    if method not in {"GET", "POST", "PUT", "PATCH", "DELETE"}:
+        return False
+    if path.startswith("/__shadow"):
+        return False
+    if path == "/events" or path.startswith("/client/terminal"):
+        return False
+    request_content_type = request_headers.get("content-type", "")
+    response_content_type = response_headers.get("content-type", "")
+    if request_content_type.startswith("multipart/"):
+        return False
+    if response_content_type.startswith("text/event-stream"):
+        return False
+    return True
+
+
+def _is_shadowable_body_content_type(content_type: str) -> bool:
+    if not content_type:
+        return False
+    normalized = content_type.split(";", 1)[0].strip().lower()
+    return any(
+        normalized == prefix.rstrip("/") or normalized.startswith(prefix)
+        for prefix in BODY_CONTENT_TYPE_PREFIXES
+    )
+
+
+def _headers_from_scope(scope: Scope) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    for raw_name, raw_value in scope.get("headers", []):
+        name = _decode_bytes(raw_name).lower()
+        if name not in headers:
+            headers[name] = _decode_bytes(raw_value)
+    return headers
+
+
+def _headers_from_message(message: Message) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    for raw_name, raw_value in message.get("headers", []):
+        name = _decode_bytes(raw_name).lower()
+        if name not in headers:
+            headers[name] = _decode_bytes(raw_value)
+    return headers
+
+
+def _sanitize_headers(headers: dict[str, str]) -> dict[str, str]:
+    sanitized: dict[str, str] = {}
+    for name, value in headers.items():
+        normalized = name.lower()
+        if normalized in SENSITIVE_HEADER_NAMES:
+            continue
+        if normalized in SAFE_HEADER_NAMES:
+            sanitized[normalized] = value[:512]
+    return sanitized
+
+
+def _decode_bytes(value: bytes | str) -> str:
+    if isinstance(value, str):
+        return value
+    return value.decode("latin-1", errors="replace")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/src/server.py
+++ b/src/server.py
@@ -71,6 +71,7 @@ from .response_relay import (
     collect_claude_assistant_outputs_after_turn,
     find_claude_inbound_turn_boundary_offset,
 )
+from .rust_shadow import RustShadowMiddleware
 
 logger = logging.getLogger(__name__)
 
@@ -1393,6 +1394,10 @@ def create_app(
 
     # Add timing middleware for debugging (with config)
     app.add_middleware(RequestTimingMiddleware, config=config)
+
+    # Disabled by default. When enabled, Python remains authoritative and sends
+    # bounded request/response hashes to the Rust shadow comparator.
+    app.add_middleware(RustShadowMiddleware, config=config)
 
     # Store references to components
     app.state.session_manager = session_manager

--- a/tests/unit/test_rust_shadow_middleware.py
+++ b/tests/unit/test_rust_shadow_middleware.py
@@ -1,0 +1,176 @@
+import json
+from pathlib import Path
+
+from fastapi import Request
+from fastapi.responses import StreamingResponse
+from fastapi.testclient import TestClient
+
+from src.server import create_app
+
+
+class _FakeShadowResponse:
+    status_code = 200
+    text = ""
+
+    def json(self):
+        return {
+            "schema_version": 1,
+            "support_status": "implemented_read",
+            "comparison": "match",
+        }
+
+
+class _FakeAsyncClient:
+    calls = []
+
+    def __init__(self, *, timeout):
+        self.timeout = timeout
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def post(self, endpoint, json):
+        self.calls.append({"endpoint": endpoint, "json": json, "timeout": self.timeout})
+        return _FakeShadowResponse()
+
+
+class _FailingAsyncClient(_FakeAsyncClient):
+    async def post(self, endpoint, json):
+        self.calls.append({"endpoint": endpoint, "json": json, "timeout": self.timeout})
+        raise RuntimeError("rust shadow offline")
+
+
+def _shadow_config(tmp_path: Path, **overrides):
+    config = {
+        "enabled": True,
+        "endpoint": "http://rust-shadow.test/__shadow/http",
+        "ledger_path": str(tmp_path / "rust_shadow.jsonl"),
+        "await_completion_for_tests": True,
+    }
+    config.update(overrides)
+    return {"rust_shadow": config}
+
+
+def test_rust_shadow_is_disabled_by_default(monkeypatch):
+    _FakeAsyncClient.calls.clear()
+    monkeypatch.setattr("src.rust_shadow.httpx.AsyncClient", _FakeAsyncClient)
+
+    response = TestClient(create_app(config={})).get("/health")
+
+    assert response.status_code == 200
+    assert _FakeAsyncClient.calls == []
+
+
+def test_rust_shadow_posts_sanitized_envelope_and_writes_ledger(tmp_path, monkeypatch):
+    _FakeAsyncClient.calls.clear()
+    monkeypatch.setattr("src.rust_shadow.httpx.AsyncClient", _FakeAsyncClient)
+    app = create_app(config=_shadow_config(tmp_path))
+
+    response = TestClient(app).get(
+        "/health?probe=1",
+        headers={"Authorization": "Bearer secret", "Cookie": "sm_auth=secret"},
+    )
+
+    assert response.status_code == 200
+    assert len(_FakeAsyncClient.calls) == 1
+    call = _FakeAsyncClient.calls[0]
+    assert call["endpoint"] == "http://rust-shadow.test/__shadow/http"
+    envelope = call["json"]
+    assert envelope["request"]["method"] == "GET"
+    assert envelope["request"]["path"] == "/health"
+    assert envelope["request"]["query_string"] == "probe=1"
+    assert "authorization" not in envelope["request"]["headers"]
+    assert "cookie" not in envelope["request"]["headers"]
+    assert envelope["python_response"]["status"] == 200
+    assert envelope["python_response"]["body_sha256"]
+
+    rows = (tmp_path / "rust_shadow.jsonl").read_text(encoding="utf-8").splitlines()
+    assert len(rows) == 1
+    ledger = json.loads(rows[0])
+    assert ledger["method"] == "GET"
+    assert ledger["path"] == "/health"
+    assert ledger["rust_result"]["comparison"] == "match"
+
+
+def test_rust_shadow_failure_keeps_authoritative_response_and_records_error(
+    tmp_path, monkeypatch
+):
+    _FailingAsyncClient.calls.clear()
+    monkeypatch.setattr("src.rust_shadow.httpx.AsyncClient", _FailingAsyncClient)
+    app = create_app(config=_shadow_config(tmp_path))
+
+    response = TestClient(app).get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy"}
+    rows = (tmp_path / "rust_shadow.jsonl").read_text(encoding="utf-8").splitlines()
+    assert len(rows) == 1
+    ledger = json.loads(rows[0])
+    assert ledger["path"] == "/health"
+    assert ledger["shadow_error"] == "RuntimeError"
+    assert "rust shadow offline" in ledger["shadow_error_message"]
+
+
+def test_rust_shadow_bounds_request_body_without_logging_raw_payload(tmp_path, monkeypatch):
+    _FakeAsyncClient.calls.clear()
+    monkeypatch.setattr("src.rust_shadow.httpx.AsyncClient", _FakeAsyncClient)
+    app = create_app(config=_shadow_config(tmp_path, max_body_bytes=8))
+
+    @app.post("/shadow-test/echo")
+    async def echo(request: Request):
+        return {"size": len(await request.body())}
+
+    response = TestClient(app).post(
+        "/shadow-test/echo",
+        content='{"message":"this body is longer than eight bytes"}',
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 200
+    envelope = _FakeAsyncClient.calls[0]["json"]
+    assert envelope["request"]["body_truncated"] is True
+    assert envelope["request"]["body_omitted"] is True
+    assert envelope["request"]["body_base64"] is None
+    rows = (tmp_path / "rust_shadow.jsonl").read_text(encoding="utf-8").splitlines()
+    assert "this body" not in rows[0]
+
+
+def test_rust_shadow_skips_multipart_requests(tmp_path, monkeypatch):
+    _FakeAsyncClient.calls.clear()
+    monkeypatch.setattr("src.rust_shadow.httpx.AsyncClient", _FakeAsyncClient)
+    app = create_app(config=_shadow_config(tmp_path))
+
+    @app.post("/shadow-test/upload")
+    async def upload():
+        return {"ok": True}
+
+    response = TestClient(app).post(
+        "/shadow-test/upload",
+        files={"artifact": ("app.apk", b"fake")},
+    )
+
+    assert response.status_code == 200
+    assert _FakeAsyncClient.calls == []
+    assert not (tmp_path / "rust_shadow.jsonl").exists()
+
+
+def test_rust_shadow_skips_sse_responses(tmp_path, monkeypatch):
+    _FakeAsyncClient.calls.clear()
+    monkeypatch.setattr("src.rust_shadow.httpx.AsyncClient", _FakeAsyncClient)
+    app = create_app(config=_shadow_config(tmp_path))
+
+    @app.get("/shadow-test/events")
+    async def events():
+        async def stream():
+            yield "event: hello\ndata: {}\n\n"
+
+        return StreamingResponse(stream(), media_type="text/event-stream")
+
+    response = TestClient(app).get("/shadow-test/events")
+
+    assert response.status_code == 200
+    assert _FakeAsyncClient.calls == []
+    assert not (tmp_path / "rust_shadow.jsonl").exists()

--- a/tests/unit/test_rust_shadow_middleware.py
+++ b/tests/unit/test_rust_shadow_middleware.py
@@ -32,14 +32,28 @@ class _FakeAsyncClient:
     async def __aexit__(self, exc_type, exc, tb):
         return False
 
-    async def post(self, endpoint, json):
-        self.calls.append({"endpoint": endpoint, "json": json, "timeout": self.timeout})
+    async def post(self, endpoint, json, headers=None):
+        self.calls.append(
+            {
+                "endpoint": endpoint,
+                "json": json,
+                "headers": headers or {},
+                "timeout": self.timeout,
+            }
+        )
         return _FakeShadowResponse()
 
 
 class _FailingAsyncClient(_FakeAsyncClient):
-    async def post(self, endpoint, json):
-        self.calls.append({"endpoint": endpoint, "json": json, "timeout": self.timeout})
+    async def post(self, endpoint, json, headers=None):
+        self.calls.append(
+            {
+                "endpoint": endpoint,
+                "json": json,
+                "headers": headers or {},
+                "timeout": self.timeout,
+            }
+        )
         raise RuntimeError("rust shadow offline")
 
 
@@ -93,6 +107,21 @@ def test_rust_shadow_posts_sanitized_envelope_and_writes_ledger(tmp_path, monkey
     assert ledger["method"] == "GET"
     assert ledger["path"] == "/health"
     assert ledger["rust_result"]["comparison"] == "match"
+
+
+def test_rust_shadow_sends_configured_secret_only_to_shadow_endpoint(tmp_path, monkeypatch):
+    _FakeAsyncClient.calls.clear()
+    monkeypatch.setattr("src.rust_shadow.httpx.AsyncClient", _FakeAsyncClient)
+    app = create_app(config=_shadow_config(tmp_path, secret="shared-shadow-secret"))
+
+    response = TestClient(app).get("/health")
+
+    assert response.status_code == 200
+    assert _FakeAsyncClient.calls[0]["headers"] == {
+        "x-sm-rust-shadow-secret": "shared-shadow-secret"
+    }
+    ledger_text = (tmp_path / "rust_shadow.jsonl").read_text(encoding="utf-8")
+    assert "shared-shadow-secret" not in ledger_text
 
 
 def test_rust_shadow_failure_keeps_authoritative_response_and_records_error(


### PR DESCRIPTION
## Summary
- add disabled-by-default Python shadow mirroring that posts bounded request/response envelopes to Rust after Python has produced the authoritative response
- add Rust `POST /__shadow/http` side-effect-free comparator for implemented read-only routes and unsupported retained writes
- document the JSONL shadow ledger and local run configuration

## Verification
- `cargo test -p sm-server`
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py tests/unit/test_rust_shadow_middleware.py`
- `cargo fmt --check && git diff --check`

Fixes #787
Refs #762