### PR TITLE
Add Rust codex-fork runtime launch support

### DIFF
--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct AppConfig {
     pub paths: PathsConfig,
     pub google_auth: GoogleAuthConfig,
@@ -12,8 +12,33 @@ pub struct AppConfig {
     pub mobile_terminal: MobileTerminalConfig,
     pub tmux: TmuxConfig,
     pub sm_send: SmSendConfig,
+    pub claude: ProviderLaunchConfig,
+    pub codex: ProviderLaunchConfig,
+    pub codex_fork: CodexForkLaunchConfig,
     pub rust_shadow: RustShadowConfig,
     pub rust_core: RustCoreConfig,
+}
+
+impl Default for AppConfig {
+    fn default() -> Self {
+        Self {
+            paths: PathsConfig::default(),
+            google_auth: GoogleAuthConfig::default(),
+            external_access: ExternalAccessConfig::default(),
+            mobile_terminal: MobileTerminalConfig::default(),
+            tmux: TmuxConfig::default(),
+            sm_send: SmSendConfig::default(),
+            claude: ProviderLaunchConfig::new(
+                "claude".to_owned(),
+                Vec::new(),
+                Some("sonnet".to_owned()),
+            ),
+            codex: ProviderLaunchConfig::new("codex".to_owned(), Vec::new(), None),
+            codex_fork: CodexForkLaunchConfig::default(),
+            rust_shadow: RustShadowConfig::default(),
+            rust_core: RustCoreConfig::default(),
+        }
+    }
 }
 
 impl AppConfig {
@@ -153,6 +178,48 @@ impl Default for SmSendConfig {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProviderLaunchConfig {
+    pub command: String,
+    pub args: Vec<String>,
+    pub default_model: Option<String>,
+}
+
+impl ProviderLaunchConfig {
+    fn new(command: String, args: Vec<String>, default_model: Option<String>) -> Self {
+        Self {
+            command,
+            args,
+            default_model,
+        }
+    }
+}
+
+impl Default for ProviderLaunchConfig {
+    fn default() -> Self {
+        Self::new("claude".to_owned(), Vec::new(), Some("sonnet".to_owned()))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodexForkLaunchConfig {
+    pub command: String,
+    pub args: Vec<String>,
+    pub default_model: Option<String>,
+    pub event_schema_version: u32,
+}
+
+impl Default for CodexForkLaunchConfig {
+    fn default() -> Self {
+        Self {
+            command: "codex".to_owned(),
+            args: codex_fork_managed_args(Vec::new()),
+            default_model: None,
+            event_schema_version: 2,
+        }
+    }
+}
+
 fn default_message_queue_db_path() -> String {
     "~/.local/share/claude-sessions/message_queue.db".to_owned()
 }
@@ -206,6 +273,12 @@ struct RawConfig {
     #[serde(default)]
     sm_send: SmSendConfig,
     #[serde(default)]
+    claude: RawProviderLaunchConfig,
+    #[serde(default)]
+    codex: RawProviderLaunchConfig,
+    #[serde(default)]
+    codex_fork: RawCodexForkLaunchConfig,
+    #[serde(default)]
     timeouts: RawTimeoutsConfig,
     #[serde(default)]
     rust_shadow: RustShadowConfig,
@@ -216,6 +289,9 @@ struct RawConfig {
 impl From<RawConfig> for AppConfig {
     fn from(raw: RawConfig) -> Self {
         let mut rust_core = raw.rust_core;
+        let claude = provider_launch_config(raw.claude, "claude", Some("sonnet"), Vec::new());
+        let codex = provider_launch_config(raw.codex, "codex", None, Vec::new());
+        let codex_fork = codex_fork_launch_config(raw.codex_fork, &codex);
         if trimmed(&rust_core.tmux_socket_name).is_none() {
             rust_core.tmux_socket_name = trimmed(&raw.tmux.socket_name);
         }
@@ -246,6 +322,9 @@ impl From<RawConfig> for AppConfig {
             mobile_terminal: raw.mobile_terminal,
             tmux: raw.tmux,
             sm_send: raw.sm_send,
+            claude,
+            codex,
+            codex_fork,
             rust_shadow: raw.rust_shadow,
             rust_core,
         }
@@ -256,6 +335,24 @@ impl From<RawConfig> for AppConfig {
 struct RawAuthConfig {
     #[serde(default)]
     google: GoogleAuthConfig,
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+struct RawProviderLaunchConfig {
+    #[serde(default)]
+    command: Option<String>,
+    #[serde(default)]
+    args: Option<Vec<String>>,
+    #[serde(default)]
+    default_model: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+struct RawCodexForkLaunchConfig {
+    #[serde(flatten)]
+    provider: RawProviderLaunchConfig,
+    #[serde(default)]
+    event_schema_version: Option<u32>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -276,6 +373,68 @@ struct RawTmuxTimeoutsConfig {
     send_keys_settle_per_extra_line: Option<f64>,
     #[serde(default)]
     send_keys_max_chunk_chars: Option<usize>,
+}
+
+fn provider_launch_config(
+    raw: RawProviderLaunchConfig,
+    default_command: &str,
+    default_model: Option<&str>,
+    default_args: Vec<String>,
+) -> ProviderLaunchConfig {
+    ProviderLaunchConfig::new(
+        raw.command
+            .as_ref()
+            .and_then(|value| trimmed(&Some(value.clone())))
+            .unwrap_or_else(|| default_command.to_owned()),
+        raw.args
+            .unwrap_or(default_args)
+            .into_iter()
+            .map(|value| value.to_string())
+            .collect(),
+        raw.default_model
+            .as_ref()
+            .and_then(|value| trimmed(&Some(value.clone())))
+            .or_else(|| default_model.map(ToOwned::to_owned)),
+    )
+}
+
+fn codex_fork_launch_config(
+    raw: RawCodexForkLaunchConfig,
+    codex: &ProviderLaunchConfig,
+) -> CodexForkLaunchConfig {
+    let command = raw
+        .provider
+        .command
+        .as_ref()
+        .and_then(|value| trimmed(&Some(value.clone())))
+        .unwrap_or_else(|| codex.command.clone());
+    let args = raw.provider.args.unwrap_or_else(|| codex.args.clone());
+    let default_model = raw
+        .provider
+        .default_model
+        .as_ref()
+        .and_then(|value| trimmed(&Some(value.clone())))
+        .or_else(|| codex.default_model.clone());
+    CodexForkLaunchConfig {
+        command,
+        args: codex_fork_managed_args(args),
+        default_model,
+        event_schema_version: raw.event_schema_version.unwrap_or(2),
+    }
+}
+
+fn codex_fork_managed_args(args: Vec<String>) -> Vec<String> {
+    let mut managed_args = args;
+    if !managed_args.iter().any(|arg| {
+        arg.replace(' ', "")
+            .contains("check_for_update_on_startup=false")
+    }) {
+        managed_args.extend([
+            "-c".to_owned(),
+            "check_for_update_on_startup=false".to_owned(),
+        ]);
+    }
+    managed_args
 }
 
 pub fn trimmed(value: &Option<String>) -> Option<String> {
@@ -504,5 +663,57 @@ sm_send:
         let config = AppConfig::from(raw);
 
         assert_eq!(config.sm_send.db_path, "/tmp/custom-message-queue.db");
+    }
+
+    #[test]
+    fn raw_config_reads_codex_fork_launch_config_with_codex_fallbacks() {
+        let raw: RawConfig = serde_yaml::from_str(
+            r#"
+codex:
+  command: "/opt/bin/codex"
+  args:
+    - "--dangerously-bypass-approvals-and-sandbox"
+  default_model: "gpt-5"
+codex_fork:
+  event_schema_version: 7
+"#,
+        )
+        .unwrap();
+        let config = AppConfig::from(raw);
+
+        assert_eq!(config.codex_fork.command, "/opt/bin/codex");
+        assert_eq!(
+            config.codex_fork.args,
+            vec![
+                "--dangerously-bypass-approvals-and-sandbox",
+                "-c",
+                "check_for_update_on_startup=false"
+            ]
+        );
+        assert_eq!(config.codex_fork.default_model.as_deref(), Some("gpt-5"));
+        assert_eq!(config.codex_fork.event_schema_version, 7);
+    }
+
+    #[test]
+    fn raw_config_does_not_duplicate_codex_fork_startup_update_disable_arg() {
+        let raw: RawConfig = serde_yaml::from_str(
+            r#"
+codex:
+  command: "codex"
+  args:
+    - "-c"
+    - "check_for_update_on_startup=false"
+codex_fork:
+  command: "/opt/bin/codex-fork"
+"#,
+        )
+        .unwrap();
+        let config = AppConfig::from(raw);
+
+        assert_eq!(config.codex_fork.command, "/opt/bin/codex-fork");
+        assert_eq!(
+            config.codex_fork.args,
+            vec!["-c", "check_for_update_on_startup=false"]
+        );
     }
 }

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -310,7 +310,7 @@ async fn create_session(
     let session = if state.config.rust_core.runtime_enabled {
         ensure_core_runtime_provider_supported(&payload)?;
         ensure_core_runtime_request_node_supported(&state, &payload)?;
-        let runtime = TmuxRuntime::from_config(&state.config.rust_core);
+        let runtime = TmuxRuntime::from_app_config(&state.config);
         state
             .session_store
             .create_core_session_with_runtime(payload, log_dir, &runtime)?
@@ -377,7 +377,7 @@ async fn spawn_session(
     let child = if state.config.rust_core.runtime_enabled {
         ensure_core_runtime_provider_supported(&create_payload)?;
         ensure_core_runtime_request_node_supported(&state, &create_payload)?;
-        let runtime = TmuxRuntime::from_config(&state.config.rust_core);
+        let runtime = TmuxRuntime::from_app_config(&state.config);
         state
             .session_store
             .create_core_session_with_runtime(create_payload, log_dir, &runtime)?
@@ -469,7 +469,7 @@ fn spawn_child_wait_monitor(state: Arc<AppState>, child: SessionRecord, wait_sec
                 parent_session_id: None,
             };
             let _ = if state.config.rust_core.runtime_enabled {
-                let runtime = TmuxRuntime::from_config(&state.config.rust_core);
+                let runtime = TmuxRuntime::from_app_config(&state.config);
                 state.session_store.send_core_input_with_runtime(
                     &parent_session_id,
                     request,
@@ -496,7 +496,7 @@ fn runtime_child_session_exited(state: &AppState, child: &SessionRecord) -> bool
     if !state.config.rust_core.runtime_enabled {
         return false;
     }
-    let runtime = TmuxRuntime::from_config(&state.config.rust_core)
+    let runtime = TmuxRuntime::from_app_config(&state.config)
         .for_socket_name(child.tmux_socket_name.as_deref());
     matches!(runtime.session_exists(&child.tmux_session), Ok(false))
 }
@@ -625,7 +625,7 @@ async fn send_session_input(
     }
     let result = if state.config.rust_core.runtime_enabled {
         ensure_core_runtime_session_node_supported(&state, &session_id)?;
-        let runtime = TmuxRuntime::from_config(&state.config.rust_core);
+        let runtime = TmuxRuntime::from_app_config(&state.config);
         state
             .session_store
             .send_core_input_with_runtime(&session_id, payload, &runtime)?
@@ -669,7 +669,7 @@ async fn send_session_input_batch(
         .config
         .rust_core
         .runtime_enabled
-        .then(|| TmuxRuntime::from_config(&state.config.rust_core));
+        .then(|| TmuxRuntime::from_app_config(&state.config));
     let mut results = Vec::with_capacity(recipients.len());
     for identifier in recipients {
         results.push(send_session_input_batch_one(
@@ -852,7 +852,7 @@ async fn task_complete(
         .config
         .rust_core
         .runtime_enabled
-        .then(|| TmuxRuntime::from_config(&state.config.rust_core));
+        .then(|| TmuxRuntime::from_app_config(&state.config));
     match state
         .session_store
         .task_complete(&session_id, payload, runtime.as_ref())?
@@ -932,7 +932,7 @@ async fn retire_session(
         .map(str::trim)
         .filter(|value| !value.is_empty());
     let outcome = if state.config.rust_core.runtime_enabled {
-        let runtime = TmuxRuntime::from_config(&state.config.rust_core);
+        let runtime = TmuxRuntime::from_app_config(&state.config);
         state.session_store.retire_core_session_with_runtime(
             &session_id,
             requester_session_id,
@@ -973,7 +973,7 @@ async fn restore_session(
     ensure_core_writes_enabled(&state)?;
     let outcome = if state.config.rust_core.runtime_enabled {
         ensure_core_runtime_session_node_supported(&state, &session_id)?;
-        let runtime = TmuxRuntime::from_config(&state.config.rust_core);
+        let runtime = TmuxRuntime::from_app_config(&state.config);
         state
             .session_store
             .restore_core_session_with_runtime(&session_id, &runtime)?
@@ -997,6 +997,10 @@ async fn restore_session(
             status: StatusCode::BAD_REQUEST,
             detail: format!("Rust runtime does not support provider {provider}"),
         }),
+        CoreRestoreOutcome::MissingProviderResumeId(provider) => Err(ApiError::Status {
+            status: StatusCode::CONFLICT,
+            detail: format!("Cannot restore {provider} session without provider_resume_id"),
+        }),
     }
 }
 
@@ -1016,7 +1020,7 @@ async fn clear_session(
     ensure_core_writes_enabled(&state)?;
     let result = if state.config.rust_core.runtime_enabled {
         ensure_core_runtime_session_node_supported(&state, &session_id)?;
-        let runtime = TmuxRuntime::from_config(&state.config.rust_core);
+        let runtime = TmuxRuntime::from_app_config(&state.config);
         state
             .session_store
             .clear_core_session_with_runtime(&session_id, payload, &runtime)?
@@ -1937,7 +1941,7 @@ fn ensure_core_runtime_provider_supported(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or("claude");
-    if provider == "claude" {
+    if matches!(provider, "claude" | "codex-fork") {
         return Ok(());
     }
     Err(ApiError::Status {

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -1,5 +1,7 @@
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::{
-    fs,
+    env, fs,
     path::{Path, PathBuf},
     process::{Command, Stdio},
     thread,
@@ -7,8 +9,9 @@ use std::{
 };
 
 use anyhow::{bail, Context, Result};
+use sha2::{Digest, Sha256};
 
-use crate::config::RustCoreConfig;
+use crate::config::{AppConfig, RustCoreConfig};
 
 const DEFAULT_SEND_KEYS_SETTLE_MS: f64 = 300.0;
 const DEFAULT_SEND_KEYS_SETTLE_MAX_MS: f64 = 900.0;
@@ -20,7 +23,12 @@ const DEFAULT_SEND_KEYS_MAX_CHUNK_CHARS: usize = 4096;
 pub struct TmuxRuntime {
     socket_name: Option<String>,
     tmux_binary: String,
-    command: String,
+    claude_command: String,
+    claude_args: Vec<String>,
+    codex_fork_command: String,
+    codex_fork_args: Vec<String>,
+    codex_fork_default_model: Option<String>,
+    codex_fork_event_schema_version: u32,
     prompt_mode: String,
     start_settle_ms: u64,
     send_keys_settle_ms: f64,
@@ -36,8 +44,15 @@ pub struct TmuxSessionSpec {
     pub tmux_session: String,
     pub working_dir: String,
     pub log_file: PathBuf,
+    pub provider: String,
     pub initial_message: Option<String>,
     pub model: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CodexForkRuntimeArtifacts {
+    pub event_stream_path: PathBuf,
+    pub control_socket_path: PathBuf,
 }
 
 impl TmuxRuntime {
@@ -50,13 +65,21 @@ impl TmuxRuntime {
                 .filter(|value| !value.is_empty())
                 .map(ToOwned::to_owned),
             tmux_binary: "tmux".to_owned(),
-            command: config
+            claude_command: config
                 .runtime_command
                 .as_deref()
                 .map(str::trim)
                 .filter(|value| !value.is_empty())
                 .unwrap_or("claude")
                 .to_owned(),
+            claude_args: Vec::new(),
+            codex_fork_command: "codex".to_owned(),
+            codex_fork_args: vec![
+                "-c".to_owned(),
+                "check_for_update_on_startup=false".to_owned(),
+            ],
+            codex_fork_default_model: None,
+            codex_fork_event_schema_version: 2,
             prompt_mode: config
                 .runtime_prompt_mode
                 .as_deref()
@@ -88,6 +111,26 @@ impl TmuxRuntime {
         }
     }
 
+    pub fn from_app_config(config: &AppConfig) -> Self {
+        let mut runtime = Self::from_config(&config.rust_core);
+        if config
+            .rust_core
+            .runtime_command
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .is_none()
+        {
+            runtime.claude_command = config.claude.command.clone();
+            runtime.claude_args = config.claude.args.clone();
+        }
+        runtime.codex_fork_command = config.codex_fork.command.clone();
+        runtime.codex_fork_args = config.codex_fork.args.clone();
+        runtime.codex_fork_default_model = config.codex_fork.default_model.clone();
+        runtime.codex_fork_event_schema_version = config.codex_fork.event_schema_version;
+        runtime
+    }
+
     pub fn socket_name(&self) -> Option<&str> {
         self.socket_name.as_deref()
     }
@@ -99,6 +142,20 @@ impl TmuxRuntime {
             .filter(|value| !value.is_empty())
             .map(ToOwned::to_owned);
         runtime
+    }
+
+    pub fn codex_fork_runtime_artifacts(
+        &self,
+        spec: &TmuxSessionSpec,
+    ) -> Result<Option<CodexForkRuntimeArtifacts>> {
+        if spec.provider != "codex-fork" {
+            return Ok(None);
+        }
+        let (event_stream_path, control_socket_path) = codex_fork_artifact_paths(spec)?;
+        Ok(Some(CodexForkRuntimeArtifacts {
+            event_stream_path,
+            control_socket_path,
+        }))
     }
 
     pub fn create_session(&self, spec: &TmuxSessionSpec) -> Result<()> {
@@ -123,25 +180,7 @@ impl TmuxRuntime {
             bail!("unsupported runtime prompt mode: {}", self.prompt_mode);
         }
 
-        let mut command = self.command.clone();
-        if let Some(model) = spec
-            .model
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-        {
-            command = format!("{command} --model {}", shell_quote(model));
-        }
-        if prompt_mode == "argv" {
-            if let Some(initial_message) = spec
-                .initial_message
-                .as_deref()
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-            {
-                command = format!("{command} -- {}", shell_quote(initial_message));
-            }
-        }
+        let mut command = self.launch_command(spec, &prompt_mode)?;
         command = managed_session_command(&command, &spec.session_id);
 
         self.run_tmux([
@@ -169,12 +208,26 @@ impl TmuxRuntime {
     ) -> Result<()> {
         let mut runtime = self.clone();
         if let Some(resume_id) = resume_id.map(str::trim).filter(|value| !value.is_empty()) {
-            runtime.command = match provider {
-                "claude" => format!("{} --resume {}", runtime.command, shell_quote(resume_id)),
-                "codex" | "codex-fork" => {
-                    format!("{} resume {}", runtime.command, shell_quote(resume_id))
+            match provider {
+                "claude" => {
+                    runtime.claude_command = format!(
+                        "{} --resume {}",
+                        runtime.claude_command,
+                        shell_quote(resume_id)
+                    );
                 }
-                _ => runtime.command,
+                "codex-fork" => {
+                    runtime.codex_fork_args =
+                        prepend_arg_pair("resume", resume_id, &runtime.codex_fork_args);
+                }
+                "codex" => {
+                    runtime.claude_command = format!(
+                        "{} resume {}",
+                        runtime.claude_command,
+                        shell_quote(resume_id)
+                    );
+                }
+                _ => {}
             };
         }
         let mut spec = spec.clone();
@@ -350,6 +403,58 @@ impl TmuxRuntime {
         command
     }
 
+    fn launch_command(&self, spec: &TmuxSessionSpec, prompt_mode: &str) -> Result<String> {
+        let mut parts = match spec.provider.as_str() {
+            "claude" => command_parts(&self.claude_command, &self.claude_args),
+            "codex-fork" => self.codex_fork_command_parts(spec)?,
+            provider => bail!("Rust runtime does not support provider {provider}"),
+        };
+        let model = spec
+            .model
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .or_else(|| {
+                (spec.provider == "codex-fork")
+                    .then_some(self.codex_fork_default_model.as_deref())
+                    .flatten()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+            });
+        if let Some(model) = model {
+            parts.push("--model".to_owned());
+            parts.push(shell_quote(model));
+        }
+        if prompt_mode == "argv" {
+            if let Some(initial_message) = spec
+                .initial_message
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                parts.push("--".to_owned());
+                parts.push(shell_quote(initial_message));
+            }
+        }
+        Ok(parts.join(" "))
+    }
+
+    fn codex_fork_command_parts(&self, spec: &TmuxSessionSpec) -> Result<Vec<String>> {
+        validate_launch_command(&self.codex_fork_command, Path::new(&spec.working_dir))?;
+        let (event_stream_path, control_socket_path) = codex_fork_artifact_paths(spec)?;
+        prepare_codex_fork_runtime_artifacts(&event_stream_path, &control_socket_path)?;
+        let mut parts = executable_command_parts(&self.codex_fork_command, &self.codex_fork_args);
+        parts.extend([
+            "--event-stream".to_owned(),
+            shell_quote_path(&event_stream_path),
+            "--event-schema-version".to_owned(),
+            shell_quote(&self.codex_fork_event_schema_version.to_string()),
+            "--control-socket".to_owned(),
+            shell_quote_path(&control_socket_path),
+        ]);
+        Ok(parts)
+    }
+
     fn attach_session_log(&self, spec: &TmuxSessionSpec, prompt_mode: &str) -> Result<()> {
         let pipe_command = format!("cat >> {}", shell_quote_path(&spec.log_file));
         self.run_tmux([
@@ -448,6 +553,159 @@ fn shell_quote(value: &str) -> String {
         return "''".to_owned();
     }
     format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn command_parts(command: &str, args: &[String]) -> Vec<String> {
+    let mut parts = vec![command.to_owned()];
+    parts.extend(args.iter().map(|arg| shell_quote(arg)));
+    parts
+}
+
+fn executable_command_parts(command: &str, args: &[String]) -> Vec<String> {
+    let mut parts = vec![shell_quote(command)];
+    parts.extend(args.iter().map(|arg| shell_quote(arg)));
+    parts
+}
+
+fn prepend_arg_pair(command: &str, value: &str, args: &[String]) -> Vec<String> {
+    let mut prefixed = vec![command.to_owned(), value.to_owned()];
+    prefixed.extend(args.iter().cloned());
+    prefixed
+}
+
+fn codex_fork_artifact_paths(spec: &TmuxSessionSpec) -> Result<(PathBuf, PathBuf)> {
+    let artifact_dir = spec
+        .log_file
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("runtime session missing log directory"))?;
+    let artifact_basename = safe_session_artifact_basename(&spec.session_id);
+    Ok((
+        artifact_dir.join(format!("{artifact_basename}.codex-fork.events.jsonl")),
+        artifact_dir.join(format!("{artifact_basename}.codex-fork.control.sock")),
+    ))
+}
+
+fn prepare_codex_fork_runtime_artifacts(event_path: &Path, control_path: &Path) -> Result<()> {
+    let parent = event_path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("codex-fork event stream path missing parent"))?;
+    fs::create_dir_all(parent).with_context(|| {
+        format!(
+            "failed to create codex-fork artifact dir {}",
+            parent.display()
+        )
+    })?;
+    remove_file_if_exists(event_path)?;
+    remove_file_if_exists(control_path)?;
+    Ok(())
+}
+
+fn remove_file_if_exists(path: &Path) -> Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error).with_context(|| format!("failed to remove {}", path.display())),
+    }
+}
+
+fn validate_launch_command(command: &str, working_dir: &Path) -> Result<()> {
+    let command = command.trim();
+    if command.is_empty() {
+        bail!("Launch command is empty");
+    }
+    if command.starts_with('~') || command.contains('/') {
+        let candidate = expand_launch_path(command, working_dir);
+        if !candidate.exists() {
+            bail!("Launch command does not exist: {}", candidate.display());
+        }
+        if !candidate.is_file() {
+            bail!("Launch command is not a file: {}", candidate.display());
+        }
+        if !is_executable_file(&candidate) {
+            bail!("Launch command is not executable: {}", candidate.display());
+        }
+        return Ok(());
+    }
+    if find_in_path(command).is_none() {
+        bail!("Launch command not found on PATH: {command}");
+    }
+    Ok(())
+}
+
+fn expand_launch_path(command: &str, working_dir: &Path) -> PathBuf {
+    let path = if command == "~" {
+        env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(command))
+    } else if let Some(rest) = command.strip_prefix("~/") {
+        env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("~"))
+            .join(rest)
+    } else {
+        PathBuf::from(command)
+    };
+    if path.is_absolute() {
+        path
+    } else {
+        working_dir.join(path)
+    }
+}
+
+fn find_in_path(command: &str) -> Option<PathBuf> {
+    let path = env::var_os("PATH")?;
+    env::split_paths(&path)
+        .map(|dir| dir.join(command))
+        .find(|path| path.is_file() && is_executable_file(path))
+}
+
+#[cfg(unix)]
+fn is_executable_file(path: &Path) -> bool {
+    fs::metadata(path)
+        .map(|metadata| metadata.permissions().mode() & 0o111 != 0)
+        .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+fn is_executable_file(path: &Path) -> bool {
+    path.is_file()
+}
+
+fn safe_session_artifact_basename(session_id: &str) -> String {
+    format!(
+        "{}-{}",
+        sanitize_path_component(session_id),
+        stable_session_id_hash(session_id)
+    )
+}
+
+fn sanitize_path_component(value: &str) -> String {
+    let mut safe = value
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_'))
+        .collect::<String>();
+    if safe.is_empty() {
+        safe = "session".to_owned();
+    }
+    safe
+}
+
+fn stable_session_id_hash(value: &str) -> String {
+    let digest = Sha256::digest(value.as_bytes());
+    let mut hash = String::with_capacity(12);
+    for byte in &digest[..6] {
+        hash.push(hex_char(byte >> 4));
+        hash.push(hex_char(byte & 0x0f));
+    }
+    hash
+}
+
+fn hex_char(value: u8) -> char {
+    match value {
+        0..=9 => char::from(b'0' + value),
+        10..=15 => char::from(b'a' + (value - 10)),
+        _ => unreachable!("hex nibble out of range"),
+    }
 }
 
 fn managed_session_command(command: &str, session_id: &str) -> String {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -5,7 +5,8 @@ use std::{
     path::{Path, PathBuf},
     sync::atomic::{AtomicU64, Ordering},
     sync::{Arc, Mutex},
-    time::Duration,
+    thread,
+    time::{Duration, Instant},
 };
 
 use anyhow::{Context, Result};
@@ -25,6 +26,8 @@ const LEGACY_TMP_SESSION_STATE_FILE: &str = "/tmp/claude-sessions/sessions.json"
 const OUTPUT_TAIL_BYTES_PER_LINE: u64 = 4096;
 const MIN_OUTPUT_TAIL_BYTES: u64 = 16 * 1024;
 const MAX_OUTPUT_TAIL_BYTES: u64 = 1024 * 1024;
+const CODEX_FORK_THREAD_STARTED_TIMEOUT: Duration = Duration::from_secs(10);
+const CODEX_FORK_EVENT_MONITOR_POLL: Duration = Duration::from_millis(250);
 static STATE_WRITE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone)]
@@ -217,7 +220,7 @@ impl SessionStore {
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
         let sessions = ensure_sessions_array_mut(&mut state)?;
-        let record = self.build_core_session_record(
+        let mut record = self.build_core_session_record(
             sessions,
             &request,
             log_dir.as_deref(),
@@ -230,18 +233,43 @@ impl SessionStore {
             .as_deref()
             .map(expand_home)
             .ok_or_else(|| anyhow::anyhow!("runtime session missing log file"))?;
-        runtime.create_session(&TmuxSessionSpec {
+        let spec = TmuxSessionSpec {
             session_id: record.id.clone(),
             tmux_session: record.tmux_session.clone(),
             working_dir: expand_home(&record.working_dir).display().to_string(),
             log_file,
+            provider: record.provider.clone(),
             initial_message: request.initial_message.clone(),
             model: request.model.clone(),
-        })?;
+        };
+        let codex_fork_artifacts = runtime.codex_fork_runtime_artifacts(&spec)?;
+        runtime.create_session(&spec)?;
+        if let Some(artifacts) = &codex_fork_artifacts {
+            match wait_for_codex_fork_provider_resume_id(
+                &artifacts.event_stream_path,
+                CODEX_FORK_THREAD_STARTED_TIMEOUT,
+            ) {
+                Ok(provider_resume_id) => {
+                    record.provider_resume_id = Some(provider_resume_id);
+                }
+                Err(error) => {
+                    let _ = runtime.kill_session(&record.tmux_session);
+                    return Err(error).with_context(|| {
+                        format!(
+                            "codex-fork session {} did not publish a provider resume id",
+                            record.id
+                        )
+                    });
+                }
+            }
+        }
         sessions.push(serde_json::to_value(&record)?);
         if let Err(error) = self.write_raw_json_value(&state) {
             let _ = runtime.kill_session(&record.tmux_session);
             return Err(error);
+        }
+        if let Some(artifacts) = codex_fork_artifacts {
+            self.start_codex_fork_event_monitor(record.id.clone(), artifacts.event_stream_path)?;
         }
         Ok(record)
     }
@@ -561,8 +589,20 @@ impl SessionStore {
         if !is_primary_node(&record.node) {
             return Ok(Some(CoreRestoreOutcome::UnsupportedNode(record.node)));
         }
-        if record.provider != "claude" {
+        if !matches!(record.provider.as_str(), "claude" | "codex-fork") {
             return Ok(Some(CoreRestoreOutcome::UnsupportedProvider(
+                record.provider,
+            )));
+        }
+        if record.provider == "codex-fork"
+            && record
+                .provider_resume_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .is_none()
+        {
+            return Ok(Some(CoreRestoreOutcome::MissingProviderResumeId(
                 record.provider,
             )));
         }
@@ -584,9 +624,11 @@ impl SessionStore {
             tmux_session: record.tmux_session.clone(),
             working_dir: expand_home(&record.working_dir).display().to_string(),
             log_file,
+            provider: record.provider.clone(),
             initial_message: None,
             model: record.model.clone(),
         };
+        let codex_fork_artifacts = session_runtime.codex_fork_runtime_artifacts(&spec)?;
         session_runtime.restore_session(
             &spec,
             &record.provider,
@@ -609,6 +651,9 @@ impl SessionStore {
         }
         let restored = serde_json::from_value::<SessionRecord>(Value::Object(session.clone()))?;
         self.write_raw_json_value(&state)?;
+        if let Some(artifacts) = codex_fork_artifacts {
+            self.start_codex_fork_event_monitor(restored.id.clone(), artifacts.event_stream_path)?;
+        }
         Ok(Some(CoreRestoreOutcome::Restored(restored)))
     }
 
@@ -1416,6 +1461,128 @@ impl SessionStore {
             .map_err(|_| anyhow::anyhow!("session state write lock poisoned"))
     }
 
+    fn start_codex_fork_event_monitor(
+        &self,
+        session_id: String,
+        event_stream_path: PathBuf,
+    ) -> Result<()> {
+        let store = self.clone();
+        let thread_session_id = format!(
+            "{}-{}",
+            sanitize_path_component(&session_id),
+            stable_session_id_hash(&session_id)
+        );
+        thread::Builder::new()
+            .name(format!("sm-codex-fork-events-{thread_session_id}"))
+            .spawn(move || store.monitor_codex_fork_event_stream(session_id, event_stream_path))
+            .with_context(|| "failed to start codex-fork event monitor")?;
+        Ok(())
+    }
+
+    fn monitor_codex_fork_event_stream(&self, session_id: String, event_stream_path: PathBuf) {
+        let mut offset = 0;
+        let mut buffer = String::new();
+        loop {
+            match self.codex_fork_monitor_should_continue(&session_id) {
+                Ok(true) => {}
+                Ok(false) | Err(_) => return,
+            }
+
+            if let Ok(chunk) = read_file_from_offset(&event_stream_path, &mut offset) {
+                for line in split_complete_event_lines(&mut buffer, &chunk) {
+                    let _ = self.apply_codex_fork_event_line(&session_id, &line);
+                }
+            }
+            thread::sleep(CODEX_FORK_EVENT_MONITOR_POLL);
+        }
+    }
+
+    fn codex_fork_monitor_should_continue(&self, session_id: &str) -> Result<bool> {
+        let state = self.load_raw_json_value()?;
+        let Some(sessions) = state.get("sessions").and_then(Value::as_array) else {
+            return Ok(false);
+        };
+        let Some(session) = sessions.iter().find(|session| {
+            session.get("id").and_then(Value::as_str) == Some(session_id)
+                || session
+                    .get("aliases")
+                    .and_then(Value::as_array)
+                    .is_some_and(|aliases| {
+                        aliases
+                            .iter()
+                            .any(|alias| alias.as_str() == Some(session_id))
+                    })
+        }) else {
+            return Ok(false);
+        };
+        let provider = json_text(session.get("provider")).unwrap_or_else(default_provider);
+        if provider != "codex-fork" {
+            return Ok(false);
+        }
+        let status = json_text(session.get("status")).unwrap_or_else(|| "running".to_owned());
+        Ok(normalized_status(&status) != "stopped")
+    }
+
+    fn apply_codex_fork_event_line(&self, session_id: &str, line: &str) -> Result<()> {
+        let raw = line.trim();
+        if raw.is_empty() {
+            return Ok(());
+        }
+        let Ok(event) = serde_json::from_str::<Value>(raw) else {
+            return Ok(());
+        };
+        let Some(event) = event.as_object() else {
+            return Ok(());
+        };
+
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let Some(session) = session_object_mut(sessions, session_id) else {
+            return Ok(());
+        };
+        let provider = json_text(session.get("provider")).unwrap_or_else(default_provider);
+        if provider != "codex-fork" {
+            return Ok(());
+        }
+        let status = json_text(session.get("status")).unwrap_or_else(|| "running".to_owned());
+        if normalized_status(&status) == "stopped" {
+            return Ok(());
+        }
+
+        let mut changed = false;
+        if let Some(provider_resume_id) = codex_fork_provider_resume_id(event) {
+            if json_text(session.get("provider_resume_id")).as_deref()
+                != Some(provider_resume_id.as_str())
+            {
+                session.insert(
+                    "provider_resume_id".to_owned(),
+                    Value::String(provider_resume_id),
+                );
+                changed = true;
+            }
+        }
+
+        if let Some(next_status) = codex_fork_status_for_event(event) {
+            if status != next_status {
+                session.insert("status".to_owned(), Value::String(next_status.to_owned()));
+            }
+            let now = now_rfc3339();
+            session.insert("last_activity".to_owned(), Value::String(now.clone()));
+            if next_status == "stopped" {
+                session.insert("stopped_at".to_owned(), Value::String(now));
+            } else {
+                session.insert("stopped_at".to_owned(), Value::Null);
+            }
+            changed = true;
+        }
+
+        if changed {
+            self.write_raw_json_value(&state)?;
+        }
+        Ok(())
+    }
+
     fn build_core_session_record(
         &self,
         sessions: &[Value],
@@ -1534,6 +1701,205 @@ impl SessionStore {
             aliases: Vec::new(),
             pending_adoption_proposals: Vec::new(),
         })
+    }
+}
+
+fn wait_for_codex_fork_provider_resume_id(
+    event_stream_path: &Path,
+    timeout: Duration,
+) -> Result<String> {
+    let started = Instant::now();
+    loop {
+        if let Ok(content) = fs::read_to_string(event_stream_path) {
+            for line in content.lines() {
+                let Ok(event) = serde_json::from_str::<Value>(line.trim()) else {
+                    continue;
+                };
+                let Some(event) = event.as_object() else {
+                    continue;
+                };
+                if let Some(provider_resume_id) = codex_fork_provider_resume_id(event) {
+                    return Ok(provider_resume_id);
+                }
+            }
+        }
+        if started.elapsed() >= timeout {
+            anyhow::bail!(
+                "timed out waiting for codex-fork thread_started event in {}",
+                event_stream_path.display()
+            );
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn read_file_from_offset(path: &Path, offset: &mut u64) -> Result<String> {
+    let mut file = match fs::OpenOptions::new().read(true).open(path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(String::new()),
+        Err(error) => {
+            return Err(error).with_context(|| format!("failed to open {}", path.display()))
+        }
+    };
+    let len = file.metadata()?.len();
+    if *offset > len {
+        *offset = 0;
+    }
+    file.seek(SeekFrom::Start(*offset))?;
+    let mut chunk = String::new();
+    file.read_to_string(&mut chunk)?;
+    *offset = file.stream_position()?;
+    Ok(chunk)
+}
+
+fn split_complete_event_lines(buffer: &mut String, chunk: &str) -> Vec<String> {
+    if chunk.is_empty() {
+        return Vec::new();
+    }
+    buffer.push_str(chunk);
+    let mut lines = Vec::new();
+    while let Some(index) = buffer.find('\n') {
+        let line = buffer[..index].to_owned();
+        buffer.drain(..=index);
+        lines.push(line);
+    }
+    lines
+}
+
+fn codex_fork_provider_resume_id(event: &Map<String, Value>) -> Option<String> {
+    extract_codex_fork_thread_started(event).or_else(|| {
+        event
+            .get("session_id")
+            .and_then(non_unknown_json_text)
+            .or_else(|| {
+                codex_fork_payload(event)
+                    .and_then(|payload| payload.get("session_id"))
+                    .and_then(non_unknown_json_text)
+            })
+    })
+}
+
+fn extract_codex_fork_thread_started(event: &Map<String, Value>) -> Option<String> {
+    let raw_event_type = codex_fork_event_type(event)?;
+    let normalized_event_type = normalize_codex_fork_event_type(&raw_event_type.replace('/', "_"));
+    if raw_event_type != "thread/started"
+        && raw_event_type != "thread_started"
+        && normalized_event_type != "thread_started"
+    {
+        return None;
+    }
+    let payload = codex_fork_payload(event)?;
+    let thread_payload = payload
+        .get("thread")
+        .and_then(Value::as_object)
+        .unwrap_or(payload);
+    thread_payload
+        .get("id")
+        .and_then(non_unknown_json_text)
+        .or_else(|| {
+            thread_payload
+                .get("thread_id")
+                .and_then(non_unknown_json_text)
+        })
+        .or_else(|| payload.get("thread_id").and_then(non_unknown_json_text))
+        .or_else(|| payload.get("session_id").and_then(non_unknown_json_text))
+}
+
+fn codex_fork_status_for_event(event: &Map<String, Value>) -> Option<&'static str> {
+    let event_type = normalize_codex_fork_event_type(codex_fork_event_type(event)?.as_str());
+    match event_type.as_str() {
+        "turn_started" => Some("running"),
+        "turn_complete" => Some("idle"),
+        "turn_aborted" => {
+            let reason = codex_fork_payload(event)
+                .and_then(|payload| payload.get("reason"))
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .map(str::to_ascii_lowercase);
+            if reason.as_deref() == Some("interrupted") {
+                Some("running")
+            } else {
+                Some("idle")
+            }
+        }
+        "approval_request"
+        | "user_input_request"
+        | "approval_resolved"
+        | "user_input_resolved"
+        | "turn_delta"
+        | "turn_diff"
+        | "item_started"
+        | "item_completed"
+        | "agent_message"
+        | "exec_command_end" => Some("running"),
+        "error" | "shutdown" => Some("stopped"),
+        "shutdown_complete" | "stream_error" | "thread_started" | "thread_name_updated" => None,
+        other if other.ends_with("_begin") || other.ends_with("_delta") => Some("running"),
+        _ => None,
+    }
+}
+
+fn codex_fork_event_type(event: &Map<String, Value>) -> Option<String> {
+    event
+        .get("event_type")
+        .or_else(|| event.get("type"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn codex_fork_payload(event: &Map<String, Value>) -> Option<&Map<String, Value>> {
+    event.get("payload").and_then(Value::as_object)
+}
+
+fn non_unknown_json_text(value: &Value) -> Option<String> {
+    let text = value.as_str()?.trim();
+    if text.is_empty()
+        || matches!(
+            text.to_ascii_lowercase().as_str(),
+            "unknown" | "none" | "null"
+        )
+    {
+        return None;
+    }
+    Some(text.to_owned())
+}
+
+fn normalize_codex_fork_event_type(event_type: &str) -> String {
+    let mut snake = String::new();
+    let mut previous_is_separator = true;
+    for ch in event_type.trim().chars() {
+        if ch == '/' || ch == '-' || ch == ' ' {
+            if !previous_is_separator {
+                snake.push('_');
+                previous_is_separator = true;
+            }
+            continue;
+        }
+        if ch.is_ascii_uppercase() {
+            if !previous_is_separator && !snake.ends_with('_') {
+                snake.push('_');
+            }
+            snake.push(ch.to_ascii_lowercase());
+            previous_is_separator = false;
+        } else {
+            snake.push(ch);
+            previous_is_separator = ch == '_';
+        }
+    }
+    let normalized = snake.trim_matches('_');
+    match normalized {
+        "task_started" => "turn_started".to_owned(),
+        "task_complete" | "turn_completed" => "turn_complete".to_owned(),
+        "exec_approval_request" | "patch_approval_request" | "request_approval" => {
+            "approval_request".to_owned()
+        }
+        "request_user_input" => "user_input_request".to_owned(),
+        "approval_decision" | "approval_submitted" => "approval_resolved".to_owned(),
+        "user_input_submitted" | "user_input_response" => "user_input_resolved".to_owned(),
+        "runtime_error" | "fatal_error" => "error".to_owned(),
+        _ => normalized.to_owned(),
     }
 }
 
@@ -1768,6 +2134,7 @@ pub enum CoreRestoreOutcome {
     NotStopped,
     UnsupportedNode(String),
     UnsupportedProvider(String),
+    MissingProviderResumeId(String),
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -17,11 +17,13 @@ use sm_server::config::RustShadowConfig;
 use sm_server::queue::RetainedQueueStore;
 use sm_server::{
     config::{
-        AppConfig, ExternalAccessConfig, GoogleAuthConfig, PathsConfig, RustCoreConfig,
-        SmSendConfig,
+        AppConfig, CodexForkLaunchConfig, ExternalAccessConfig, GoogleAuthConfig, PathsConfig,
+        RustCoreConfig, SmSendConfig,
     },
     http::{router, AppState},
 };
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::{
     fs,
     net::SocketAddr,
@@ -4537,6 +4539,304 @@ async fn runtime_core_rejects_unsupported_provider() {
 }
 
 #[tokio::test]
+async fn runtime_core_lifecycle_uses_codex_fork_launch_config() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let queue_db_path = queue_db_path_for_state_file(&state_file);
+    let log_dir = unique_temp_path();
+    let working_dir = unique_temp_path();
+    fs::create_dir_all(&log_dir).unwrap();
+    fs::create_dir_all(&working_dir).unwrap();
+    let codex_bin_dir = working_dir.join("codex fork bin");
+    fs::create_dir_all(&codex_bin_dir).unwrap();
+    let codex_binary = codex_bin_dir.join("fake-codex-fork");
+    fs::write(
+        &codex_binary,
+        r#"#!/bin/sh
+event_stream=""
+previous=""
+for arg in "$@"; do
+  if [ "$previous" = "--event-stream" ]; then
+    event_stream="$arg"
+  fi
+  previous="$arg"
+done
+if [ -n "$event_stream" ]; then
+  printf '{"event_type":"thread/started","payload":{"thread":{"id":"provider-thread-123"}}}\n' >> "$event_stream"
+  printf '{"event_type":"turn_started","payload":{}}\n' >> "$event_stream"
+fi
+sleep 0.2
+printf 'argv:%s\n' "$*"
+printf 'ids:%s:%s:%s\n' "$SESSION_MANAGER_ID" "$CLAUDE_SESSION_MANAGER_ID" "$ENABLE_TOOL_SEARCH"
+if [ -n "$event_stream" ]; then
+  printf '{"event_type":"turn_complete","payload":{}}\n' >> "$event_stream"
+fi
+while true; do sleep 1; done
+"#,
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&codex_binary).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&codex_binary, permissions).unwrap();
+    }
+    let (event_path, control_path) = codex_fork_artifact_paths(&log_dir, "runtimefork");
+    fs::write(&event_path, "stale event").unwrap();
+    fs::write(&control_path, "stale control").unwrap();
+    let tmux_socket = format!(
+        "sm-rust-test-codex-fork-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        sm_send: SmSendConfig {
+            db_path: queue_db_path.display().to_string(),
+        },
+        codex_fork: CodexForkLaunchConfig {
+            command: codex_binary.display().to_string(),
+            args: vec![
+                "--dangerously-bypass-approvals-and-sandbox".to_owned(),
+                "-c".to_owned(),
+                "check_for_update_on_startup=false".to_owned(),
+            ],
+            default_model: Some("gpt-default".to_owned()),
+            event_schema_version: 7,
+        },
+        rust_core: RustCoreConfig {
+            runtime_enabled: true,
+            log_dir: Some(log_dir.display().to_string()),
+            tmux_socket_name: Some(tmux_socket.clone()),
+            runtime_prompt_mode: Some("argv".to_owned()),
+            runtime_start_settle_ms: Some(100),
+            ..RustCoreConfig::default()
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimefork",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "codex-fork",
+            "initial_message": "hello from codex fork"
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["provider"], "codex-fork");
+    assert_eq!(payload["status"], "running");
+    assert_eq!(payload["tmux_socket_name"], tmux_socket);
+    assert_eq!(payload["provider_resume_id"], "provider-thread-123");
+    assert!(payload["tmux_session"]
+        .as_str()
+        .unwrap()
+        .contains("codex-fork"));
+    let event_text = fs::read_to_string(&event_path).unwrap();
+    assert!(!event_text.contains("stale event"));
+    assert!(event_text.contains("provider-thread-123"));
+    assert!(
+        !control_path.exists(),
+        "Rust runtime should remove stale codex-fork control sockets before launch"
+    );
+
+    let output = wait_for_output_contains(app.clone(), "runtimefork", "--event-stream").await;
+    let output_text = output["output"].as_str().unwrap();
+    assert!(output_text.contains("--dangerously-bypass-approvals-and-sandbox"));
+    assert!(output_text.contains("-c check_for_update_on_startup=false"));
+    assert!(output_text.contains(&event_path.display().to_string()));
+    assert!(output_text.contains("--event-schema-version 7"));
+    assert!(output_text.contains(&control_path.display().to_string()));
+    assert!(output_text.contains("--model gpt-default"));
+    assert!(output_text.contains("-- hello from codex fork"));
+    assert!(output_text.contains("ids:runtimefork:runtimefork:false"));
+    let mut lifecycle_status = String::new();
+    for _ in 0..30 {
+        let (_, session) = get_json(app.clone(), "/sessions/runtimefork").await;
+        lifecycle_status = session["status"].as_str().unwrap().to_owned();
+        if session["status"] == "idle" {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert_eq!(lifecycle_status, "idle");
+
+    let tmux_session = payload["tmux_session"].as_str().unwrap().to_owned();
+    let (status, payload) = post_json(app.clone(), "/sessions/runtimefork/kill", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "killed");
+    assert!(!tmux_session_exists(&tmux_socket, &tmux_session));
+    fs::write(&event_path, "stale event after stop").unwrap();
+    fs::write(&control_path, "stale control after stop").unwrap();
+
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    state["sessions"][0]["provider_resume_id"] = Value::Null;
+    fs::write(&state_file, state.to_string()).unwrap();
+
+    let (status, payload) =
+        post_json(app.clone(), "/sessions/runtimefork/restore", json!({})).await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert_eq!(
+        payload,
+        json!({ "detail": "Cannot restore codex-fork session without provider_resume_id" })
+    );
+    assert!(!tmux_session_exists(&tmux_socket, &tmux_session));
+
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    state["sessions"][0]["provider_resume_id"] = json!("provider-thread-123");
+    fs::write(&state_file, state.to_string()).unwrap();
+
+    let (status, payload) =
+        post_json(app.clone(), "/sessions/runtimefork/restore", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["provider"], "codex-fork");
+    assert_eq!(payload["status"], "running");
+    assert!(tmux_session_exists(&tmux_socket, &tmux_session));
+    let restore_event_text = wait_for_file_contains(&event_path, "provider-thread-123").await;
+    assert!(!restore_event_text.contains("stale event after stop"));
+    assert!(
+        !control_path.exists(),
+        "Rust runtime should remove stale codex-fork control sockets before restore"
+    );
+    let mut restored_text = String::new();
+    for _ in 0..30 {
+        let output = wait_for_output_contains(app.clone(), "runtimefork", "--event-stream").await;
+        restored_text = output["output"].as_str().unwrap().to_owned();
+        if restored_text
+            .matches("ids:runtimefork:runtimefork:false")
+            .count()
+            >= 2
+        {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(
+        restored_text
+            .matches("ids:runtimefork:runtimefork:false")
+            .count()
+            >= 2,
+        "restore should launch a second codex-fork process; output={restored_text:?}"
+    );
+    assert!(restored_text.contains("--dangerously-bypass-approvals-and-sandbox"));
+    assert!(restored_text.contains("resume provider-thread-123"));
+    assert!(restored_text.contains("--event-schema-version 7"));
+    assert!(restored_text.contains("--model gpt-default"));
+}
+
+#[tokio::test]
+async fn runtime_core_codex_fork_sanitizes_artifact_paths() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let working_dir = unique_temp_path();
+    fs::create_dir_all(&log_dir).unwrap();
+    fs::create_dir_all(&working_dir).unwrap();
+    let codex_binary = working_dir.join("fake-codex-fork");
+    fs::write(
+        &codex_binary,
+        r#"#!/bin/sh
+event_stream=""
+previous=""
+for arg in "$@"; do
+  if [ "$previous" = "--event-stream" ]; then
+    event_stream="$arg"
+  fi
+  previous="$arg"
+done
+if [ -n "$event_stream" ]; then
+  printf '{"event_type":"thread/started","payload":{"thread_id":"safe-provider-thread"}}\n' >> "$event_stream"
+fi
+sleep 0.2
+printf 'argv:%s\n' "$*"
+while true; do sleep 1; done
+"#,
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&codex_binary).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&codex_binary, permissions).unwrap();
+    }
+    let raw_session_id = "../runtimefork";
+    let (event_path, control_path) = codex_fork_artifact_paths(&log_dir, raw_session_id);
+    let unsafe_event_path = log_dir.join("../runtimefork.codex-fork.events.jsonl");
+    let tmux_socket = format!(
+        "sm-rust-test-codex-fork-safe-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        codex_fork: CodexForkLaunchConfig {
+            command: codex_binary.display().to_string(),
+            args: vec![
+                "-c".to_owned(),
+                "check_for_update_on_startup=false".to_owned(),
+            ],
+            default_model: None,
+            event_schema_version: 2,
+        },
+        rust_core: RustCoreConfig {
+            runtime_enabled: true,
+            log_dir: Some(log_dir.display().to_string()),
+            tmux_socket_name: Some(tmux_socket),
+            runtime_prompt_mode: Some("argv".to_owned()),
+            runtime_start_settle_ms: Some(100),
+            ..RustCoreConfig::default()
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = post_json(
+        app,
+        "/sessions",
+        json!({
+            "id": raw_session_id,
+            "working_dir": working_dir.display().to_string(),
+            "provider": "codex-fork"
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["id"], raw_session_id);
+    let log_file = core_log_file_path(&log_dir, raw_session_id);
+    let output_text = wait_for_file_contains(&log_file, "--event-stream").await;
+    assert!(output_text.contains(&event_path.display().to_string()));
+    assert!(output_text.contains(&control_path.display().to_string()));
+    assert!(
+        !output_text.contains("../runtimefork.codex-fork.events.jsonl"),
+        "codex-fork artifact path must not include caller-controlled path separators"
+    );
+    assert!(
+        !unsafe_event_path.exists(),
+        "codex-fork launch must not create artifacts outside the configured log directory"
+    );
+}
+
+#[tokio::test]
 async fn runtime_core_rejects_remote_node_create_before_local_tmux_launch() {
     let state_file = unique_temp_path();
     let log_dir = unique_temp_path();
@@ -5283,6 +5583,60 @@ async fn wait_for_output_contains(app: axum::Router, session_id: &str, needle: &
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
     panic!("timed out waiting for output containing {needle:?}");
+}
+
+async fn wait_for_file_contains(path: &PathBuf, needle: &str) -> String {
+    for _ in 0..30 {
+        let text = fs::read_to_string(path).unwrap_or_default();
+        if text.contains(needle) {
+            return text;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    panic!(
+        "timed out waiting for {} to contain {needle:?}",
+        path.display()
+    );
+}
+
+fn core_log_file_path(log_dir: &PathBuf, session_id: &str) -> PathBuf {
+    log_dir.join(format!("{}.log", safe_session_basename(session_id)))
+}
+
+fn codex_fork_artifact_paths(log_dir: &PathBuf, session_id: &str) -> (PathBuf, PathBuf) {
+    let basename = safe_session_basename(session_id);
+    (
+        log_dir.join(format!("{basename}.codex-fork.events.jsonl")),
+        log_dir.join(format!("{basename}.codex-fork.control.sock")),
+    )
+}
+
+fn safe_session_basename(session_id: &str) -> String {
+    format!(
+        "{}-{}",
+        sanitize_path_component(session_id),
+        stable_session_id_hash(session_id)
+    )
+}
+
+fn sanitize_path_component(value: &str) -> String {
+    let mut safe = value
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_'))
+        .collect::<String>();
+    if safe.is_empty() {
+        safe = "session".to_owned();
+    }
+    safe
+}
+
+fn stable_session_id_hash(value: &str) -> String {
+    let digest = Sha256::digest(value.as_bytes());
+    let mut hash = String::with_capacity(12);
+    for byte in &digest[..6] {
+        hash.push_str(&format!("{byte:02x}"));
+    }
+    hash
 }
 
 fn tmux_available() -> bool {


### PR DESCRIPTION
## Summary

- parse retained `claude`, `codex`, and `codex_fork` launch config in the Rust server
- allow local runtime-backed `codex-fork` session creation and build its tmux command with managed startup-update args
- prepare sanitized per-session codex-fork event/control artifact paths before launch
- read codex-fork startup events so successful launches persist `provider_resume_id`, then tail the event stream for basic lifecycle status updates
- keep legacy `codex` rejected in Rust runtime mode rather than falling back to retired behavior

## Scope note

This is local tmux launch support with minimal codex-fork event ingestion for provider resume id and basic lifecycle state. Full Codex event reducer/cursor recovery/control-socket command handling and remote node-agent bridge support remain later Rust-port slices.

## Tests

- `cargo test --manifest-path crates/sm-server/Cargo.toml raw_config`
- `cargo test --manifest-path crates/sm-server/Cargo.toml runtime_core_lifecycle_uses_codex_fork_launch_config`
- `cargo test --manifest-path crates/sm-server/Cargo.toml runtime_core_codex_fork_sanitizes_artifact_paths`
- `cargo test --manifest-path crates/sm-server/Cargo.toml runtime_core_rejects_unsupported_provider`
- `cargo test --manifest-path crates/sm-server/Cargo.toml`

Fixes #821