### PR TITLE
Add Rust message queue persistence foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +133,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -255,6 +273,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,9 +367,27 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -443,7 +491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -463,6 +511,17 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "log"
@@ -530,6 +589,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,6 +630,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -741,6 +820,7 @@ dependencies = [
  "clap",
  "futures-util",
  "hmac",
+ "rusqlite",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -967,6 +1047,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,6 +1160,26 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zeroize"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ futures-util = "0.3"
 serde = "1.0"
 serde_json = "1.0"
 serde_yaml = "0.9"
+rusqlite = { version = "0.32", features = ["bundled"] }
 sha1 = "0.10"
 sha2 = "0.10"
 time = "0.3"

--- a/crates/sm-server/Cargo.toml
+++ b/crates/sm-server/Cargo.toml
@@ -12,6 +12,7 @@ base64 = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 futures-util = { workspace = true }
 hmac = { workspace = true }
+rusqlite = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -11,6 +11,7 @@ pub struct AppConfig {
     pub external_access: ExternalAccessConfig,
     pub mobile_terminal: MobileTerminalConfig,
     pub tmux: TmuxConfig,
+    pub sm_send: SmSendConfig,
     pub rust_shadow: RustShadowConfig,
     pub rust_core: RustCoreConfig,
 }
@@ -138,6 +139,24 @@ pub struct TmuxConfig {
     pub socket_name: Option<String>,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct SmSendConfig {
+    #[serde(default = "default_message_queue_db_path")]
+    pub db_path: String,
+}
+
+impl Default for SmSendConfig {
+    fn default() -> Self {
+        Self {
+            db_path: default_message_queue_db_path(),
+        }
+    }
+}
+
+fn default_message_queue_db_path() -> String {
+    "~/.local/share/claude-sessions/message_queue.db".to_owned()
+}
+
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct RustShadowConfig {
     #[serde(default)]
@@ -185,6 +204,8 @@ struct RawConfig {
     #[serde(default)]
     tmux: TmuxConfig,
     #[serde(default)]
+    sm_send: SmSendConfig,
+    #[serde(default)]
     timeouts: RawTimeoutsConfig,
     #[serde(default)]
     rust_shadow: RustShadowConfig,
@@ -224,6 +245,7 @@ impl From<RawConfig> for AppConfig {
             external_access: raw.external_access,
             mobile_terminal: raw.mobile_terminal,
             tmux: raw.tmux,
+            sm_send: raw.sm_send,
             rust_shadow: raw.rust_shadow,
             rust_core,
         }
@@ -468,5 +490,19 @@ mod tests {
             trimmed(&config.external_access.ssh_proxy_command).as_deref(),
             Some("cloudflared access ssh --hostname %h")
         );
+    }
+
+    #[test]
+    fn raw_config_reads_python_sm_send_db_path() {
+        let raw: RawConfig = serde_yaml::from_str(
+            r#"
+sm_send:
+  db_path: /tmp/custom-message-queue.db
+"#,
+        )
+        .unwrap();
+        let config = AppConfig::from(raw);
+
+        assert_eq!(config.sm_send.db_path, "/tmp/custom-message-queue.db");
     }
 }

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -58,26 +58,13 @@ pub struct AppState {
 impl AppState {
     pub fn new(config: AppConfig) -> Self {
         let state_file = expand_home(&config.paths.state_file);
-        let queue_db_path = queue_db_path_for_config(&config, &state_file);
+        let queue_db_path = expand_home(&config.sm_send.db_path);
         let session_store = SessionStore::new_with_queue(state_file, queue_db_path);
         Self {
             config,
             session_store,
         }
     }
-}
-
-fn queue_db_path_for_config(
-    config: &AppConfig,
-    state_file: &std::path::Path,
-) -> std::path::PathBuf {
-    let configured = expand_home(&config.sm_send.db_path);
-    let default_queue = expand_home("~/.local/share/claude-sessions/message_queue.db");
-    let default_state = expand_home("~/.local/share/claude-sessions/sessions.json");
-    if configured == default_queue && state_file != default_state {
-        return state_file.with_extension("message_queue.db");
-    }
-    configured
 }
 
 pub fn router(state: AppState) -> Router {

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -57,12 +57,27 @@ pub struct AppState {
 
 impl AppState {
     pub fn new(config: AppConfig) -> Self {
-        let session_store = SessionStore::new(expand_home(&config.paths.state_file));
+        let state_file = expand_home(&config.paths.state_file);
+        let queue_db_path = queue_db_path_for_config(&config, &state_file);
+        let session_store = SessionStore::new_with_queue(state_file, queue_db_path);
         Self {
             config,
             session_store,
         }
     }
+}
+
+fn queue_db_path_for_config(
+    config: &AppConfig,
+    state_file: &std::path::Path,
+) -> std::path::PathBuf {
+    let configured = expand_home(&config.sm_send.db_path);
+    let default_queue = expand_home("~/.local/share/claude-sessions/message_queue.db");
+    let default_state = expand_home("~/.local/share/claude-sessions/sessions.json");
+    if configured == default_queue && state_file != default_state {
+        return state_file.with_extension("message_queue.db");
+    }
+    configured
 }
 
 pub fn router(state: AppState) -> Router {

--- a/crates/sm-server/src/lib.rs
+++ b/crates/sm-server/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod config;
 pub mod http;
+pub mod queue;
 pub mod runtime;
 pub mod sessions;

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -1,0 +1,399 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection, OptionalExtension};
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+#[derive(Debug, Clone)]
+pub struct RetainedQueueStore {
+    db_path: PathBuf,
+}
+
+impl RetainedQueueStore {
+    pub fn new(db_path: PathBuf) -> Self {
+        Self { db_path }
+    }
+
+    pub fn db_path(&self) -> &Path {
+        &self.db_path
+    }
+
+    pub fn ensure_schema(&self) -> Result<()> {
+        self.with_connection(|_| Ok(()))
+    }
+
+    pub fn enqueue_message(
+        &self,
+        target_session_id: &str,
+        text: &str,
+        delivery_mode: &str,
+        message_category: Option<&str>,
+    ) -> Result<String> {
+        self.with_connection(|conn| {
+            let id = generate_record_id("msg");
+            conn.execute(
+                r#"
+                INSERT INTO message_queue
+                    (id, target_session_id, text, delivery_mode, from_sm_send, queued_at, message_category)
+                VALUES
+                    (?1, ?2, ?3, ?4, 0, ?5, ?6)
+                "#,
+                params![
+                    id,
+                    target_session_id,
+                    text,
+                    delivery_mode,
+                    now_rfc3339(),
+                    message_category
+                ],
+            )?;
+            Ok(id)
+        })
+    }
+
+    pub fn active_parent_wake_parent(&self, child_session_id: &str) -> Result<Option<String>> {
+        self.with_connection(|conn| {
+            conn.query_row(
+                r#"
+                SELECT parent_session_id
+                FROM parent_wake_registrations
+                WHERE child_session_id = ?1 AND is_active = 1
+                LIMIT 1
+                "#,
+                params![child_session_id],
+                |row| row.get(0),
+            )
+            .optional()
+            .map_err(Into::into)
+        })
+    }
+
+    pub fn register_parent_wake(
+        &self,
+        child_session_id: &str,
+        parent_session_id: &str,
+        period_seconds: i64,
+    ) -> Result<String> {
+        self.with_connection(|conn| {
+            self.cancel_parent_wake_with_connection(conn, child_session_id)?;
+            let id = generate_record_id("wake");
+            conn.execute(
+                r#"
+                INSERT OR REPLACE INTO parent_wake_registrations
+                    (id, child_session_id, parent_session_id, period_seconds, registered_at,
+                     last_wake_at, last_status_at_prev_wake, escalated, is_active)
+                VALUES
+                    (?1, ?2, ?3, ?4, ?5, NULL, NULL, 0, 1)
+                "#,
+                params![
+                    id,
+                    child_session_id,
+                    parent_session_id,
+                    period_seconds,
+                    now_rfc3339()
+                ],
+            )?;
+            Ok(id)
+        })
+    }
+
+    pub fn cancel_parent_wake(&self, child_session_id: &str) -> Result<()> {
+        self.with_connection(|conn| self.cancel_parent_wake_with_connection(conn, child_session_id))
+    }
+
+    pub fn cancel_remind(&self, target_session_id: &str) -> Result<()> {
+        self.with_connection(|conn| {
+            conn.execute(
+                r#"
+                UPDATE remind_registrations
+                SET is_active = 0
+                WHERE target_session_id = ?1
+                "#,
+                params![target_session_id],
+            )?;
+            Ok(())
+        })
+    }
+
+    pub fn upsert_stop_notify(
+        &self,
+        session_id: &str,
+        sender_session_id: &str,
+        sender_name: &str,
+        delay_seconds: i64,
+    ) -> Result<()> {
+        self.with_connection(|conn| {
+            conn.execute(
+                r#"
+                INSERT INTO rust_stop_notify_states
+                    (session_id, sender_session_id, sender_name, delay_seconds, armed_at)
+                VALUES
+                    (?1, ?2, ?3, ?4, ?5)
+                ON CONFLICT(session_id) DO UPDATE SET
+                    sender_session_id = excluded.sender_session_id,
+                    sender_name = excluded.sender_name,
+                    delay_seconds = excluded.delay_seconds,
+                    armed_at = excluded.armed_at
+                "#,
+                params![
+                    session_id,
+                    sender_session_id,
+                    sender_name,
+                    delay_seconds,
+                    now_rfc3339()
+                ],
+            )?;
+            Ok(())
+        })
+    }
+
+    fn with_connection<T>(&self, f: impl FnOnce(&Connection) -> Result<T>) -> Result<T> {
+        if let Some(parent) = self.db_path.parent() {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!("failed to create queue db directory {}", parent.display())
+            })?;
+        }
+        let conn = Connection::open(&self.db_path)
+            .with_context(|| format!("failed to open queue db {}", self.db_path.display()))?;
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        conn.pragma_update(None, "busy_timeout", 5000)?;
+        init_schema(&conn)?;
+        f(&conn)
+    }
+
+    fn cancel_parent_wake_with_connection(
+        &self,
+        conn: &Connection,
+        child_session_id: &str,
+    ) -> Result<()> {
+        conn.execute(
+            r#"
+            UPDATE parent_wake_registrations
+            SET is_active = 0
+            WHERE child_session_id = ?1
+                "#,
+            params![child_session_id],
+        )?;
+        Ok(())
+    }
+}
+
+fn init_schema(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        r#"
+        CREATE TABLE IF NOT EXISTS message_queue (
+            id TEXT PRIMARY KEY,
+            target_session_id TEXT NOT NULL,
+            sender_session_id TEXT,
+            sender_name TEXT,
+            text TEXT NOT NULL,
+            delivery_mode TEXT DEFAULT 'sequential',
+            from_sm_send INTEGER DEFAULT 0,
+            queued_at TIMESTAMP NOT NULL,
+            timeout_at TIMESTAMP,
+            notify_on_delivery INTEGER DEFAULT 0,
+            notify_after_seconds INTEGER,
+            notify_on_stop INTEGER DEFAULT 0,
+            delivered_at TIMESTAMP,
+            remind_soft_threshold INTEGER,
+            remind_hard_threshold INTEGER,
+            remind_cancel_on_reply_session_id TEXT,
+            parent_session_id TEXT,
+            message_category TEXT DEFAULT NULL,
+            response_relay_source TEXT DEFAULT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_pending
+            ON message_queue(target_session_id, delivered_at)
+            WHERE delivered_at IS NULL;
+        CREATE TABLE IF NOT EXISTS remind_registrations (
+            id TEXT PRIMARY KEY,
+            target_session_id TEXT NOT NULL UNIQUE,
+            soft_threshold_seconds INTEGER NOT NULL,
+            hard_threshold_seconds INTEGER NOT NULL,
+            registered_at TIMESTAMP NOT NULL,
+            last_reset_at TIMESTAMP NOT NULL,
+            cancel_on_reply_session_id TEXT,
+            soft_fired INTEGER DEFAULT 0,
+            is_active INTEGER DEFAULT 1,
+            tracked_status_nudge_fired INTEGER DEFAULT 0,
+            persistent_tracking INTEGER DEFAULT 0
+        );
+        CREATE TABLE IF NOT EXISTS parent_wake_registrations (
+            id TEXT PRIMARY KEY,
+            child_session_id TEXT NOT NULL UNIQUE,
+            parent_session_id TEXT NOT NULL,
+            period_seconds INTEGER NOT NULL,
+            registered_at TIMESTAMP NOT NULL,
+            last_wake_at TIMESTAMP,
+            last_status_at_prev_wake TIMESTAMP,
+            escalated INTEGER DEFAULT 0,
+            is_active INTEGER DEFAULT 1
+        );
+        CREATE TABLE IF NOT EXISTS rust_stop_notify_states (
+            session_id TEXT PRIMARY KEY,
+            sender_session_id TEXT NOT NULL,
+            sender_name TEXT,
+            delay_seconds INTEGER NOT NULL DEFAULT 0,
+            armed_at TIMESTAMP NOT NULL
+        );
+                "#,
+    )?;
+    ensure_column(conn, "message_queue", "notify_on_stop", "INTEGER DEFAULT 0")?;
+    ensure_column(conn, "message_queue", "from_sm_send", "INTEGER DEFAULT 0")?;
+    ensure_column(conn, "message_queue", "remind_soft_threshold", "INTEGER")?;
+    ensure_column(conn, "message_queue", "remind_hard_threshold", "INTEGER")?;
+    ensure_column(
+        conn,
+        "message_queue",
+        "remind_cancel_on_reply_session_id",
+        "TEXT",
+    )?;
+    ensure_column(conn, "message_queue", "parent_session_id", "TEXT")?;
+    ensure_column(
+        conn,
+        "message_queue",
+        "message_category",
+        "TEXT DEFAULT NULL",
+    )?;
+    ensure_column(
+        conn,
+        "message_queue",
+        "response_relay_source",
+        "TEXT DEFAULT NULL",
+    )?;
+    ensure_column(
+        conn,
+        "remind_registrations",
+        "cancel_on_reply_session_id",
+        "TEXT",
+    )?;
+    ensure_column(
+        conn,
+        "remind_registrations",
+        "tracked_status_nudge_fired",
+        "INTEGER DEFAULT 0",
+    )?;
+    ensure_column(
+        conn,
+        "remind_registrations",
+        "persistent_tracking",
+        "INTEGER DEFAULT 0",
+    )?;
+    Ok(())
+}
+
+fn ensure_column(conn: &Connection, table: &str, column: &str, column_type: &str) -> Result<()> {
+    let mut statement = conn.prepare(&format!("PRAGMA table_info({table})"))?;
+    let columns = statement
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    if !columns.iter().any(|name| name == column) {
+        conn.execute(
+            &format!("ALTER TABLE {table} ADD COLUMN {column} {column_type}"),
+            [],
+        )?;
+    }
+    Ok(())
+}
+
+fn generate_record_id(prefix: &str) -> String {
+    let nanos = OffsetDateTime::now_utc().unix_timestamp_nanos();
+    format!("{prefix}{:x}{:x}", std::process::id(), nanos as u128)
+}
+
+fn now_rfc3339() -> String {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusqlite::params;
+    use std::{
+        env,
+        sync::atomic::{AtomicU64, Ordering},
+    };
+
+    static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    #[test]
+    fn queue_store_creates_schema_and_writes_retained_rows() {
+        let db_path = unique_temp_path("queue");
+        let store = RetainedQueueStore::new(db_path.clone());
+
+        store.ensure_schema().unwrap();
+        let message_id = store
+            .enqueue_message(
+                "child001",
+                "[sm task-complete] agent child001(worker) completed its task.",
+                "important",
+                Some("task_complete"),
+            )
+            .unwrap();
+        let wake_id = store
+            .register_parent_wake("child001", "em001", 600)
+            .unwrap();
+        assert!(message_id.starts_with("msg"));
+        assert!(wake_id.starts_with("wake"));
+        assert_eq!(
+            store
+                .active_parent_wake_parent("child001")
+                .unwrap()
+                .as_deref(),
+            Some("em001")
+        );
+        store
+            .upsert_stop_notify("child001", "em001", "em", 8)
+            .unwrap();
+        store
+            .upsert_stop_notify("child001", "em002", "other-em", 0)
+            .unwrap();
+        store.cancel_parent_wake("child001").unwrap();
+        store.cancel_remind("child001").unwrap();
+
+        let conn = Connection::open(&db_path).unwrap();
+        let row: (String, String, String) = conn
+            .query_row(
+                "SELECT target_session_id, delivery_mode, message_category FROM message_queue WHERE id = ?1",
+                params![message_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            row,
+            (
+                "child001".to_owned(),
+                "important".to_owned(),
+                "task_complete".to_owned()
+            )
+        );
+        let active: i64 = conn
+            .query_row(
+                "SELECT is_active FROM parent_wake_registrations WHERE child_session_id = 'child001'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(active, 0);
+        let stop_notify: (String, String, i64) = conn
+            .query_row(
+                "SELECT sender_session_id, sender_name, delay_seconds FROM rust_stop_notify_states WHERE session_id = 'child001'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(stop_notify, ("em002".to_owned(), "other-em".to_owned(), 0));
+    }
+
+    fn unique_temp_path(label: &str) -> PathBuf {
+        let mut path = env::temp_dir();
+        path.push(format!(
+            "sm-rust-queue-{label}-{}-{}",
+            std::process::id(),
+            TEST_COUNTER.fetch_add(1, Ordering::Relaxed)
+        ));
+        path
+    }
+}

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -13,6 +13,7 @@ use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
+use crate::queue::RetainedQueueStore;
 use crate::runtime::{TmuxRuntime, TmuxSessionSpec};
 
 const DEFAULT_SESSION_STATE_FILE: &str = "~/.local/share/claude-sessions/sessions.json";
@@ -27,6 +28,7 @@ pub struct SessionStore {
     state_file: PathBuf,
     legacy_state_file: Option<PathBuf>,
     write_lock: Arc<Mutex<()>>,
+    queue_store: Option<RetainedQueueStore>,
 }
 
 impl SessionStore {
@@ -40,7 +42,14 @@ impl SessionStore {
             state_file,
             legacy_state_file,
             write_lock: Arc::new(Mutex::new(())),
+            queue_store: None,
         }
+    }
+
+    pub fn new_with_queue(state_file: PathBuf, queue_db_path: PathBuf) -> Self {
+        let mut store = Self::new(state_file);
+        store.queue_store = Some(RetainedQueueStore::new(queue_db_path));
+        store
     }
 
     #[cfg(test)]
@@ -49,6 +58,7 @@ impl SessionStore {
             state_file,
             legacy_state_file: Some(legacy_state_file),
             write_lock: Arc::new(Mutex::new(())),
+            queue_store: None,
         }
     }
 
@@ -934,8 +944,17 @@ impl SessionStore {
             )));
         };
 
-        let em_session_id = active_parent_wake_parent_raw(&state, session_id)?
+        let queue_parent = match &self.queue_store {
+            Some(queue) => queue.active_parent_wake_parent(session_id)?,
+            None => None,
+        };
+        let em_session_id = queue_parent
+            .or(active_parent_wake_parent_raw(&state, session_id)?)
             .or_else(|| session.parent_session_id.clone());
+        if let Some(queue) = &self.queue_store {
+            queue.cancel_remind(session_id)?;
+            queue.cancel_parent_wake(session_id)?;
+        }
         deactivate_remind_raw(&mut state, session_id)?;
         deactivate_parent_wake_raw(&mut state, session_id)?;
 
@@ -953,10 +972,15 @@ impl SessionStore {
             let friendly = session
                 .cached_display_name()
                 .unwrap_or_else(|| non_empty_or(session.name.clone(), &session.id));
+            let text =
+                format!("[sm task-complete] agent {session_id}({friendly}) completed its task.");
+            if let Some(queue) = &self.queue_store {
+                queue.enqueue_message(&em_session_id, &text, "important", Some("task_complete"))?;
+            }
             push_retained_message_raw(
                 &mut state,
                 &em_session_id,
-                &format!("[sm task-complete] agent {session_id}({friendly}) completed its task."),
+                &text,
                 "important",
                 Some("task_complete"),
             )?;
@@ -993,6 +1017,9 @@ impl SessionStore {
             )));
         }
 
