### PR TITLE
Rust MVP: implement queue jobs list

### DIFF
--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -1,4 +1,8 @@
-use std::{collections::BTreeMap, env, fs, path::Path};
+use std::{
+    collections::BTreeMap,
+    env, fs,
+    path::{Path, PathBuf},
+};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -18,6 +22,7 @@ pub struct AppConfig {
     pub codex: ProviderLaunchConfig,
     pub codex_fork: CodexForkLaunchConfig,
     pub nodes: NodesConfig,
+    pub queue_runner: QueueRunnerConfig,
     pub rust_shadow: RustShadowConfig,
     pub rust_core: RustCoreConfig,
 }
@@ -40,6 +45,7 @@ impl Default for AppConfig {
             codex: ProviderLaunchConfig::new("codex".to_owned(), Vec::new(), None),
             codex_fork: CodexForkLaunchConfig::default(),
             nodes: NodesConfig::default(),
+            queue_runner: QueueRunnerConfig::default(),
             rust_shadow: RustShadowConfig::default(),
             rust_core: RustCoreConfig::default(),
         }
@@ -81,6 +87,13 @@ impl AppConfig {
         }
 
         Ok(config)
+    }
+
+    pub fn queue_runner_state_dir(&self) -> PathBuf {
+        if !self.queue_runner.configured && self.paths.state_file != default_state_file() {
+            return queue_runner_state_dir_for_state_file(&self.paths.state_file);
+        }
+        PathBuf::from(&self.queue_runner.state_dir)
     }
 }
 
