### PR TITLE
Materialize Rust queue delivery side effects

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -614,16 +614,6 @@ async fn send_session_input(
     }
     let result = if state.config.rust_core.runtime_enabled {
         ensure_core_runtime_session_node_supported(&state, &session_id)?;
-        if state
-            .session_store
-            .runtime_send_delivery_side_effects_requested(&session_id, &payload)?
-            .unwrap_or(false)
-        {
-            return Err(ApiError::Status {
-                status: StatusCode::NOT_IMPLEMENTED,
-                detail: "Rust runtime send delivery side effects are not implemented".to_owned(),
-            });
-        }
         let runtime = TmuxRuntime::from_config(&state.config.rust_core);
         state
             .session_store

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -19,6 +19,18 @@ pub struct PendingMessage {
     pub text: String,
     pub delivery_mode: String,
     pub has_delivery_side_effects: bool,
+    pub sender_session_id: Option<String>,
+    pub sender_name: Option<String>,
+    pub from_sm_send: bool,
+    pub notify_on_delivery: bool,
+    pub notify_after_seconds: Option<u64>,
+    pub notify_on_stop: bool,
+    pub remind_soft_threshold: Option<u64>,
+    pub remind_hard_threshold: Option<u64>,
+    pub remind_cancel_on_reply_session_id: Option<String>,
+    pub parent_session_id: Option<String>,
+    pub message_category: Option<String>,
+    pub response_relay_source: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -95,44 +107,13 @@ impl RetainedQueueStore {
         metadata: QueueMessageMetadata,
     ) -> Result<String> {
         self.with_connection(|conn| {
-            let id = generate_record_id("msg");
-            let timeout_at = timeout_at_rfc3339(metadata.timeout_seconds)?;
-            let response_relay_source = metadata
-                .response_relay_source
-                .or_else(|| metadata.from_sm_send.then(|| "sm-send".to_owned()));
-            conn.execute(
-                r#"
-                INSERT INTO message_queue
-                    (id, target_session_id, sender_session_id, sender_name, text,
-                     delivery_mode, from_sm_send, queued_at, timeout_at, notify_on_delivery,
-                     notify_after_seconds, notify_on_stop, remind_soft_threshold,
-                     remind_hard_threshold, remind_cancel_on_reply_session_id, parent_session_id,
-                     message_category, response_relay_source)
-                VALUES
-                    (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)
-                "#,
-                params![
-                    id,
-                    target_session_id,
-                    metadata.sender_session_id,
-                    metadata.sender_name,
-                    text,
-                    delivery_mode,
-                    metadata.from_sm_send,
-                    now_rfc3339(),
-                    timeout_at,
-                    metadata.notify_on_delivery,
-                    metadata.notify_after_seconds.map(u64_to_i64).transpose()?,
-                    metadata.notify_on_stop,
-                    metadata.remind_soft_threshold.map(u64_to_i64).transpose()?,
-                    metadata.remind_hard_threshold.map(u64_to_i64).transpose()?,
-                    metadata.remind_cancel_on_reply_session_id,
-                    metadata.parent_session_id,
-                    metadata.message_category,
-                    response_relay_source,
-                ],
-            )?;
-            Ok(id)
+            enqueue_message_with_metadata_conn(
+                conn,
+                target_session_id,
+                text,
+                delivery_mode,
+                metadata,
+            )
         })
     }
 
@@ -177,7 +158,11 @@ impl RetainedQueueStore {
                             parent_session_id IS NOT NULL
                             AND trim(parent_session_id) != ''
                         )
-                    THEN 1 ELSE 0 END AS has_delivery_side_effects
+                    THEN 1 ELSE 0 END AS has_delivery_side_effects,
+                    sender_session_id, sender_name, from_sm_send, notify_on_delivery,
+                    notify_after_seconds, notify_on_stop, remind_soft_threshold,
+                    remind_hard_threshold, remind_cancel_on_reply_session_id,
+                    parent_session_id, message_category, response_relay_source
                 FROM message_queue
                 WHERE target_session_id = ?1 AND delivered_at IS NULL
                 ORDER BY queued_at ASC, id ASC
@@ -192,6 +177,18 @@ impl RetainedQueueStore {
                         text: row.get(2)?,
                         delivery_mode: row.get(3)?,
                         has_delivery_side_effects: row.get::<_, i64>(4)? != 0,
+                        sender_session_id: row.get(5)?,
+                        sender_name: row.get(6)?,
+                        from_sm_send: row.get::<_, Option<i64>>(7)?.unwrap_or(0) != 0,
+                        notify_on_delivery: row.get::<_, Option<i64>>(8)?.unwrap_or(0) != 0,
+                        notify_after_seconds: row.get::<_, Option<i64>>(9)?.map(i64_to_u64),
+                        notify_on_stop: row.get::<_, Option<i64>>(10)?.unwrap_or(0) != 0,
+                        remind_soft_threshold: row.get::<_, Option<i64>>(11)?.map(i64_to_u64),
+                        remind_hard_threshold: row.get::<_, Option<i64>>(12)?.map(i64_to_u64),
+                        remind_cancel_on_reply_session_id: row.get(13)?,
+                        parent_session_id: row.get(14)?,
+                        message_category: row.get(15)?,
+                        response_relay_source: row.get(16)?,
                     })
                 })?
                 .collect::<std::result::Result<Vec<_>, _>>()?;
@@ -224,7 +221,11 @@ impl RetainedQueueStore {
                             parent_session_id IS NOT NULL
                             AND trim(parent_session_id) != ''
                         )
-                    THEN 1 ELSE 0 END AS has_delivery_side_effects
+                    THEN 1 ELSE 0 END AS has_delivery_side_effects,
+                    sender_session_id, sender_name, from_sm_send, notify_on_delivery,
+                    notify_after_seconds, notify_on_stop, remind_soft_threshold,
+                    remind_hard_threshold, remind_cancel_on_reply_session_id,
+                    parent_session_id, message_category, response_relay_source
                 FROM message_queue
                 WHERE target_session_id = ?1
                     AND delivery_mode = ?2
