### PR TITLE
Preserve deferred Rust core handoff

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -779,19 +779,12 @@ async fn schedule_handoff(
         &format!("/sessions/{session_id}/handoff"),
     )?;
     ensure_core_writes_enabled(&state)?;
-    let result = if state.config.rust_core.runtime_enabled {
+    if state.config.rust_core.runtime_enabled {
         ensure_core_runtime_session_node_supported(&state, &session_id)?;
-        let runtime = TmuxRuntime::from_config(&state.config.rust_core);
-        state
-            .session_store
-            .execute_handoff_with_runtime(&session_id, payload, &runtime)?
-    } else {
-        state.session_store.schedule_handoff(&session_id, payload)?
-    };
+    }
+    let result = state.session_store.schedule_handoff(&session_id, payload)?;
     match result {
-        HandoffOutcome::Recorded(result) | HandoffOutcome::Executed(result) => {
-            Ok(Json(serde_json::to_value(result)?))
-        }
+        HandoffOutcome::Recorded(result) => Ok(Json(serde_json::to_value(result)?)),
         HandoffOutcome::Error(error) => Ok(Json(json!({ "error": error }))),
     }
 }

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -585,78 +585,12 @@ impl SessionStore {
             ));
         }
         session.insert(
-            "last_handoff_path".to_owned(),
+            "pending_handoff_path".to_owned(),
             Value::String(request.file_path.clone()),
         );
         self.write_raw_json_value(&state)?;
         Ok(HandoffOutcome::Recorded(HandoffResult {
             status: "recorded".to_owned(),
-        }))
-    }
-
-    pub fn execute_handoff_with_runtime(
-        &self,
-        session_id: &str,
-        request: HandoffRequest,
-        runtime: &TmuxRuntime,
-    ) -> Result<HandoffOutcome> {
-        let _guard = self.write_guard()?;
-        let mut state = self.load_raw_json_value()?;
-        let sessions = ensure_sessions_array_mut(&mut state)?;
-        if request.requester_session_id.trim() != session_id {
-            return Ok(HandoffOutcome::Error(
-                "sm handoff is self-directed only - requester must equal target session".to_owned(),
-            ));
-        }
-        let Some(session) = session_object_mut(sessions, session_id) else {
-            return Ok(HandoffOutcome::Error(format!(
-                "Session {session_id} not found"
-            )));
-        };
-        let provider = json_text(session.get("provider")).unwrap_or_else(default_provider);
-        if provider == "codex-app" {
-            return Ok(HandoffOutcome::Error(
-                "sm handoff is not supported for codex-app sessions".to_owned(),
-            ));
-        }
-        let node = json_text(session.get("node")).unwrap_or_else(default_node);
-        ensure_runtime_local_node(&node)?;
-        let tmux_session = json_text(session.get("tmux_session"))
-            .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?;
-        let session_socket_name = json_text(session.get("tmux_socket_name"));
-        let session_runtime = runtime.for_socket_name(session_socket_name.as_deref());
-        let clear_command = if matches!(provider.as_str(), "codex" | "codex-fork") {
-            "/new"
-        } else {
-            "/clear"
-        };
-        let prompt = format!(
-            "Read {} and continue from where you left off.",
-            request.file_path
-        );
-        let wake_completed =
-            json_text(session.get("completion_status")).is_some_and(|value| value == "completed");
-        let delivered = session_runtime.clear_session(
-            &tmux_session,
-            clear_command,
-            Some(&prompt),
-            wake_completed,
-        )?;
-        if !delivered {
-            return Ok(HandoffOutcome::Error(
-                "tmux session is not running".to_owned(),
-            ));
-        }
-
-        let now = now_rfc3339();
-        reset_session_after_clear(session, &now);
-        session.insert(
-            "last_handoff_path".to_owned(),
-            Value::String(request.file_path.clone()),
-        );
-        self.write_raw_json_value(&state)?;
-        Ok(HandoffOutcome::Executed(HandoffResult {
-            status: "executed".to_owned(),
         }))
     }
 
@@ -1113,7 +1047,6 @@ pub struct HandoffResult {
 #[derive(Debug, Clone)]
 pub enum HandoffOutcome {
     Recorded(HandoffResult),
-    Executed(HandoffResult),
     Error(String),
 }
 

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -1300,7 +1300,15 @@ async fn fixture_core_session_graph_endpoints_round_trip_state() {
 
     let (status, payload) = get_json(app.clone(), "/sessions/graphchild").await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(payload["last_handoff_path"], "/tmp/handoff.md");
+    assert_eq!(payload["last_handoff_path"], Value::Null);
+    let raw_state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let graph_child = raw_state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "graphchild")
+        .unwrap();
+    assert_eq!(graph_child["pending_handoff_path"], "/tmp/handoff.md");
 
     let (status, payload) = post_json(app.clone(), "/sessions/graphchild/kill", json!({})).await;
     assert_eq!(status, StatusCode::OK);
@@ -1762,7 +1770,7 @@ async fn runtime_core_lifecycle_uses_tmux_backend_when_enabled() {
 }
 
 #[tokio::test]
-async fn runtime_core_handoff_executes_clear_and_prompt() {
+async fn runtime_core_handoff_records_without_interrupting_active_turn() {
     if !tmux_available() {
         return;
     }
@@ -1818,21 +1826,27 @@ async fn runtime_core_handoff_executes_clear_and_prompt() {
     )
     .await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(payload["status"], "executed");
-    wait_for_output_contains(
-        app.clone(),
-        "runtimehandoff",
-        &format!(
-            "runtime:Read {} and continue from where you left off.",
-            handoff_path.display()
-        ),
-    )
-    .await;
+    assert_eq!(payload["status"], "recorded");
+
+    let (status, output) = get_json(app.clone(), "/sessions/runtimehandoff/output?lines=20").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(!output["output"]
+        .as_str()
+        .unwrap()
+        .contains("continue from where you left off"));
 
     let (status, payload) = get_json(app, "/sessions/runtimehandoff").await;
     assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["last_handoff_path"], Value::Null);
+    let raw_state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let runtime_handoff = raw_state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "runtimehandoff")
+        .unwrap();
     assert_eq!(
-        payload["last_handoff_path"],
+        runtime_handoff["pending_handoff_path"],
         handoff_path.display().to_string()
     );
 }


### PR DESCRIPTION
## Summary
- preserve deferred handoff semantics in Rust runtime mode instead of clearing/prompting during the HTTP request
- keep Codex/Codex-fork runtime restore gated until provider-specific runtime launch is implemented
- add a focused runtime test proving handoff records without injecting into the active pane

Follow-up to #798
Refs #797
Refs #762

## Verification
- cargo test -p sm-server --test read_only_http runtime_core_handoff_records_without_interrupting_active_turn -- --nocapture
- cargo test -p sm-server --test read_only_http runtime_core_rejects_unsupported_provider -- --nocapture
- cargo test -p sm-server
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py
- git diff --check && cargo fmt --check
- cargo build -p sm-server --bin sm --bin sm-server
- ./venv/bin/python -m scripts.rust_migration.contracts --target rust --sm-binary target/debug/sm --json | jq '.summary'
- disposable Rust server fixture contract run: 20 passed, 0 failed, 0 skipped