### PR TITLE
Deliver Rust stop notifications on retire

### DIFF
--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -33,6 +33,14 @@ pub struct PendingMessage {
     pub response_relay_source: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StopNotifyState {
+    pub session_id: String,
+    pub sender_session_id: String,
+    pub sender_name: String,
+    pub delay_seconds: i64,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct QueueMessageMetadata {
     pub sender_session_id: Option<String>,
@@ -415,6 +423,39 @@ impl RetainedQueueStore {
                 sender_session_id,
                 sender_name,
                 delay_seconds,
+            )?;
+            Ok(())
+        })
+    }
+
+    pub fn stop_notify_state(&self, session_id: &str) -> Result<Option<StopNotifyState>> {
+        self.with_connection(|conn| {
+            conn.query_row(
+                r#"
+                SELECT session_id, sender_session_id, COALESCE(sender_name, ''), delay_seconds
+                FROM rust_stop_notify_states
+                WHERE session_id = ?1
+                "#,
+                params![session_id],
+                |row| {
+                    Ok(StopNotifyState {
+                        session_id: row.get(0)?,
+                        sender_session_id: row.get(1)?,
+                        sender_name: row.get(2)?,
+                        delay_seconds: row.get(3)?,
+                    })
+                },
+            )
+            .optional()
+            .map_err(Into::into)
+        })
+    }
+
+    pub fn clear_stop_notify(&self, session_id: &str) -> Result<()> {
+        self.with_connection(|conn| {
+            conn.execute(
+                "DELETE FROM rust_stop_notify_states WHERE session_id = ?1",
+                params![session_id],
             )?;
             Ok(())
         })

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -398,18 +398,25 @@ impl SessionStore {
         Ok(())
     }
 
-    pub fn enqueue_runtime_stop_notification_for_session(
+    pub fn enqueue_stop_notification_for_session(
         &self,
         session_id: &str,
         text: &str,
-        runtime: &TmuxRuntime,
+        runtime: Option<&TmuxRuntime>,
     ) -> Result<()> {
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
-        let Some(queue) = &self.queue_store else {
-            return Ok(());
-        };
-        enqueue_stop_notification_raw(self, &mut state, Some(runtime), queue, session_id, text)?;
+        if let Some(queue) = &self.queue_store {
+            enqueue_stop_notification_raw(self, &mut state, runtime, queue, session_id, text)?;
+        } else if raw_session_object(&state, session_id).is_some() {
+            push_retained_message_raw(
+                &mut state,
+                session_id,
+                text,
+                "important",
+                Some("stop_notify"),
+            )?;
+        }
         self.write_raw_json_value(&state)?;
         Ok(())
     }
@@ -2308,16 +2315,14 @@ fn complete_stop_notify_after_stop_raw(
 
     let text = runtime_stop_notification_text(recipient_name, session_id);
     if stop_notify.delay_seconds > 0 {
-        if let Some(runtime) = runtime {
-            schedule_runtime_stop_notification(
-                store.clone(),
-                runtime.clone(),
-                stop_notify.sender_session_id,
-                text,
-                stop_notify.delay_seconds as u64,
-            );
-            return Ok(());
-        }
+        schedule_stop_notification(
+            store.clone(),
+            runtime.cloned(),
+            stop_notify.sender_session_id,
+            text,
+            stop_notify.delay_seconds as u64,
+        );
+        return Ok(());
     }
 
     if let Some(queue) = queue {
@@ -2374,9 +2379,9 @@ fn enqueue_stop_notification_raw(
     Ok(())
 }
 
-fn schedule_runtime_stop_notification(
+fn schedule_stop_notification(
     store: SessionStore,
-    runtime: TmuxRuntime,
+    runtime: Option<TmuxRuntime>,
     sender_session_id: String,
     text: String,
     delay_seconds: u64,
@@ -2384,10 +2389,10 @@ fn schedule_runtime_stop_notification(
     if let Ok(handle) = tokio::runtime::Handle::try_current() {
         handle.spawn(async move {
             tokio::time::sleep(Duration::from_secs(delay_seconds)).await;
-            let _ = store.enqueue_runtime_stop_notification_for_session(
+            let _ = store.enqueue_stop_notification_for_session(
                 &sender_session_id,
                 &text,
-                &runtime,
+                runtime.as_ref(),
             );
         });
     }

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -16,6 +16,7 @@ use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 use crate::queue::{
     followup_notification_text, PendingMessage, QueueMessageMetadata, RetainedQueueStore,
+    StopNotifyState,
 };
 use crate::runtime::{TmuxRuntime, TmuxSessionSpec};
 
@@ -394,6 +395,22 @@ impl SessionStore {
             )?;
             self.write_raw_json_value(&state)?;
         }
+        Ok(())
+    }
+
+    pub fn enqueue_runtime_stop_notification_for_session(
+        &self,
+        session_id: &str,
+        text: &str,
+        runtime: &TmuxRuntime,
+    ) -> Result<()> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let Some(queue) = &self.queue_store else {
+            return Ok(());
+        };
+        enqueue_stop_notification_raw(self, &mut state, Some(runtime), queue, session_id, text)?;
+        self.write_raw_json_value(&state)?;
         Ok(())
     }
 
@@ -890,26 +907,31 @@ impl SessionStore {
     ) -> Result<CoreRetireOutcome> {
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
-        let sessions = ensure_sessions_array_mut(&mut state)?;
-        let Some(session) = session_object_mut(sessions, session_id) else {
-            return Ok(CoreRetireOutcome::NotFound);
-        };
-        if let Some(requester_session_id) = requester_session_id {
-            if !requester_session_id.is_empty()
-                && json_text(session.get("parent_session_id")).as_deref()
-                    != Some(requester_session_id)
-            {
-                return Ok(CoreRetireOutcome::NotChild);
+        let recipient_name = {
+            let sessions = ensure_sessions_array_mut(&mut state)?;
+            let Some(session) = session_object_mut(sessions, session_id) else {
+                return Ok(CoreRetireOutcome::NotFound);
+            };
+            if let Some(requester_session_id) = requester_session_id {
+                if !requester_session_id.is_empty()
+                    && json_text(session.get("parent_session_id")).as_deref()
+                        != Some(requester_session_id)
+                {
+                    return Ok(CoreRetireOutcome::NotChild);
+                }
             }
-        }
-        let now = now_rfc3339();
-        session.insert("status".to_owned(), Value::String("stopped".to_owned()));
-        mark_session_killed(session, &now);
-        session.insert("stopped_at".to_owned(), Value::String(now.clone()));
-        session.insert("last_activity".to_owned(), Value::String(now));
-        if let Some(log_file) = json_text(session.get("log_file")) {
-            append_log_line(&expand_home(&log_file), "[sm-rust] fixture session retired")?;
-        }
+            let recipient_name = raw_session_display_name(session, session_id);
+            let now = now_rfc3339();
+            session.insert("status".to_owned(), Value::String("stopped".to_owned()));
+            mark_session_killed(session, &now);
+            session.insert("stopped_at".to_owned(), Value::String(now.clone()));
+            session.insert("last_activity".to_owned(), Value::String(now));
+            if let Some(log_file) = json_text(session.get("log_file")) {
+                append_log_line(&expand_home(&log_file), "[sm-rust] fixture session retired")?;
+            }
+            recipient_name
+        };
+        complete_stop_notify_after_stop_raw(self, &mut state, None, session_id, &recipient_name)?;
         self.write_raw_json_value(&state)?;
         Ok(CoreRetireOutcome::Retired(CoreRetireResult {
             ok: true,
@@ -926,32 +948,46 @@ impl SessionStore {
     ) -> Result<CoreRetireOutcome> {
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
-        let sessions = ensure_sessions_array_mut(&mut state)?;
-        let Some(session) = session_object_mut(sessions, session_id) else {
-            return Ok(CoreRetireOutcome::NotFound);
-        };
-        if let Some(requester_session_id) = requester_session_id {
-            if !requester_session_id.is_empty()
-                && json_text(session.get("parent_session_id")).as_deref()
-                    != Some(requester_session_id)
-            {
-                return Ok(CoreRetireOutcome::NotChild);
+        let (node, tmux_session, session_socket_name, recipient_name) = {
+            let sessions = ensure_sessions_array_mut(&mut state)?;
+            let Some(session) = session_object_mut(sessions, session_id) else {
+                return Ok(CoreRetireOutcome::NotFound);
+            };
+            if let Some(requester_session_id) = requester_session_id {
+                if !requester_session_id.is_empty()
+                    && json_text(session.get("parent_session_id")).as_deref()
+                        != Some(requester_session_id)
+                {
+                    return Ok(CoreRetireOutcome::NotChild);
+                }
             }
-        }
-        let node = json_text(session.get("node")).unwrap_or_else(default_node);
+            let node = json_text(session.get("node")).unwrap_or_else(default_node);
+            let tmux_session = json_text(session.get("tmux_session"))
+                .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?;
+            let session_socket_name = json_text(session.get("tmux_socket_name"));
+            let recipient_name = raw_session_display_name(session, session_id);
+            (node, tmux_session, session_socket_name, recipient_name)
+        };
         if !is_primary_node(&node) {
             return Ok(CoreRetireOutcome::UnsupportedNode(node));
         }
-        let tmux_session = json_text(session.get("tmux_session"))
-            .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?;
-        let session_socket_name = json_text(session.get("tmux_socket_name"));
         let session_runtime = runtime.for_socket_name(session_socket_name.as_deref());
         let _ = session_runtime.kill_session(&tmux_session)?;
         let now = now_rfc3339();
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let session = session_object_mut(sessions, session_id)
+            .ok_or_else(|| anyhow::anyhow!("session {session_id} disappeared during retire"))?;
         session.insert("status".to_owned(), Value::String("stopped".to_owned()));
         mark_session_killed(session, &now);
         session.insert("stopped_at".to_owned(), Value::String(now.clone()));
         session.insert("last_activity".to_owned(), Value::String(now));
+        complete_stop_notify_after_stop_raw(
+            self,
+            &mut state,
+            Some(runtime),
+            session_id,
+            &recipient_name,
+        )?;
         self.write_raw_json_value(&state)?;
         Ok(CoreRetireOutcome::Retired(CoreRetireResult {
             ok: true,
@@ -1728,6 +1764,30 @@ fn deactivate_remind_raw(state: &mut Value, session_id: &str) -> Result<()> {
     Ok(())
 }
 
+fn stop_notify_state_raw(state: &Value, session_id: &str) -> Option<StopNotifyState> {
+    state
+        .get("retained_stop_notify_states")
+        .and_then(Value::as_array)?
+        .iter()
+        .find(|entry| entry.get("session_id").and_then(Value::as_str) == Some(session_id))
+        .map(|entry| StopNotifyState {
+            session_id: session_id.to_owned(),
+            sender_session_id: json_text(entry.get("sender_session_id")).unwrap_or_default(),
+            sender_name: json_text(entry.get("sender_name")).unwrap_or_default(),
+            delay_seconds: entry
+                .get("delay_seconds")
+                .and_then(Value::as_i64)
+                .unwrap_or(0),
+        })
+        .filter(|entry| !entry.sender_session_id.is_empty())
+}
+
+fn clear_stop_notify_raw(state: &mut Value, session_id: &str) -> Result<()> {
+    let entries = ensure_array_field_mut(state, "retained_stop_notify_states")?;
+    entries.retain(|entry| entry.get("session_id").and_then(Value::as_str) != Some(session_id));
+    Ok(())
+}
+
 fn push_retained_message_raw(
     state: &mut Value,
     target_session_id: &str,
@@ -2219,6 +2279,126 @@ fn schedule_runtime_followup_notification(
             }
         });
     }
+}
+
+fn complete_stop_notify_after_stop_raw(
+    store: &SessionStore,
+    state: &mut Value,
+    runtime: Option<&TmuxRuntime>,
+    session_id: &str,
+    recipient_name: &str,
+) -> Result<()> {
+    let queue = store.queue_store.as_ref();
+    let stop_notify = match queue {
+        Some(queue) => queue.stop_notify_state(session_id)?,
+        None => stop_notify_state_raw(state, session_id),
+    };
+    let Some(stop_notify) = stop_notify else {
+        return Ok(());
+    };
+
+    if let Some(queue) = queue {
+        queue.clear_stop_notify(session_id)?;
+    }
+    clear_stop_notify_raw(state, session_id)?;
+
+    if raw_session_object(state, &stop_notify.sender_session_id).is_none() {
+        return Ok(());
+    }
+
+    let text = runtime_stop_notification_text(recipient_name, session_id);
+    if stop_notify.delay_seconds > 0 {
+        if let Some(runtime) = runtime {
+            schedule_runtime_stop_notification(
+                store.clone(),
+                runtime.clone(),
+                stop_notify.sender_session_id,
+                text,
+                stop_notify.delay_seconds as u64,
+            );
+            return Ok(());
+        }
+    }
+
+    if let Some(queue) = queue {
+        enqueue_stop_notification_raw(
+            store,
+            state,
+            runtime,
+            queue,
+            &stop_notify.sender_session_id,
+            &text,
+        )?;
+    } else {
+        push_retained_message_raw(
+            state,
+            &stop_notify.sender_session_id,
+            &text,
+            "important",
+            Some("stop_notify"),
+        )?;
+    }
+    Ok(())
+}
+
+fn enqueue_stop_notification_raw(
+    store: &SessionStore,
+    state: &mut Value,
+    runtime: Option<&TmuxRuntime>,
+    queue: &RetainedQueueStore,
+    sender_session_id: &str,
+    text: &str,
+) -> Result<()> {
+    if raw_session_object(state, sender_session_id).is_none() {
+        return Ok(());
+    }
+    queue.enqueue_message(sender_session_id, text, "important", Some("stop_notify"))?;
+    push_retained_message_raw(
+        state,
+        sender_session_id,
+        text,
+        "important",
+        Some("stop_notify"),
+    )?;
+    if let Some(runtime) = runtime {
+        drain_pending_runtime_messages_raw(
+            store,
+            state,
+            sender_session_id,
+            runtime,
+            queue,
+            Some("important"),
+            None,
+        )?;
+    }
+    Ok(())
+}
+
+fn schedule_runtime_stop_notification(
+    store: SessionStore,
+    runtime: TmuxRuntime,
+    sender_session_id: String,
+    text: String,
+    delay_seconds: u64,
+) {
+    if let Ok(handle) = tokio::runtime::Handle::try_current() {
+        handle.spawn(async move {
+            tokio::time::sleep(Duration::from_secs(delay_seconds)).await;
+            let _ = store.enqueue_runtime_stop_notification_for_session(
+                &sender_session_id,
+                &text,
+                &runtime,
+            );
+        });
+    }
+}
+
+fn runtime_stop_notification_text(recipient_name: &str, recipient_session_id: &str) -> String {
+    format!(
+        "[sm] {} ({}) completed (Stop hook fired)",
+        recipient_name,
+        short_session_id(recipient_session_id)
+    )
 }
 
 fn deliver_urgent_runtime_message_raw(

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -2861,6 +2861,218 @@ async fn runtime_core_materializes_send_delivery_side_effects() {
 }
 
 #[tokio::test]
+async fn runtime_core_retire_delivers_stop_notify_side_effects() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let queue_db_path = queue_db_path_for_state_file(&state_file);
+    let log_dir = unique_temp_path();
+    let working_dir = unique_temp_path();
+    fs::create_dir_all(&working_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-test-stop-notify-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app(&state_file, &log_dir, &tmux_socket);
+
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimestopem",
+            "name": "runtime-stop-em",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude",
+            "initial_message": "stop em initial"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimestopchild",
+            "name": "runtime-stop-child",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude",
+            "parent_session_id": "runtimestopem",
+            "initial_message": "stop child initial"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let mut raw_state: Value =
+        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let em = raw_state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "runtimestopem")
+        .unwrap();
+    em["is_em"] = Value::Bool(true);
+    fs::write(
+        &state_file,
+        serde_json::to_string_pretty(&raw_state).unwrap(),
+    )
+    .unwrap();
+    wait_for_output_contains(
+        app.clone(),
+        "runtimestopchild",
+        "runtime:stop child initial",
+    )
+    .await;
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/runtimestopchild/notify-on-stop",
+        json!({
+            "sender_session_id": "runtimestopem",
+            "requester_session_id": "runtimestopem",
+            "delay_seconds": 0
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "ok");
+
+    let (status, payload) =
+        post_json(app.clone(), "/sessions/runtimestopchild/kill", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "killed");
+    wait_for_output_contains(
+        app.clone(),
+        "runtimestopem",
+        "[sm] runtime-stop-child (runtimes) completed (Stop hook fired)",
+    )
+    .await;
+
+    let queue_conn = Connection::open(&queue_db_path).unwrap();
+    let notification: (i64, String, String) = queue_conn
+        .query_row(
+            r#"
+            SELECT delivered_at IS NOT NULL, delivery_mode, COALESCE(message_category, '')
+            FROM message_queue
+            WHERE target_session_id = 'runtimestopem'
+              AND text LIKE '[sm] runtime-stop-child%'
+            "#,
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        notification,
+        (1, "important".to_owned(), "stop_notify".to_owned())
+    );
+    let remaining_stop_notify_count: i64 = queue_conn
+        .query_row(
+            "SELECT COUNT(*) FROM rust_stop_notify_states WHERE session_id = 'runtimestopchild'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(remaining_stop_notify_count, 0);
+    let raw_state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    assert!(raw_state["retained_stop_notify_states"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|entry| entry["session_id"] != "runtimestopchild"));
+
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimegoneem",
+            "name": "runtime-gone-em",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude",
+            "initial_message": "gone em initial"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimeghostchild",
+            "name": "runtime-ghost-child",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude",
+            "parent_session_id": "runtimegoneem",
+            "initial_message": "ghost child initial"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let mut raw_state: Value =
+        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let sessions = raw_state["sessions"].as_array_mut().unwrap();
+    let gone_em = sessions
+        .iter_mut()
+        .find(|session| session["id"] == "runtimegoneem")
+        .unwrap();
+    gone_em["is_em"] = Value::Bool(true);
+    fs::write(
+        &state_file,
+        serde_json::to_string_pretty(&raw_state).unwrap(),
+    )
+    .unwrap();
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/runtimeghostchild/notify-on-stop",
+        json!({
+            "sender_session_id": "runtimegoneem",
+            "requester_session_id": "runtimegoneem",
+            "delay_seconds": 0
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "ok");
+
+    let mut raw_state: Value =
+        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    raw_state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .retain(|session| session["id"] != "runtimegoneem");
+    fs::write(
+        &state_file,
+        serde_json::to_string_pretty(&raw_state).unwrap(),
+    )
+    .unwrap();
+
+    let (status, payload) =
+        post_json(app.clone(), "/sessions/runtimeghostchild/kill", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "killed");
+    let stale_sender_notification_count: i64 = queue_conn
+        .query_row(
+            "SELECT COUNT(*) FROM message_queue WHERE target_session_id = 'runtimegoneem'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(stale_sender_notification_count, 0);
+    let remaining_ghost_stop_notify_count: i64 = queue_conn
+        .query_row(
+            "SELECT COUNT(*) FROM rust_stop_notify_states WHERE session_id = 'runtimeghostchild'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(remaining_ghost_stop_notify_count, 0);
+}
+
+#[tokio::test]
 async fn runtime_core_priority_sends_bypass_sequential_queue_backlog() {
     if !tmux_available() {
         return;

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -1642,6 +1642,71 @@ async fn fixture_notify_on_stop_preserves_authorization_and_state_contract() {
 }
 
 #[tokio::test]
+async fn fixture_retire_honors_delayed_stop_notify_without_runtime() {
+    let state_file = write_completion_fixture();
+    let queue_db_path = queue_db_path_for_state_file(&state_file);
+    let mut config = config_with_state_file_and_queue(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/child001/notify-on-stop",
+        json!({
+            "sender_session_id": "em001",
+            "requester_session_id": "em001",
+            "delay_seconds": 1
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "ok");
+
+    let (status, payload) = post_json(app.clone(), "/sessions/child001/kill", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "killed");
+
+    let queue_conn = Connection::open(&queue_db_path).unwrap();
+    let immediate_count: i64 = queue_conn
+        .query_row(
+            "SELECT COUNT(*) FROM message_queue WHERE target_session_id = 'em001' AND message_category = 'stop_notify'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(immediate_count, 0);
+
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    let delayed: (String, String, Option<String>) = queue_conn
+        .query_row(
+            r#"
+            SELECT text, delivery_mode, message_category
+            FROM message_queue
+            WHERE target_session_id = 'em001' AND message_category = 'stop_notify'
+            "#,
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        delayed,
+        (
+            "[sm] worker-1 (child001) completed (Stop hook fired)".to_owned(),
+            "important".to_owned(),
+            Some("stop_notify".to_owned())
+        )
+    );
+    let remaining_stop_notify_count: i64 = queue_conn
+        .query_row(
+            "SELECT COUNT(*) FROM rust_stop_notify_states WHERE session_id = 'child001'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(remaining_stop_notify_count, 0);
+}
+
+#[tokio::test]
 async fn fixture_registry_and_maintainer_endpoints_round_trip_state() {
     let state_file = unique_temp_path();
     let log_dir = unique_temp_path();


### PR DESCRIPTION
Fixes #811

## Summary
- add retained queue accessors for Rust stop-notify registrations
- consume armed stop-notify state when Rust retire/kill marks a session stopped
- enqueue Python-compatible important stop notifications and drain them to live sender runtimes
- clear consumed stop-notify state and skip notification delivery when the sender session disappeared
- add runtime coverage for delivered stop notifications and stale-sender cleanup

## Verification
- `cargo test --manifest-path crates/sm-server/Cargo.toml runtime_core_retire_delivers_stop_notify_side_effects -- --nocapture`
- `cargo test --manifest-path crates/sm-server/Cargo.toml runtime_core_materializes_send_delivery_side_effects -- --nocapture`
- `cargo test --manifest-path crates/sm-server/Cargo.toml runtime_core_marks_missing_tmux_stopped_on_send_and_retire -- --nocapture`
- `cargo fmt --manifest-path crates/sm-server/Cargo.toml --check`
- `cargo check --manifest-path crates/sm-server/Cargo.toml --bin sm-server --bin sm`
- `cargo test --manifest-path crates/sm-server/Cargo.toml`
- `git diff --check`