### PR TITLE
Add Rust core CLI session graph slice

### DIFF
--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -41,7 +41,7 @@ enum Command {
     Restore(SessionIdArgs),
     Attach(SessionIdArgs),
     Output(OutputArgs),
-    Clear(SessionIdArgs),
+    Clear(ClearArgs),
     Handoff(HandoffArgs),
     #[command(name = "context-monitor")]
     ContextMonitor(ContextMonitorArgs),
@@ -125,13 +125,26 @@ struct NewArgs {
 
 #[derive(Args)]
 struct ChildrenArgs {
+    session_id: Option<String>,
     #[arg(long)]
     recursive: bool,
+    #[arg(long)]
+    terminated: bool,
+    #[arg(long, value_parser = ["running", "completed", "error", "all"])]
+    status: Option<String>,
+    #[arg(long)]
+    json: bool,
 }
 
 #[derive(Args)]
 struct SessionIdArgs {
     session_id: String,
+}
+
+#[derive(Args)]
+struct ClearArgs {
+    session_id: String,
+    prompt: Vec<String>,
 }
 
 #[derive(Args)]
@@ -163,8 +176,8 @@ struct ContextMonitorArgs {
 
 #[derive(Subcommand)]
 enum ContextMonitorCommand {
-    Enable,
-    Disable,
+    Enable { target: Option<String> },
+    Disable { target: Option<String> },
     Status,
 }
 
@@ -328,6 +341,49 @@ fn run() -> Result<()> {
                 }
             }
         }
+        Command::Me(_) => {
+            let session_id = current_session_id()?;
+            let session = client.get_json(&format!("/sessions/{session_id}"))?;
+            println!("{}", format_session_line(&session, true));
+        }
+        Command::Who(_) => {
+            let session_id = current_session_id()?;
+            let current = client.get_json(&format!("/sessions/{session_id}"))?;
+            let working_dir = current["working_dir"].as_str().unwrap_or_default();
+            let payload = client.get_json("/sessions")?;
+            let sessions = payload["sessions"].as_array().cloned().unwrap_or_default();
+            let mut found = false;
+            for session in sessions {
+                if session["id"].as_str() == Some(session_id.as_str()) {
+                    continue;
+                }
+                if session["working_dir"].as_str() != Some(working_dir) {
+                    continue;
+                }
+                if !matches!(
+                    session["status"].as_str().unwrap_or_default(),
+                    "running" | "waiting_permission" | "idle"
+                ) {
+                    continue;
+                }
+                println!("{}", format_session_line(&session, false));
+                found = true;
+            }
+            if !found {
+                process::exit(1);
+            }
+        }
+        Command::All(_) => {
+            let payload = client.get_json("/sessions")?;
+            let sessions = payload["sessions"].as_array().cloned().unwrap_or_default();
+            if sessions.is_empty() {
+                println!("No active sessions");
+                process::exit(1);
+            }
+            for session in sessions {
+                println!("{}", format_session_line(&session, true));
+            }
+        }
         Command::Spawn(args) => {
             let prompt = args.prompt.join(" ");
             let parent_session_id = optional_current_session_id();
@@ -403,10 +459,99 @@ fn run() -> Result<()> {
         }
         Command::Output(args) => print_output(&client, &args.session_id, args.lines)?,
         Command::Tail(args) => print_output(&client, &args.session_id, args.lines)?,
+        Command::Children(args) => {
+            let parent_session_id = match args.session_id {
+                Some(target) => {
+                    let session = client.get_json(&format!("/sessions/{target}"))?;
+                    session["id"]
+                        .as_str()
+                        .ok_or_else(|| anyhow!("session response missing id"))?
+                        .to_owned()
+                }
+                None => current_session_id()?,
+            };
+            let mut query = Vec::new();
+            if args.recursive {
+                query.push("recursive=true".to_owned());
+            }
+            if args.terminated {
+                query.push("include_terminated=true".to_owned());
+            }
+            if let Some(status) = args.status {
+                query.push(format!("status={status}"));
+            }
+            let path = if query.is_empty() {
+                format!("/sessions/{parent_session_id}/children")
+            } else {
+                format!("/sessions/{parent_session_id}/children?{}", query.join("&"))
+            };
+            let payload = client.get_json(&path)?;
+            let children = payload["children"].as_array().cloned().unwrap_or_default();
+            if args.json {
+                println!("{}", serde_json::to_string_pretty(&children)?);
+            } else if children.is_empty() {
+                println!("No child sessions");
+            } else {
+                for child in children {
+                    println!("{}", format_child_line(&child));
+                }
+            }
+        }
         Command::Retire(args) => {
             let payload =
                 client.post_json(&format!("/sessions/{}/kill", args.session_id), json!({}))?;
             println!("{}", payload["status"].as_str().unwrap_or("stopped"));
+        }
+        Command::Restore(args) => {
+            let payload =
+                client.post_json(&format!("/sessions/{}/restore", args.session_id), json!({}))?;
+            println!(
+                "Session restored: {}",
+                payload["id"].as_str().unwrap_or(&args.session_id)
+            );
+        }
+        Command::Attach(args) => attach_session(&client, &args.session_id)?,
+        Command::Clear(args) => {
+            let requester_session_id = optional_current_session_id();
+            ensure_clear_authorized(&client, &args.session_id, requester_session_id.as_deref())?;
+            let prompt = args.prompt.join(" ");
+            let prompt = (!prompt.trim().is_empty()).then_some(prompt);
+            let payload = client.post_json(
+                &format!("/sessions/{}/clear", args.session_id),
+                json!({
+                    "prompt": prompt,
+                    "requester_session_id": requester_session_id
+                }),
+            )?;
+            println!(
+                "{} {}",
+                payload["status"].as_str().unwrap_or("cleared"),
+                payload["session_id"].as_str().unwrap_or(&args.session_id)
+            );
+        }
+        Command::Handoff(args) => {
+            let session_id = current_session_id()?;
+            let file_path = args.file_path.unwrap_or_else(|| "HANDOFF.md".to_owned());
+            let absolute = fs::canonicalize(&file_path)
+                .with_context(|| format!("File not found: {file_path}"))?;
+            let payload = client.post_json(
+                &format!("/sessions/{session_id}/handoff"),
+                json!({
+                    "requester_session_id": session_id,
+                    "file_path": absolute.display().to_string()
+                }),
+            )?;
+            if let Some(error) = payload["error"].as_str() {
+                bail!("{error}");
+            }
+            match payload["status"].as_str() {
+                Some("executed") => println!("Handoff executed"),
+                Some("recorded") => println!("Handoff recorded"),
+                _ => println!("Handoff scheduled - will execute after current turn completes"),
+            }
+        }
+        Command::ContextMonitor(args) => {
+            run_context_monitor(&client, args)?;
         }
         Command::Wait(args) => wait_for_session(&client, &args.session_id, args.seconds)?,
         _ => bail!("this retained command is not implemented in the Rust core slice yet"),
@@ -436,6 +581,149 @@ fn wait_for_session(client: &ApiClient, session_id: &str, seconds: u64) -> Resul
         }
         thread::sleep(Duration::from_millis(200));
     }
