### PR TITLE
Add Rust input-batch send support

### DIFF
--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -444,22 +444,44 @@ fn run() -> Result<()> {
             if text.trim().is_empty() {
                 bail!("send text is required");
             }
-            let payload = client.post_json(
-                &format!("/sessions/{}/input", args.session_id),
-                json!({
-                    "text": text,
-                    "delivery_mode": if args.urgent { "urgent" } else { "sequential" },
-                    "notify_after_seconds": args.wait
-                }),
-            )?;
-            println!(
-                "{}",
-                if payload["delivered"].as_bool().unwrap_or(false) {
-                    "delivered"
-                } else {
-                    "not delivered"
+            let delivery_mode = if args.urgent { "urgent" } else { "sequential" };
+            let targets = split_send_targets(&args.session_id);
+            if targets.len() > 1 {
+                let payload = client.post_json(
+                    "/sessions/input-batch",
+                    json!({
+                        "recipients": targets,
+                        "text": text,
+                        "delivery_mode": delivery_mode,
+                        "notify_after_seconds": args.wait
+                    }),
+                )?;
+                print_batch_send_result(&payload)?;
+                if payload["failure_count"].as_u64().unwrap_or(0) > 0 {
+                    bail!("one or more sends failed");
                 }
-            );
+            } else {
+                let target = targets
+                    .first()
+                    .map(String::as_str)
+                    .unwrap_or(args.session_id.as_str());
+                let payload = client.post_json(
+                    &format!("/sessions/{target}/input"),
+                    json!({
+                        "text": text,
+                        "delivery_mode": delivery_mode,
+                        "notify_after_seconds": args.wait
+                    }),
+                )?;
+                println!(
+                    "{}",
+                    if payload["delivered"].as_bool().unwrap_or(false) {
+                        "delivered"
+                    } else {
+                        "not delivered"
+                    }
+                );
+            }
         }
         Command::Output(args) => print_output(&client, &args.session_id, args.lines)?,
         Command::Tail(args) => print_output(&client, &args.session_id, args.lines)?,
@@ -661,6 +683,43 @@ fn print_output(client: &ApiClient, session_id: &str, lines: usize) -> Result<()
         print!("{output}");
     }
     Ok(())