@@ -325,6 +338,45 @@ fn default_server_log_file() -> String {
     "/tmp/session-manager.log".to_owned()
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct QueueRunnerConfig {
+    #[serde(default = "default_queue_runner_state_dir")]
+    pub state_dir: String,
+    #[serde(skip)]
+    pub configured: bool,
+}
+
+impl Default for QueueRunnerConfig {
+    fn default() -> Self {
+        Self {
+            state_dir: default_queue_runner_state_dir(),
+            configured: false,
+        }
+    }
+}
+
+fn default_queue_runner_state_dir() -> String {
+    "~/.local/share/claude-sessions/queue-runner".to_owned()
+}
+
+fn queue_runner_config_for_state_file(state_file: &str) -> QueueRunnerConfig {
+    if state_file == default_state_file() {
+        return QueueRunnerConfig::default();
+    }
+    QueueRunnerConfig {
+        state_dir: queue_runner_state_dir_for_state_file(state_file)
+            .to_string_lossy()
+            .into_owned(),
+        configured: false,
+    }
+}
+
+fn queue_runner_state_dir_for_state_file(state_file: &str) -> PathBuf {
+    let state_file = Path::new(state_file);
+    let parent = state_file.parent().unwrap_or_else(|| Path::new("."));
+    parent.join("queue-runner")
+}
+
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct RustShadowConfig {
     #[serde(default)]
@@ -382,6 +434,8 @@ struct RawConfig {
     #[serde(default)]
     nodes: YamlValue,
     #[serde(default)]
+    queue_runner: Option<QueueRunnerConfig>,
+    #[serde(default)]
     timeouts: RawTimeoutsConfig,
     #[serde(default)]
     rust_shadow: RustShadowConfig,
@@ -393,6 +447,13 @@ impl From<RawConfig> for AppConfig {
     fn from(raw: RawConfig) -> Self {
         let mut rust_core = raw.rust_core;
         let paths = raw.paths;
+        let queue_runner = raw
+            .queue_runner
+            .map(|mut config| {
+                config.configured = true;
+                config
+            })
+            .unwrap_or_else(|| queue_runner_config_for_state_file(&paths.state_file));
         let claude = provider_launch_config(raw.claude, "claude", Some("sonnet"), Vec::new());
         let codex = provider_launch_config(raw.codex, "codex", None, Vec::new());
         let codex_fork = codex_fork_launch_config(raw.codex_fork, &codex);
@@ -436,6 +497,7 @@ impl From<RawConfig> for AppConfig {
             codex,
             codex_fork,
             nodes: nodes_config_from_yaml(raw.nodes),
+            queue_runner,
             rust_shadow: raw.rust_shadow,
             rust_core,
         }
@@ -883,6 +945,37 @@ sm_send:
         let config = AppConfig::from(raw);
 
         assert_eq!(config.sm_send.db_path, "/tmp/custom-message-queue.db");
+    }
+
+    #[test]
+    fn raw_config_reads_queue_runner_state_dir() {
+        let raw: RawConfig = serde_yaml::from_str(
+            r#"
+queue_runner:
+  state_dir: /tmp/custom-queue-runner
+"#,
+        )
+        .unwrap();
+        let config = AppConfig::from(raw);
+
+        assert_eq!(config.queue_runner.state_dir, "/tmp/custom-queue-runner");
+    }
+
+    #[test]
+    fn raw_config_derives_queue_runner_state_dir_from_custom_state_file() {
+        let raw: RawConfig = serde_yaml::from_str(
+            r#"
+paths:
+  state_file: /tmp/sm-fixture/sessions.json
+"#,
+        )
+        .unwrap();
+        let config = AppConfig::from(raw);
+
+        assert_eq!(
+            config.queue_runner.state_dir,
+            "/tmp/sm-fixture/queue-runner"
+        );
     }
 
     #[test]

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -34,7 +34,10 @@ use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 use crate::config::{trimmed, AppConfig, PublicNodeConfig};
 use crate::mobile_analytics::build_mobile_analytics_summary;
-use crate::queue::{CodexReviewRequestFilters, CodexReviewRequestRegistration, RetainedQueueStore};
+use crate::queue::{
+    CodexReviewRequestFilters, CodexReviewRequestRegistration, QueueJobFilters, QueueJobRecord,
+    RetainedQueueStore,
+};
 use crate::runtime::TmuxRuntime;
 use crate::sessions::{
     expand_home, is_primary_node, AgentStatusRequest, ArmStopNotifyOutcome, ArmStopNotifyRequest,
@@ -81,6 +84,7 @@ pub fn router(state: AppState) -> Router {
         .route("/events/state", get(events_state))
         .route("/events", get(events_stream))
         .route("/__shadow/http", post(shadow_http))
+        .route("/queue-jobs", get(list_queue_jobs))
         .route("/codex-review-requests", get(list_codex_review_requests))
         .route("/nodes", get(list_nodes))
         .route("/sessions", get(list_sessions).post(create_session))
@@ -618,6 +622,50 @@ async fn list_codex_review_requests(
         requests.push(codex_review_request_response(&state, registration)?);
     }
     Ok(Json(json!({ "requests": requests })))
+}
+
+async fn list_queue_jobs(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<ListQueueJobsQuery>,
+    request: Request,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    let notify_session_id = if let Some(notify_target) = query
+        .notify_target
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let Some(session) = resolve_session_or_registry_role(&state, notify_target)? else {
+            return Err(ApiError::NotFound("Notify target not found"));
+        };
+        Some(session.id)
+    } else {
+        None
+    };
+
+    let queue_state_dir = state.config.queue_runner_state_dir();
+    let queue_db_path = expand_home(&queue_state_dir.to_string_lossy()).join("queue_runner.db");
+    let jobs = RetainedQueueStore::list_queue_jobs_from_path(
+        &queue_db_path,
+        QueueJobFilters {
+            notify_session_id,
+            job_type: query
+                .job_type
+                .as_ref()
+                .and_then(|value| trimmed(&Some(value.clone()))),
+            state: query
+                .state
+                .as_ref()
+                .and_then(|value| trimmed(&Some(value.clone()))),
+            include_terminal: query.include_terminal,
+        },
+    )?;
+    let mut response_jobs = Vec::with_capacity(jobs.len());
+    for job in jobs {
+        response_jobs.push(queue_job_response(&state, job)?);
+    }
+    Ok(Json(json!({ "jobs": response_jobs })))
 }
 
 fn resolve_session_or_registry_role(
@@ -1591,6 +1639,13 @@ fn shadow_predict_read(
                 support_status: "implemented_read_status_only",
             }));
         }
+        "/queue-jobs" => {
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::OK.as_u16(),
+                body_sha256: None,
+                support_status: "implemented_read_status_only",
+            }));
+        }
         "/client/bootstrap" => Some(serde_json::to_vec(&shadow_client_bootstrap_response(
             &state.config,
         ))?),