+}
+
+fn run_context_monitor(client: &ApiClient, args: ContextMonitorArgs) -> Result<()> {
+    match args.command.unwrap_or(ContextMonitorCommand::Status) {
+        ContextMonitorCommand::Status => {
+            let payload = client.get_json("/sessions/context-monitor")?;
+            let monitored = payload["monitored"].as_array().cloned().unwrap_or_default();
+            if monitored.is_empty() {
+                println!("No sessions currently registered for context monitoring.");
+                return Ok(());
+            }
+            println!("{:<12} {:<24} Notify Target", "Session", "Name");
+            println!("{}", "-".repeat(52));
+            for entry in monitored {
+                let session_id = entry["session_id"].as_str().unwrap_or("unknown");
+                let name = entry["friendly_name"].as_str().unwrap_or("");
+                let notify = entry["notify_session_id"].as_str().unwrap_or("(none)");
+                println!("{session_id:<12} {name:<24} {notify}");
+            }
+        }
+        ContextMonitorCommand::Enable { target } => {
+            let requester = current_session_id()?;
+            let target = target.unwrap_or_else(|| requester.clone());
+            client.post_json(
+                &format!("/sessions/{target}/context-monitor"),
+                json!({
+                    "enabled": true,
+                    "requester_session_id": requester,
+                    "notify_session_id": requester
+                }),
+            )?;
+            if target == requester {
+                println!("Context monitoring enabled - notifications -> self ({requester})");
+            } else {
+                println!("Context monitoring enabled for {target} - notifications -> {requester}");
+            }
+        }
+        ContextMonitorCommand::Disable { target } => {
+            let requester = current_session_id()?;
+            let target = target.unwrap_or_else(|| requester.clone());
+            client.post_json(
+                &format!("/sessions/{target}/context-monitor"),
+                json!({
+                    "enabled": false,
+                    "requester_session_id": requester,
+                    "notify_session_id": null
+                }),
+            )?;
+            println!("Context monitoring disabled for {target}");
+        }
+    }
+    Ok(())
+}
+
+fn attach_session(client: &ApiClient, session_id: &str) -> Result<()> {
+    let response = client.get_json(&format!("/sessions/{session_id}/attach-descriptor"))?;
+    let descriptor = response.get("attach").unwrap_or(&response);
+    if descriptor["attach_supported"].as_bool() == Some(false) {
+        let message = descriptor["message"]
+            .as_str()
+            .unwrap_or("Attach not supported for this session");
+        bail!("{message}");
+    }
+    let tmux_session = descriptor["tmux_session"]
+        .as_str()
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| anyhow!("Session has no tmux session"))?;
+    let mut command = process::Command::new("tmux");
+    if let Some(socket_name) = descriptor["tmux_socket_name"]
+        .as_str()
+        .filter(|value| !value.trim().is_empty())
+    {
+        command.arg("-L").arg(socket_name);
+    }
+    let status = command
+        .arg("attach")
+        .arg("-t")
+        .arg(tmux_session)
+        .status()
+        .with_context(|| "failed to run tmux attach")?;
+    if !status.success() {
+        bail!("tmux attach exited with {status}");
+    }
+    Ok(())
+}
+
+fn ensure_clear_authorized(
+    client: &ApiClient,
+    target_session_id: &str,
+    requester_session_id: Option<&str>,
+) -> Result<()> {
+    let session = client.get_json(&format!("/sessions/{target_session_id}"))?;
+    let parent_id = session["parent_session_id"]
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if let Some(requester_session_id) = requester_session_id {
+        if parent_id != Some(requester_session_id) {
+            bail!(
+                "Not authorized. You can only clear your child sessions.\nTarget session parent: {}",
+                parent_id.unwrap_or("none")
+            );
+        }
+    } else if parent_id.is_none() {
+        bail!("Can only clear child sessions. Target session has no parent.");
+    }
+    Ok(())
+}
+
+fn format_session_line(session: &Value, show_working_dir: bool) -> String {
+    let id = session["id"].as_str().unwrap_or("unknown");
+    let name = session["friendly_name"]
+        .as_str()
+        .or_else(|| session["name"].as_str())
+        .unwrap_or(id);
+    let provider = session["provider"].as_str().unwrap_or("claude");
+    let status = session["activity_state"]
+        .as_str()
+        .or_else(|| session["status"].as_str())
+        .unwrap_or("unknown");
+    let mut line = format!("{name} ({id}) | {provider} | {status}");
+    if show_working_dir {
+        if let Some(working_dir) = session["working_dir"].as_str() {
+            line.push_str(" | ");
+            line.push_str(working_dir);
+        }
+    }
+    line
+}
+
+fn format_child_line(child: &Value) -> String {
+    let id = child["id"].as_str().unwrap_or("unknown");
+    let name = child["friendly_name"]
+        .as_str()
+        .or_else(|| child["name"].as_str())
+        .unwrap_or(id);
+    let provider = child["provider"].as_str().unwrap_or("claude");
+    let status = child["completion_status"]
+        .as_str()
+        .or_else(|| child["activity_state"].as_str())
+        .or_else(|| child["status"].as_str())
+        .unwrap_or("unknown");
+    format!("{name} ({id}) | {provider} | {status}")
 }
 
 impl ApiClient {

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -35,9 +35,10 @@ use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use crate::config::{trimmed, AppConfig};
 use crate::runtime::TmuxRuntime;
 use crate::sessions::{
-    expand_home, is_primary_node, AgentStatusRequest, ClientSessionResponse, CoreRetireOutcome,
-    CreateCoreSessionRequest, SendCoreInputRequest, SessionRecord, SessionResponse, SessionStore,
-    SessionsEnvelope,
+    expand_home, is_primary_node, AgentStatusRequest, ClearSessionRequest, ClientSessionResponse,
+    ContextMonitorOutcome, ContextMonitorRequest, CoreClearOutcome, CoreRestoreOutcome,
+    CoreRetireOutcome, CreateCoreSessionRequest, HandoffOutcome, HandoffRequest,
+    SendCoreInputRequest, SessionRecord, SessionResponse, SessionStore, SessionsEnvelope,
 };
 
 const SESSION_COOKIE_NAME: &str = "sm_auth";
@@ -71,13 +72,29 @@ pub fn router(state: AppState) -> Router {
         .route("/__shadow/http", post(shadow_http))
         .route("/sessions", get(list_sessions).post(create_session))
         .route("/sessions/spawn", post(spawn_session))
+        .route("/sessions/context-monitor", get(get_context_monitor_status))
         .route("/sessions/{session_id}", get(get_session))
+        .route(
+            "/sessions/{parent_session_id}/children",
+            get(list_children_sessions),
+        )
+        .route(
+            "/sessions/{session_id}/attach-descriptor",
+            get(get_attach_descriptor),
+        )
         .route(
             "/sessions/{session_id}/agent-status",
             post(set_agent_status),
         )
+        .route(
+            "/sessions/{session_id}/context-monitor",
+            post(set_context_monitor),
+        )
         .route("/sessions/{session_id}/input", post(send_session_input))
         .route("/sessions/{session_id}/kill", post(retire_session))
+        .route("/sessions/{session_id}/restore", post(restore_session))
+        .route("/sessions/{session_id}/clear", post(clear_session))
+        .route("/sessions/{session_id}/handoff", post(schedule_handoff))
         .route("/sessions/{session_id}/output", get(session_output))
         .route("/client/sessions", get(list_client_sessions))
         .route("/client/sessions/{session_id}", get(get_client_session))
@@ -227,6 +244,25 @@ async fn list_sessions(
         .map(SessionResponse::from)
         .collect::<Vec<_>>();
     Ok(Json(SessionsEnvelope::from(sessions)))
+}
+
+async fn list_children_sessions(
+    State(state): State<Arc<AppState>>,
+    Path(parent_session_id): Path<String>,
+    Query(query): Query<ListChildrenQuery>,
+    request: Request,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    let children = state.session_store.list_children(
+        &parent_session_id,
+        query.recursive,
+        query.status.as_deref(),
+        query.include_terminated,
+    )?;
+    Ok(Json(json!({
+        "parent_session_id": parent_session_id,
+        "children": children,
+    })))
 }
 
 async fn create_session(
@@ -493,6 +529,28 @@ async fn get_client_session(
     Ok(Json(ClientSessionResponse::from(session)))
 }
 
+async fn get_attach_descriptor(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+    request: Request,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    let Some(session) = state.session_store.get_session(&session_id)? else {
+        return Err(ApiError::NotFound("Session not found"));
+    };
+    Ok(Json(attach_descriptor_response(session)))
+}
+
+async fn get_context_monitor_status(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    Ok(Json(json!({
+        "monitored": state.session_store.list_context_monitors()?,
+    })))
+}
+
 async fn send_session_input(
     State(state): State<Arc<AppState>>,
     Path(session_id): Path<String>,
@@ -591,6 +649,150 @@ async fn retire_session(
             status: StatusCode::BAD_REQUEST,
             detail: format!("Rust runtime does not support remote node {node}"),
         }),
+    }
+}
+
+async fn restore_session(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+) -> Result<Json<SessionResponse>, ApiError> {
+    ensure_session_allowed_from_parts(
+        &state.config,
+        &headers,
+        Some(peer_addr),
+        &format!("/sessions/{session_id}/restore"),
+    )?;
+    ensure_core_writes_enabled(&state)?;
+    let outcome = if state.config.rust_core.runtime_enabled {
+        ensure_core_runtime_session_node_supported(&state, &session_id)?;
+        let runtime = TmuxRuntime::from_config(&state.config.rust_core);
+        state
+            .session_store
+            .restore_core_session_with_runtime(&session_id, &runtime)?
+    } else {
+        state.session_store.restore_core_session(&session_id)?
+    };
+    let Some(outcome) = outcome else {
+        return Err(ApiError::NotFound("Session not found"));
+    };
+    match outcome {
+        CoreRestoreOutcome::Restored(session) => Ok(Json(SessionResponse::from(session))),
+        CoreRestoreOutcome::NotStopped => Err(ApiError::Status {
+            status: StatusCode::CONFLICT,
+            detail: "Session is not stopped".to_owned(),
+        }),
+        CoreRestoreOutcome::UnsupportedNode(node) => Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: format!("Rust runtime does not support remote node {node}"),
+        }),
+        CoreRestoreOutcome::UnsupportedProvider(provider) => Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: format!("Rust runtime does not support provider {provider}"),
+        }),
+    }
+}
+
+async fn clear_session(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(payload): Json<ClearSessionRequest>,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_allowed_from_parts(
+        &state.config,
+        &headers,
+        Some(peer_addr),
+        &format!("/sessions/{session_id}/clear"),
+    )?;
+    ensure_core_writes_enabled(&state)?;
+    let result = if state.config.rust_core.runtime_enabled {
+        ensure_core_runtime_session_node_supported(&state, &session_id)?;
+        let runtime = TmuxRuntime::from_config(&state.config.rust_core);
+        state
+            .session_store
+            .clear_core_session_with_runtime(&session_id, payload, &runtime)?
+    } else {
+        state
+            .session_store
+            .clear_core_session(&session_id, payload)?
+    };
+    match result {
+        CoreClearOutcome::Cleared(result) => Ok(Json(serde_json::to_value(result)?)),
+        CoreClearOutcome::NotFound => Err(ApiError::NotFound("Session not found")),
+        CoreClearOutcome::Unauthorized(detail) => Err(ApiError::Status {
+            status: StatusCode::FORBIDDEN,
+            detail,
+        }),
+    }
+}
+
+async fn set_context_monitor(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(payload): Json<ContextMonitorRequest>,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_allowed_from_parts(
+        &state.config,
+        &headers,
+        Some(peer_addr),
+        &format!("/sessions/{session_id}/context-monitor"),
+    )?;
+    ensure_core_writes_enabled(&state)?;
+    match state
+        .session_store
+        .set_context_monitor(&session_id, payload)?
+    {
+        ContextMonitorOutcome::Updated(result) => Ok(Json(serde_json::to_value(result)?)),
+        ContextMonitorOutcome::NotFound => Err(ApiError::NotFound("Session not found")),
+        ContextMonitorOutcome::MissingNotifyTarget => Err(ApiError::Status {
+            status: StatusCode::UNPROCESSABLE_ENTITY,
+            detail: "notify_session_id required when enabling".to_owned(),
+        }),
+        ContextMonitorOutcome::NotifyTargetNotFound(notify_session_id) => Err(ApiError::Status {
+            status: StatusCode::UNPROCESSABLE_ENTITY,
+            detail: format!("notify_session_id {notify_session_id:?} not found"),
+        }),
+        ContextMonitorOutcome::Unauthorized => Err(ApiError::Status {
+            status: StatusCode::FORBIDDEN,
+            detail: "Cannot configure context monitor - not your session or child session"
+                .to_owned(),
+        }),
+    }
+}
+
+async fn schedule_handoff(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(payload): Json<HandoffRequest>,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_allowed_from_parts(
+        &state.config,
+        &headers,
+        Some(peer_addr),
+        &format!("/sessions/{session_id}/handoff"),
+    )?;
+    ensure_core_writes_enabled(&state)?;
+    let result = if state.config.rust_core.runtime_enabled {
+        ensure_core_runtime_session_node_supported(&state, &session_id)?;
+        let runtime = TmuxRuntime::from_config(&state.config.rust_core);
+        state
+            .session_store
+            .execute_handoff_with_runtime(&session_id, payload, &runtime)?
+    } else {
+        state.session_store.schedule_handoff(&session_id, payload)?
+    };
+    match result {
+        HandoffOutcome::Recorded(result) | HandoffOutcome::Executed(result) => {
+            Ok(Json(serde_json::to_value(result)?))
+        }
+        HandoffOutcome::Error(error) => Ok(Json(json!({ "error": error }))),
     }
 }
 
