### PR TITLE
Rust MVP: implement codex review request list

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -34,6 +34,7 @@ use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 use crate::config::{trimmed, AppConfig, PublicNodeConfig};
 use crate::mobile_analytics::build_mobile_analytics_summary;
+use crate::queue::{CodexReviewRequestFilters, CodexReviewRequestRegistration, RetainedQueueStore};
 use crate::runtime::TmuxRuntime;
 use crate::sessions::{
     expand_home, is_primary_node, AgentStatusRequest, ArmStopNotifyOutcome, ArmStopNotifyRequest,
@@ -80,6 +81,7 @@ pub fn router(state: AppState) -> Router {
         .route("/events/state", get(events_state))
         .route("/events", get(events_stream))
         .route("/__shadow/http", post(shadow_http))
+        .route("/codex-review-requests", get(list_codex_review_requests))
         .route("/nodes", get(list_nodes))
         .route("/sessions", get(list_sessions).post(create_session))
         .route("/sessions/input-batch", post(send_session_input_batch))
@@ -577,6 +579,58 @@ async fn list_nodes(
 ) -> Result<Json<NodesListResponse>, ApiError> {
     ensure_session_read_allowed(&state, &request)?;
     Ok(Json(nodes_list_response(&state.config)))
+}
+
+async fn list_codex_review_requests(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<ListCodexReviewRequestsQuery>,
+    request: Request,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    let notify_session_id = if let Some(notify_target) = query
+        .notify_target
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let Some(session) = resolve_session_or_registry_role(&state, notify_target)? else {
+            return Err(ApiError::NotFound("Notify target not found"));
+        };
+        Some(session.id)
+    } else {
+        None
+    };
+    let queue_db_path = expand_home(&state.config.sm_send.db_path);
+    let registrations = RetainedQueueStore::list_codex_review_requests_from_path(
+        &queue_db_path,
+        CodexReviewRequestFilters {
+            notify_session_id,
+            repo: query
+                .repo
+                .as_ref()
+                .and_then(|value| trimmed(&Some(value.clone()))),
+            pr_number: query.pr_number,
+            include_inactive: query.include_inactive,
+        },
+    )?;
+    let mut requests = Vec::with_capacity(registrations.len());
+    for registration in registrations {
+        requests.push(codex_review_request_response(&state, registration)?);
+    }
+    Ok(Json(json!({ "requests": requests })))
+}
+
+fn resolve_session_or_registry_role(
+    state: &AppState,
+    identifier: &str,
+) -> Result<Option<SessionRecord>, ApiError> {
+    if let Some(session) = state.session_store.get_session(identifier)? {
+        return Ok(Some(session));
+    }
+    let Some(registration) = state.session_store.lookup_agent_registration(identifier)? else {
+        return Ok(None);
+    };
+    Ok(state.session_store.get_session(&registration.session_id)?)
 }
 
 async fn get_session(
@@ -1530,6 +1584,13 @@ fn shadow_predict_read(
                 support_status: "implemented_read_status_only",
             }));
         }
+        "/codex-review-requests" => {
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::OK.as_u16(),
+                body_sha256: None,
+                support_status: "implemented_read_status_only",
+            }));
+        }
         "/client/bootstrap" => Some(serde_json::to_vec(&shadow_client_bootstrap_response(
             &state.config,
         ))?),