+        if let Some(queue) = &self.queue_store {
+            queue.cancel_remind(session_id)?;
+        }
         deactivate_remind_raw(&mut state, session_id)?;
         self.write_raw_json_value(&state)?;
         Ok(TurnCompleteOutcome::Completed(TurnCompleteResult {
@@ -1049,6 +1076,14 @@ impl SessionStore {
         let sender_name = sender
             .cached_display_name()
             .unwrap_or_else(|| non_empty_or(sender.name.clone(), &sender.id));
+        if let Some(queue) = &self.queue_store {
+            queue.upsert_stop_notify(
+                session_id,
+                &request.sender_session_id,
+                &sender_name,
+                request.delay_seconds.max(0),
+            )?;
+        }
         upsert_stop_notify_raw(
             &mut state,
             session_id,

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -15,7 +15,10 @@ use sha1::{Digest, Sha1};
 use sha2::Sha256;
 use sm_server::config::RustShadowConfig;
 use sm_server::{
-    config::{AppConfig, ExternalAccessConfig, GoogleAuthConfig, PathsConfig, RustCoreConfig},
+    config::{
+        AppConfig, ExternalAccessConfig, GoogleAuthConfig, PathsConfig, RustCoreConfig,
+        SmSendConfig,
+    },
     http::{router, AppState},
 };
 use std::{
@@ -874,8 +877,8 @@ async fn session_output_tails_fixture_log_file() {
 #[tokio::test]
 async fn fixture_core_writes_are_disabled_by_default() {
     let state_file = write_session_fixture();
-    let queue_db_path = state_file.with_extension("message_queue.db");
-    let app = router(AppState::new(config_with_state_file(&state_file)));
+    let queue_db_path = queue_db_path_for_state_file(&state_file);
+    let app = router(AppState::new(config_with_state_file_and_queue(&state_file)));
 
     let (status, payload) = post_json(
         app,
@@ -1424,16 +1427,10 @@ async fn fixture_core_session_graph_endpoints_round_trip_state() {
 #[tokio::test]
 async fn fixture_completion_endpoints_preserve_python_compatible_state() {
     let state_file = write_completion_fixture();
-    let app = router(AppState::new(AppConfig {
-        paths: PathsConfig {
-            state_file: state_file.display().to_string(),
-        },
-        rust_core: RustCoreConfig {
-            fixture_writes_enabled: true,
-            ..RustCoreConfig::default()
-        },
-        ..AppConfig::default()
-    }));
+    let queue_db_path = queue_db_path_for_state_file(&state_file);
+    let mut config = config_with_state_file_and_queue(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
 
     let (status, payload) = post_json(
         app.clone(),
@@ -1484,7 +1481,7 @@ async fn fixture_completion_endpoints_preserve_python_compatible_state() {
         state["retained_pending_messages"][0]["delivery_mode"],
         "important"
     );
-    let queue_conn = Connection::open(state_file.with_extension("message_queue.db")).unwrap();
+    let queue_conn = Connection::open(&queue_db_path).unwrap();
     let queued_message: (String, String, String) = queue_conn
         .query_row(
             "SELECT target_session_id, text, delivery_mode FROM message_queue WHERE message_category = 'task_complete'",
@@ -1502,16 +1499,9 @@ async fn fixture_completion_endpoints_preserve_python_compatible_state() {
     );
 
     let state_file = write_completion_fixture();
-    let app = router(AppState::new(AppConfig {
-        paths: PathsConfig {
-            state_file: state_file.display().to_string(),
-        },
-        rust_core: RustCoreConfig {
-            fixture_writes_enabled: true,
-            ..RustCoreConfig::default()
-        },
-        ..AppConfig::default()
-    }));
+    let mut config = config_with_state_file_and_queue(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
     let (status, payload) = post_json(
         app.clone(),
         "/sessions/child001/turn-complete",
@@ -1545,16 +1535,10 @@ async fn fixture_completion_endpoints_preserve_python_compatible_state() {
 #[tokio::test]
 async fn fixture_notify_on_stop_preserves_authorization_and_state_contract() {
     let state_file = write_completion_fixture();
-    let app = router(AppState::new(AppConfig {
-        paths: PathsConfig {
-            state_file: state_file.display().to_string(),
-        },
-        rust_core: RustCoreConfig {
-            fixture_writes_enabled: true,
-            ..RustCoreConfig::default()
-        },
-        ..AppConfig::default()
-    }));
+    let queue_db_path = queue_db_path_for_state_file(&state_file);
+    let mut config = config_with_state_file_and_queue(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
 
     let (status, payload) = post_json(
         app.clone(),
@@ -1645,7 +1629,7 @@ async fn fixture_notify_on_stop_preserves_authorization_and_state_contract() {
             .len(),
         1
     );
-    let queue_conn = Connection::open(state_file.with_extension("message_queue.db")).unwrap();
+    let queue_conn = Connection::open(&queue_db_path).unwrap();
     let stop_notify: (String, String, i64) = queue_conn
         .query_row(
             "SELECT sender_session_id, sender_name, delay_seconds FROM rust_stop_notify_states WHERE session_id = 'child001'",
@@ -2150,17 +2134,11 @@ async fn fixture_core_spawn_endpoint_inherits_parent_fields() {
 async fn fixture_core_spawn_auto_arms_em_stop_notify_for_retained_children() {
     let state_file = write_completion_fixture();
     let log_dir = unique_temp_path();
-    let app = router(AppState::new(AppConfig {
-        paths: PathsConfig {
-            state_file: state_file.display().to_string(),
-        },
-        rust_core: RustCoreConfig {
-            fixture_writes_enabled: true,
-            log_dir: Some(log_dir.display().to_string()),
-            ..RustCoreConfig::default()
-        },
-        ..AppConfig::default()
-    }));
+    let queue_db_path = queue_db_path_for_state_file(&state_file);
+    let mut config = config_with_state_file_and_queue(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    config.rust_core.log_dir = Some(log_dir.display().to_string());
+    let app = router(AppState::new(config));
 
     let (status, payload) = post_json(
         app.clone(),
@@ -2187,7 +2165,7 @@ async fn fixture_core_spawn_auto_arms_em_stop_notify_for_retained_children() {
     assert_eq!(stop_notify["sender_session_id"], "em001");
     assert_eq!(stop_notify["sender_name"], "em");
     assert_eq!(stop_notify["delay_seconds"], 8);
-    let queue_conn = Connection::open(state_file.with_extension("message_queue.db")).unwrap();
+    let queue_conn = Connection::open(&queue_db_path).unwrap();
     let db_stop_notify: (String, String, i64) = queue_conn
         .query_row(
             "SELECT sender_session_id, sender_name, delay_seconds FROM rust_stop_notify_states WHERE session_id = 'spawnchild'",
@@ -3449,6 +3427,24 @@ fn config_with_state_file(state_file: &PathBuf) -> AppConfig {
         },
         ..AppConfig::default()
     }
+}
+
+fn config_with_state_file_and_queue(state_file: &PathBuf) -> AppConfig {
+    AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        sm_send: SmSendConfig {
+            db_path: queue_db_path_for_state_file(state_file)
+                .display()
+                .to_string(),
+        },
+        ..AppConfig::default()
+    }
+}
+
+fn queue_db_path_for_state_file(state_file: &PathBuf) -> PathBuf {
+    state_file.with_extension("message_queue.db")
 }
 
 fn config_with_state_file_and_auth(state_file: &PathBuf) -> AppConfig {

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -9,6 +9,7 @@ use base64::{
 };
 use futures_util::{future::join, StreamExt as _};
 use hmac::{Hmac, Mac};
+use rusqlite::Connection;
 use serde_json::{json, Value};
 use sha1::{Digest, Sha1};
 use sha2::Sha256;
@@ -872,7 +873,9 @@ async fn session_output_tails_fixture_log_file() {
 
 #[tokio::test]
 async fn fixture_core_writes_are_disabled_by_default() {
-    let app = router(AppState::new(AppConfig::default()));
+    let state_file = write_session_fixture();
+    let queue_db_path = state_file.with_extension("message_queue.db");
+    let app = router(AppState::new(config_with_state_file(&state_file)));
 
     let (status, payload) = post_json(
         app,
@@ -890,6 +893,10 @@ async fn fixture_core_writes_are_disabled_by_default() {
     assert_eq!(
         payload,
         json!({ "detail": "Rust core writes are disabled" })
+    );
+    assert!(
+        !queue_db_path.exists(),
+        "disabled Rust core writes must not create the retained queue DB"
     );
 }
 
@@ -1477,6 +1484,22 @@ async fn fixture_completion_endpoints_preserve_python_compatible_state() {
         state["retained_pending_messages"][0]["delivery_mode"],
         "important"
     );
+    let queue_conn = Connection::open(state_file.with_extension("message_queue.db")).unwrap();
+    let queued_message: (String, String, String) = queue_conn
+        .query_row(
+            "SELECT target_session_id, text, delivery_mode FROM message_queue WHERE message_category = 'task_complete'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        queued_message,
+        (
+            "em001".to_owned(),
+            "[sm task-complete] agent child001(worker-1) completed its task.".to_owned(),
+            "important".to_owned()
+        )
+    );
 
     let state_file = write_completion_fixture();
     let app = router(AppState::new(AppConfig {
@@ -1622,6 +1645,15 @@ async fn fixture_notify_on_stop_preserves_authorization_and_state_contract() {
             .len(),
         1
     );
+    let queue_conn = Connection::open(state_file.with_extension("message_queue.db")).unwrap();
+    let stop_notify: (String, String, i64) = queue_conn
+        .query_row(
+            "SELECT sender_session_id, sender_name, delay_seconds FROM rust_stop_notify_states WHERE session_id = 'child001'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(stop_notify, ("em001".to_owned(), "em".to_owned(), 8));
 }
 
 #[tokio::test]
@@ -2155,6 +2187,15 @@ async fn fixture_core_spawn_auto_arms_em_stop_notify_for_retained_children() {
     assert_eq!(stop_notify["sender_session_id"], "em001");
     assert_eq!(stop_notify["sender_name"], "em");
     assert_eq!(stop_notify["delay_seconds"], 8);
+    let queue_conn = Connection::open(state_file.with_extension("message_queue.db")).unwrap();
+    let db_stop_notify: (String, String, i64) = queue_conn
+        .query_row(
+            "SELECT sender_session_id, sender_name, delay_seconds FROM rust_stop_notify_states WHERE session_id = 'spawnchild'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(db_stop_notify, ("em001".to_owned(), "em".to_owned(), 8));
 
     let (status, payload) = post_json(
         app.clone(),


### PR DESCRIPTION
Fixes #805

## Summary
- add Rust `sm_send.db_path` config support with the Python-compatible message queue DB default
- add a SQLite-backed retained queue module for `message_queue`, `remind_registrations`, `parent_wake_registrations`, and Rust stop-notify state
- mirror Rust task-complete, turn-complete, notify-on-stop, and EM spawn auto-arm side effects into SQLite while preserving transition JSON fixture mirrors
- verify disabled Rust writes do not create the retained queue DB

## Verification
- `cargo fmt --manifest-path crates/sm-server/Cargo.toml --check`
- `cargo test --manifest-path crates/sm-server/Cargo.toml`
- `cargo check --manifest-path crates/sm-server/Cargo.toml --bin sm-server --bin sm`
- `git diff --check`