@@ -831,6 +1033,58 @@ fn shadow_predict_session_read(
         return Ok(None);
     }
 
+    if path == "/sessions/context-monitor" {
+        let body = serde_json::to_vec(&json!({
+            "monitored": state.session_store.list_context_monitors()?,
+        }))?;
+        return Ok(Some(ShadowPrediction {
+            status: StatusCode::OK.as_u16(),
+            body_sha256: Some(sha256_hex(&body)),
+            support_status: "implemented_read",
+        }));
+    }
+
+    if let Some(parent_session_id) = path
+        .strip_prefix("/sessions/")
+        .and_then(|value| value.strip_suffix("/children"))
+    {
+        let children = state.session_store.list_children(
+            parent_session_id,
+            query_bool(query_string, "recursive"),
+            query_value(query_string, "status"),
+            query_bool(query_string, "include_terminated"),
+        )?;
+        let body = serde_json::to_vec(&json!({
+            "parent_session_id": parent_session_id,
+            "children": children,
+        }))?;
+        return Ok(Some(ShadowPrediction {
+            status: StatusCode::OK.as_u16(),
+            body_sha256: Some(sha256_hex(&body)),
+            support_status: "implemented_read",
+        }));
+    }
+
+    if let Some(session_id) = path
+        .strip_prefix("/sessions/")
+        .and_then(|value| value.strip_suffix("/attach-descriptor"))
+    {
+        let Some(session) = state.session_store.get_session(session_id)? else {
+            let body = serde_json::to_vec(&json!({ "detail": "Session not found" }))?;
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::NOT_FOUND.as_u16(),
+                body_sha256: Some(sha256_hex(&body)),
+                support_status: "implemented_read",
+            }));
+        };
+        let body = serde_json::to_vec(&attach_descriptor_response(session))?;
+        return Ok(Some(ShadowPrediction {
+            status: StatusCode::OK.as_u16(),
+            body_sha256: Some(sha256_hex(&body)),
+            support_status: "implemented_read",
+        }));
+    }
+
     if let Some(session_id) = path
         .strip_prefix("/client/sessions/")
         .filter(|value| !value.contains('/'))
@@ -928,14 +1182,47 @@ fn shadow_client_bootstrap_response(config: &AppConfig) -> ClientBootstrapRespon
     }
 }
 
+fn attach_descriptor_payload(session: SessionRecord) -> Value {
+    let provider = session.provider.clone();
+    let is_stopped = matches!(
+        session.status.trim().to_ascii_lowercase().as_str(),
+        "stopped" | "killed"
+    );
+    let has_tmux_session = !session.tmux_session.trim().is_empty();
+    let (attach_supported, message) = if is_stopped {
+        (false, Some("Session is stopped".to_owned()))
+    } else if provider == "codex-app" {
+        (
+            false,
+            Some("Attach not supported for Codex app sessions".to_owned()),
+        )
+    } else if !has_tmux_session {
+        (false, Some("Session has no tmux session".to_owned()))
+    } else {
+        (true, None)
+    };
+    json!({
+        "session_id": session.id,
+        "provider": provider,
+        "attach_supported": attach_supported,
+        "tmux_session": session.tmux_session,
+        "tmux_socket_name": session.tmux_socket_name,
+        "runtime_id": null,
+        "lifecycle_state": session.status,
+        "message": message,
+    })
+}
+
+fn attach_descriptor_response(session: SessionRecord) -> Value {
+    json!({
+        "attach": attach_descriptor_payload(session),
+    })
+}
+
 fn is_static_sessions_path(path: &str) -> bool {
     matches!(
         path,
-        "/sessions/context-monitor"
-            | "/sessions/create"
-            | "/sessions/input-batch"
-            | "/sessions/spawn"
-            | "/sessions/review"
+        "/sessions/create" | "/sessions/input-batch" | "/sessions/spawn" | "/sessions/review"
     )
 }
 
