### PR TITLE
Rust MVP: implement /nodes read-only surface

### DIFF
--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -1,7 +1,8 @@
-use std::{collections::BTreeMap, fs, path::Path};
+use std::{collections::BTreeMap, env, fs, path::Path};
 
 use anyhow::{Context, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
+use serde_yaml::{Mapping as YamlMapping, Value as YamlValue};
 use sha2::{Digest, Sha256};
 
 #[derive(Debug, Clone)]
@@ -15,6 +16,7 @@ pub struct AppConfig {
     pub claude: ProviderLaunchConfig,
     pub codex: ProviderLaunchConfig,
     pub codex_fork: CodexForkLaunchConfig,
+    pub nodes: NodesConfig,
     pub rust_shadow: RustShadowConfig,
     pub rust_core: RustCoreConfig,
 }
@@ -35,6 +37,7 @@ impl Default for AppConfig {
             ),
             codex: ProviderLaunchConfig::new("codex".to_owned(), Vec::new(), None),
             codex_fork: CodexForkLaunchConfig::default(),
+            nodes: NodesConfig::default(),
             rust_shadow: RustShadowConfig::default(),
             rust_core: RustCoreConfig::default(),
         }
@@ -178,6 +181,81 @@ impl Default for SmSendConfig {
     }
 }
 