@@ -243,6 +244,18 @@ impl RetainedQueueStore {
                             text: row.get(2)?,
                             delivery_mode: row.get(3)?,
                             has_delivery_side_effects: row.get::<_, i64>(4)? != 0,
+                            sender_session_id: row.get(5)?,
+                            sender_name: row.get(6)?,
+                            from_sm_send: row.get::<_, Option<i64>>(7)?.unwrap_or(0) != 0,
+                            notify_on_delivery: row.get::<_, Option<i64>>(8)?.unwrap_or(0) != 0,
+                            notify_after_seconds: row.get::<_, Option<i64>>(9)?.map(i64_to_u64),
+                            notify_on_stop: row.get::<_, Option<i64>>(10)?.unwrap_or(0) != 0,
+                            remind_soft_threshold: row.get::<_, Option<i64>>(11)?.map(i64_to_u64),
+                            remind_hard_threshold: row.get::<_, Option<i64>>(12)?.map(i64_to_u64),
+                            remind_cancel_on_reply_session_id: row.get(13)?,
+                            parent_session_id: row.get(14)?,
+                            message_category: row.get(15)?,
+                            response_relay_source: row.get(16)?,
                         })
                     },
                 )?
@@ -253,15 +266,74 @@ impl RetainedQueueStore {
 
     pub fn mark_delivered(&self, message_id: &str) -> Result<()> {
         self.with_connection(|conn| {
-            conn.execute(
-                r#"
-                UPDATE message_queue
-                SET delivered_at = ?2
-                WHERE id = ?1 AND delivered_at IS NULL
-                "#,
-                params![message_id, now_rfc3339()],
-            )?;
+            let _ = mark_delivered_conn(conn, message_id)?;
             Ok(())
+        })
+    }
+
+    pub fn mark_delivered_and_apply_side_effects(&self, message: &PendingMessage) -> Result<()> {
+        self.with_connection(|conn| {
+            conn.execute_batch("BEGIN IMMEDIATE")?;
+            let result = (|| -> Result<()> {
+                if !mark_delivered_conn(conn, &message.id)? {
+                    return Ok(());
+                }
+                if message.notify_on_delivery {
+                    if let Some(sender_session_id) = message.sender_session_id.as_deref() {
+                        enqueue_message_with_metadata_conn(
+                            conn,
+                            sender_session_id,
+                            &delivery_notification_text(message),
+                            "sequential",
+                            QueueMessageMetadata::default(),
+                        )?;
+                    }
+                }
+                if message.notify_on_stop {
+                    if let Some(sender_session_id) = message.sender_session_id.as_deref() {
+                        upsert_stop_notify_conn(
+                            conn,
+                            &message.target_session_id,
+                            sender_session_id,
+                            message.sender_name.as_deref().unwrap_or(""),
+                            0,
+                        )?;
+                    }
+                }
+                if let Some(soft_threshold) = message.remind_soft_threshold {
+                    let hard_threshold = message
+                        .remind_hard_threshold
+                        .unwrap_or_else(|| soft_threshold.saturating_add(120));
+                    register_remind_conn(
+                        conn,
+                        &message.target_session_id,
+                        soft_threshold,
+                        hard_threshold,
+                        message.remind_cancel_on_reply_session_id.as_deref(),
+                    )?;
+                }
+                if message.remind_soft_threshold.is_some() {
+                    if let Some(parent_session_id) = message.parent_session_id.as_deref() {
+                        register_parent_wake_conn(
+                            conn,
+                            &message.target_session_id,
+                            parent_session_id,
+                            600,
+                        )?;
+                    }
+                }
+                Ok(())
+            })();
+            match result {
+                Ok(()) => {
+                    conn.execute_batch("COMMIT")?;
+                    Ok(())
+                }
+                Err(error) => {
+                    let _ = conn.execute_batch("ROLLBACK");
+                    Err(error)
+                }
+            }
         })
     }
 
@@ -289,30 +361,30 @@ impl RetainedQueueStore {
         period_seconds: i64,
     ) -> Result<String> {
         self.with_connection(|conn| {
-            self.cancel_parent_wake_with_connection(conn, child_session_id)?;
-            let id = generate_record_id("wake");
-            conn.execute(
-                r#"
-                INSERT OR REPLACE INTO parent_wake_registrations
-                    (id, child_session_id, parent_session_id, period_seconds, registered_at,
-                     last_wake_at, last_status_at_prev_wake, escalated, is_active)
-                VALUES
-                    (?1, ?2, ?3, ?4, ?5, NULL, NULL, 0, 1)
-                "#,
-                params![
-                    id,
-                    child_session_id,
-                    parent_session_id,
-                    period_seconds,
-                    now_rfc3339()
-                ],
-            )?;
-            Ok(id)
+            register_parent_wake_conn(conn, child_session_id, parent_session_id, period_seconds)
+        })
+    }
+
+    pub fn register_remind(
+        &self,
+        target_session_id: &str,
+        soft_threshold_seconds: u64,
+        hard_threshold_seconds: u64,
+        cancel_on_reply_session_id: Option<&str>,
+    ) -> Result<String> {
+        self.with_connection(|conn| {
+            register_remind_conn(
+                conn,
+                target_session_id,
+                soft_threshold_seconds,
+                hard_threshold_seconds,
+                cancel_on_reply_session_id,
+            )
         })
     }
 
     pub fn cancel_parent_wake(&self, child_session_id: &str) -> Result<()> {
-        self.with_connection(|conn| self.cancel_parent_wake_with_connection(conn, child_session_id))
+        self.with_connection(|conn| cancel_parent_wake_conn(conn, child_session_id))
     }
 
     pub fn cancel_remind(&self, target_session_id: &str) -> Result<()> {
@@ -337,25 +409,12 @@ impl RetainedQueueStore {
         delay_seconds: i64,
     ) -> Result<()> {
         self.with_connection(|conn| {
-            conn.execute(
-                r#"
-                INSERT INTO rust_stop_notify_states
-                    (session_id, sender_session_id, sender_name, delay_seconds, armed_at)
-                VALUES
-                    (?1, ?2, ?3, ?4, ?5)
-                ON CONFLICT(session_id) DO UPDATE SET
-                    sender_session_id = excluded.sender_session_id,
-                    sender_name = excluded.sender_name,
-                    delay_seconds = excluded.delay_seconds,
-                    armed_at = excluded.armed_at
-                "#,
-                params![
-                    session_id,
-                    sender_session_id,
-                    sender_name,
-                    delay_seconds,
-                    now_rfc3339()
-                ],
+            upsert_stop_notify_conn(
+                conn,
+                session_id,
+                sender_session_id,
+                sender_name,
+                delay_seconds,
             )?;
             Ok(())
         })
@@ -374,21 +433,195 @@ impl RetainedQueueStore {
         init_schema(&conn)?;
         f(&conn)
     }
+}
 
-    fn cancel_parent_wake_with_connection(
-        &self,
-        conn: &Connection,
-        child_session_id: &str,
-    ) -> Result<()> {
-        conn.execute(
-            r#"
-            UPDATE parent_wake_registrations
-            SET is_active = 0
-            WHERE child_session_id = ?1
-                "#,
-            params![child_session_id],
-        )?;
-        Ok(())
+fn enqueue_message_with_metadata_conn(
+    conn: &Connection,
+    target_session_id: &str,
+    text: &str,
+    delivery_mode: &str,
+    metadata: QueueMessageMetadata,
+) -> Result<String> {
+    let id = generate_record_id("msg");
+    let timeout_at = timeout_at_rfc3339(metadata.timeout_seconds)?;
+    let response_relay_source = metadata
+        .response_relay_source
+        .or_else(|| metadata.from_sm_send.then(|| "sm-send".to_owned()));
+    conn.execute(
+        r#"
+        INSERT INTO message_queue
+            (id, target_session_id, sender_session_id, sender_name, text,
+             delivery_mode, from_sm_send, queued_at, timeout_at, notify_on_delivery,
+             notify_after_seconds, notify_on_stop, remind_soft_threshold,
+             remind_hard_threshold, remind_cancel_on_reply_session_id, parent_session_id,
+             message_category, response_relay_source)
+        VALUES
+            (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)
+        "#,
+        params![
+            id,
+            target_session_id,
+            metadata.sender_session_id,
+            metadata.sender_name,
+            text,
+            delivery_mode,
+            metadata.from_sm_send,
+            now_rfc3339(),
+            timeout_at,
+            metadata.notify_on_delivery,
+            metadata.notify_after_seconds.map(u64_to_i64).transpose()?,
+            metadata.notify_on_stop,
+            metadata.remind_soft_threshold.map(u64_to_i64).transpose()?,
+            metadata.remind_hard_threshold.map(u64_to_i64).transpose()?,
+            metadata.remind_cancel_on_reply_session_id,
+            metadata.parent_session_id,
+            metadata.message_category,
+            response_relay_source,
+        ],
+    )?;
+    Ok(id)
+}
+
+fn mark_delivered_conn(conn: &Connection, message_id: &str) -> Result<bool> {
+    let changed = conn.execute(
+        r#"
+        UPDATE message_queue
+        SET delivered_at = ?2
+        WHERE id = ?1 AND delivered_at IS NULL
+        "#,
+        params![message_id, now_rfc3339()],
+    )?;
+    Ok(changed > 0)
+}
+
+fn register_remind_conn(
+    conn: &Connection,
+    target_session_id: &str,
+    soft_threshold_seconds: u64,
+    hard_threshold_seconds: u64,
+    cancel_on_reply_session_id: Option<&str>,
+) -> Result<String> {
+    let id = generate_record_id("remind");
+    let now = now_rfc3339();
+    conn.execute(
+        "UPDATE remind_registrations SET is_active = 0 WHERE target_session_id = ?1",
+        params![target_session_id],
+    )?;
+    conn.execute(
+        r#"
+        INSERT OR REPLACE INTO remind_registrations
+            (id, target_session_id, soft_threshold_seconds, hard_threshold_seconds,
+             registered_at, last_reset_at, cancel_on_reply_session_id, persistent_tracking,
+             tracked_status_nudge_fired, soft_fired, is_active)
+        VALUES (?1, ?2, ?3, ?4, ?5, ?5, ?6, 0, 0, 0, 1)
+        "#,
+        params![
+            id,
+            target_session_id,
+            u64_to_i64(soft_threshold_seconds)?,
+            u64_to_i64(hard_threshold_seconds)?,
+            now,
+            cancel_on_reply_session_id,
+        ],
+    )?;
+    Ok(id)
+}
+
+fn register_parent_wake_conn(
+    conn: &Connection,
+    child_session_id: &str,
+    parent_session_id: &str,
+    period_seconds: i64,
+) -> Result<String> {
+    cancel_parent_wake_conn(conn, child_session_id)?;
+    let id = generate_record_id("wake");
+    conn.execute(
+        r#"
+        INSERT OR REPLACE INTO parent_wake_registrations
+            (id, child_session_id, parent_session_id, period_seconds, registered_at,
+             last_wake_at, last_status_at_prev_wake, escalated, is_active)
+        VALUES
+            (?1, ?2, ?3, ?4, ?5, NULL, NULL, 0, 1)
+        "#,
+        params![
+            id,
+            child_session_id,
+            parent_session_id,
+            period_seconds,
+            now_rfc3339()
+        ],
+    )?;
+    Ok(id)
+}
+
+fn cancel_parent_wake_conn(conn: &Connection, child_session_id: &str) -> Result<()> {
+    conn.execute(
+        r#"
+        UPDATE parent_wake_registrations
+        SET is_active = 0
+        WHERE child_session_id = ?1
+            "#,
+        params![child_session_id],
+    )?;
+    Ok(())
+}
+
+fn upsert_stop_notify_conn(
+    conn: &Connection,
+    session_id: &str,
+    sender_session_id: &str,
+    sender_name: &str,
+    delay_seconds: i64,
+) -> Result<()> {
+    conn.execute(
+        r#"
+        INSERT INTO rust_stop_notify_states
+            (session_id, sender_session_id, sender_name, delay_seconds, armed_at)
+        VALUES
+            (?1, ?2, ?3, ?4, ?5)
+        ON CONFLICT(session_id) DO UPDATE SET
+            sender_session_id = excluded.sender_session_id,
+            sender_name = excluded.sender_name,
+            delay_seconds = excluded.delay_seconds,
+            armed_at = excluded.armed_at
+        "#,
+        params![
+            session_id,
+            sender_session_id,
+            sender_name,
+            delay_seconds,
+            now_rfc3339()
+        ],
+    )?;
+    Ok(())
+}
+
+fn delivery_notification_text(message: &PendingMessage) -> String {
+    let truncated = truncate_chars(&message.text, 100);
+    format!(
+        "[sm] Message delivered to {}\nOriginal: \"{}\"",
+        message.target_session_id, truncated
+    )
+}
+
+pub fn followup_notification_text(message: &PendingMessage) -> Option<String> {
+    let seconds = message.notify_after_seconds?;
+    let truncated = truncate_chars(&message.text, 100);
+    Some(format!(
+        "[sm] Reminder: {seconds}s since your message to {} was delivered\n\
+Original: \"{}\"\n\
+You can check status with: sm output {}",
+        message.target_session_id, truncated, message.target_session_id
+    ))
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    let mut chars = value.chars();
+    let truncated = chars.by_ref().take(max_chars).collect::<String>();
+    if chars.next().is_some() {
+        format!("{truncated}...")
+    } else {
+        truncated
     }
 }
 
@@ -596,6 +829,10 @@ fn timeout_at_rfc3339(timeout_seconds: Option<u64>) -> Result<Option<String>> {
 
 fn u64_to_i64(value: u64) -> Result<i64> {
     i64::try_from(value).context("queue metadata seconds value is too large")
+}
+
+fn i64_to_u64(value: i64) -> u64 {
+    u64::try_from(value).unwrap_or(0)
 }
 
 #[cfg(test)]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -329,6 +329,7 @@ impl SessionStore {
                 };
                 let drain = if delivery_mode == "urgent" {
                     deliver_urgent_runtime_message_raw(
+                        self,
                         &mut state,
                         session_id,
                         runtime,
@@ -337,6 +338,7 @@ impl SessionStore {
                     )?
                 } else {
                     drain_pending_runtime_messages_raw(
+                        self,
                         &mut state,
                         session_id,
                         runtime,
@@ -377,6 +379,22 @@ impl SessionStore {
             notify_after_seconds: request.notify_after_seconds,
             status,
         }))
+    }
+
+    pub fn drain_runtime_pending_messages_for_session(
+        &self,
+        session_id: &str,
+        runtime: &TmuxRuntime,
+    ) -> Result<()> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        if let Some(queue) = &self.queue_store {
+            drain_pending_runtime_messages_raw(
+                self, &mut state, session_id, runtime, queue, None, None,
+            )?;
+            self.write_raw_json_value(&state)?;
+        }
+        Ok(())
     }
 
     pub fn clear_core_session(
@@ -2010,6 +2028,7 @@ fn deliver_urgent_runtime_text_to_session_raw(
 }
 
 fn drain_pending_runtime_messages_raw(
+    store: &SessionStore,
     state: &mut Value,
     session_id: &str,
     runtime: &TmuxRuntime,
@@ -2049,7 +2068,7 @@ fn drain_pending_runtime_messages_raw(
                 should_continue = false;
                 break;
             }
-            complete_runtime_message_delivery_raw(state, queue, &message)?;
+            complete_runtime_message_delivery_raw(store, state, runtime, queue, &message)?;
             let delivered_target =
                 stop_after_message_id.is_some_and(|target_id| target_id == message.id);
             delivered_message_ids.push(message.id);
@@ -2070,7 +2089,9 @@ fn drain_pending_runtime_messages_raw(
 }
 
 fn complete_runtime_message_delivery_raw(
+    store: &SessionStore,
     state: &mut Value,
+    runtime: &TmuxRuntime,
     queue: &RetainedQueueStore,
     message: &PendingMessage,
 ) -> Result<()> {
@@ -2116,7 +2137,26 @@ fn complete_runtime_message_delivery_raw(
         }
     }
 
-    schedule_runtime_followup_notification(queue.clone(), message.clone());
+    if message.notify_on_delivery {
+        if let Some(sender_session_id) = message.sender_session_id.as_deref() {
+            drain_pending_runtime_messages_raw(
+                store,
+                state,
+                sender_session_id,
+                runtime,
+                queue,
+                Some("sequential"),
+                None,
+            )?;
+        }
+    }
+
+    schedule_runtime_followup_notification(
+        store.clone(),
+        runtime.clone(),
+        queue.clone(),
+        message.clone(),
+    );
     Ok(())
 }
 
@@ -2128,7 +2168,12 @@ fn runtime_delivery_notification_text(message: &PendingMessage) -> String {
     )
 }
 
-fn schedule_runtime_followup_notification(queue: RetainedQueueStore, message: PendingMessage) {
+fn schedule_runtime_followup_notification(
+    store: SessionStore,
+    runtime: TmuxRuntime,
+    queue: RetainedQueueStore,
+    message: PendingMessage,
+) {
     let Some(sender_session_id) = message.sender_session_id.clone() else {
         return;
     };
@@ -2144,12 +2189,19 @@ fn schedule_runtime_followup_notification(queue: RetainedQueueStore, message: Pe
     if let Ok(handle) = tokio::runtime::Handle::try_current() {
         handle.spawn(async move {
             tokio::time::sleep(Duration::from_secs(seconds)).await;
-            let _ = queue.enqueue_message(&sender_session_id, &text, "sequential", None);
+            if queue
+                .enqueue_message(&sender_session_id, &text, "sequential", None)
+                .is_ok()
+            {
+                let _ =
+                    store.drain_runtime_pending_messages_for_session(&sender_session_id, &runtime);
+            }
         });
     }
 }
 
 fn deliver_urgent_runtime_message_raw(
+    store: &SessionStore,
     state: &mut Value,
     session_id: &str,
     runtime: &TmuxRuntime,
@@ -2160,7 +2212,7 @@ fn deliver_urgent_runtime_message_raw(
         deliver_urgent_runtime_text_to_session_raw(state, session_id, &message.text, runtime)?;
     let mut delivered_message_ids = Vec::new();
     if delivered {
-        complete_runtime_message_delivery_raw(state, queue, message)?;
+        complete_runtime_message_delivery_raw(store, state, runtime, queue, message)?;
         delivered_message_ids.push(message.id.clone());
     }
     Ok(QueueDrainResult {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -5,6 +5,7 @@ use std::{
     path::{Path, PathBuf},
     sync::atomic::{AtomicU64, Ordering},
     sync::{Arc, Mutex},
+    time::Duration,
 };
 
 use anyhow::{Context, Result};
@@ -13,7 +14,9 @@ use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
-use crate::queue::{QueueMessageMetadata, RetainedQueueStore};
+use crate::queue::{
+    followup_notification_text, PendingMessage, QueueMessageMetadata, RetainedQueueStore,
+};
 use crate::runtime::{TmuxRuntime, TmuxSessionSpec};
 
 const DEFAULT_SESSION_STATE_FILE: &str = "~/.local/share/claude-sessions/sessions.json";
@@ -308,31 +311,29 @@ impl SessionStore {
             if let Some(queue) = &self.queue_store {
                 let metadata =
                     queue_metadata_for_send_request(&state, session_id, &request, sender_name);
-                let has_delivery_side_effects = metadata.has_delivery_side_effects();
+                let pending_message = pending_message_from_metadata(
+                    session_id,
+                    &queued_text,
+                    &delivery_mode,
+                    &metadata,
+                );
                 let message_id = queue.enqueue_message_with_metadata(
                     session_id,
                     &queued_text,
                     &delivery_mode,
                     metadata,
                 )?;
-                if has_delivery_side_effects {
-                    return Ok(Some(CoreInputResult {
-                        ok: true,
-                        session_id: session_id.to_owned(),
-                        delivered: false,
-                        delivery_mode: request.delivery_mode,
-                        notify_after_seconds: request.notify_after_seconds,
-                        status: initial_status,
-                    }));
-                }
+                let pending_message = PendingMessage {
+                    id: message_id.clone(),
+                    ..pending_message
+                };
                 let drain = if delivery_mode == "urgent" {
                     deliver_urgent_runtime_message_raw(
                         &mut state,
                         session_id,
                         runtime,
                         queue,
-                        &message_id,
-                        &queued_text,
+                        &pending_message,
                     )?
                 } else {
                     drain_pending_runtime_messages_raw(
@@ -376,19 +377,6 @@ impl SessionStore {
             notify_after_seconds: request.notify_after_seconds,
             status,
         }))
-    }
-
-    pub fn runtime_send_delivery_side_effects_requested(
-        &self,
-        session_id: &str,
-        request: &SendCoreInputRequest,
-    ) -> Result<Option<bool>> {
-        let state = self.load_raw_json_value()?;
-        if raw_session_object(&state, session_id).is_none() {
-            return Ok(None);
-        }
-        let metadata = queue_metadata_for_send_request(&state, session_id, request, None);
-        Ok(Some(metadata.has_delivery_side_effects()))
     }
 
     pub fn clear_core_session(
@@ -1740,6 +1728,67 @@ fn push_retained_message_raw(
     Ok(())
 }
 
+fn upsert_remind_raw(
+    state: &mut Value,
+    target_session_id: &str,
+    soft_threshold_seconds: u64,
+    hard_threshold_seconds: u64,
+    cancel_on_reply_session_id: Option<&str>,
+) -> Result<()> {
+    let registrations = ensure_array_field_mut(state, "retained_remind_registrations")?;
+    let record = json!({
+        "id": format!("rust-remind-{target_session_id}"),
+        "session_id": target_session_id,
+        "target_session_id": target_session_id,
+        "soft_threshold_seconds": soft_threshold_seconds,
+        "hard_threshold_seconds": hard_threshold_seconds,
+        "cancel_on_reply_session_id": cancel_on_reply_session_id,
+        "registered_at": now_rfc3339(),
+        "last_reset_at": now_rfc3339(),
+        "tracked_status_nudge_fired": false,
+        "soft_fired": false,
+        "persistent_tracking": false,
+        "is_active": true,
+    });
+    if let Some(existing) = registrations.iter_mut().find(|entry| {
+        entry.get("session_id").and_then(Value::as_str) == Some(target_session_id)
+            || entry.get("target_session_id").and_then(Value::as_str) == Some(target_session_id)
+    }) {
+        *existing = record;
+    } else {
+        registrations.push(record);
+    }
+    Ok(())
+}
+
+fn upsert_parent_wake_raw(
+    state: &mut Value,
+    child_session_id: &str,
+    parent_session_id: &str,
+    period_seconds: i64,
+) -> Result<()> {
+    let registrations = ensure_array_field_mut(state, "retained_parent_wake_registrations")?;
+    let record = json!({
+        "id": format!("rust-wake-{child_session_id}"),
+        "child_session_id": child_session_id,
+        "parent_session_id": parent_session_id,
+        "period_seconds": period_seconds,
+        "registered_at": now_rfc3339(),
+        "last_wake_at": null,
+        "last_status_at_prev_wake": null,
+        "escalated": false,
+        "is_active": true,
+    });
+    if let Some(existing) = registrations.iter_mut().find(|entry| {
+        entry.get("child_session_id").and_then(Value::as_str) == Some(child_session_id)
+    }) {
+        *existing = record;
+    } else {
+        registrations.push(record);
+    }
+    Ok(())
+}
+
 #[derive(Debug)]
 struct QueueDrainResult {
     status: String,
@@ -1779,6 +1828,36 @@ fn format_send_input_text_raw(
         ),
         Some(sender_name),
     )
+}
+
+fn pending_message_from_metadata(
+    target_session_id: &str,
+    text: &str,
+    delivery_mode: &str,
+    metadata: &QueueMessageMetadata,
+) -> PendingMessage {
+    PendingMessage {
+        id: String::new(),
+        target_session_id: target_session_id.to_owned(),
+        text: text.to_owned(),
+        delivery_mode: delivery_mode.to_owned(),
+        has_delivery_side_effects: metadata.has_delivery_side_effects(),
+        sender_session_id: metadata.sender_session_id.clone(),
+        sender_name: metadata.sender_name.clone(),
+        from_sm_send: metadata.from_sm_send,
+        notify_on_delivery: metadata.notify_on_delivery,
+        notify_after_seconds: metadata.notify_after_seconds,
+        notify_on_stop: metadata.notify_on_stop,
+        remind_soft_threshold: metadata.remind_soft_threshold,
+        remind_hard_threshold: metadata.remind_hard_threshold,
+        remind_cancel_on_reply_session_id: metadata.remind_cancel_on_reply_session_id.clone(),
+        parent_session_id: metadata.parent_session_id.clone(),
+        message_category: metadata.message_category.clone(),
+        response_relay_source: metadata
+            .response_relay_source
+            .clone()
+            .or_else(|| metadata.from_sm_send.then(|| "sm-send".to_owned())),
+    }
 }
 
 fn queue_metadata_for_send_request(
@@ -1835,6 +1914,16 @@ fn raw_session_object<'a>(state: &'a Value, session_id: &str) -> Option<&'a Map<
 
 fn short_session_id(session_id: &str) -> String {
     session_id.chars().take(8).collect()
+}
+
+fn truncate_chars(value: &str, max_chars: usize) -> String {
+    let mut chars = value.chars();
+    let truncated = chars.by_ref().take(max_chars).collect::<String>();
+    if chars.next().is_some() {
+        format!("{truncated}...")
+    } else {
+        truncated
+    }
 }
 
 fn runtime_session_status_raw(state: &mut Value, session_id: &str) -> Result<Option<String>> {
@@ -1944,10 +2033,6 @@ fn drain_pending_runtime_messages_raw(
 
         let mut should_continue = true;
         for message in messages {
-            if message.has_delivery_side_effects {
-                should_continue = false;
-                break;
-            }
             let (next_status, delivered) =
                 if normalized_delivery_mode(&message.delivery_mode) == "urgent" {
                     deliver_urgent_runtime_text_to_session_raw(
@@ -1964,7 +2049,7 @@ fn drain_pending_runtime_messages_raw(
                 should_continue = false;
                 break;
             }
-            queue.mark_delivered(&message.id)?;
+            complete_runtime_message_delivery_raw(state, queue, &message)?;
             let delivered_target =
                 stop_after_message_id.is_some_and(|target_id| target_id == message.id);
             delivered_message_ids.push(message.id);
@@ -1984,20 +2069,99 @@ fn drain_pending_runtime_messages_raw(
     })
 }
 
+fn complete_runtime_message_delivery_raw(
+    state: &mut Value,
+    queue: &RetainedQueueStore,
+    message: &PendingMessage,
+) -> Result<()> {
+    queue.mark_delivered_and_apply_side_effects(message)?;
+
+    if message.notify_on_delivery {
+        if let Some(sender_session_id) = message.sender_session_id.as_deref() {
+            push_retained_message_raw(
+                state,
+                sender_session_id,
+                &runtime_delivery_notification_text(message),
+                "sequential",
+                None,
+            )?;
+        }
+    }
+
+    if message.notify_on_stop {
+        if let Some(sender_session_id) = message.sender_session_id.as_deref() {
+            upsert_stop_notify_raw(
+                state,
+                &message.target_session_id,
+                sender_session_id,
+                message.sender_name.as_deref().unwrap_or(""),
+                0,
+            )?;
+        }
+    }
+
+    if let Some(soft_threshold) = message.remind_soft_threshold {
+        let hard_threshold = message
+            .remind_hard_threshold
+            .unwrap_or_else(|| soft_threshold.saturating_add(120));
+        upsert_remind_raw(
+            state,
+            &message.target_session_id,
+            soft_threshold,
+            hard_threshold,
+            message.remind_cancel_on_reply_session_id.as_deref(),
+        )?;
+        if let Some(parent_session_id) = message.parent_session_id.as_deref() {
+            upsert_parent_wake_raw(state, &message.target_session_id, parent_session_id, 600)?;
+        }
+    }
+
+    schedule_runtime_followup_notification(queue.clone(), message.clone());
+    Ok(())
+}
+
+fn runtime_delivery_notification_text(message: &PendingMessage) -> String {
+    let truncated = truncate_chars(&message.text, 100);
+    format!(
+        "[sm] Message delivered to {}\nOriginal: \"{}\"",
+        message.target_session_id, truncated
+    )
+}
+
+fn schedule_runtime_followup_notification(queue: RetainedQueueStore, message: PendingMessage) {
+    let Some(sender_session_id) = message.sender_session_id.clone() else {
+        return;
+    };
+    let Some(seconds) = message.notify_after_seconds else {
+        return;
+    };
+    if seconds == 0 {
+        return;
+    }
+    let Some(text) = followup_notification_text(&message) else {
+        return;
+    };
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        handle.spawn(async move {
+            tokio::time::sleep(Duration::from_secs(seconds)).await;
+            let _ = queue.enqueue_message(&sender_session_id, &text, "sequential", None);
+        });
+    }
+}
+
 fn deliver_urgent_runtime_message_raw(
     state: &mut Value,
     session_id: &str,
     runtime: &TmuxRuntime,
     queue: &RetainedQueueStore,
-    message_id: &str,
-    text: &str,
+    message: &PendingMessage,
 ) -> Result<QueueDrainResult> {
     let (status, delivered) =
-        deliver_urgent_runtime_text_to_session_raw(state, session_id, text, runtime)?;
+        deliver_urgent_runtime_text_to_session_raw(state, session_id, &message.text, runtime)?;
     let mut delivered_message_ids = Vec::new();
     if delivered {
-        queue.mark_delivered(message_id)?;
-        delivered_message_ids.push(message_id.to_owned());
+        complete_runtime_message_delivery_raw(state, queue, message)?;
+        delivered_message_ids.push(message.id.clone());
     }
     Ok(QueueDrainResult {
         status,

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1884,7 +1884,9 @@ fn queue_metadata_for_send_request(
     request: &SendCoreInputRequest,
     sender_name: Option<String>,
 ) -> QueueMessageMetadata {
-    let sender_session_id = optional_trimmed(request.sender_session_id.as_deref());
+    let sender_session_id = optional_trimmed(request.sender_session_id.as_deref())
+        .filter(|sender_id| raw_session_object(state, sender_id).is_some());
+    let has_sender = sender_session_id.is_some();
     let notify_on_stop = request.notify_on_stop
         && sender_session_id.as_deref().is_some_and(|sender_id| {
             sender_id != target_session_id
@@ -1896,8 +1898,8 @@ fn queue_metadata_for_send_request(
         sender_name,
         from_sm_send: request.from_sm_send,
         timeout_seconds: request.timeout_seconds,
-        notify_on_delivery: request.notify_on_delivery,
-        notify_after_seconds: request.notify_after_seconds,
+        notify_on_delivery: request.notify_on_delivery && has_sender,
+        notify_after_seconds: has_sender.then_some(request.notify_after_seconds).flatten(),
         notify_on_stop,
         remind_soft_threshold: request.remind_soft_threshold,
         remind_hard_threshold: request.remind_hard_threshold,
@@ -2095,6 +2097,25 @@ fn complete_runtime_message_delivery_raw(
     queue: &RetainedQueueStore,
     message: &PendingMessage,
 ) -> Result<()> {
+    let sanitized_message;
+    let message = if message
+        .sender_session_id
+        .as_deref()
+        .is_some_and(|sender_id| raw_session_object(state, sender_id).is_none())
+    {
+        sanitized_message = PendingMessage {
+            sender_session_id: None,
+            sender_name: None,
+            notify_on_delivery: false,
+            notify_after_seconds: None,
+            notify_on_stop: false,
+            ..message.clone()
+        };
+        &sanitized_message
+    } else {
+        message
+    };
+
     queue.mark_delivered_and_apply_side_effects(message)?;
 
     if message.notify_on_delivery {

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -2705,6 +2705,12 @@ async fn runtime_core_materializes_send_delivery_side_effects() {
         "runtime:side effect delivery should be materialized",
     )
     .await;
+    wait_for_output_contains(
+        app.clone(),
+        "runtimeem",
+        "[sm] Message delivered to runtimechild",
+    )
+    .await;
 
     let queue_conn = Connection::open(&queue_db_path).unwrap();
     let original: (
@@ -2752,6 +2758,12 @@ async fn runtime_core_materializes_send_delivery_side_effects() {
     assert_eq!(delivery_notification_count, 1);
 
     tokio::time::sleep(Duration::from_millis(1200)).await;
+    wait_for_output_contains(
+        app.clone(),
+        "runtimeem",
+        "[sm] Reminder: 1s since your message to runtimechild was delivered",
+    )
+    .await;
     let followup_count: i64 = queue_conn
         .query_row(
             "SELECT COUNT(*) FROM message_queue WHERE target_session_id = 'runtimeem' AND text LIKE '[sm] Reminder: 1s since%'",

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -2612,7 +2612,7 @@ async fn runtime_core_delivers_sm_send_metadata_rows() {
 }
 
 #[tokio::test]
-async fn runtime_core_rejects_unimplemented_send_side_effect_options() {
+async fn runtime_core_materializes_send_delivery_side_effects() {
     if !tmux_available() {
         return;
     }
@@ -2636,53 +2636,172 @@ async fn runtime_core_rejects_unimplemented_send_side_effect_options() {
         app.clone(),
         "/sessions",
         json!({
-            "id": "runtimesideeffects",
+            "id": "runtimeem",
             "working_dir": working_dir.display().to_string(),
             "provider": "claude",
-            "initial_message": "side effect initial"
+            "initial_message": "em side effect initial"
         }),
     )
     .await;
     assert_eq!(status, StatusCode::OK);
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimechild",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude",
+            "parent_session_id": "runtimeem",
+            "initial_message": "child side effect initial"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let mut raw_state: Value =
+        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let em = raw_state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "runtimeem")
+        .unwrap();
+    em["is_em"] = Value::Bool(true);
+    em["friendly_name"] = Value::String("runtime-em".to_owned());
+    fs::write(
+        &state_file,
+        serde_json::to_string_pretty(&raw_state).unwrap(),
+    )
+    .unwrap();
     wait_for_output_contains(
         app.clone(),
-        "runtimesideeffects",
-        "runtime:side effect initial",
+        "runtimechild",
+        "runtime:child side effect initial",
     )
     .await;
 
     let (status, payload) = post_json(
         app.clone(),
-        "/sessions/runtimesideeffects/input",
+        "/sessions/runtimechild/input",
         json!({
-            "text": "side effect delivery should be rejected",
+            "text": "side effect delivery should be materialized",
             "delivery_mode": "sequential",
-            "notify_on_delivery": true
+            "sender_session_id": "runtimeem",
+            "from_sm_send": true,
+            "notify_on_delivery": true,
+            "notify_after_seconds": 1,
+            "notify_on_stop": true,
+            "remind_soft_threshold": 30,
+            "remind_hard_threshold": 45,
+            "remind_cancel_on_reply_session_id": "runtimeem",
+            "parent_session_id": "runtimeem"
         }),
     )
     .await;
-    assert_eq!(status, StatusCode::NOT_IMPLEMENTED);
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["delivered"], true);
+    wait_for_output_contains(
+        app.clone(),
+        "runtimechild",
+        "runtime:side effect delivery should be materialized",
+    )
+    .await;
+
+    let queue_conn = Connection::open(&queue_db_path).unwrap();
+    let original: (
+        Option<String>,
+        i64,
+        Option<i64>,
+        i64,
+        Option<i64>,
+        Option<String>,
+    ) = queue_conn
+        .query_row(
+            r#"
+                SELECT delivered_at, notify_on_delivery, notify_after_seconds,
+                       notify_on_stop, remind_soft_threshold, parent_session_id
+                FROM message_queue
+                WHERE target_session_id = 'runtimechild'
+                "#,
+            [],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                ))
+            },
+        )
+        .unwrap();
+    assert!(original.0.is_some());
+    assert_eq!(original.1, 1);
+    assert_eq!(original.2, Some(1));
+    assert_eq!(original.3, 1);
+    assert_eq!(original.4, Some(30));
+    assert_eq!(original.5.as_deref(), Some("runtimeem"));
+
+    let delivery_notification_count: i64 = queue_conn
+        .query_row(
+            "SELECT COUNT(*) FROM message_queue WHERE target_session_id = 'runtimeem' AND text LIKE '[sm] Message delivered%'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(delivery_notification_count, 1);
+
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    let followup_count: i64 = queue_conn
+        .query_row(
+            "SELECT COUNT(*) FROM message_queue WHERE target_session_id = 'runtimeem' AND text LIKE '[sm] Reminder: 1s since%'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(followup_count, 1);
+
+    let remind: (i64, i64, Option<String>, i64) = queue_conn
+        .query_row(
+            "SELECT soft_threshold_seconds, hard_threshold_seconds, cancel_on_reply_session_id, is_active FROM remind_registrations WHERE target_session_id = 'runtimechild'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .unwrap();
+    assert_eq!(remind, (30, 45, Some("runtimeem".to_owned()), 1));
+    let parent_wake: (String, i64, i64) = queue_conn
+        .query_row(
+            "SELECT parent_session_id, period_seconds, is_active FROM parent_wake_registrations WHERE child_session_id = 'runtimechild'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(parent_wake, ("runtimeem".to_owned(), 600, 1));
+    let stop_notify: (String, String, i64) = queue_conn
+        .query_row(
+            "SELECT sender_session_id, sender_name, delay_seconds FROM rust_stop_notify_states WHERE session_id = 'runtimechild'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
     assert_eq!(
-        payload["detail"],
-        "Rust runtime send delivery side effects are not implemented"
+        stop_notify,
+        ("runtimeem".to_owned(), "runtime-em".to_owned(), 0)
     );
 
-    RetainedQueueStore::new(queue_db_path.clone())
-        .ensure_schema()
-        .unwrap();
-    let queue_conn = Connection::open(&queue_db_path).unwrap();
-    let row_count: i64 = queue_conn
-        .query_row("SELECT COUNT(*) FROM message_queue", [], |row| row.get(0))
-        .unwrap();
-    assert_eq!(row_count, 0);
-
-    let (status, output) =
-        get_json(app.clone(), "/sessions/runtimesideeffects/output?lines=20").await;
-    assert_eq!(status, StatusCode::OK);
-    assert!(!output["output"]
-        .as_str()
-        .unwrap_or_default()
-        .contains("side effect delivery should be rejected"));
+    let raw_state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    assert_eq!(
+        raw_state["retained_stop_notify_states"][0]["sender_session_id"],
+        "runtimeem"
+    );
+    assert_eq!(
+        raw_state["retained_remind_registrations"][0]["target_session_id"],
+        "runtimechild"
+    );
+    assert_eq!(
+        raw_state["retained_parent_wake_registrations"][0]["parent_session_id"],
+        "runtimeem"
+    );
 }
 
 #[tokio::test]
@@ -3366,6 +3485,20 @@ async fn runtime_core_marks_missing_tmux_stopped_on_send_and_retire() {
     let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
     let app = runtime_app(&state_file, &log_dir, &tmux_socket);
 
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimemissingsender",
+            "name": "runtime-missing-sender",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude",
+            "initial_message": "missing sender initial"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
     let (status, payload) = post_json(
         app.clone(),
         "/sessions",
@@ -3387,7 +3520,10 @@ async fn runtime_core_marks_missing_tmux_stopped_on_send_and_retire() {
         "/sessions/runtimemissingsend/input",
         json!({
             "text": "after external kill",
-            "delivery_mode": "sequential"
+            "delivery_mode": "sequential",
+            "sender_session_id": "runtimemissingsender",
+            "from_sm_send": true,
+            "notify_on_delivery": true
         }),
     )
     .await;
@@ -3395,18 +3531,34 @@ async fn runtime_core_marks_missing_tmux_stopped_on_send_and_retire() {
     assert_eq!(payload["delivered"], false);
     assert_eq!(payload["status"], "stopped");
     let queue_conn = Connection::open(queue_db_path_for_state_file(&state_file)).unwrap();
-    let pending: (String, Option<String>) = queue_conn
+    let pending: (String, Option<String>, i64) = queue_conn
         .query_row(
             r#"
-            SELECT text, delivered_at
+            SELECT text, delivered_at, notify_on_delivery
             FROM message_queue
             WHERE target_session_id = 'runtimemissingsend'
             "#,
             [],
-            |row| Ok((row.get(0)?, row.get(1)?)),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
         )
         .unwrap();
-    assert_eq!(pending, ("after external kill".to_owned(), None));
+    assert_eq!(
+        pending,
+        (
+            "[Input from: runtime-missing-sender (runtimem) via sm send]\nafter external kill"
+                .to_owned(),
+            None,
+            1
+        )
+    );
+    let sender_notification_count: i64 = queue_conn
+        .query_row(
+            "SELECT COUNT(*) FROM message_queue WHERE target_session_id = 'runtimemissingsender' AND text LIKE '[sm] Message delivered%'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(sender_notification_count, 0);
 
     let (status, payload) = get_json(app.clone(), "/sessions/runtimemissingsend").await;
     assert_eq!(status, StatusCode::OK);

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -2773,6 +2773,50 @@ async fn runtime_core_materializes_send_delivery_side_effects() {
         .unwrap();
     assert_eq!(followup_count, 1);
 
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/runtimechild/input",
+        json!({
+            "text": "stale sender still reaches target",
+            "delivery_mode": "sequential",
+            "sender_session_id": "missing-runtime-sender",
+            "from_sm_send": true,
+            "notify_on_delivery": true,
+            "notify_after_seconds": 1,
+            "notify_on_stop": true
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["delivered"], true);
+    wait_for_output_contains(
+        app.clone(),
+        "runtimechild",
+        "runtime:stale sender still reaches target",
+    )
+    .await;
+    let stale_sender_row: (Option<String>, i64, Option<i64>, i64) = queue_conn
+        .query_row(
+            r#"
+            SELECT sender_session_id, notify_on_delivery, notify_after_seconds, notify_on_stop
+            FROM message_queue
+            WHERE target_session_id = 'runtimechild'
+              AND text = 'stale sender still reaches target'
+            "#,
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .unwrap();
+    assert_eq!(stale_sender_row, (None, 0, None, 0));
+    let stale_sender_notification_count: i64 = queue_conn
+        .query_row(
+            "SELECT COUNT(*) FROM message_queue WHERE target_session_id = 'missing-runtime-sender'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(stale_sender_notification_count, 0);
+
     let remind: (i64, i64, Option<String>, i64) = queue_conn
         .query_row(
             "SELECT soft_threshold_seconds, hard_threshold_seconds, cancel_on_reply_session_id, is_active FROM remind_registrations WHERE target_session_id = 'runtimechild'",


### PR DESCRIPTION
Fixes #809

## Summary
- extend retained Rust queue reads to carry delivery metadata through runtime drains
- complete delivered runtime rows with durable side effects for delivery notifications, stop-notify state, reminders, and parent wake registrations
- schedule Rust runtime notify-after follow-ups with the same in-process timer shape as Python
- remove the temporary runtime HTTP 501 guard for delivery side-effect send options
- add runtime tests for successful side-effect materialization and failed-delivery no-side-effect behavior

## Verification
- `cargo fmt --manifest-path crates/sm-server/Cargo.toml --check`
- `cargo check --manifest-path crates/sm-server/Cargo.toml --bin sm-server --bin sm`
- `cargo test --manifest-path crates/sm-server/Cargo.toml`
- `git diff --check`