@@ -1438,6 +1725,16 @@ struct HealthCheck {
 struct ListSessionsQuery {
     #[serde(default)]
     include_stopped: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct ListChildrenQuery {
+    #[serde(default)]
+    recursive: bool,
+    #[serde(default)]
+    status: Option<String>,
+    #[serde(default)]
+    include_terminated: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -3,7 +3,7 @@ use std::{
     path::{Path, PathBuf},
     process::{Command, Stdio},
     thread,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use anyhow::{bail, Context, Result};
@@ -19,6 +19,7 @@ const DEFAULT_SEND_KEYS_MAX_CHUNK_CHARS: usize = 4096;
 #[derive(Debug, Clone)]
 pub struct TmuxRuntime {
     socket_name: Option<String>,
+    tmux_binary: String,
     command: String,
     prompt_mode: String,
     start_settle_ms: u64,
@@ -48,6 +49,7 @@ impl TmuxRuntime {
                 .map(str::trim)
                 .filter(|value| !value.is_empty())
                 .map(ToOwned::to_owned),
+            tmux_binary: "tmux".to_owned(),
             command: config
                 .runtime_command
                 .as_deref()
@@ -159,16 +161,59 @@ impl TmuxRuntime {
         Ok(())
     }
 
+    pub fn restore_session(
+        &self,
+        spec: &TmuxSessionSpec,
+        provider: &str,
+        resume_id: Option<&str>,
+    ) -> Result<()> {
+        let mut runtime = self.clone();
+        if let Some(resume_id) = resume_id.map(str::trim).filter(|value| !value.is_empty()) {
+            runtime.command = match provider {
+                "claude" => format!("{} --resume {}", runtime.command, shell_quote(resume_id)),
+                "codex" | "codex-fork" => {
+                    format!("{} resume {}", runtime.command, shell_quote(resume_id))
+                }
+                _ => runtime.command,
+            };
+        }
+        let mut spec = spec.clone();
+        spec.initial_message = None;
+        runtime.create_session(&spec)
+    }
+
     pub fn send_input(&self, tmux_session: &str, text: &str) -> Result<bool> {
         if !self.session_exists(tmux_session)? {
             return Ok(false);
         }
-        self.exit_copy_mode_if_needed(tmux_session);
-        for chunk in split_send_text_chunks(text, self.send_keys_max_chunk_chars) {
-            self.run_tmux(["send-keys", "-t", tmux_session, "-l", "--", chunk])?;
+        self.send_text_then_enter(tmux_session, text)?;
+        Ok(true)
+    }
+
+    pub fn clear_session(
+        &self,
+        tmux_session: &str,
+        clear_command: &str,
+        prompt: Option<&str>,
+        wake_completed: bool,
+    ) -> Result<bool> {
+        if !self.session_exists(tmux_session)? {
+            return Ok(false);
         }
-        thread::sleep(self.compute_settle_delay(text));
-        self.run_tmux(["send-keys", "-t", tmux_session, "Enter"])?;
+        if wake_completed {
+            self.send_key(tmux_session, "Enter")?;
+            let _ = self.wait_for_prompt(tmux_session, Duration::from_secs_f64(3.0));
+        }
+
+        self.send_key(tmux_session, "Escape")?;
+        let _ = self.wait_for_prompt(tmux_session, Duration::from_secs_f64(3.0));
+
+        self.send_text_then_enter(tmux_session, clear_command)?;
+        let _ = self.wait_for_prompt(tmux_session, Duration::from_secs_f64(5.0));
+
+        if let Some(prompt) = prompt.map(str::trim).filter(|value| !value.is_empty()) {
+            self.send_text_then_enter(tmux_session, prompt)?;
+        }
         Ok(true)
     }
 
@@ -219,6 +264,50 @@ impl TmuxRuntime {
         }
     }
 
+    fn send_text_then_enter(&self, tmux_session: &str, text: &str) -> Result<()> {
+        self.exit_copy_mode_if_needed(tmux_session);
+        for chunk in split_send_text_chunks(text, self.send_keys_max_chunk_chars) {
+            self.run_tmux(["send-keys", "-t", tmux_session, "-l", "--", chunk])?;
+        }
+        thread::sleep(self.compute_settle_delay(text));
+        self.send_key(tmux_session, "Enter")
+    }
+
+    fn send_key(&self, tmux_session: &str, key: &str) -> Result<()> {
+        self.run_tmux(["send-keys", "-t", tmux_session, key])
+    }
+
+    fn wait_for_prompt(&self, tmux_session: &str, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if self.capture_pane_last_line(tmux_session).as_deref() == Some(">") {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+    }
+
+    fn capture_pane_last_line(&self, tmux_session: &str) -> Option<String> {
+        let output = self
+            .tmux_command(["capture-pane", "-p", "-t", tmux_session])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        String::from_utf8_lossy(&output.stdout)
+            .trim_end_matches('\n')
+            .split('\n')
+            .last()
+            .map(str::trim)
+            .map(ToOwned::to_owned)
+    }
+
     fn run_tmux<'a>(&self, args: impl IntoIterator<Item = &'a str>) -> Result<()> {
         let output = self
             .tmux_command(args)
@@ -234,7 +323,7 @@ impl TmuxRuntime {
     }
 
     fn tmux_command<'a>(&self, args: impl IntoIterator<Item = &'a str>) -> Command {
-        let mut command = Command::new("tmux");
+        let mut command = Command::new(&self.tmux_binary);
         if let Some(socket_name) = &self.socket_name {
             command.arg("-L").arg(socket_name);
         }
@@ -356,6 +445,7 @@ fn managed_session_command(command: &str, session_id: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::os::unix::fs::PermissionsExt;
 
     #[test]
     fn split_send_text_chunks_prefers_newline_after_half_chunk() {
@@ -388,5 +478,84 @@ mod tests {
         assert!(command.contains("unset CLAUDECODE"));
         assert!(command.contains("export ENABLE_TOOL_SEARCH=false"));
         assert!(command.ends_with("; claude"));
+    }
+
+    #[test]
+    fn clear_session_interrupts_waits_and_prompts_before_success() {
+        let (tmux_binary, log_path, _temp_dir) = fake_tmux_binary();
+        let mut runtime = TmuxRuntime::from_config(&RustCoreConfig {
+            send_keys_settle_ms: Some(0.0),
+            send_keys_settle_max_ms: Some(0.0),
+            ..RustCoreConfig::default()
+        });
+        runtime.tmux_binary = tmux_binary.display().to_string();
+
+        assert!(runtime
+            .clear_session("sm-test", "/clear", Some("fresh task"), true)
+            .unwrap());
+
+        let log = fs::read_to_string(log_path).unwrap();
+        let lines = log.lines().collect::<Vec<_>>();
+        let wake_enter = position_after(&lines, "send-keys -t sm-test Enter", 0);
+        let escape = position_after(&lines, "send-keys -t sm-test Escape", wake_enter + 1);
+        let clear_text = position_after(&lines, "send-keys -t sm-test -l -- /clear", escape + 1);
+        let clear_enter = position_after(&lines, "send-keys -t sm-test Enter", clear_text + 1);
+        let post_clear_wait = position_after(&lines, "capture-pane -p -t sm-test", clear_enter + 1);
+        let prompt_text = position_after(
+            &lines,
+            "send-keys -t sm-test -l -- fresh task",
+            post_clear_wait + 1,
+        );
+        let prompt_enter = position_after(&lines, "send-keys -t sm-test Enter", prompt_text + 1);
+
+        assert!(wake_enter < escape);
+        assert!(escape < clear_text);
+        assert!(clear_text < clear_enter);
+        assert!(clear_enter < post_clear_wait);
+        assert!(post_clear_wait < prompt_text);
+        assert!(prompt_text < prompt_enter);
+    }
+
+    fn fake_tmux_binary() -> (PathBuf, PathBuf, PathBuf) {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let temp_dir = std::env::temp_dir().join(format!(
+            "sm-runtime-fake-tmux-{}-{unique}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&temp_dir).unwrap();
+        let tmux_binary = temp_dir.join("tmux");
+        let log_path = temp_dir.join("tmux.log");
+        fs::write(
+            &tmux_binary,
+            format!(
+                r#"#!/bin/sh
+printf '%s\n' "$*" >> "{}"
+case "$1" in
+  has-session) exit 0 ;;
+  display-message) echo 0; exit 0 ;;
+  capture-pane) printf 'ready\n>\n'; exit 0 ;;
+  *) exit 0 ;;
+esac
+"#,
+                log_path.display()
+            ),
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&tmux_binary).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&tmux_binary, permissions).unwrap();
+        (tmux_binary, log_path, temp_dir)
+    }
+
+    fn position_after(lines: &[&str], needle: &str, start: usize) -> usize {
+        lines
+            .iter()
+            .enumerate()
+            .skip(start)
+            .find_map(|(index, line)| line.contains(needle).then_some(index))
+            .unwrap_or_else(|| panic!("missing {needle:?} after line {start}; log: {lines:?}"))
     }
 }

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -61,6 +61,49 @@ impl SessionStore {
             .collect())
     }
 
+    pub fn list_children(
+        &self,
+        parent_session_id: &str,
+        recursive: bool,
+        status_filter: Option<&str>,
+        include_terminated: bool,
+    ) -> Result<Vec<ChildSessionResponse>> {
+        let all_sessions = self.load_snapshot()?.into_sessions();
+        let mut children = if recursive {
+            let mut descendants = Vec::new();
+            let mut visited = BTreeSet::new();
+            collect_descendants_preorder(
+                &all_sessions,
+                parent_session_id,
+                &mut visited,
+                &mut descendants,
+            );
+            descendants
+        } else {
+            direct_children(&all_sessions, parent_session_id)
+        };
+
+        let status_filter = status_filter
+            .map(str::trim)
+            .filter(|value| !value.is_empty() && *value != "all");
+        if let Some(status_filter) = status_filter {
+            children.retain(|session| match status_filter {
+                "running" => normalized_status(&session.status) == "running",
+                "completed" => session.completion_status.as_deref() == Some("completed"),
+                "error" => session.completion_status.as_deref() == Some("error"),
+                _ => true,
+            });
+        }
+        if !include_terminated {
+            children.retain(|session| session.completion_status.as_deref() != Some("killed"));
+        }
+
+        Ok(children
+            .into_iter()
+            .map(ChildSessionResponse::from)
+            .collect())
+    }
+
     pub fn get_session(&self, session_id: &str) -> Result<Option<SessionRecord>> {
         let session_id = session_id.trim();
         if session_id.is_empty() {
@@ -97,6 +140,23 @@ impl SessionStore {
             }
         };
         Ok(Some(output))
+    }
+
+    pub fn list_context_monitors(&self) -> Result<Vec<ContextMonitorStatus>> {
+        Ok(self
+            .load_snapshot()?
+            .into_sessions()
+            .into_iter()
+            .filter(|session| session.context_monitor_enabled)
+            .map(|session| {
+                let friendly_name = session.cached_display_name();
+                ContextMonitorStatus {
+                    session_id: session.id,
+                    friendly_name,
+                    notify_session_id: session.context_monitor_notify,
+                }
+            })
+            .collect())
     }
 
     pub fn create_core_session(
@@ -252,6 +312,354 @@ impl SessionStore {
         }))
     }
 
+    pub fn clear_core_session(
+        &self,
+        session_id: &str,
+        request: ClearSessionRequest,
+    ) -> Result<CoreClearOutcome> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let Some(session) = session_object_mut(sessions, session_id) else {
+            return Ok(CoreClearOutcome::NotFound);
+        };
+        if let Some(message) =
+            clear_authorization_error(session, request.requester_session_id.as_deref())
+        {
+            return Ok(CoreClearOutcome::Unauthorized(message));
+        }
+        let now = now_rfc3339();
+        reset_session_after_clear(session, &now);
+        if let Some(log_file) = json_text(session.get("log_file")) {
+            append_log_line(&expand_home(&log_file), "[sm-rust] fixture context cleared")?;
+            if let Some(prompt) = request
+                .prompt
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                append_log_line(&expand_home(&log_file), prompt)?;
+            }
+        }
+        self.write_raw_json_value(&state)?;
+        Ok(CoreClearOutcome::Cleared(CoreClearResult {
+            status: "cleared".to_owned(),
+            session_id: session_id.to_owned(),
+        }))
+    }
+
+    pub fn clear_core_session_with_runtime(
+        &self,
+        session_id: &str,
+        request: ClearSessionRequest,
+        runtime: &TmuxRuntime,
+    ) -> Result<CoreClearOutcome> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let Some(session) = session_object_mut(sessions, session_id) else {
+            return Ok(CoreClearOutcome::NotFound);
+        };
+        if let Some(message) =
+            clear_authorization_error(session, request.requester_session_id.as_deref())
+        {
+            return Ok(CoreClearOutcome::Unauthorized(message));
+        }
+        let node = json_text(session.get("node")).unwrap_or_else(default_node);
+        ensure_runtime_local_node(&node)?;
+        let tmux_session = json_text(session.get("tmux_session"))
+            .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?;
+        let session_socket_name = json_text(session.get("tmux_socket_name"));
+        let session_runtime = runtime.for_socket_name(session_socket_name.as_deref());
+        let provider = json_text(session.get("provider")).unwrap_or_else(default_provider);
+        let clear_command = if matches!(provider.as_str(), "codex" | "codex-fork") {
+            "/new"
+        } else {
+            "/clear"
+        };
+        let prompt = request
+            .prompt
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
+        let wake_completed =
+            json_text(session.get("completion_status")).is_some_and(|value| value == "completed");
+        let delivered = session_runtime.clear_session(
+            &tmux_session,
+            clear_command,
+            prompt.as_deref(),
+            wake_completed,
+        )?;
+        if !delivered {
+            return Err(anyhow::anyhow!("tmux session is not running"));
+        }
+        let now = now_rfc3339();
+        reset_session_after_clear(session, &now);
+        self.write_raw_json_value(&state)?;
+        Ok(CoreClearOutcome::Cleared(CoreClearResult {
+            status: "cleared".to_owned(),
+            session_id: session_id.to_owned(),
+        }))
+    }
+
+    pub fn restore_core_session(&self, session_id: &str) -> Result<Option<CoreRestoreOutcome>> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let Some(session) = session_object_mut(sessions, session_id) else {
+            return Ok(None);
+        };
+        let status = json_text(session.get("status")).unwrap_or_else(|| "running".to_owned());
+        if normalized_status(&status) != "stopped" {
+            return Ok(Some(CoreRestoreOutcome::NotStopped));
+        }
+        let now = now_rfc3339();
+        session.insert("status".to_owned(), Value::String("running".to_owned()));
+        session.insert("stopped_at".to_owned(), Value::Null);
+        session.insert("completion_status".to_owned(), Value::Null);
+        session.insert("completion_message".to_owned(), Value::Null);
+        session.insert("completed_at".to_owned(), Value::Null);
+        session.insert("agent_task_completed_at".to_owned(), Value::Null);
+        session.insert("last_activity".to_owned(), Value::String(now));
+        if let Some(log_file) = json_text(session.get("log_file")) {
+            append_log_line(
+                &expand_home(&log_file),
+                "[sm-rust] fixture session restored",
+            )?;
+        }
+        let restored = serde_json::from_value::<SessionRecord>(Value::Object(session.clone()))?;
+        self.write_raw_json_value(&state)?;
+        Ok(Some(CoreRestoreOutcome::Restored(restored)))
+    }
+
+    pub fn restore_core_session_with_runtime(
+        &self,
+        session_id: &str,
+        runtime: &TmuxRuntime,
+    ) -> Result<Option<CoreRestoreOutcome>> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let Some(session) = session_object_mut(sessions, session_id) else {
+            return Ok(None);
+        };
+        let status = json_text(session.get("status")).unwrap_or_else(|| "running".to_owned());
+        if normalized_status(&status) != "stopped" {
+            return Ok(Some(CoreRestoreOutcome::NotStopped));
+        }
+        let record = serde_json::from_value::<SessionRecord>(Value::Object(session.clone()))?;
+        if !is_primary_node(&record.node) {
+            return Ok(Some(CoreRestoreOutcome::UnsupportedNode(record.node)));
+        }
+        if record.provider != "claude" {
+            return Ok(Some(CoreRestoreOutcome::UnsupportedProvider(
+                record.provider,
+            )));
+        }
+        let Some(log_file) = record
+            .log_file
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(expand_home)
+        else {
+            return Err(anyhow::anyhow!("session {session_id} missing log_file"));
+        };
+        let session_runtime = runtime.for_socket_name(record.tmux_socket_name.as_deref());
+        if session_runtime.session_exists(&record.tmux_session)? {
+            let _ = session_runtime.kill_session(&record.tmux_session)?;
+        }
+        let spec = TmuxSessionSpec {
+            session_id: record.id.clone(),
+            tmux_session: record.tmux_session.clone(),
+            working_dir: expand_home(&record.working_dir).display().to_string(),
+            log_file,
+            initial_message: None,
+            model: record.model.clone(),
+        };
+        session_runtime.restore_session(
+            &spec,
+            &record.provider,
+            record.provider_resume_id.as_deref(),
+        )?;
+
+        let now = now_rfc3339();
+        session.insert("status".to_owned(), Value::String("running".to_owned()));
+        session.insert("stopped_at".to_owned(), Value::Null);
+        session.insert("completion_status".to_owned(), Value::Null);
+        session.insert("completion_message".to_owned(), Value::Null);
+        session.insert("completed_at".to_owned(), Value::Null);
+        session.insert("agent_task_completed_at".to_owned(), Value::Null);
+        session.insert("last_activity".to_owned(), Value::String(now));
+        if let Some(socket_name) = session_runtime.socket_name() {
+            session.insert(
+                "tmux_socket_name".to_owned(),
+                Value::String(socket_name.to_owned()),
+            );
+        }
+        let restored = serde_json::from_value::<SessionRecord>(Value::Object(session.clone()))?;
+        self.write_raw_json_value(&state)?;
+        Ok(Some(CoreRestoreOutcome::Restored(restored)))
+    }
+
+    pub fn set_context_monitor(
+        &self,
+        session_id: &str,
+        request: ContextMonitorRequest,
+    ) -> Result<ContextMonitorOutcome> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let requester_session_id = request.requester_session_id.trim();
+        if requester_session_id.is_empty() {
+            return Ok(ContextMonitorOutcome::Unauthorized);
+        }
+        let notify_session_id = request
+            .notify_session_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned);
+        if request.enabled && notify_session_id.is_none() {
+            return Ok(ContextMonitorOutcome::MissingNotifyTarget);
+        }
+        if request.enabled {
+            let notify_session_id = notify_session_id.as_deref().unwrap_or_default();
+            if session_object(sessions, notify_session_id).is_none() {
+                return Ok(ContextMonitorOutcome::NotifyTargetNotFound(
+                    notify_session_id.to_owned(),
+                ));
+            }
+        }
+        let Some(session) = session_object_mut(sessions, session_id) else {
+            return Ok(ContextMonitorOutcome::NotFound);
+        };
+        let is_self = requester_session_id == session_id;
+        let is_parent =
+            json_text(session.get("parent_session_id")).as_deref() == Some(requester_session_id);
+        if !is_self && !is_parent {
+            return Ok(ContextMonitorOutcome::Unauthorized);
+        }
+        session.insert(
+            "context_monitor_enabled".to_owned(),
+            Value::Bool(request.enabled),
+        );
+        if request.enabled {
+            session.insert(
+                "context_monitor_notify".to_owned(),
+                Value::String(notify_session_id.unwrap()),
+            );
+        } else {
+            session.insert("context_monitor_notify".to_owned(), Value::Null);
+        }
+        self.write_raw_json_value(&state)?;
+        Ok(ContextMonitorOutcome::Updated(ContextMonitorResult {
+            status: "ok".to_owned(),
+            enabled: request.enabled,
+        }))
+    }
+
+    pub fn schedule_handoff(
+        &self,
+        session_id: &str,
+        request: HandoffRequest,
+    ) -> Result<HandoffOutcome> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        if request.requester_session_id.trim() != session_id {
+            return Ok(HandoffOutcome::Error(
+                "sm handoff is self-directed only - requester must equal target session".to_owned(),
+            ));
+        }
+        let Some(session) = session_object_mut(sessions, session_id) else {
+            return Ok(HandoffOutcome::Error(format!(
+                "Session {session_id} not found"
+            )));
+        };
+        let provider = json_text(session.get("provider")).unwrap_or_else(default_provider);
+        if provider == "codex-app" {
+            return Ok(HandoffOutcome::Error(
+                "sm handoff is not supported for codex-app sessions".to_owned(),
+            ));
+        }
+        session.insert(
+            "last_handoff_path".to_owned(),
+            Value::String(request.file_path.clone()),
+        );
+        self.write_raw_json_value(&state)?;
+        Ok(HandoffOutcome::Recorded(HandoffResult {
+            status: "recorded".to_owned(),
+        }))
+    }
+
+    pub fn execute_handoff_with_runtime(
+        &self,
+        session_id: &str,
+        request: HandoffRequest,
+        runtime: &TmuxRuntime,
+    ) -> Result<HandoffOutcome> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        if request.requester_session_id.trim() != session_id {
+            return Ok(HandoffOutcome::Error(
+                "sm handoff is self-directed only - requester must equal target session".to_owned(),
+            ));
+        }
+        let Some(session) = session_object_mut(sessions, session_id) else {
+            return Ok(HandoffOutcome::Error(format!(
+                "Session {session_id} not found"
+            )));
+        };
+        let provider = json_text(session.get("provider")).unwrap_or_else(default_provider);
+        if provider == "codex-app" {
+            return Ok(HandoffOutcome::Error(
+                "sm handoff is not supported for codex-app sessions".to_owned(),
+            ));
+        }
+        let node = json_text(session.get("node")).unwrap_or_else(default_node);
+        ensure_runtime_local_node(&node)?;
+        let tmux_session = json_text(session.get("tmux_session"))
+            .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?;
+        let session_socket_name = json_text(session.get("tmux_socket_name"));
+        let session_runtime = runtime.for_socket_name(session_socket_name.as_deref());
+        let clear_command = if matches!(provider.as_str(), "codex" | "codex-fork") {
+            "/new"
+        } else {
+            "/clear"
+        };
+        let prompt = format!(
+            "Read {} and continue from where you left off.",
+            request.file_path
+        );
+        let wake_completed =
+            json_text(session.get("completion_status")).is_some_and(|value| value == "completed");
+        let delivered = session_runtime.clear_session(
+            &tmux_session,
+            clear_command,
+            Some(&prompt),
+            wake_completed,
+        )?;
+        if !delivered {
+            return Ok(HandoffOutcome::Error(
+                "tmux session is not running".to_owned(),
+            ));
+        }
+
+        let now = now_rfc3339();
+        reset_session_after_clear(session, &now);
+        session.insert(
+            "last_handoff_path".to_owned(),
+            Value::String(request.file_path.clone()),
+        );
+        self.write_raw_json_value(&state)?;
+        Ok(HandoffOutcome::Executed(HandoffResult {
+            status: "executed".to_owned(),
+        }))
+    }
+
     pub fn retire_core_session(
         &self,
         session_id: &str,
@@ -273,6 +681,7 @@ impl SessionStore {
         }
         let now = now_rfc3339();
         session.insert("status".to_owned(), Value::String("stopped".to_owned()));
+        mark_session_killed(session, &now);
         session.insert("stopped_at".to_owned(), Value::String(now.clone()));
         session.insert("last_activity".to_owned(), Value::String(now));
         if let Some(log_file) = json_text(session.get("log_file")) {
@@ -317,6 +726,7 @@ impl SessionStore {
         let _ = session_runtime.kill_session(&tmux_session)?;
         let now = now_rfc3339();
         session.insert("status".to_owned(), Value::String("stopped".to_owned()));
+        mark_session_killed(session, &now);
         session.insert("stopped_at".to_owned(), Value::String(now.clone()));
         session.insert("last_activity".to_owned(), Value::String(now));
         self.write_raw_json_value(&state)?;
@@ -540,17 +950,21 @@ impl SessionStore {
             agent_status_text: None,
             agent_status_at: None,
             agent_task_completed_at: None,
+            completion_status: None,
+            completion_message: None,
             completed_at: None,
             stopped_at: None,
             is_em: false,
             role: None,
             status: "running".to_owned(),
+            spawned_at: Some(now.clone()),
             created_at: now.clone(),
             last_activity: now,
             last_tool_call: None,
             last_tool_name: None,
             tokens_used: 0,
             context_monitor_enabled: false,
+            context_monitor_notify: None,
             aliases: Vec::new(),
             pending_adoption_proposals: Vec::new(),
         })
@@ -594,6 +1008,28 @@ pub struct AgentStatusRequest {
     pub text: Option<String>,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct ClearSessionRequest {
+    #[serde(default)]
+    pub prompt: Option<String>,
+    #[serde(default)]
+    pub requester_session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ContextMonitorRequest {
+    pub enabled: bool,
+    pub requester_session_id: String,
+    #[serde(default)]
+    pub notify_session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct HandoffRequest {
+    pub requester_session_id: String,
+    pub file_path: String,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct CoreInputResult {
     pub ok: bool,
@@ -620,10 +1056,65 @@ pub enum CoreRetireOutcome {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub struct CoreClearResult {
+    pub status: String,
+    pub session_id: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum CoreClearOutcome {
+    Cleared(CoreClearResult),
+    NotFound,
+    Unauthorized(String),
+}
+
+#[derive(Debug, Clone)]
+pub enum CoreRestoreOutcome {
+    Restored(SessionRecord),
+    NotStopped,
+    UnsupportedNode(String),
+    UnsupportedProvider(String),
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct AgentStatusResult {
     pub status: String,
     pub session_id: String,
     pub agent_status_text: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ContextMonitorStatus {
+    pub session_id: String,
+    pub friendly_name: Option<String>,
+    pub notify_session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ContextMonitorResult {
+    pub status: String,
+    pub enabled: bool,
+}
+
+#[derive(Debug, Clone)]
+pub enum ContextMonitorOutcome {
+    Updated(ContextMonitorResult),
+    NotFound,
+    MissingNotifyTarget,
+    NotifyTargetNotFound(String),
+    Unauthorized,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HandoffResult {
+    pub status: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum HandoffOutcome {
+    Recorded(HandoffResult),
+    Executed(HandoffResult),
+    Error(String),
 }
 
 fn read_snapshot(path: &Path) -> Result<StateSnapshot> {
@@ -660,6 +1151,83 @@ fn session_object_mut<'a>(
             None
         }
     })
+}
+
+fn session_object<'a>(sessions: &'a [Value], session_id: &str) -> Option<&'a Map<String, Value>> {
+    sessions.iter().find_map(|value| {
+        if value.get("id").and_then(Value::as_str) == Some(session_id) {
+            value.as_object()
+        } else {
+            None
+        }
+    })
+}
+
+fn direct_children(sessions: &[SessionRecord], parent_session_id: &str) -> Vec<SessionRecord> {
+    sessions
+        .iter()
+        .filter(|session| session.parent_session_id.as_deref() == Some(parent_session_id))
+        .cloned()
+        .collect()
+}
+
+fn collect_descendants_preorder(
+    sessions: &[SessionRecord],
+    parent_session_id: &str,
+    visited: &mut BTreeSet<String>,
+    descendants: &mut Vec<SessionRecord>,
+) {
+    for child in direct_children(sessions, parent_session_id) {
+        if !visited.insert(child.id.clone()) {
+            continue;
+        }
+        let child_id = child.id.clone();
+        descendants.push(child);
+        collect_descendants_preorder(sessions, &child_id, visited, descendants);
+    }
+}
+
+fn reset_session_after_clear(session: &mut Map<String, Value>, now: &str) {
+    session.insert("agent_status_text".to_owned(), Value::Null);
+    session.insert("agent_status_at".to_owned(), Value::Null);
+    session.insert("agent_task_completed_at".to_owned(), Value::Null);
+    session.insert("completion_status".to_owned(), Value::Null);
+    session.insert("completion_message".to_owned(), Value::Null);
+    session.insert("completed_at".to_owned(), Value::Null);
+    session.insert("last_activity".to_owned(), Value::String(now.to_owned()));
+}
+
+fn mark_session_killed(session: &mut Map<String, Value>, now: &str) {
+    session.insert(
+        "completion_status".to_owned(),
+        Value::String("killed".to_owned()),
+    );
+    session.insert(
+        "completion_message".to_owned(),
+        Value::String("Terminated via sm kill".to_owned()),
+    );
+    session.insert("completed_at".to_owned(), Value::String(now.to_owned()));
+}
+
+fn clear_authorization_error(
+    session: &Map<String, Value>,
+    requester_session_id: Option<&str>,
+) -> Option<String> {
+    let parent_id = json_text(session.get("parent_session_id"));
+    let requester_session_id = requester_session_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if let Some(requester_session_id) = requester_session_id {
+        if parent_id.as_deref() != Some(requester_session_id) {
+            return Some(format!(
+                "Not authorized. You can only clear your child sessions. Target session parent: {}",
+                parent_id.as_deref().unwrap_or("none")
+            ));
+        }
+    } else if parent_id.is_none() {
+        return Some("Can only clear child sessions. Target session has no parent.".to_owned());
+    }
+    None
 }
 
 fn json_text(value: Option<&Value>) -> Option<String> {
@@ -1007,6 +1575,10 @@ pub struct SessionRecord {
     #[serde(default)]
     pub agent_task_completed_at: Option<String>,
     #[serde(default)]
+    pub completion_status: Option<String>,
+    #[serde(default)]
+    pub completion_message: Option<String>,
+    #[serde(default)]
     pub completed_at: Option<String>,
     #[serde(default)]
     pub stopped_at: Option<String>,
@@ -1016,6 +1588,8 @@ pub struct SessionRecord {
     pub role: Option<String>,
     #[serde(default)]
     pub status: String,
+    #[serde(default)]
+    pub spawned_at: Option<String>,
     pub created_at: String,
     pub last_activity: String,
     #[serde(default)]
@@ -1026,6 +1600,8 @@ pub struct SessionRecord {
     pub tokens_used: i64,
     #[serde(default)]
     pub context_monitor_enabled: bool,
+    #[serde(default)]
+    pub context_monitor_notify: Option<String>,
     #[serde(skip)]
     pub aliases: Vec<String>,
     #[serde(skip)]
@@ -1218,6 +1794,55 @@ impl From<SessionRecord> for SessionResponse {
             pending_adoption_proposals: session.pending_adoption_proposals,
             aliases: session.aliases,
             is_maintainer,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ChildSessionResponse {
+    id: String,
+    name: String,
+    friendly_name: Option<String>,
+    status: String,
+    activity_state: String,
+    completion_status: Option<String>,
+    completion_message: Option<String>,
+    last_activity: String,
+    spawned_at: Option<String>,
+    completed_at: Option<String>,
+    tmux_session: String,
+    tmux_socket_name: Option<String>,
+    agent_status_text: Option<String>,
+    agent_status_at: Option<String>,
+    provider: String,
+    activity_projection: Option<Value>,
+}
+
+impl From<SessionRecord> for ChildSessionResponse {
+    fn from(session: SessionRecord) -> Self {
+        let status = normalized_status(&session.status).to_owned();
+        let friendly_name = session.cached_display_name();
+        let spawned_at = session
+            .spawned_at
+            .clone()
+            .or(Some(session.created_at.clone()));
+        Self {
+            id: session.id,
+            name: session.name,
+            friendly_name,
+            status: status.clone(),
+            activity_state: fallback_activity_state(&status),
+            completion_status: session.completion_status,
+            completion_message: session.completion_message,
+            last_activity: session.last_activity,
+            spawned_at,
+            completed_at: session.completed_at,
+            tmux_session: session.tmux_session,
+            tmux_socket_name: session.tmux_socket_name,
+            agent_status_text: session.agent_status_text,
+            agent_status_at: session.agent_status_at,
+            provider: non_empty_or(session.provider, "claude"),
+            activity_projection: None,
         }
     }
 }
@@ -1445,17 +2070,21 @@ mod tests {
             agent_status_text: None,
             agent_status_at: None,
             agent_task_completed_at: None,
+            completion_status: None,
+            completion_message: None,
             completed_at: None,
             stopped_at: None,
             is_em: false,
             role: None,
             status: status.to_owned(),
+            spawned_at: Some("2026-06-01T00:00:00".to_owned()),
             created_at: "2026-06-01T00:00:00".to_owned(),
             last_activity: "2026-06-01T00:01:00".to_owned(),
             last_tool_call: None,
             last_tool_name: None,
             tokens_used: 0,
             context_monitor_enabled: false,
+            context_monitor_notify: None,
             aliases: Vec::new(),
             pending_adoption_proposals: Vec::new(),
         }

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -461,9 +461,9 @@ async fn shadow_http_does_not_treat_static_sessions_route_as_session_id() {
     .await;
 
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(payload["support_status"], "unsupported");
-    assert_eq!(payload["comparison"], "not_compared");
-    assert_eq!(payload["predicted_status"], Value::Null);
+    assert_eq!(payload["support_status"], "implemented_read");
+    assert_eq!(payload["comparison"], "body_mismatch");
+    assert_eq!(payload["predicted_status"], 200);
 }
 
 #[tokio::test]
@@ -1060,6 +1060,360 @@ async fn fixture_core_lifecycle_creates_sends_outputs_and_retires() {
 }
 
 #[tokio::test]
+async fn fixture_core_session_graph_endpoints_round_trip_state() {
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        rust_core: RustCoreConfig {
+            fixture_writes_enabled: true,
+            log_dir: Some(log_dir.display().to_string()),
+            ..RustCoreConfig::default()
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "graphparent",
+            "name": "graph-parent",
+            "working_dir": "/repo",
+            "provider": "claude"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "graphchild",
+            "name": "graph-child",
+            "parent_session_id": "graphparent",
+            "provider": "claude"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "graphgrandchild",
+            "name": "graph-grandchild",
+            "parent_session_id": "graphchild",
+            "provider": "claude"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "graphgreatgrandchild",
+            "name": "graph-great-grandchild",
+            "parent_session_id": "graphgrandchild",
+            "provider": "claude"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, payload) = get_json(app.clone(), "/sessions/graphparent/children").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["parent_session_id"], "graphparent");
+    assert_eq!(payload["children"].as_array().unwrap().len(), 1);
+    assert_eq!(payload["children"][0]["id"], "graphchild");
+    assert_eq!(payload["children"][0]["friendly_name"], "graph-child");
+
+    let (status, payload) =
+        get_json(app.clone(), "/sessions/graphparent/children?recursive=true").await;
+    assert_eq!(status, StatusCode::OK);
+    let child_ids = payload["children"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|child| child["id"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        child_ids,
+        vec!["graphchild", "graphgrandchild", "graphgreatgrandchild"]
+    );
+
+    let (status, payload) = get_json(app.clone(), "/sessions/graphchild/attach-descriptor").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["attach"]["attach_supported"], true);
+    assert_eq!(payload["attach"]["tmux_session"], "sm-rust-graphchild");
+
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "graphcodexapp",
+            "name": "graph-codex-app",
+            "provider": "codex-app"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, payload) =
+        get_json(app.clone(), "/sessions/graphcodexapp/attach-descriptor").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["attach"]["attach_supported"], false);
+    assert_eq!(
+        payload["attach"]["message"],
+        "Attach not supported for Codex app sessions"
+    );
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/graphchild/context-monitor",
+        json!({
+            "enabled": true,
+            "requester_session_id": "graphparent",
+            "notify_session_id": "graphparent"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload, json!({ "status": "ok", "enabled": true }));
+
+    let (status, payload) = get_json(app.clone(), "/sessions/context-monitor").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["monitored"][0]["session_id"], "graphchild");
+    assert_eq!(payload["monitored"][0]["notify_session_id"], "graphparent");
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/graphchild/agent-status",
+        json!({ "text": "old task state" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["agent_status_text"], "old task state");
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/graphparent/clear",
+        json!({ "prompt": "root reset denied" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(
+        payload["detail"],
+        "Can only clear child sessions. Target session has no parent."
+    );
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/graphchild/clear",
+        json!({
+            "prompt": "sibling reset denied",
+            "requester_session_id": "graphgrandchild"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(
+        payload["detail"],
+        "Not authorized. You can only clear your child sessions. Target session parent: graphparent"
+    );
+
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let child_entry = state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "graphchild")
+        .unwrap();
+    child_entry["completion_status"] = json!("completed");
+    child_entry["completion_message"] = json!("stale completed message");
+    child_entry["completed_at"] = json!("2026-06-01T00:02:00Z");
+    child_entry["agent_task_completed_at"] = json!("2026-06-01T00:03:00Z");
+    fs::write(&state_file, state.to_string()).unwrap();
+
+    let (status, payload) = get_json(
+        app.clone(),
+        "/sessions/graphparent/children?status=completed",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["children"].as_array().unwrap().len(), 1);
+    assert_eq!(payload["children"][0]["completion_status"], "completed");
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/graphchild/clear",
+        json!({ "prompt": "new task after clear" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        payload,
+        json!({ "status": "cleared", "session_id": "graphchild" })
+    );
+
+    let (status, payload) = get_json(app.clone(), "/sessions/graphchild").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["agent_status_text"], Value::Null);
+
+    let (status, payload) = get_json(app.clone(), "/sessions/graphparent/children").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["children"][0]["completion_status"], Value::Null);
+    assert_eq!(payload["children"][0]["completion_message"], Value::Null);
+
+    let (status, payload) = get_json(
+        app.clone(),
+        "/sessions/graphparent/children?status=completed",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["children"].as_array().unwrap().len(), 0);
+
+    let (status, payload) = get_json(app.clone(), "/sessions/graphchild/output?lines=5").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(payload["output"]
+        .as_str()
+        .unwrap()
+        .contains("new task after clear"));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/graphchild/handoff",
+        json!({
+            "requester_session_id": "graphchild",
+            "file_path": "/tmp/handoff.md"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload, json!({ "status": "recorded" }));
+
+    let (status, payload) = get_json(app.clone(), "/sessions/graphchild").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["last_handoff_path"], "/tmp/handoff.md");
+
+    let (status, payload) = post_json(app.clone(), "/sessions/graphchild/kill", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "killed");
+
+    let (status, payload) = get_json(app.clone(), "/sessions/graphparent/children").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(payload["children"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|child| child["id"] != "graphchild"));
+
+    let (status, payload) = get_json(
+        app.clone(),
+        "/sessions/graphparent/children?include_terminated=true",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let graphchild = payload["children"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|child| child["id"] == "graphchild")
+        .unwrap();
+    assert_eq!(graphchild["completion_status"], "killed");
+    assert_eq!(graphchild["completion_message"], "Terminated via sm kill");
+
+    let (status, payload) = get_json(app.clone(), "/sessions/graphchild/attach-descriptor").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["attach"]["attach_supported"], false);
+    assert_eq!(payload["attach"]["message"], "Session is stopped");
+
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let child = state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "graphchild")
+        .unwrap()
+        .clone();
+    let mut state = state;
+    let sessions = state["sessions"].as_array_mut().unwrap();
+    let child_entry = sessions
+        .iter_mut()
+        .find(|session| session["id"] == "graphchild")
+        .unwrap();
+    child_entry["completion_status"] = json!("killed");
+    child_entry["completion_message"] = json!("stale killed message");
+    child_entry["completed_at"] = json!("2026-06-01T00:02:00Z");
+    child_entry["agent_task_completed_at"] = json!("2026-06-01T00:03:00Z");
+    assert_ne!(child, *child_entry);
+    fs::write(&state_file, state.to_string()).unwrap();
+
+    let (status, payload) = post_json(app.clone(), "/sessions/graphchild/restore", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["id"], "graphchild");
+    assert_eq!(payload["status"], "running");
+    assert_eq!(payload["stopped_at"], Value::Null);
+    assert_eq!(payload["completion_status"], Value::Null);
+    assert_eq!(payload["completion_message"], Value::Null);
+    assert_eq!(payload["completed_at"], Value::Null);
+    assert_eq!(payload["agent_task_completed_at"], Value::Null);
+
+    let (status, payload) = post_json(app, "/sessions/graphchild/restore", json!({})).await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert_eq!(payload, json!({ "detail": "Session is not stopped" }));
+}
+
+#[tokio::test]
+async fn shadow_attach_descriptor_reuses_real_attach_support_rules() {
+    let state_file = write_session_fixture();
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+    let expected_body = serde_json::to_vec(&json!({
+        "attach": {
+            "session_id": "stop1234",
+            "provider": "claude",
+            "attach_supported": false,
+            "tmux_session": "claude-stop1234",
+            "tmux_socket_name": null,
+            "runtime_id": null,
+            "lifecycle_state": "stopped",
+            "message": "Session is stopped"
+        }
+    }))
+    .unwrap();
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/sessions/stop1234/attach-descriptor",
+                "query_string": "",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 200,
+                "body_sha256": sha256_hex(&expected_body)
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read");
+    assert_eq!(payload["comparison"], "match");
+    assert_eq!(payload["body_sha256_match"], true);
+}
+
+#[tokio::test]
 async fn fixture_core_spawn_endpoint_inherits_parent_fields() {
     let state_file = unique_temp_path();
     let log_dir = unique_temp_path();
@@ -1380,10 +1734,107 @@ async fn runtime_core_lifecycle_uses_tmux_backend_when_enabled() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "killed");
 
-    let (status, payload) = get_json(app, "/sessions/runtimecore").await;
+    let (status, payload) = get_json(app.clone(), "/sessions/runtimecore").await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "stopped");
     assert!(!tmux_session_exists(&tmux_socket, &tmux_session));
+
+    let (status, payload) =
+        post_json(app.clone(), "/sessions/runtimecore/restore", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["id"], "runtimecore");
+    assert_eq!(payload["status"], "running");
+    assert_eq!(payload["completion_status"], Value::Null);
+    assert!(tmux_session_exists(&tmux_socket, &tmux_session));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/runtimecore/input",
+        json!({
+            "text": "restored runtime message",
+            "delivery_mode": "sequential"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["delivered"], true);
+    wait_for_output_contains(app, "runtimecore", "runtime:restored runtime message").await;
+}
+
+#[tokio::test]
+async fn runtime_core_handoff_executes_clear_and_prompt() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let working_dir = unique_temp_path();
+    fs::create_dir_all(&working_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-test-handoff-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket);
+    let app = runtime_app_with_command(
+        &state_file,
+        &log_dir,
+        _tmux_guard.0.as_str(),
+        r#"/bin/sh -lc 'printf ">\n"; while IFS= read -r line; do printf "runtime:%s\n>\n" "$line"; done' runtime-sh"#,
+    );
+
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimehandoff",
+            "name": "runtime-handoff",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude",
+            "initial_message": "initial handoff prompt"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    wait_for_output_contains(
+        app.clone(),
+        "runtimehandoff",
+        "runtime:initial handoff prompt",
+    )
+    .await;
+
+    let handoff_path = unique_temp_path();
+    fs::write(&handoff_path, "handoff body").unwrap();
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/runtimehandoff/handoff",
+        json!({
+            "requester_session_id": "runtimehandoff",
+            "file_path": handoff_path.display().to_string()
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "executed");
+    wait_for_output_contains(
+        app.clone(),
+        "runtimehandoff",
+        &format!(
+            "runtime:Read {} and continue from where you left off.",
+            handoff_path.display()
+        ),
+    )
+    .await;
+
+    let (status, payload) = get_json(app, "/sessions/runtimehandoff").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        payload["last_handoff_path"],
+        handoff_path.display().to_string()
+    );
 }
 
 #[tokio::test]
@@ -1734,9 +2185,18 @@ async fn runtime_core_expands_bare_home_working_dir_for_tmux() {
         Some(home_path.as_path())
     );
 
-    let (status, payload) = post_json(app, "/sessions/runtimehome/kill", json!({})).await;
+    let (status, payload) = post_json(app.clone(), "/sessions/runtimehome/kill", json!({})).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "killed");
+
+    let (status, payload) = post_json(app, "/sessions/runtimehome/restore", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["id"], "runtimehome");
+    assert_eq!(payload["status"], "running");
+    assert_eq!(
+        tmux_pane_current_path(&tmux_socket, &tmux_session).as_deref(),
+        Some(home_path.as_path())
+    );
 }
 
 #[tokio::test]

--- a/scripts/rust_migration/contracts_manifest.json
+++ b/scripts/rust_migration/contracts_manifest.json
@@ -920,6 +920,81 @@
       "source": "https://github.com/rajeshgoli/session-manager/issues/795"
     },
     {
+      "id": "cli.rust_core_me_fixture",
+      "surface": "cli",
+      "classification": "retained",
+      "target": "rust_only",
+      "safety": "mutating",
+      "command": ["--api-url", "{base_url}", "me"],
+      "env": {"SESSION_MANAGER_ID": "{session_id}"},
+      "expected_exit": [0],
+      "expected_output_contains_all": ["{session_id}", "{session_name}", "{working_dir}"],
+      "preconditions": ["sm_cli", "fixture:base_url", "session_id", "fixture:session_name", "fixture:working_dir", "mutating_opt_in"],
+      "source": "https://github.com/rajeshgoli/session-manager/issues/797"
+    },
+    {
+      "id": "cli.rust_core_all_fixture",
+      "surface": "cli",
+      "classification": "retained",
+      "target": "rust_only",
+      "safety": "mutating",
+      "command": ["--api-url", "{base_url}", "all"],
+      "expected_exit": [0],
+      "expected_output_contains_all": ["{session_id}", "{session_name}", "{child_session_id}", "{child_session_name}"],
+      "preconditions": ["sm_cli", "fixture:base_url", "session_id", "fixture:session_name", "fixture:child_session_id", "fixture:child_session_name", "mutating_opt_in"],
+      "source": "https://github.com/rajeshgoli/session-manager/issues/797"
+    },
+    {
+      "id": "cli.rust_core_children_fixture",
+      "surface": "cli",
+      "classification": "retained",
+      "target": "rust_only",
+      "safety": "mutating",
+      "command": ["--api-url", "{base_url}", "children"],
+      "env": {"SESSION_MANAGER_ID": "{session_id}"},
+      "expected_exit": [0],
+      "expected_output_contains_all": ["{child_session_id}", "{child_session_name}"],
+      "preconditions": ["sm_cli", "fixture:base_url", "session_id", "fixture:child_session_id", "fixture:child_session_name", "mutating_opt_in"],
+      "source": "https://github.com/rajeshgoli/session-manager/issues/797"
+    },
+    {
+      "id": "cli.rust_core_children_target_fixture",
+      "surface": "cli",
+      "classification": "retained",
+      "target": "rust_only",
+      "safety": "mutating",
+      "command": ["--api-url", "{base_url}", "children", "{session_id}", "--json"],
+      "expected_exit": [0],
+      "expected_output_contains_all": ["{child_session_id}", "{child_session_name}"],
+      "preconditions": ["sm_cli", "fixture:base_url", "session_id", "fixture:child_session_id", "fixture:child_session_name", "mutating_opt_in"],
+      "source": "https://github.com/rajeshgoli/session-manager/issues/797"
+    },
+    {
+      "id": "cli.rust_core_context_monitor_enable_child_fixture",
+      "surface": "cli",
+      "classification": "retained",
+      "target": "rust_only",
+      "safety": "mutating",
+      "command": ["--api-url", "{base_url}", "context-monitor", "enable", "{child_session_id}"],
+      "env": {"SESSION_MANAGER_ID": "{session_id}"},
+      "expected_exit": [0],
+      "expected_output_contains_all": ["Context monitoring enabled", "{child_session_id}", "{session_id}"],
+      "preconditions": ["sm_cli", "fixture:base_url", "session_id", "fixture:child_session_id", "mutating_opt_in"],
+      "source": "https://github.com/rajeshgoli/session-manager/issues/797"
+    },
+    {
+      "id": "cli.rust_core_context_monitor_status_fixture",
+      "surface": "cli",
+      "classification": "retained",
+      "target": "rust_only",
+      "safety": "mutating",
+      "command": ["--api-url", "{base_url}", "context-monitor", "status"],
+      "expected_exit": [0],
+      "expected_output_contains_all": ["{child_session_id}", "{session_id}"],
+      "preconditions": ["sm_cli", "fixture:base_url", "session_id", "fixture:child_session_id", "mutating_opt_in"],
+      "source": "https://github.com/rajeshgoli/session-manager/issues/797"
+    },
+    {
       "id": "cli.rust_core_status_fixture",
       "surface": "cli",
       "classification": "retained",
@@ -969,6 +1044,19 @@
       "source": "https://github.com/rajeshgoli/session-manager/issues/791"
     },
     {
+      "id": "cli.rust_core_clear_child_fixture",
+      "surface": "cli",
+      "classification": "retained",
+      "target": "rust_only",
+      "safety": "mutating",
+      "command": ["--api-url", "{base_url}", "clear", "{child_session_id}", "{clear_prompt_text}"],
+      "env": {"SESSION_MANAGER_ID": "{session_id}"},
+      "expected_exit": [0],
+      "expected_output_contains_all": ["cleared", "{child_session_id}"],
+      "preconditions": ["sm_cli", "fixture:base_url", "fixture:child_session_id", "fixture:clear_prompt_text", "mutating_opt_in"],
+      "source": "https://github.com/rajeshgoli/session-manager/issues/797"
+    },
+    {
       "id": "cli.rust_core_tail_fixture",
       "surface": "cli",
       "classification": "retained",
@@ -991,6 +1079,49 @@
       "expected_output_contains_any": ["killed"],
       "preconditions": ["sm_cli", "fixture:base_url", "session_id", "mutating_opt_in"],
       "source": "https://github.com/rajeshgoli/session-manager/issues/791"
+    },
+    {
+      "id": "http.attach_descriptor_fixture",
+      "surface": "http",
+      "classification": "retained",
+      "target": "python_and_rust",
+      "safety": "read_only",
+      "method": "GET",
+      "path": "/sessions/{session_id}/attach-descriptor",
+      "expected_status": [200],
+      "expected_json": [
+        {"path": "/attach", "type": "object"},
+        {"path": "/attach/session_id", "equals": "{session_id}"},
+        {"path": "/attach/attach_supported", "type": "boolean"},
+        {"path": "/attach/provider", "type": "string"},
+        {"path": "/attach/lifecycle_state", "type": "string"}
+      ],
+      "preconditions": ["live_server", "session_id"],
+      "source": "specs/762_stage2_artifacts/route_manifest.md:GET /sessions/{session_id}/attach-descriptor"
+    },
+    {
+      "id": "cli.rust_core_restore_fixture",
+      "surface": "cli",
+      "classification": "retained",
+      "target": "rust_only",
+      "safety": "mutating",
+      "command": ["--api-url", "{base_url}", "restore", "{session_id}"],
+      "expected_exit": [0],
+      "expected_output_contains_all": ["Session restored", "{session_id}"],
+      "preconditions": ["sm_cli", "fixture:base_url", "session_id", "mutating_opt_in"],
+      "source": "https://github.com/rajeshgoli/session-manager/issues/797"
+    },
+    {
+      "id": "cli.rust_core_retire_restored_fixture",
+      "surface": "cli",
+      "classification": "retained",
+      "target": "rust_only",
+      "safety": "mutating",
+      "command": ["--api-url", "{base_url}", "retire", "{session_id}"],
+      "expected_exit": [0],
+      "expected_output_contains_any": ["killed"],
+      "preconditions": ["sm_cli", "fixture:base_url", "session_id", "mutating_opt_in"],
+      "source": "https://github.com/rajeshgoli/session-manager/issues/797"
     },
     {
       "id": "cli.rust_core_wait_retired_fixture",

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -170,13 +170,22 @@ def test_manifest_covers_rust_core_fixture_lifecycle_cli_checks():
     required_ids = {
         "cli.rust_core_spawn_fixture",
         "cli.rust_core_spawn_child_inherits_parent_fixture",
+        "cli.rust_core_me_fixture",
+        "cli.rust_core_all_fixture",
+        "cli.rust_core_children_fixture",
+        "cli.rust_core_children_target_fixture",
+        "cli.rust_core_context_monitor_enable_child_fixture",
+        "cli.rust_core_context_monitor_status_fixture",
         "cli.rust_core_status_fixture",
         "cli.rust_core_send_fixture",
         "cli.rust_core_send_urgent_fixture",
         "cli.rust_core_send_wait_fixture",
         "cli.rust_core_output_fixture",
+        "cli.rust_core_clear_child_fixture",
         "cli.rust_core_tail_fixture",
         "cli.rust_core_retire_fixture",
+        "cli.rust_core_restore_fixture",
+        "cli.rust_core_retire_restored_fixture",
         "cli.rust_core_wait_retired_fixture",
     }
 


### PR DESCRIPTION
## Summary
- implement retained Rust CLI commands for me/who/all/children/restore/attach/clear/handoff/context-monitor
- add Rust HTTP/session-store support for children, attach descriptors, context monitor, clear, restore, and handoff state
- extend migration contract fixture coverage for the new Rust core CLI session graph slice

Fixes #797
Refs #762

## Verification
- cargo fmt --check
- cargo check -p sm-server --bin sm-server --bin sm
- cargo test -p sm-server (57 HTTP tests; 18 lib tests)
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py
- ./venv/bin/python -m scripts.rust_migration.contracts --target rust --sm-binary target/debug/sm --json | jq '.summary'
- disposable Rust server fixture contract run: 20 passed, 0 failed, 0 skipped for Rust core CLI lifecycle/session graph checks