+const PRIMARY_NODE: &str = "primary";
+
+#[derive(Debug, Clone)]
+pub struct NodesConfig {
+    pub default_node: String,
+    pub registry: BTreeMap<String, NodeConfig>,
+    pub restore_inventory_cache_seconds: f64,
+}
+
+impl Default for NodesConfig {
+    fn default() -> Self {
+        let mut registry = BTreeMap::new();
+        registry.insert(
+            PRIMARY_NODE.to_owned(),
+            NodeConfig::new(PRIMARY_NODE.to_owned()),
+        );
+        Self {
+            default_node: PRIMARY_NODE.to_owned(),
+            registry,
+            restore_inventory_cache_seconds: 10.0,
+        }
+    }
+}
+
+impl NodesConfig {
+    pub fn redacted_nodes(&self) -> Vec<PublicNodeConfig> {
+        self.registry
+            .values()
+            .map(|node| PublicNodeConfig {
+                id: node.id.clone(),
+                primary: node.id == PRIMARY_NODE,
+                ssh: node.ssh.clone(),
+                api_url: node.api_url.clone(),
+                hook_base_url: node.hook_base_url.clone(),
+                projects_root: node.projects_root.clone(),
+                log_dir: node.log_dir.clone(),
+            })
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct NodeConfig {
+    pub id: String,
+    pub ssh: Option<String>,
+    pub ssh_proxy_command: Option<String>,
+    pub control_path: Option<String>,
+    pub api_url: Option<String>,
+    pub hook_base_url: Option<String>,
+    pub hook_secret: Option<String>,
+    pub node_token: Option<String>,
+    pub projects_root: Option<String>,
+    pub log_dir: Option<String>,
+}
+
+impl NodeConfig {
+    fn new(id: String) -> Self {
+        Self {
+            id,
+            ..Self::default()
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PublicNodeConfig {
+    pub id: String,
+    pub primary: bool,
+    pub ssh: Option<String>,
+    pub api_url: Option<String>,
+    pub hook_base_url: Option<String>,
+    pub projects_root: Option<String>,
+    pub log_dir: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProviderLaunchConfig {
     pub command: String,
@@ -279,6 +357,8 @@ struct RawConfig {
     #[serde(default)]
     codex_fork: RawCodexForkLaunchConfig,
     #[serde(default)]
+    nodes: YamlValue,
+    #[serde(default)]
     timeouts: RawTimeoutsConfig,
     #[serde(default)]
     rust_shadow: RustShadowConfig,
@@ -325,6 +405,7 @@ impl From<RawConfig> for AppConfig {
             claude,
             codex,
             codex_fork,
+            nodes: nodes_config_from_yaml(raw.nodes),
             rust_shadow: raw.rust_shadow,
             rust_core,
         }
@@ -435,6 +516,95 @@ fn codex_fork_managed_args(args: Vec<String>) -> Vec<String> {
         ]);
     }
     managed_args
+}
+
+fn nodes_config_from_yaml(value: YamlValue) -> NodesConfig {
+    let mut config = NodesConfig::default();
+    let Some(root) = value.as_mapping() else {
+        return config;
+    };
+
+    if let Some(seconds) = yaml_mapping_get(root, "restore_inventory_cache_seconds")
+        .and_then(yaml_f64)
+        .filter(|value| value.is_finite())
+    {
+        config.restore_inventory_cache_seconds = seconds;
+    }
+
+    if let Some(registry) = yaml_mapping_get(root, "registry").and_then(YamlValue::as_mapping) {
+        for (raw_id, raw_value) in registry {
+            let Some(node_id) = yaml_clean_optional(raw_id) else {
+                continue;
+            };
+            let mut node = NodeConfig::new(node_id.clone());
+            if let Some(value) = raw_value.as_mapping() {
+                node.ssh = yaml_mapping_get(value, "ssh").and_then(yaml_clean_optional);
+                node.ssh_proxy_command =
+                    yaml_mapping_get(value, "ssh_proxy_command").and_then(yaml_clean_optional);
+                node.control_path = yaml_mapping_get(value, "control_path")
+                    .and_then(yaml_clean_optional)
+                    .map(expand_user_path);
+                node.api_url = yaml_mapping_get(value, "api_url").and_then(yaml_clean_optional);
+                node.hook_base_url =
+                    yaml_mapping_get(value, "hook_base_url").and_then(yaml_clean_optional);
+                node.hook_secret =
+                    yaml_mapping_get(value, "hook_secret").and_then(yaml_clean_optional);
+                node.node_token =
+                    yaml_mapping_get(value, "node_token").and_then(yaml_clean_optional);
+                node.projects_root =
+                    yaml_mapping_get(value, "projects_root").and_then(yaml_clean_optional);
+                node.log_dir = yaml_mapping_get(value, "log_dir").and_then(yaml_clean_optional);
+            }
+            config.registry.insert(node_id, node);
+        }
+    }
+
+    let requested_default = yaml_mapping_get(root, "default")
+        .and_then(yaml_clean_optional)
+        .unwrap_or_else(|| PRIMARY_NODE.to_owned());
+    config.default_node = if config.registry.contains_key(&requested_default) {
+        requested_default
+    } else {
+        PRIMARY_NODE.to_owned()
+    };
+
+    config
+}
+
+fn yaml_mapping_get<'a>(mapping: &'a YamlMapping, key: &str) -> Option<&'a YamlValue> {
+    mapping.get(YamlValue::String(key.to_owned()))
+}
+
+fn yaml_clean_optional(value: &YamlValue) -> Option<String> {
+    let text = match value {
+        YamlValue::Null => return None,
+        YamlValue::Bool(value) => value.to_string(),
+        YamlValue::Number(value) => value.to_string(),
+        YamlValue::String(value) => value.clone(),
+        _ => serde_yaml::to_string(value).ok()?,
+    };
+    let text = text.trim();
+    (!text.is_empty()).then(|| text.to_owned())
+}
+
+fn yaml_f64(value: &YamlValue) -> Option<f64> {
+    match value {
+        YamlValue::Number(value) => value.as_f64(),
+        YamlValue::String(value) => value.trim().parse::<f64>().ok(),
+        _ => None,
+    }
+}
+
+fn expand_user_path(value: String) -> String {
+    if value == "~" {
+        return env::var("HOME").unwrap_or(value);
+    }
+    if let Some(rest) = value.strip_prefix("~/") {
+        if let Ok(home) = env::var("HOME") {
+            return format!("{home}/{rest}");
+        }
+    }
+    value
 }
 
 pub fn trimmed(value: &Option<String>) -> Option<String> {

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -32,7 +32,7 @@ use sha1::{Digest, Sha1};
 use sha2::Sha256;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
-use crate::config::{trimmed, AppConfig};
+use crate::config::{trimmed, AppConfig, PublicNodeConfig};
 use crate::runtime::TmuxRuntime;
 use crate::sessions::{
     expand_home, is_primary_node, AgentStatusRequest, ArmStopNotifyOutcome, ArmStopNotifyRequest,
@@ -78,6 +78,7 @@ pub fn router(state: AppState) -> Router {
         .route("/events/state", get(events_state))
         .route("/events", get(events_stream))
         .route("/__shadow/http", post(shadow_http))
+        .route("/nodes", get(list_nodes))
         .route("/sessions", get(list_sessions).post(create_session))
         .route("/sessions/input-batch", post(send_session_input_batch))
         .route("/sessions/spawn", post(spawn_session))
@@ -555,6 +556,14 @@ async fn list_client_sessions(
         .map(ClientSessionResponse::from)
         .collect::<Vec<_>>();
     Ok(Json(SessionsEnvelope::from(sessions)))
+}
+
+async fn list_nodes(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+) -> Result<Json<NodesListResponse>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    Ok(Json(nodes_list_response(&state.config)))
 }
 
 async fn get_session(
@@ -1505,6 +1514,7 @@ fn shadow_predict_read(
             &state.config,
         ))?),
         "/events/state" => Some(serde_json::to_vec(&event_state_payload())?),
+        "/nodes" => Some(serde_json::to_vec(&nodes_list_response(&state.config))?),
         "/sessions" => {
             let include_stopped = query_bool(query_string, "include_stopped");
             let sessions = state
@@ -1788,6 +1798,7 @@ fn is_protected_read_surface(method: &str, path: &str) -> bool {
     }
     path == "/events"
         || path == "/events/state"
+        || path == "/nodes"
         || path == "/sessions"
         || path == "/client/sessions"
         || path.starts_with("/sessions/")
@@ -2349,6 +2360,19 @@ impl From<SessionRecord> for SpawnSessionResponse {
 struct SessionOutputResponse {
     session_id: String,
     output: Option<String>,
+}
+
+#[derive(Serialize)]
+struct NodesListResponse {
+    default: String,
+    nodes: Vec<PublicNodeConfig>,
+}
+
+fn nodes_list_response(config: &AppConfig) -> NodesListResponse {
+    NodesListResponse {
+        default: config.nodes.default_node.clone(),
+        nodes: config.nodes.redacted_nodes(),
+    }
 }
 
 #[derive(Serialize)]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -197,6 +197,132 @@ async fn detailed_health_has_required_top_level_fields() {
 }
 
 #[tokio::test]
+async fn nodes_list_defaults_to_implicit_primary_node() {
+    let app = router(AppState::new(AppConfig::default()));
+
+    let (status, payload) = get_json(app, "/nodes").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["default"], "primary");
+    assert_eq!(
+        payload["nodes"],
+        json!([
+            {
+                "id": "primary",
+                "primary": true,
+                "ssh": null,
+                "api_url": null,
+                "hook_base_url": null,
+                "projects_root": null,
+                "log_dir": null
+            }
+        ])
+    );
+}
+
+#[tokio::test]
+async fn nodes_list_preserves_configured_metadata_and_redacts_secrets() {
+    let config_path = unique_temp_path();
+    let local_env_path = unique_temp_path();
+    fs::write(
+        &config_path,
+        r#"
+nodes:
+  default: macbook
+  restore_inventory_cache_seconds: 42
+  registry:
+    macbook:
+      ssh: macbook.local
+      ssh_proxy_command: "cloudflared access ssh --hostname macbook.example.com"
+      control_path: "~/Library/Caches/sm/macbook.sock"
+      api_url: "http://macbook.local:8420"
+      hook_base_url: "https://macbook.example.com/hooks"
+      hook_secret: "secret-hook-value"
+      node_token: "secret-node-token"
+      projects_root: "/Users/rajesh/projects"
+      log_dir: "/tmp/sm-node"
+    worker:
+      ssh: " worker.example.com "
+    empty-value: "not a mapping"
+"#,
+    )
+    .unwrap();
+    let config =
+        AppConfig::load_from_path_with_local_env(&config_path, Some(&local_env_path)).unwrap();
+    let app = router(AppState::new(config));
+
+    let (status, payload) = get_json(app, "/nodes").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["default"], "macbook");
+    let nodes = payload["nodes"].as_array().unwrap();
+    let ids = nodes
+        .iter()
+        .map(|entry| entry["id"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(ids, vec!["empty-value", "macbook", "primary", "worker"]);
+
+    let macbook = nodes.iter().find(|entry| entry["id"] == "macbook").unwrap();
+    assert_eq!(macbook["primary"], false);
+    assert_eq!(macbook["ssh"], "macbook.local");
+    assert_eq!(macbook["api_url"], "http://macbook.local:8420");
+    assert_eq!(
+        macbook["hook_base_url"],
+        "https://macbook.example.com/hooks"
+    );
+    assert_eq!(macbook["projects_root"], "/Users/rajesh/projects");
+    assert_eq!(macbook["log_dir"], "/tmp/sm-node");
+
+    let worker = nodes.iter().find(|entry| entry["id"] == "worker").unwrap();
+    assert_eq!(worker["ssh"], "worker.example.com");
+
+    let empty_value = nodes
+        .iter()
+        .find(|entry| entry["id"] == "empty-value")
+        .unwrap();
+    assert_eq!(empty_value["ssh"], Value::Null);
+    assert_eq!(empty_value["api_url"], Value::Null);
+
+    let serialized = payload.to_string();
+    assert!(!serialized.contains("secret-hook-value"));
+    assert!(!serialized.contains("secret-node-token"));
+    assert!(!serialized.contains("cloudflared access ssh"));
+    assert!(!serialized.contains("macbook.sock"));
+}
+
+#[tokio::test]
+async fn nodes_list_falls_back_to_primary_when_default_is_unknown() {
+    let config_path = unique_temp_path();
+    let local_env_path = unique_temp_path();
+    fs::write(
+        &config_path,
+        r#"
+nodes:
+  default: missing-node
+  registry:
+    remote:
+      ssh: remote.example.com
+"#,
+    )
+    .unwrap();
+    let config =
+        AppConfig::load_from_path_with_local_env(&config_path, Some(&local_env_path)).unwrap();
+    let app = router(AppState::new(config));
+
+    let (status, payload) = get_json(app, "/nodes").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["default"], "primary");
+    let ids = payload["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["id"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(ids, vec!["primary", "remote"]);
+}
+
+#[tokio::test]
 async fn auth_session_reports_disabled_bypass_when_google_auth_not_requested() {
     let app = router(AppState::new(AppConfig::default()));
 
@@ -234,6 +360,38 @@ async fn shadow_http_reports_match_for_stable_read_only_route() {
             "python_response": {
                 "status": 200,
                 "body_sha256": sha256_hex(&python_body)
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read");
+    assert_eq!(payload["comparison"], "match");
+    assert_eq!(payload["would_write"], false);
+    assert_eq!(payload["predicted_status"], 200);
+    assert_eq!(payload["body_sha256_match"], true);
+}
+
+#[tokio::test]
+async fn shadow_http_reports_match_for_nodes_list() {
+    let app = router(AppState::new(AppConfig::default()));
+    let python_body = br#"{"default":"primary","nodes":[{"id":"primary","primary":true,"ssh":null,"api_url":null,"hook_base_url":null,"projects_root":null,"log_dir":null}]}"#;
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/nodes",
+                "query_string": "",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 200,
+                "body_sha256": sha256_hex(python_body)
             }
         }),
     )

--- a/scripts/rust_migration/mvp_rehearsal.py
+++ b/scripts/rust_migration/mvp_rehearsal.py
@@ -38,6 +38,7 @@ CORE_READ_CHECK_IDS = (
     "http.events_sse_hello",
     "http.sessions",
     "http.client_sessions",
+    "http.nodes_list",
     "http.api_sessions_absent",
     "http.public_watch_operational_data_denied",
     "http.scheduler_remind_retired",
@@ -47,7 +48,6 @@ CORE_READ_CHECK_IDS = (
 
 MVP_GAP_PROBE_CHECK_IDS = (
     "http.client_analytics_summary",
-    "http.nodes_list",
     "http.queue_jobs_list",
     "http.codex_review_requests_list",
 )
@@ -70,6 +70,7 @@ SHADOW_COMPARE_PATHS = (
     "/client/bootstrap",
     "/sessions",
     "/client/sessions",
+    "/nodes",
     "/events/state",
 )
 


### PR DESCRIPTION
## Summary
- add Rust config parsing for `nodes.default` and `nodes.registry.*`
- implement authenticated read-only `GET /nodes` with Python-compatible default/node response shape
- preserve node metadata redaction for secrets, proxy commands, and control paths
- move `http.nodes_list` from MVP gap probes into core sidecar/shadow rehearsal checks

## Verification
- `cargo test -p sm-server nodes_list --test read_only_http`
- `cargo test -p sm-server --test read_only_http`
- `cargo test -p sm-server`
- `python -m scripts.rust_migration.mvp_rehearsal --config scripts/rust_migration/fixtures/read_only/config.yaml --output-dir .local/rust-mvp-rehearsal/nodes-827 --skip-python-health --skip-smoke --skip-baseline --skip-shadow --core-only --startup-timeout 30 --timeout 5`
- `python -m scripts.rust_migration.mvp_rehearsal --config scripts/rust_migration/fixtures/read_only/config.yaml --output-dir .local/rust-mvp-rehearsal/nodes-827-gaps --skip-python-health --skip-smoke --skip-baseline --skip-shadow --allow-blockers --startup-timeout 30 --timeout 5` confirmed the remaining MVP gap blockers are `http.client_analytics_summary`, `http.queue_jobs_list`, and `http.codex_review_requests_list`.

Fixes #827
