### PR TITLE
Add gated Rust tmux runtime

### DIFF
--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -10,6 +10,7 @@ pub struct AppConfig {
     pub google_auth: GoogleAuthConfig,
     pub external_access: ExternalAccessConfig,
     pub mobile_terminal: MobileTerminalConfig,
+    pub tmux: TmuxConfig,
     pub rust_shadow: RustShadowConfig,
     pub rust_core: RustCoreConfig,
 }
@@ -132,6 +133,12 @@ pub struct MobileTerminalConfig {
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
+pub struct TmuxConfig {
+    #[serde(default)]
+    pub socket_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct RustShadowConfig {
     #[serde(default)]
     pub secret: Option<String>,
@@ -142,7 +149,27 @@ pub struct RustCoreConfig {
     #[serde(default)]
     pub fixture_writes_enabled: bool,
     #[serde(default)]
+    pub runtime_enabled: bool,
+    #[serde(default)]
     pub log_dir: Option<String>,
+    #[serde(default)]
+    pub tmux_socket_name: Option<String>,
+    #[serde(default)]
+    pub runtime_command: Option<String>,
+    #[serde(default)]
+    pub runtime_prompt_mode: Option<String>,
+    #[serde(default)]
+    pub runtime_start_settle_ms: Option<u64>,
+    #[serde(default)]
+    pub send_keys_settle_ms: Option<f64>,
+    #[serde(default)]
+    pub send_keys_settle_max_ms: Option<f64>,
+    #[serde(default)]
+    pub send_keys_settle_per_ki_ms: Option<f64>,
+    #[serde(default)]
+    pub send_keys_settle_per_extra_line_ms: Option<f64>,
+    #[serde(default)]
+    pub send_keys_max_chunk_chars: Option<usize>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -156,6 +183,10 @@ struct RawConfig {
     #[serde(default)]
     mobile_terminal: MobileTerminalConfig,
     #[serde(default)]
+    tmux: TmuxConfig,
+    #[serde(default)]
+    timeouts: RawTimeoutsConfig,
+    #[serde(default)]
     rust_shadow: RustShadowConfig,
     #[serde(default)]
     rust_core: RustCoreConfig,
@@ -163,13 +194,38 @@ struct RawConfig {
 
 impl From<RawConfig> for AppConfig {
     fn from(raw: RawConfig) -> Self {
+        let mut rust_core = raw.rust_core;
+        if trimmed(&rust_core.tmux_socket_name).is_none() {
+            rust_core.tmux_socket_name = trimmed(&raw.tmux.socket_name);
+        }
+        let tmux_timeouts = raw.timeouts.tmux;
+        if rust_core.send_keys_settle_ms.is_none() {
+            rust_core.send_keys_settle_ms =
+                seconds_to_millis(tmux_timeouts.send_keys_settle_seconds);
+        }
+        if rust_core.send_keys_settle_max_ms.is_none() {
+            rust_core.send_keys_settle_max_ms =
+                seconds_to_millis(tmux_timeouts.send_keys_settle_max_seconds);
+        }
+        if rust_core.send_keys_settle_per_ki_ms.is_none() {
+            rust_core.send_keys_settle_per_ki_ms =
+                seconds_to_millis(tmux_timeouts.send_keys_settle_per_ki_chars);
+        }
+        if rust_core.send_keys_settle_per_extra_line_ms.is_none() {
+            rust_core.send_keys_settle_per_extra_line_ms =
+                seconds_to_millis(tmux_timeouts.send_keys_settle_per_extra_line);
+        }
+        if rust_core.send_keys_max_chunk_chars.is_none() {
+            rust_core.send_keys_max_chunk_chars = tmux_timeouts.send_keys_max_chunk_chars;
+        }
         Self {
             paths: raw.paths,
             google_auth: raw.auth.google,
             external_access: raw.external_access,
             mobile_terminal: raw.mobile_terminal,
+            tmux: raw.tmux,
             rust_shadow: raw.rust_shadow,
-            rust_core: raw.rust_core,
+            rust_core,
         }
     }
 }
@@ -178,6 +234,26 @@ impl From<RawConfig> for AppConfig {
 struct RawAuthConfig {
     #[serde(default)]
     google: GoogleAuthConfig,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawTimeoutsConfig {
+    #[serde(default)]
+    tmux: RawTmuxTimeoutsConfig,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawTmuxTimeoutsConfig {
+    #[serde(default)]
+    send_keys_settle_seconds: Option<f64>,
+    #[serde(default)]
+    send_keys_settle_max_seconds: Option<f64>,
+    #[serde(default)]
+    send_keys_settle_per_ki_chars: Option<f64>,
+    #[serde(default)]
+    send_keys_settle_per_extra_line: Option<f64>,
+    #[serde(default)]
+    send_keys_max_chunk_chars: Option<usize>,
 }
 
 pub fn trimmed(value: &Option<String>) -> Option<String> {
@@ -190,6 +266,12 @@ pub fn trimmed(value: &Option<String>) -> Option<String> {
 
 fn has_text(value: &Option<String>) -> bool {
     trimmed(value).is_some()
+}
+
+fn seconds_to_millis(value: Option<f64>) -> Option<f64> {
+    value
+        .filter(|seconds| seconds.is_finite() && *seconds >= 0.0)
+        .map(|seconds| seconds * 1000.0)
 }
 
 fn load_env_file(path: &Path) -> Result<BTreeMap<String, String>> {

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -27,8 +27,9 @@ use sha2::Sha256;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 use crate::config::{trimmed, AppConfig};
+use crate::runtime::TmuxRuntime;
 use crate::sessions::{
-    expand_home, AgentStatusRequest, ClientSessionResponse, CoreRetireOutcome,
+    expand_home, is_primary_node, AgentStatusRequest, ClientSessionResponse, CoreRetireOutcome,
     CreateCoreSessionRequest, SendCoreInputRequest, SessionResponse, SessionStore,
     SessionsEnvelope,
 };
@@ -228,9 +229,18 @@ async fn create_session(
     Json(payload): Json<CreateCoreSessionRequest>,
 ) -> Result<Json<SessionResponse>, ApiError> {
     ensure_session_allowed_from_parts(&state.config, &headers, Some(peer_addr), "/sessions")?;
-    ensure_core_fixture_writes_enabled(&state)?;
+    ensure_core_writes_enabled(&state)?;
     let log_dir = state.config.rust_core.log_dir.as_deref().map(expand_home);
-    let session = state.session_store.create_core_session(payload, log_dir)?;
+    let session = if state.config.rust_core.runtime_enabled {
+        ensure_core_runtime_provider_supported(&payload)?;
+        ensure_core_runtime_request_node_supported(&state, &payload)?;
+        let runtime = TmuxRuntime::from_config(&state.config.rust_core);
+        state
+            .session_store
+            .create_core_session_with_runtime(payload, log_dir, &runtime)?
+    } else {
+        state.session_store.create_core_session(payload, log_dir)?
+    };
     Ok(Json(SessionResponse::from(session)))
 }
 
@@ -285,14 +295,23 @@ async fn send_session_input(
         Some(peer_addr),
         &format!("/sessions/{session_id}/input"),
     )?;
-    ensure_core_fixture_writes_enabled(&state)?;
+    ensure_core_writes_enabled(&state)?;
     if payload.text.trim().is_empty() {
         return Err(ApiError::Status {
             status: StatusCode::BAD_REQUEST,
             detail: "text is required".to_owned(),
         });
     }
-    let Some(result) = state.session_store.send_core_input(&session_id, payload)? else {
+    let result = if state.config.rust_core.runtime_enabled {
+        ensure_core_runtime_session_node_supported(&state, &session_id)?;
+        let runtime = TmuxRuntime::from_config(&state.config.rust_core);
+        state
+            .session_store
+            .send_core_input_with_runtime(&session_id, payload, &runtime)?
+    } else {
+        state.session_store.send_core_input(&session_id, payload)?
+    };
+    let Some(result) = result else {
         return Err(ApiError::NotFound("Session not found"));
     };
     Ok(Json(serde_json::to_value(result)?))
@@ -311,7 +330,7 @@ async fn set_agent_status(
         Some(peer_addr),
         &format!("/sessions/{session_id}/agent-status"),
     )?;
-    ensure_core_fixture_writes_enabled(&state)?;
+    ensure_core_writes_enabled(&state)?;
     let Some(result) = state.session_store.set_agent_status(&session_id, payload)? else {
         return Err(ApiError::NotFound("Session not found"));
     };
@@ -331,16 +350,25 @@ async fn retire_session(
         Some(peer_addr),
         &format!("/sessions/{session_id}/kill"),
     )?;
-    ensure_core_fixture_writes_enabled(&state)?;
+    ensure_core_writes_enabled(&state)?;
     let requester_session_id = payload
         .requester_session_id
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty());
-    match state
-        .session_store
-        .retire_core_session(&session_id, requester_session_id)?
-    {
+    let outcome = if state.config.rust_core.runtime_enabled {
+        let runtime = TmuxRuntime::from_config(&state.config.rust_core);
+        state.session_store.retire_core_session_with_runtime(
+            &session_id,
+            requester_session_id,
+            &runtime,
+        )?
+    } else {
+        state
+            .session_store
+            .retire_core_session(&session_id, requester_session_id)?
+    };
+    match outcome {
         CoreRetireOutcome::Retired(result) => Ok(Json(serde_json::to_value(result)?)),
         CoreRetireOutcome::NotFound => Ok(Json(json!({
             "error": format!("Session {session_id} not found")
@@ -348,6 +376,10 @@ async fn retire_session(
         CoreRetireOutcome::NotChild => Ok(Json(json!({
             "error": format!("Cannot kill session {session_id} - not your child session")
         }))),
+        CoreRetireOutcome::UnsupportedNode(node) => Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: format!("Rust runtime does not support remote node {node}"),
+        }),
     }
 }
 
@@ -862,13 +894,76 @@ impl IntoResponse for ApiError {
     }
 }
 
-fn ensure_core_fixture_writes_enabled(state: &AppState) -> Result<(), ApiError> {
-    if state.config.rust_core.fixture_writes_enabled {
+fn ensure_core_writes_enabled(state: &AppState) -> Result<(), ApiError> {
+    if state.config.rust_core.fixture_writes_enabled || state.config.rust_core.runtime_enabled {
         return Ok(());
     }
     Err(ApiError::Status {
         status: StatusCode::SERVICE_UNAVAILABLE,
-        detail: "Rust core fixture writes are disabled".to_owned(),
+        detail: "Rust core writes are disabled".to_owned(),
+    })
+}
+
+fn ensure_core_runtime_provider_supported(
+    payload: &CreateCoreSessionRequest,
+) -> Result<(), ApiError> {
+    let provider = payload
+        .provider
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("claude");
+    if provider == "claude" {
+        return Ok(());
+    }
+    Err(ApiError::Status {
+        status: StatusCode::BAD_REQUEST,
+        detail: format!("Rust runtime does not support provider {provider}"),
+    })
+}
+
+fn ensure_core_runtime_request_node_supported(
+    state: &AppState,
+    payload: &CreateCoreSessionRequest,
+) -> Result<(), ApiError> {
+    if let Some(node) = payload
+        .node
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        return ensure_core_runtime_node_supported(node);
+    }
+    if let Some(parent_session_id) = payload
+        .parent_session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        if let Some(parent) = state.session_store.get_session(parent_session_id)? {
+            return ensure_core_runtime_node_supported(&parent.node);
+        }
+    }
+    ensure_core_runtime_node_supported("primary")
+}
+
+fn ensure_core_runtime_session_node_supported(
+    state: &AppState,
+    session_id: &str,
+) -> Result<(), ApiError> {
+    let Some(session) = state.session_store.get_session(session_id)? else {
+        return Ok(());
+    };
+    ensure_core_runtime_node_supported(&session.node)
+}
+
+fn ensure_core_runtime_node_supported(node: &str) -> Result<(), ApiError> {
+    if is_primary_node(node) {
+        return Ok(());
+    }
+    Err(ApiError::Status {
+        status: StatusCode::BAD_REQUEST,
+        detail: format!("Rust runtime does not support remote node {node}"),
     })
 }
 

--- a/crates/sm-server/src/lib.rs
+++ b/crates/sm-server/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod config;
 pub mod http;
+pub mod runtime;
 pub mod sessions;

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -1,0 +1,383 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    thread,
+    time::Duration,
+};
+
+use anyhow::{bail, Context, Result};
+
+use crate::config::RustCoreConfig;
+
+const DEFAULT_SEND_KEYS_SETTLE_MS: f64 = 300.0;
+const DEFAULT_SEND_KEYS_SETTLE_MAX_MS: f64 = 900.0;
+const DEFAULT_SEND_KEYS_SETTLE_PER_KI_MS: f64 = 60.0;
+const DEFAULT_SEND_KEYS_SETTLE_PER_EXTRA_LINE_MS: f64 = 15.0;
+const DEFAULT_SEND_KEYS_MAX_CHUNK_CHARS: usize = 4096;
+
+#[derive(Debug, Clone)]
+pub struct TmuxRuntime {
+    socket_name: Option<String>,
+    command: String,
+    prompt_mode: String,
+    start_settle_ms: u64,
+    send_keys_settle_ms: f64,
+    send_keys_settle_max_ms: f64,
+    send_keys_settle_per_ki_ms: f64,
+    send_keys_settle_per_extra_line_ms: f64,
+    send_keys_max_chunk_chars: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct TmuxSessionSpec {
+    pub session_id: String,
+    pub tmux_session: String,
+    pub working_dir: String,
+    pub log_file: PathBuf,
+    pub initial_message: Option<String>,
+}
+
+impl TmuxRuntime {
+    pub fn from_config(config: &RustCoreConfig) -> Self {
+        Self {
+            socket_name: config
+                .tmux_socket_name
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned),
+            command: config
+                .runtime_command
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .unwrap_or("claude")
+                .to_owned(),
+            prompt_mode: config
+                .runtime_prompt_mode
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .unwrap_or("argv")
+                .to_owned(),
+            start_settle_ms: config.runtime_start_settle_ms.unwrap_or(300),
+            send_keys_settle_ms: finite_nonnegative_or_default(
+                config.send_keys_settle_ms,
+                DEFAULT_SEND_KEYS_SETTLE_MS,
+            ),
+            send_keys_settle_max_ms: finite_nonnegative_or_default(
+                config.send_keys_settle_max_ms,
+                DEFAULT_SEND_KEYS_SETTLE_MAX_MS,
+            ),
+            send_keys_settle_per_ki_ms: finite_nonnegative_or_default(
+                config.send_keys_settle_per_ki_ms,
+                DEFAULT_SEND_KEYS_SETTLE_PER_KI_MS,
+            ),
+            send_keys_settle_per_extra_line_ms: finite_nonnegative_or_default(
+                config.send_keys_settle_per_extra_line_ms,
+                DEFAULT_SEND_KEYS_SETTLE_PER_EXTRA_LINE_MS,
+            ),
+            send_keys_max_chunk_chars: config
+                .send_keys_max_chunk_chars
+                .unwrap_or(DEFAULT_SEND_KEYS_MAX_CHUNK_CHARS)
+                .max(1),
+        }
+    }
+
+    pub fn socket_name(&self) -> Option<&str> {
+        self.socket_name.as_deref()
+    }
+
+    pub fn for_socket_name(&self, socket_name: Option<&str>) -> Self {
+        let mut runtime = self.clone();
+        runtime.socket_name = socket_name
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
+        runtime
+    }
+
+    pub fn create_session(&self, spec: &TmuxSessionSpec) -> Result<()> {
+        if self.session_exists(&spec.tmux_session)? {
+            bail!("tmux session already exists: {}", spec.tmux_session);
+        }
+        if !Path::new(&spec.working_dir).is_dir() {
+            bail!("working dir does not exist: {}", spec.working_dir);
+        }
+        if let Some(parent) = spec.log_file.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create log dir {}", parent.display()))?;
+        }
+        fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&spec.log_file)
+            .with_context(|| format!("failed to prepare log file {}", spec.log_file.display()))?;
+
+        let prompt_mode = self.prompt_mode.to_ascii_lowercase();
+        if prompt_mode != "argv" && prompt_mode != "stdin" {
+            bail!("unsupported runtime prompt mode: {}", self.prompt_mode);
+        }
+
+        let mut command = self.command.clone();
+        if prompt_mode == "argv" {
+            if let Some(initial_message) = spec
+                .initial_message
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                command = format!("{command} -- {}", shell_quote(initial_message));
+            }
+        }
+        command = managed_session_command(&command, &spec.session_id);
+
+        self.run_tmux([
+            "new-session",
+            "-d",
+            "-s",
+            spec.tmux_session.as_str(),
+            "-c",
+            spec.working_dir.as_str(),
+            command.as_str(),
+        ])?;
+
+        if let Err(error) = self.attach_session_log(spec, &prompt_mode) {
+            let _ = self.kill_session(&spec.tmux_session);
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    pub fn send_input(&self, tmux_session: &str, text: &str) -> Result<bool> {
+        if !self.session_exists(tmux_session)? {
+            return Ok(false);
+        }
+        self.exit_copy_mode_if_needed(tmux_session);
+        for chunk in split_send_text_chunks(text, self.send_keys_max_chunk_chars) {
+            self.run_tmux(["send-keys", "-t", tmux_session, "-l", "--", chunk])?;
+        }
+        thread::sleep(self.compute_settle_delay(text));
+        self.run_tmux(["send-keys", "-t", tmux_session, "Enter"])?;
+        Ok(true)
+    }
+
+    pub fn kill_session(&self, tmux_session: &str) -> Result<bool> {
+        if !self.session_exists(tmux_session)? {
+            return Ok(false);
+        }
+        self.run_tmux(["kill-session", "-t", tmux_session])?;
+        Ok(true)
+    }
+
+    fn session_exists(&self, tmux_session: &str) -> Result<bool> {
+        let output = self
+            .tmux_command(["has-session", "-t", tmux_session])
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .output()
+            .with_context(|| "failed to run tmux has-session")?;
+        Ok(output.status.success())
+    }
+
+    fn pane_in_mode(&self, tmux_session: &str) -> Option<i32> {
+        let output = self
+            .tmux_command([
+                "display-message",
+                "-p",
+                "-t",
+                tmux_session,
+                "#{pane_in_mode}",
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        match String::from_utf8_lossy(&output.stdout).trim() {
+            "0" => Some(0),
+            "1" => Some(1),
+            _ => None,
+        }
+    }
+
+    fn exit_copy_mode_if_needed(&self, tmux_session: &str) {
+        if self.pane_in_mode(tmux_session) == Some(1) {
+            let _ = self.run_tmux(["send-keys", "-t", tmux_session, "-X", "cancel"]);
+        }
+    }
+
+    fn run_tmux<'a>(&self, args: impl IntoIterator<Item = &'a str>) -> Result<()> {
+        let output = self
+            .tmux_command(args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .with_context(|| "failed to run tmux")?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("tmux command failed: {}", stderr.trim());
+        }
+        Ok(())
+    }
+
+    fn tmux_command<'a>(&self, args: impl IntoIterator<Item = &'a str>) -> Command {
+        let mut command = Command::new("tmux");
+        if let Some(socket_name) = &self.socket_name {
+            command.arg("-L").arg(socket_name);
+        }
+        command.args(args);
+        command
+    }
+
+    fn attach_session_log(&self, spec: &TmuxSessionSpec, prompt_mode: &str) -> Result<()> {
+        let pipe_command = format!("cat >> {}", shell_quote_path(&spec.log_file));
+        self.run_tmux([
+            "pipe-pane",
+            "-t",
+            spec.tmux_session.as_str(),
+            pipe_command.as_str(),
+        ])?;
+
+        if prompt_mode == "stdin" {
+            if let Some(initial_message) = spec
+                .initial_message
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                thread::sleep(Duration::from_millis(self.start_settle_ms));
+                if !self.send_input(&spec.tmux_session, initial_message)? {
+                    bail!("tmux session exited before initial prompt could be delivered");
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn compute_settle_delay(&self, text: &str) -> Duration {
+        let base = self.send_keys_settle_ms;
+        let max_delay = base.max(self.send_keys_settle_max_ms);
+        let text_len = text.chars().count();
+        let line_count = text.matches('\n').count() + 1;
+        if text_len <= 512 && line_count <= 1 {
+            return duration_from_millis(base);
+        }
+
+        let extra = ((text_len.saturating_sub(512) as f64) / 1024.0)
+            * self.send_keys_settle_per_ki_ms
+            + (line_count.saturating_sub(1) as f64) * self.send_keys_settle_per_extra_line_ms;
+        duration_from_millis((base + extra).clamp(base, max_delay))
+    }
+}
+
+fn split_send_text_chunks(text: &str, max_chunk_chars: usize) -> Vec<&str> {
+    let max_chunk_chars = max_chunk_chars.max(1);
+    if text.chars().count() <= max_chunk_chars {
+        return vec![text];
+    }
+
+    let mut chunks = Vec::new();
+    let mut remaining = text;
+    while !remaining.is_empty() {
+        if remaining.chars().count() <= max_chunk_chars {
+            chunks.push(remaining);
+            break;
+        }
+
+        let boundary = byte_index_after_chars(remaining, max_chunk_chars);
+        let half_chars = max_chunk_chars / 2;
+        let newline_split = remaining[..boundary].rfind('\n').and_then(|idx| {
+            if remaining[..idx].chars().count() >= half_chars {
+                Some(idx + '\n'.len_utf8())
+            } else {
+                None
+            }
+        });
+        let split_at = newline_split.unwrap_or(boundary);
+        chunks.push(&remaining[..split_at]);
+        remaining = &remaining[split_at..];
+    }
+    chunks
+}
+
+fn byte_index_after_chars(value: &str, char_count: usize) -> usize {
+    value
+        .char_indices()
+        .nth(char_count)
+        .map(|(idx, _)| idx)
+        .unwrap_or(value.len())
+}
+
+fn finite_nonnegative_or_default(value: Option<f64>, default: f64) -> f64 {
+    value
+        .filter(|candidate| candidate.is_finite() && *candidate >= 0.0)
+        .unwrap_or(default)
+}
+
+fn duration_from_millis(millis: f64) -> Duration {
+    Duration::from_secs_f64((millis.max(0.0)) / 1000.0)
+}
+
+fn shell_quote_path(path: &Path) -> String {
+    shell_quote(&path.display().to_string())
+}
+
+fn shell_quote(value: &str) -> String {
+    if value.is_empty() {
+        return "''".to_owned();
+    }
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn managed_session_command(command: &str, session_id: &str) -> String {
+    let session_id = shell_quote(session_id);
+    format!(
+        "export SESSION_MANAGER_ID={session_id}; \
+         export CLAUDE_SESSION_MANAGER_ID={session_id}; \
+         unset CLAUDECODE; \
+         export ENABLE_TOOL_SEARCH=false; \
+         {command}"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_send_text_chunks_prefers_newline_after_half_chunk() {
+        let chunks = split_send_text_chunks("abcd\nefghij", 8);
+        assert_eq!(chunks, vec!["abcd\n", "efghij"]);
+    }
+
+    #[test]
+    fn split_send_text_chunks_preserves_utf8_boundaries() {
+        let chunks = split_send_text_chunks("åßçdé", 2);
+        assert_eq!(chunks, vec!["åß", "çd", "é"]);
+    }
+
+    #[test]
+    fn settle_delay_grows_for_large_multiline_input() {
+        let runtime = TmuxRuntime::from_config(&RustCoreConfig::default());
+        assert_eq!(
+            runtime.compute_settle_delay("short"),
+            Duration::from_millis(300)
+        );
+        assert!(runtime.compute_settle_delay(&"x".repeat(2048)) > Duration::from_millis(300));
+        assert!(runtime.compute_settle_delay("one\ntwo\nthree") > Duration::from_millis(300));
+    }
+
+    #[test]
+    fn managed_session_command_exports_canonical_and_legacy_session_ids() {
+        let command = managed_session_command("claude", "session'42");
+        assert!(command.contains("export SESSION_MANAGER_ID='session'\\''42'"));
+        assert!(command.contains("export CLAUDE_SESSION_MANAGER_ID='session'\\''42'"));
+        assert!(command.contains("unset CLAUDECODE"));
+        assert!(command.contains("export ENABLE_TOOL_SEARCH=false"));
+        assert!(command.ends_with("; claude"));
+    }
+}

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -13,6 +13,8 @@ use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
+use crate::runtime::{TmuxRuntime, TmuxSessionSpec};
+
 const DEFAULT_SESSION_STATE_FILE: &str = "~/.local/share/claude-sessions/sessions.json";
 const LEGACY_TMP_SESSION_STATE_FILE: &str = "/tmp/claude-sessions/sessions.json";
 const OUTPUT_TAIL_BYTES_PER_LINE: u64 = 4096;
@@ -105,54 +107,13 @@ impl SessionStore {
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
         let sessions = ensure_sessions_array_mut(&mut state)?;
-        let session_id = request
-            .id
+        let record =
+            self.build_core_session_record(sessions, &request, log_dir.as_deref(), false, None)?;
+        let log_file = record
+            .log_file
             .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(ToOwned::to_owned)
-            .unwrap_or_else(generate_session_id);
-        if session_object_mut(sessions, &session_id).is_some() {
-            anyhow::bail!("session already exists: {session_id}");
-        }
-        let parent_working_dir = request.parent_session_id.as_deref().and_then(|parent_id| {
-            sessions
-                .iter()
-                .find(|value| value.get("id").and_then(Value::as_str) == Some(parent_id))
-                .and_then(|value| json_text(value.get("working_dir")))
-        });
-
-        let provider = request
-            .provider
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .unwrap_or("claude")
-            .to_owned();
-        let name = request
-            .name
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(ToOwned::to_owned)
-            .unwrap_or_else(|| format!("{provider}-{session_id}"));
-        let working_dir = request
-            .working_dir
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .or(parent_working_dir.as_deref())
-            .unwrap_or(".")
-            .to_owned();
-        let node = request
-            .node
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .unwrap_or("primary")
-            .to_owned();
-        let now = now_rfc3339();
-        let log_file = core_log_file_path(&self.state_file, log_dir.as_deref(), &session_id);
+            .map(expand_home)
+            .ok_or_else(|| anyhow::anyhow!("fixture session missing log file"))?;
         append_log_line(&log_file, "[sm-rust] fixture session created")?;
         if let Some(initial_message) = request
             .initial_message
@@ -168,57 +129,45 @@ impl SessionStore {
                 &format!("[sm-rust] fixture watch requested: {wait}s"),
             )?;
         }
-
-        let record = SessionRecord {
-            id: session_id.clone(),
-            name,
-            working_dir,
-            tmux_session: format!("sm-rust-{session_id}"),
-            tmux_socket_name: None,
-            node,
-            provider,
-            log_file: Some(log_file.display().to_string()),
-            provider_resume_id: None,
-            transcript_path: None,
-            codex_thread_id: None,
-            forked_from_session_id: None,
-            forked_from_provider_resume_id: None,
-            forked_provider_resume_id: None,
-            forked_at: None,
-            forked_by_session_id: None,
-            friendly_name: request.name,
-            friendly_name_is_explicit: true,
-            friendly_name_updated_at_ns: None,
-            native_title: None,
-            native_title_updated_at_ns: None,
-            native_title_source_mtime_ns: None,
-            telegram_chat_id: None,
-            telegram_thread_id: None,
-            telegram_topic_id: None,
-            telegram_root_msg_id: None,
-            current_task: None,
-            git_remote_url: None,
-            parent_session_id: request.parent_session_id,
-            last_handoff_path: None,
-            agent_status_text: None,
-            agent_status_at: None,
-            agent_task_completed_at: None,
-            completed_at: None,
-            stopped_at: None,
-            is_em: false,
-            role: None,
-            status: "running".to_owned(),
-            created_at: now.clone(),
-            last_activity: now,
-            last_tool_call: None,
-            last_tool_name: None,
-            tokens_used: 0,
-            context_monitor_enabled: false,
-            aliases: Vec::new(),
-            pending_adoption_proposals: Vec::new(),
-        };
         sessions.push(serde_json::to_value(&record)?);
         self.write_raw_json_value(&state)?;
+        Ok(record)
+    }
+
+    pub fn create_core_session_with_runtime(
+        &self,
+        request: CreateCoreSessionRequest,
+        log_dir: Option<PathBuf>,
+        runtime: &TmuxRuntime,
+    ) -> Result<SessionRecord> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let record = self.build_core_session_record(
+            sessions,
+            &request,
+            log_dir.as_deref(),
+            true,
+            runtime.socket_name(),
+        )?;
+        ensure_runtime_local_node(&record.node)?;
+        let log_file = record
+            .log_file
+            .as_deref()
+            .map(expand_home)
+            .ok_or_else(|| anyhow::anyhow!("runtime session missing log file"))?;
+        runtime.create_session(&TmuxSessionSpec {
+            session_id: record.id.clone(),
+            tmux_session: record.tmux_session.clone(),
+            working_dir: expand_home(&record.working_dir).display().to_string(),
+            log_file,
+            initial_message: request.initial_message.clone(),
+        })?;
+        sessions.push(serde_json::to_value(&record)?);
+        if let Err(error) = self.write_raw_json_value(&state) {
+            let _ = runtime.kill_session(&record.tmux_session);
+            return Err(error);
+        }
         Ok(record)
     }
 
@@ -259,6 +208,49 @@ impl SessionStore {
         }))
     }
 
+    pub fn send_core_input_with_runtime(
+        &self,
+        session_id: &str,
+        request: SendCoreInputRequest,
+        runtime: &TmuxRuntime,
+    ) -> Result<Option<CoreInputResult>> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let Some(session) = session_object_mut(sessions, session_id) else {
+            return Ok(None);
+        };
+        let node = json_text(session.get("node")).unwrap_or_else(default_node);
+        ensure_runtime_local_node(&node)?;
+        let mut status = json_text(session.get("status")).unwrap_or_else(|| "running".to_owned());
+        let tmux_session = json_text(session.get("tmux_session"))
+            .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?;
+        let session_socket_name = json_text(session.get("tmux_socket_name"));
+        let session_runtime = runtime.for_socket_name(session_socket_name.as_deref());
+        let mut delivered = false;
+        if normalized_status(&status) != "stopped" {
+            delivered = session_runtime.send_input(&tmux_session, &request.text)?;
+            let now = now_rfc3339();
+            if delivered {
+                session.insert("last_activity".to_owned(), Value::String(now));
+            } else {
+                status = "stopped".to_owned();
+                session.insert("status".to_owned(), Value::String(status.clone()));
+                session.insert("stopped_at".to_owned(), Value::String(now.clone()));
+                session.insert("last_activity".to_owned(), Value::String(now));
+            }
+        }
+        self.write_raw_json_value(&state)?;
+        Ok(Some(CoreInputResult {
+            ok: true,
+            session_id: session_id.to_owned(),
+            delivered,
+            delivery_mode: request.delivery_mode,
+            notify_after_seconds: request.notify_after_seconds,
+            status,
+        }))
+    }
+
     pub fn retire_core_session(
         &self,
         session_id: &str,
@@ -285,6 +277,47 @@ impl SessionStore {
         if let Some(log_file) = json_text(session.get("log_file")) {
             append_log_line(&expand_home(&log_file), "[sm-rust] fixture session retired")?;
         }
+        self.write_raw_json_value(&state)?;
+        Ok(CoreRetireOutcome::Retired(CoreRetireResult {
+            ok: true,
+            session_id: session_id.to_owned(),
+            status: "killed".to_owned(),
+        }))
+    }
+
+    pub fn retire_core_session_with_runtime(
+        &self,
+        session_id: &str,
+        requester_session_id: Option<&str>,
+        runtime: &TmuxRuntime,
+    ) -> Result<CoreRetireOutcome> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let Some(session) = session_object_mut(sessions, session_id) else {
+            return Ok(CoreRetireOutcome::NotFound);
+        };
+        if let Some(requester_session_id) = requester_session_id {
+            if !requester_session_id.is_empty()
+                && json_text(session.get("parent_session_id")).as_deref()
+                    != Some(requester_session_id)
+            {
+                return Ok(CoreRetireOutcome::NotChild);
+            }
+        }
+        let node = json_text(session.get("node")).unwrap_or_else(default_node);
+        if !is_primary_node(&node) {
+            return Ok(CoreRetireOutcome::UnsupportedNode(node));
+        }
+        let tmux_session = json_text(session.get("tmux_session"))
+            .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?;
+        let session_socket_name = json_text(session.get("tmux_socket_name"));
+        let session_runtime = runtime.for_socket_name(session_socket_name.as_deref());
+        let _ = session_runtime.kill_session(&tmux_session)?;
+        let now = now_rfc3339();
+        session.insert("status".to_owned(), Value::String("stopped".to_owned()));
+        session.insert("stopped_at".to_owned(), Value::String(now.clone()));
+        session.insert("last_activity".to_owned(), Value::String(now));
         self.write_raw_json_value(&state)?;
         Ok(CoreRetireOutcome::Retired(CoreRetireResult {
             ok: true,
@@ -405,6 +438,121 @@ impl SessionStore {
             .lock()
             .map_err(|_| anyhow::anyhow!("session state write lock poisoned"))
     }
+
+    fn build_core_session_record(
+        &self,
+        sessions: &[Value],
+        request: &CreateCoreSessionRequest,
+        log_dir: Option<&Path>,
+        runtime_backed: bool,
+        tmux_socket_name: Option<&str>,
+    ) -> Result<SessionRecord> {
+        let session_id = request
+            .id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(generate_session_id);
+        if sessions
+            .iter()
+            .any(|value| value.get("id").and_then(Value::as_str) == Some(session_id.as_str()))
+        {
+            anyhow::bail!("session already exists: {session_id}");
+        }
+        let parent_session = request.parent_session_id.as_deref().and_then(|parent_id| {
+            sessions
+                .iter()
+                .find(|value| value.get("id").and_then(Value::as_str) == Some(parent_id))
+        });
+        let parent_working_dir =
+            parent_session.and_then(|value| json_text(value.get("working_dir")));
+        let parent_node = parent_session.and_then(|value| json_text(value.get("node")));
+        let provider = request
+            .provider
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or("claude")
+            .to_owned();
+        let name = request
+            .name
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| format!("{provider}-{session_id}"));
+        let working_dir = request
+            .working_dir
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .or(parent_working_dir.as_deref())
+            .unwrap_or(".")
+            .to_owned();
+        let node = request
+            .node
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .or(parent_node.as_deref())
+            .unwrap_or("primary")
+            .to_owned();
+        let now = now_rfc3339();
+        let log_file = core_log_file_path(&self.state_file, log_dir, &session_id);
+        Ok(SessionRecord {
+            id: session_id.clone(),
+            name,
+            working_dir,
+            tmux_session: if runtime_backed {
+                core_tmux_session_name(&provider, &session_id)
+            } else {
+                format!("sm-rust-{session_id}")
+            },
+            tmux_socket_name: tmux_socket_name.map(ToOwned::to_owned),
+            node,
+            provider,
+            log_file: Some(log_file.display().to_string()),
+            provider_resume_id: None,
+            transcript_path: None,
+            codex_thread_id: None,
+            forked_from_session_id: None,
+            forked_from_provider_resume_id: None,
+            forked_provider_resume_id: None,
+            forked_at: None,
+            forked_by_session_id: None,
+            friendly_name: request.name.clone(),
+            friendly_name_is_explicit: true,
+            friendly_name_updated_at_ns: None,
+            native_title: None,
+            native_title_updated_at_ns: None,
+            native_title_source_mtime_ns: None,
+            telegram_chat_id: None,
+            telegram_thread_id: None,
+            telegram_topic_id: None,
+            telegram_root_msg_id: None,
+            current_task: None,
+            git_remote_url: None,
+            parent_session_id: request.parent_session_id.clone(),
+            last_handoff_path: None,
+            agent_status_text: None,
+            agent_status_at: None,
+            agent_task_completed_at: None,
+            completed_at: None,
+            stopped_at: None,
+            is_em: false,
+            role: None,
+            status: "running".to_owned(),
+            created_at: now.clone(),
+            last_activity: now,
+            last_tool_call: None,
+            last_tool_name: None,
+            tokens_used: 0,
+            context_monitor_enabled: false,
+            aliases: Vec::new(),
+            pending_adoption_proposals: Vec::new(),
+        })
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -464,6 +612,7 @@ pub enum CoreRetireOutcome {
     Retired(CoreRetireResult),
     NotFound,
     NotChild,
+    UnsupportedNode(String),
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -542,6 +691,13 @@ fn core_log_file_path(state_file: &Path, log_dir: Option<&Path>, session_id: &st
     dir.join(format!("{safe_id}-{id_hash}.log"))
 }
 
+fn core_tmux_session_name(provider: &str, session_id: &str) -> String {
+    let safe_provider = sanitize_path_component(provider);
+    let safe_id = sanitize_path_component(session_id);
+    let id_hash = stable_session_id_hash(session_id);
+    format!("sm-rust-{safe_provider}-{safe_id}-{id_hash}")
+}
+
 fn sanitize_path_component(value: &str) -> String {
     let mut safe = value
         .chars()
@@ -583,6 +739,11 @@ fn now_rfc3339() -> String {
 }
 
 pub fn expand_home(path: &str) -> PathBuf {
+    if path == "~" {
+        return env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(path));
+    }
     let Some(rest) = path.strip_prefix("~/") else {
         return PathBuf::from(path);
     };
@@ -1180,6 +1341,18 @@ fn default_node() -> String {
     "primary".to_owned()
 }
 
+pub fn is_primary_node(node: &str) -> bool {
+    let node = node.trim();
+    node.is_empty() || node == "primary"
+}
+
+fn ensure_runtime_local_node(node: &str) -> Result<()> {
+    if is_primary_node(node) {
+        return Ok(());
+    }
+    anyhow::bail!("Rust runtime does not support remote node {node}");
+}
+
 fn default_provider() -> String {
     "claude".to_owned()
 }
@@ -1209,6 +1382,17 @@ fn normalize_role(role: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn expand_home_handles_bare_home_and_home_relative_paths() {
+        let Some(home) = env::var_os("HOME") else {
+            return;
+        };
+        let home = PathBuf::from(home);
+        assert_eq!(expand_home("~"), home);
+        assert_eq!(expand_home("~/work"), home.join("work"));
+        assert_eq!(expand_home("/tmp/work"), PathBuf::from("/tmp/work"));
+    }
 
     fn session_record(status: &str) -> SessionRecord {
         SessionRecord {

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -21,6 +21,7 @@ use std::{
     fs,
     net::SocketAddr,
     path::PathBuf,
+    process::Command,
     sync::atomic::{AtomicU64, Ordering},
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -852,7 +853,63 @@ async fn fixture_core_writes_are_disabled_by_default() {
     assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
     assert_eq!(
         payload,
-        json!({ "detail": "Rust core fixture writes are disabled" })
+        json!({ "detail": "Rust core writes are disabled" })
+    );
+}
+
+#[test]
+fn runtime_core_inherits_existing_tmux_socket_config() {
+    let config_path = unique_temp_path();
+    let missing_env_path = unique_temp_path();
+
+    fs::write(
+        &config_path,
+        r#"
+tmux:
+  socket_name: "session-manager"
+timeouts:
+  tmux:
+    send_keys_settle_seconds: 0.25
+    send_keys_settle_max_seconds: 1.25
+    send_keys_settle_per_ki_chars: 0.07
+    send_keys_settle_per_extra_line: 0.02
+    send_keys_max_chunk_chars: 2048
+rust_core:
+  runtime_enabled: true
+"#,
+    )
+    .unwrap();
+    let config =
+        AppConfig::load_from_path_with_local_env(&config_path, Some(&missing_env_path)).unwrap();
+    assert_eq!(
+        config.rust_core.tmux_socket_name.as_deref(),
+        Some("session-manager")
+    );
+    assert_eq!(config.rust_core.send_keys_settle_ms, Some(250.0));
+    assert_eq!(config.rust_core.send_keys_settle_max_ms, Some(1250.0));
+    assert_eq!(config.rust_core.send_keys_settle_per_ki_ms, Some(70.0));
+    assert_eq!(
+        config.rust_core.send_keys_settle_per_extra_line_ms,
+        Some(20.0)
+    );
+    assert_eq!(config.rust_core.send_keys_max_chunk_chars, Some(2048));
+
+    fs::write(
+        &config_path,
+        r#"
+tmux:
+  socket_name: "session-manager"
+rust_core:
+  runtime_enabled: true
+  tmux_socket_name: "rust-core-only"
+"#,
+    )
+    .unwrap();
+    let config =
+        AppConfig::load_from_path_with_local_env(&config_path, Some(&missing_env_path)).unwrap();
+    assert_eq!(
+        config.rust_core.tmux_socket_name.as_deref(),
+        Some("rust-core-only")
     );
 }
 
@@ -867,6 +924,7 @@ async fn fixture_core_lifecycle_creates_sends_outputs_and_retires() {
         rust_core: RustCoreConfig {
             fixture_writes_enabled: true,
             log_dir: Some(log_dir.display().to_string()),
+            ..RustCoreConfig::default()
         },
         ..AppConfig::default()
     }));
@@ -1011,6 +1069,7 @@ async fn fixture_core_writes_preserve_concurrent_session_updates() {
         rust_core: RustCoreConfig {
             fixture_writes_enabled: true,
             log_dir: Some(unique_temp_path().display().to_string()),
+            ..RustCoreConfig::default()
         },
         ..AppConfig::default()
     }));
@@ -1063,6 +1122,7 @@ async fn fixture_core_logs_do_not_collide_for_sanitized_session_ids() {
         rust_core: RustCoreConfig {
             fixture_writes_enabled: true,
             log_dir: Some(log_dir.display().to_string()),
+            ..RustCoreConfig::default()
         },
         ..AppConfig::default()
     }));
@@ -1106,6 +1166,553 @@ async fn fixture_core_logs_do_not_collide_for_sanitized_session_ids() {
     let output = payload["output"].as_str().unwrap();
     assert!(output.contains("first prompt only"));
     assert!(!output.contains("second prompt only"));
+}
+
+#[tokio::test]
+async fn runtime_core_lifecycle_uses_tmux_backend_when_enabled() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let working_dir = unique_temp_path();
+    fs::create_dir_all(&working_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-test-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        rust_core: RustCoreConfig {
+            runtime_enabled: true,
+            log_dir: Some(log_dir.display().to_string()),
+            tmux_socket_name: Some(tmux_socket.clone()),
+            runtime_command: Some(
+                r#"/bin/sh -lc 'while IFS= read -r line; do printf "ids:%s:%s:%s\nruntime:%s\n" "$SESSION_MANAGER_ID" "$CLAUDE_SESSION_MANAGER_ID" "$ENABLE_TOOL_SEARCH" "$line"; done'"#
+                    .to_owned(),
+            ),
+            runtime_prompt_mode: Some("stdin".to_owned()),
+            runtime_start_settle_ms: Some(100),
+            send_keys_settle_ms: Some(10.0),
+            send_keys_settle_max_ms: Some(50.0),
+            send_keys_max_chunk_chars: Some(128),
+            ..RustCoreConfig::default()
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimecore",
+            "name": "runtime-core",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude",
+            "initial_message": "initial runtime prompt"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["id"], "runtimecore");
+    assert_eq!(payload["status"], "running");
+    assert_eq!(payload["tmux_socket_name"], tmux_socket);
+    let tmux_session = payload["tmux_session"].as_str().unwrap().to_owned();
+
+    let payload =
+        wait_for_output_contains(app.clone(), "runtimecore", "runtime:initial runtime prompt")
+            .await;
+    assert_eq!(payload["session_id"], "runtimecore");
+    wait_for_output_contains(
+        app.clone(),
+        "runtimecore",
+        "ids:runtimecore:runtimecore:false",
+    )
+    .await;
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/runtimecore/input",
+        json!({
+            "text": "second runtime message",
+            "delivery_mode": "sequential"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["delivered"], true);
+
+    wait_for_output_contains(app.clone(), "runtimecore", "runtime:second runtime message").await;
+
+    let long_runtime_message = format!("{}chunked-runtime-tail", "x".repeat(500));
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/runtimecore/input",
+        json!({
+            "text": long_runtime_message,
+            "delivery_mode": "sequential"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["delivered"], true);
+    wait_for_output_contains(app.clone(), "runtimecore", "chunked-runtime-tail").await;
+
+    assert!(tmux_enter_copy_mode(&tmux_socket, &tmux_session));
+    assert_eq!(tmux_pane_in_mode(&tmux_socket, &tmux_session), Some(1));
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/runtimecore/input",
+        json!({
+            "text": "copy mode runtime message",
+            "delivery_mode": "sequential"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["delivered"], true);
+    wait_for_output_contains(
+        app.clone(),
+        "runtimecore",
+        "runtime:copy mode runtime message",
+    )
+    .await;
+
+    let (status, payload) = post_json(app.clone(), "/sessions/runtimecore/kill", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "killed");
+
+    let (status, payload) = get_json(app, "/sessions/runtimecore").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "stopped");
+    assert!(!tmux_session_exists(&tmux_socket, &tmux_session));
+}
+
+#[tokio::test]
+async fn runtime_core_send_and_retire_use_persisted_tmux_socket() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let working_dir = unique_temp_path();
+    fs::create_dir_all(&working_dir).unwrap();
+    let socket_a = format!(
+        "sm-rust-test-a-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let socket_b = format!("{socket_a}-b");
+    let _guard_a = TestTmuxSocket(socket_a.clone());
+    let _guard_b = TestTmuxSocket(socket_b.clone());
+    let app_a = runtime_app(&state_file, &log_dir, &socket_a);
+    let app_b = runtime_app(&state_file, &log_dir, &socket_b);
+
+    let (status, payload) = post_json(
+        app_a.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimepersisted",
+            "name": "runtime-persisted",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude",
+            "initial_message": "persisted socket initial"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["tmux_socket_name"], socket_a);
+    let tmux_session = payload["tmux_session"].as_str().unwrap().to_owned();
+    wait_for_output_contains(
+        app_a.clone(),
+        "runtimepersisted",
+        "runtime:persisted socket initial",
+    )
+    .await;
+
+    let (status, payload) = post_json(
+        app_b.clone(),
+        "/sessions/runtimepersisted/input",
+        json!({ "text": "sent through changed config socket" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["delivered"], true);
+    wait_for_output_contains(
+        app_b.clone(),
+        "runtimepersisted",
+        "runtime:sent through changed config socket",
+    )
+    .await;
+
+    let (status, payload) = post_json(app_b, "/sessions/runtimepersisted/kill", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "killed");
+    assert!(!tmux_session_exists(&socket_a, &tmux_session));
+}
+
+#[tokio::test]
+async fn runtime_core_expands_bare_home_working_dir_for_tmux() {
+    if !tmux_available() {
+        return;
+    }
+    let Some(home) = std::env::var_os("HOME") else {
+        return;
+    };
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let tmux_socket = format!(
+        "sm-rust-test-home-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app(&state_file, &log_dir, &tmux_socket);
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimehome",
+            "name": "runtime-home",
+            "working_dir": "~",
+            "provider": "claude",
+            "initial_message": "home runtime prompt"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["working_dir"], "~");
+    let tmux_session = payload["tmux_session"].as_str().unwrap().to_owned();
+    let home_path = PathBuf::from(home);
+    assert_eq!(
+        tmux_pane_current_path(&tmux_socket, &tmux_session).as_deref(),
+        Some(home_path.as_path())
+    );
+
+    let (status, payload) = post_json(app, "/sessions/runtimehome/kill", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "killed");
+}
+
+#[tokio::test]
+async fn runtime_core_marks_missing_tmux_stopped_on_send_and_retire() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let working_dir = unique_temp_path();
+    fs::create_dir_all(&working_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-test-missing-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app(&state_file, &log_dir, &tmux_socket);
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimemissingsend",
+            "name": "runtime-missing-send",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude",
+            "initial_message": "missing send initial"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let tmux_session = payload["tmux_session"].as_str().unwrap().to_owned();
+    assert!(tmux_kill_session(&tmux_socket, &tmux_session));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/runtimemissingsend/input",
+        json!({ "text": "after external kill" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["delivered"], false);
+    assert_eq!(payload["status"], "stopped");
+
+    let (status, payload) = get_json(app.clone(), "/sessions/runtimemissingsend").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "stopped");
+    assert!(payload["stopped_at"].as_str().is_some());
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimemissingretire",
+            "name": "runtime-missing-retire",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude",
+            "initial_message": "missing retire initial"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let tmux_session = payload["tmux_session"].as_str().unwrap().to_owned();
+    assert!(tmux_kill_session(&tmux_socket, &tmux_session));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/runtimemissingretire/kill",
+        json!({}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "killed");
+
+    let (status, payload) = get_json(app, "/sessions/runtimemissingretire").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "stopped");
+    assert!(payload["stopped_at"].as_str().is_some());
+}
+
+#[tokio::test]
+async fn runtime_core_rejects_unsupported_provider() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let working_dir = unique_temp_path();
+    fs::create_dir_all(&working_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-test-provider-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app(&state_file, &log_dir, &tmux_socket);
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimecodex",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "codex",
+            "initial_message": "codex should not launch claude"
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        payload,
+        json!({ "detail": "Rust runtime does not support provider codex" })
+    );
+    let (status, _) = get_json(app, "/sessions/runtimecodex").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn runtime_core_rejects_remote_node_create_before_local_tmux_launch() {
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let app = runtime_app(&state_file, &log_dir, "sm-rust-test-remote-create");
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimeremote",
+            "working_dir": ".",
+            "provider": "claude",
+            "node": "macbook",
+            "initial_message": "remote node should not launch locally"
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        payload,
+        json!({ "detail": "Rust runtime does not support remote node macbook" })
+    );
+    let (status, _) = get_json(app, "/sessions/runtimeremote").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn runtime_core_rejects_child_create_that_inherits_remote_parent_node() {
+    let state_file = unique_temp_path();
+    fs::write(
+        &state_file,
+        json!({
+            "sessions": [
+                {
+                    "id": "remoteparent",
+                    "name": "claude-remoteparent",
+                    "working_dir": "/remote/repo",
+                    "tmux_session": "claude-remoteparent",
+                    "node": "macbook",
+                    "provider": "claude",
+                    "log_file": "/tmp/remoteparent.log",
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00",
+                    "last_activity": "2026-06-01T00:01:00"
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let log_dir = unique_temp_path();
+    let app = runtime_app(&state_file, &log_dir, "sm-rust-test-remote-child");
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "remotechild",
+            "parent_session_id": "remoteparent",
+            "provider": "claude",
+            "initial_message": "child should inherit remote node and reject"
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        payload,
+        json!({ "detail": "Rust runtime does not support remote node macbook" })
+    );
+    let (status, _) = get_json(app, "/sessions/remotechild").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn runtime_core_rejects_remote_node_send_and_retire_without_mutating_state() {
+    let state_file = unique_temp_path();
+    fs::write(
+        &state_file,
+        json!({
+            "sessions": [
+                {
+                    "id": "remoteruntime",
+                    "name": "claude-remoteruntime",
+                    "working_dir": "/repo",
+                    "tmux_session": "claude-remoteruntime",
+                    "node": "macbook",
+                    "provider": "claude",
+                    "log_file": "/tmp/remoteruntime.log",
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00",
+                    "last_activity": "2026-06-01T00:01:00"
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let log_dir = unique_temp_path();
+    let app = runtime_app(&state_file, &log_dir, "sm-rust-test-remote-existing");
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/remoteruntime/input",
+        json!({ "text": "do not send to local tmux" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        payload,
+        json!({ "detail": "Rust runtime does not support remote node macbook" })
+    );
+
+    let (status, payload) = post_json(app.clone(), "/sessions/remoteruntime/kill", json!({})).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        payload,
+        json!({ "detail": "Rust runtime does not support remote node macbook" })
+    );
+
+    let (status, payload) = get_json(app, "/sessions/remoteruntime").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["node"], "macbook");
+    assert_eq!(payload["status"], "running");
+    assert_eq!(payload["stopped_at"], Value::Null);
+}
+
+#[tokio::test]
+async fn runtime_core_fails_create_when_stdin_prompt_cannot_be_delivered() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let working_dir = unique_temp_path();
+    fs::create_dir_all(&working_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-test-exit-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        rust_core: RustCoreConfig {
+            runtime_enabled: true,
+            log_dir: Some(log_dir.display().to_string()),
+            tmux_socket_name: Some(tmux_socket.clone()),
+            runtime_command: Some("/bin/sh -lc 'exit 0'".to_owned()),
+            runtime_prompt_mode: Some("stdin".to_owned()),
+            runtime_start_settle_ms: Some(100),
+            ..RustCoreConfig::default()
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimeexited",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude",
+            "initial_message": "cannot be delivered"
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(
+        payload,
+        json!({ "detail": "tmux session exited before initial prompt could be delivered" })
+    );
+    let (status, _) = get_json(app, "/sessions/runtimeexited").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]
@@ -1477,6 +2084,156 @@ fn unique_temp_path() -> PathBuf {
         std::process::id(),
         COUNTER.fetch_add(1, Ordering::Relaxed)
     ))
+}
+
+fn runtime_app(state_file: &PathBuf, log_dir: &PathBuf, tmux_socket: &str) -> axum::Router {
+    router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        rust_core: RustCoreConfig {
+            runtime_enabled: true,
+            log_dir: Some(log_dir.display().to_string()),
+            tmux_socket_name: Some(tmux_socket.to_owned()),
+            runtime_command: Some(
+                r#"/bin/sh -lc 'while IFS= read -r line; do printf "ids:%s:%s:%s\nruntime:%s\n" "$SESSION_MANAGER_ID" "$CLAUDE_SESSION_MANAGER_ID" "$ENABLE_TOOL_SEARCH" "$line"; done'"#
+                    .to_owned(),
+            ),
+            runtime_prompt_mode: Some("stdin".to_owned()),
+            runtime_start_settle_ms: Some(100),
+            send_keys_settle_ms: Some(10.0),
+            send_keys_settle_max_ms: Some(50.0),
+            send_keys_max_chunk_chars: Some(128),
+            ..RustCoreConfig::default()
+        },
+        ..AppConfig::default()
+    }))
+}
+
+async fn wait_for_output_contains(app: axum::Router, session_id: &str, needle: &str) -> Value {
+    for _ in 0..30 {
+        let (status, payload) = get_json(
+            app.clone(),
+            &format!("/sessions/{session_id}/output?lines=20"),
+        )
+        .await;
+        if status == StatusCode::OK
+            && payload["output"]
+                .as_str()
+                .unwrap_or_default()
+                .contains(needle)
+        {
+            return payload;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    panic!("timed out waiting for output containing {needle:?}");
+}
+
+fn tmux_available() -> bool {
+    Command::new("tmux")
+        .arg("-V")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+fn tmux_session_exists(socket: &str, session: &str) -> bool {
+    Command::new("tmux")
+        .arg("-L")
+        .arg(socket)
+        .arg("has-session")
+        .arg("-t")
+        .arg(session)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+fn tmux_kill_session(socket: &str, session: &str) -> bool {
+    Command::new("tmux")
+        .arg("-L")
+        .arg(socket)
+        .arg("kill-session")
+        .arg("-t")
+        .arg(session)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+fn tmux_enter_copy_mode(socket: &str, session: &str) -> bool {
+    Command::new("tmux")
+        .arg("-L")
+        .arg(socket)
+        .arg("copy-mode")
+        .arg("-t")
+        .arg(session)
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+fn tmux_pane_in_mode(socket: &str, session: &str) -> Option<i32> {
+    let output = Command::new("tmux")
+        .arg("-L")
+        .arg(socket)
+        .arg("display-message")
+        .arg("-p")
+        .arg("-t")
+        .arg(session)
+        .arg("#{pane_in_mode}")
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    match String::from_utf8_lossy(&output.stdout).trim() {
+        "0" => Some(0),
+        "1" => Some(1),
+        _ => None,
+    }
+}
+
+fn tmux_pane_current_path(socket: &str, session: &str) -> Option<PathBuf> {
+    let output = Command::new("tmux")
+        .arg("-L")
+        .arg(socket)
+        .arg("display-message")
+        .arg("-p")
+        .arg("-t")
+        .arg(session)
+        .arg("#{pane_current_path}")
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(PathBuf::from(
+        String::from_utf8_lossy(&output.stdout).trim(),
+    ))
+}
+
+struct TestTmuxSocket(String);
+
+impl Drop for TestTmuxSocket {
+    fn drop(&mut self) {
+        let _ = Command::new("tmux")
+            .arg("-L")
+            .arg(&self.0)
+            .arg("kill-server")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+    }
 }
 
 fn device_access_token(secret: &str, email: &str, name: &str) -> String {


### PR DESCRIPTION
## Summary
- add a gated Rust tmux runtime backend for core session create/send/retire
- preserve the existing fixture-write path while routing runtime-enabled writes through real tmux sessions and log files
- add a real-tmux lifecycle test and verify the Rust core CLI contract subset against an isolated Rust server

## Verification
- cargo fmt --check
- cargo test -p sm-server
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py
- ./venv/bin/python -m scripts.rust_migration.contracts --target rust --sm-binary target/debug/sm --json
- focused live Rust core harness: 10 passed, 0 failed, 0 skipped
- git diff --check

Fixes #793
Refs #762