@@ -1881,6 +1936,7 @@ fn is_protected_read_surface(method: &str, path: &str) -> bool {
         || path == "/events/state"
         || path == "/client/analytics/summary"
         || path == "/codex-review-requests"
+        || path == "/queue-jobs"
         || path == "/nodes"
         || path == "/sessions"
         || path == "/client/sessions"
@@ -2374,6 +2430,18 @@ struct ListCodexReviewRequestsQuery {
 }
 
 #[derive(Debug, Deserialize)]
+struct ListQueueJobsQuery {
+    #[serde(default)]
+    notify_target: Option<String>,
+    #[serde(default, rename = "type")]
+    job_type: Option<String>,
+    #[serde(default)]
+    state: Option<String>,
+    #[serde(default)]
+    include_terminal: bool,
+}
+
+#[derive(Debug, Deserialize)]
 struct SessionOutputQuery {
     lines: Option<usize>,
 }
@@ -2514,6 +2582,46 @@ fn codex_review_request_response(
         "last_error": registration.last_error,
         "state": registration.state,
         "is_active": registration.is_active,
+    }))
+}
+
+fn queue_job_response(state: &AppState, job: QueueJobRecord) -> Result<Value, ApiError> {
+    let requester_name = match job.requester_session_id.as_deref() {
+        Some(session_id) => state
+            .session_store
+            .get_session(session_id)?
+            .map(session_display_name),
+        None => None,
+    };
+    let notify_name = match job.notify_session_id.as_deref() {
+        Some(session_id) => state
+            .session_store
+            .get_session(session_id)?
+            .map(session_display_name)
+            .or_else(|| Some(session_id.to_owned())),
+        None => None,
+    };
+    Ok(json!({
+        "id": job.id,
+        "type": job.job_type,
+        "label": job.label,
+        "requester_session_id": job.requester_session_id,
+        "requester_name": requester_name,
+        "notify_session_id": job.notify_session_id,
+        "notify_name": notify_name,
+        "cwd": job.cwd,
+        "argv": job.argv,
+        "script_path": job.script_path,
+        "timeout_seconds": job.timeout_seconds,
+        "state": job.state,
+        "holding_reason": job.holding_reason,
+        "queued_at": job.queued_at,
+        "started_at": job.started_at,
+        "finished_at": job.finished_at,
+        "pid": job.pid,
+        "process_group_id": job.process_group_id,
+        "exit_code": job.exit_code,
+        "log_path": job.log_path,
     }))
 }
 

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -53,6 +53,36 @@ pub struct CodexReviewRequestRegistration {
     pub is_active: bool,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct QueueJobFilters {
+    pub notify_session_id: Option<String>,
+    pub job_type: Option<String>,
+    pub state: Option<String>,
+    pub include_terminal: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QueueJobRecord {
+    pub id: String,
+    pub job_type: String,
+    pub label: String,
+    pub requester_session_id: Option<String>,
+    pub notify_session_id: Option<String>,
+    pub cwd: String,
+    pub argv: Option<Vec<String>>,
+    pub script_path: Option<String>,
+    pub timeout_seconds: i64,
+    pub state: String,
+    pub holding_reason: Option<String>,
+    pub queued_at: String,
+    pub started_at: Option<String>,
+    pub finished_at: Option<String>,
+    pub pid: Option<i64>,
+    pub process_group_id: Option<i64>,
+    pub exit_code: Option<i64>,
+    pub log_path: Option<String>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PendingMessage {
     pub id: String,
@@ -138,6 +168,20 @@ impl RetainedQueueStore {
             Err(_) => return Ok(Vec::new()),
         };
         list_codex_review_requests_conn(&conn, filters)
+    }
+
+    pub fn list_queue_jobs_from_path(
+        db_path: &Path,
+        filters: QueueJobFilters,
+    ) -> Result<Vec<QueueJobRecord>> {
+        if !db_path.exists() {
+            return Ok(Vec::new());
+        }
+        let conn = match Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY) {
+            Ok(conn) => conn,
+            Err(_) => return Ok(Vec::new()),
+        };
+        list_queue_jobs_conn(&conn, filters)
     }
 
     pub fn ensure_schema(&self) -> Result<()> {
@@ -898,6 +942,97 @@ fn list_codex_review_requests_conn(
             last_error: row.get(21)?,
             state: row.get(22)?,
             is_active: row.get::<_, Option<i64>>(23)?.unwrap_or(1) != 0,
+        })
+    })?;
+    Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
+}
+
+fn list_queue_jobs_conn(
+    conn: &Connection,
+    filters: QueueJobFilters,
+) -> Result<Vec<QueueJobRecord>> {
+    let mut where_clauses = Vec::new();
+    let mut values = Vec::<SqlValue>::new();
+    if let Some(value) = filters.notify_session_id {
+        where_clauses.push("notify_session_id = ?");
+        values.push(value.into());
+    }
+    if let Some(value) = filters.job_type {
+        where_clauses.push("type = ?");
+        values.push(value.into());
+    }
+    if let Some(value) = filters.state {
+        if value == "done" {
+            where_clauses
+                .push("state IN ('succeeded', 'failed', 'timed_out', 'cancelled', 'displaced')");
+        } else {
+            where_clauses.push("state = ?");
+            values.push(value.into());
+        }
+    } else if !filters.include_terminal {
+        where_clauses.push("state IN ('pending', 'running')");
+    }
+
+    let mut query = r#"
+        SELECT id, type, label, requester_session_id, notify_session_id, cwd,
+               argv_json, script_path, timeout_seconds, state, holding_reason,
+               queued_at, started_at, finished_at, pid, process_group_id,
+               exit_code, log_path
+        FROM queue_jobs
+    "#
+    .to_owned();
+    if !where_clauses.is_empty() {
+        query.push_str(" WHERE ");
+        query.push_str(&where_clauses.join(" AND "));
+    }
+    query.push_str(" ORDER BY queued_at");
+
+    let mut statement = match conn.prepare(&query) {
+        Ok(statement) => statement,
+        Err(rusqlite::Error::SqliteFailure(_, Some(message)))
+            if message.contains("no such table") =>
+        {
+            return Ok(Vec::new());
+        }
+        Err(error) => return Err(error.into()),
+    };
+    let rows = statement.query_map(rusqlite::params_from_iter(values), |row| {
+        let argv_json: Option<String> = row.get(6)?;
+        let argv = match argv_json
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            Some(raw) => Some(serde_json::from_str::<Vec<String>>(raw).map_err(|error| {
+                rusqlite::Error::FromSqlConversionFailure(
+                    6,
+                    rusqlite::types::Type::Text,
+                    Box::new(error),
+                )
+            })?),
+            None => None,
+        };
+        Ok(QueueJobRecord {
+            id: row.get(0)?,
+            job_type: row.get(1)?,
+            label: row.get(2)?,
+            requester_session_id: row.get(3)?,
+            notify_session_id: row
+                .get::<_, Option<String>>(4)?
+                .filter(|value| !value.is_empty()),
+            cwd: row.get(5)?,
+            argv,
+            script_path: row.get(7)?,
+            timeout_seconds: row.get(8)?,
+            state: row.get(9)?,
+            holding_reason: row.get(10)?,
+            queued_at: row.get(11)?,
+            started_at: row.get(12)?,
+            finished_at: row.get(13)?,
+            pid: row.get(14)?,
+            process_group_id: row.get(15)?,
+            exit_code: row.get(16)?,
+            log_path: row.get(17)?,
         })
     })?;
     Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -18,7 +18,7 @@ use sm_server::queue::RetainedQueueStore;
 use sm_server::{
     config::{
         AppConfig, CodexForkLaunchConfig, ExternalAccessConfig, GoogleAuthConfig,
-        MobileAnalyticsConfig, PathsConfig, RustCoreConfig, SmSendConfig,
+        MobileAnalyticsConfig, PathsConfig, QueueRunnerConfig, RustCoreConfig, SmSendConfig,
     },
     http::{router, AppState},
 };