+}
+
+fn print_batch_send_result(payload: &Value) -> Result<()> {
+    let Some(results) = payload["results"].as_array() else {
+        bail!("batch send response missing results");
+    };
+    for item in results {
+        let identifier = item["identifier"].as_str().unwrap_or("<unknown>");
+        let status = item["status"].as_str().unwrap_or("failed");
+        let session_id = item["session_id"].as_str().unwrap_or(identifier);
+        let target_name = item["target_name"]
+            .as_str()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or(session_id);
+        match status {
+            "delivered" => println!("Input sent to {target_name} ({session_id})"),
+            "queued" => println!("Input queued for {target_name} ({session_id})"),
+            _ => {
+                let detail = item["detail"].as_str().unwrap_or("Failed to send input");
+                eprintln!("Error: {identifier}: {detail}");
+            }
+        }
+    }
+    Ok(())
+}
+
+fn split_send_targets(raw_value: &str) -> Vec<String> {
+    let mut identifiers = Vec::new();
+    let mut seen = std::collections::BTreeSet::new();
+    for part in raw_value.split(',') {
+        let identifier = part.trim();
+        if identifier.is_empty() || !seen.insert(identifier.to_owned()) {
+            continue;
+        }
+        identifiers.push(identifier.to_owned());
+    }
+    identifiers
 }
 
 fn wait_for_session(client: &ApiClient, session_id: &str, seconds: u64) -> Result<()> {

--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -446,16 +446,10 @@ fn run() -> Result<()> {
             }
             let delivery_mode = if args.urgent { "urgent" } else { "sequential" };
             let targets = split_send_targets(&args.session_id);
+            let mut payload = send_input_payload(text, delivery_mode, args.wait);
             if targets.len() > 1 {
-                let payload = client.post_json(
-                    "/sessions/input-batch",
-                    json!({
-                        "recipients": targets,
-                        "text": text,
-                        "delivery_mode": delivery_mode,
-                        "notify_after_seconds": args.wait
-                    }),
-                )?;
+                payload["recipients"] = json!(targets);
+                let payload = client.post_json("/sessions/input-batch", payload)?;
                 print_batch_send_result(&payload)?;
                 if payload["failure_count"].as_u64().unwrap_or(0) > 0 {
                     bail!("one or more sends failed");
@@ -465,14 +459,7 @@ fn run() -> Result<()> {
                     .first()
                     .map(String::as_str)
                     .unwrap_or(args.session_id.as_str());
-                let payload = client.post_json(
-                    &format!("/sessions/{target}/input"),
-                    json!({
-                        "text": text,
-                        "delivery_mode": delivery_mode,
-                        "notify_after_seconds": args.wait
-                    }),
-                )?;
+                let payload = client.post_json(&format!("/sessions/{target}/input"), payload)?;
                 println!(
                     "{}",
                     if payload["delivered"].as_bool().unwrap_or(false) {
@@ -720,6 +707,19 @@ fn split_send_targets(raw_value: &str) -> Vec<String> {
         identifiers.push(identifier.to_owned());
     }
     identifiers
+}
+
+fn send_input_payload(text: String, delivery_mode: &str, wait: Option<u64>) -> Value {
+    let mut payload = json!({
+        "text": text,
+        "delivery_mode": delivery_mode,
+        "notify_after_seconds": wait,
+        "from_sm_send": true
+    });
+    if let Some(sender_session_id) = optional_current_session_id() {
+        payload["sender_session_id"] = json!(sender_session_id);
+    }
+    payload
 }
 
 fn wait_for_session(client: &ApiClient, session_id: &str, seconds: u64) -> Result<()> {
@@ -1486,6 +1486,21 @@ mod tests {
         assert_eq!(https.host, "sm.example.test");
         assert_eq!(https.port, 443);
         assert_eq!(https.path_prefix, "/client");
+    }
+
+    #[test]
+    fn send_input_payload_includes_sm_send_sender_metadata() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _env = EnvRestore::new(&["SESSION_MANAGER_ID", "CLAUDE_SESSION_MANAGER_ID"]);
+        env::set_var("SESSION_MANAGER_ID", "sender001");
+
+        let payload = send_input_payload("hello".to_owned(), "sequential", Some(7));
+
+        assert_eq!(payload["text"], "hello");
+        assert_eq!(payload["delivery_mode"], "sequential");
+        assert_eq!(payload["notify_after_seconds"], 7);
+        assert_eq!(payload["from_sm_send"], true);
+        assert_eq!(payload["sender_session_id"], "sender001");
     }
 
     fn write_temp_config(content: &str) -> PathBuf {

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -727,6 +727,15 @@ fn send_session_input_batch_one(
             "Session not found".to_owned(),
         ));
     };
+    if !outcome.delivered && matches!(outcome.status.as_str(), "stopped" | "killed") {
+        return Ok(failed_batch_result(
+            identifier,
+            Some(outcome.session_id),
+            session_target_name(&session),
+            Some(session.provider),
+            format!("Session {identifier} is stopped"),
+        ));
+    }
     let status = if outcome.delivered {
         "delivered".to_owned()
     } else {

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -37,9 +37,10 @@ use crate::runtime::TmuxRuntime;
 use crate::sessions::{
     expand_home, is_primary_node, AgentStatusRequest, ArmStopNotifyOutcome, ArmStopNotifyRequest,
     ClearSessionRequest, ClientSessionResponse, ContextMonitorOutcome, ContextMonitorRequest,
-    CoreClearOutcome, CoreRestoreOutcome, CoreRetireOutcome, CreateCoreSessionRequest,
-    HandoffOutcome, HandoffRequest, MaintainerMutationOutcome, RegistryMutationOutcome,
-    RoleRegistrationRequest, SendCoreInputRequest, SessionRecord, SessionResponse, SessionStore,
+    CoreClearOutcome, CoreInputBatchResponse, CoreInputBatchResult, CoreRestoreOutcome,
+    CoreRetireOutcome, CreateCoreSessionRequest, HandoffOutcome, HandoffRequest,
+    MaintainerMutationOutcome, RegistryMutationOutcome, RoleRegistrationRequest,
+    SendCoreInputBatchRequest, SendCoreInputRequest, SessionRecord, SessionResponse, SessionStore,
     SessionsEnvelope, SetMaintainerRequest, TaskCompleteOutcome, TaskCompleteRequest,
     TurnCompleteOutcome,
 };
@@ -77,6 +78,7 @@ pub fn router(state: AppState) -> Router {
         .route("/events", get(events_stream))
         .route("/__shadow/http", post(shadow_http))
         .route("/sessions", get(list_sessions).post(create_session))
+        .route("/sessions/input-batch", post(send_session_input_batch))
         .route("/sessions/spawn", post(spawn_session))
         .route("/sessions/context-monitor", get(get_context_monitor_status))
         .route("/sessions/{session_id}", get(get_session))
@@ -625,6 +627,173 @@ async fn send_session_input(
         return Err(ApiError::NotFound("Session not found"));
     };
     Ok(Json(serde_json::to_value(result)?))
+}
+
+async fn send_session_input_batch(
+    State(state): State<Arc<AppState>>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(payload): Json<SendCoreInputBatchRequest>,
+) -> Result<Json<CoreInputBatchResponse>, ApiError> {
+    ensure_session_allowed_from_parts(
+        &state.config,
+        &headers,
+        Some(peer_addr),
+        "/sessions/input-batch",
+    )?;
+    ensure_core_writes_enabled(&state)?;
+    if payload.input.text.trim().is_empty() {
+        return Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: "text is required".to_owned(),
+        });
+    }
+    let recipients = unique_identifiers(&payload.recipients);
+    if recipients.is_empty() {
+        return Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: "At least one recipient is required".to_owned(),
+        });
+    }
+
+    let runtime = state
+        .config
+        .rust_core
+        .runtime_enabled
+        .then(|| TmuxRuntime::from_config(&state.config.rust_core));
+    let mut results = Vec::with_capacity(recipients.len());
+    for identifier in recipients {
+        results.push(send_session_input_batch_one(
+            &state,
+            runtime.as_ref(),
+            &identifier,
+            payload.input.clone(),
+        )?);
+    }
+    let success_count = results
+        .iter()
+        .filter(|result| matches!(result.status.as_str(), "delivered" | "queued" | "emailed"))
+        .count();
+    let failure_count = results.len().saturating_sub(success_count);
+
+    Ok(Json(CoreInputBatchResponse {
+        ok: failure_count == 0,
+        requested_count: results.len(),
+        success_count,
+        failure_count,
+        delivery_mode: payload.input.delivery_mode,
+        results,
+    }))
+}
+
+fn send_session_input_batch_one(
+    state: &AppState,
+    runtime: Option<&TmuxRuntime>,
+    identifier: &str,
+    payload: SendCoreInputRequest,
+) -> Result<CoreInputBatchResult, ApiError> {
+    let Some(session) = state.session_store.get_session(identifier)? else {
+        return Ok(failed_batch_result(
+            identifier,
+            None,
+            None,
+            None,
+            format!("Session '{identifier}' not found"),
+        ));
+    };
+    if runtime.is_some() && !is_primary_node(&session.node) {
+        return Ok(failed_batch_result(
+            identifier,
+            Some(session.id.clone()),
+            session_target_name(&session),
+            Some(session.provider.clone()),
+            format!("Rust runtime does not support remote node {}", session.node),
+        ));
+    }
+
+    let outcome = if let Some(runtime) = runtime {
+        state
+            .session_store
+            .send_core_input_with_runtime(&session.id, payload, runtime)?
+    } else {
+        state.session_store.send_core_input(&session.id, payload)?
+    };
+    let Some(outcome) = outcome else {
+        return Ok(failed_batch_result(
+            identifier,
+            None,
+            None,
+            None,
+            "Session not found".to_owned(),
+        ));
+    };
+    let status = if outcome.delivered {
+        "delivered".to_owned()
+    } else {
+        "queued".to_owned()
+    };
+    Ok(CoreInputBatchResult {
+        identifier: identifier.to_owned(),
+        status: status.clone(),
+        delivery_kind: "session".to_owned(),
+        session_id: Some(outcome.session_id),
+        target_name: session_target_name(&session),
+        provider: Some(session.provider),
+        bootstrapped: false,
+        queue_position: None,
+        estimated_delivery: (status == "queued").then(|| "deferred".to_owned()),
+        email_username: None,
+        email_address: None,
+        detail: None,
+    })
+}
+
+fn session_target_name(session: &SessionRecord) -> Option<String> {
+    session
+        .friendly_name
+        .as_deref()
+        .or(Some(session.name.as_str()))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn failed_batch_result(
+    identifier: &str,
+    session_id: Option<String>,
+    target_name: Option<String>,
+    provider: Option<String>,
+    detail: String,
+) -> CoreInputBatchResult {
+    CoreInputBatchResult {
+        identifier: identifier.to_owned(),
+        status: "failed".to_owned(),
+        delivery_kind: "none".to_owned(),
+        session_id,
+        target_name,
+        provider,
+        bootstrapped: false,
+        queue_position: None,
+        estimated_delivery: None,
+        email_username: None,
+        email_address: None,
+        detail: Some(detail),
+    }
+}
+
+fn unique_identifiers(values: &[String]) -> Vec<String> {
+    let mut identifiers = Vec::new();
+    let mut seen = std::collections::BTreeSet::new();
+    for value in values {
+        for part in value.split(',') {
+            let identifier = part.trim();
+            if identifier.is_empty() || !seen.insert(identifier.to_owned()) {
+                continue;
+            }
+            identifiers.push(identifier.to_owned());
+        }
+    }
+    identifiers
 }
 
 async fn set_agent_status(

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1494,6 +1494,14 @@ pub struct SendCoreInputRequest {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct SendCoreInputBatchRequest {
+    #[serde(flatten)]
+    pub input: SendCoreInputRequest,
+    #[serde(default)]
+    pub recipients: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
 pub struct AgentStatusRequest {
     #[serde(default)]
     pub text: Option<String>,
@@ -1564,6 +1572,32 @@ pub struct CoreInputResult {
     pub delivery_mode: String,
     pub notify_after_seconds: Option<u64>,
     pub status: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CoreInputBatchResult {
+    pub identifier: String,
+    pub status: String,
+    pub delivery_kind: String,
+    pub session_id: Option<String>,
+    pub target_name: Option<String>,
+    pub provider: Option<String>,
+    pub bootstrapped: bool,
+    pub queue_position: Option<u64>,
+    pub estimated_delivery: Option<String>,
+    pub email_username: Option<String>,
+    pub email_address: Option<String>,
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CoreInputBatchResponse {
+    pub ok: bool,
+    pub requested_count: usize,
+    pub success_count: usize,
+    pub failure_count: usize,
+    pub delivery_mode: String,
+    pub results: Vec<CoreInputBatchResult>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -1125,6 +1125,7 @@ async fn fixture_core_input_batch_reports_per_recipient_results() {
     for (id, name) in [
         ("batchfixturea", "batch-fixture-a"),
         ("batchfixtureb", "batch-fixture-b"),
+        ("batchstopped", "batch-stopped"),
     ] {
         let (status, payload) = post_json(
             app.clone(),
@@ -1140,12 +1141,15 @@ async fn fixture_core_input_batch_reports_per_recipient_results() {
         assert_eq!(status, StatusCode::OK);
         assert_eq!(payload["id"], id);
     }
+    let (status, payload) = post_json(app.clone(), "/sessions/batchstopped/kill", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "killed");
 
     let (status, payload) = post_json(
         app.clone(),
         "/sessions/input-batch",
         json!({
-            "recipients": ["batchfixturea, batchfixtureb", "missingbatch", "batchfixturea"],
+            "recipients": ["batchfixturea, batchfixtureb", "batchstopped", "missingbatch", "batchfixturea"],
             "text": "fixture batch payload",
             "delivery_mode": "sequential"
         }),
@@ -1153,9 +1157,9 @@ async fn fixture_core_input_batch_reports_per_recipient_results() {
     .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["ok"], false);
-    assert_eq!(payload["requested_count"], 3);
+    assert_eq!(payload["requested_count"], 4);
     assert_eq!(payload["success_count"], 2);
-    assert_eq!(payload["failure_count"], 1);
+    assert_eq!(payload["failure_count"], 2);
     assert_eq!(payload["delivery_mode"], "sequential");
     let results = payload["results"].as_array().unwrap();
     assert_eq!(results[0]["identifier"], "batchfixturea");
@@ -1165,10 +1169,14 @@ async fn fixture_core_input_batch_reports_per_recipient_results() {
     assert_eq!(results[0]["target_name"], "batch-fixture-a");
     assert_eq!(results[1]["identifier"], "batchfixtureb");
     assert_eq!(results[1]["status"], "delivered");
-    assert_eq!(results[2]["identifier"], "missingbatch");
+    assert_eq!(results[2]["identifier"], "batchstopped");
     assert_eq!(results[2]["status"], "failed");
     assert_eq!(results[2]["delivery_kind"], "none");
-    assert_eq!(results[2]["detail"], "Session 'missingbatch' not found");
+    assert_eq!(results[2]["detail"], "Session batchstopped is stopped");
+    assert_eq!(results[3]["identifier"], "missingbatch");
+    assert_eq!(results[3]["status"], "failed");
+    assert_eq!(results[3]["delivery_kind"], "none");
+    assert_eq!(results[3]["detail"], "Session 'missingbatch' not found");
 
     let (status, payload) = get_json(app.clone(), "/sessions/batchfixturea/output?lines=5").await;
     assert_eq!(status, StatusCode::OK);

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -1107,6 +1107,84 @@ async fn fixture_core_lifecycle_creates_sends_outputs_and_retires() {
 }
 
 #[tokio::test]
+async fn fixture_core_input_batch_reports_per_recipient_results() {
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        rust_core: RustCoreConfig {
+            fixture_writes_enabled: true,
+            log_dir: Some(log_dir.display().to_string()),
+            ..RustCoreConfig::default()
+        },
+        ..AppConfig::default()
+    }));
+
+    for (id, name) in [
+        ("batchfixturea", "batch-fixture-a"),
+        ("batchfixtureb", "batch-fixture-b"),
+    ] {
+        let (status, payload) = post_json(
+            app.clone(),
+            "/sessions",
+            json!({
+                "id": id,
+                "name": name,
+                "working_dir": "/repo",
+                "provider": "claude"
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(payload["id"], id);
+    }
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/input-batch",
+        json!({
+            "recipients": ["batchfixturea, batchfixtureb", "missingbatch", "batchfixturea"],
+            "text": "fixture batch payload",
+            "delivery_mode": "sequential"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["ok"], false);
+    assert_eq!(payload["requested_count"], 3);
+    assert_eq!(payload["success_count"], 2);
+    assert_eq!(payload["failure_count"], 1);
+    assert_eq!(payload["delivery_mode"], "sequential");
+    let results = payload["results"].as_array().unwrap();
+    assert_eq!(results[0]["identifier"], "batchfixturea");
+    assert_eq!(results[0]["status"], "delivered");
+    assert_eq!(results[0]["delivery_kind"], "session");
+    assert_eq!(results[0]["session_id"], "batchfixturea");
+    assert_eq!(results[0]["target_name"], "batch-fixture-a");
+    assert_eq!(results[1]["identifier"], "batchfixtureb");
+    assert_eq!(results[1]["status"], "delivered");
+    assert_eq!(results[2]["identifier"], "missingbatch");
+    assert_eq!(results[2]["status"], "failed");
+    assert_eq!(results[2]["delivery_kind"], "none");
+    assert_eq!(results[2]["detail"], "Session 'missingbatch' not found");
+
+    let (status, payload) = get_json(app.clone(), "/sessions/batchfixturea/output?lines=5").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(payload["output"]
+        .as_str()
+        .unwrap()
+        .contains("fixture batch payload"));
+    let (status, payload) = get_json(app, "/sessions/batchfixtureb/output?lines=5").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(payload["output"]
+        .as_str()
+        .unwrap()
+        .contains("fixture batch payload"));
+}
+
+#[tokio::test]
 async fn fixture_core_session_graph_endpoints_round_trip_state() {
     let state_file = unique_temp_path();
     let log_dir = unique_temp_path();
@@ -2674,6 +2752,82 @@ async fn runtime_core_delivers_sm_send_metadata_rows() {
     assert_eq!(pending.11, None);
     assert_eq!(pending.12.as_deref(), Some("sm-send"));
     assert!(pending.13.is_some());
+}
+
+#[tokio::test]
+async fn runtime_core_input_batch_delivers_to_multiple_sessions() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let working_dir = unique_temp_path();
+    fs::create_dir_all(&working_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-test-input-batch-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app(&state_file, &log_dir, &tmux_socket);
+
+    for (id, prompt) in [
+        ("runtimebatcha", "runtime batch a initial"),
+        ("runtimebatchb", "runtime batch b initial"),
+    ] {
+        let (status, payload) = post_json(
+            app.clone(),
+            "/sessions",
+            json!({
+                "id": id,
+                "working_dir": working_dir.display().to_string(),
+                "provider": "claude",
+                "initial_message": prompt
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(payload["id"], id);
+        wait_for_output_contains(app.clone(), id, &format!("runtime:{prompt}")).await;
+    }
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/input-batch",
+        json!({
+            "recipients": ["runtimebatcha,runtimebatchb", "missingruntimebatch"],
+            "text": "runtime batch payload",
+            "delivery_mode": "sequential"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["ok"], false);
+    assert_eq!(payload["requested_count"], 3);
+    assert_eq!(payload["success_count"], 2);
+    assert_eq!(payload["failure_count"], 1);
+    let results = payload["results"].as_array().unwrap();
+    assert_eq!(results[0]["identifier"], "runtimebatcha");
+    assert_eq!(results[0]["status"], "delivered");
+    assert_eq!(results[0]["delivery_kind"], "session");
+    assert_eq!(results[1]["identifier"], "runtimebatchb");
+    assert_eq!(results[1]["status"], "delivered");
+    assert_eq!(results[2]["identifier"], "missingruntimebatch");
+    assert_eq!(results[2]["status"], "failed");
+    assert_eq!(
+        results[2]["detail"],
+        "Session 'missingruntimebatch' not found"
+    );
+    wait_for_output_contains(
+        app.clone(),
+        "runtimebatcha",
+        "runtime:runtime batch payload",
+    )
+    .await;
+    wait_for_output_contains(app, "runtimebatchb", "runtime:runtime batch payload").await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #815

## Summary
- add Rust `POST /sessions/input-batch` support for retained session recipients
- dedupe comma-delimited recipients while preserving order and return Python-compatible aggregate/per-target result rows
- route comma-delimited Rust CLI `sm send` targets through the new batch endpoint
- add fixture and runtime coverage for multi-recipient delivery plus missing-recipient failures

## Scope
- This keeps email/human fallback out of this core Rust slice; unresolved non-session recipients return per-target failed rows.

## Verification
- `cargo fmt --manifest-path crates/sm-server/Cargo.toml --check`
- `cargo check --manifest-path crates/sm-server/Cargo.toml --bin sm-server --bin sm`
- `cargo test --manifest-path crates/sm-server/Cargo.toml`
- `git diff --check`