### PR TITLE
Wake Rust parent on task complete

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -661,7 +661,15 @@ async fn task_complete(
         &format!("/sessions/{session_id}/task-complete"),
     )?;
     ensure_core_writes_enabled(&state)?;
-    match state.session_store.task_complete(&session_id, payload)? {
+    let runtime = state
+        .config
+        .rust_core
+        .runtime_enabled
+        .then(|| TmuxRuntime::from_config(&state.config.rust_core));
+    match state
+        .session_store
+        .task_complete(&session_id, payload, runtime.as_ref())?
+    {
         TaskCompleteOutcome::Completed(result) => Ok(Json(serde_json::to_value(result)?)),
         TaskCompleteOutcome::Error(error) => Ok(Json(json!({ "error": error }))),
     }

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1045,6 +1045,7 @@ impl SessionStore {
         &self,
         session_id: &str,
         request: TaskCompleteRequest,
+        runtime: Option<&TmuxRuntime>,
     ) -> Result<TaskCompleteOutcome> {
         if request.requester_session_id.trim() != session_id {
             return Ok(TaskCompleteOutcome::Error(
@@ -1093,7 +1094,25 @@ impl SessionStore {
             let text =
                 format!("[sm task-complete] agent {session_id}({friendly}) completed its task.");
             if let Some(queue) = &self.queue_store {
-                queue.enqueue_message(&em_session_id, &text, "important", Some("task_complete"))?;
+                let message_id = queue.enqueue_message(
+                    &em_session_id,
+                    &text,
+                    "important",
+                    Some("task_complete"),
+                )?;
+                if let Some(runtime) = runtime {
+                    if raw_session_object(&state, &em_session_id).is_some() {
+                        drain_pending_runtime_messages_raw(
+                            self,
+                            &mut state,
+                            &em_session_id,
+                            runtime,
+                            queue,
+                            Some("important"),
+                            Some(&message_id),
+                        )?;
+                    }
+                }
             }
             push_retained_message_raw(
                 &mut state,

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1105,7 +1105,7 @@ impl SessionStore {
                         .and_then(|session| json_text(session.get("node")))
                         .unwrap_or_else(default_node);
                     if is_primary_node(&parent_node) {
-                        drain_pending_runtime_messages_raw(
+                        let drain = drain_pending_runtime_messages_raw(
                             self,
                             &mut state,
                             &em_session_id,
@@ -1114,6 +1114,13 @@ impl SessionStore {
                             Some("important"),
                             Some(&message_id),
                         )?;
+                        if drain
+                            .delivered_message_ids
+                            .iter()
+                            .any(|delivered_id| delivered_id == &message_id)
+                        {
+                            clear_agent_task_completed_raw(&mut state, &em_session_id)?;
+                        }
                     }
                 }
             }
@@ -1764,6 +1771,14 @@ fn active_parent_wake_parent_raw(state: &Value, child_session_id: &str) -> Resul
                 .unwrap_or(true)
         })
         .and_then(|entry| json_text(entry.get("parent_session_id"))))
+}
+
+fn clear_agent_task_completed_raw(state: &mut Value, session_id: &str) -> Result<()> {
+    let sessions = ensure_sessions_array_mut(state)?;
+    if let Some(session) = session_object_mut(sessions, session_id) {
+        session.insert("agent_task_completed_at".to_owned(), Value::Null);
+    }
+    Ok(())
 }
 
 fn deactivate_parent_wake_raw(state: &mut Value, child_session_id: &str) -> Result<()> {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1101,7 +1101,10 @@ impl SessionStore {
                     Some("task_complete"),
                 )?;
                 if let Some(runtime) = runtime {
-                    if raw_session_object(&state, &em_session_id).is_some() {
+                    let parent_node = raw_session_object(&state, &em_session_id)
+                        .and_then(|session| json_text(session.get("node")))
+                        .unwrap_or_else(default_node);
+                    if is_primary_node(&parent_node) {
                         drain_pending_runtime_messages_raw(
                             self,
                             &mut state,

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1101,25 +1101,26 @@ impl SessionStore {
                     Some("task_complete"),
                 )?;
                 if let Some(runtime) = runtime {
-                    let parent_node = raw_session_object(&state, &em_session_id)
-                        .and_then(|session| json_text(session.get("node")))
-                        .unwrap_or_else(default_node);
-                    if is_primary_node(&parent_node) {
-                        let drain = drain_pending_runtime_messages_raw(
-                            self,
-                            &mut state,
-                            &em_session_id,
-                            runtime,
-                            queue,
-                            Some("important"),
-                            Some(&message_id),
-                        )?;
-                        if drain
-                            .delivered_message_ids
-                            .iter()
-                            .any(|delivered_id| delivered_id == &message_id)
-                        {
-                            clear_agent_task_completed_raw(&mut state, &em_session_id)?;
+                    if let Some(parent_session) = raw_session_object(&state, &em_session_id) {
+                        let parent_node =
+                            json_text(parent_session.get("node")).unwrap_or_else(default_node);
+                        if is_primary_node(&parent_node) {
+                            let drain = drain_pending_runtime_messages_raw(
+                                self,
+                                &mut state,
+                                &em_session_id,
+                                runtime,
+                                queue,
+                                Some("important"),
+                                Some(&message_id),
+                            )?;
+                            if drain
+                                .delivered_message_ids
+                                .iter()
+                                .any(|delivered_id| delivered_id == &message_id)
+                            {
+                                clear_agent_task_completed_raw(&mut state, &em_session_id)?;
+                            }
                         }
                     }
                 }

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -3191,6 +3191,19 @@ async fn runtime_core_task_complete_wakes_parent_runtime() {
         "runtime:task child initial",
     )
     .await;
+    let mut raw_state: Value =
+        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    raw_state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "runtimetaskparent")
+        .unwrap()["agent_task_completed_at"] = json!("2026-06-09T00:01:00Z");
+    fs::write(
+        &state_file,
+        serde_json::to_string_pretty(&raw_state).unwrap(),
+    )
+    .unwrap();
 
     let (status, payload) = post_json(
         app.clone(),
@@ -3224,6 +3237,13 @@ async fn runtime_core_task_complete_wakes_parent_runtime() {
         (1, "important".to_owned(), Some("task_complete".to_owned()))
     );
     let raw_state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let parent = raw_state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "runtimetaskparent")
+        .unwrap();
+    assert_eq!(parent["agent_task_completed_at"], Value::Null);
     let child = raw_state["sessions"]
         .as_array()
         .unwrap()
@@ -3250,7 +3270,8 @@ async fn runtime_core_task_complete_wakes_parent_runtime() {
                 "status": "running",
                 "node": "macbook",
                 "created_at": "2026-06-09T00:00:00Z",
-                "last_activity": "2026-06-09T00:00:00Z"
+                "last_activity": "2026-06-09T00:00:00Z",
+                "agent_task_completed_at": "2026-06-09T00:01:00Z"
             },
             {
                 "id": "remotetaskchild",
@@ -3301,6 +3322,15 @@ async fn runtime_core_task_complete_wakes_parent_runtime() {
         remote_queued,
         (0, "important".to_owned(), Some("task_complete".to_owned()))
     );
+    let remote_raw_state: Value =
+        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let remote_parent = remote_raw_state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "remotetaskparent")
+        .unwrap();
+    assert!(remote_parent["agent_task_completed_at"].is_string());
 }
 
 #[tokio::test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -3331,6 +3331,68 @@ async fn runtime_core_task_complete_wakes_parent_runtime() {
         .find(|session| session["id"] == "remotetaskparent")
         .unwrap();
     assert!(remote_parent["agent_task_completed_at"].is_string());
+
+    let missing_parent_child_log = unique_temp_path();
+    let missing_parent_state = json!({
+        "sessions": [
+            {
+                "id": "missingparentchild",
+                "name": "missing-parent-child",
+                "friendly_name": "missing-parent-child",
+                "working_dir": working_dir.display().to_string(),
+                "tmux_session": "missing-parent-child",
+                "log_file": missing_parent_child_log.display().to_string(),
+                "status": "running",
+                "node": "primary",
+                "parent_session_id": "deletedparent",
+                "created_at": "2026-06-09T00:00:00Z",
+                "last_activity": "2026-06-09T00:00:00Z"
+            }
+        ],
+        "retained_pending_messages": [],
+        "retained_remind_registrations": [],
+        "retained_parent_wake_registrations": [],
+        "retained_stop_notify_states": []
+    });
+    fs::write(
+        &state_file,
+        serde_json::to_string_pretty(&missing_parent_state).unwrap(),
+    )
+    .unwrap();
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/missingparentchild/task-complete",
+        json!({ "requester_session_id": "missingparentchild" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "completed");
+    assert_eq!(payload["em_notified"], true);
+    let missing_parent_queued: (i64, String, Option<String>) = queue_conn
+        .query_row(
+            r#"
+            SELECT delivered_at IS NOT NULL, delivery_mode, message_category
+            FROM message_queue
+            WHERE target_session_id = 'deletedparent'
+              AND message_category = 'task_complete'
+            "#,
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        missing_parent_queued,
+        (0, "important".to_owned(), Some("task_complete".to_owned()))
+    );
+    let missing_parent_raw_state: Value =
+        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let missing_parent_child = missing_parent_raw_state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "missingparentchild")
+        .unwrap();
+    assert!(missing_parent_child["agent_task_completed_at"].is_string());
 }
 
 #[tokio::test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -3138,6 +3138,106 @@ async fn runtime_core_retire_delivers_stop_notify_side_effects() {
 }
 
 #[tokio::test]
+async fn runtime_core_task_complete_wakes_parent_runtime() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let queue_db_path = queue_db_path_for_state_file(&state_file);
+    let log_dir = unique_temp_path();
+    let working_dir = unique_temp_path();
+    fs::create_dir_all(&working_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-test-task-complete-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app(&state_file, &log_dir, &tmux_socket);
+
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimetaskparent",
+            "name": "runtime-task-parent",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude",
+            "initial_message": "task parent initial"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimetaskchild",
+            "name": "runtime-task-child",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude",
+            "parent_session_id": "runtimetaskparent",
+            "initial_message": "task child initial"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    wait_for_output_contains(
+        app.clone(),
+        "runtimetaskchild",
+        "runtime:task child initial",
+    )
+    .await;
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/runtimetaskchild/task-complete",
+        json!({ "requester_session_id": "runtimetaskchild" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "completed");
+    assert_eq!(payload["em_notified"], true);
+
+    let notification =
+        "[sm task-complete] agent runtimetaskchild(runtime-task-child) completed its task.";
+    wait_for_output_contains(app.clone(), "runtimetaskparent", notification).await;
+
+    let queue_conn = Connection::open(&queue_db_path).unwrap();
+    let queued: (i64, String, Option<String>) = queue_conn
+        .query_row(
+            r#"
+            SELECT delivered_at IS NOT NULL, delivery_mode, message_category
+            FROM message_queue
+            WHERE target_session_id = 'runtimetaskparent'
+              AND message_category = 'task_complete'
+            "#,
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        queued,
+        (1, "important".to_owned(), Some("task_complete".to_owned()))
+    );
+    let raw_state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let child = raw_state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "runtimetaskchild")
+        .unwrap();
+    assert!(child["agent_task_completed_at"].is_string());
+    assert_eq!(
+        raw_state["retained_pending_messages"][0]["text"],
+        notification
+    );
+}
+
+#[tokio::test]
 async fn runtime_core_priority_sends_bypass_sequential_queue_backlog() {
     if !tmux_available() {
         return;

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -3235,6 +3235,72 @@ async fn runtime_core_task_complete_wakes_parent_runtime() {
         raw_state["retained_pending_messages"][0]["text"],
         notification
     );
+
+    let remote_parent_log = unique_temp_path();
+    let child_log = unique_temp_path();
+    let remote_state = json!({
+        "sessions": [
+            {
+                "id": "remotetaskparent",
+                "name": "remote-task-parent",
+                "friendly_name": "remote-parent",
+                "working_dir": working_dir.display().to_string(),
+                "tmux_session": "remote-task-parent",
+                "log_file": remote_parent_log.display().to_string(),
+                "status": "running",
+                "node": "macbook",
+                "created_at": "2026-06-09T00:00:00Z",
+                "last_activity": "2026-06-09T00:00:00Z"
+            },
+            {
+                "id": "remotetaskchild",
+                "name": "remote-task-child",
+                "friendly_name": "remote-child",
+                "working_dir": working_dir.display().to_string(),
+                "tmux_session": "remote-task-child",
+                "log_file": child_log.display().to_string(),
+                "status": "running",
+                "node": "primary",
+                "parent_session_id": "remotetaskparent",
+                "created_at": "2026-06-09T00:00:00Z",
+                "last_activity": "2026-06-09T00:00:00Z"
+            }
+        ],
+        "retained_pending_messages": [],
+        "retained_remind_registrations": [],
+        "retained_parent_wake_registrations": [],
+        "retained_stop_notify_states": []
+    });
+    fs::write(
+        &state_file,
+        serde_json::to_string_pretty(&remote_state).unwrap(),
+    )
+    .unwrap();
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/remotetaskchild/task-complete",
+        json!({ "requester_session_id": "remotetaskchild" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "completed");
+    assert_eq!(payload["em_notified"], true);
+    let remote_queued: (i64, String, Option<String>) = queue_conn
+        .query_row(
+            r#"
+            SELECT delivered_at IS NOT NULL, delivery_mode, message_category
+            FROM message_queue
+            WHERE target_session_id = 'remotetaskparent'
+              AND message_category = 'task_complete'
+            "#,
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        remote_queued,
+        (0, "important".to_owned(), Some("task_complete".to_owned()))
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #813

## Summary
- pass the Rust runtime into task-complete when runtime mode is enabled
- drain the queued important `task_complete` message to the selected parent/EM when that session is live
- preserve fixture-write behavior and existing response shape
- add runtime coverage proving task-complete reaches the parent tmux output and marks the queue row delivered

## Verification
- `cargo test --manifest-path crates/sm-server/Cargo.toml runtime_core_task_complete_wakes_parent_runtime -- --nocapture`
- `cargo test --manifest-path crates/sm-server/Cargo.toml fixture_completion_endpoints_preserve_python_compatible_state -- --nocapture`
- `cargo fmt --manifest-path crates/sm-server/Cargo.toml --check`
- `cargo check --manifest-path crates/sm-server/Cargo.toml --bin sm-server --bin sm`
- `cargo test --manifest-path crates/sm-server/Cargo.toml`
- `git diff --check`