### PR TITLE
Deliver Rust queued messages through retained queue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -565,6 +565,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,7 +894,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",

--- a/crates/sm-server/Cargo.toml
+++ b/crates/sm-server/Cargo.toml
@@ -18,7 +18,7 @@ serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 sha1 = { workspace = true }
 sha2 = { workspace = true }
-time = { workspace = true, features = ["formatting"] }
+time = { workspace = true, features = ["formatting", "local-offset", "macros", "parsing"] }
 tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "signal"] }
 ureq = { workspace = true }
 

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -614,6 +614,15 @@ async fn send_session_input(
     }
     let result = if state.config.rust_core.runtime_enabled {
         ensure_core_runtime_session_node_supported(&state, &session_id)?;
+        if runtime_send_side_effects_requested(&payload) {
+            if state.session_store.get_session(&session_id)?.is_none() {
+                return Err(ApiError::NotFound("Session not found"));
+            }
+            return Err(ApiError::Status {
+                status: StatusCode::NOT_IMPLEMENTED,
+                detail: "Rust runtime send delivery side effects are not implemented".to_owned(),
+            });
+        }
         let runtime = TmuxRuntime::from_config(&state.config.rust_core);
         state
             .session_store
@@ -625,6 +634,22 @@ async fn send_session_input(
         return Err(ApiError::NotFound("Session not found"));
     };
     Ok(Json(serde_json::to_value(result)?))
+}
+
+fn runtime_send_side_effects_requested(payload: &SendCoreInputRequest) -> bool {
+    payload.notify_on_delivery
+        || payload.notify_after_seconds.is_some()
+        || payload.notify_on_stop
+        || payload.remind_soft_threshold.is_some()
+        || payload.remind_hard_threshold.is_some()
+        || payload
+            .remind_cancel_on_reply_session_id
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty())
+        || payload
+            .parent_session_id
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty())
 }
 
 async fn set_agent_status(

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -614,10 +614,11 @@ async fn send_session_input(
     }
     let result = if state.config.rust_core.runtime_enabled {
         ensure_core_runtime_session_node_supported(&state, &session_id)?;
-        if runtime_send_side_effects_requested(&payload) {
-            if state.session_store.get_session(&session_id)?.is_none() {
-                return Err(ApiError::NotFound("Session not found"));
-            }
+        if state
+            .session_store
+            .runtime_send_delivery_side_effects_requested(&session_id, &payload)?
+            .unwrap_or(false)
+        {
             return Err(ApiError::Status {
                 status: StatusCode::NOT_IMPLEMENTED,
                 detail: "Rust runtime send delivery side effects are not implemented".to_owned(),
@@ -634,22 +635,6 @@ async fn send_session_input(
         return Err(ApiError::NotFound("Session not found"));
     };
     Ok(Json(serde_json::to_value(result)?))
-}
-
-fn runtime_send_side_effects_requested(payload: &SendCoreInputRequest) -> bool {
-    payload.notify_on_delivery
-        || payload.notify_after_seconds.is_some()
-        || payload.notify_on_stop
-        || payload.remind_soft_threshold.is_some()
-        || payload.remind_hard_threshold.is_some()
-        || payload
-            .remind_cancel_on_reply_session_id
-            .as_deref()
-            .is_some_and(|value| !value.trim().is_empty())
-        || payload
-            .parent_session_id
-            .as_deref()
-            .is_some_and(|value| !value.trim().is_empty())
 }
 
 async fn set_agent_status(

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -446,7 +446,16 @@ fn spawn_child_wait_monitor(state: Arc<AppState>, child: SessionRecord, wait_sec
             let request = SendCoreInputRequest {
                 text: notification,
                 delivery_mode: "sequential".to_owned(),
+                sender_session_id: None,
+                from_sm_send: false,
+                timeout_seconds: None,
+                notify_on_delivery: false,
                 notify_after_seconds: None,
+                notify_on_stop: false,
+                remind_soft_threshold: None,
+                remind_hard_threshold: None,
+                remind_cancel_on_reply_session_id: None,
+                parent_session_id: None,
             };
             let _ = if state.config.rust_core.runtime_enabled {
                 let runtime = TmuxRuntime::from_config(&state.config.rust_core);

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -2,7 +2,10 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 use rusqlite::{params, Connection, OptionalExtension};
-use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+use time::{
+    format_description::well_known::Rfc3339, macros::format_description, OffsetDateTime,
+    PrimitiveDateTime,
+};
 
 #[derive(Debug, Clone)]
 pub struct RetainedQueueStore {
@@ -82,6 +85,7 @@ impl RetainedQueueStore {
         limit: usize,
     ) -> Result<Vec<PendingMessage>> {
         self.with_connection(|conn| {
+            expire_pending_messages_for_target(conn, target_session_id)?;
             let mut statement = conn.prepare(
                 r#"
                 SELECT id, target_session_id, text, delivery_mode
@@ -112,6 +116,7 @@ impl RetainedQueueStore {
         limit: usize,
     ) -> Result<Vec<PendingMessage>> {
         self.with_connection(|conn| {
+            expire_pending_messages_for_target(conn, target_session_id)?;
             let mut statement = conn.prepare(
                 r#"
                 SELECT id, target_session_id, text, delivery_mode
@@ -385,6 +390,71 @@ fn init_schema(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+fn expire_pending_messages_for_target(conn: &Connection, target_session_id: &str) -> Result<()> {
+    let mut statement = conn.prepare(
+        r#"
+        SELECT id, timeout_at
+        FROM message_queue
+        WHERE target_session_id = ?1
+            AND delivered_at IS NULL
+            AND timeout_at IS NOT NULL
+        "#,
+    )?;
+    let rows = statement
+        .query_map(params![target_session_id], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let now_utc = OffsetDateTime::now_utc();
+    let now_local = local_now_naive(now_utc);
+    for (id, timeout_at) in rows {
+        if timeout_is_expired(&timeout_at, now_utc, now_local) {
+            conn.execute(
+                "DELETE FROM message_queue WHERE id = ?1 AND delivered_at IS NULL",
+                params![id],
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn timeout_is_expired(
+    timeout_at: &str,
+    now_utc: OffsetDateTime,
+    now_local: PrimitiveDateTime,
+) -> bool {
+    let timeout_at = timeout_at.trim();
+    if timeout_at.is_empty() {
+        return false;
+    }
+    if let Ok(parsed) = OffsetDateTime::parse(timeout_at, &Rfc3339) {
+        return parsed <= now_utc;
+    }
+    if let Some(parsed) = parse_python_naive_datetime(timeout_at) {
+        return parsed <= now_local;
+    }
+    false
+}
+
+fn parse_python_naive_datetime(value: &str) -> Option<PrimitiveDateTime> {
+    PrimitiveDateTime::parse(
+        value,
+        format_description!("[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond]"),
+    )
+    .or_else(|_| {
+        PrimitiveDateTime::parse(
+            value,
+            format_description!("[year]-[month]-[day]T[hour]:[minute]:[second]"),
+        )
+    })
+    .ok()
+}
+
+fn local_now_naive(now_utc: OffsetDateTime) -> PrimitiveDateTime {
+    let local = OffsetDateTime::now_local().unwrap_or(now_utc);
+    PrimitiveDateTime::new(local.date(), local.time())
+}
+
 fn ensure_column(conn: &Connection, table: &str, column: &str, column_type: &str) -> Result<()> {
     let mut statement = conn.prepare(&format!("PRAGMA table_info({table})"))?;
     let columns = statement
@@ -418,6 +488,7 @@ mod tests {
         env,
         sync::atomic::{AtomicU64, Ordering},
     };
+    use time::Duration;
 
     static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -499,6 +570,60 @@ mod tests {
         assert_eq!(stop_notify, ("em002".to_owned(), "other-em".to_owned(), 0));
     }
 
+    #[test]
+    fn pending_messages_skip_and_delete_expired_timeouts() {
+        let db_path = unique_temp_path("queue-expiry");
+        let store = RetainedQueueStore::new(db_path.clone());
+        store.ensure_schema().unwrap();
+        let now_utc = OffsetDateTime::now_utc();
+        let now_local = local_now_naive(now_utc);
+        let expired_naive = python_naive_timestamp(now_local - Duration::seconds(5));
+        let future_naive = python_naive_timestamp(now_local + Duration::minutes(5));
+        let expired_rfc3339 = (now_utc - Duration::seconds(5)).format(&Rfc3339).unwrap();
+        let queued_at = now_rfc3339();
+        let conn = Connection::open(&db_path).unwrap();
+        for (id, text, timeout_at) in [
+            (
+                "expired-naive",
+                "expired naive",
+                Some(expired_naive.as_str()),
+            ),
+            (
+                "expired-rfc3339",
+                "expired rfc3339",
+                Some(expired_rfc3339.as_str()),
+            ),
+            ("future-naive", "future naive", Some(future_naive.as_str())),
+            ("no-timeout", "no timeout", None),
+        ] {
+            conn.execute(
+                r#"
+                INSERT INTO message_queue
+                    (id, target_session_id, text, delivery_mode, from_sm_send, queued_at, timeout_at)
+                VALUES
+                    (?1, 'child001', ?2, 'sequential', 1, ?3, ?4)
+                "#,
+                params![id, text, queued_at, timeout_at],
+            )
+            .unwrap();
+        }
+
+        let pending = store.pending_messages_for_target("child001", 10).unwrap();
+        let pending_texts = pending
+            .iter()
+            .map(|message| message.text.as_str())
+            .collect::<Vec<_>>();
+        assert_eq!(pending_texts, vec!["future naive", "no timeout"]);
+        let expired_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM message_queue WHERE id IN ('expired-naive', 'expired-rfc3339')",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(expired_count, 0);
+    }
+
     fn unique_temp_path(label: &str) -> PathBuf {
         let mut path = env::temp_dir();
         path.push(format!(
@@ -507,5 +632,13 @@ mod tests {
             TEST_COUNTER.fetch_add(1, Ordering::Relaxed)
         ));
         path
+    }
+
+    fn python_naive_timestamp(value: PrimitiveDateTime) -> String {
+        value
+            .format(format_description!(
+                "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:6]"
+            ))
+            .unwrap()
     }
 }

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{Context, Result};
 use rusqlite::{params, Connection, OptionalExtension};
 use time::{
-    format_description::well_known::Rfc3339, macros::format_description, OffsetDateTime,
+    format_description::well_known::Rfc3339, macros::format_description, Duration, OffsetDateTime,
     PrimitiveDateTime,
 };
 
@@ -18,6 +18,23 @@ pub struct PendingMessage {
     pub target_session_id: String,
     pub text: String,
     pub delivery_mode: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct QueueMessageMetadata {
+    pub sender_session_id: Option<String>,
+    pub sender_name: Option<String>,
+    pub from_sm_send: bool,
+    pub timeout_seconds: Option<u64>,
+    pub notify_on_delivery: bool,
+    pub notify_after_seconds: Option<u64>,
+    pub notify_on_stop: bool,
+    pub remind_soft_threshold: Option<u64>,
+    pub remind_hard_threshold: Option<u64>,
+    pub remind_cancel_on_reply_session_id: Option<String>,
+    pub parent_session_id: Option<String>,
+    pub message_category: Option<String>,
+    pub response_relay_source: Option<String>,
 }
 
 impl RetainedQueueStore {
@@ -40,22 +57,60 @@ impl RetainedQueueStore {
         delivery_mode: &str,
         message_category: Option<&str>,
     ) -> Result<String> {
+        self.enqueue_message_with_metadata(
+            target_session_id,
+            text,
+            delivery_mode,
+            QueueMessageMetadata {
+                message_category: message_category.map(ToOwned::to_owned),
+                ..QueueMessageMetadata::default()
+            },
+        )
+    }
+
+    pub fn enqueue_message_with_metadata(
+        &self,
+        target_session_id: &str,
+        text: &str,
+        delivery_mode: &str,
+        metadata: QueueMessageMetadata,
+    ) -> Result<String> {
         self.with_connection(|conn| {
             let id = generate_record_id("msg");
+            let timeout_at = timeout_at_rfc3339(metadata.timeout_seconds)?;
+            let response_relay_source = metadata
+                .response_relay_source
+                .or_else(|| metadata.from_sm_send.then(|| "sm-send".to_owned()));
             conn.execute(
                 r#"
                 INSERT INTO message_queue
-                    (id, target_session_id, text, delivery_mode, from_sm_send, queued_at, message_category)
+                    (id, target_session_id, sender_session_id, sender_name, text,
+                     delivery_mode, from_sm_send, queued_at, timeout_at, notify_on_delivery,
+                     notify_after_seconds, notify_on_stop, remind_soft_threshold,
+                     remind_hard_threshold, remind_cancel_on_reply_session_id, parent_session_id,
+                     message_category, response_relay_source)
                 VALUES
-                    (?1, ?2, ?3, ?4, 0, ?5, ?6)
+                    (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)
                 "#,
                 params![
                     id,
                     target_session_id,
+                    metadata.sender_session_id,
+                    metadata.sender_name,
                     text,
                     delivery_mode,
+                    metadata.from_sm_send,
                     now_rfc3339(),
-                    message_category
+                    timeout_at,
+                    metadata.notify_on_delivery,
+                    metadata.notify_after_seconds.map(u64_to_i64).transpose()?,
+                    metadata.notify_on_stop,
+                    metadata.remind_soft_threshold.map(u64_to_i64).transpose()?,
+                    metadata.remind_hard_threshold.map(u64_to_i64).transpose()?,
+                    metadata.remind_cancel_on_reply_session_id,
+                    metadata.parent_session_id,
+                    metadata.message_category,
+                    response_relay_source,
                 ],
             )?;
             Ok(id)
@@ -478,6 +533,18 @@ fn now_rfc3339() -> String {
     OffsetDateTime::now_utc()
         .format(&Rfc3339)
         .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned())
+}
+
+fn timeout_at_rfc3339(timeout_seconds: Option<u64>) -> Result<Option<String>> {
+    let Some(timeout_seconds) = timeout_seconds.filter(|seconds| *seconds > 0) else {
+        return Ok(None);
+    };
+    let timeout_at = OffsetDateTime::now_utc() + Duration::seconds(u64_to_i64(timeout_seconds)?);
+    Ok(Some(timeout_at.format(&Rfc3339)?))
+}
+
+fn u64_to_i64(value: u64) -> Result<i64> {
+    i64::try_from(value).context("queue metadata seconds value is too large")
 }
 
 #[cfg(test)]

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -9,6 +9,14 @@ pub struct RetainedQueueStore {
     db_path: PathBuf,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PendingMessage {
+    pub id: String,
+    pub target_session_id: String,
+    pub text: String,
+    pub delivery_mode: String,
+}
+
 impl RetainedQueueStore {
     pub fn new(db_path: PathBuf) -> Self {
         Self { db_path }
@@ -64,6 +72,66 @@ impl RetainedQueueStore {
                 |row| row.get(0),
             )
             .optional()
+            .map_err(Into::into)
+        })
+    }
+
+    pub fn pending_messages_for_target(
+        &self,
+        target_session_id: &str,
+        limit: usize,
+    ) -> Result<Vec<PendingMessage>> {
+        self.with_connection(|conn| {
+            let mut statement = conn.prepare(
+                r#"
+                SELECT id, target_session_id, text, delivery_mode
+                FROM message_queue
+                WHERE target_session_id = ?1 AND delivered_at IS NULL
+                ORDER BY queued_at ASC, id ASC
+                LIMIT ?2
+                "#,
+            )?;
+            let rows = statement
+                .query_map(params![target_session_id, limit.max(1) as i64], |row| {
+                    Ok(PendingMessage {
+                        id: row.get(0)?,
+                        target_session_id: row.get(1)?,
+                        text: row.get(2)?,
+                        delivery_mode: row.get(3)?,
+                    })
+                })?
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            Ok(rows)
+        })
+    }
+
+    pub fn mark_delivered(&self, message_id: &str) -> Result<()> {
+        self.with_connection(|conn| {
+            conn.execute(
+                r#"
+                UPDATE message_queue
+                SET delivered_at = ?2
+                WHERE id = ?1 AND delivered_at IS NULL
+                "#,
+                params![message_id, now_rfc3339()],
+            )?;
+            Ok(())
+        })
+    }
+
+    pub fn message_delivered(&self, message_id: &str) -> Result<bool> {
+        self.with_connection(|conn| {
+            conn.query_row(
+                r#"
+                SELECT delivered_at IS NOT NULL
+                FROM message_queue
+                WHERE id = ?1
+                "#,
+                params![message_id],
+                |row| row.get::<_, i64>(0),
+            )
+            .optional()
+            .map(|value| value.unwrap_or(0) != 0)
             .map_err(Into::into)
         })
     }
@@ -369,6 +437,15 @@ mod tests {
                 "task_complete".to_owned()
             )
         );
+        let pending = store.pending_messages_for_target("child001", 10).unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].id, message_id);
+        store.mark_delivered(&message_id).unwrap();
+        assert!(store.message_delivered(&message_id).unwrap());
+        assert!(store
+            .pending_messages_for_target("child001", 10)
+            .unwrap()
+            .is_empty());
         let active: i64 = conn
             .query_row(
                 "SELECT is_active FROM parent_wake_registrations WHERE child_session_id = 'child001'",

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -40,11 +40,7 @@ pub struct QueueMessageMetadata {
 
 impl QueueMessageMetadata {
     pub fn has_delivery_side_effects(&self) -> bool {
-        self.sender_session_id
-            .as_deref()
-            .is_some_and(|value| !value.trim().is_empty())
-            || self.from_sm_send
-            || self.notify_on_delivery
+        self.notify_on_delivery
             || self.notify_after_seconds.is_some()
             || self.notify_on_stop
             || self.remind_soft_threshold.is_some()
@@ -55,10 +51,6 @@ impl QueueMessageMetadata {
                 .is_some_and(|value| !value.trim().is_empty())
             || self
                 .parent_session_id
-                .as_deref()
-                .is_some_and(|value| !value.trim().is_empty())
-            || self
-                .response_relay_source
                 .as_deref()
                 .is_some_and(|value| !value.trim().is_empty())
     }
@@ -172,9 +164,7 @@ impl RetainedQueueStore {
                 r#"
                 SELECT id, target_session_id, text, delivery_mode,
                     CASE WHEN
-                        (sender_session_id IS NOT NULL AND trim(sender_session_id) != '')
-                        OR from_sm_send != 0
-                        OR notify_on_delivery != 0
+                        notify_on_delivery != 0
                         OR notify_after_seconds IS NOT NULL
                         OR notify_on_stop != 0
                         OR remind_soft_threshold IS NOT NULL
@@ -186,10 +176,6 @@ impl RetainedQueueStore {
                         OR (
                             parent_session_id IS NOT NULL
                             AND trim(parent_session_id) != ''
-                        )
-                        OR (
-                            response_relay_source IS NOT NULL
-                            AND trim(response_relay_source) != ''
                         )
                     THEN 1 ELSE 0 END AS has_delivery_side_effects
                 FROM message_queue
@@ -225,9 +211,7 @@ impl RetainedQueueStore {
                 r#"
                 SELECT id, target_session_id, text, delivery_mode,
                     CASE WHEN
-                        (sender_session_id IS NOT NULL AND trim(sender_session_id) != '')
-                        OR from_sm_send != 0
-                        OR notify_on_delivery != 0
+                        notify_on_delivery != 0
                         OR notify_after_seconds IS NOT NULL
                         OR notify_on_stop != 0
                         OR remind_soft_threshold IS NOT NULL
@@ -239,10 +223,6 @@ impl RetainedQueueStore {
                         OR (
                             parent_session_id IS NOT NULL
                             AND trim(parent_session_id) != ''
-                        )
-                        OR (
-                            response_relay_source IS NOT NULL
-                            AND trim(response_relay_source) != ''
                         )
                     THEN 1 ELSE 0 END AS has_delivery_side_effects
                 FROM message_queue

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -105,6 +105,41 @@ impl RetainedQueueStore {
         })
     }
 
+    pub fn pending_messages_for_target_by_mode(
+        &self,
+        target_session_id: &str,
+        delivery_mode: &str,
+        limit: usize,
+    ) -> Result<Vec<PendingMessage>> {
+        self.with_connection(|conn| {
+            let mut statement = conn.prepare(
+                r#"
+                SELECT id, target_session_id, text, delivery_mode
+                FROM message_queue
+                WHERE target_session_id = ?1
+                    AND delivery_mode = ?2
+                    AND delivered_at IS NULL
+                ORDER BY queued_at ASC, id ASC
+                LIMIT ?3
+                "#,
+            )?;
+            let rows = statement
+                .query_map(
+                    params![target_session_id, delivery_mode, limit.max(1) as i64],
+                    |row| {
+                        Ok(PendingMessage {
+                            id: row.get(0)?,
+                            target_session_id: row.get(1)?,
+                            text: row.get(2)?,
+                            delivery_mode: row.get(3)?,
+                        })
+                    },
+                )?
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            Ok(rows)
+        })
+    }
+
     pub fn mark_delivered(&self, message_id: &str) -> Result<()> {
         self.with_connection(|conn| {
             conn.execute(

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -18,6 +18,7 @@ pub struct PendingMessage {
     pub target_session_id: String,
     pub text: String,
     pub delivery_mode: String,
+    pub has_delivery_side_effects: bool,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -35,6 +36,32 @@ pub struct QueueMessageMetadata {
     pub parent_session_id: Option<String>,
     pub message_category: Option<String>,
     pub response_relay_source: Option<String>,
+}
+
+impl QueueMessageMetadata {
+    pub fn has_delivery_side_effects(&self) -> bool {
+        self.sender_session_id
+            .as_deref()
+            .is_some_and(|value| !value.trim().is_empty())
+            || self.from_sm_send
+            || self.notify_on_delivery
+            || self.notify_after_seconds.is_some()
+            || self.notify_on_stop
+            || self.remind_soft_threshold.is_some()
+            || self.remind_hard_threshold.is_some()
+            || self
+                .remind_cancel_on_reply_session_id
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+            || self
+                .parent_session_id
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+            || self
+                .response_relay_source
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+    }
 }
 
 impl RetainedQueueStore {
@@ -143,7 +170,28 @@ impl RetainedQueueStore {
             expire_pending_messages_for_target(conn, target_session_id)?;
             let mut statement = conn.prepare(
                 r#"
-                SELECT id, target_session_id, text, delivery_mode
+                SELECT id, target_session_id, text, delivery_mode,
+                    CASE WHEN
+                        (sender_session_id IS NOT NULL AND trim(sender_session_id) != '')
+                        OR from_sm_send != 0
+                        OR notify_on_delivery != 0
+                        OR notify_after_seconds IS NOT NULL
+                        OR notify_on_stop != 0
+                        OR remind_soft_threshold IS NOT NULL
+                        OR remind_hard_threshold IS NOT NULL
+                        OR (
+                            remind_cancel_on_reply_session_id IS NOT NULL
+                            AND trim(remind_cancel_on_reply_session_id) != ''
+                        )
+                        OR (
+                            parent_session_id IS NOT NULL
+                            AND trim(parent_session_id) != ''
+                        )
+                        OR (
+                            response_relay_source IS NOT NULL
+                            AND trim(response_relay_source) != ''
+                        )
+                    THEN 1 ELSE 0 END AS has_delivery_side_effects
                 FROM message_queue
                 WHERE target_session_id = ?1 AND delivered_at IS NULL
                 ORDER BY queued_at ASC, id ASC
@@ -157,6 +205,7 @@ impl RetainedQueueStore {
                         target_session_id: row.get(1)?,
                         text: row.get(2)?,
                         delivery_mode: row.get(3)?,
+                        has_delivery_side_effects: row.get::<_, i64>(4)? != 0,
                     })
                 })?
                 .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -174,7 +223,28 @@ impl RetainedQueueStore {
             expire_pending_messages_for_target(conn, target_session_id)?;
             let mut statement = conn.prepare(
                 r#"
-                SELECT id, target_session_id, text, delivery_mode
+                SELECT id, target_session_id, text, delivery_mode,
+                    CASE WHEN
+                        (sender_session_id IS NOT NULL AND trim(sender_session_id) != '')
+                        OR from_sm_send != 0
+                        OR notify_on_delivery != 0
+                        OR notify_after_seconds IS NOT NULL
+                        OR notify_on_stop != 0
+                        OR remind_soft_threshold IS NOT NULL
+                        OR remind_hard_threshold IS NOT NULL
+                        OR (
+                            remind_cancel_on_reply_session_id IS NOT NULL
+                            AND trim(remind_cancel_on_reply_session_id) != ''
+                        )
+                        OR (
+                            parent_session_id IS NOT NULL
+                            AND trim(parent_session_id) != ''
+                        )
+                        OR (
+                            response_relay_source IS NOT NULL
+                            AND trim(response_relay_source) != ''
+                        )
+                    THEN 1 ELSE 0 END AS has_delivery_side_effects
                 FROM message_queue
                 WHERE target_session_id = ?1
                     AND delivery_mode = ?2
@@ -192,6 +262,7 @@ impl RetainedQueueStore {
                             target_session_id: row.get(1)?,
                             text: row.get(2)?,
                             delivery_mode: row.get(3)?,
+                            has_delivery_side_effects: row.get::<_, i64>(4)? != 0,
                         })
                     },
                 )?

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -190,6 +190,25 @@ impl TmuxRuntime {
         Ok(true)
     }
 
+    pub fn send_urgent_input(
+        &self,
+        tmux_session: &str,
+        text: &str,
+        background_claude_task: bool,
+    ) -> Result<bool> {
+        if !self.session_exists(tmux_session)? {
+            return Ok(false);
+        }
+        if background_claude_task {
+            self.send_key(tmux_session, "C-b")?;
+            let _ = self.wait_for_prompt(tmux_session, Duration::from_millis(300));
+        }
+        self.send_key(tmux_session, "Escape")?;
+        let _ = self.wait_for_prompt(tmux_session, Duration::from_millis(300));
+        self.send_text_then_enter(tmux_session, text)?;
+        Ok(true)
+    }
+
     pub fn clear_session(
         &self,
         tmux_session: &str,
@@ -514,6 +533,40 @@ mod tests {
         assert!(clear_enter < post_clear_wait);
         assert!(post_clear_wait < prompt_text);
         assert!(prompt_text < prompt_enter);
+    }
+
+    #[test]
+    fn urgent_input_backgrounds_interrupts_and_sends_payload() {
+        let (tmux_binary, log_path, _temp_dir) = fake_tmux_binary();
+        let mut runtime = TmuxRuntime::from_config(&RustCoreConfig {
+            send_keys_settle_ms: Some(0.0),
+            send_keys_settle_max_ms: Some(0.0),
+            ..RustCoreConfig::default()
+        });
+        runtime.tmux_binary = tmux_binary.display().to_string();
+
+        assert!(runtime
+            .send_urgent_input("sm-test", "urgent task", true)
+            .unwrap());
+
+        let log = fs::read_to_string(log_path).unwrap();
+        let lines = log.lines().collect::<Vec<_>>();
+        let background = position_after(&lines, "send-keys -t sm-test C-b", 0);
+        let background_wait = position_after(&lines, "capture-pane -p -t sm-test", background + 1);
+        let escape = position_after(&lines, "send-keys -t sm-test Escape", background_wait + 1);
+        let interrupt_wait = position_after(&lines, "capture-pane -p -t sm-test", escape + 1);
+        let payload = position_after(
+            &lines,
+            "send-keys -t sm-test -l -- urgent task",
+            interrupt_wait + 1,
+        );
+        let enter = position_after(&lines, "send-keys -t sm-test Enter", payload + 1);
+
+        assert!(background < background_wait);
+        assert!(background_wait < escape);
+        assert!(escape < interrupt_wait);
+        assert!(interrupt_wait < payload);
+        assert!(payload < enter);
     }
 
     fn fake_tmux_binary() -> (PathBuf, PathBuf, PathBuf) {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -317,6 +317,7 @@ impl SessionStore {
                         } else {
                             None
                         },
+                        Some(&message_id),
                     )?
                 };
                 self.write_raw_json_value(&state)?;
@@ -1749,25 +1750,44 @@ fn drain_pending_runtime_messages_raw(
     runtime: &TmuxRuntime,
     queue: &RetainedQueueStore,
     delivery_mode_filter: Option<&str>,
+    stop_after_message_id: Option<&str>,
 ) -> Result<QueueDrainResult> {
     let mut status =
         runtime_session_status_raw(state, session_id)?.unwrap_or_else(|| "stopped".to_owned());
     let mut delivered_message_ids = Vec::new();
-    let messages = match delivery_mode_filter {
-        Some(delivery_mode) => {
-            queue.pending_messages_for_target_by_mode(session_id, delivery_mode, 10)?
-        }
-        None => queue.pending_messages_for_target(session_id, 10)?,
-    };
-    for message in messages {
-        let (next_status, delivered) =
-            deliver_runtime_text_to_session_raw(state, session_id, &message.text, runtime)?;
-        status = next_status;
-        if !delivered {
+    loop {
+        let messages = match delivery_mode_filter {
+            Some(delivery_mode) => {
+                queue.pending_messages_for_target_by_mode(session_id, delivery_mode, 10)?
+            }
+            None => queue.pending_messages_for_target(session_id, 10)?,
+        };
+        if messages.is_empty() {
             break;
         }
-        queue.mark_delivered(&message.id)?;
-        delivered_message_ids.push(message.id);
+
+        let mut should_continue = true;
+        for message in messages {
+            let (next_status, delivered) =
+                deliver_runtime_text_to_session_raw(state, session_id, &message.text, runtime)?;
+            status = next_status;
+            if !delivered {
+                should_continue = false;
+                break;
+            }
+            queue.mark_delivered(&message.id)?;
+            let delivered_target =
+                stop_after_message_id.is_some_and(|target_id| target_id == message.id);
+            delivered_message_ids.push(message.id);
+            if delivered_target {
+                should_continue = false;
+                break;
+            }
+        }
+
+        if !should_continue {
+            break;
+        }
     }
     Ok(QueueDrainResult {
         status,

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -287,30 +287,40 @@ impl SessionStore {
     ) -> Result<Option<CoreInputResult>> {
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
-        let sessions = ensure_sessions_array_mut(&mut state)?;
-        let Some(session) = session_object_mut(sessions, session_id) else {
+
+        if runtime_session_status_raw(&mut state, session_id)?.is_none() {
             return Ok(None);
-        };
-        let node = json_text(session.get("node")).unwrap_or_else(default_node);
-        ensure_runtime_local_node(&node)?;
-        let mut status = json_text(session.get("status")).unwrap_or_else(|| "running".to_owned());
-        let tmux_session = json_text(session.get("tmux_session"))
-            .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?;
-        let session_socket_name = json_text(session.get("tmux_socket_name"));
-        let session_runtime = runtime.for_socket_name(session_socket_name.as_deref());
-        let mut delivered = false;
-        if normalized_status(&status) != "stopped" {
-            delivered = session_runtime.send_input(&tmux_session, &request.text)?;
-            let now = now_rfc3339();
-            if delivered {
-                session.insert("last_activity".to_owned(), Value::String(now));
-            } else {
-                status = "stopped".to_owned();
-                session.insert("status".to_owned(), Value::String(status.clone()));
-                session.insert("stopped_at".to_owned(), Value::String(now.clone()));
-                session.insert("last_activity".to_owned(), Value::String(now));
+        }
+
+        if should_persist_runtime_send(&request.delivery_mode) {
+            if let Some(queue) = &self.queue_store {
+                let message_id = queue.enqueue_message(
+                    session_id,
+                    &request.text,
+                    &request.delivery_mode,
+                    None,
+                )?;
+                let drain =
+                    drain_pending_runtime_messages_raw(&mut state, session_id, runtime, queue)?;
+                self.write_raw_json_value(&state)?;
+                let delivered = drain
+                    .delivered_message_ids
+                    .iter()
+                    .any(|id| id == &message_id)
+                    || queue.message_delivered(&message_id)?;
+                return Ok(Some(CoreInputResult {
+                    ok: true,
+                    session_id: session_id.to_owned(),
+                    delivered,
+                    delivery_mode: request.delivery_mode,
+                    notify_after_seconds: request.notify_after_seconds,
+                    status: drain.status,
+                }));
             }
         }
+
+        let (status, delivered) =
+            deliver_runtime_text_to_session_raw(&mut state, session_id, &request.text, runtime)?;
         self.write_raw_json_value(&state)?;
         Ok(Some(CoreInputResult {
             ok: true,
@@ -1651,6 +1661,90 @@ fn push_retained_message_raw(
         "created_at": now_rfc3339(),
     }));
     Ok(())
+}
+
+#[derive(Debug)]
+struct QueueDrainResult {
+    status: String,
+    delivered_message_ids: Vec<String>,
+}
+
+fn should_persist_runtime_send(delivery_mode: &str) -> bool {
+    matches!(
+        delivery_mode.trim().to_ascii_lowercase().as_str(),
+        "sequential" | "important" | "urgent"
+    )
+}
+
+fn runtime_session_status_raw(state: &mut Value, session_id: &str) -> Result<Option<String>> {
+    let sessions = ensure_sessions_array_mut(state)?;
+    let Some(session) = session_object_mut(sessions, session_id) else {
+        return Ok(None);
+    };
+    let node = json_text(session.get("node")).unwrap_or_else(default_node);
+    ensure_runtime_local_node(&node)?;
+    let _tmux_session = json_text(session.get("tmux_session"))
+        .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?;
+    Ok(Some(
+        json_text(session.get("status")).unwrap_or_else(|| "running".to_owned()),
+    ))
+}
+
+fn deliver_runtime_text_to_session_raw(
+    state: &mut Value,
+    session_id: &str,
+    text: &str,
+    runtime: &TmuxRuntime,
+) -> Result<(String, bool)> {
+    let sessions = ensure_sessions_array_mut(state)?;
+    let session = session_object_mut(sessions, session_id)
+        .ok_or_else(|| anyhow::anyhow!("session {session_id} disappeared during delivery"))?;
+    let node = json_text(session.get("node")).unwrap_or_else(default_node);
+    ensure_runtime_local_node(&node)?;
+    let mut status = json_text(session.get("status")).unwrap_or_else(|| "running".to_owned());
+    let tmux_session = json_text(session.get("tmux_session"))
+        .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?;
+    let session_socket_name = json_text(session.get("tmux_socket_name"));
+    let session_runtime = runtime.for_socket_name(session_socket_name.as_deref());
+    let mut delivered = false;
+    if normalized_status(&status) != "stopped" {
+        delivered = session_runtime.send_input(&tmux_session, text)?;
+        let now = now_rfc3339();
+        if delivered {
+            session.insert("last_activity".to_owned(), Value::String(now));
+        } else {
+            status = "stopped".to_owned();
+            session.insert("status".to_owned(), Value::String(status.clone()));
+            session.insert("stopped_at".to_owned(), Value::String(now.clone()));
+            session.insert("last_activity".to_owned(), Value::String(now));
+        }
+    }
+    Ok((status, delivered))
+}
+
+fn drain_pending_runtime_messages_raw(
+    state: &mut Value,
+    session_id: &str,
+    runtime: &TmuxRuntime,
+    queue: &RetainedQueueStore,
+) -> Result<QueueDrainResult> {
+    let mut status =
+        runtime_session_status_raw(state, session_id)?.unwrap_or_else(|| "stopped".to_owned());
+    let mut delivered_message_ids = Vec::new();
+    for message in queue.pending_messages_for_target(session_id, 10)? {
+        let (next_status, delivered) =
+            deliver_runtime_text_to_session_raw(state, session_id, &message.text, runtime)?;
+        status = next_status;
+        if !delivered {
+            break;
+        }
+        queue.mark_delivered(&message.id)?;
+        delivered_message_ids.push(message.id);
+    }
+    Ok(QueueDrainResult {
+        status,
+        delivered_message_ids,
+    })
 }
 
 fn upsert_stop_notify_raw(

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1816,7 +1816,16 @@ fn drain_pending_runtime_messages_raw(
         let mut should_continue = true;
         for message in messages {
             let (next_status, delivered) =
-                deliver_runtime_text_to_session_raw(state, session_id, &message.text, runtime)?;
+                if normalized_delivery_mode(&message.delivery_mode) == "urgent" {
+                    deliver_urgent_runtime_text_to_session_raw(
+                        state,
+                        session_id,
+                        &message.text,
+                        runtime,
+                    )?
+                } else {
+                    deliver_runtime_text_to_session_raw(state, session_id, &message.text, runtime)?
+                };
             status = next_status;
             if !delivered {
                 should_continue = false;

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1754,6 +1754,43 @@ fn deliver_runtime_text_to_session_raw(
     Ok((status, delivered))
 }
 
+fn deliver_urgent_runtime_text_to_session_raw(
+    state: &mut Value,
+    session_id: &str,
+    text: &str,
+    runtime: &TmuxRuntime,
+) -> Result<(String, bool)> {
+    let sessions = ensure_sessions_array_mut(state)?;
+    let session = session_object_mut(sessions, session_id)
+        .ok_or_else(|| anyhow::anyhow!("session {session_id} disappeared during delivery"))?;
+    let node = json_text(session.get("node")).unwrap_or_else(default_node);
+    ensure_runtime_local_node(&node)?;
+    let mut status = json_text(session.get("status")).unwrap_or_else(|| "running".to_owned());
+    let tmux_session = json_text(session.get("tmux_session"))
+        .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?;
+    let provider = json_text(session.get("provider")).unwrap_or_else(|| "claude".to_owned());
+    let session_socket_name = json_text(session.get("tmux_socket_name"));
+    let session_runtime = runtime.for_socket_name(session_socket_name.as_deref());
+    let mut delivered = false;
+    if normalized_status(&status) != "stopped" {
+        delivered = session_runtime.send_urgent_input(
+            &tmux_session,
+            text,
+            provider.eq_ignore_ascii_case("claude"),
+        )?;
+        let now = now_rfc3339();
+        if delivered {
+            session.insert("last_activity".to_owned(), Value::String(now));
+        } else {
+            status = "stopped".to_owned();
+            session.insert("status".to_owned(), Value::String(status.clone()));
+            session.insert("stopped_at".to_owned(), Value::String(now.clone()));
+            session.insert("last_activity".to_owned(), Value::String(now));
+        }
+    }
+    Ok((status, delivered))
+}
+
 fn drain_pending_runtime_messages_raw(
     state: &mut Value,
     session_id: &str,
@@ -1814,7 +1851,7 @@ fn deliver_urgent_runtime_message_raw(
     text: &str,
 ) -> Result<QueueDrainResult> {
     let (status, delivered) =
-        deliver_runtime_text_to_session_raw(state, session_id, text, runtime)?;
+        deliver_urgent_runtime_text_to_session_raw(state, session_id, text, runtime)?;
     let mut delivered_message_ids = Vec::new();
     if delivered {
         queue.mark_delivered(message_id)?;

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -306,12 +306,25 @@ impl SessionStore {
         let (queued_text, sender_name) = format_send_input_text_raw(&state, &request);
         if should_persist_runtime_send(&delivery_mode) {
             if let Some(queue) = &self.queue_store {
+                let metadata =
+                    queue_metadata_for_send_request(&state, session_id, &request, sender_name);
+                let has_delivery_side_effects = metadata.has_delivery_side_effects();
                 let message_id = queue.enqueue_message_with_metadata(
                     session_id,
                     &queued_text,
                     &delivery_mode,
-                    queue_metadata_for_send_request(&state, session_id, &request, sender_name),
+                    metadata,
                 )?;
+                if has_delivery_side_effects {
+                    return Ok(Some(CoreInputResult {
+                        ok: true,
+                        session_id: session_id.to_owned(),
+                        delivered: false,
+                        delivery_mode: request.delivery_mode,
+                        notify_after_seconds: request.notify_after_seconds,
+                        status: initial_status,
+                    }));
+                }
                 let drain = if delivery_mode == "urgent" {
                     deliver_urgent_runtime_message_raw(
                         &mut state,
@@ -1918,6 +1931,10 @@ fn drain_pending_runtime_messages_raw(
 
         let mut should_continue = true;
         for message in messages {
+            if message.has_delivery_side_effects {
+                should_continue = false;
+                break;
+            }
             let (next_status, delivered) =
                 if normalized_delivery_mode(&message.delivery_mode) == "urgent" {
                     deliver_urgent_runtime_text_to_session_raw(

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -378,6 +378,19 @@ impl SessionStore {
         }))
     }
 
+    pub fn runtime_send_delivery_side_effects_requested(
+        &self,
+        session_id: &str,
+        request: &SendCoreInputRequest,
+    ) -> Result<Option<bool>> {
+        let state = self.load_raw_json_value()?;
+        if raw_session_object(&state, session_id).is_none() {
+            return Ok(None);
+        }
+        let metadata = queue_metadata_for_send_request(&state, session_id, request, None);
+        Ok(Some(metadata.has_delivery_side_effects()))
+    }
+
     pub fn clear_core_session(
         &self,
         session_id: &str,

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -288,8 +288,18 @@ impl SessionStore {
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
 
-        if runtime_session_status_raw(&mut state, session_id)?.is_none() {
+        let Some(initial_status) = runtime_session_status_raw(&mut state, session_id)? else {
             return Ok(None);
+        };
+        if normalized_status(&initial_status) == "stopped" {
+            return Ok(Some(CoreInputResult {
+                ok: true,
+                session_id: session_id.to_owned(),
+                delivered: false,
+                delivery_mode: request.delivery_mode,
+                notify_after_seconds: request.notify_after_seconds,
+                status: initial_status,
+            }));
         }
 
         let delivery_mode = normalized_delivery_mode(&request.delivery_mode);

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -292,16 +292,33 @@ impl SessionStore {
             return Ok(None);
         }
 
-        if should_persist_runtime_send(&request.delivery_mode) {
+        let delivery_mode = normalized_delivery_mode(&request.delivery_mode);
+        if should_persist_runtime_send(&delivery_mode) {
             if let Some(queue) = &self.queue_store {
-                let message_id = queue.enqueue_message(
-                    session_id,
-                    &request.text,
-                    &request.delivery_mode,
-                    None,
-                )?;
-                let drain =
-                    drain_pending_runtime_messages_raw(&mut state, session_id, runtime, queue)?;
+                let message_id =
+                    queue.enqueue_message(session_id, &request.text, &delivery_mode, None)?;
+                let drain = if delivery_mode == "urgent" {
+                    deliver_urgent_runtime_message_raw(
+                        &mut state,
+                        session_id,
+                        runtime,
+                        queue,
+                        &message_id,
+                        &request.text,
+                    )?
+                } else {
+                    drain_pending_runtime_messages_raw(
+                        &mut state,
+                        session_id,
+                        runtime,
+                        queue,
+                        if delivery_mode == "important" {
+                            Some("important")
+                        } else {
+                            None
+                        },
+                    )?
+                };
                 self.write_raw_json_value(&state)?;
                 let delivered = drain
                     .delivered_message_ids
@@ -1671,9 +1688,13 @@ struct QueueDrainResult {
 
 fn should_persist_runtime_send(delivery_mode: &str) -> bool {
     matches!(
-        delivery_mode.trim().to_ascii_lowercase().as_str(),
+        normalized_delivery_mode(delivery_mode).as_str(),
         "sequential" | "important" | "urgent"
     )
+}
+
+fn normalized_delivery_mode(delivery_mode: &str) -> String {
+    delivery_mode.trim().to_ascii_lowercase()
 }
 
 fn runtime_session_status_raw(state: &mut Value, session_id: &str) -> Result<Option<String>> {
@@ -1727,11 +1748,18 @@ fn drain_pending_runtime_messages_raw(
     session_id: &str,
     runtime: &TmuxRuntime,
     queue: &RetainedQueueStore,
+    delivery_mode_filter: Option<&str>,
 ) -> Result<QueueDrainResult> {
     let mut status =
         runtime_session_status_raw(state, session_id)?.unwrap_or_else(|| "stopped".to_owned());
     let mut delivered_message_ids = Vec::new();
-    for message in queue.pending_messages_for_target(session_id, 10)? {
+    let messages = match delivery_mode_filter {
+        Some(delivery_mode) => {
+            queue.pending_messages_for_target_by_mode(session_id, delivery_mode, 10)?
+        }
+        None => queue.pending_messages_for_target(session_id, 10)?,
+    };
+    for message in messages {
         let (next_status, delivered) =
             deliver_runtime_text_to_session_raw(state, session_id, &message.text, runtime)?;
         status = next_status;
@@ -1740,6 +1768,27 @@ fn drain_pending_runtime_messages_raw(
         }
         queue.mark_delivered(&message.id)?;
         delivered_message_ids.push(message.id);
+    }
+    Ok(QueueDrainResult {
+        status,
+        delivered_message_ids,
+    })
+}
+
+fn deliver_urgent_runtime_message_raw(
+    state: &mut Value,
+    session_id: &str,
+    runtime: &TmuxRuntime,
+    queue: &RetainedQueueStore,
+    message_id: &str,
+    text: &str,
+) -> Result<QueueDrainResult> {
+    let (status, delivered) =
+        deliver_runtime_text_to_session_raw(state, session_id, text, runtime)?;
+    let mut delivered_message_ids = Vec::new();
+    if delivered {
+        queue.mark_delivered(message_id)?;
+        delivered_message_ids.push(message_id.to_owned());
     }
     Ok(QueueDrainResult {
         status,

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -13,7 +13,7 @@ use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
-use crate::queue::RetainedQueueStore;
+use crate::queue::{QueueMessageMetadata, RetainedQueueStore};
 use crate::runtime::{TmuxRuntime, TmuxSessionSpec};
 
 const DEFAULT_SESSION_STATE_FILE: &str = "~/.local/share/claude-sessions/sessions.json";
@@ -303,10 +303,15 @@ impl SessionStore {
         }
 
         let delivery_mode = normalized_delivery_mode(&request.delivery_mode);
+        let (queued_text, sender_name) = format_send_input_text_raw(&state, &request);
         if should_persist_runtime_send(&delivery_mode) {
             if let Some(queue) = &self.queue_store {
-                let message_id =
-                    queue.enqueue_message(session_id, &request.text, &delivery_mode, None)?;
+                let message_id = queue.enqueue_message_with_metadata(
+                    session_id,
+                    &queued_text,
+                    &delivery_mode,
+                    queue_metadata_for_send_request(&state, session_id, &request, sender_name),
+                )?;
                 let drain = if delivery_mode == "urgent" {
                     deliver_urgent_runtime_message_raw(
                         &mut state,
@@ -314,7 +319,7 @@ impl SessionStore {
                         runtime,
                         queue,
                         &message_id,
-                        &request.text,
+                        &queued_text,
                     )?
                 } else {
                     drain_pending_runtime_messages_raw(
@@ -348,7 +353,7 @@ impl SessionStore {
         }
 
         let (status, delivered) =
-            deliver_runtime_text_to_session_raw(&mut state, session_id, &request.text, runtime)?;
+            deliver_runtime_text_to_session_raw(&mut state, session_id, &queued_text, runtime)?;
         self.write_raw_json_value(&state)?;
         Ok(Some(CoreInputResult {
             ok: true,
@@ -1362,7 +1367,25 @@ pub struct SendCoreInputRequest {
     #[serde(default = "default_delivery_mode")]
     pub delivery_mode: String,
     #[serde(default)]
+    pub sender_session_id: Option<String>,
+    #[serde(default)]
+    pub from_sm_send: bool,
+    #[serde(default)]
+    pub timeout_seconds: Option<u64>,
+    #[serde(default)]
+    pub notify_on_delivery: bool,
+    #[serde(default)]
     pub notify_after_seconds: Option<u64>,
+    #[serde(default)]
+    pub notify_on_stop: bool,
+    #[serde(default)]
+    pub remind_soft_threshold: Option<u64>,
+    #[serde(default)]
+    pub remind_hard_threshold: Option<u64>,
+    #[serde(default)]
+    pub remind_cancel_on_reply_session_id: Option<String>,
+    #[serde(default)]
+    pub parent_session_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1706,6 +1729,86 @@ fn should_persist_runtime_send(delivery_mode: &str) -> bool {
 
 fn normalized_delivery_mode(delivery_mode: &str) -> String {
     delivery_mode.trim().to_ascii_lowercase()
+}
+
+fn format_send_input_text_raw(
+    state: &Value,
+    request: &SendCoreInputRequest,
+) -> (String, Option<String>) {
+    let Some(sender_session_id) = optional_trimmed(request.sender_session_id.as_deref()) else {
+        return (request.text.clone(), None);
+    };
+    let Some(sessions) = state.get("sessions").and_then(Value::as_array) else {
+        return (request.text.clone(), None);
+    };
+    let Some(sender) = session_object(sessions, &sender_session_id) else {
+        return (request.text.clone(), None);
+    };
+    let sender_name = raw_session_display_name(sender, &sender_session_id);
+    (
+        format!(
+            "[Input from: {sender_name} ({}) via sm send]\n{}",
+            short_session_id(&sender_session_id),
+            request.text
+        ),
+        Some(sender_name),
+    )
+}
+
+fn queue_metadata_for_send_request(
+    state: &Value,
+    target_session_id: &str,
+    request: &SendCoreInputRequest,
+    sender_name: Option<String>,
+) -> QueueMessageMetadata {
+    let sender_session_id = optional_trimmed(request.sender_session_id.as_deref());
+    let notify_on_stop = request.notify_on_stop
+        && sender_session_id.as_deref().is_some_and(|sender_id| {
+            sender_id != target_session_id
+                && raw_session_is_em(state, sender_id)
+                && raw_session_provider(state, target_session_id).as_deref() != Some("codex-fork")
+        });
+    QueueMessageMetadata {
+        sender_session_id,
+        sender_name,
+        from_sm_send: request.from_sm_send,
+        timeout_seconds: request.timeout_seconds,
+        notify_on_delivery: request.notify_on_delivery,
+        notify_after_seconds: request.notify_after_seconds,
+        notify_on_stop,
+        remind_soft_threshold: request.remind_soft_threshold,
+        remind_hard_threshold: request.remind_hard_threshold,
+        remind_cancel_on_reply_session_id: request.remind_cancel_on_reply_session_id.clone(),
+        parent_session_id: request.parent_session_id.clone(),
+        message_category: None,
+        response_relay_source: None,
+    }
+}
+
+fn raw_session_display_name(session: &Map<String, Value>, fallback_id: &str) -> String {
+    json_text(session.get("friendly_name"))
+        .or_else(|| json_text(session.get("name")))
+        .unwrap_or_else(|| fallback_id.to_owned())
+}
+
+fn raw_session_is_em(state: &Value, session_id: &str) -> bool {
+    raw_session_object(state, session_id)
+        .and_then(|session| session.get("is_em"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn raw_session_provider(state: &Value, session_id: &str) -> Option<String> {
+    raw_session_object(state, session_id).and_then(|session| json_text(session.get("provider")))
+}
+
+fn raw_session_object<'a>(state: &'a Value, session_id: &str) -> Option<&'a Map<String, Value>> {
+    let sessions = state.get("sessions").and_then(Value::as_array)?;
+    session_object(sessions, session_id)
+}
+
+fn short_session_id(session_id: &str) -> String {
+    session_id.chars().take(8).collect()
 }
 
 fn runtime_session_status_raw(state: &mut Value, session_id: &str) -> Result<Option<String>> {

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -2614,6 +2614,81 @@ async fn runtime_core_priority_sends_bypass_sequential_queue_backlog() {
 }
 
 #[tokio::test]
+async fn runtime_core_replays_retained_urgent_rows_with_interrupt_semantics() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let queue_db_path = queue_db_path_for_state_file(&state_file);
+    let log_dir = unique_temp_path();
+    let working_dir = unique_temp_path();
+    fs::create_dir_all(&working_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-test-retained-urgent-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app(&state_file, &log_dir, &tmux_socket);
+
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimeurgentreplay",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude",
+            "initial_message": "urgent replay initial"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    wait_for_output_contains(
+        app.clone(),
+        "runtimeurgentreplay",
+        "runtime:urgent replay initial",
+    )
+    .await;
+
+    let queue = RetainedQueueStore::new(queue_db_path.clone());
+    let urgent_id = queue
+        .enqueue_message(
+            "runtimeurgentreplay",
+            "retained urgent replay",
+            "urgent",
+            None,
+        )
+        .unwrap();
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/runtimeurgentreplay/input",
+        json!({
+            "text": "sequential trigger after retained urgent",
+            "delivery_mode": "sequential"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["delivered"], true);
+    let payload = wait_for_output_contains(
+        app.clone(),
+        "runtimeurgentreplay",
+        "sequential trigger after retained urgent",
+    )
+    .await;
+    let output = payload["output"].as_str().unwrap_or_default();
+    assert!(
+        output.contains("runtime:\u{2}\u{1b}retained urgent replay"),
+        "retained urgent row was not replayed through the interrupt path: {output:?}",
+    );
+    assert!(queue.message_delivered(&urgent_id).unwrap());
+}
+
+#[tokio::test]
 async fn runtime_core_handoff_records_without_interrupting_active_turn() {
     if !tmux_available() {
         return;

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -2576,12 +2576,7 @@ async fn runtime_core_priority_sends_bypass_sequential_queue_backlog() {
     .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["delivered"], true);
-    wait_for_output_contains(
-        app.clone(),
-        "runtimepriority",
-        "runtime:urgent priority message",
-    )
-    .await;
+    wait_for_output_contains(app.clone(), "runtimepriority", "urgent priority message").await;
 
     let queue_conn = Connection::open(&queue_db_path).unwrap();
     let delivered_priority_count: i64 = queue_conn

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -3154,6 +3154,52 @@ async fn runtime_core_marks_missing_tmux_stopped_on_send_and_retire() {
 }
 
 #[tokio::test]
+async fn runtime_core_does_not_queue_sends_to_already_stopped_sessions() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    fs::write(
+        &state_file,
+        json!({
+            "sessions": [
+                {
+                    "id": "runtimestopped",
+                    "name": "runtime-stopped",
+                    "working_dir": "/repo",
+                    "tmux_session": "claude-runtimestopped",
+                    "node": "primary",
+                    "provider": "claude",
+                    "log_file": "/tmp/runtimestopped.log",
+                    "status": "stopped",
+                    "created_at": "2026-06-01T00:00:00",
+                    "last_activity": "2026-06-01T00:01:00",
+                    "stopped_at": "2026-06-01T00:02:00"
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let log_dir = unique_temp_path();
+    let app = runtime_app(&state_file, &log_dir, "sm-rust-test-stopped-send");
+
+    let (status, payload) = post_json(
+        app,
+        "/sessions/runtimestopped/input",
+        json!({
+            "text": "do not retain for stopped session",
+            "delivery_mode": "sequential"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["delivered"], false);
+    assert_eq!(payload["status"], "stopped");
+    assert!(!queue_db_path_for_state_file(&state_file).exists());
+}
+
+#[tokio::test]
 async fn runtime_core_rejects_unsupported_provider() {
     if !tmux_available() {
         return;

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -2313,6 +2313,7 @@ async fn runtime_core_lifecycle_uses_tmux_backend_when_enabled() {
         return;
     }
     let state_file = unique_temp_path();
+    let queue_db_path = queue_db_path_for_state_file(&state_file);
     let log_dir = unique_temp_path();
     let working_dir = unique_temp_path();
     fs::create_dir_all(&working_dir).unwrap();
@@ -2328,6 +2329,11 @@ async fn runtime_core_lifecycle_uses_tmux_backend_when_enabled() {
     let app = router(AppState::new(AppConfig {
         paths: PathsConfig {
             state_file: state_file.display().to_string(),
+        },
+        sm_send: SmSendConfig {
+            db_path: queue_db_path_for_state_file(&state_file)
+                .display()
+                .to_string(),
         },
         rust_core: RustCoreConfig {
             runtime_enabled: true,
@@ -2389,6 +2395,15 @@ async fn runtime_core_lifecycle_uses_tmux_backend_when_enabled() {
     assert_eq!(payload["delivered"], true);
 
     wait_for_output_contains(app.clone(), "runtimecore", "runtime:second runtime message").await;
+    let queue_conn = Connection::open(&queue_db_path).unwrap();
+    let delivered_at: Option<String> = queue_conn
+        .query_row(
+            "SELECT delivered_at FROM message_queue WHERE target_session_id = 'runtimecore' AND text = 'second runtime message'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert!(delivered_at.is_some());
 
     let long_runtime_message = format!("{}chunked-runtime-tail", "x".repeat(500));
     let (status, payload) = post_json(
@@ -2944,6 +2959,15 @@ async fn runtime_core_marks_missing_tmux_stopped_on_send_and_retire() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["delivered"], false);
     assert_eq!(payload["status"], "stopped");
+    let queue_conn = Connection::open(queue_db_path_for_state_file(&state_file)).unwrap();
+    let pending: (String, Option<String>) = queue_conn
+        .query_row(
+            "SELECT text, delivered_at FROM message_queue WHERE target_session_id = 'runtimemissingsend'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(pending, ("after external kill".to_owned(), None));
 
     let (status, payload) = get_json(app.clone(), "/sessions/runtimemissingsend").await;
     assert_eq!(status, StatusCode::OK);
@@ -3172,6 +3196,11 @@ async fn runtime_core_fails_create_when_stdin_prompt_cannot_be_delivered() {
     let app = router(AppState::new(AppConfig {
         paths: PathsConfig {
             state_file: state_file.display().to_string(),
+        },
+        sm_send: SmSendConfig {
+            db_path: queue_db_path_for_state_file(&state_file)
+                .display()
+                .to_string(),
         },
         rust_core: RustCoreConfig {
             runtime_enabled: true,
@@ -3708,6 +3737,11 @@ fn runtime_app_with_command(
     router(AppState::new(AppConfig {
         paths: PathsConfig {
             state_file: state_file.display().to_string(),
+        },
+        sm_send: SmSendConfig {
+            db_path: queue_db_path_for_state_file(state_file)
+                .display()
+                .to_string(),
         },
         rust_core: RustCoreConfig {
             runtime_enabled: true,

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -3166,26 +3166,124 @@ async fn runtime_core_marks_missing_tmux_stopped_on_send_and_retire() {
     .await;
     assert_eq!(status, StatusCode::OK);
     let tmux_session = payload["tmux_session"].as_str().unwrap().to_owned();
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimesender",
+            "name": "runtime-sender",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude",
+            "initial_message": "sender initial"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let mut raw_state: Value =
+        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let sender = raw_state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "runtimesender")
+        .unwrap();
+    sender["is_em"] = Value::Bool(true);
+    fs::write(
+        &state_file,
+        serde_json::to_string_pretty(&raw_state).unwrap(),
+    )
+    .unwrap();
     assert!(tmux_kill_session(&tmux_socket, &tmux_session));
 
     let (status, payload) = post_json(
         app.clone(),
         "/sessions/runtimemissingsend/input",
-        json!({ "text": "after external kill" }),
+        json!({
+            "text": "after external kill",
+            "sender_session_id": "runtimesender",
+            "delivery_mode": "sequential",
+            "from_sm_send": true,
+            "timeout_seconds": 60,
+            "notify_on_delivery": true,
+            "notify_after_seconds": 7,
+            "notify_on_stop": true,
+            "remind_soft_threshold": 11,
+            "remind_hard_threshold": 17,
+            "remind_cancel_on_reply_session_id": "runtimesender",
+            "parent_session_id": "runtimeparent"
+        }),
     )
     .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["delivered"], false);
     assert_eq!(payload["status"], "stopped");
     let queue_conn = Connection::open(queue_db_path_for_state_file(&state_file)).unwrap();
-    let pending: (String, Option<String>) = queue_conn
+    let pending: (
+        String,
+        Option<String>,
+        Option<String>,
+        i64,
+        Option<String>,
+        i64,
+        i64,
+        i64,
+        Option<i64>,
+        Option<i64>,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+    ) = queue_conn
         .query_row(
-            "SELECT text, delivered_at FROM message_queue WHERE target_session_id = 'runtimemissingsend'",
+            r#"
+            SELECT text, sender_session_id, sender_name, from_sm_send, timeout_at,
+                   notify_on_delivery, notify_after_seconds, notify_on_stop,
+                   remind_soft_threshold, remind_hard_threshold,
+                   remind_cancel_on_reply_session_id, parent_session_id,
+                   response_relay_source, delivered_at
+            FROM message_queue
+            WHERE target_session_id = 'runtimemissingsend'
+            "#,
             [],
-            |row| Ok((row.get(0)?, row.get(1)?)),
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                    row.get(6)?,
+                    row.get(7)?,
+                    row.get(8)?,
+                    row.get(9)?,
+                    row.get(10)?,
+                    row.get(11)?,
+                    row.get(12)?,
+                    row.get(13)?,
+                ))
+            },
         )
         .unwrap();
-    assert_eq!(pending, ("after external kill".to_owned(), None));
+    let timeout_at = pending.4.clone();
+    assert!(timeout_at.is_some());
+    assert_eq!(
+        pending.0,
+        "[Input from: runtime-sender (runtimes) via sm send]\nafter external kill"
+    );
+    assert_eq!(pending.1.as_deref(), Some("runtimesender"));
+    assert_eq!(pending.2.as_deref(), Some("runtime-sender"));
+    assert_eq!(pending.3, 1);
+    assert_eq!(pending.4, timeout_at);
+    assert_eq!(pending.5, 1);
+    assert_eq!(pending.6, 7);
+    assert_eq!(pending.7, 1);
+    assert_eq!(pending.8, Some(11));
+    assert_eq!(pending.9, Some(17));
+    assert_eq!(pending.10.as_deref(), Some("runtimesender"));
+    assert_eq!(pending.11.as_deref(), Some("runtimeparent"));
+    assert_eq!(pending.12.as_deref(), Some("sm-send"));
+    assert_eq!(pending.13, None);
 
     let (status, payload) = get_json(app.clone(), "/sessions/runtimemissingsend").await;
     assert_eq!(status, StatusCode::OK);

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -14,6 +14,7 @@ use serde_json::{json, Value};
 use sha1::{Digest, Sha1};
 use sha2::Sha256;
 use sm_server::config::RustShadowConfig;
+use sm_server::queue::RetainedQueueStore;
 use sm_server::{
     config::{
         AppConfig, ExternalAccessConfig, GoogleAuthConfig, PathsConfig, RustCoreConfig,
@@ -2468,6 +2469,120 @@ async fn runtime_core_lifecycle_uses_tmux_backend_when_enabled() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["delivered"], true);
     wait_for_output_contains(app, "runtimecore", "runtime:restored runtime message").await;
+}
+
+#[tokio::test]
+async fn runtime_core_priority_sends_bypass_sequential_queue_backlog() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let queue_db_path = queue_db_path_for_state_file(&state_file);
+    let log_dir = unique_temp_path();
+    let working_dir = unique_temp_path();
+    fs::create_dir_all(&working_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-test-priority-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app(&state_file, &log_dir, &tmux_socket);
+
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimepriority",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude",
+            "initial_message": "priority initial"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    wait_for_output_contains(app.clone(), "runtimepriority", "runtime:priority initial").await;
+
+    let queue = RetainedQueueStore::new(queue_db_path.clone());
+    for index in 0..12 {
+        queue
+            .enqueue_message(
+                "runtimepriority",
+                &format!("stale sequential backlog {index}"),
+                "sequential",
+                None,
+            )
+            .unwrap();
+    }
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/runtimepriority/input",
+        json!({
+            "text": "important priority message",
+            "delivery_mode": "important"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["delivered"], true);
+    wait_for_output_contains(
+        app.clone(),
+        "runtimepriority",
+        "runtime:important priority message",
+    )
+    .await;
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/runtimepriority/input",
+        json!({
+            "text": "urgent priority message",
+            "delivery_mode": "urgent"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["delivered"], true);
+    wait_for_output_contains(
+        app.clone(),
+        "runtimepriority",
+        "runtime:urgent priority message",
+    )
+    .await;
+
+    let queue_conn = Connection::open(&queue_db_path).unwrap();
+    let delivered_priority_count: i64 = queue_conn
+        .query_row(
+            r#"
+            SELECT COUNT(*)
+            FROM message_queue
+            WHERE target_session_id = 'runtimepriority'
+                AND text IN ('important priority message', 'urgent priority message')
+                AND delivered_at IS NOT NULL
+            "#,
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(delivered_priority_count, 2);
+    let delivered_backlog_count: i64 = queue_conn
+        .query_row(
+            r#"
+            SELECT COUNT(*)
+            FROM message_queue
+            WHERE target_session_id = 'runtimepriority'
+                AND text LIKE 'stale sequential backlog%'
+                AND delivered_at IS NOT NULL
+            "#,
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(delivered_backlog_count, 0);
 }
 
 #[tokio::test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -2472,7 +2472,7 @@ async fn runtime_core_lifecycle_uses_tmux_backend_when_enabled() {
 }
 
 #[tokio::test]
-async fn runtime_core_keeps_side_effect_queue_rows_pending() {
+async fn runtime_core_delivers_sm_send_metadata_rows() {
     if !tmux_available() {
         return;
     }
@@ -2496,10 +2496,10 @@ async fn runtime_core_keeps_side_effect_queue_rows_pending() {
         app.clone(),
         "/sessions",
         json!({
-            "id": "runtimesideeffects",
+            "id": "runtimesmsend",
             "working_dir": working_dir.display().to_string(),
             "provider": "claude",
-            "initial_message": "side effect initial"
+            "initial_message": "sm send initial"
         }),
     )
     .await;
@@ -2531,35 +2531,29 @@ async fn runtime_core_keeps_side_effect_queue_rows_pending() {
         serde_json::to_string_pretty(&raw_state).unwrap(),
     )
     .unwrap();
-    wait_for_output_contains(
-        app.clone(),
-        "runtimesideeffects",
-        "runtime:side effect initial",
-    )
-    .await;
+    wait_for_output_contains(app.clone(), "runtimesmsend", "runtime:sm send initial").await;
 
     let (status, payload) = post_json(
         app.clone(),
-        "/sessions/runtimesideeffects/input",
+        "/sessions/runtimesmsend/input",
         json!({
-            "text": "side effect delivery should wait",
+            "text": "ordinary sm send metadata delivered",
             "sender_session_id": "runtimesender",
             "delivery_mode": "sequential",
             "from_sm_send": true,
-            "timeout_seconds": 60,
-            "notify_on_delivery": true,
-            "notify_after_seconds": 5,
-            "notify_on_stop": true,
-            "remind_soft_threshold": 11,
-            "remind_hard_threshold": 17,
-            "remind_cancel_on_reply_session_id": "runtimesender",
-            "parent_session_id": "runtimeparent"
+            "timeout_seconds": 60
         }),
     )
     .await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(payload["delivered"], false);
+    assert_eq!(payload["delivered"], true);
     assert_eq!(payload["status"], "running");
+    wait_for_output_contains(
+        app.clone(),
+        "runtimesmsend",
+        "runtime:ordinary sm send metadata delivered",
+    )
+    .await;
 
     let queue_conn = Connection::open(&queue_db_path).unwrap();
     let pending: (
@@ -2569,7 +2563,7 @@ async fn runtime_core_keeps_side_effect_queue_rows_pending() {
         i64,
         Option<String>,
         i64,
-        i64,
+        Option<i64>,
         i64,
         Option<i64>,
         Option<i64>,
@@ -2586,7 +2580,7 @@ async fn runtime_core_keeps_side_effect_queue_rows_pending() {
                    remind_cancel_on_reply_session_id, parent_session_id,
                    response_relay_source, delivered_at
             FROM message_queue
-            WHERE target_session_id = 'runtimesideeffects'
+            WHERE target_session_id = 'runtimesmsend'
             "#,
             [],
             |row| {
@@ -2613,21 +2607,87 @@ async fn runtime_core_keeps_side_effect_queue_rows_pending() {
     assert!(timeout_at.is_some());
     assert_eq!(
         pending.0,
-        "[Input from: runtime-sender (runtimes) via sm send]\nside effect delivery should wait"
+        "[Input from: runtime-sender (runtimes) via sm send]\nordinary sm send metadata delivered"
     );
     assert_eq!(pending.1.as_deref(), Some("runtimesender"));
     assert_eq!(pending.2.as_deref(), Some("runtime-sender"));
     assert_eq!(pending.3, 1);
     assert_eq!(pending.4, timeout_at);
-    assert_eq!(pending.5, 1);
-    assert_eq!(pending.6, 5);
-    assert_eq!(pending.7, 1);
-    assert_eq!(pending.8, Some(11));
-    assert_eq!(pending.9, Some(17));
-    assert_eq!(pending.10.as_deref(), Some("runtimesender"));
-    assert_eq!(pending.11.as_deref(), Some("runtimeparent"));
+    assert_eq!(pending.5, 0);
+    assert_eq!(pending.6, None);
+    assert_eq!(pending.7, 0);
+    assert_eq!(pending.8, None);
+    assert_eq!(pending.9, None);
+    assert_eq!(pending.10, None);
+    assert_eq!(pending.11, None);
     assert_eq!(pending.12.as_deref(), Some("sm-send"));
-    assert_eq!(pending.13, None);
+    assert!(pending.13.is_some());
+}
+
+#[tokio::test]
+async fn runtime_core_rejects_unimplemented_send_side_effect_options() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let queue_db_path = queue_db_path_for_state_file(&state_file);
+    let log_dir = unique_temp_path();
+    let working_dir = unique_temp_path();
+    fs::create_dir_all(&working_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-test-side-effects-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app(&state_file, &log_dir, &tmux_socket);
+
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimesideeffects",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude",
+            "initial_message": "side effect initial"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    wait_for_output_contains(
+        app.clone(),
+        "runtimesideeffects",
+        "runtime:side effect initial",
+    )
+    .await;
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/runtimesideeffects/input",
+        json!({
+            "text": "side effect delivery should be rejected",
+            "delivery_mode": "sequential",
+            "notify_on_delivery": true
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_IMPLEMENTED);
+    assert_eq!(
+        payload["detail"],
+        "Rust runtime send delivery side effects are not implemented"
+    );
+
+    RetainedQueueStore::new(queue_db_path.clone())
+        .ensure_schema()
+        .unwrap();
+    let queue_conn = Connection::open(&queue_db_path).unwrap();
+    let row_count: i64 = queue_conn
+        .query_row("SELECT COUNT(*) FROM message_queue", [], |row| row.get(0))
+        .unwrap();
+    assert_eq!(row_count, 0);
 
     let (status, output) =
         get_json(app.clone(), "/sessions/runtimesideeffects/output?lines=20").await;
@@ -2635,7 +2695,7 @@ async fn runtime_core_keeps_side_effect_queue_rows_pending() {
     assert!(!output["output"]
         .as_str()
         .unwrap_or_default()
-        .contains("side effect delivery should wait"));
+        .contains("side effect delivery should be rejected"));
 }
 
 #[tokio::test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -2472,6 +2472,173 @@ async fn runtime_core_lifecycle_uses_tmux_backend_when_enabled() {
 }
 
 #[tokio::test]
+async fn runtime_core_keeps_side_effect_queue_rows_pending() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let queue_db_path = queue_db_path_for_state_file(&state_file);
+    let log_dir = unique_temp_path();
+    let working_dir = unique_temp_path();
+    fs::create_dir_all(&working_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-test-side-effects-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app(&state_file, &log_dir, &tmux_socket);
+
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimesideeffects",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude",
+            "initial_message": "side effect initial"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimesender",
+            "name": "runtime-sender",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude",
+            "initial_message": "sender initial"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let mut raw_state: Value =
+        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let sender = raw_state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "runtimesender")
+        .unwrap();
+    sender["is_em"] = Value::Bool(true);
+    fs::write(
+        &state_file,
+        serde_json::to_string_pretty(&raw_state).unwrap(),
+    )
+    .unwrap();
+    wait_for_output_contains(
+        app.clone(),
+        "runtimesideeffects",
+        "runtime:side effect initial",
+    )
+    .await;
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/runtimesideeffects/input",
+        json!({
+            "text": "side effect delivery should wait",
+            "sender_session_id": "runtimesender",
+            "delivery_mode": "sequential",
+            "from_sm_send": true,
+            "timeout_seconds": 60,
+            "notify_on_delivery": true,
+            "notify_after_seconds": 5,
+            "notify_on_stop": true,
+            "remind_soft_threshold": 11,
+            "remind_hard_threshold": 17,
+            "remind_cancel_on_reply_session_id": "runtimesender",
+            "parent_session_id": "runtimeparent"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["delivered"], false);
+    assert_eq!(payload["status"], "running");
+
+    let queue_conn = Connection::open(&queue_db_path).unwrap();
+    let pending: (
+        String,
+        Option<String>,
+        Option<String>,
+        i64,
+        Option<String>,
+        i64,
+        i64,
+        i64,
+        Option<i64>,
+        Option<i64>,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+        Option<String>,
+    ) = queue_conn
+        .query_row(
+            r#"
+            SELECT text, sender_session_id, sender_name, from_sm_send, timeout_at,
+                   notify_on_delivery, notify_after_seconds, notify_on_stop,
+                   remind_soft_threshold, remind_hard_threshold,
+                   remind_cancel_on_reply_session_id, parent_session_id,
+                   response_relay_source, delivered_at
+            FROM message_queue
+            WHERE target_session_id = 'runtimesideeffects'
+            "#,
+            [],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                    row.get(6)?,
+                    row.get(7)?,
+                    row.get(8)?,
+                    row.get(9)?,
+                    row.get(10)?,
+                    row.get(11)?,
+                    row.get(12)?,
+                    row.get(13)?,
+                ))
+            },
+        )
+        .unwrap();
+    let timeout_at = pending.4.clone();
+    assert!(timeout_at.is_some());
+    assert_eq!(
+        pending.0,
+        "[Input from: runtime-sender (runtimes) via sm send]\nside effect delivery should wait"
+    );
+    assert_eq!(pending.1.as_deref(), Some("runtimesender"));
+    assert_eq!(pending.2.as_deref(), Some("runtime-sender"));
+    assert_eq!(pending.3, 1);
+    assert_eq!(pending.4, timeout_at);
+    assert_eq!(pending.5, 1);
+    assert_eq!(pending.6, 5);
+    assert_eq!(pending.7, 1);
+    assert_eq!(pending.8, Some(11));
+    assert_eq!(pending.9, Some(17));
+    assert_eq!(pending.10.as_deref(), Some("runtimesender"));
+    assert_eq!(pending.11.as_deref(), Some("runtimeparent"));
+    assert_eq!(pending.12.as_deref(), Some("sm-send"));
+    assert_eq!(pending.13, None);
+
+    let (status, output) =
+        get_json(app.clone(), "/sessions/runtimesideeffects/output?lines=20").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(!output["output"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("side effect delivery should wait"));
+}
+
+#[tokio::test]
 async fn runtime_core_priority_sends_bypass_sequential_queue_backlog() {
     if !tmux_available() {
         return;
@@ -3166,33 +3333,6 @@ async fn runtime_core_marks_missing_tmux_stopped_on_send_and_retire() {
     .await;
     assert_eq!(status, StatusCode::OK);
     let tmux_session = payload["tmux_session"].as_str().unwrap().to_owned();
-    let (status, _payload) = post_json(
-        app.clone(),
-        "/sessions",
-        json!({
-            "id": "runtimesender",
-            "name": "runtime-sender",
-            "working_dir": working_dir.display().to_string(),
-            "provider": "claude",
-            "initial_message": "sender initial"
-        }),
-    )
-    .await;
-    assert_eq!(status, StatusCode::OK);
-    let mut raw_state: Value =
-        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
-    let sender = raw_state["sessions"]
-        .as_array_mut()
-        .unwrap()
-        .iter_mut()
-        .find(|session| session["id"] == "runtimesender")
-        .unwrap();
-    sender["is_em"] = Value::Bool(true);
-    fs::write(
-        &state_file,
-        serde_json::to_string_pretty(&raw_state).unwrap(),
-    )
-    .unwrap();
     assert!(tmux_kill_session(&tmux_socket, &tmux_session));
 
     let (status, payload) = post_json(
@@ -3200,17 +3340,7 @@ async fn runtime_core_marks_missing_tmux_stopped_on_send_and_retire() {
         "/sessions/runtimemissingsend/input",
         json!({
             "text": "after external kill",
-            "sender_session_id": "runtimesender",
-            "delivery_mode": "sequential",
-            "from_sm_send": true,
-            "timeout_seconds": 60,
-            "notify_on_delivery": true,
-            "notify_after_seconds": 7,
-            "notify_on_stop": true,
-            "remind_soft_threshold": 11,
-            "remind_hard_threshold": 17,
-            "remind_cancel_on_reply_session_id": "runtimesender",
-            "parent_session_id": "runtimeparent"
+            "delivery_mode": "sequential"
         }),
     )
     .await;
@@ -3218,72 +3348,18 @@ async fn runtime_core_marks_missing_tmux_stopped_on_send_and_retire() {
     assert_eq!(payload["delivered"], false);
     assert_eq!(payload["status"], "stopped");
     let queue_conn = Connection::open(queue_db_path_for_state_file(&state_file)).unwrap();
-    let pending: (
-        String,
-        Option<String>,
-        Option<String>,
-        i64,
-        Option<String>,
-        i64,
-        i64,
-        i64,
-        Option<i64>,
-        Option<i64>,
-        Option<String>,
-        Option<String>,
-        Option<String>,
-        Option<String>,
-    ) = queue_conn
+    let pending: (String, Option<String>) = queue_conn
         .query_row(
             r#"
-            SELECT text, sender_session_id, sender_name, from_sm_send, timeout_at,
-                   notify_on_delivery, notify_after_seconds, notify_on_stop,
-                   remind_soft_threshold, remind_hard_threshold,
-                   remind_cancel_on_reply_session_id, parent_session_id,
-                   response_relay_source, delivered_at
+            SELECT text, delivered_at
             FROM message_queue
             WHERE target_session_id = 'runtimemissingsend'
             "#,
             [],
-            |row| {
-                Ok((
-                    row.get(0)?,
-                    row.get(1)?,
-                    row.get(2)?,
-                    row.get(3)?,
-                    row.get(4)?,
-                    row.get(5)?,
-                    row.get(6)?,
-                    row.get(7)?,
-                    row.get(8)?,
-                    row.get(9)?,
-                    row.get(10)?,
-                    row.get(11)?,
-                    row.get(12)?,
-                    row.get(13)?,
-                ))
-            },
+            |row| Ok((row.get(0)?, row.get(1)?)),
         )
         .unwrap();
-    let timeout_at = pending.4.clone();
-    assert!(timeout_at.is_some());
-    assert_eq!(
-        pending.0,
-        "[Input from: runtime-sender (runtimes) via sm send]\nafter external kill"
-    );
-    assert_eq!(pending.1.as_deref(), Some("runtimesender"));
-    assert_eq!(pending.2.as_deref(), Some("runtime-sender"));
-    assert_eq!(pending.3, 1);
-    assert_eq!(pending.4, timeout_at);
-    assert_eq!(pending.5, 1);
-    assert_eq!(pending.6, 7);
-    assert_eq!(pending.7, 1);
-    assert_eq!(pending.8, Some(11));
-    assert_eq!(pending.9, Some(17));
-    assert_eq!(pending.10.as_deref(), Some("runtimesender"));
-    assert_eq!(pending.11.as_deref(), Some("runtimeparent"));
-    assert_eq!(pending.12.as_deref(), Some("sm-send"));
-    assert_eq!(pending.13, None);
+    assert_eq!(pending, ("after external kill".to_owned(), None));
 
     let (status, payload) = get_json(app.clone(), "/sessions/runtimemissingsend").await;
     assert_eq!(status, StatusCode::OK);

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -2517,20 +2517,6 @@ async fn runtime_core_delivers_sm_send_metadata_rows() {
     )
     .await;
     assert_eq!(status, StatusCode::OK);
-    let mut raw_state: Value =
-        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
-    let sender = raw_state["sessions"]
-        .as_array_mut()
-        .unwrap()
-        .iter_mut()
-        .find(|session| session["id"] == "runtimesender")
-        .unwrap();
-    sender["is_em"] = Value::Bool(true);
-    fs::write(
-        &state_file,
-        serde_json::to_string_pretty(&raw_state).unwrap(),
-    )
-    .unwrap();
     wait_for_output_contains(app.clone(), "runtimesmsend", "runtime:sm send initial").await;
 
     let (status, payload) = post_json(
@@ -2541,7 +2527,8 @@ async fn runtime_core_delivers_sm_send_metadata_rows() {
             "sender_session_id": "runtimesender",
             "delivery_mode": "sequential",
             "from_sm_send": true,
-            "timeout_seconds": 60
+            "timeout_seconds": 60,
+            "notify_on_stop": true
         }),
     )
     .await;

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -2522,6 +2522,35 @@ async fn runtime_core_priority_sends_bypass_sequential_queue_backlog() {
         app.clone(),
         "/sessions/runtimepriority/input",
         json!({
+            "text": "sequential after large backlog",
+            "delivery_mode": "sequential"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["delivered"], true);
+    wait_for_output_contains(
+        app.clone(),
+        "runtimepriority",
+        "runtime:sequential after large backlog",
+    )
+    .await;
+
+    for index in 0..12 {
+        queue
+            .enqueue_message(
+                "runtimepriority",
+                &format!("second stale sequential backlog {index}"),
+                "sequential",
+                None,
+            )
+            .unwrap();
+    }
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/runtimepriority/input",
+        json!({
             "text": "important priority message",
             "delivery_mode": "important"
         }),
@@ -2561,21 +2590,25 @@ async fn runtime_core_priority_sends_bypass_sequential_queue_backlog() {
             SELECT COUNT(*)
             FROM message_queue
             WHERE target_session_id = 'runtimepriority'
-                AND text IN ('important priority message', 'urgent priority message')
+                AND text IN (
+                    'sequential after large backlog',
+                    'important priority message',
+                    'urgent priority message'
+                )
                 AND delivered_at IS NOT NULL
             "#,
             [],
             |row| row.get(0),
         )
         .unwrap();
-    assert_eq!(delivered_priority_count, 2);
+    assert_eq!(delivered_priority_count, 3);
     let delivered_backlog_count: i64 = queue_conn
         .query_row(
             r#"
             SELECT COUNT(*)
             FROM message_queue
             WHERE target_session_id = 'runtimepriority'
-                AND text LIKE 'stale sequential backlog%'
+                AND text LIKE 'second stale sequential backlog%'
                 AND delivered_at IS NOT NULL
             "#,
             [],


### PR DESCRIPTION
Fixes #807

## Summary
- add pending-message reads and delivered marking to the Rust retained queue store
- persist Rust runtime sequential/important/urgent sends before injection, then drain pending rows for that target in queue order
- mark queue rows delivered only after tmux input delivery succeeds; missing tmux leaves the new row pending and marks the session stopped
- keep runtime tests isolated with explicit temp `sm_send.db_path` values

## Verification
- `cargo fmt --manifest-path crates/sm-server/Cargo.toml --check`
- `cargo test --manifest-path crates/sm-server/Cargo.toml`
- `cargo check --manifest-path crates/sm-server/Cargo.toml --bin sm-server --bin sm`
- `git diff --check`