### PR TITLE
Add Rust completion and stop-notify core slice

### DIFF
--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -43,6 +43,10 @@ enum Command {
     Output(OutputArgs),
     Clear(ClearArgs),
     Handoff(HandoffArgs),
+    #[command(name = "task-complete")]
+    TaskComplete(EmptyArgs),
+    #[command(name = "turn-complete")]
+    TurnComplete(EmptyArgs),
     #[command(name = "context-monitor")]
     ContextMonitor(ContextMonitorArgs),
     Email(EmailArgs),
@@ -549,6 +553,44 @@ fn run() -> Result<()> {
                 Some("recorded") => println!("Handoff recorded"),
                 _ => println!("Handoff scheduled - will execute after current turn completes"),
             }
+        }
+        Command::TaskComplete(_) => {
+            let Some(session_id) = optional_current_session_id() else {
+                eprintln!(
+                    "Error: SESSION_MANAGER_ID not set. sm task-complete can only be called from within a session."
+                );
+                process::exit(2);
+            };
+            let payload = client.post_json(
+                &format!("/sessions/{session_id}/task-complete"),
+                json!({ "requester_session_id": session_id }),
+            )?;
+            if payload["error"].as_str().is_some() {
+                bail!("Failed to mark task complete");
+            }
+            if payload["em_notified"].as_bool().unwrap_or(false) {
+                println!("Task complete. Remind cancelled. EM notified.");
+            } else {
+                println!(
+                    "Task complete. Remind cancelled. (No EM registered - no notification sent.)"
+                );
+            }
+        }
+        Command::TurnComplete(_) => {
+            let Some(session_id) = optional_current_session_id() else {
+                eprintln!(
+                    "Error: SESSION_MANAGER_ID not set. sm turn-complete can only be called from within a session."
+                );
+                process::exit(2);
+            };
+            let payload = client.post_json(
+                &format!("/sessions/{session_id}/turn-complete"),
+                json!({ "requester_session_id": session_id }),
+            )?;
+            if payload["error"].as_str().is_some() {
+                bail!("Failed to mark turn complete");
+            }
+            println!("Turn complete. Remind cancelled until new work is assigned.");
         }
         Command::ContextMonitor(args) => {
             run_context_monitor(&client, args)?;

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -35,17 +35,19 @@ use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use crate::config::{trimmed, AppConfig};
 use crate::runtime::TmuxRuntime;
 use crate::sessions::{
-    expand_home, is_primary_node, AgentStatusRequest, ClearSessionRequest, ClientSessionResponse,
-    ContextMonitorOutcome, ContextMonitorRequest, CoreClearOutcome, CoreRestoreOutcome,
-    CoreRetireOutcome, CreateCoreSessionRequest, HandoffOutcome, HandoffRequest,
-    MaintainerMutationOutcome, RegistryMutationOutcome, RoleRegistrationRequest,
-    SendCoreInputRequest, SessionRecord, SessionResponse, SessionStore, SessionsEnvelope,
-    SetMaintainerRequest,
+    expand_home, is_primary_node, AgentStatusRequest, ArmStopNotifyOutcome, ArmStopNotifyRequest,
+    ClearSessionRequest, ClientSessionResponse, ContextMonitorOutcome, ContextMonitorRequest,
+    CoreClearOutcome, CoreRestoreOutcome, CoreRetireOutcome, CreateCoreSessionRequest,
+    HandoffOutcome, HandoffRequest, MaintainerMutationOutcome, RegistryMutationOutcome,
+    RoleRegistrationRequest, SendCoreInputRequest, SessionRecord, SessionResponse, SessionStore,
+    SessionsEnvelope, SetMaintainerRequest, TaskCompleteOutcome, TaskCompleteRequest,
+    TurnCompleteOutcome,
 };
 
 const SESSION_COOKIE_NAME: &str = "sm_auth";
 const SESSION_COOKIE_MAX_AGE_SECONDS: i64 = 60 * 60 * 24 * 14;
 const SHADOW_ENVELOPE_MAX_BYTES: usize = 1024 * 1024;
+const EM_SPAWN_STOP_NOTIFY_DELAY_SECONDS: i64 = 8;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -87,6 +89,12 @@ pub fn router(state: AppState) -> Router {
         .route(
             "/sessions/{session_id}/agent-status",
             post(set_agent_status),
+        )
+        .route("/sessions/{session_id}/task-complete", post(task_complete))
+        .route("/sessions/{session_id}/turn-complete", post(turn_complete))
+        .route(
+            "/sessions/{session_id}/notify-on-stop",
+            post(arm_stop_notify),
         )
         .route(
             "/sessions/{session_id}/context-monitor",
@@ -365,6 +373,16 @@ async fn spawn_session(
             .session_store
             .create_core_session(create_payload, log_dir)?
     };
+    if parent.is_em && child.provider != "codex-fork" {
+        let _ = state.session_store.arm_stop_notify(
+            &child.id,
+            ArmStopNotifyRequest {
+                sender_session_id: parent.id.clone(),
+                requester_session_id: parent.id.clone(),
+                delay_seconds: EM_SPAWN_STOP_NOTIFY_DELAY_SECONDS,
+            },
+        )?;
+    }
     if let Some(wait_seconds) = wait_seconds {
         spawn_child_wait_monitor(state.clone(), child.clone(), wait_seconds);
     }
@@ -616,6 +634,76 @@ async fn set_agent_status(
         return Err(ApiError::NotFound("Session not found"));
     };
     Ok(Json(serde_json::to_value(result)?))
+}
+
+async fn task_complete(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(payload): Json<TaskCompleteRequest>,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_allowed_from_parts(
+        &state.config,
+        &headers,
+        Some(peer_addr),
+        &format!("/sessions/{session_id}/task-complete"),
+    )?;
+    ensure_core_writes_enabled(&state)?;
+    match state.session_store.task_complete(&session_id, payload)? {
+        TaskCompleteOutcome::Completed(result) => Ok(Json(serde_json::to_value(result)?)),
+        TaskCompleteOutcome::Error(error) => Ok(Json(json!({ "error": error }))),
+    }
+}
+
+async fn turn_complete(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(payload): Json<TaskCompleteRequest>,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_allowed_from_parts(
+        &state.config,
+        &headers,
+        Some(peer_addr),
+        &format!("/sessions/{session_id}/turn-complete"),
+    )?;
+    ensure_core_writes_enabled(&state)?;
+    match state.session_store.turn_complete(&session_id, payload)? {
+        TurnCompleteOutcome::Completed(result) => Ok(Json(serde_json::to_value(result)?)),
+        TurnCompleteOutcome::Error(error) => Ok(Json(json!({ "error": error }))),
+    }
+}
+
+async fn arm_stop_notify(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(payload): Json<ArmStopNotifyRequest>,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_allowed_from_parts(
+        &state.config,
+        &headers,
+        Some(peer_addr),
+        &format!("/sessions/{session_id}/notify-on-stop"),
+    )?;
+    ensure_core_writes_enabled(&state)?;
+    match state.session_store.arm_stop_notify(&session_id, payload)? {
+        ArmStopNotifyOutcome::Armed(result) | ArmStopNotifyOutcome::Suppressed(result) => {
+            Ok(Json(serde_json::to_value(result)?))
+        }
+        ArmStopNotifyOutcome::NotFound => Err(ApiError::NotFound("Session not found")),
+        ArmStopNotifyOutcome::Forbidden(detail) => Err(ApiError::Status {
+            status: StatusCode::FORBIDDEN,
+            detail,
+        }),
+        ArmStopNotifyOutcome::UnknownSender(sender_session_id) => Err(ApiError::Status {
+            status: StatusCode::UNPROCESSABLE_ENTITY,
+            detail: format!("sender_session_id {sender_session_id:?} not found"),
+        }),
+    }
 }
 
 async fn retire_session(

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -913,6 +913,158 @@ impl SessionStore {
         }
     }
 
+    pub fn task_complete(
+        &self,
+        session_id: &str,
+        request: TaskCompleteRequest,
+    ) -> Result<TaskCompleteOutcome> {
+        if request.requester_session_id.trim() != session_id {
+            return Ok(TaskCompleteOutcome::Error(
+                "sm task-complete is self-directed only — requester must equal target session"
+                    .to_owned(),
+            ));
+        }
+
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = snapshot_from_raw_value(&state)?.into_sessions();
+        let Some(session) = sessions.iter().find(|session| session.id == session_id) else {
+            return Ok(TaskCompleteOutcome::Error(format!(
+                "Session {session_id} not found"
+            )));
+        };
+
+        let em_session_id = active_parent_wake_parent_raw(&state, session_id)?
+            .or_else(|| session.parent_session_id.clone());
+        deactivate_remind_raw(&mut state, session_id)?;
+        deactivate_parent_wake_raw(&mut state, session_id)?;
+
+        let completed_at = now_rfc3339();
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let session_object = session_object_mut(sessions, session_id)
+            .ok_or_else(|| anyhow::anyhow!("session disappeared during task-complete"))?;
+        session_object.insert(
+            "agent_task_completed_at".to_owned(),
+            Value::String(completed_at.clone()),
+        );
+
+        let mut em_notified = false;
+        if let Some(em_session_id) = em_session_id {
+            let friendly = session
+                .cached_display_name()
+                .unwrap_or_else(|| non_empty_or(session.name.clone(), &session.id));
+            push_retained_message_raw(
+                &mut state,
+                &em_session_id,
+                &format!("[sm task-complete] agent {session_id}({friendly}) completed its task."),
+                "important",
+                Some("task_complete"),
+            )?;
+            em_notified = true;
+        }
+
+        self.write_raw_json_value(&state)?;
+        Ok(TaskCompleteOutcome::Completed(TaskCompleteResult {
+            status: "completed".to_owned(),
+            session_id: session_id.to_owned(),
+            em_notified,
+            agent_task_completed_at: completed_at,
+        }))
+    }
+
+    pub fn turn_complete(
+        &self,
+        session_id: &str,
+        request: TaskCompleteRequest,
+    ) -> Result<TurnCompleteOutcome> {
+        if request.requester_session_id.trim() != session_id {
+            return Ok(TurnCompleteOutcome::Error(
+                "sm turn-complete is self-directed only — requester must equal target session"
+                    .to_owned(),
+            ));
+        }
+
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = snapshot_from_raw_value(&state)?.into_sessions();
+        if !sessions.iter().any(|session| session.id == session_id) {
+            return Ok(TurnCompleteOutcome::Error(format!(
+                "Session {session_id} not found"
+            )));
+        }
+
+        deactivate_remind_raw(&mut state, session_id)?;
+        self.write_raw_json_value(&state)?;
+        Ok(TurnCompleteOutcome::Completed(TurnCompleteResult {
+            status: "turn_completed".to_owned(),
+            session_id: session_id.to_owned(),
+        }))
+    }
+
+    pub fn arm_stop_notify(
+        &self,
+        session_id: &str,
+        request: ArmStopNotifyRequest,
+    ) -> Result<ArmStopNotifyOutcome> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = snapshot_from_raw_value(&state)?.into_sessions();
+        let Some(target) = sessions.iter().find(|session| session.id == session_id) else {
+            return Ok(ArmStopNotifyOutcome::NotFound);
+        };
+
+        let requester = sessions
+            .iter()
+            .find(|session| session.id == request.requester_session_id);
+        if !requester.is_some_and(|session| session.is_em) {
+            return Ok(ArmStopNotifyOutcome::Forbidden(
+                "Only EM sessions (is_em=True) may arm stop notifications".to_owned(),
+            ));
+        }
+
+        if target.parent_session_id.as_deref() != Some(request.requester_session_id.as_str()) {
+            return Ok(ArmStopNotifyOutcome::Forbidden(
+                "Cannot arm stop notify — not the parent of target session".to_owned(),
+            ));
+        }
+
+        let Some(sender) = sessions
+            .iter()
+            .find(|session| session.id == request.sender_session_id)
+        else {
+            return Ok(ArmStopNotifyOutcome::UnknownSender(
+                request.sender_session_id,
+            ));
+        };
+
+        if target.provider == "codex-fork" {
+            return Ok(ArmStopNotifyOutcome::Suppressed(ArmStopNotifyResult {
+                status: "suppressed".to_owned(),
+                session_id: session_id.to_owned(),
+                sender_session_id: request.sender_session_id,
+                reason: Some("notify_on_stop disabled for codex-fork sessions".to_owned()),
+            }));
+        }
+
+        let sender_name = sender
+            .cached_display_name()
+            .unwrap_or_else(|| non_empty_or(sender.name.clone(), &sender.id));
+        upsert_stop_notify_raw(
+            &mut state,
+            session_id,
+            &request.sender_session_id,
+            &sender_name,
+            request.delay_seconds.max(0),
+        )?;
+        self.write_raw_json_value(&state)?;
+        Ok(ArmStopNotifyOutcome::Armed(ArmStopNotifyResult {
+            status: "ok".to_owned(),
+            session_id: session_id.to_owned(),
+            sender_session_id: request.sender_session_id,
+            reason: None,
+        }))
+    }
+
     fn load_snapshot(&self) -> Result<StateSnapshot> {
         let state_file = self.readable_state_file();
         if !state_file.exists() {
@@ -1179,6 +1331,19 @@ pub struct RoleRegistrationRequest {
     pub role: String,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct TaskCompleteRequest {
+    pub requester_session_id: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ArmStopNotifyRequest {
+    pub sender_session_id: String,
+    pub requester_session_id: String,
+    #[serde(default)]
+    pub delay_seconds: i64,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct AgentRegistrationResponse {
     pub role: String,
@@ -1293,6 +1458,50 @@ pub enum MaintainerMutationOutcome {
     BadRequest(String),
 }
 
+#[derive(Debug, Clone, Serialize)]
+pub struct TaskCompleteResult {
+    pub status: String,
+    pub session_id: String,
+    pub em_notified: bool,
+    pub agent_task_completed_at: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum TaskCompleteOutcome {
+    Completed(TaskCompleteResult),
+    Error(String),
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TurnCompleteResult {
+    pub status: String,
+    pub session_id: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum TurnCompleteOutcome {
+    Completed(TurnCompleteResult),
+    Error(String),
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ArmStopNotifyResult {
+    pub status: String,
+    pub session_id: String,
+    pub sender_session_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub enum ArmStopNotifyOutcome {
+    Armed(ArmStopNotifyResult),
+    Suppressed(ArmStopNotifyResult),
+    NotFound,
+    Forbidden(String),
+    UnknownSender(String),
+}
+
 fn read_snapshot(path: &Path) -> Result<StateSnapshot> {
     let content = fs::read_to_string(path)
         .with_context(|| format!("failed to read session state {}", path.display()))?;
@@ -1335,6 +1544,104 @@ fn ensure_agent_registrations_array_mut(value: &mut Value) -> Result<&mut Vec<Va
         anyhow::bail!("session state field 'agent_registrations' is not an array");
     }
     Ok(registrations.as_array_mut().expect("array checked above"))
+}
+
+fn ensure_array_field_mut<'a>(value: &'a mut Value, field: &str) -> Result<&'a mut Vec<Value>> {
+    let object = ensure_object_mut(value)?;
+    let entries = object.entry(field.to_owned()).or_insert_with(|| json!([]));
+    if !entries.is_array() {
+        anyhow::bail!("session state field '{field}' is not an array");
+    }
+    Ok(entries.as_array_mut().expect("array checked above"))
+}
+
+fn active_parent_wake_parent_raw(state: &Value, child_session_id: &str) -> Result<Option<String>> {
+    Ok(state
+        .get("retained_parent_wake_registrations")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|entry| {
+            entry.get("child_session_id").and_then(Value::as_str) == Some(child_session_id)
+        })
+        .find(|entry| {
+            entry
+                .get("is_active")
+                .and_then(Value::as_bool)
+                .unwrap_or(true)
+        })
+        .and_then(|entry| json_text(entry.get("parent_session_id"))))
+}
+
+fn deactivate_parent_wake_raw(state: &mut Value, child_session_id: &str) -> Result<()> {
+    let registrations = ensure_array_field_mut(state, "retained_parent_wake_registrations")?;
+    for entry in registrations.iter_mut().filter(|entry| {
+        entry.get("child_session_id").and_then(Value::as_str) == Some(child_session_id)
+    }) {
+        if let Some(object) = entry.as_object_mut() {
+            object.insert("is_active".to_owned(), Value::Bool(false));
+            object.insert("cancelled_at".to_owned(), Value::String(now_rfc3339()));
+        }
+    }
+    Ok(())
+}
+
+fn deactivate_remind_raw(state: &mut Value, session_id: &str) -> Result<()> {
+    let registrations = ensure_array_field_mut(state, "retained_remind_registrations")?;
+    for entry in registrations.iter_mut().filter(|entry| {
+        entry.get("session_id").and_then(Value::as_str) == Some(session_id)
+            || entry.get("target_session_id").and_then(Value::as_str) == Some(session_id)
+    }) {
+        if let Some(object) = entry.as_object_mut() {
+            object.insert("is_active".to_owned(), Value::Bool(false));
+            object.insert("cancelled_at".to_owned(), Value::String(now_rfc3339()));
+        }
+    }
+    Ok(())
+}
+
+fn push_retained_message_raw(
+    state: &mut Value,
+    target_session_id: &str,
+    text: &str,
+    delivery_mode: &str,
+    message_category: Option<&str>,
+) -> Result<()> {
+    let messages = ensure_array_field_mut(state, "retained_pending_messages")?;
+    messages.push(json!({
+        "target_session_id": target_session_id,
+        "text": text,
+        "delivery_mode": delivery_mode,
+        "message_category": message_category,
+        "created_at": now_rfc3339(),
+    }));
+    Ok(())
+}
+
+fn upsert_stop_notify_raw(
+    state: &mut Value,
+    session_id: &str,
+    sender_session_id: &str,
+    sender_name: &str,
+    delay_seconds: i64,
+) -> Result<()> {
+    let entries = ensure_array_field_mut(state, "retained_stop_notify_states")?;
+    let record = json!({
+        "session_id": session_id,
+        "sender_session_id": sender_session_id,
+        "sender_name": sender_name,
+        "delay_seconds": delay_seconds,
+        "armed_at": now_rfc3339(),
+    });
+    if let Some(existing) = entries
+        .iter_mut()
+        .find(|entry| entry.get("session_id").and_then(Value::as_str) == Some(session_id))
+    {
+        *existing = record;
+    } else {
+        entries.push(record);
+    }
+    Ok(())
 }
 
 fn raw_registration_record(value: &Value) -> Option<AgentRegistrationRecord> {

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -1415,6 +1415,216 @@ async fn fixture_core_session_graph_endpoints_round_trip_state() {
 }
 
 #[tokio::test]
+async fn fixture_completion_endpoints_preserve_python_compatible_state() {
+    let state_file = write_completion_fixture();
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        rust_core: RustCoreConfig {
+            fixture_writes_enabled: true,
+            ..RustCoreConfig::default()
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/child001/task-complete",
+        json!({ "requester_session_id": "other001" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(payload["error"].as_str().unwrap().contains("self-directed"));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/child001/task-complete",
+        json!({ "requester_session_id": "child001" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "completed");
+    assert_eq!(payload["session_id"], "child001");
+    assert_eq!(payload["em_notified"], true);
+    assert!(payload["agent_task_completed_at"].is_string());
+
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let child = state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "child001")
+        .unwrap();
+    assert!(child["agent_task_completed_at"].is_string());
+    assert_eq!(
+        state["retained_remind_registrations"][0]["is_active"],
+        false
+    );
+    assert_eq!(
+        state["retained_parent_wake_registrations"][0]["is_active"],
+        false
+    );
+    assert_eq!(
+        state["retained_pending_messages"][0]["text"],
+        "[sm task-complete] agent child001(worker-1) completed its task."
+    );
+    assert_eq!(
+        state["retained_pending_messages"][0]["target_session_id"],
+        "em001"
+    );
+    assert_eq!(
+        state["retained_pending_messages"][0]["delivery_mode"],
+        "important"
+    );
+
+    let state_file = write_completion_fixture();
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        rust_core: RustCoreConfig {
+            fixture_writes_enabled: true,
+            ..RustCoreConfig::default()
+        },
+        ..AppConfig::default()
+    }));
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/child001/turn-complete",
+        json!({ "requester_session_id": "child001" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        payload,
+        json!({ "status": "turn_completed", "session_id": "child001" })
+    );
+
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let child = state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "child001")
+        .unwrap();
+    assert_eq!(child["agent_task_completed_at"], Value::Null);
+    assert_eq!(
+        state["retained_remind_registrations"][0]["is_active"],
+        false
+    );
+    assert_eq!(
+        state["retained_parent_wake_registrations"][0]["is_active"],
+        true
+    );
+}
+
+#[tokio::test]
+async fn fixture_notify_on_stop_preserves_authorization_and_state_contract() {
+    let state_file = write_completion_fixture();
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        rust_core: RustCoreConfig {
+            fixture_writes_enabled: true,
+            ..RustCoreConfig::default()
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/missing/notify-on-stop",
+        json!({ "sender_session_id": "em001", "requester_session_id": "em001" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(payload["detail"], "Session not found");
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/child001/notify-on-stop",
+        json!({ "sender_session_id": "child001", "requester_session_id": "child001" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(
+        payload["detail"],
+        "Only EM sessions (is_em=True) may arm stop notifications"
+    );
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/child001/notify-on-stop",
+        json!({ "sender_session_id": "em002", "requester_session_id": "em002" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(
+        payload["detail"],
+        "Cannot arm stop notify — not the parent of target session"
+    );
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/child001/notify-on-stop",
+        json!({ "sender_session_id": "missing", "requester_session_id": "em001" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(payload["detail"], "sender_session_id \"missing\" not found");
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/fork001/notify-on-stop",
+        json!({ "sender_session_id": "em001", "requester_session_id": "em001" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "suppressed");
+    assert_eq!(
+        payload["reason"],
+        "notify_on_stop disabled for codex-fork sessions"
+    );
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/child001/notify-on-stop",
+        json!({
+            "sender_session_id": "em001",
+            "requester_session_id": "em001",
+            "delay_seconds": 8
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        payload,
+        json!({ "status": "ok", "session_id": "child001", "sender_session_id": "em001" })
+    );
+
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    assert_eq!(
+        state["retained_stop_notify_states"][0]["session_id"],
+        "child001"
+    );
+    assert_eq!(
+        state["retained_stop_notify_states"][0]["sender_session_id"],
+        "em001"
+    );
+    assert_eq!(state["retained_stop_notify_states"][0]["sender_name"], "em");
+    assert_eq!(state["retained_stop_notify_states"][0]["delay_seconds"], 8);
+    assert_eq!(
+        state["retained_stop_notify_states"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
 async fn fixture_registry_and_maintainer_endpoints_round_trip_state() {
     let state_file = unique_temp_path();
     let log_dir = unique_temp_path();
@@ -1902,6 +2112,71 @@ async fn fixture_core_spawn_endpoint_inherits_parent_fields() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["parent_session_id"], "parentfixture");
     assert_eq!(payload["working_dir"], parent_dir.display().to_string());
+}
+
+#[tokio::test]
+async fn fixture_core_spawn_auto_arms_em_stop_notify_for_retained_children() {
+    let state_file = write_completion_fixture();
+    let log_dir = unique_temp_path();
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        rust_core: RustCoreConfig {
+            fixture_writes_enabled: true,
+            log_dir: Some(log_dir.display().to_string()),
+            ..RustCoreConfig::default()
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/spawn",
+        json!({
+            "id": "spawnchild",
+            "parent_session_id": "em001",
+            "prompt": "spawn child prompt",
+            "name": "spawn-child",
+            "provider": "claude"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["session_id"], "spawnchild");
+
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let stop_notify = state["retained_stop_notify_states"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["session_id"] == "spawnchild")
+        .unwrap();
+    assert_eq!(stop_notify["sender_session_id"], "em001");
+    assert_eq!(stop_notify["sender_name"], "em");
+    assert_eq!(stop_notify["delay_seconds"], 8);
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/spawn",
+        json!({
+            "id": "spawnfork",
+            "parent_session_id": "em001",
+            "prompt": "spawn codex fork prompt",
+            "name": "spawn-fork",
+            "provider": "codex-fork"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["session_id"], "spawnfork");
+
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    assert!(state["retained_stop_notify_states"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|entry| entry["session_id"] != "spawnfork"));
 }
 
 #[tokio::test]
@@ -3209,6 +3484,85 @@ fn write_session_fixture() -> PathBuf {
                     "stopped_at": "2026-06-01T00:02:00"
                 }
             ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    path
+}
+
+fn write_completion_fixture() -> PathBuf {
+    let path = unique_temp_path();
+    fs::write(
+        &path,
+        json!({
+            "sessions": [
+                {
+                    "id": "em001",
+                    "name": "claude-em001",
+                    "working_dir": "/repo",
+                    "tmux_session": "claude-em001",
+                    "log_file": "/tmp/em001.log",
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00Z",
+                    "last_activity": "2026-06-01T00:01:00Z",
+                    "friendly_name": "em",
+                    "is_em": true
+                },
+                {
+                    "id": "em002",
+                    "name": "claude-em002",
+                    "working_dir": "/repo",
+                    "tmux_session": "claude-em002",
+                    "log_file": "/tmp/em002.log",
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00Z",
+                    "last_activity": "2026-06-01T00:01:00Z",
+                    "friendly_name": "other-em",
+                    "is_em": true
+                },
+                {
+                    "id": "child001",
+                    "name": "claude-child001",
+                    "working_dir": "/repo",
+                    "tmux_session": "claude-child001",
+                    "log_file": "/tmp/child001.log",
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00Z",
+                    "last_activity": "2026-06-01T00:01:00Z",
+                    "friendly_name": "worker-1",
+                    "parent_session_id": "em001",
+                    "agent_task_completed_at": null
+                },
+                {
+                    "id": "fork001",
+                    "name": "codex-fork-fork001",
+                    "working_dir": "/repo",
+                    "tmux_session": "codex-fork-fork001",
+                    "log_file": "/tmp/fork001.log",
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00Z",
+                    "last_activity": "2026-06-01T00:01:00Z",
+                    "provider": "codex-fork",
+                    "parent_session_id": "em001"
+                }
+            ],
+            "retained_remind_registrations": [
+                {
+                    "session_id": "child001",
+                    "is_active": true
+                }
+            ],
+            "retained_parent_wake_registrations": [
+                {
+                    "child_session_id": "child001",
+                    "parent_session_id": "em001",
+                    "period_seconds": 600,
+                    "is_active": true
+                }
+            ],
+            "retained_pending_messages": [],
+            "retained_stop_notify_states": []
         })
         .to_string(),
     )

--- a/scripts/rust_migration/contracts_manifest.json
+++ b/scripts/rust_migration/contracts_manifest.json
@@ -995,6 +995,32 @@
       "source": "https://github.com/rajeshgoli/session-manager/issues/797"
     },
     {
+      "id": "cli.rust_core_task_complete_fixture",
+      "surface": "cli",
+      "classification": "retained",
+      "target": "rust_only",
+      "safety": "mutating",
+      "command": ["--api-url", "{base_url}", "task-complete"],
+      "env": {"SESSION_MANAGER_ID": "{child_session_id}"},
+      "expected_exit": [0],
+      "expected_output_contains_all": ["Task complete", "Remind cancelled"],
+      "preconditions": ["sm_cli", "fixture:base_url", "fixture:child_session_id", "mutating_opt_in"],
+      "source": "https://github.com/rajeshgoli/session-manager/issues/803"
+    },
+    {
+      "id": "cli.rust_core_turn_complete_fixture",
+      "surface": "cli",
+      "classification": "retained",
+      "target": "rust_only",
+      "safety": "mutating",
+      "command": ["--api-url", "{base_url}", "turn-complete"],
+      "env": {"SESSION_MANAGER_ID": "{child_session_id}"},
+      "expected_exit": [0],
+      "expected_output_contains_all": ["Turn complete", "Remind cancelled"],
+      "preconditions": ["sm_cli", "fixture:base_url", "fixture:child_session_id", "mutating_opt_in"],
+      "source": "https://github.com/rajeshgoli/session-manager/issues/803"
+    },
+    {
       "id": "cli.rust_core_status_fixture",
       "surface": "cli",
       "classification": "retained",
@@ -1174,6 +1200,59 @@
       ],
       "preconditions": ["live_server", "session_id"],
       "source": "specs/762_stage2_artifacts/route_manifest.md:GET /sessions/{session_id}/attach-descriptor"
+    },
+    {
+      "id": "http.rust_core_task_complete_fixture",
+      "surface": "http",
+      "classification": "retained",
+      "target": "rust_only",
+      "safety": "mutating",
+      "method": "POST",
+      "path": "/sessions/{child_session_id}/task-complete",
+      "body": {"requester_session_id": "{child_session_id}"},
+      "expected_status": [200],
+      "expected_json": [
+        {"path": "/status", "equals": "completed"},
+        {"path": "/session_id", "equals": "{child_session_id}"},
+        {"path": "/agent_task_completed_at", "type": "string"}
+      ],
+      "preconditions": ["live_server", "fixture:child_session_id", "mutating_opt_in"],
+      "source": "https://github.com/rajeshgoli/session-manager/issues/803"
+    },
+    {
+      "id": "http.rust_core_turn_complete_fixture",
+      "surface": "http",
+      "classification": "retained",
+      "target": "rust_only",
+      "safety": "mutating",
+      "method": "POST",
+      "path": "/sessions/{child_session_id}/turn-complete",
+      "body": {"requester_session_id": "{child_session_id}"},
+      "expected_status": [200],
+      "expected_json": [
+        {"path": "/status", "equals": "turn_completed"},
+        {"path": "/session_id", "equals": "{child_session_id}"}
+      ],
+      "preconditions": ["live_server", "fixture:child_session_id", "mutating_opt_in"],
+      "source": "https://github.com/rajeshgoli/session-manager/issues/803"
+    },
+    {
+      "id": "http.rust_core_notify_on_stop_fixture",
+      "surface": "http",
+      "classification": "retained",
+      "target": "rust_only",
+      "safety": "mutating",
+      "method": "POST",
+      "path": "/sessions/{child_session_id}/notify-on-stop",
+      "body": {"sender_session_id": "{em_session_id}", "requester_session_id": "{em_session_id}", "delay_seconds": 0},
+      "expected_status": [200],
+      "expected_json": [
+        {"path": "/status", "equals": "ok"},
+        {"path": "/session_id", "equals": "{child_session_id}"},
+        {"path": "/sender_session_id", "equals": "{em_session_id}"}
+      ],
+      "preconditions": ["live_server", "fixture:em_session_id", "fixture:child_session_id", "mutating_opt_in"],
+      "source": "https://github.com/rajeshgoli/session-manager/issues/803"
     },
     {
       "id": "cli.rust_core_restore_fixture",


### PR DESCRIPTION
## Summary

Fixes #803.

Part of #762. Adds the retained Rust core completion/stop-notify slice:

- Implements `POST /sessions/{session_id}/task-complete` with Python-compatible self-directed 200-with-error behavior, `agent_task_completed_at`, retained remind/parent-wake cancellation, and EM completion notification recording.
- Implements `POST /sessions/{session_id}/turn-complete` with remind-only cancellation and no task-complete metadata.
- Implements `POST /sessions/{session_id}/notify-on-stop` with EM-parent authorization, unknown target/sender errors, codex-fork suppression, and retained stop-notify state.
- Auto-arms retained stop-notify state from Rust `spawn` when the parent is an EM and the child is not `codex-fork`.
- Adds Rust CLI commands `sm task-complete` and `sm turn-complete`.
- Adds endpoint/CLI contract manifest entries for the new retained surfaces.

## Verification

- `cargo fmt --manifest-path crates/sm-server/Cargo.toml --check`
- `cargo test --manifest-path crates/sm-server/Cargo.toml`
- `python3 -m json.tool scripts/rust_migration/contracts_manifest.json >/dev/null`
- `git diff --check`
- Disposable Rust server contract run:
  - `cli.rust_core_task_complete_fixture`
  - `cli.rust_core_turn_complete_fixture`
  - `http.rust_core_notify_on_stop_fixture`
