### PR TITLE
Add Rust core spawn lifecycle slice

### DIFF
--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -331,26 +331,50 @@ fn run() -> Result<()> {
         Command::Spawn(args) => {
             let prompt = args.prompt.join(" ");
             let parent_session_id = optional_current_session_id();
-            let payload = client.post_json(
-                "/sessions",
-                json!({
-                    "id": args.id,
-                    "name": args.name,
-                    "parent_session_id": parent_session_id,
-                    "working_dir": args.working_dir,
-                    "provider": args.provider,
-                    "node": args.node,
-                    "initial_message": prompt,
-                    "wait": args.wait
-                }),
-            )?;
+            let payload = if let Some(parent_session_id) = parent_session_id {
+                client.post_json(
+                    "/sessions/spawn",
+                    json!({
+                        "id": args.id,
+                        "parent_session_id": parent_session_id,
+                        "prompt": prompt,
+                        "name": args.name,
+                        "wait": args.wait,
+                        "model": args.model,
+                        "working_dir": args.working_dir,
+                        "provider": args.provider,
+                        "node": args.node
+                    }),
+                )?
+            } else {
+                client.post_json(
+                    "/sessions",
+                    json!({
+                        "id": args.id,
+                        "name": args.name,
+                        "working_dir": args.working_dir,
+                        "provider": args.provider,
+                        "node": args.node,
+                        "initial_message": prompt,
+                        "model": args.model,
+                        "wait": args.wait
+                    }),
+                )?
+            };
+            if let Some(error) = payload["error"]
+                .as_str()
+                .or_else(|| payload["detail"].as_str())
+            {
+                bail!("{error}");
+            }
             if args.json {
                 println!("{}", serde_json::to_string_pretty(&payload)?);
             } else {
                 println!(
                     "{}",
-                    payload["id"]
+                    payload["session_id"]
                         .as_str()
+                        .or_else(|| payload["id"].as_str())
                         .ok_or_else(|| anyhow!("spawn response missing id"))?
                 );
             }

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -1,4 +1,10 @@
-use std::{collections::BTreeMap, convert::Infallible, net::SocketAddr, sync::Arc, time::Duration};
+use std::{
+    collections::BTreeMap,
+    convert::Infallible,
+    net::SocketAddr,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use axum::{
     body::to_bytes,
@@ -30,7 +36,7 @@ use crate::config::{trimmed, AppConfig};
 use crate::runtime::TmuxRuntime;
 use crate::sessions::{
     expand_home, is_primary_node, AgentStatusRequest, ClientSessionResponse, CoreRetireOutcome,
-    CreateCoreSessionRequest, SendCoreInputRequest, SessionResponse, SessionStore,
+    CreateCoreSessionRequest, SendCoreInputRequest, SessionRecord, SessionResponse, SessionStore,
     SessionsEnvelope,
 };
 
@@ -64,6 +70,7 @@ pub fn router(state: AppState) -> Router {
         .route("/events", get(events_stream))
         .route("/__shadow/http", post(shadow_http))
         .route("/sessions", get(list_sessions).post(create_session))
+        .route("/sessions/spawn", post(spawn_session))
         .route("/sessions/{session_id}", get(get_session))
         .route(
             "/sessions/{session_id}/agent-status",
@@ -242,6 +249,210 @@ async fn create_session(
         state.session_store.create_core_session(payload, log_dir)?
     };
     Ok(Json(SessionResponse::from(session)))
+}
+
+async fn spawn_session(
+    State(state): State<Arc<AppState>>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(payload): Json<SpawnCoreSessionRequest>,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_allowed_from_parts(&state.config, &headers, Some(peer_addr), "/sessions/spawn")?;
+    ensure_core_writes_enabled(&state)?;
+    let Some(parent) = state
+        .session_store
+        .get_session(&payload.parent_session_id)?
+    else {
+        return Ok(Json(json!({ "error": "Parent session not found" })));
+    };
+    if payload.track_seconds.is_some() {
+        return Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: "Rust core spawn does not support track_seconds yet".to_owned(),
+        });
+    }
+    let wait_seconds = payload.wait;
+    let provider = payload
+        .provider
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(parent.provider.as_str())
+        .to_owned();
+    let working_dir = payload
+        .working_dir
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(parent.working_dir.as_str())
+        .to_owned();
+    let node = payload
+        .node
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(parent.node.as_str())
+        .to_owned();
+    let create_payload = CreateCoreSessionRequest {
+        id: payload.id,
+        name: payload.name,
+        working_dir: Some(working_dir),
+        provider: Some(provider),
+        parent_session_id: Some(parent.id.clone()),
+        node: Some(node),
+        initial_message: Some(payload.prompt),
+        model: payload.model,
+        wait: wait_seconds,
+    };
+    let log_dir = state.config.rust_core.log_dir.as_deref().map(expand_home);
+    let child = if state.config.rust_core.runtime_enabled {
+        ensure_core_runtime_provider_supported(&create_payload)?;
+        ensure_core_runtime_request_node_supported(&state, &create_payload)?;
+        let runtime = TmuxRuntime::from_config(&state.config.rust_core);
+        state
+            .session_store
+            .create_core_session_with_runtime(create_payload, log_dir, &runtime)?
+    } else {
+        state
+            .session_store
+            .create_core_session(create_payload, log_dir)?
+    };
+    if let Some(wait_seconds) = wait_seconds {
+        spawn_child_wait_monitor(state.clone(), child.clone(), wait_seconds);
+    }
+    Ok(Json(serde_json::to_value(SpawnSessionResponse::from(
+        child,
+    ))?))
+}
+
+fn spawn_child_wait_monitor(state: Arc<AppState>, child: SessionRecord, wait_seconds: u64) {
+    let Some(parent_session_id) = child
+        .parent_session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+    else {
+        return;
+    };
+    let child_session_id = child.id.clone();
+
+    tokio::spawn(async move {
+        let mut last_activity = child.last_activity.clone();
+        let mut last_output_size = child_output_size(&child);
+        let mut idle_since = Instant::now();
+        loop {
+            tokio::time::sleep(Duration::from_millis(250)).await;
+            let Ok(Some(child)) = state.session_store.get_session(&child_session_id) else {
+                break;
+            };
+            let output_size = child_output_size(&child);
+            if child.last_activity != last_activity || output_size != last_output_size {
+                last_activity = child.last_activity.clone();
+                last_output_size = output_size;
+                idle_since = Instant::now();
+            }
+
+            let completion_message = if session_status_is_stopped(&child.status)
+                || runtime_child_session_exited(&state, &child)
+            {
+                Some("Session exited".to_owned())
+            } else {
+                Some(idle_since.elapsed().as_secs())
+                    .filter(|idle_seconds| *idle_seconds >= wait_seconds)
+                    .map(|idle_seconds| {
+                        completion_summary(&state.session_store, &child_session_id)
+                            .unwrap_or_else(|| format!("Idle for {idle_seconds}s"))
+                    })
+            };
+            let Some(completion_message) = completion_message else {
+                continue;
+            };
+
+            let notification = format!(
+                "Child {} ({}) completed: {}",
+                child_display_name(&child),
+                short_session_id(&child_session_id),
+                completion_message
+            );
+            let request = SendCoreInputRequest {
+                text: notification,
+                delivery_mode: "sequential".to_owned(),
+                notify_after_seconds: None,
+            };
+            let _ = if state.config.rust_core.runtime_enabled {
+                let runtime = TmuxRuntime::from_config(&state.config.rust_core);
+                state.session_store.send_core_input_with_runtime(
+                    &parent_session_id,
+                    request,
+                    &runtime,
+                )
+            } else {
+                state
+                    .session_store
+                    .send_core_input(&parent_session_id, request)
+            };
+            break;
+        }
+    });
+}
+
+fn session_status_is_stopped(status: &str) -> bool {
+    matches!(
+        status.trim().to_ascii_lowercase().as_str(),
+        "stopped" | "killed"
+    )
+}
+
+fn runtime_child_session_exited(state: &AppState, child: &SessionRecord) -> bool {
+    if !state.config.rust_core.runtime_enabled {
+        return false;
+    }
+    let runtime = TmuxRuntime::from_config(&state.config.rust_core)
+        .for_socket_name(child.tmux_socket_name.as_deref());
+    matches!(runtime.session_exists(&child.tmux_session), Ok(false))
+}
+
+fn child_output_size(child: &SessionRecord) -> Option<u64> {
+    let log_file = child
+        .log_file
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?;
+    expand_home(log_file)
+        .metadata()
+        .ok()
+        .map(|metadata| metadata.len())
+}
+
+fn completion_summary(session_store: &SessionStore, child_session_id: &str) -> Option<String> {
+    let output = session_store.capture_output(child_session_id, 10).ok()??;
+    output
+        .lines()
+        .map(str::trim)
+        .find(|line| line.len() > 10)
+        .map(|line| {
+            if line.chars().count() > 100 {
+                format!("{}...", line.chars().take(100).collect::<String>())
+            } else {
+                line.to_owned()
+            }
+        })
+}
+
+fn child_display_name(child: &SessionRecord) -> String {
+    child
+        .friendly_name
+        .as_deref()
+        .or(Some(child.name.as_str()))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(child.id.as_str())
+        .to_owned()
+}
+
+fn short_session_id(session_id: &str) -> String {
+    session_id.chars().take(8).collect()
 }
 
 async fn list_client_sessions(
@@ -1238,6 +1449,73 @@ struct SessionOutputQuery {
 struct KillSessionRequest {
     #[serde(default)]
     requester_session_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SpawnCoreSessionRequest {
+    #[serde(default)]
+    id: Option<String>,
+    parent_session_id: String,
+    prompt: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    wait: Option<u64>,
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    working_dir: Option<String>,
+    #[serde(default)]
+    provider: Option<String>,
+    #[serde(default)]
+    node: Option<String>,
+    #[serde(default)]
+    track_seconds: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+struct SpawnSessionResponse {
+    session_id: String,
+    name: String,
+    friendly_name: String,
+    working_dir: String,
+    parent_session_id: Option<String>,
+    tmux_session: String,
+    node: String,
+    provider: String,
+    model: Option<String>,
+    created_at: String,
+}
+
+impl From<SessionRecord> for SpawnSessionResponse {
+    fn from(session: SessionRecord) -> Self {
+        let friendly_name = session
+            .friendly_name
+            .as_ref()
+            .filter(|value| !value.trim().is_empty())
+            .cloned()
+            .unwrap_or_else(|| session.name.clone());
+        Self {
+            session_id: session.id,
+            name: session.name,
+            friendly_name,
+            working_dir: session.working_dir,
+            parent_session_id: session.parent_session_id,
+            tmux_session: session.tmux_session,
+            node: if session.node.trim().is_empty() {
+                "primary".to_owned()
+            } else {
+                session.node
+            },
+            provider: if session.provider.trim().is_empty() {
+                "claude".to_owned()
+            } else {
+                session.provider
+            },
+            model: session.model,
+            created_at: session.created_at,
+        }
+    }
 }
 
 #[derive(Serialize)]

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -36,6 +36,7 @@ pub struct TmuxSessionSpec {
     pub working_dir: String,
     pub log_file: PathBuf,
     pub initial_message: Option<String>,
+    pub model: Option<String>,
 }
 
 impl TmuxRuntime {
@@ -121,6 +122,14 @@ impl TmuxRuntime {
         }
 
         let mut command = self.command.clone();
+        if let Some(model) = spec
+            .model
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            command = format!("{command} --model {}", shell_quote(model));
+        }
         if prompt_mode == "argv" {
             if let Some(initial_message) = spec
                 .initial_message
@@ -171,7 +180,7 @@ impl TmuxRuntime {
         Ok(true)
     }
 
-    fn session_exists(&self, tmux_session: &str) -> Result<bool> {
+    pub fn session_exists(&self, tmux_session: &str) -> Result<bool> {
         let output = self
             .tmux_command(["has-session", "-t", tmux_session])
             .stdout(Stdio::null())

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -162,6 +162,7 @@ impl SessionStore {
             working_dir: expand_home(&record.working_dir).display().to_string(),
             log_file,
             initial_message: request.initial_message.clone(),
+            model: request.model.clone(),
         })?;
         sessions.push(serde_json::to_value(&record)?);
         if let Err(error) = self.write_raw_json_value(&state) {
@@ -512,6 +513,7 @@ impl SessionStore {
             tmux_socket_name: tmux_socket_name.map(ToOwned::to_owned),
             node,
             provider,
+            model: optional_trimmed(request.model.as_deref()),
             log_file: Some(log_file.display().to_string()),
             provider_resume_id: None,
             transcript_path: None,
@@ -571,6 +573,8 @@ pub struct CreateCoreSessionRequest {
     pub node: Option<String>,
     #[serde(default, alias = "prompt")]
     pub initial_message: Option<String>,
+    #[serde(default)]
+    pub model: Option<String>,
     #[serde(default)]
     pub wait: Option<u64>,
 }
@@ -949,6 +953,8 @@ pub struct SessionRecord {
     #[serde(default = "default_provider")]
     pub provider: String,
     #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
     pub log_file: Option<String>,
     #[serde(default)]
     pub provider_resume_id: Option<String>,
@@ -1133,6 +1139,7 @@ pub struct SessionResponse {
     tmux_socket_name: Option<String>,
     node: String,
     provider: Option<String>,
+    model: Option<String>,
     provider_resume_id: Option<String>,
     forked_from_session_id: Option<String>,
     forked_from_provider_resume_id: Option<String>,
@@ -1182,6 +1189,7 @@ impl From<SessionRecord> for SessionResponse {
             tmux_socket_name: session.tmux_socket_name,
             node: non_empty_or(session.node, "primary"),
             provider: Some(non_empty_or(session.provider, "claude")),
+            model: session.model,
             provider_resume_id: session.provider_resume_id,
             forked_from_session_id: session.forked_from_session_id,
             forked_from_provider_resume_id: session.forked_from_provider_resume_id,
@@ -1294,6 +1302,13 @@ fn non_empty_or(value: String, fallback: &str) -> String {
     }
 }
 
+fn optional_trimmed(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
 fn has_text(value: Option<&str>) -> bool {
     value.is_some_and(|value| !value.trim().is_empty())
 }
@@ -1403,6 +1418,7 @@ mod tests {
             tmux_socket_name: None,
             node: "primary".to_owned(),
             provider: "claude".to_owned(),
+            model: None,
             log_file: Some("/tmp/abc12345.log".to_owned()),
             provider_resume_id: None,
             transcript_path: None,

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -1060,6 +1060,97 @@ async fn fixture_core_lifecycle_creates_sends_outputs_and_retires() {
 }
 
 #[tokio::test]
+async fn fixture_core_spawn_endpoint_inherits_parent_fields() {
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let parent_dir = unique_temp_path();
+    fs::create_dir_all(&parent_dir).unwrap();
+    fs::write(
+        &state_file,
+        json!({
+            "sessions": [
+                {
+                    "id": "parentfixture",
+                    "name": "claude-parentfixture",
+                    "working_dir": parent_dir.display().to_string(),
+                    "tmux_session": "claude-parentfixture",
+                    "node": "primary",
+                    "provider": "claude",
+                    "log_file": "/tmp/parentfixture.log",
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00",
+                    "last_activity": "2026-06-01T00:01:00"
+                }
+            ],
+            "agent_registrations": [
+                {
+                    "role": "parent-alias",
+                    "session_id": "parentfixture"
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        rust_core: RustCoreConfig {
+            fixture_writes_enabled: true,
+            log_dir: Some(log_dir.display().to_string()),
+            ..RustCoreConfig::default()
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/spawn",
+        json!({
+            "id": "trackedchildfixture",
+            "parent_session_id": "parentfixture",
+            "prompt": "tracked child fixture prompt",
+            "name": "tracked-child-fixture",
+            "track_seconds": 300
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        payload,
+        json!({ "detail": "Rust core spawn does not support track_seconds yet" })
+    );
+    let (status, _payload) = get_json(app.clone(), "/sessions/trackedchildfixture").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/spawn",
+        json!({
+            "id": "childfixture",
+            "parent_session_id": "parent-alias",
+            "prompt": "child fixture prompt",
+            "name": "child-fixture"
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["session_id"], "childfixture");
+    assert_eq!(payload["friendly_name"], "child-fixture");
+    assert_eq!(payload["parent_session_id"], "parentfixture");
+    assert_eq!(payload["working_dir"], parent_dir.display().to_string());
+    assert_eq!(payload["node"], "primary");
+    assert_eq!(payload["provider"], "claude");
+
+    let (status, payload) = get_json(app, "/sessions/childfixture").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["parent_session_id"], "parentfixture");
+    assert_eq!(payload["working_dir"], parent_dir.display().to_string());
+}
+
+#[tokio::test]
 async fn fixture_core_writes_preserve_concurrent_session_updates() {
     let state_file = unique_temp_path();
     let app = router(AppState::new(AppConfig {
@@ -1195,7 +1286,7 @@ async fn runtime_core_lifecycle_uses_tmux_backend_when_enabled() {
             log_dir: Some(log_dir.display().to_string()),
             tmux_socket_name: Some(tmux_socket.clone()),
             runtime_command: Some(
-                r#"/bin/sh -lc 'while IFS= read -r line; do printf "ids:%s:%s:%s\nruntime:%s\n" "$SESSION_MANAGER_ID" "$CLAUDE_SESSION_MANAGER_ID" "$ENABLE_TOOL_SEARCH" "$line"; done'"#
+                r#"/bin/sh -lc 'while IFS= read -r line; do printf "argv:%s\nids:%s:%s:%s\nruntime:%s\n" "$*" "$SESSION_MANAGER_ID" "$CLAUDE_SESSION_MANAGER_ID" "$ENABLE_TOOL_SEARCH" "$line"; done' runtime-sh"#
                     .to_owned(),
             ),
             runtime_prompt_mode: Some("stdin".to_owned()),
@@ -1293,6 +1384,246 @@ async fn runtime_core_lifecycle_uses_tmux_backend_when_enabled() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "stopped");
     assert!(!tmux_session_exists(&tmux_socket, &tmux_session));
+}
+
+#[tokio::test]
+async fn runtime_core_spawn_endpoint_uses_tmux_and_parent_fields() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let parent_dir = unique_temp_path();
+    fs::create_dir_all(&parent_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-test-spawn-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app(&state_file, &log_dir, &tmux_socket);
+
+    let (status, parent_payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimeparent",
+            "name": "runtime-parent",
+            "working_dir": parent_dir.display().to_string(),
+            "provider": "claude",
+            "initial_message": "parent runtime prompt"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let parent_tmux_session = parent_payload["tmux_session"].as_str().unwrap().to_owned();
+    wait_for_output_contains(
+        app.clone(),
+        "runtimeparent",
+        "runtime:parent runtime prompt",
+    )
+    .await;
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/spawn",
+        json!({
+            "id": "runtimechild",
+            "parent_session_id": "runtimeparent",
+            "prompt": "spawn endpoint runtime prompt",
+            "name": "runtime-child",
+            "model": "opus",
+            "wait": 5
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["session_id"], "runtimechild");
+    assert_eq!(payload["friendly_name"], "runtime-child");
+    assert_eq!(payload["parent_session_id"], "runtimeparent");
+    assert_eq!(payload["working_dir"], parent_dir.display().to_string());
+    assert_eq!(payload["node"], "primary");
+    assert_eq!(payload["provider"], "claude");
+    assert_eq!(payload["model"], "opus");
+    let tmux_session = payload["tmux_session"].as_str().unwrap().to_owned();
+    assert!(tmux_session.starts_with("sm-rust-claude-runtimechild-"));
+
+    wait_for_output_contains(
+        app.clone(),
+        "runtimechild",
+        "runtime:spawn endpoint runtime prompt",
+    )
+    .await;
+    wait_for_output_contains(app.clone(), "runtimechild", "argv:--model opus").await;
+
+    let (status, payload) = get_json(app.clone(), "/sessions/runtimechild").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["model"], "opus");
+
+    let (status, payload) = post_json(app.clone(), "/sessions/runtimechild/kill", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "killed");
+    assert!(!tmux_session_exists(&tmux_socket, &tmux_session));
+
+    wait_for_output_contains(
+        app.clone(),
+        "runtimeparent",
+        "Child runtime-child (runtimec) completed: Session exited",
+    )
+    .await;
+
+    let (status, payload) = post_json(app.clone(), "/sessions/runtimeparent/kill", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "killed");
+    assert!(!tmux_session_exists(&tmux_socket, &parent_tmux_session));
+}
+
+#[tokio::test]
+async fn runtime_core_spawn_wait_detects_naturally_exited_tmux_child() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let parent_dir = unique_temp_path();
+    fs::create_dir_all(&parent_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-test-spawn-exit-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app_with_command(
+        &state_file,
+        &log_dir,
+        &tmux_socket,
+        r#"/bin/sh -lc 'while IFS= read -r line; do printf "runtime:%s\n" "$line"; case "$line" in *natural-child-prompt*) exit 0;; esac; done' runtime-sh"#,
+    );
+
+    let (status, parent_payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "naturalparent",
+            "name": "natural-parent",
+            "working_dir": parent_dir.display().to_string(),
+            "provider": "claude",
+            "initial_message": "parent prompt"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let parent_tmux_session = parent_payload["tmux_session"].as_str().unwrap().to_owned();
+    wait_for_output_contains(app.clone(), "naturalparent", "runtime:parent prompt").await;
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/spawn",
+        json!({
+            "id": "naturalchild",
+            "parent_session_id": "naturalparent",
+            "prompt": "natural-child-prompt",
+            "name": "natural-child",
+            "wait": 10
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let child_tmux_session = payload["tmux_session"].as_str().unwrap();
+
+    wait_for_output_contains(
+        app.clone(),
+        "naturalparent",
+        "Child natural-child (naturalc) completed: Session exited",
+    )
+    .await;
+    assert!(!tmux_session_exists(&tmux_socket, child_tmux_session));
+
+    let (status, payload) = post_json(app.clone(), "/sessions/naturalparent/kill", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "killed");
+    assert!(!tmux_session_exists(&tmux_socket, &parent_tmux_session));
+}
+
+#[tokio::test]
+async fn runtime_core_spawn_wait_uses_runtime_output_as_activity() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let parent_dir = unique_temp_path();
+    fs::create_dir_all(&parent_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-test-spawn-active-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app_with_command(
+        &state_file,
+        &log_dir,
+        &tmux_socket,
+        r#"/bin/sh -lc 'while IFS= read -r line; do case "$line" in *active-child-prompt*) for i in 1 2 3 4 5 6 7 8; do printf "runtime:heartbeat-%s\n" "$i"; sleep 0.2; done; exit 0;; *) printf "runtime:%s\n" "$line";; esac; done' runtime-sh"#,
+    );
+
+    let (status, parent_payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "activeparent",
+            "name": "active-parent",
+            "working_dir": parent_dir.display().to_string(),
+            "provider": "claude",
+            "initial_message": "parent prompt"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let parent_tmux_session = parent_payload["tmux_session"].as_str().unwrap().to_owned();
+    wait_for_output_contains(app.clone(), "activeparent", "runtime:parent prompt").await;
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/spawn",
+        json!({
+            "id": "activechild",
+            "parent_session_id": "activeparent",
+            "prompt": "active-child-prompt",
+            "name": "active-child",
+            "wait": 1
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let child_tmux_session = payload["tmux_session"].as_str().unwrap();
+
+    let parent_output = wait_for_output_contains(
+        app.clone(),
+        "activeparent",
+        "Child active-child (activech) completed: Session exited",
+    )
+    .await;
+    assert!(!parent_output["output"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("Idle for"));
+    assert!(!tmux_session_exists(&tmux_socket, child_tmux_session));
+
+    let (status, payload) = post_json(app.clone(), "/sessions/activeparent/kill", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "killed");
+    assert!(!tmux_session_exists(&tmux_socket, &parent_tmux_session));
 }
 
 #[tokio::test]
@@ -2087,6 +2418,20 @@ fn unique_temp_path() -> PathBuf {
 }
 
 fn runtime_app(state_file: &PathBuf, log_dir: &PathBuf, tmux_socket: &str) -> axum::Router {
+    runtime_app_with_command(
+        state_file,
+        log_dir,
+        tmux_socket,
+        r#"/bin/sh -lc 'while IFS= read -r line; do printf "argv:%s\nids:%s:%s:%s\nruntime:%s\n" "$*" "$SESSION_MANAGER_ID" "$CLAUDE_SESSION_MANAGER_ID" "$ENABLE_TOOL_SEARCH" "$line"; done' runtime-sh"#,
+    )
+}
+
+fn runtime_app_with_command(
+    state_file: &PathBuf,
+    log_dir: &PathBuf,
+    tmux_socket: &str,
+    runtime_command: &str,
+) -> axum::Router {
     router(AppState::new(AppConfig {
         paths: PathsConfig {
             state_file: state_file.display().to_string(),
@@ -2095,10 +2440,7 @@ fn runtime_app(state_file: &PathBuf, log_dir: &PathBuf, tmux_socket: &str) -> ax
             runtime_enabled: true,
             log_dir: Some(log_dir.display().to_string()),
             tmux_socket_name: Some(tmux_socket.to_owned()),
-            runtime_command: Some(
-                r#"/bin/sh -lc 'while IFS= read -r line; do printf "ids:%s:%s:%s\nruntime:%s\n" "$SESSION_MANAGER_ID" "$CLAUDE_SESSION_MANAGER_ID" "$ENABLE_TOOL_SEARCH" "$line"; done'"#
-                    .to_owned(),
-            ),
+            runtime_command: Some(runtime_command.to_owned()),
             runtime_prompt_mode: Some("stdin".to_owned()),
             runtime_start_settle_ms: Some(100),
             send_keys_settle_ms: Some(10.0),

--- a/scripts/rust_migration/contracts_manifest.json
+++ b/scripts/rust_migration/contracts_manifest.json
@@ -888,10 +888,11 @@
       "target": "rust_only",
       "safety": "mutating",
       "command": ["--api-url", "{base_url}", "spawn", "claude", "initial fixture prompt", "--id", "{session_id}", "--name", "{session_name}", "--working-dir", "{working_dir}", "--json"],
+      "env": {"SESSION_MANAGER_ID": "", "CLAUDE_SESSION_MANAGER_ID": ""},
       "expected_exit": [0],
       "expected_output_contains_all": ["{session_id}", "{session_name}", "running"],
       "preconditions": ["sm_cli", "fixture:base_url", "session_id", "fixture:session_name", "fixture:working_dir", "mutating_opt_in"],
-      "source": "https://github.com/rajeshgoli/session-manager/issues/791"
+      "source": "https://github.com/rajeshgoli/session-manager/issues/795"
     },
     {
       "id": "cli.rust_core_send_fixture",
@@ -916,7 +917,7 @@
       "expected_exit": [0],
       "expected_output_contains_all": ["{child_session_id}", "{child_session_name}", "{session_id}", "{working_dir}"],
       "preconditions": ["sm_cli", "fixture:base_url", "session_id", "fixture:child_session_id", "fixture:child_session_name", "fixture:working_dir", "mutating_opt_in"],
-      "source": "https://github.com/rajeshgoli/session-manager/issues/791"
+      "source": "https://github.com/rajeshgoli/session-manager/issues/795"
     },
     {
       "id": "cli.rust_core_status_fixture",


### PR DESCRIPTION
## Summary
- add Rust `/sessions/spawn` support with parent lookup, parent working_dir/node/provider inheritance, and Python-shaped spawn response fields
- route managed Rust CLI `sm spawn` through `/sessions/spawn` while preserving the direct-create fixture path outside a managed session
- extend Rust HTTP tests and live CLI contract fixture coverage for child spawn on the tmux-backed runtime

## Verification
- cargo test -p sm-server
- cargo fmt --check
- git diff --check
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py
- ./venv/bin/python -m scripts.rust_migration.contracts --target rust --sm-binary target/debug/sm --json
- live Rust core CLI fixture: 10 passed, 0 failed, 0 skipped

Fixes #795
Refs #762
