### PR TITLE
Add Rust subagent tracking surface

### DIFF
--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -1,6 +1,6 @@
 use std::{
     env, fs,
-    io::{Read, Write},
+    io::{self, Read, Write},
     net::TcpStream,
     path::{Path, PathBuf},
     process, thread,
@@ -59,6 +59,11 @@ enum Command {
     Review(ReviewArgs),
     #[command(name = "request-codex-review")]
     RequestCodexReview(RequestCodexReviewArgs),
+    #[command(name = "subagent-start")]
+    SubagentStart(EmptyArgs),
+    #[command(name = "subagent-stop")]
+    SubagentStop(EmptyArgs),
+    Subagents(SessionIdArgs),
     Claude(ProviderLaunchArgs),
     Codex(ProviderLaunchArgs),
     #[command(name = "codex-app")]
@@ -652,6 +657,9 @@ fn run() -> Result<()> {
         }
         Command::Roster(_) => print_roster(&client)?,
         Command::Wait(args) => wait_for_session(&client, &args.session_id, args.seconds)?,
+        Command::SubagentStart(_) => run_subagent_start(&client)?,
+        Command::SubagentStop(_) => run_subagent_stop(&client)?,
+        Command::Subagents(args) => print_subagents(&client, &args.session_id)?,
         _ => bail!("this retained command is not implemented in the Rust core slice yet"),
     }
     Ok(())
@@ -694,6 +702,98 @@ fn print_batch_send_result(payload: &Value) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn run_subagent_start(client: &ApiClient) -> Result<()> {
+    let Some(session_id) = optional_current_session_id() else {
+        let mut ignored = String::new();
+        io::stdin().read_to_string(&mut ignored)?;
+        return Ok(());
+    };
+    let payload = read_json_stdin()?;
+    let agent_id = json_value_string(&payload, "agent_id")
+        .ok_or_else(|| anyhow!("Missing agent_id in hook payload"))?;
+    let agent_type = json_value_string(&payload, "agent_type")
+        .or_else(|| json_value_string(&payload, "subagent_type"))
+        .unwrap_or_else(|| "unknown".to_owned());
+    let transcript_path = json_value_string(&payload, "agent_transcript_path");
+    client.post_json(
+        &format!("/sessions/{}/subagents", encode_path_segment(&session_id)),
+        json!({
+            "agent_id": agent_id,
+            "agent_type": agent_type,
+            "transcript_path": transcript_path
+        }),
+    )?;
+    Ok(())
+}
+
+fn run_subagent_stop(client: &ApiClient) -> Result<()> {
+    let Some(session_id) = optional_current_session_id() else {
+        let mut ignored = String::new();
+        io::stdin().read_to_string(&mut ignored)?;
+        return Ok(());
+    };
+    let payload = read_json_stdin()?;
+    let agent_id = json_value_string(&payload, "agent_id")
+        .ok_or_else(|| anyhow!("Missing agent_id in hook payload"))?;
+    let summary = json_value_string(&payload, "summary");
+    client.post_json(
+        &format!(
+            "/sessions/{}/subagents/{}/stop",
+            encode_path_segment(&session_id),
+            encode_path_segment(&agent_id)
+        ),
+        json!({ "summary": summary }),
+    )?;
+    Ok(())
+}
+
+fn print_subagents(client: &ApiClient, session_id: &str) -> Result<()> {
+    let session = client.get_json(&format!("/sessions/{}", encode_path_segment(session_id)))?;
+    let payload = client.get_json(&format!(
+        "/sessions/{}/subagents",
+        encode_path_segment(session_id)
+    ))?;
+    let name = session["friendly_name"]
+        .as_str()
+        .or_else(|| session["name"].as_str())
+        .unwrap_or(session_id);
+    let subagents = payload["subagents"].as_array().cloned().unwrap_or_default();
+    if subagents.is_empty() {
+        println!("{name} has no subagents");
+        return Ok(());
+    }
+    println!("{name} ({session_id}) subagents:");
+    for subagent in subagents {
+        let agent_id = subagent["agent_id"].as_str().unwrap_or("unknown");
+        let short_id = agent_id.chars().take(6).collect::<String>();
+        let agent_type = subagent["agent_type"].as_str().unwrap_or("unknown");
+        let status = subagent["status"].as_str().unwrap_or("unknown");
+        let started_at = subagent["started_at"].as_str().unwrap_or("");
+        println!("  {agent_type} ({short_id}) | {status} | {started_at}");
+        if let Some(summary) = subagent["summary"]
+            .as_str()
+            .filter(|value| !value.is_empty())
+        {
+            println!("     {summary}");
+        }
+    }
+    Ok(())
+}
+
+fn read_json_stdin() -> Result<Value> {
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input)?;
+    serde_json::from_str(&input).with_context(|| "Failed to parse hook payload")
+}
+
+fn json_value_string(value: &Value, key: &str) -> Option<String> {
+    value[key]
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
 }
 
 fn split_send_targets(raw_value: &str) -> Vec<String> {

--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -737,14 +737,18 @@ fn run_subagent_stop(client: &ApiClient) -> Result<()> {
     let payload = read_json_stdin()?;
     let agent_id = json_value_string(&payload, "agent_id")
         .ok_or_else(|| anyhow!("Missing agent_id in hook payload"))?;
-    let summary = json_value_string(&payload, "summary");
+    let transcript_path = json_value_string(&payload, "agent_transcript_path");
+    let summary = subagent_stop_summary(&payload);
     client.post_json(
         &format!(
             "/sessions/{}/subagents/{}/stop",
             encode_path_segment(&session_id),
             encode_path_segment(&agent_id)
         ),
-        json!({ "summary": summary }),
+        json!({
+            "summary": summary,
+            "transcript_path": transcript_path
+        }),
     )?;
     Ok(())
 }
@@ -794,6 +798,11 @@ fn json_value_string(value: &Value, key: &str) -> Option<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned)
+}
+
+fn subagent_stop_summary(payload: &Value) -> Option<String> {
+    json_value_string(payload, "last_assistant_message")
+        .or_else(|| json_value_string(payload, "summary"))
 }
 
 fn split_send_targets(raw_value: &str) -> Vec<String> {
@@ -1601,6 +1610,25 @@ mod tests {
         assert_eq!(payload["notify_after_seconds"], 7);
         assert_eq!(payload["from_sm_send"], true);
         assert_eq!(payload["sender_session_id"], "sender001");
+    }
+
+    #[test]
+    fn subagent_stop_summary_prefers_current_hook_field() {
+        let payload = json!({
+            "last_assistant_message": "done from hook",
+            "summary": "legacy summary"
+        });
+
+        assert_eq!(
+            subagent_stop_summary(&payload).as_deref(),
+            Some("done from hook")
+        );
+
+        let legacy_payload = json!({ "summary": "legacy summary" });
+        assert_eq!(
+            subagent_stop_summary(&legacy_payload).as_deref(),
+            Some("legacy summary")
+        );
     }
 
     fn write_temp_config(content: &str) -> PathBuf {

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -41,7 +41,8 @@ use crate::sessions::{
     CoreRetireOutcome, CreateCoreSessionRequest, HandoffOutcome, HandoffRequest,
     MaintainerMutationOutcome, RegistryMutationOutcome, RoleRegistrationRequest,
     SendCoreInputBatchRequest, SendCoreInputRequest, SessionRecord, SessionResponse, SessionStore,
-    SessionsEnvelope, SetMaintainerRequest, TaskCompleteOutcome, TaskCompleteRequest,
+    SessionsEnvelope, SetMaintainerRequest, SubagentStartOutcome, SubagentStartRequest,
+    SubagentStopOutcome, SubagentStopRequest, TaskCompleteOutcome, TaskCompleteRequest,
     TurnCompleteOutcome,
 };
 
@@ -103,6 +104,14 @@ pub fn router(state: AppState) -> Router {
         .route(
             "/sessions/{session_id}/context-monitor",
             post(set_context_monitor),
+        )
+        .route(
+            "/sessions/{session_id}/subagents",
+            get(list_subagents).post(register_subagent_start),
+        )
+        .route(
+            "/sessions/{session_id}/subagents/{agent_id}/stop",
+            post(register_subagent_stop),
         )
         .route("/sessions/{session_id}/input", post(send_session_input))
         .route("/sessions/{session_id}/kill", post(retire_session))
@@ -1062,6 +1071,68 @@ async fn set_context_monitor(
     }
 }
 
+async fn register_subagent_start(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(payload): Json<SubagentStartRequest>,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_allowed_from_parts(
+        &state.config,
+        &headers,
+        Some(peer_addr),
+        &format!("/sessions/{session_id}/subagents"),
+    )?;
+    ensure_core_writes_enabled(&state)?;
+    match state
+        .session_store
+        .register_subagent_start(&session_id, payload)?
+    {
+        SubagentStartOutcome::Registered(result) => Ok(Json(serde_json::to_value(result)?)),
+        SubagentStartOutcome::NotFound => Err(ApiError::NotFound("Session not found")),
+    }
+}
+
+async fn register_subagent_stop(
+    State(state): State<Arc<AppState>>,
+    Path((session_id, agent_id)): Path<(String, String)>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(payload): Json<SubagentStopRequest>,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_allowed_from_parts(
+        &state.config,
+        &headers,
+        Some(peer_addr),
+        &format!("/sessions/{session_id}/subagents/{agent_id}/stop"),
+    )?;
+    ensure_core_writes_enabled(&state)?;
+    match state
+        .session_store
+        .register_subagent_stop(&session_id, &agent_id, payload)?
+    {
+        SubagentStopOutcome::Stopped(result) => Ok(Json(serde_json::to_value(result)?)),
+        SubagentStopOutcome::SessionNotFound => Err(ApiError::NotFound("Session not found")),
+        SubagentStopOutcome::SubagentNotFound(agent_id) => Err(ApiError::Status {
+            status: StatusCode::NOT_FOUND,
+            detail: format!("Subagent {agent_id} not found"),
+        }),
+    }
+}
+
+async fn list_subagents(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+    request: Request,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    let Some(result) = state.session_store.list_subagents(&session_id)? else {
+        return Err(ApiError::NotFound("Session not found"));
+    };
+    Ok(Json(serde_json::to_value(result)?))
+}
+
 async fn schedule_handoff(
     State(state): State<Arc<AppState>>,
     Path(session_id): Path<String>,
@@ -1559,6 +1630,26 @@ fn shadow_predict_session_read(
             session_id: session_id.to_owned(),
             output,
         })?;
+        return Ok(Some(ShadowPrediction {
+            status: StatusCode::OK.as_u16(),
+            body_sha256: Some(sha256_hex(&body)),
+            support_status: "implemented_read",
+        }));
+    }
+
+    if let Some(session_id) = path
+        .strip_prefix("/sessions/")
+        .and_then(|value| value.strip_suffix("/subagents"))
+    {
+        let Some(response) = state.session_store.list_subagents(session_id)? else {
+            let body = serde_json::to_vec(&json!({ "detail": "Session not found" }))?;
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::NOT_FOUND.as_u16(),
+                body_sha256: Some(sha256_hex(&body)),
+                support_status: "implemented_read",
+            }));
+        };
+        let body = serde_json::to_vec(&response)?;
         return Ok(Some(ShadowPrediction {
             status: StatusCode::OK.as_u16(),
             body_sha256: Some(sha256_hex(&body)),

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -12,7 +12,7 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256};
-use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+use time::{format_description::well_known::Rfc3339, macros::format_description, OffsetDateTime};
 
 use crate::queue::{
     followup_notification_text, PendingMessage, QueueMessageMetadata, RetainedQueueStore,
@@ -1255,7 +1255,7 @@ impl SessionStore {
     ) -> Result<SubagentStartOutcome> {
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
-        let now = now_rfc3339();
+        let now = now_python_naive_iso();
         let sessions = ensure_sessions_array_mut(&mut state)?;
         let Some(session) = session_object_mut(sessions, session_id) else {
             return Ok(SubagentStartOutcome::NotFound);
@@ -1284,7 +1284,7 @@ impl SessionStore {
     ) -> Result<SubagentStopOutcome> {
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
-        let now = now_rfc3339();
+        let now = now_python_naive_iso();
         let sessions = ensure_sessions_array_mut(&mut state)?;
         let Some(session) = session_object_mut(sessions, session_id) else {
             return Ok(SubagentStopOutcome::SessionNotFound);
@@ -3110,6 +3110,16 @@ fn now_rfc3339() -> String {
     OffsetDateTime::now_utc()
         .format(&Rfc3339)
         .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned())
+}
+
+fn now_python_naive_iso() -> String {
+    let now_utc = OffsetDateTime::now_utc();
+    let local = OffsetDateTime::now_local().unwrap_or(now_utc);
+    local
+        .format(format_description!(
+            "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:6]"
+        ))
+        .unwrap_or_else(|_| "1970-01-01T00:00:00.000000".to_owned())
 }
 
 pub fn expand_home(path: &str) -> PathBuf {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1299,6 +1299,9 @@ impl SessionStore {
         if let Some(subagent) = subagent.as_object_mut() {
             subagent.insert("stopped_at".to_owned(), Value::String(now));
             subagent.insert("status".to_owned(), Value::String("completed".to_owned()));
+            if let Some(transcript_path) = request.transcript_path {
+                subagent.insert("transcript_path".to_owned(), Value::String(transcript_path));
+            }
             if let Some(summary) = request.summary {
                 subagent.insert("summary".to_owned(), Value::String(summary));
             }
@@ -1655,6 +1658,8 @@ pub struct SubagentStartRequest {
 pub struct SubagentStopRequest {
     #[serde(default)]
     pub summary: Option<String>,
+    #[serde(default)]
+    pub transcript_path: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1248,6 +1248,96 @@ impl SessionStore {
         }))
     }
 
+    pub fn register_subagent_start(
+        &self,
+        session_id: &str,
+        request: SubagentStartRequest,
+    ) -> Result<SubagentStartOutcome> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let now = now_rfc3339();
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let Some(session) = session_object_mut(sessions, session_id) else {
+            return Ok(SubagentStartOutcome::NotFound);
+        };
+        let subagent = json!({
+            "agent_id": request.agent_id,
+            "agent_type": request.agent_type,
+            "parent_session_id": session_id,
+            "transcript_path": request.transcript_path,
+            "started_at": now,
+            "stopped_at": null,
+            "status": "running",
+            "summary": null
+        });
+        let response = subagent_response_from_value(&subagent)?;
+        ensure_subagents_array_mut(session).push(subagent);
+        self.write_raw_json_value(&state)?;
+        Ok(SubagentStartOutcome::Registered(response))
+    }
+
+    pub fn register_subagent_stop(
+        &self,
+        session_id: &str,
+        agent_id: &str,
+        request: SubagentStopRequest,
+    ) -> Result<SubagentStopOutcome> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let now = now_rfc3339();
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let Some(session) = session_object_mut(sessions, session_id) else {
+            return Ok(SubagentStopOutcome::SessionNotFound);
+        };
+        let subagents = ensure_subagents_array_mut(session);
+        let Some(subagent) = subagents
+            .iter_mut()
+            .find(|subagent| subagent.get("agent_id").and_then(Value::as_str) == Some(agent_id))
+        else {
+            return Ok(SubagentStopOutcome::SubagentNotFound(agent_id.to_owned()));
+        };
+        if let Some(subagent) = subagent.as_object_mut() {
+            subagent.insert("stopped_at".to_owned(), Value::String(now));
+            subagent.insert("status".to_owned(), Value::String("completed".to_owned()));
+            if let Some(summary) = request.summary {
+                subagent.insert("summary".to_owned(), Value::String(summary));
+            }
+        }
+        let summary = subagent
+            .get("summary")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+        self.write_raw_json_value(&state)?;
+        Ok(SubagentStopOutcome::Stopped(SubagentStopResult {
+            session_id: session_id.to_owned(),
+            agent_id: agent_id.to_owned(),
+            status: "stopped".to_owned(),
+            summary,
+        }))
+    }
+
+    pub fn list_subagents(&self, session_id: &str) -> Result<Option<SubagentListResponse>> {
+        let state = self.load_raw_json_value()?;
+        let Some(session) = raw_session_object(&state, session_id) else {
+            return Ok(None);
+        };
+        let subagents = session
+            .get("subagents")
+            .and_then(Value::as_array)
+            .map(|items| {
+                items
+                    .iter()
+                    .map(subagent_response_from_value)
+                    .collect::<Result<Vec<_>>>()
+            })
+            .transpose()?
+            .unwrap_or_default();
+        Ok(Some(SubagentListResponse {
+            session_id: session_id.to_owned(),
+            subagents,
+        }))
+    }
+
     fn load_snapshot(&self) -> Result<StateSnapshot> {
         let state_file = self.readable_state_file();
         if !state_file.exists() {
@@ -1553,6 +1643,20 @@ pub struct ArmStopNotifyRequest {
     pub delay_seconds: i64,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct SubagentStartRequest {
+    pub agent_id: String,
+    pub agent_type: String,
+    #[serde(default)]
+    pub transcript_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SubagentStopRequest {
+    #[serde(default)]
+    pub summary: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct AgentRegistrationResponse {
     pub role: String,
@@ -1598,6 +1702,31 @@ pub struct CoreInputBatchResponse {
     pub failure_count: usize,
     pub delivery_mode: String,
     pub results: Vec<CoreInputBatchResult>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SubagentResponse {
+    pub agent_id: String,
+    pub agent_type: String,
+    pub parent_session_id: String,
+    pub started_at: String,
+    pub stopped_at: Option<String>,
+    pub status: String,
+    pub summary: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SubagentStopResult {
+    pub session_id: String,
+    pub agent_id: String,
+    pub status: String,
+    pub summary: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SubagentListResponse {
+    pub session_id: String,
+    pub subagents: Vec<SubagentResponse>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1737,6 +1866,17 @@ pub enum ArmStopNotifyOutcome {
     UnknownSender(String),
 }
 
+pub enum SubagentStartOutcome {
+    Registered(SubagentResponse),
+    NotFound,
+}
+
+pub enum SubagentStopOutcome {
+    Stopped(SubagentStopResult),
+    SessionNotFound,
+    SubagentNotFound(String),
+}
+
 fn read_snapshot(path: &Path) -> Result<StateSnapshot> {
     let content = fs::read_to_string(path)
         .with_context(|| format!("failed to read session state {}", path.display()))?;
@@ -1768,6 +1908,16 @@ fn ensure_sessions_array_mut(value: &mut Value) -> Result<&mut Vec<Value>> {
         anyhow::bail!("session state field 'sessions' is not an array");
     }
     Ok(sessions.as_array_mut().expect("array checked above"))
+}
+
+fn ensure_subagents_array_mut(session: &mut Map<String, Value>) -> &mut Vec<Value> {
+    let subagents = session
+        .entry("subagents".to_owned())
+        .or_insert_with(|| json!([]));
+    if !subagents.is_array() {
+        *subagents = json!([]);
+    }
+    subagents.as_array_mut().expect("array value set above")
 }
 
 fn ensure_agent_registrations_array_mut(value: &mut Value) -> Result<&mut Vec<Value>> {
@@ -2876,6 +3026,18 @@ fn json_text(value: Option<&Value>) -> Option<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned)
+}
+
+fn subagent_response_from_value(value: &Value) -> Result<SubagentResponse> {
+    Ok(SubagentResponse {
+        agent_id: json_text(value.get("agent_id")).unwrap_or_default(),
+        agent_type: json_text(value.get("agent_type")).unwrap_or_else(|| "unknown".to_owned()),
+        parent_session_id: json_text(value.get("parent_session_id")).unwrap_or_default(),
+        started_at: json_text(value.get("started_at")).unwrap_or_default(),
+        stopped_at: json_text(value.get("stopped_at")),
+        status: json_text(value.get("status")).unwrap_or_else(|| "running".to_owned()),
+        summary: json_text(value.get("summary")),
+    })
 }
 
 fn append_log_line(path: &Path, line: &str) -> Result<()> {

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -1542,8 +1542,7 @@ async fn fixture_subagent_endpoints_round_trip_python_state_shape() {
         "/sessions/run12345/subagents",
         json!({
             "agent_id": "agent456789",
-            "agent_type": "engineer",
-            "transcript_path": "/tmp/agent456789.jsonl"
+            "agent_type": "engineer"
         }),
     )
     .await;
@@ -1568,7 +1567,10 @@ async fn fixture_subagent_endpoints_round_trip_python_state_shape() {
     let (status, payload) = post_json(
         app.clone(),
         "/sessions/run12345/subagents/agent456789/stop",
-        json!({ "summary": "Finished useful work" }),
+        json!({
+            "summary": "Finished useful work",
+            "transcript_path": "/tmp/agent456789.jsonl"
+        }),
     )
     .await;
     assert_eq!(status, StatusCode::OK);

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -1512,6 +1512,108 @@ async fn fixture_core_session_graph_endpoints_round_trip_state() {
 }
 
 #[tokio::test]
+async fn fixture_subagent_endpoints_round_trip_python_state_shape() {
+    let state_file = write_session_fixture();
+    let mut config = config_with_state_file(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/missing/subagents",
+        json!({
+            "agent_id": "agent-missing",
+            "agent_type": "engineer"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(payload["detail"], "Session not found");
+
+    let (status, payload) = get_json(app.clone(), "/sessions/run12345/subagents").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        payload,
+        json!({ "session_id": "run12345", "subagents": [] })
+    );
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/run12345/subagents",
+        json!({
+            "agent_id": "agent456789",
+            "agent_type": "engineer",
+            "transcript_path": "/tmp/agent456789.jsonl"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["agent_id"], "agent456789");
+    assert_eq!(payload["agent_type"], "engineer");
+    assert_eq!(payload["parent_session_id"], "run12345");
+    assert_eq!(payload["status"], "running");
+    assert_eq!(payload["stopped_at"], Value::Null);
+    assert_eq!(payload["summary"], Value::Null);
+    assert!(payload["started_at"]
+        .as_str()
+        .unwrap_or_default()
+        .contains('T'));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/run12345/subagents/not-there/stop",
+        json!({ "summary": "ignored" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(payload["detail"], "Subagent not-there not found");
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/run12345/subagents/agent456789/stop",
+        json!({ "summary": "Finished useful work" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        payload,
+        json!({
+            "session_id": "run12345",
+            "agent_id": "agent456789",
+            "status": "stopped",
+            "summary": "Finished useful work"
+        })
+    );
+
+    let (status, payload) = get_json(app.clone(), "/sessions/run12345/subagents").await;
+    assert_eq!(status, StatusCode::OK);
+    let subagents = payload["subagents"].as_array().unwrap();
+    assert_eq!(subagents.len(), 1);
+    assert_eq!(subagents[0]["agent_id"], "agent456789");
+    assert_eq!(subagents[0]["status"], "completed");
+    assert_eq!(subagents[0]["summary"], "Finished useful work");
+    assert!(subagents[0]["stopped_at"]
+        .as_str()
+        .unwrap_or_default()
+        .contains('T'));
+
+    let raw_state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let session = raw_state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "run12345")
+        .unwrap();
+    let stored = &session["subagents"][0];
+    assert_eq!(stored["agent_id"], "agent456789");
+    assert_eq!(stored["agent_type"], "engineer");
+    assert_eq!(stored["parent_session_id"], "run12345");
+    assert_eq!(stored["transcript_path"], "/tmp/agent456789.jsonl");
+    assert_eq!(stored["status"], "completed");
+    assert_eq!(stored["summary"], "Finished useful work");
+}
+
+#[tokio::test]
 async fn fixture_completion_endpoints_preserve_python_compatible_state() {
     let state_file = write_completion_fixture();
     let queue_db_path = queue_db_path_for_state_file(&state_file);

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -1554,10 +1554,7 @@ async fn fixture_subagent_endpoints_round_trip_python_state_shape() {
     assert_eq!(payload["status"], "running");
     assert_eq!(payload["stopped_at"], Value::Null);
     assert_eq!(payload["summary"], Value::Null);
-    assert!(payload["started_at"]
-        .as_str()
-        .unwrap_or_default()
-        .contains('T'));
+    assert_python_naive_timestamp(payload["started_at"].as_str().unwrap_or_default());
 
     let (status, payload) = post_json(
         app.clone(),
@@ -1592,10 +1589,7 @@ async fn fixture_subagent_endpoints_round_trip_python_state_shape() {
     assert_eq!(subagents[0]["agent_id"], "agent456789");
     assert_eq!(subagents[0]["status"], "completed");
     assert_eq!(subagents[0]["summary"], "Finished useful work");
-    assert!(subagents[0]["stopped_at"]
-        .as_str()
-        .unwrap_or_default()
-        .contains('T'));
+    assert_python_naive_timestamp(subagents[0]["stopped_at"].as_str().unwrap_or_default());
 
     let raw_state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
     let session = raw_state["sessions"]
@@ -1611,6 +1605,8 @@ async fn fixture_subagent_endpoints_round_trip_python_state_shape() {
     assert_eq!(stored["transcript_path"], "/tmp/agent456789.jsonl");
     assert_eq!(stored["status"], "completed");
     assert_eq!(stored["summary"], "Finished useful work");
+    assert_python_naive_timestamp(stored["started_at"].as_str().unwrap_or_default());
+    assert_python_naive_timestamp(stored["stopped_at"].as_str().unwrap_or_default());
 }
 
 #[tokio::test]
@@ -4966,6 +4962,22 @@ fn config_with_state_file_and_queue(state_file: &PathBuf) -> AppConfig {
 
 fn queue_db_path_for_state_file(state_file: &PathBuf) -> PathBuf {
     state_file.with_extension("message_queue.db")
+}
+
+fn assert_python_naive_timestamp(value: &str) {
+    assert!(
+        value.contains('T'),
+        "timestamp should use ISO separator: {value}"
+    );
+    assert!(!value.ends_with('Z'), "timestamp should be naive: {value}");
+    assert!(
+        value.len() > 10,
+        "timestamp should include a date and time: {value}"
+    );
+    assert!(
+        !value[10..].contains('+') && !value[10..].contains('-'),
+        "timestamp should not include an offset: {value}"
+    );
 }
 
 fn config_with_state_file_and_auth(state_file: &PathBuf) -> AppConfig {


### PR DESCRIPTION
Fixes #817

## Summary
- add Rust subagent start/stop/list HTTP routes backed by Python-compatible session JSON state
- add retained Rust CLI commands for subagent hook tracking and operator listing
- add fixture coverage for start/list/stop, missing-session/subagent errors, persisted subagent shape, and shadow read prediction

## Verification
- `cargo fmt --manifest-path crates/sm-server/Cargo.toml --check`
- `cargo check --manifest-path crates/sm-server/Cargo.toml --bin sm-server --bin sm`
- `cargo test --manifest-path crates/sm-server/Cargo.toml`
- `git diff --check`