@@ -1819,6 +1880,7 @@ fn is_protected_read_surface(method: &str, path: &str) -> bool {
     path == "/events"
         || path == "/events/state"
         || path == "/client/analytics/summary"
+        || path == "/codex-review-requests"
         || path == "/nodes"
         || path == "/sessions"
         || path == "/client/sessions"
@@ -2300,6 +2362,18 @@ struct ListChildrenQuery {
 }
 
 #[derive(Debug, Deserialize)]
+struct ListCodexReviewRequestsQuery {
+    #[serde(default)]
+    notify_target: Option<String>,
+    #[serde(default)]
+    repo: Option<String>,
+    #[serde(default)]
+    pr_number: Option<i64>,
+    #[serde(default)]
+    include_inactive: bool,
+}
+
+#[derive(Debug, Deserialize)]
 struct SessionOutputQuery {
     lines: Option<usize>,
 }
@@ -2394,6 +2468,57 @@ fn nodes_list_response(config: &AppConfig) -> NodesListResponse {
         default: config.nodes.default_node.clone(),
         nodes: config.nodes.redacted_nodes(),
     }
+}
+
+fn codex_review_request_response(
+    state: &AppState,
+    registration: CodexReviewRequestRegistration,
+) -> Result<Value, ApiError> {
+    let requester_name = match registration.requester_session_id.as_deref() {
+        Some(session_id) => state
+            .session_store
+            .get_session(session_id)?
+            .map(session_display_name)
+            .or_else(|| Some(session_id.to_owned())),
+        None => None,
+    };
+    let notify_name = state
+        .session_store
+        .get_session(&registration.notify_session_id)?
+        .map(session_display_name)
+        .unwrap_or_else(|| registration.notify_session_id.clone());
+    Ok(json!({
+        "id": registration.id,
+        "repo": registration.repo,
+        "pr_number": registration.pr_number,
+        "requester_session_id": registration.requester_session_id,
+        "requester_name": requester_name,
+        "notify_session_id": registration.notify_session_id,
+        "notify_name": notify_name,
+        "steer": registration.steer,
+        "requested_at": registration.requested_at,
+        "latest_request_comment_id": registration.latest_request_comment_id,
+        "latest_request_comment_url": registration.latest_request_comment_url,
+        "latest_request_posted_at": registration.latest_request_posted_at,
+        "attempt_count": registration.attempt_count,
+        "next_retry_at": registration.next_retry_at,
+        "poll_interval_seconds": registration.poll_interval_seconds,
+        "retry_interval_seconds": registration.retry_interval_seconds,
+        "pickup_detected_at": registration.pickup_detected_at,
+        "pickup_source": registration.pickup_source,
+        "review_landed_at": registration.review_landed_at,
+        "review_source": registration.review_source,
+        "review_comment_id": registration.review_comment_id,
+        "review_url": registration.review_url,
+        "last_polled_at": registration.last_polled_at,
+        "last_error": registration.last_error,
+        "state": registration.state,
+        "is_active": registration.is_active,
+    }))
+}
+
+fn session_display_name(session: SessionRecord) -> String {
+    session.cached_display_name().unwrap_or(session.id)
 }
 
 #[derive(Serialize)]

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -1,7 +1,12 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{
+    params,
+    types::{Value as SqlValue, ValueRef},
+    Connection, OpenFlags, OptionalExtension,
+};
+use serde_json::{Number as JsonNumber, Value as JsonValue};
 use time::{
     format_description::well_known::Rfc3339, macros::format_description, Duration, OffsetDateTime,
     PrimitiveDateTime,
@@ -10,6 +15,42 @@ use time::{
 #[derive(Debug, Clone)]
 pub struct RetainedQueueStore {
     db_path: PathBuf,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CodexReviewRequestFilters {
+    pub notify_session_id: Option<String>,
+    pub repo: Option<String>,
+    pub pr_number: Option<i64>,
+    pub include_inactive: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CodexReviewRequestRegistration {
+    pub id: String,
+    pub repo: String,
+    pub pr_number: i64,
+    pub requester_session_id: Option<String>,
+    pub notify_session_id: String,
+    pub steer: Option<String>,
+    pub requested_at: String,
+    pub latest_request_comment_id: Option<i64>,
+    pub latest_request_comment_url: Option<String>,
+    pub latest_request_posted_at: Option<String>,
+    pub attempt_count: i64,
+    pub next_retry_at: Option<String>,
+    pub poll_interval_seconds: i64,
+    pub retry_interval_seconds: i64,
+    pub pickup_detected_at: Option<String>,
+    pub pickup_source: Option<String>,
+    pub review_landed_at: Option<String>,
+    pub review_source: Option<String>,
+    pub review_comment_id: Option<JsonValue>,
+    pub review_url: Option<String>,
+    pub last_polled_at: Option<String>,
+    pub last_error: Option<String>,
+    pub state: String,
+    pub is_active: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -83,6 +124,20 @@ impl RetainedQueueStore {
 
     pub fn db_path(&self) -> &Path {
         &self.db_path
+    }
+
+    pub fn list_codex_review_requests_from_path(
+        db_path: &Path,
+        filters: CodexReviewRequestFilters,
+    ) -> Result<Vec<CodexReviewRequestRegistration>> {
+        if !db_path.exists() {
+            return Ok(Vec::new());
+        }
+        let conn = match Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY) {
+            Ok(conn) => conn,
+            Err(_) => return Ok(Vec::new()),
+        };
+        list_codex_review_requests_conn(&conn, filters)
     }
 
     pub fn ensure_schema(&self) -> Result<()> {
@@ -768,6 +823,98 @@ fn init_schema(conn: &Connection) -> Result<()> {
         "INTEGER DEFAULT 0",
     )?;
     Ok(())
+}
+
+fn list_codex_review_requests_conn(
+    conn: &Connection,
+    filters: CodexReviewRequestFilters,
+) -> Result<Vec<CodexReviewRequestRegistration>> {
+    let mut where_clauses = Vec::new();
+    let mut values = Vec::<SqlValue>::new();
+    if let Some(value) = filters.notify_session_id {
+        where_clauses.push("notify_session_id = ?");
+        values.push(value.into());
+    }
+    if let Some(value) = filters.repo {
+        where_clauses.push("repo = ?");
+        values.push(value.into());
+    }
+    if let Some(value) = filters.pr_number {
+        where_clauses.push("pr_number = ?");
+        values.push(value.into());
+    }
+    if !filters.include_inactive {
+        where_clauses.push("is_active = 1");
+    }
+
+    let mut query = r#"
+        SELECT id, repo, pr_number, requester_session_id, notify_session_id, steer,
+               requested_at, latest_request_comment_id, latest_request_comment_url,
+               latest_request_posted_at, attempt_count, next_retry_at,
+               poll_interval_seconds, retry_interval_seconds, pickup_detected_at,
+               pickup_source, review_landed_at, review_source, review_comment_id,
+               review_url, last_polled_at, last_error, state, is_active
+        FROM codex_review_request_registrations
+    "#
+    .to_owned();
+    if !where_clauses.is_empty() {
+        query.push_str(" WHERE ");
+        query.push_str(&where_clauses.join(" AND "));
+    }
+    query.push_str(" ORDER BY requested_at");
+
+    let mut statement = match conn.prepare(&query) {
+        Ok(statement) => statement,
+        Err(rusqlite::Error::SqliteFailure(_, Some(message)))
+            if message.contains("no such table") =>
+        {
+            return Ok(Vec::new());
+        }
+        Err(error) => return Err(error.into()),
+    };
+    let rows = statement.query_map(rusqlite::params_from_iter(values), |row| {
+        Ok(CodexReviewRequestRegistration {
+            id: row.get(0)?,
+            repo: row.get(1)?,
+            pr_number: row.get(2)?,
+            requester_session_id: row.get(3)?,
+            notify_session_id: row.get(4)?,
+            steer: row.get(5)?,
+            requested_at: row.get(6)?,
+            latest_request_comment_id: row.get(7)?,
+            latest_request_comment_url: row.get(8)?,
+            latest_request_posted_at: row.get(9)?,
+            attempt_count: row.get(10)?,
+            next_retry_at: row.get(11)?,
+            poll_interval_seconds: row.get(12)?,
+            retry_interval_seconds: row.get(13)?,
+            pickup_detected_at: row.get(14)?,
+            pickup_source: row.get(15)?,
+            review_landed_at: row.get(16)?,
+            review_source: row.get(17)?,
+            review_comment_id: optional_sqlite_json_scalar(row.get_ref(18)?),
+            review_url: row.get(19)?,
+            last_polled_at: row.get(20)?,
+            last_error: row.get(21)?,
+            state: row.get(22)?,
+            is_active: row.get::<_, Option<i64>>(23)?.unwrap_or(1) != 0,
+        })
+    })?;
+    Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
+}
+
+fn optional_sqlite_json_scalar(value: ValueRef<'_>) -> Option<JsonValue> {
+    match value {
+        ValueRef::Null => None,
+        ValueRef::Integer(value) => Some(JsonValue::Number(value.into())),
+        ValueRef::Real(value) => JsonNumber::from_f64(value).map(JsonValue::Number),
+        ValueRef::Text(value) => Some(JsonValue::String(
+            String::from_utf8_lossy(value).into_owned(),
+        )),
+        ValueRef::Blob(value) => Some(JsonValue::String(
+            String::from_utf8_lossy(value).into_owned(),
+        )),
+    }
 }
 
 fn expire_pending_messages_for_target(conn: &Connection, target_session_id: &str) -> Result<()> {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -4032,7 +4032,7 @@ impl SessionRecord {
         }
     }
 
-    fn cached_display_name(&self) -> Option<String> {
+    pub(crate) fn cached_display_name(&self) -> Option<String> {
         if let Some(alias) = self.aliases.first() {
             return Some(alias.clone());
         }

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -572,6 +572,183 @@ async fn client_analytics_summary_rejects_public_host_without_auth() {
 }
 
 #[tokio::test]
+async fn codex_review_requests_missing_db_returns_empty_requests() {
+    let state_file = unique_temp_path();
+    fs::write(&state_file, json!({ "sessions": [] }).to_string()).unwrap();
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        sm_send: SmSendConfig {
+            db_path: state_file
+                .with_extension("missing-codex-review.db")
+                .display()
+                .to_string(),
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = get_json(app, "/codex-review-requests").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload, json!({ "requests": [] }));
+}
+
+#[tokio::test]
+async fn codex_review_requests_lists_rows_with_filters_and_session_names() {
+    let state_file = unique_temp_path();
+    let queue_db = state_file.with_extension("codex-review-requests.db");
+    fs::write(
+        &state_file,
+        json!({
+            "sessions": [
+                {
+                    "id": "requester1",
+                    "name": "codex-fork-requester1",
+                    "working_dir": "/repo/requester",
+                    "tmux_session": "codex-fork-requester1",
+                    "log_file": "/tmp/requester1.log",
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00Z",
+                    "last_activity": "2026-06-01T00:01:00Z",
+                    "provider": "codex-fork",
+                    "friendly_name": "stale requester",
+                    "friendly_name_updated_at_ns": 10,
+                    "native_title": "native requester",
+                    "native_title_updated_at_ns": 20
+                },
+                {
+                    "id": "notify1",
+                    "name": "codex-fork-notify1",
+                    "working_dir": "/repo/notify",
+                    "tmux_session": "codex-fork-notify1",
+                    "log_file": "/tmp/notify1.log",
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00Z",
+                    "last_activity": "2026-06-01T00:01:00Z",
+                    "native_title": "native notify"
+                },
+                {
+                    "id": "notify2",
+                    "name": "codex-fork-notify2",
+                    "working_dir": "/repo/notify",
+                    "tmux_session": "codex-fork-notify2",
+                    "log_file": "/tmp/notify2.log",
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00Z",
+                    "last_activity": "2026-06-01T00:01:00Z"
+                }
+            ],
+            "agent_registrations": [
+                {
+                    "role": "reviewer",
+                    "session_id": "notify1",
+                    "created_at": "2026-06-01T00:02:00Z"
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    create_codex_review_request_fixture_db(&queue_db);
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        sm_send: SmSendConfig {
+            db_path: queue_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = get_json(app.clone(), "/codex-review-requests").await;
+    assert_eq!(status, StatusCode::OK);
+    let requests = payload["requests"].as_array().unwrap();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0]["id"], "active-old");
+    assert_eq!(requests[0]["repo"], "rajeshgoli/session-manager");
+    assert_eq!(requests[0]["pr_number"], 830);
+    assert_eq!(requests[0]["requester_name"], "native requester");
+    assert_eq!(requests[0]["notify_name"], "reviewer");
+    assert_eq!(requests[0]["latest_request_comment_id"], 111);
+    assert_eq!(requests[0]["review_comment_id"], 222);
+    assert_eq!(requests[0]["is_active"], true);
+    assert_eq!(requests[1]["id"], "active-new");
+    assert_eq!(requests[1]["review_comment_id"], "R_kw123");
+
+    let (status, payload) = get_json(
+        app.clone(),
+        "/codex-review-requests?repo=rajeshgoli/session-manager&pr_number=830&notify_target=notify1",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["requests"].as_array().unwrap().len(), 1);
+    assert_eq!(payload["requests"][0]["id"], "active-old");
+
+    let (status, payload) = get_json(app.clone(), "/registry/reviewer").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["session_id"], "notify1");
+
+    let (status, payload) = get_json(
+        app.clone(),
+        "/codex-review-requests?repo=rajeshgoli/session-manager&pr_number=830&notify_target=reviewer",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["requests"].as_array().unwrap().len(), 1);
+    assert_eq!(payload["requests"][0]["id"], "active-old");
+
+    let (status, payload) = get_json(app, "/codex-review-requests?include_inactive=true").await;
+    assert_eq!(status, StatusCode::OK);
+    let ids = payload["requests"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["id"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(ids, vec!["active-old", "inactive", "active-new"]);
+}
+
+#[tokio::test]
+async fn codex_review_requests_unknown_notify_target_returns_404() {
+    let state_file = unique_temp_path();
+    let queue_db = state_file.with_extension("codex-review-requests-empty.db");
+    fs::write(&state_file, json!({ "sessions": [] }).to_string()).unwrap();
+    create_codex_review_request_fixture_db(&queue_db);
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        sm_send: SmSendConfig {
+            db_path: queue_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = get_json(app, "/codex-review-requests?notify_target=missing").await;
+
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(payload["detail"], "Notify target not found");
+}
+
+#[tokio::test]
+async fn codex_review_requests_rejects_public_host_without_auth() {
+    let state_file = unique_temp_path();
+    fs::write(&state_file, json!({ "sessions": [] }).to_string()).unwrap();
+    let app = router(AppState::new(config_with_state_file_and_auth(&state_file)));
+
+    let (status, payload) =
+        get_json_with_host(app, "/codex-review-requests", "sm.example.com").await;
+
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(payload["detail"], "Authentication required");
+    assert_eq!(
+        payload["login_url"],
+        "/auth/google/login?next=%2Fcodex-review-requests"
+    );
+}
+
+#[tokio::test]
 async fn auth_session_reports_disabled_bypass_when_google_auth_not_requested() {
     let app = router(AppState::new(AppConfig::default()));
 
@@ -5753,6 +5930,73 @@ fn config_with_state_file_and_queue(state_file: &PathBuf) -> AppConfig {
 
 fn queue_db_path_for_state_file(state_file: &PathBuf) -> PathBuf {
     state_file.with_extension("message_queue.db")
+}
+
+fn create_codex_review_request_fixture_db(path: &PathBuf) {
+    let conn = Connection::open(path).unwrap();
+    conn.execute_batch(
+        r#"
+        CREATE TABLE codex_review_request_registrations (
+            id TEXT PRIMARY KEY,
+            repo TEXT NOT NULL,
+            pr_number INTEGER NOT NULL,
+            requester_session_id TEXT,
+            notify_session_id TEXT NOT NULL,
+            steer TEXT,
+            requested_at TIMESTAMP NOT NULL,
+            latest_request_comment_id INTEGER,
+            latest_request_comment_url TEXT,
+            latest_request_posted_at TIMESTAMP,
+            attempt_count INTEGER NOT NULL,
+            next_retry_at TIMESTAMP,
+            poll_interval_seconds INTEGER NOT NULL,
+            retry_interval_seconds INTEGER NOT NULL,
+            pickup_detected_at TIMESTAMP,
+            pickup_source TEXT,
+            review_landed_at TIMESTAMP,
+            review_source TEXT,
+            review_comment_id INTEGER,
+            review_url TEXT,
+            last_polled_at TIMESTAMP,
+            last_error TEXT,
+            state TEXT NOT NULL,
+            is_active INTEGER DEFAULT 1
+        );
+        "#,
+    )
+    .unwrap();
+    conn.execute(
+        r#"
+        INSERT INTO codex_review_request_registrations
+            (id, repo, pr_number, requester_session_id, notify_session_id, steer,
+             requested_at, latest_request_comment_id, latest_request_comment_url,
+             latest_request_posted_at, attempt_count, next_retry_at,
+             poll_interval_seconds, retry_interval_seconds, pickup_detected_at,
+             pickup_source, review_landed_at, review_source, review_comment_id,
+             review_url, last_polled_at, last_error, state, is_active)
+        VALUES
+            ('active-old', 'rajeshgoli/session-manager', 830, 'requester1', 'notify1', 'focus nodes',
+             '2026-06-01T00:00:00', 111, 'https://example.com/comment/111',
+             '2026-06-01T00:00:01', 2, '2026-06-01T00:10:00',
+             30, 600, '2026-06-01T00:02:00',
+             'issue_comment', '2026-06-01T00:03:00', 'pull_review', 222,
+             'https://example.com/review/222', '2026-06-01T00:04:00', NULL, 'completed', 1),
+            ('inactive', 'rajeshgoli/session-manager', 831, NULL, 'notify1', NULL,
+             '2026-06-01T00:01:00', NULL, NULL,
+             NULL, 1, NULL,
+             30, 600, NULL,
+             NULL, NULL, NULL, NULL,
+             NULL, NULL, 'cancelled', 'cancelled', 0),
+            ('active-new', 'rajeshgoli/other', 7, NULL, 'notify2', NULL,
+             '2026-06-01T00:02:00', NULL, NULL,
+             NULL, 1, NULL,
+             45, 900, NULL,
+             NULL, '2026-06-01T00:03:30', 'pull_review', 'R_kw123',
+             'https://example.com/review/R_kw123', NULL, NULL, 'completed', 1)
+        "#,
+        [],
+    )
+    .unwrap();
 }
 
 fn rfc3339(value: time::OffsetDateTime) -> String {

--- a/scripts/rust_migration/mvp_rehearsal.py
+++ b/scripts/rust_migration/mvp_rehearsal.py
@@ -40,6 +40,7 @@ CORE_READ_CHECK_IDS = (
     "http.sessions",
     "http.client_sessions",
     "http.nodes_list",
+    "http.codex_review_requests_list",
     "http.api_sessions_absent",
     "http.public_watch_operational_data_denied",
     "http.scheduler_remind_retired",
@@ -49,7 +50,6 @@ CORE_READ_CHECK_IDS = (
 
 MVP_GAP_PROBE_CHECK_IDS = (
     "http.queue_jobs_list",
-    "http.codex_review_requests_list",
 )
 
 BASELINE_CHECK_IDS = (


### PR DESCRIPTION
## Summary
- add Rust read-only `GET /codex-review-requests` support backed by the retained message queue DB
- preserve active/inactive filtering, repo/PR filtering, notify-target resolution, and requester/notify display names
- move the codex review request probe from MVP gap coverage into core rehearsal checks

## Verification
- `cargo test -p sm-server codex_review_requests --test read_only_http`
- `cargo test -p sm-server --test read_only_http`
- `cargo test -p sm-server`
- `python -m scripts.rust_migration.mvp_rehearsal --config scripts/rust_migration/fixtures/read_only/config.yaml --output-dir .local/rust-mvp-rehearsal/codex-review-831 --skip-python-health --skip-smoke --skip-baseline --skip-shadow --core-only --startup-timeout 30 --timeout 5`
- `python -m scripts.rust_migration.mvp_rehearsal --config scripts/rust_migration/fixtures/read_only/config.yaml --output-dir .local/rust-mvp-rehearsal/codex-review-831-gaps --skip-python-health --skip-smoke --skip-baseline --skip-shadow --allow-blockers --startup-timeout 30 --timeout 5`

Fixes #831
