### PR TITLE
Rust MVP: implement client analytics summary

### DIFF
--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -8,6 +8,7 @@ use sha2::{Digest, Sha256};
 #[derive(Debug, Clone)]
 pub struct AppConfig {
     pub paths: PathsConfig,
+    pub mobile_analytics: MobileAnalyticsConfig,
     pub google_auth: GoogleAuthConfig,
     pub external_access: ExternalAccessConfig,
     pub mobile_terminal: MobileTerminalConfig,
@@ -25,6 +26,7 @@ impl Default for AppConfig {
     fn default() -> Self {
         Self {
             paths: PathsConfig::default(),
+            mobile_analytics: MobileAnalyticsConfig::default(),
             google_auth: GoogleAuthConfig::default(),
             external_access: ExternalAccessConfig::default(),
             mobile_terminal: MobileTerminalConfig::default(),
@@ -302,6 +304,27 @@ fn default_message_queue_db_path() -> String {
     "~/.local/share/claude-sessions/message_queue.db".to_owned()
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct MobileAnalyticsConfig {
+    #[serde(default = "default_message_queue_db_path")]
+    pub message_queue_db: String,
+    #[serde(default = "default_server_log_file")]
+    pub server_log_file: String,
+}
+
+impl Default for MobileAnalyticsConfig {
+    fn default() -> Self {
+        Self {
+            message_queue_db: default_message_queue_db_path(),
+            server_log_file: default_server_log_file(),
+        }
+    }
+}
+
+fn default_server_log_file() -> String {
+    "/tmp/session-manager.log".to_owned()
+}
+
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct RustShadowConfig {
     #[serde(default)]
@@ -339,7 +362,7 @@ pub struct RustCoreConfig {
 #[derive(Debug, Default, Deserialize)]
 struct RawConfig {
     #[serde(default)]
-    paths: PathsConfig,
+    paths: RawPathsConfig,
     #[serde(default)]
     auth: RawAuthConfig,
     #[serde(default)]
@@ -369,6 +392,7 @@ struct RawConfig {
 impl From<RawConfig> for AppConfig {
     fn from(raw: RawConfig) -> Self {
         let mut rust_core = raw.rust_core;
+        let paths = raw.paths;
         let claude = provider_launch_config(raw.claude, "claude", Some("sonnet"), Vec::new());
         let codex = provider_launch_config(raw.codex, "codex", None, Vec::new());
         let codex_fork = codex_fork_launch_config(raw.codex_fork, &codex);
@@ -396,7 +420,13 @@ impl From<RawConfig> for AppConfig {
             rust_core.send_keys_max_chunk_chars = tmux_timeouts.send_keys_max_chunk_chars;
         }
         Self {
-            paths: raw.paths,
+            paths: PathsConfig {
+                state_file: paths.state_file,
+            },
+            mobile_analytics: MobileAnalyticsConfig {
+                message_queue_db: paths.message_queue_db,
+                server_log_file: paths.server_log_file,
+            },
             google_auth: raw.auth.google,
             external_access: raw.external_access,
             mobile_terminal: raw.mobile_terminal,
@@ -408,6 +438,26 @@ impl From<RawConfig> for AppConfig {
             nodes: nodes_config_from_yaml(raw.nodes),
             rust_shadow: raw.rust_shadow,
             rust_core,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RawPathsConfig {
+    #[serde(default = "default_state_file")]
+    state_file: String,
+    #[serde(default = "default_message_queue_db_path")]
+    message_queue_db: String,
+    #[serde(default = "default_server_log_file")]
+    server_log_file: String,
+}
+
+impl Default for RawPathsConfig {
+    fn default() -> Self {
+        Self {
+            state_file: default_state_file(),
+            message_queue_db: default_message_queue_db_path(),
+            server_log_file: default_server_log_file(),
         }
     }
 }

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -33,6 +33,7 @@ use sha2::Sha256;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 use crate::config::{trimmed, AppConfig, PublicNodeConfig};
+use crate::mobile_analytics::build_mobile_analytics_summary;
 use crate::runtime::TmuxRuntime;
 use crate::sessions::{
     expand_home, is_primary_node, AgentStatusRequest, ArmStopNotifyOutcome, ArmStopNotifyRequest,
@@ -75,6 +76,7 @@ pub fn router(state: AppState) -> Router {
         .route("/health/detailed", get(health_detailed))
         .route("/auth/session", get(auth_session))
         .route("/client/bootstrap", get(client_bootstrap))
+        .route("/client/analytics/summary", get(client_analytics_summary))
         .route("/events/state", get(events_state))
         .route("/events", get(events_stream))
         .route("/__shadow/http", post(shadow_http))
@@ -233,6 +235,17 @@ async fn client_bootstrap(State(state): State<Arc<AppState>>) -> Json<ClientBoot
             preferred_action: "details",
         },
     })
+}
+
+async fn client_analytics_summary(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    Ok(Json(build_mobile_analytics_summary(
+        &state.config,
+        &state.session_store,
+    )?))
 }
 
 async fn events_state(
@@ -1510,6 +1523,13 @@ fn shadow_predict_read(
                 support_status: "implemented_read_status_only",
             }));
         }
+        "/client/analytics/summary" => {
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::OK.as_u16(),
+                body_sha256: None,
+                support_status: "implemented_read_status_only",
+            }));
+        }
         "/client/bootstrap" => Some(serde_json::to_vec(&shadow_client_bootstrap_response(
             &state.config,
         ))?),
@@ -1798,6 +1818,7 @@ fn is_protected_read_surface(method: &str, path: &str) -> bool {
     }
     path == "/events"
         || path == "/events/state"
+        || path == "/client/analytics/summary"
         || path == "/nodes"
         || path == "/sessions"
         || path == "/client/sessions"

--- a/crates/sm-server/src/lib.rs
+++ b/crates/sm-server/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod http;
+pub mod mobile_analytics;
 pub mod queue;
 pub mod runtime;
 pub mod sessions;

--- a/crates/sm-server/src/mobile_analytics.rs
+++ b/crates/sm-server/src/mobile_analytics.rs
@@ -1,0 +1,501 @@
+use std::{
+    collections::{BTreeMap, HashMap},
+    fs,
+    path::Path,
+};
+
+use anyhow::Result;
+use rusqlite::{Connection, OpenFlags};
+use serde_json::{json, Value};
+use time::{
+    format_description::well_known::Rfc3339, macros::format_description, Duration, OffsetDateTime,
+    PrimitiveDateTime,
+};
+
+use crate::{
+    config::AppConfig,
+    sessions::{expand_home, SessionRecord, SessionStore},
+};
+
+const WINDOW_HOURS: i64 = 24;
+const BUCKET_HOURS: i64 = 2;
+
+pub fn build_mobile_analytics_summary(
+    config: &AppConfig,
+    session_store: &SessionStore,
+) -> Result<Value> {
+    let now = OffsetDateTime::now_utc();
+    build_mobile_analytics_summary_at(config, session_store, now)
+}
+
+fn build_mobile_analytics_summary_at(
+    config: &AppConfig,
+    session_store: &SessionStore,
+    now: OffsetDateTime,
+) -> Result<Value> {
+    let current_start = now - Duration::hours(WINDOW_HOURS);
+    let previous_start = now - Duration::hours(WINDOW_HOURS * 2);
+    let sessions = session_store.list_sessions(false)?;
+    let queue_path = expand_home(&config.mobile_analytics.message_queue_db);
+    let server_log_path = expand_home(&config.mobile_analytics.server_log_file);
+
+    let (send_times_current, send_times_previous) =
+        read_send_timestamps(&queue_path, current_start, previous_start, now);
+    let track_times_current = read_track_remind_timestamps(&queue_path, current_start, now);
+    let (active_tracks, overdue_tracks) = read_track_registration_counts(&queue_path);
+    let (spawn_times_current, spawn_times_previous, restart_count, self_heal_count) =
+        read_log_metrics(&server_log_path, current_start, previous_start, now);
+
+    let sends_series = series_points(&send_times_current, current_start, now);
+    let spawn_series = series_points(&spawn_times_current, current_start, now);
+    let track_series = series_points(&track_times_current, current_start, now);
+
+    let total_sessions = sessions.len() as i64;
+    let state_counts = activity_state_counts(&sessions);
+    let provider_distribution = provider_distribution(&sessions);
+    let (repo_distribution, total_tokens_live) = repo_distribution(&sessions, total_sessions);
+    let longest_running = longest_running_sessions(&sessions, now);
+
+    Ok(json!({
+        "generated_at": format_rfc3339(now),
+        "window_hours": WINDOW_HOURS,
+        "kpis": {
+            "active_sessions": {
+                "label": "Active sessions",
+                "value": total_sessions,
+            },
+            "sends_24h": {
+                "label": "Sends",
+                "value": send_times_current.len(),
+                "delta_pct": delta_pct(send_times_current.len(), send_times_previous.len()),
+            },
+            "spawns_24h": {
+                "label": "Dispatches",
+                "value": spawn_times_current.len(),
+                "delta_pct": delta_pct(spawn_times_current.len(), spawn_times_previous.len()),
+            },
+            "active_tracks": {
+                "label": "Tracks active",
+                "value": active_tracks,
+            },
+            "overdue_tracks": {
+                "label": "Overdue tracks",
+                "value": overdue_tracks,
+            },
+            "incidents_24h": {
+                "label": "Incidents",
+                "value": restart_count + self_heal_count,
+            },
+        },
+        "throughput": throughput_series(sends_series, spawn_series, track_series),
+        "state_distribution": [
+            {"key": "working", "label": "working", "count": *state_counts.get("working").unwrap_or(&0)},
+            {"key": "thinking", "label": "thinking", "count": *state_counts.get("thinking").unwrap_or(&0)},
+            {"key": "waiting", "label": "waiting", "count": *state_counts.get("waiting").unwrap_or(&0)},
+            {"key": "idle", "label": "idle", "count": *state_counts.get("idle").unwrap_or(&0)},
+        ],
+        "provider_distribution": provider_distribution,
+        "repo_distribution": repo_distribution,
+        "longest_running": longest_running,
+        "reliability": {
+            "restart_count_24h": restart_count,
+            "self_heal_count_24h": self_heal_count,
+        },
+        "totals": {
+            "tokens_live": total_tokens_live,
+            "track_reminders_24h": track_times_current.len(),
+        },
+        "health_checks": [],
+        "attach_available": true,
+    }))
+}
+
+fn read_send_timestamps(
+    db_path: &Path,
+    current_start: OffsetDateTime,
+    previous_start: OffsetDateTime,
+    now: OffsetDateTime,
+) -> (Vec<OffsetDateTime>, Vec<OffsetDateTime>) {
+    let mut current = Vec::new();
+    let mut previous = Vec::new();
+    let rows = query_timestamp_column(
+        db_path,
+        r#"
+        SELECT queued_at
+        FROM message_queue
+        WHERE from_sm_send = 1
+          AND queued_at >= ?1
+          AND queued_at < ?2
+        "#,
+        &[format_rfc3339(previous_start), format_rfc3339(now)],
+    );
+    for timestamp in rows {
+        if timestamp >= current_start {
+            current.push(timestamp);
+        } else {
+            previous.push(timestamp);
+        }
+    }
+    (current, previous)
+}
+
+fn read_track_remind_timestamps(
+    db_path: &Path,
+    current_start: OffsetDateTime,
+    now: OffsetDateTime,
+) -> Vec<OffsetDateTime> {
+    query_timestamp_column(
+        db_path,
+        r#"
+        SELECT queued_at
+        FROM message_queue
+        WHERE message_category = 'track_remind'
+          AND queued_at >= ?1
+          AND queued_at < ?2
+        "#,
+        &[format_rfc3339(current_start), format_rfc3339(now)],
+    )
+}
+
+fn query_timestamp_column(db_path: &Path, sql: &str, params: &[String; 2]) -> Vec<OffsetDateTime> {
+    let Ok(conn) = open_existing_read_only_db(db_path) else {
+        return Vec::new();
+    };
+    let Ok(mut statement) = conn.prepare(sql) else {
+        return Vec::new();
+    };
+    let Ok(rows) = statement.query_map([params[0].as_str(), params[1].as_str()], |row| {
+        row.get::<_, String>(0)
+    }) else {
+        return Vec::new();
+    };
+    rows.filter_map(|row| row.ok())
+        .filter_map(|value| parse_any_datetime(&value))
+        .collect()
+}
+
+fn read_track_registration_counts(db_path: &Path) -> (i64, i64) {
+    let Ok(conn) = open_existing_read_only_db(db_path) else {
+        return (0, 0);
+    };
+    conn.query_row(
+        r#"
+        SELECT
+            SUM(CASE WHEN is_active = 1 AND cancel_on_reply_session_id IS NOT NULL AND TRIM(cancel_on_reply_session_id) != '' THEN 1 ELSE 0 END),
+            SUM(CASE WHEN is_active = 1 AND soft_fired = 1 AND cancel_on_reply_session_id IS NOT NULL AND TRIM(cancel_on_reply_session_id) != '' THEN 1 ELSE 0 END)
+        FROM remind_registrations
+        "#,
+        [],
+        |row| {
+            Ok((
+                row.get::<_, Option<i64>>(0)?.unwrap_or(0),
+                row.get::<_, Option<i64>>(1)?.unwrap_or(0),
+            ))
+        },
+    )
+    .unwrap_or((0, 0))
+}
+
+fn open_existing_read_only_db(path: &Path) -> Result<Connection, rusqlite::Error> {
+    if !path.exists() {
+        return Err(rusqlite::Error::InvalidPath(path.to_path_buf()));
+    }
+    Connection::open_with_flags(path, OpenFlags::SQLITE_OPEN_READ_ONLY)
+}
+
+fn read_log_metrics(
+    log_path: &Path,
+    current_start: OffsetDateTime,
+    previous_start: OffsetDateTime,
+    now: OffsetDateTime,
+) -> (Vec<OffsetDateTime>, Vec<OffsetDateTime>, i64, i64) {
+    let Ok(content) = fs::read_to_string(log_path) else {
+        return (Vec::new(), Vec::new(), 0, 0);
+    };
+    let mut current_spawns = Vec::new();
+    let mut previous_spawns = Vec::new();
+    let mut restart_count = 0;
+    let mut self_heal_count = 0;
+    for line in content.lines() {
+        let Some(timestamp) = parse_log_timestamp(line) else {
+            continue;
+        };
+        if timestamp < previous_start || timestamp >= now {
+            continue;
+        }
+        if line.contains("Created session ") && !line.contains("Created session with CLI prompt") {
+            if timestamp >= current_start {
+                current_spawns.push(timestamp);
+            } else {
+                previous_spawns.push(timestamp);
+            }
+        }
+        if timestamp >= current_start && line.contains("Starting Claude Session Manager...") {
+            restart_count += 1;
+        }
+        if timestamp >= current_start && line.contains("Recovered ") {
+            self_heal_count += 1;
+        }
+    }
+    (
+        current_spawns,
+        previous_spawns,
+        restart_count,
+        self_heal_count,
+    )
+}
+
+fn series_points(
+    timestamps: &[OffsetDateTime],
+    window_start: OffsetDateTime,
+    window_end: OffsetDateTime,
+) -> Vec<(OffsetDateTime, i64)> {
+    let bucket_count = ((window_end - window_start).whole_seconds() / (BUCKET_HOURS * 3600)) as i64;
+    let mut buckets = (0..bucket_count)
+        .map(|index| (window_start + Duration::hours(index * BUCKET_HOURS), 0_i64))
+        .collect::<Vec<_>>();
+    for timestamp in timestamps {
+        if *timestamp < window_start || *timestamp >= window_end {
+            continue;
+        }
+        let elapsed_hours = (*timestamp - window_start).whole_seconds() / 3600;
+        let bucket_index = (elapsed_hours / BUCKET_HOURS).clamp(0, bucket_count.saturating_sub(1));
+        if let Some((_, count)) = buckets.get_mut(bucket_index as usize) {
+            *count += 1;
+        }
+    }
+    buckets
+}
+
+fn throughput_series(
+    sends: Vec<(OffsetDateTime, i64)>,
+    spawns: Vec<(OffsetDateTime, i64)>,
+    tracks: Vec<(OffsetDateTime, i64)>,
+) -> Vec<Value> {
+    sends
+        .into_iter()
+        .enumerate()
+        .map(|(index, (bucket_start, send_count))| {
+            json!({
+                "bucket_start": format_rfc3339(bucket_start),
+                "bucket_label": format_hour_minute(bucket_start),
+                "sends": send_count,
+                "spawns": spawns.get(index).map(|(_, count)| *count).unwrap_or(0),
+                "track_reminders": tracks.get(index).map(|(_, count)| *count).unwrap_or(0),
+            })
+        })
+        .collect()
+}
+
+fn activity_state_counts(sessions: &[SessionRecord]) -> HashMap<&'static str, i64> {
+    let mut counts = HashMap::new();
+    for session in sessions {
+        *counts.entry(activity_state(session)).or_insert(0) += 1;
+    }
+    counts
+}
+
+fn activity_state(session: &SessionRecord) -> &'static str {
+    match session.status.trim().to_ascii_lowercase().as_str() {
+        "running" | "starting" => "working",
+        "thinking" => "thinking",
+        "waiting_permission" | "waiting_input" => "waiting",
+        _ => "idle",
+    }
+}
+
+fn provider_distribution(sessions: &[SessionRecord]) -> Vec<Value> {
+    let mut first_seen = Vec::<String>::new();
+    let mut counts = HashMap::<String, i64>::new();
+    for session in sessions {
+        let provider = non_empty_or(&session.provider, "claude");
+        if !counts.contains_key(&provider) {
+            first_seen.push(provider.clone());
+        }
+        *counts.entry(provider).or_insert(0) += 1;
+    }
+    first_seen.sort_by(|left, right| {
+        counts
+            .get(right)
+            .unwrap_or(&0)
+            .cmp(counts.get(left).unwrap_or(&0))
+            .then_with(|| left.cmp(right))
+    });
+    let total = sessions.len() as f64;
+    first_seen
+        .into_iter()
+        .map(|provider| {
+            let count = *counts.get(&provider).unwrap_or(&0);
+            json!({
+                "key": provider,
+                "label": provider,
+                "count": count,
+                "share_pct": percentage(count, total),
+            })
+        })
+        .collect()
+}
+
+fn repo_distribution(sessions: &[SessionRecord], total_sessions: i64) -> (Vec<Value>, i64) {
+    let mut repos = BTreeMap::<String, (i64, i64)>::new();
+    let mut total_tokens = 0_i64;
+    for session in sessions {
+        let repo = repo_label(&session.working_dir);
+        let entry = repos.entry(repo).or_insert((0, 0));
+        entry.0 += 1;
+        entry.1 += session.tokens_used;
+        total_tokens += session.tokens_used;
+    }
+    let mut rows = repos
+        .into_iter()
+        .map(|(repo, (session_count, tokens_used))| {
+            (
+                repo,
+                session_count,
+                tokens_used,
+                percentage(session_count, total_sessions as f64),
+            )
+        })
+        .collect::<Vec<_>>();
+    rows.sort_by(|left, right| right.1.cmp(&left.1).then_with(|| left.0.cmp(&right.0)));
+    (
+        rows.into_iter()
+            .take(6)
+            .map(|(repo, session_count, tokens_used, share_pct)| {
+                json!({
+                    "key": repo,
+                    "label": repo,
+                    "session_count": session_count,
+                    "tokens_used": tokens_used,
+                    "share_pct": share_pct,
+                })
+            })
+            .collect(),
+        total_tokens,
+    )
+}
+
+fn longest_running_sessions(sessions: &[SessionRecord], now: OffsetDateTime) -> Vec<Value> {
+    let mut rows = sessions
+        .iter()
+        .map(|session| {
+            let age_hours = parse_any_datetime(&session.created_at)
+                .map(|created_at| round_one((now - created_at).whole_seconds() as f64 / 3600.0))
+                .unwrap_or(0.0);
+            (
+                age_hours,
+                display_name(session),
+                json!({
+                    "id": session.id,
+                    "name": display_name(session),
+                    "repo": repo_label(&session.working_dir),
+                    "provider": non_empty_or(&session.provider, "claude"),
+                    "age_hours": age_hours,
+                }),
+            )
+        })
+        .collect::<Vec<_>>();
+    rows.sort_by(|left, right| {
+        right
+            .0
+            .partial_cmp(&left.0)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| left.1.cmp(&right.1))
+    });
+    rows.into_iter()
+        .take(5)
+        .map(|(_, _, value)| value)
+        .collect()
+}
+
+fn display_name(session: &SessionRecord) -> String {
+    non_empty_opt(&session.friendly_name)
+        .unwrap_or_else(|| non_empty_or(&session.name, &session.id))
+}
+
+fn repo_label(working_dir: &str) -> String {
+    let normalized = working_dir.trim();
+    if normalized.is_empty() {
+        return "unknown".to_owned();
+    }
+    normalized
+        .trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .filter(|value| !value.is_empty())
+        .unwrap_or(normalized)
+        .to_owned()
+}
+
+fn delta_pct(current: usize, previous: usize) -> Option<f64> {
+    if previous == 0 {
+        return None;
+    }
+    Some(round_one(
+        ((current as f64 - previous as f64) / previous as f64) * 100.0,
+    ))
+}
+
+fn percentage(count: i64, total: f64) -> f64 {
+    if total <= 0.0 {
+        return 0.0;
+    }
+    round_one((count as f64 / total) * 100.0)
+}
+
+fn round_one(value: f64) -> f64 {
+    (value * 10.0).round() / 10.0
+}
+
+fn parse_any_datetime(value: &str) -> Option<OffsetDateTime> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    if let Ok(parsed) = OffsetDateTime::parse(value, &Rfc3339) {
+        return Some(parsed.to_offset(time::UtcOffset::UTC));
+    }
+    parse_python_naive_datetime(value).map(|parsed| parsed.assume_utc())
+}
+
+fn parse_log_timestamp(line: &str) -> Option<OffsetDateTime> {
+    let prefix = line.get(..19)?;
+    parse_python_naive_datetime(prefix).map(|parsed| parsed.assume_utc())
+}
+
+fn parse_python_naive_datetime(value: &str) -> Option<PrimitiveDateTime> {
+    let value = value.trim().replace('T', " ");
+    let seconds = value.get(..19).unwrap_or(value.as_str());
+    PrimitiveDateTime::parse(
+        seconds,
+        &format_description!("[year]-[month]-[day] [hour]:[minute]:[second]"),
+    )
+    .ok()
+}
+
+fn format_rfc3339(value: OffsetDateTime) -> String {
+    value.format(&Rfc3339).unwrap_or_else(|_| value.to_string())
+}
+
+fn format_hour_minute(value: OffsetDateTime) -> String {
+    value
+        .format(format_description!("[hour]:[minute]"))
+        .unwrap_or_else(|_| "".to_owned())
+}
+
+fn non_empty_opt(value: &Option<String>) -> Option<String> {
+    value
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn non_empty_or(value: &str, fallback: &str) -> String {
+    let value = value.trim();
+    if value.is_empty() {
+        fallback.to_owned()
+    } else {
+        value.to_owned()
+    }
+}

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -17,8 +17,8 @@ use sm_server::config::RustShadowConfig;
 use sm_server::queue::RetainedQueueStore;
 use sm_server::{
     config::{
-        AppConfig, CodexForkLaunchConfig, ExternalAccessConfig, GoogleAuthConfig, PathsConfig,
-        RustCoreConfig, SmSendConfig,
+        AppConfig, CodexForkLaunchConfig, ExternalAccessConfig, GoogleAuthConfig,
+        MobileAnalyticsConfig, PathsConfig, RustCoreConfig, SmSendConfig,
     },
     http::{router, AppState},
 };
@@ -320,6 +320,255 @@ nodes:
         .map(|entry| entry["id"].as_str().unwrap())
         .collect::<Vec<_>>();
     assert_eq!(ids, vec!["primary", "remote"]);
+}
+
+#[tokio::test]
+async fn client_analytics_summary_reports_live_metrics_from_state_queue_and_logs() {
+    let state_file = unique_temp_path();
+    let queue_db = state_file.with_extension("analytics-message-queue.db");
+    let server_log = state_file.with_extension("analytics-server.log");
+    let now = time::OffsetDateTime::now_utc();
+    let session_a_created = now - time::Duration::hours(2);
+    let session_b_created = now - time::Duration::hours(1);
+    let send_a = now - time::Duration::minutes(90);
+    let send_b = now - time::Duration::minutes(30);
+    let send_previous = now - time::Duration::hours(25);
+    let track_send = now - time::Duration::minutes(15);
+    let restart = now - time::Duration::hours(2);
+    let spawn_current = now - time::Duration::minutes(80);
+    let spawn_previous = now - time::Duration::hours(26);
+    let self_heal = now - time::Duration::minutes(70);
+
+    fs::write(
+        &state_file,
+        json!({
+            "sessions": [
+                {
+                    "id": "analyticsa",
+                    "name": "claude-analyticsa",
+                    "working_dir": "/tmp/repo-a",
+                    "tmux_session": "claude-analyticsa",
+                    "log_file": "/tmp/analyticsa.log",
+                    "status": "running",
+                    "created_at": rfc3339(session_a_created),
+                    "last_activity": rfc3339(now),
+                    "provider": "claude",
+                    "tokens_used": 1200,
+                    "friendly_name": "agent-a"
+                },
+                {
+                    "id": "analyticsb",
+                    "name": "codex-fork-analyticsb",
+                    "working_dir": "/tmp/repo-b",
+                    "tmux_session": "codex-fork-analyticsb",
+                    "log_file": "/tmp/analyticsb.log",
+                    "status": "thinking",
+                    "created_at": rfc3339(session_b_created),
+                    "last_activity": rfc3339(now),
+                    "provider": "codex-fork",
+                    "tokens_used": 800,
+                    "friendly_name": "agent-b"
+                },
+                {
+                    "id": "analyticsstopped",
+                    "name": "claude-analyticsstopped",
+                    "working_dir": "/tmp/repo-c",
+                    "tmux_session": "claude-analyticsstopped",
+                    "log_file": "/tmp/analyticsstopped.log",
+                    "status": "stopped",
+                    "created_at": rfc3339(now - time::Duration::hours(5)),
+                    "last_activity": rfc3339(now),
+                    "stopped_at": rfc3339(now)
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    {
+        let conn = Connection::open(&queue_db).unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE message_queue (
+                id TEXT PRIMARY KEY,
+                target_session_id TEXT NOT NULL,
+                text TEXT NOT NULL,
+                delivery_mode TEXT DEFAULT 'sequential',
+                from_sm_send INTEGER DEFAULT 0,
+                queued_at TIMESTAMP NOT NULL,
+                message_category TEXT DEFAULT NULL
+            );
+            CREATE TABLE remind_registrations (
+                id TEXT PRIMARY KEY,
+                target_session_id TEXT NOT NULL UNIQUE,
+                soft_threshold_seconds INTEGER NOT NULL,
+                hard_threshold_seconds INTEGER NOT NULL,
+                registered_at TIMESTAMP NOT NULL,
+                last_reset_at TIMESTAMP NOT NULL,
+                soft_fired INTEGER DEFAULT 0,
+                is_active INTEGER DEFAULT 1,
+                cancel_on_reply_session_id TEXT
+            );
+            "#,
+        )
+        .unwrap();
+        conn.execute(
+            r#"
+            INSERT INTO message_queue
+                (id, target_session_id, text, queued_at, message_category, from_sm_send)
+            VALUES
+                ('send-a', 'analyticsa', 'msg', ?1, NULL, 1),
+                ('send-b', 'analyticsa', 'msg', ?2, NULL, 1),
+                ('send-prev', 'analyticsb', 'msg', ?3, NULL, 1),
+                ('track-a', 'analyticsb', 'track', ?4, 'track_remind', 0)
+            "#,
+            (
+                rfc3339(send_a),
+                rfc3339(send_b),
+                rfc3339(send_previous),
+                rfc3339(track_send),
+            ),
+        )
+        .unwrap();
+        conn.execute(
+            r#"
+            INSERT INTO remind_registrations
+                (id, target_session_id, soft_threshold_seconds, hard_threshold_seconds,
+                 registered_at, last_reset_at, soft_fired, is_active, cancel_on_reply_session_id)
+            VALUES
+                ('track-active', 'analyticsa', 300, 600, ?1, ?1, 1, 1, 'owner-a'),
+                ('track-waiting', 'analyticsb', 300, 600, ?1, ?1, 0, 1, 'owner-b'),
+                ('track-unowned', 'ignored', 300, 600, ?1, ?1, 1, 1, NULL)
+            "#,
+            [rfc3339(now - time::Duration::hours(3))],
+        )
+        .unwrap();
+    }
+
+    fs::write(
+        &server_log,
+        [
+            format!(
+                "{} - __main__ - INFO - Starting Claude Session Manager...",
+                log_timestamp(restart)
+            ),
+            format!(
+                "{} - src.session_manager - INFO - Created session claude-analyticsa (id=analyticsa)",
+                log_timestamp(spawn_current)
+            ),
+            format!(
+                "{} - src.session_manager - INFO - Created session with CLI prompt should be ignored",
+                log_timestamp(now - time::Duration::minutes(75))
+            ),
+            format!(
+                "{} - src.session_manager - INFO - Created session codex-fork-old (id=old)",
+                log_timestamp(spawn_previous)
+            ),
+            format!(
+                "{} - src.infra_supervisor - WARNING - Recovered android attach sshd via launchctl",
+                log_timestamp(self_heal)
+            ),
+        ]
+        .join("\n"),
+    )
+    .unwrap();
+
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        mobile_analytics: MobileAnalyticsConfig {
+            message_queue_db: queue_db.display().to_string(),
+            server_log_file: server_log.display().to_string(),
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = get_json(app, "/client/analytics/summary").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["window_hours"], 24);
+    assert!(payload["generated_at"].is_string());
+    assert_eq!(payload["kpis"]["active_sessions"]["value"], 2);
+    assert_eq!(payload["kpis"]["sends_24h"]["value"], 2);
+    assert_eq!(payload["kpis"]["sends_24h"]["delta_pct"], 100.0);
+    assert_eq!(payload["kpis"]["spawns_24h"]["value"], 1);
+    assert_eq!(payload["kpis"]["spawns_24h"]["delta_pct"], 0.0);
+    assert_eq!(payload["kpis"]["active_tracks"]["value"], 2);
+    assert_eq!(payload["kpis"]["overdue_tracks"]["value"], 1);
+    assert_eq!(payload["kpis"]["incidents_24h"]["value"], 2);
+    assert_eq!(payload["totals"]["tokens_live"], 2000);
+    assert_eq!(payload["totals"]["track_reminders_24h"], 1);
+    assert_eq!(payload["reliability"]["restart_count_24h"], 1);
+    assert_eq!(payload["reliability"]["self_heal_count_24h"], 1);
+    assert_eq!(
+        payload["state_distribution"],
+        json!([
+            {"key": "working", "label": "working", "count": 1},
+            {"key": "thinking", "label": "thinking", "count": 1},
+            {"key": "waiting", "label": "waiting", "count": 0},
+            {"key": "idle", "label": "idle", "count": 0}
+        ])
+    );
+    assert_eq!(
+        payload["provider_distribution"].as_array().unwrap().len(),
+        2
+    );
+    assert_eq!(payload["repo_distribution"].as_array().unwrap().len(), 2);
+    assert_eq!(payload["longest_running"][0]["id"], "analyticsa");
+    assert_eq!(payload["throughput"].as_array().unwrap().len(), 12);
+    assert_eq!(payload["health_checks"], json!([]));
+    assert_eq!(payload["attach_available"], true);
+}
+
+#[tokio::test]
+async fn client_analytics_summary_uses_zero_fallbacks_for_missing_telemetry_files() {
+    let state_file = unique_temp_path();
+    fs::write(&state_file, json!({ "sessions": [] }).to_string()).unwrap();
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        mobile_analytics: MobileAnalyticsConfig {
+            message_queue_db: state_file
+                .with_extension("missing-queue.db")
+                .display()
+                .to_string(),
+            server_log_file: state_file
+                .with_extension("missing.log")
+                .display()
+                .to_string(),
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = get_json(app, "/client/analytics/summary").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["kpis"]["active_sessions"]["value"], 0);
+    assert_eq!(payload["kpis"]["sends_24h"]["value"], 0);
+    assert_eq!(payload["kpis"]["active_tracks"]["value"], 0);
+    assert_eq!(payload["reliability"]["restart_count_24h"], 0);
+    assert_eq!(payload["totals"]["tokens_live"], 0);
+    assert_eq!(payload["throughput"].as_array().unwrap().len(), 12);
+}
+
+#[tokio::test]
+async fn client_analytics_summary_rejects_public_host_without_auth() {
+    let state_file = unique_temp_path();
+    fs::write(&state_file, json!({ "sessions": [] }).to_string()).unwrap();
+    let app = router(AppState::new(config_with_state_file_and_auth(&state_file)));
+
+    let (status, payload) =
+        get_json_with_host(app, "/client/analytics/summary", "sm.example.com").await;
+
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(payload["detail"], "Authentication required");
+    assert_eq!(
+        payload["login_url"],
+        "/auth/google/login?next=%2Fclient%2Fanalytics%2Fsummary"
+    );
 }
 
 #[tokio::test]
@@ -5504,6 +5753,23 @@ fn config_with_state_file_and_queue(state_file: &PathBuf) -> AppConfig {
 
 fn queue_db_path_for_state_file(state_file: &PathBuf) -> PathBuf {
     state_file.with_extension("message_queue.db")
+}
+
+fn rfc3339(value: time::OffsetDateTime) -> String {
+    value
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap()
+}
+
+fn log_timestamp(value: time::OffsetDateTime) -> String {
+    format!(
+        "{},000",
+        value
+            .format(time::macros::format_description!(
+                "[year]-[month]-[day] [hour]:[minute]:[second]"
+            ))
+            .unwrap()
+    )
 }
 
 fn assert_python_naive_timestamp(value: &str) {

--- a/scripts/rust_migration/mvp_rehearsal.py
+++ b/scripts/rust_migration/mvp_rehearsal.py
@@ -34,6 +34,7 @@ CORE_READ_CHECK_IDS = (
     "http.health_detailed",
     "http.auth_session",
     "http.client_bootstrap",
+    "http.client_analytics_summary",
     "http.events_state",
     "http.events_sse_hello",
     "http.sessions",
@@ -47,7 +48,6 @@ CORE_READ_CHECK_IDS = (
 )
 
 MVP_GAP_PROBE_CHECK_IDS = (
-    "http.client_analytics_summary",
     "http.queue_jobs_list",
     "http.codex_review_requests_list",
 )


### PR DESCRIPTION
## Summary
- add Rust read-only `/client/analytics/summary` for the native mobile dashboard
- preserve the Python summary shape across KPIs, throughput, state/provider/repo distributions, longest-running sessions, reliability, totals, `health_checks`, and `attach_available`
- read optional queue/log telemetry without creating or mutating files, with zero fallbacks when telemetry is absent or unreadable
- honor `paths.message_queue_db` and `paths.server_log_file` from config for analytics inputs
- move `http.client_analytics_summary` from MVP gap probes into core sidecar checks

## Verification
- `cargo test -p sm-server client_analytics_summary --test read_only_http`
- `cargo test -p sm-server --test read_only_http`
- `cargo test -p sm-server`
- `python -m scripts.rust_migration.mvp_rehearsal --config scripts/rust_migration/fixtures/read_only/config.yaml --output-dir .local/rust-mvp-rehearsal/analytics-829 --skip-python-health --skip-smoke --skip-baseline --skip-shadow --core-only --startup-timeout 30 --timeout 5`
- `python -m scripts.rust_migration.mvp_rehearsal --config scripts/rust_migration/fixtures/read_only/config.yaml --output-dir .local/rust-mvp-rehearsal/analytics-829-gaps --skip-python-health --skip-smoke --skip-baseline --skip-shadow --allow-blockers --startup-timeout 30 --timeout 5` confirmed the remaining MVP gap blockers are `http.queue_jobs_list` and `http.codex_review_requests_list`.

Fixes #829
