### PR TITLE
Prevent Rust shadow secret leakage

### DIFF
--- a/scripts/rust_migration/README.md
+++ b/scripts/rust_migration/README.md
@@ -152,10 +152,15 @@ rust_shadow:
   max_body_bytes: 65536
 ```
 
-The ledger is JSONL. Each row includes method/path/query, Python status and body
-hash, Rust comparison result, Rust support status, latency, and any shadow
-transport error. Raw bodies, cookies, bearer tokens, worker secrets, hook
-secrets, and device signatures are not written to the ledger.
+The ledger is JSONL. Each row includes method/path, redacted query metadata,
+Python status and body hash, Rust comparison result, Rust support status,
+latency, and any shadow transport error. Raw request and response bodies are not
+forwarded or written to the ledger. Cookies, bearer tokens, worker secrets, hook
+secrets, device signatures, and sensitive query values such as OAuth
+`code`/`state` are omitted or redacted before the Rust envelope and ledger are
+written. Shadow mode preserves only query values currently needed for
+side-effect-free comparisons, such as `/sessions?include_stopped=...` and
+`/sessions/{id}/output?lines=...`.
 
 The Rust shadow endpoint accepts loopback callers by default only when no
 `rust_shadow.secret` is configured. If Rust is behind a proxy, tunnel, or bound

--- a/src/rust_shadow.py
+++ b/src/rust_shadow.py
@@ -297,23 +297,24 @@ def _sanitize_query_string(*, method: str, path: str, query_string: str) -> str:
     if not query_string:
         return ""
 
-    safe_keys = _safe_query_keys(method=method, path=path)
     sanitized_pairs: list[tuple[str, str]] = []
     for key, value in parse_qsl(query_string, keep_blank_values=True):
-        sanitized_pairs.append(
-            (key, value if key in safe_keys else REDACTED_QUERY_VALUE)
-        )
+        sanitized_pairs.append((key, _sanitize_query_value(method, path, key, value)))
     return urlencode(sanitized_pairs)
 
 
-def _safe_query_keys(*, method: str, path: str) -> set[str]:
+def _sanitize_query_value(method: str, path: str, key: str, value: str) -> str:
     if method != "GET":
-        return set()
-    if path == "/sessions":
-        return {"include_stopped"}
-    if path.startswith("/sessions/") and path.endswith("/output"):
-        return {"lines"}
-    return set()
+        return REDACTED_QUERY_VALUE
+    if path == "/sessions" and key == "include_stopped":
+        if value in {"1", "true", "True", "TRUE", "yes", "on"}:
+            return value
+        return REDACTED_QUERY_VALUE
+    if path.startswith("/sessions/") and path.endswith("/output") and key == "lines":
+        if value.isascii() and value.isdigit():
+            return value
+        return REDACTED_QUERY_VALUE
+    return REDACTED_QUERY_VALUE
 
 
 def _decode_bytes(value: bytes | str) -> str:

--- a/src/rust_shadow.py
+++ b/src/rust_shadow.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import asyncio
-import base64
 import hashlib
 import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
+from urllib.parse import parse_qsl, urlencode
 
 import httpx
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
@@ -41,11 +41,7 @@ SAFE_HEADER_NAMES = {
     "x-sm-shadow-mode",
 }
 
-BODY_CONTENT_TYPE_PREFIXES = (
-    "application/json",
-    "application/x-www-form-urlencoded",
-    "text/",
-)
+REDACTED_QUERY_VALUE = "REDACTED"
 
 
 class RustShadowMiddleware:
@@ -85,7 +81,7 @@ class RustShadowMiddleware:
         path = str(scope.get("path") or "")
         query_string = _decode_bytes(scope.get("query_string", b""))
         request_headers = _headers_from_scope(scope)
-        request_capture = _CaptureBuffer(self.max_body_bytes)
+        request_capture = _CaptureBuffer(0)
         response_capture = _CaptureBuffer(self.max_body_bytes)
         response_status: Optional[int] = None
         response_headers: dict[str, str] = {}
@@ -144,9 +140,11 @@ class RustShadowMiddleware:
         ):
             return None
 
-        body_content_type = request_headers.get("content-type", "")
-        include_request_body = _is_shadowable_body_content_type(body_content_type)
-        request_body = request_capture.bytes if include_request_body else b""
+        sanitized_query_string = _sanitize_query_string(
+            method=method,
+            path=path,
+            query_string=query_string,
+        )
 
         return {
             "schema_version": 1,
@@ -154,14 +152,11 @@ class RustShadowMiddleware:
             "request": {
                 "method": method,
                 "path": path,
-                "query_string": query_string,
+                "query_string": sanitized_query_string,
                 "headers": _sanitize_headers(request_headers),
                 "body_sha256": request_capture.sha256_hex,
-                "body_base64": base64.b64encode(request_body).decode("ascii")
-                if request_body and not request_capture.truncated
-                else None,
                 "body_truncated": request_capture.truncated,
-                "body_omitted": not include_request_body or request_capture.truncated,
+                "body_omitted": True,
             },
             "python_response": {
                 "status": response_status,
@@ -269,16 +264,6 @@ def _is_shadowable_http(
     return True
 
 
-def _is_shadowable_body_content_type(content_type: str) -> bool:
-    if not content_type:
-        return False
-    normalized = content_type.split(";", 1)[0].strip().lower()
-    return any(
-        normalized == prefix.rstrip("/") or normalized.startswith(prefix)
-        for prefix in BODY_CONTENT_TYPE_PREFIXES
-    )
-
-
 def _headers_from_scope(scope: Scope) -> dict[str, str]:
     headers: dict[str, str] = {}
     for raw_name, raw_value in scope.get("headers", []):
@@ -306,6 +291,29 @@ def _sanitize_headers(headers: dict[str, str]) -> dict[str, str]:
         if normalized in SAFE_HEADER_NAMES:
             sanitized[normalized] = value[:512]
     return sanitized
+
+
+def _sanitize_query_string(*, method: str, path: str, query_string: str) -> str:
+    if not query_string:
+        return ""
+
+    safe_keys = _safe_query_keys(method=method, path=path)
+    sanitized_pairs: list[tuple[str, str]] = []
+    for key, value in parse_qsl(query_string, keep_blank_values=True):
+        sanitized_pairs.append(
+            (key, value if key in safe_keys else REDACTED_QUERY_VALUE)
+        )
+    return urlencode(sanitized_pairs)
+
+
+def _safe_query_keys(*, method: str, path: str) -> set[str]:
+    if method != "GET":
+        return set()
+    if path == "/sessions":
+        return {"include_stopped"}
+    if path.startswith("/sessions/") and path.endswith("/output"):
+        return {"lines"}
+    return set()
 
 
 def _decode_bytes(value: bytes | str) -> str:

--- a/tests/unit/test_rust_shadow_middleware.py
+++ b/tests/unit/test_rust_shadow_middleware.py
@@ -245,6 +245,46 @@ def test_rust_shadow_preserves_safe_query_values_for_comparison(tmp_path, monkey
     assert "lines=10&token=REDACTED" in ledger_text
 
 
+def test_rust_shadow_redacts_invalid_safe_query_values(tmp_path, monkeypatch):
+    _FakeAsyncClient.calls.clear()
+    monkeypatch.setattr("src.rust_shadow.httpx.AsyncClient", _FakeAsyncClient)
+    app = _standalone_shadow_app(tmp_path)
+
+    @app.get("/sessions/{session_id}/output")
+    async def output(session_id: str):
+        return {"session_id": session_id}
+
+    response = TestClient(app).get("/sessions/abc123/output?lines=secret-token")
+
+    assert response.status_code == 200
+    envelope = _FakeAsyncClient.calls[0]["json"]
+    assert envelope["request"]["query_string"] == "lines=REDACTED"
+    ledger_text = (tmp_path / "rust_shadow.jsonl").read_text(encoding="utf-8")
+    assert "secret-token" not in ledger_text
+    assert "lines=REDACTED" in ledger_text
+
+
+def test_rust_shadow_redacts_invalid_include_stopped_query_value(
+    tmp_path, monkeypatch
+):
+    _FakeAsyncClient.calls.clear()
+    monkeypatch.setattr("src.rust_shadow.httpx.AsyncClient", _FakeAsyncClient)
+    app = _standalone_shadow_app(tmp_path)
+
+    @app.get("/sessions")
+    async def sessions():
+        return {"sessions": []}
+
+    response = TestClient(app).get("/sessions?include_stopped=secret-token")
+
+    assert response.status_code == 200
+    envelope = _FakeAsyncClient.calls[0]["json"]
+    assert envelope["request"]["query_string"] == "include_stopped=REDACTED"
+    ledger_text = (tmp_path / "rust_shadow.jsonl").read_text(encoding="utf-8")
+    assert "secret-token" not in ledger_text
+    assert "include_stopped=REDACTED" in ledger_text
+
+
 def test_rust_shadow_skips_multipart_requests(tmp_path, monkeypatch):
     _FakeAsyncClient.calls.clear()
     monkeypatch.setattr("src.rust_shadow.httpx.AsyncClient", _FakeAsyncClient)

--- a/tests/unit/test_rust_shadow_middleware.py
+++ b/tests/unit/test_rust_shadow_middleware.py
@@ -1,10 +1,11 @@
 import json
 from pathlib import Path
 
-from fastapi import Request
+from fastapi import FastAPI, Request
 from fastapi.responses import StreamingResponse
 from fastapi.testclient import TestClient
 
+from src.rust_shadow import RustShadowMiddleware
 from src.server import create_app
 
 
@@ -68,6 +69,12 @@ def _shadow_config(tmp_path: Path, **overrides):
     return {"rust_shadow": config}
 
 
+def _standalone_shadow_app(tmp_path: Path, **overrides) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(RustShadowMiddleware, config=_shadow_config(tmp_path, **overrides))
+    return app
+
+
 def test_rust_shadow_is_disabled_by_default(monkeypatch):
     _FakeAsyncClient.calls.clear()
     monkeypatch.setattr("src.rust_shadow.httpx.AsyncClient", _FakeAsyncClient)
@@ -95,7 +102,7 @@ def test_rust_shadow_posts_sanitized_envelope_and_writes_ledger(tmp_path, monkey
     envelope = call["json"]
     assert envelope["request"]["method"] == "GET"
     assert envelope["request"]["path"] == "/health"
-    assert envelope["request"]["query_string"] == "probe=1"
+    assert envelope["request"]["query_string"] == "probe=REDACTED"
     assert "authorization" not in envelope["request"]["headers"]
     assert "cookie" not in envelope["request"]["headers"]
     assert envelope["python_response"]["status"] == 200
@@ -106,6 +113,7 @@ def test_rust_shadow_posts_sanitized_envelope_and_writes_ledger(tmp_path, monkey
     ledger = json.loads(rows[0])
     assert ledger["method"] == "GET"
     assert ledger["path"] == "/health"
+    assert ledger["query_string"] == "probe=REDACTED"
     assert ledger["rust_result"]["comparison"] == "match"
 
 
@@ -143,7 +151,9 @@ def test_rust_shadow_failure_keeps_authoritative_response_and_records_error(
     assert "rust shadow offline" in ledger["shadow_error_message"]
 
 
-def test_rust_shadow_bounds_request_body_without_logging_raw_payload(tmp_path, monkeypatch):
+def test_rust_shadow_hashes_request_body_without_forwarding_raw_payload(
+    tmp_path, monkeypatch
+):
     _FakeAsyncClient.calls.clear()
     monkeypatch.setattr("src.rust_shadow.httpx.AsyncClient", _FakeAsyncClient)
     app = create_app(config=_shadow_config(tmp_path, max_body_bytes=8))
@@ -162,9 +172,77 @@ def test_rust_shadow_bounds_request_body_without_logging_raw_payload(tmp_path, m
     envelope = _FakeAsyncClient.calls[0]["json"]
     assert envelope["request"]["body_truncated"] is True
     assert envelope["request"]["body_omitted"] is True
-    assert envelope["request"]["body_base64"] is None
+    assert "body_base64" not in envelope["request"]
+    assert envelope["request"]["body_sha256"]
     rows = (tmp_path / "rust_shadow.jsonl").read_text(encoding="utf-8").splitlines()
     assert "this body" not in rows[0]
+    assert "body_base64" not in rows[0]
+
+
+def test_rust_shadow_never_forwards_small_raw_request_body(tmp_path, monkeypatch):
+    _FakeAsyncClient.calls.clear()
+    monkeypatch.setattr("src.rust_shadow.httpx.AsyncClient", _FakeAsyncClient)
+    app = create_app(config=_shadow_config(tmp_path, max_body_bytes=1024))
+
+    @app.post("/shadow-test/token")
+    async def token(request: Request):
+        return {"size": len(await request.body())}
+
+    response = TestClient(app).post(
+        "/shadow-test/token",
+        content='{"id_token":"secret-google-token"}',
+        headers={"content-type": "application/json"},
+    )
+
+    assert response.status_code == 200
+    envelope_text = json.dumps(_FakeAsyncClient.calls[0]["json"])
+    ledger_text = (tmp_path / "rust_shadow.jsonl").read_text(encoding="utf-8")
+    assert "secret-google-token" not in envelope_text
+    assert "body_base64" not in envelope_text
+    assert "secret-google-token" not in ledger_text
+
+
+def test_rust_shadow_redacts_sensitive_query_values(tmp_path, monkeypatch):
+    _FakeAsyncClient.calls.clear()
+    monkeypatch.setattr("src.rust_shadow.httpx.AsyncClient", _FakeAsyncClient)
+    app = _standalone_shadow_app(tmp_path)
+
+    @app.get("/auth/google/callback")
+    async def callback():
+        return {"ok": True}
+
+    response = TestClient(app).get(
+        "/auth/google/callback?code=oauth-code&state=csrf-state"
+    )
+
+    assert response.status_code == 200
+    envelope = _FakeAsyncClient.calls[0]["json"]
+    assert envelope["request"]["query_string"] == "code=REDACTED&state=REDACTED"
+    ledger_text = (tmp_path / "rust_shadow.jsonl").read_text(encoding="utf-8")
+    assert "oauth-code" not in ledger_text
+    assert "csrf-state" not in ledger_text
+    assert "code=REDACTED&state=REDACTED" in ledger_text
+
+
+def test_rust_shadow_preserves_safe_query_values_for_comparison(tmp_path, monkeypatch):
+    _FakeAsyncClient.calls.clear()
+    monkeypatch.setattr("src.rust_shadow.httpx.AsyncClient", _FakeAsyncClient)
+    app = _standalone_shadow_app(tmp_path)
+
+    @app.get("/sessions/{session_id}/output")
+    async def output(session_id: str):
+        return {"session_id": session_id}
+
+    response = TestClient(app).get(
+        "/sessions/abc123/output?lines=10&token=secret-token"
+    )
+
+    assert response.status_code == 200
+    envelope = _FakeAsyncClient.calls[0]["json"]
+    assert envelope["request"]["query_string"] == "lines=10&token=REDACTED"
+    ledger_text = (tmp_path / "rust_shadow.jsonl").read_text(encoding="utf-8")
+    assert "secret-token" not in ledger_text
+    assert "lines=10&token=REDACTED" in ledger_text
 
 
 def test_rust_shadow_skips_multipart_requests(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary\n- Remove raw request body forwarding from Rust shadow envelopes; request bodies are hash-only.\n- Redact query values before forwarding to Rust or writing the JSONL shadow ledger, preserving only comparator-safe values.\n- Add regression coverage for small body secrets, OAuth callback query redaction, and safe query preservation.\n\nFixes #789\nRefs #762\nRefs #788\n\n## Tests\n- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py tests/unit/test_rust_shadow_middleware.py\n- cargo test -p sm-server\n- python -m py_compile src/rust_shadow.py tests/unit/test_rust_shadow_middleware.py\n- cargo fmt --check\n- git diff --check