@@ -745,6 +745,249 @@ async fn codex_review_requests_rejects_public_host_without_auth() {
     assert_eq!(
         payload["login_url"],
         "/auth/google/login?next=%2Fcodex-review-requests"
+    );
+}
+
+#[tokio::test]
+async fn queue_jobs_missing_db_returns_empty_jobs() {
+    let state_file = unique_temp_path();
+    let queue_state_dir = state_file.with_extension("missing-queue-runner");
+    fs::write(&state_file, json!({ "sessions": [] }).to_string()).unwrap();
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        queue_runner: QueueRunnerConfig {
+            state_dir: queue_state_dir.display().to_string(),
+            configured: true,
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = get_json(app, "/queue-jobs").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload, json!({ "jobs": [] }));
+}
+
+#[tokio::test]
+async fn queue_jobs_lists_rows_with_filters_and_session_names() {
+    let state_file = unique_temp_path();
+    let queue_state_dir = state_file.with_extension("queue-runner");
+    fs::write(
+        &state_file,
+        json!({
+            "sessions": [
+                {
+                    "id": "requester1",
+                    "name": "codex-fork-requester1",
+                    "working_dir": "/repo/requester",
+                    "tmux_session": "codex-fork-requester1",
+                    "log_file": "/tmp/requester1.log",
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00Z",
+                    "last_activity": "2026-06-01T00:01:00Z",
+                    "provider": "codex-fork",
+                    "friendly_name": "stale requester",
+                    "friendly_name_updated_at_ns": 10,
+                    "native_title": "native requester",
+                    "native_title_updated_at_ns": 20
+                },
+                {
+                    "id": "notify1",
+                    "name": "codex-fork-notify1",
+                    "working_dir": "/repo/notify",
+                    "tmux_session": "codex-fork-notify1",
+                    "log_file": "/tmp/notify1.log",
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00Z",
+                    "last_activity": "2026-06-01T00:01:00Z",
+                    "native_title": "native notify"
+                },
+                {
+                    "id": "notify2",
+                    "name": "codex-fork-notify2",
+                    "working_dir": "/repo/notify",
+                    "tmux_session": "codex-fork-notify2",
+                    "log_file": "/tmp/notify2.log",
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00Z",
+                    "last_activity": "2026-06-01T00:01:00Z"
+                }
+            ],
+            "agent_registrations": [
+                {
+                    "role": "reviewer",
+                    "session_id": "notify1",
+                    "created_at": "2026-06-01T00:02:00Z"
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    create_queue_jobs_fixture_db(&queue_state_dir);
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        queue_runner: QueueRunnerConfig {
+            state_dir: queue_state_dir.display().to_string(),
+            configured: true,
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = get_json(app.clone(), "/queue-jobs").await;
+    assert_eq!(status, StatusCode::OK);
+    let jobs = payload["jobs"].as_array().unwrap();
+    assert_eq!(jobs.len(), 2);
+    assert_eq!(jobs[0]["id"], "job-pending");
+    assert_eq!(jobs[0]["type"], "tests");
+    assert_eq!(jobs[0]["requester_name"], "native requester");
+    assert_eq!(jobs[0]["notify_name"], "reviewer");
+    assert_eq!(jobs[0]["argv"], json!(["cargo", "test"]));
+    assert_eq!(jobs[0]["script_path"], Value::Null);
+    assert_eq!(jobs[0]["holding_reason"], "memory");
+    assert_eq!(jobs[1]["id"], "job-running");
+    assert_eq!(jobs[1]["notify_name"], "codex-fork-notify2");
+    assert_eq!(jobs[1]["script_path"], "/tmp/run-perf.sh");
+    assert_eq!(jobs[1]["pid"], 4242);
+
+    let (status, payload) =
+        get_json(app.clone(), "/queue-jobs?notify_target=notify1&type=tests").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["jobs"].as_array().unwrap().len(), 1);
+    assert_eq!(payload["jobs"][0]["id"], "job-pending");
+
+    let (status, payload) =
+        get_json(app.clone(), "/queue-jobs?notify_target=reviewer&type=tests").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["jobs"].as_array().unwrap().len(), 1);
+    assert_eq!(payload["jobs"][0]["id"], "job-pending");
+
+    let (status, payload) = get_json(app.clone(), "/queue-jobs?state=done").await;
+    assert_eq!(status, StatusCode::OK);
+    let failed_job = payload["jobs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|entry| entry["id"] == "job-failed")
+        .unwrap();
+    assert_eq!(failed_job["requester_session_id"], "missing-requester");
+    assert_eq!(failed_job["requester_name"], Value::Null);
+    let done_ids = payload["jobs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["id"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(done_ids, vec!["job-succeeded", "job-failed"]);
+
+    let (status, payload) = get_json(app.clone(), "/queue-jobs?state=succeeded").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["jobs"].as_array().unwrap().len(), 1);
+    assert_eq!(payload["jobs"][0]["id"], "job-succeeded");
+
+    let (status, payload) = get_json(app, "/queue-jobs?include_terminal=true").await;
+    assert_eq!(status, StatusCode::OK);
+    let all_ids = payload["jobs"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["id"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(
+        all_ids,
+        vec!["job-pending", "job-running", "job-succeeded", "job-failed"]
+    );
+}
+
+#[tokio::test]
+async fn queue_jobs_uses_custom_state_file_relative_dir_by_default() {
+    let base_dir = unique_temp_path().with_extension("queue-job-state-dir");
+    fs::create_dir_all(&base_dir).unwrap();
+    let state_file = base_dir.join("sessions.json");
+    let config_file = base_dir.join("config.yaml");
+    fs::write(&state_file, json!({ "sessions": [] }).to_string()).unwrap();
+    fs::write(
+        &config_file,
+        format!("paths:\n  state_file: \"{}\"\n", state_file.display()),
+    )
+    .unwrap();
+    create_queue_jobs_fixture_db(&base_dir.join("queue-runner"));
+    let app = router(AppState::new(
+        AppConfig::load_from_path(&config_file).unwrap(),
+    ));
+
+    let (status, payload) = get_json(app, "/queue-jobs").await;
+
+    assert_eq!(status, StatusCode::OK);
+    let jobs = payload["jobs"].as_array().unwrap();
+    assert_eq!(jobs.len(), 2);
+    assert_eq!(jobs[0]["id"], "job-pending");
+    assert_eq!(jobs[1]["id"], "job-running");
+}
+
+#[tokio::test]
+async fn queue_jobs_derives_state_dir_for_direct_custom_state_config() {
+    let base_dir = unique_temp_path().with_extension("queue-job-direct-state-dir");
+    fs::create_dir_all(&base_dir).unwrap();
+    let state_file = base_dir.join("sessions.json");
+    fs::write(&state_file, json!({ "sessions": [] }).to_string()).unwrap();
+    create_queue_jobs_fixture_db(&base_dir.join("queue-runner"));
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = get_json(app, "/queue-jobs").await;
+
+    assert_eq!(status, StatusCode::OK);
+    let jobs = payload["jobs"].as_array().unwrap();
+    assert_eq!(jobs.len(), 2);
+    assert_eq!(jobs[0]["id"], "job-pending");
+    assert_eq!(jobs[1]["id"], "job-running");
+}
+
+#[tokio::test]
+async fn queue_jobs_unknown_notify_target_returns_404() {
+    let state_file = unique_temp_path();
+    let queue_state_dir = state_file.with_extension("queue-runner-empty");
+    fs::write(&state_file, json!({ "sessions": [] }).to_string()).unwrap();
+    create_queue_jobs_fixture_db(&queue_state_dir);
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        queue_runner: QueueRunnerConfig {
+            state_dir: queue_state_dir.display().to_string(),
+            configured: true,
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = get_json(app, "/queue-jobs?notify_target=missing").await;
+
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(payload["detail"], "Notify target not found");
+}
+
+#[tokio::test]
+async fn queue_jobs_rejects_public_host_without_auth() {
+    let state_file = unique_temp_path();
+    fs::write(&state_file, json!({ "sessions": [] }).to_string()).unwrap();
+    let app = router(AppState::new(config_with_state_file_and_auth(&state_file)));
+
+    let (status, payload) = get_json_with_host(app, "/queue-jobs", "sm.example.com").await;
+
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(payload["detail"], "Authentication required");
+    assert_eq!(
+        payload["login_url"],
+        "/auth/google/login?next=%2Fqueue-jobs"
     );
 }
 
@@ -5993,6 +6236,75 @@ fn create_codex_review_request_fixture_db(path: &PathBuf) {
              45, 900, NULL,
              NULL, '2026-06-01T00:03:30', 'pull_review', 'R_kw123',
              'https://example.com/review/R_kw123', NULL, NULL, 'completed', 1)
+        "#,
+        [],
+    )
+    .unwrap();
+}
+
+fn create_queue_jobs_fixture_db(state_dir: &PathBuf) {
+    fs::create_dir_all(state_dir).unwrap();
+    let conn = Connection::open(state_dir.join("queue_runner.db")).unwrap();
+    conn.execute_batch(
+        r#"
+        CREATE TABLE queue_jobs (
+            id TEXT PRIMARY KEY,
+            type TEXT NOT NULL,
+            label TEXT NOT NULL,
+            requester_session_id TEXT,
+            notify_session_id TEXT NOT NULL,
+            cwd TEXT NOT NULL,
+            argv_json TEXT,
+            script_path TEXT,
+            env_json TEXT NOT NULL,
+            timeout_seconds INTEGER NOT NULL,
+            state TEXT NOT NULL,
+            holding_reason TEXT,
+            queued_at TEXT NOT NULL,
+            started_at TEXT,
+            finished_at TEXT,
+            pid INTEGER,
+            process_group_id INTEGER,
+            exit_code INTEGER,
+            log_path TEXT,
+            exit_code_path TEXT,
+            wrapper_path TEXT,
+            queued_notified_at TEXT,
+            started_notified_at TEXT,
+            completion_notified_at TEXT
+        );
+        "#,
+    )
+    .unwrap();
+    conn.execute(
+        r#"
+        INSERT INTO queue_jobs
+            (id, type, label, requester_session_id, notify_session_id, cwd,
+             argv_json, script_path, env_json, timeout_seconds, state,
+             holding_reason, queued_at, started_at, finished_at, pid,
+             process_group_id, exit_code, log_path, exit_code_path, wrapper_path,
+             queued_notified_at, started_notified_at, completion_notified_at)
+        VALUES
+            ('job-pending', 'tests', 'cargo tests', 'requester1', 'notify1', '/repo',
+             '["cargo","test"]', NULL, '{}', 900, 'pending',
+             'memory', '2026-06-01T00:00:00', NULL, NULL, NULL,
+             NULL, NULL, '/tmp/job-pending.log', NULL, NULL,
+             NULL, NULL, NULL),
+            ('job-running', 'perf', 'perf run', NULL, 'notify2', '/repo/perf',
+             NULL, '/tmp/run-perf.sh', '{}', 2700, 'running',
+             NULL, '2026-06-01T00:01:00', '2026-06-01T00:01:30', NULL, 4242,
+             4242, NULL, '/tmp/job-running.log', NULL, NULL,
+             NULL, NULL, NULL),
+            ('job-succeeded', 'tests', 'done tests', 'requester1', 'notify1', '/repo',
+             '["true"]', NULL, '{}', 900, 'succeeded',
+             NULL, '2026-06-01T00:02:00', '2026-06-01T00:02:10', '2026-06-01T00:02:20', 4343,
+             4343, 0, '/tmp/job-succeeded.log', NULL, NULL,
+             NULL, NULL, NULL),
+            ('job-failed', 'background', 'failed background', 'missing-requester', 'notify2', '/repo/bg',
+             NULL, '/tmp/fail.sh', '{}', 3600, 'failed',
+             NULL, '2026-06-01T00:03:00', '2026-06-01T00:03:10', '2026-06-01T00:03:20', 4444,
+             4444, 2, '/tmp/job-failed.log', NULL, NULL,
+             NULL, NULL, NULL)
         "#,
         [],
     )

--- a/scripts/rust_migration/README.md
+++ b/scripts/rust_migration/README.md
@@ -199,8 +199,7 @@ By default this:
 - starts Rust `sm-server` on `http://127.0.0.1:8421` with `config.yaml`;
 - runs `scripts/rust-mvp-smoke.sh` for isolated mutating runtime coverage;
 - runs core read/retired-surface contracts against Rust;
-- probes retained MVP gaps such as `/nodes`, `/queue-jobs`, and
-  `/codex-review-requests`;
+- probes retained MVP gaps when any remain;
 - posts shadow-style read comparisons to Rust `POST /__shadow/http`;
 - writes Python and Rust baseline JSON under the report directory.
 

--- a/scripts/rust_migration/fixtures/read_only/config.yaml
+++ b/scripts/rust_migration/fixtures/read_only/config.yaml
@@ -1,2 +1,5 @@
 paths:
   state_file: "scripts/rust_migration/fixtures/read_only/sessions.json"
+
+queue_runner:
+  state_dir: "scripts/rust_migration/fixtures/read_only/queue-runner"

--- a/scripts/rust_migration/mvp_rehearsal.py
+++ b/scripts/rust_migration/mvp_rehearsal.py
@@ -41,6 +41,7 @@ CORE_READ_CHECK_IDS = (
     "http.client_sessions",
     "http.nodes_list",
     "http.codex_review_requests_list",
+    "http.queue_jobs_list",
     "http.api_sessions_absent",
     "http.public_watch_operational_data_denied",
     "http.scheduler_remind_retired",
@@ -48,9 +49,7 @@ CORE_READ_CHECK_IDS = (
     "http.queue_policy_runs_retired",
 )
 
-MVP_GAP_PROBE_CHECK_IDS = (
-    "http.queue_jobs_list",
-)
+MVP_GAP_PROBE_CHECK_IDS = ()
 
 BASELINE_CHECK_IDS = (
     "http.health",


### PR DESCRIPTION
## Summary
- add Rust read-only `GET /queue-jobs` support backed by the retained queue runner DB
- preserve Python-compatible filters for `notify_target`, `type`, `state`, `state=done`, and `include_terminal`
- parse `queue_runner.state_dir` for source-compatible DB discovery
- move `http.queue_jobs_list` from MVP gap probes into core rehearsal checks, leaving the gap probe list empty

## Verification
- `cargo test -p sm-server queue_jobs --test read_only_http`
- `cargo test -p sm-server`
- `python -m scripts.rust_migration.mvp_rehearsal --config scripts/rust_migration/fixtures/read_only/config.yaml --output-dir .local/rust-mvp-rehearsal/queue-jobs-833 --skip-python-health --skip-smoke --skip-baseline --skip-shadow --core-only --startup-timeout 30 --timeout 5`
- `python -m scripts.rust_migration.mvp_rehearsal --config scripts/rust_migration/fixtures/read_only/config.yaml --output-dir .local/rust-mvp-rehearsal/queue-jobs-833-full --skip-python-health --skip-smoke --skip-baseline --skip-shadow --startup-timeout 30 --timeout 5`

Fixes #833
