### PR TITLE
Rust MVP: retain native mobile support endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -254,6 +255,15 @@ dependencies = [
  "block-buffer",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -559,6 +569,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +883,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "strsim"

--- a/crates/sm-server/Cargo.toml
+++ b/crates/sm-server/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-axum = { workspace = true }
+axum = { workspace = true, features = ["multipart"] }
 base64 = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 futures-util = { workspace = true }

--- a/crates/sm-server/src/app_artifacts.rs
+++ b/crates/sm-server/src/app_artifacts.rs
@@ -1,0 +1,146 @@
+use std::{
+    fs,
+    io::Write,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+pub const APP_ARTIFACT_MAX_SIZE_BYTES: usize = 100 * 1024 * 1024;
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AppArtifactMetadata {
+    pub artifact_hash: String,
+    pub size_bytes: u64,
+    pub uploaded_at: String,
+    pub uploaded_by: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version_code: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version_name: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StoredArtifact {
+    pub artifact_hash: String,
+    pub size_bytes: u64,
+}
+
+pub fn valid_app_name(value: &str) -> bool {
+    let value = value.trim();
+    !value.is_empty()
+        && value.len() <= 80
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+}
+
+pub fn valid_artifact_hash(value: &str) -> bool {
+    value.len() == 8 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+pub fn app_dir(root: &Path, app_name: &str) -> PathBuf {
+    root.join(app_name)
+}
+
+pub fn latest_path(root: &Path, app_name: &str) -> PathBuf {
+    app_dir(root, app_name).join("latest.apk")
+}
+
+pub fn hashed_path(root: &Path, app_name: &str, artifact_hash: &str) -> PathBuf {
+    app_dir(root, app_name).join(format!("{artifact_hash}.apk"))
+}
+
+pub fn meta_path(root: &Path, app_name: &str) -> PathBuf {
+    app_dir(root, app_name).join("meta.json")
+}
+
+pub fn store_artifact(
+    root: &Path,
+    app_name: &str,
+    bytes: &[u8],
+    uploaded_by: Option<String>,
+    version_code: Option<i64>,
+    version_name: Option<String>,
+) -> Result<StoredArtifact> {
+    if bytes.is_empty() {
+        anyhow::bail!("Uploaded artifact is empty");
+    }
+    if bytes.len() > APP_ARTIFACT_MAX_SIZE_BYTES {
+        anyhow::bail!("Artifact exceeds 100 MB limit");
+    }
+    let app_dir = app_dir(root, app_name);
+    fs::create_dir_all(&app_dir)
+        .with_context(|| format!("failed to create app artifact dir {}", app_dir.display()))?;
+
+    let digest = Sha256::digest(bytes);
+    let artifact_hash = digest
+        .iter()
+        .take(4)
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    let latest = latest_path(root, app_name);
+    write_atomically(&latest, bytes, ".tmp-artifact-", ".apk")?;
+    let hashed = hashed_path(root, app_name, &artifact_hash);
+    if !hashed.exists() {
+        write_atomically(&hashed, bytes, ".tmp-artifact-copy-", ".apk")?;
+    }
+    let metadata = AppArtifactMetadata {
+        artifact_hash: artifact_hash.clone(),
+        size_bytes: bytes.len() as u64,
+        uploaded_at: now_rfc3339(),
+        uploaded_by,
+        version_code,
+        version_name,
+    };
+    write_json_atomically(&meta_path(root, app_name), &metadata)?;
+    Ok(StoredArtifact {
+        artifact_hash,
+        size_bytes: bytes.len() as u64,
+    })
+}
+
+pub fn read_metadata(root: &Path, app_name: &str) -> Result<AppArtifactMetadata> {
+    let path = meta_path(root, app_name);
+    let content = fs::read_to_string(&path)
+        .with_context(|| format!("failed to read artifact metadata {}", path.display()))?;
+    serde_json::from_str(&content)
+        .with_context(|| format!("failed to parse artifact metadata {}", path.display()))
+}
+
+fn write_json_atomically(path: &Path, metadata: &AppArtifactMetadata) -> Result<()> {
+    let bytes = serde_json::to_vec(metadata)?;
+    write_atomically(path, &bytes, ".tmp-meta-", ".json")
+}
+
+fn write_atomically(path: &Path, bytes: &[u8], prefix: &str, suffix: &str) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("artifact path has no parent: {}", path.display()))?;
+    fs::create_dir_all(parent)?;
+    let temp = parent.join(format!(
+        "{prefix}{}-{}{suffix}",
+        std::process::id(),
+        TEMP_COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    {
+        let mut handle = fs::File::create(&temp)
+            .with_context(|| format!("failed to create {}", temp.display()))?;
+        handle.write_all(bytes)?;
+        handle.sync_all()?;
+    }
+    fs::rename(&temp, path)
+        .with_context(|| format!("failed to publish artifact {}", path.display()))?;
+    Ok(())
+}
+
+fn now_rfc3339() -> String {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned())
+}

--- a/crates/sm-server/src/app_artifacts.rs
+++ b/crates/sm-server/src/app_artifacts.rs
@@ -33,15 +33,20 @@ pub struct StoredArtifact {
 
 pub fn valid_app_name(value: &str) -> bool {
     let value = value.trim();
-    !value.is_empty()
-        && value.len() <= 80
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+    let mut bytes = value.bytes();
+    let Some(first) = bytes.next() else {
+        return false;
+    };
+    value.len() <= 80
+        && (first.is_ascii_lowercase() || first.is_ascii_digit())
+        && bytes.all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
 }
 
 pub fn valid_artifact_hash(value: &str) -> bool {
-    value.len() == 8 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+    value.len() == 8
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
 }
 
 pub fn app_dir(root: &Path, app_name: &str) -> PathBuf {
@@ -143,4 +148,26 @@ fn now_rfc3339() -> String {
     OffsetDateTime::now_utc()
         .format(&Rfc3339)
         .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{valid_app_name, valid_artifact_hash};
+
+    #[test]
+    fn app_names_match_python_managed_artifact_contract() {
+        assert!(valid_app_name("session-manager-android"));
+        assert!(valid_app_name("app1"));
+        for name in ["", ".", "..", "foo.bar", "_bad", "-bad", "Bad", "bad_name"] {
+            assert!(!valid_app_name(name), "{name}");
+        }
+    }
+
+    #[test]
+    fn artifact_hashes_match_python_lower_hex_contract() {
+        assert!(valid_artifact_hash("deadbeef"));
+        for hash in ["DEADBEEF", "deadbee", "deadbeef0", "zzzzzzzz"] {
+            assert!(!valid_artifact_hash(hash), "{hash}");
+        }
+    }
 }

--- a/crates/sm-server/src/app_artifacts.rs
+++ b/crates/sm-server/src/app_artifacts.rs
@@ -32,7 +32,6 @@ pub struct StoredArtifact {
 }
 
 pub fn valid_app_name(value: &str) -> bool {
-    let value = value.trim();
     let mut bytes = value.bytes();
     let Some(first) = bytes.next() else {
         return false;
@@ -158,7 +157,9 @@ mod tests {
     fn app_names_match_python_managed_artifact_contract() {
         assert!(valid_app_name("session-manager-android"));
         assert!(valid_app_name("app1"));
-        for name in ["", ".", "..", "foo.bar", "_bad", "-bad", "Bad", "bad_name"] {
+        for name in [
+            "", ".", "..", "foo.bar", "_bad", "-bad", "Bad", "bad_name", "app ", " app", "app\t",
+        ] {
             assert!(!valid_app_name(name), "{name}");
         }
     }

--- a/crates/sm-server/src/bug_reports.rs
+++ b/crates/sm-server/src/bug_reports.rs
@@ -1,0 +1,218 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection, OptionalExtension};
+use serde_json::Value;
+use time::{format_description::well_known::Rfc3339, macros::format_description, OffsetDateTime};
+
+static BUG_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Debug, Clone)]
+pub struct BugReportStore {
+    db_path: PathBuf,
+    max_reports: usize,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreateBugReport {
+    pub report_text: String,
+    pub reported_by: Option<String>,
+    pub selected_session_id: Option<String>,
+    pub route: Option<String>,
+    pub app_version: Option<String>,
+    pub artifact_hash: Option<String>,
+    pub include_debug_state: bool,
+    pub client_state: Option<Value>,
+    pub server_state: Option<Value>,
+}
+
+#[derive(Debug, Clone)]
+pub struct CreatedBugReport {
+    pub id: String,
+}
+
+impl BugReportStore {
+    pub fn new(db_path: PathBuf, max_reports: usize) -> Self {
+        Self {
+            db_path,
+            max_reports: max_reports.max(1),
+        }
+    }
+
+    pub fn create_report(&self, report: CreateBugReport) -> Result<CreatedBugReport> {
+        if let Some(parent) = self.db_path.parent() {
+            fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create bug report dir {}", parent.display()))?;
+        }
+        let conn = self.open()?;
+        let id = bug_id();
+        let created_at = now_rfc3339();
+        let client_state_json = report
+            .include_debug_state
+            .then(|| report.client_state.as_ref().map(compact_json))
+            .flatten()
+            .transpose()?;
+        let server_state_json = report
+            .include_debug_state
+            .then(|| report.server_state.as_ref().map(compact_json))
+            .flatten()
+            .transpose()?;
+
+        conn.execute("BEGIN IMMEDIATE", [])?;
+        let result = (|| -> Result<()> {
+            conn.execute(
+                r#"
+                INSERT INTO bug_reports (
+                    id, created_at, reported_by, report_text, selected_session_id,
+                    route, app_version, artifact_hash, include_debug_state,
+                    client_state_json, server_state_json, status,
+                    maintainer_delivery_result
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'new', NULL)
+                "#,
+                params![
+                    id,
+                    created_at,
+                    report.reported_by,
+                    report.report_text,
+                    report.selected_session_id,
+                    report.route,
+                    report.app_version,
+                    report.artifact_hash,
+                    if report.include_debug_state { 1 } else { 0 },
+                    client_state_json,
+                    server_state_json,
+                ],
+            )?;
+            self.prune_locked(&conn)?;
+            Ok(())
+        })();
+        match result {
+            Ok(()) => conn.execute("COMMIT", [])?,
+            Err(error) => {
+                let _ = conn.execute("ROLLBACK", []);
+                return Err(error);
+            }
+        };
+
+        Ok(CreatedBugReport { id })
+    }
+
+    pub fn update_delivery_result(&self, bug_id: &str, result: &str) -> Result<()> {
+        let conn = self.open()?;
+        conn.execute(
+            "UPDATE bug_reports SET maintainer_delivery_result = ?, status = 'submitted' WHERE id = ?",
+            params![result, bug_id],
+        )?;
+        Ok(())
+    }
+
+    pub fn report_exists(&self, bug_id: &str) -> Result<bool> {
+        let conn = self.open()?;
+        let value = conn
+            .query_row("SELECT 1 FROM bug_reports WHERE id = ?", [bug_id], |row| {
+                row.get::<_, i64>(0)
+            })
+            .optional()?;
+        Ok(value.is_some())
+    }
+
+    fn open(&self) -> Result<Connection> {
+        let conn = Connection::open(&self.db_path)
+            .with_context(|| format!("failed to open bug report DB {}", self.db_path.display()))?;
+        conn.execute_batch(
+            r#"
+            PRAGMA journal_mode=WAL;
+            PRAGMA busy_timeout=5000;
+            PRAGMA foreign_keys=ON;
+            CREATE TABLE IF NOT EXISTS bug_reports (
+                id TEXT PRIMARY KEY,
+                created_at TEXT NOT NULL,
+                reported_by TEXT,
+                report_text TEXT NOT NULL,
+                selected_session_id TEXT,
+                route TEXT,
+                app_version TEXT,
+                artifact_hash TEXT,
+                include_debug_state INTEGER NOT NULL,
+                client_state_json TEXT,
+                server_state_json TEXT,
+                status TEXT NOT NULL DEFAULT 'new',
+                maintainer_delivery_result TEXT
+            );
+            CREATE TABLE IF NOT EXISTS bug_report_attachments (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                bug_report_id TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                mime_type TEXT NOT NULL,
+                payload BLOB NOT NULL,
+                FOREIGN KEY (bug_report_id) REFERENCES bug_reports(id) ON DELETE CASCADE
+            );
+            CREATE INDEX IF NOT EXISTS idx_bug_reports_created_at ON bug_reports(created_at, id);
+            CREATE INDEX IF NOT EXISTS idx_bug_reports_selected_session ON bug_reports(selected_session_id, created_at);
+            "#,
+        )?;
+        Ok(conn)
+    }
+
+    fn prune_locked(&self, conn: &Connection) -> Result<()> {
+        let total: i64 =
+            conn.query_row("SELECT COUNT(*) FROM bug_reports", [], |row| row.get(0))?;
+        let excess = total - self.max_reports as i64;
+        if excess <= 0 {
+            return Ok(());
+        }
+        let doomed = conn
+            .prepare(
+                r#"
+                SELECT id
+                FROM bug_reports
+                ORDER BY created_at ASC, id ASC
+                LIMIT ?
+                "#,
+            )?
+            .query_map([excess], |row| row.get::<_, String>(0))?
+            .collect::<Result<Vec<_>, _>>()?;
+        for id in doomed {
+            conn.execute(
+                "DELETE FROM bug_report_attachments WHERE bug_report_id = ?",
+                [&id],
+            )?;
+            conn.execute("DELETE FROM bug_reports WHERE id = ?", [&id])?;
+        }
+        Ok(())
+    }
+}
+
+fn compact_json(value: &Value) -> Result<String> {
+    serde_json::to_string(value).context("failed to serialize bug report JSON payload")
+}
+
+fn bug_id() -> String {
+    let now = OffsetDateTime::now_utc();
+    let date = now
+        .format(format_description!(
+            "[year][month][day]-[hour][minute][second]"
+        ))
+        .unwrap_or_else(|_| "19700101-000000".to_owned());
+    let counter = BUG_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let suffix = format!(
+        "{:06x}",
+        (std::process::id() as u64 ^ counter) & 0x00ff_ffff
+    );
+    format!("BR-{date}-{suffix}")
+}
+
+fn now_rfc3339() -> String {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned())
+}
+
+pub fn bug_report_db_path(path: impl AsRef<Path>) -> PathBuf {
+    path.as_ref().to_path_buf()
+}

--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -13,6 +13,8 @@ use sha2::{Digest, Sha256};
 pub struct AppConfig {
     pub paths: PathsConfig,
     pub mobile_analytics: MobileAnalyticsConfig,
+    pub app_artifacts: AppArtifactsConfig,
+    pub bug_reports: BugReportsConfig,
     pub google_auth: GoogleAuthConfig,
     pub external_access: ExternalAccessConfig,
     pub mobile_terminal: MobileTerminalConfig,
@@ -32,6 +34,8 @@ impl Default for AppConfig {
         Self {
             paths: PathsConfig::default(),
             mobile_analytics: MobileAnalyticsConfig::default(),
+            app_artifacts: AppArtifactsConfig::default(),
+            bug_reports: BugReportsConfig::default(),
             google_auth: GoogleAuthConfig::default(),
             external_access: ExternalAccessConfig::default(),
             mobile_terminal: MobileTerminalConfig::default(),
@@ -113,6 +117,49 @@ impl Default for PathsConfig {
 
 fn default_state_file() -> String {
     "~/.local/share/claude-sessions/sessions.json".to_owned()
+}
+
+fn default_app_artifacts_dir() -> String {
+    "data/apps".to_owned()
+}
+
+fn default_bug_reports_db_path() -> String {
+    "data/bug_reports.db".to_owned()
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AppArtifactsConfig {
+    #[serde(default = "default_app_artifacts_dir")]
+    pub root_dir: String,
+}
+
+impl Default for AppArtifactsConfig {
+    fn default() -> Self {
+        Self {
+            root_dir: default_app_artifacts_dir(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BugReportsConfig {
+    #[serde(default = "default_bug_reports_db_path")]
+    pub db_path: String,
+    #[serde(default = "default_bug_reports_max_reports")]
+    pub max_reports: usize,
+}
+
+impl Default for BugReportsConfig {
+    fn default() -> Self {
+        Self {
+            db_path: default_bug_reports_db_path(),
+            max_reports: default_bug_reports_max_reports(),
+        }
+    }
+}
+
+fn default_bug_reports_max_reports() -> usize {
+    30
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -424,6 +471,8 @@ struct RawConfig {
     #[serde(default)]
     mobile_terminal: MobileTerminalConfig,
     #[serde(default)]
+    bug_reports: RawBugReportsConfig,
+    #[serde(default)]
     tmux: TmuxConfig,
     #[serde(default)]
     sm_send: SmSendConfig,
@@ -490,6 +539,13 @@ impl From<RawConfig> for AppConfig {
                 message_queue_db: paths.message_queue_db,
                 server_log_file: paths.server_log_file,
             },
+            app_artifacts: AppArtifactsConfig {
+                root_dir: paths.app_artifacts_dir,
+            },
+            bug_reports: BugReportsConfig {
+                db_path: paths.bug_reports_db,
+                max_reports: raw.bug_reports.max_reports,
+            },
             google_auth: raw.auth.google,
             external_access: raw.external_access,
             mobile_terminal: raw.mobile_terminal,
@@ -514,6 +570,10 @@ struct RawPathsConfig {
     message_queue_db: String,
     #[serde(default = "default_server_log_file")]
     server_log_file: String,
+    #[serde(default = "default_app_artifacts_dir")]
+    app_artifacts_dir: String,
+    #[serde(default = "default_bug_reports_db_path")]
+    bug_reports_db: String,
 }
 
 impl Default for RawPathsConfig {
@@ -522,6 +582,22 @@ impl Default for RawPathsConfig {
             state_file: default_state_file(),
             message_queue_db: default_message_queue_db_path(),
             server_log_file: default_server_log_file(),
+            app_artifacts_dir: default_app_artifacts_dir(),
+            bug_reports_db: default_bug_reports_db_path(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct RawBugReportsConfig {
+    #[serde(default = "default_bug_reports_max_reports")]
+    max_reports: usize,
+}
+
+impl Default for RawBugReportsConfig {
+    fn default() -> Self {
+        Self {
+            max_reports: default_bug_reports_max_reports(),
         }
     }
 }

--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -120,11 +120,22 @@ fn default_state_file() -> String {
 }
 
 fn default_app_artifacts_dir() -> String {
-    "data/apps".to_owned()
+    repo_data_path("apps")
 }
 
 fn default_bug_reports_db_path() -> String {
-    "data/bug_reports.db".to_owned()
+    repo_data_path("bug_reports.db")
+}
+
+fn repo_data_path(name: &str) -> String {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .unwrap_or_else(|| Path::new("."))
+        .join("data")
+        .join(name)
+        .display()
+        .to_string()
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1023,6 +1034,24 @@ sm_send:
         let config = AppConfig::from(raw);
 
         assert_eq!(config.sm_send.db_path, "/tmp/custom-message-queue.db");
+    }
+
+    #[test]
+    fn raw_config_defaults_mobile_state_paths_to_repo_data_dir() {
+        let config = AppConfig::from(RawConfig::default());
+        let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(Path::parent)
+            .unwrap();
+
+        assert_eq!(
+            PathBuf::from(config.app_artifacts.root_dir),
+            repo_root.join("data/apps")
+        );
+        assert_eq!(
+            PathBuf::from(config.bug_reports.db_path),
+            repo_root.join("data/bug_reports.db")
+        );
     }
 
     #[test]

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -383,14 +383,15 @@ async fn submit_client_bug_report(
     } else {
         None
     };
+    let bug_report_db_path = expand_home(&state.config.bug_reports.db_path);
     let store = BugReportStore::new(
-        expand_home(&state.config.bug_reports.db_path),
+        bug_report_db_path.clone(),
         state.config.bug_reports.max_reports,
     );
     let created = store.create_report(CreateBugReport {
-        report_text,
+        report_text: report_text.clone(),
         reported_by: actor_email,
-        selected_session_id: payload.selected_session_id,
+        selected_session_id: payload.selected_session_id.clone(),
         route,
         app_version: payload.app_version,
         artifact_hash: payload.artifact_hash,
@@ -398,12 +399,104 @@ async fn submit_client_bug_report(
         client_state,
         server_state,
     })?;
-    store.update_delivery_result(&created.id, "not_attempted")?;
+    let (maintainer_notified, delivery_result) = notify_maintainer_of_bug_report(
+        &state,
+        &created.id,
+        &report_text,
+        &payload.selected_session_id,
+        &bug_report_db_path,
+    )
+    .unwrap_or_else(|error| (false, format!("failed:{}", error_name(&error))));
+    store.update_delivery_result(&created.id, &delivery_result)?;
     Ok(Json(ClientBugReportResponse {
         status: "submitted",
         bug_id: created.id,
-        maintainer_notified: false,
+        maintainer_notified,
     }))
+}
+
+fn notify_maintainer_of_bug_report(
+    state: &AppState,
+    bug_id: &str,
+    report_text: &str,
+    selected_session_id: &Option<String>,
+    db_path: &std::path::Path,
+) -> Result<(bool, String), ApiError> {
+    let Some(maintainer) = state
+        .session_store
+        .lookup_agent_registration("maintainer")?
+    else {
+        return Ok((false, "maintainer_not_found".to_owned()));
+    };
+    let Some(maintainer_session) = state.session_store.get_session(&maintainer.session_id)? else {
+        return Ok((false, "maintainer_not_found".to_owned()));
+    };
+    if state.config.rust_core.runtime_enabled && !is_primary_node(&maintainer_session.node) {
+        return Ok((
+            false,
+            format!("unsupported_remote_node:{}", maintainer_session.node),
+        ));
+    }
+    let selected = selected_session_id.as_deref().unwrap_or("-");
+    let message = format!(
+        "[app bug] {bug_id}\nreport: {}\nsession: {selected}\ndb: {}",
+        bug_report_summary(report_text),
+        db_path.display()
+    );
+    let payload = SendCoreInputRequest {
+        text: message,
+        delivery_mode: "important".to_owned(),
+        sender_session_id: None,
+        from_sm_send: false,
+        timeout_seconds: None,
+        notify_on_delivery: false,
+        notify_after_seconds: None,
+        notify_on_stop: false,
+        remind_soft_threshold: None,
+        remind_hard_threshold: None,
+        remind_cancel_on_reply_session_id: None,
+        parent_session_id: None,
+    };
+    let outcome = if state.config.rust_core.runtime_enabled {
+        let runtime = TmuxRuntime::from_app_config(&state.config);
+        state.session_store.send_core_input_with_runtime(
+            &maintainer.session_id,
+            payload,
+            &runtime,
+        )?
+    } else {
+        state
+            .session_store
+            .send_core_input(&maintainer.session_id, payload)?
+    };
+    let Some(outcome) = outcome else {
+        return Ok((false, "maintainer_not_found".to_owned()));
+    };
+    if outcome.delivered {
+        return Ok((true, "delivered".to_owned()));
+    }
+    if matches!(outcome.status.as_str(), "stopped" | "killed") {
+        return Ok((false, outcome.status));
+    }
+    Ok((true, "queued".to_owned()))
+}
+
+fn bug_report_summary(report_text: &str) -> String {
+    let mut summary = report_text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if summary.chars().count() > 160 {
+        summary = summary.chars().take(157).collect::<String>();
+        summary.push_str("...");
+    }
+    summary
+}
+
+fn error_name(error: &ApiError) -> &'static str {
+    match error {
+        ApiError::Internal(_) => "internal",
+        ApiError::NotFound(_) => "not_found",
+        ApiError::Status { .. } => "status",
+        ApiError::Auth { .. } => "auth",
+    }
 }
 
 async fn deploy_app_artifact(

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -11,7 +11,9 @@ use axum::{
     body::{to_bytes, Body},
     extract::{ConnectInfo, DefaultBodyLimit, Multipart, Path, Query, Request, State},
     http::{
-        header::{AUTHORIZATION, CACHE_CONTROL, CONTENT_TYPE, COOKIE, HOST, LOCATION},
+        header::{
+            AUTHORIZATION, CACHE_CONTROL, CONTENT_DISPOSITION, CONTENT_TYPE, COOKIE, HOST, LOCATION,
+        },
         HeaderMap, StatusCode,
     },
     response::{
@@ -659,8 +661,18 @@ async fn get_hashed_app_artifact(
     Ok((
         StatusCode::OK,
         [
-            (CONTENT_TYPE, "application/vnd.android.package-archive"),
-            (CACHE_CONTROL, "public, max-age=31536000, immutable"),
+            (
+                CONTENT_TYPE,
+                "application/vnd.android.package-archive".to_owned(),
+            ),
+            (
+                CACHE_CONTROL,
+                "public, max-age=31536000, immutable".to_owned(),
+            ),
+            (
+                CONTENT_DISPOSITION,
+                format!("attachment; filename=\"{app_name}.apk\""),
+            ),
         ],
         Body::from(bytes),
     )

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -277,6 +277,10 @@ async fn client_request_status(
     let mut targeted_session_ids = Vec::with_capacity(sessions.len());
     for session in sessions {
         targeted_session_ids.push(session.id.clone());
+        if session.provider == "codex-app" {
+            failed_count += 1;
+            continue;
+        }
         let payload = SendCoreInputRequest {
             text: REQUEST_STATUS_PROMPT.to_owned(),
             delivery_mode: "important".to_owned(),

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -1,16 +1,17 @@
 use std::{
     collections::BTreeMap,
     convert::Infallible,
+    fs,
     net::SocketAddr,
     sync::Arc,
     time::{Duration, Instant},
 };
 
 use axum::{
-    body::to_bytes,
-    extract::{ConnectInfo, Path, Query, Request, State},
+    body::{to_bytes, Body},
+    extract::{ConnectInfo, DefaultBodyLimit, Multipart, Path, Query, Request, State},
     http::{
-        header::{AUTHORIZATION, COOKIE, HOST},
+        header::{AUTHORIZATION, CACHE_CONTROL, CONTENT_TYPE, COOKIE, HOST, LOCATION},
         HeaderMap, StatusCode,
     },
     response::{
@@ -32,6 +33,11 @@ use sha1::{Digest, Sha1};
 use sha2::Sha256;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
+use crate::app_artifacts::{
+    hashed_path, read_metadata, store_artifact, valid_app_name, valid_artifact_hash,
+    APP_ARTIFACT_MAX_SIZE_BYTES,
+};
+use crate::bug_reports::{BugReportStore, CreateBugReport};
 use crate::config::{trimmed, AppConfig, PublicNodeConfig};
 use crate::mobile_analytics::build_mobile_analytics_summary;
 use crate::queue::{
@@ -55,6 +61,10 @@ const SESSION_COOKIE_NAME: &str = "sm_auth";
 const SESSION_COOKIE_MAX_AGE_SECONDS: i64 = 60 * 60 * 24 * 14;
 const SHADOW_ENVELOPE_MAX_BYTES: usize = 1024 * 1024;
 const EM_SPAWN_STOP_NOTIFY_DELAY_SECONDS: i64 = 8;
+const REQUEST_STATUS_PROMPT: &str = "[sm] user requests status, please update now using sm status";
+const BUG_REPORT_MAX_TEXT_CHARS: usize = 4000;
+const BUG_REPORT_MAX_CLIENT_STATE_CHARS: usize = 100_000;
+const BUG_REPORT_MAX_SERVER_STATE_CHARS: usize = 200_000;
 
 #[derive(Clone)]
 pub struct AppState {
@@ -81,6 +91,16 @@ pub fn router(state: AppState) -> Router {
         .route("/auth/session", get(auth_session))
         .route("/client/bootstrap", get(client_bootstrap))
         .route("/client/analytics/summary", get(client_analytics_summary))
+        .route("/client/request-status", post(client_request_status))
+        .route("/client/bug-reports", post(submit_client_bug_report))
+        .route("/deploy/{app_name}", post(deploy_app_artifact))
+        .route("/apps/{app_name}/latest.apk", get(get_latest_app_artifact))
+        .route("/apps/{app_name}/meta.json", get(get_app_artifact_metadata))
+        .route(
+            "/apps/{app_name}/{artifact_file}",
+            get(get_hashed_app_artifact),
+        )
+        .route("/apk", get(get_legacy_apk_download))
         .route("/events/state", get(events_state))
         .route("/events", get(events_stream))
         .route("/__shadow/http", post(shadow_http))
@@ -141,6 +161,9 @@ pub fn router(state: AppState) -> Router {
         .route("/client/sessions", get(list_client_sessions))
         .route("/client/sessions/{session_id}", get(get_client_session))
         .fallback(not_found)
+        .layer(DefaultBodyLimit::max(
+            APP_ARTIFACT_MAX_SIZE_BYTES + 1024 * 1024,
+        ))
         .with_state(Arc::new(state))
 }
 
@@ -228,6 +251,350 @@ async fn client_analytics_summary(
         &state.config,
         &state.session_store,
     )?))
+}
+
+async fn client_request_status(
+    State(state): State<Arc<AppState>>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+) -> Result<Json<ClientRequestStatusResponse>, ApiError> {
+    ensure_session_allowed_from_parts(
+        &state.config,
+        &headers,
+        Some(peer_addr),
+        "/client/request-status",
+    )?;
+    ensure_core_writes_enabled(&state)?;
+    let sessions = state.session_store.list_sessions(false)?;
+    let runtime = state
+        .config
+        .rust_core
+        .runtime_enabled
+        .then(|| TmuxRuntime::from_app_config(&state.config));
+    let mut delivered_count = 0;
+    let mut queued_count = 0;
+    let mut failed_count = 0;
+    let mut targeted_session_ids = Vec::with_capacity(sessions.len());
+    for session in sessions {
+        targeted_session_ids.push(session.id.clone());
+        let payload = SendCoreInputRequest {
+            text: REQUEST_STATUS_PROMPT.to_owned(),
+            delivery_mode: "important".to_owned(),
+            sender_session_id: None,
+            from_sm_send: false,
+            timeout_seconds: None,
+            notify_on_delivery: false,
+            notify_after_seconds: None,
+            notify_on_stop: false,
+            remind_soft_threshold: None,
+            remind_hard_threshold: None,
+            remind_cancel_on_reply_session_id: None,
+            parent_session_id: None,
+        };
+        let outcome = if let Some(runtime) = runtime.as_ref() {
+            if !is_primary_node(&session.node) {
+                failed_count += 1;
+                continue;
+            }
+            state
+                .session_store
+                .send_core_input_with_runtime(&session.id, payload, runtime)?
+        } else {
+            state.session_store.send_core_input(&session.id, payload)?
+        };
+        match outcome {
+            Some(result) if result.delivered => delivered_count += 1,
+            Some(result) if !matches!(result.status.as_str(), "stopped" | "killed") => {
+                queued_count += 1
+            }
+            _ => failed_count += 1,
+        }
+    }
+    Ok(Json(ClientRequestStatusResponse {
+        status: "requested",
+        prompt: REQUEST_STATUS_PROMPT,
+        targeted_count: targeted_session_ids.len(),
+        delivered_count,
+        queued_count,
+        failed_count,
+        targeted_session_ids,
+    }))
+}
+
+async fn submit_client_bug_report(
+    State(state): State<Arc<AppState>>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(payload): Json<ClientBugReportRequest>,
+) -> Result<Json<ClientBugReportResponse>, ApiError> {
+    ensure_session_allowed_from_parts(
+        &state.config,
+        &headers,
+        Some(peer_addr),
+        "/client/bug-reports",
+    )?;
+    let actor_email = request_actor_email_from_parts(&state.config, &headers, Some(peer_addr));
+    if actor_email.is_none() && state.config.google_auth.requested() {
+        return Err(ApiError::Auth {
+            status: StatusCode::UNAUTHORIZED,
+            detail: "Authentication required",
+            login_url: None,
+        });
+    }
+    let report_text = payload.report_text.trim().to_owned();
+    if report_text.is_empty() {
+        return Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: "report_text is required".to_owned(),
+        });
+    }
+    if report_text.chars().count() > BUG_REPORT_MAX_TEXT_CHARS {
+        return Err(ApiError::Status {
+            status: StatusCode::PAYLOAD_TOO_LARGE,
+            detail: format!("report_text exceeds {BUG_REPORT_MAX_TEXT_CHARS} characters"),
+        });
+    }
+    let route = payload
+        .client_state
+        .as_ref()
+        .and_then(|value| value.get("route"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+    let client_state = if payload.include_debug_state {
+        validate_json_payload_size(
+            "client_state",
+            payload.client_state.clone(),
+            BUG_REPORT_MAX_CLIENT_STATE_CHARS,
+        )?
+    } else {
+        None
+    };
+    let server_state = if payload.include_debug_state {
+        validate_json_payload_size(
+            "server_state",
+            Some(bug_report_server_state(
+                &state,
+                payload.selected_session_id.as_deref(),
+            )?),
+            BUG_REPORT_MAX_SERVER_STATE_CHARS,
+        )?
+    } else {
+        None
+    };
+    let store = BugReportStore::new(
+        expand_home(&state.config.bug_reports.db_path),
+        state.config.bug_reports.max_reports,
+    );
+    let created = store.create_report(CreateBugReport {
+        report_text,
+        reported_by: actor_email,
+        selected_session_id: payload.selected_session_id,
+        route,
+        app_version: payload.app_version,
+        artifact_hash: payload.artifact_hash,
+        include_debug_state: payload.include_debug_state,
+        client_state,
+        server_state,
+    })?;
+    store.update_delivery_result(&created.id, "not_attempted")?;
+    Ok(Json(ClientBugReportResponse {
+        status: "submitted",
+        bug_id: created.id,
+        maintainer_notified: false,
+    }))
+}
+
+async fn deploy_app_artifact(
+    State(state): State<Arc<AppState>>,
+    Path(app_name): Path<String>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    mut multipart: Multipart,
+) -> Result<Json<AppArtifactDeployResponse>, ApiError> {
+    if !valid_app_name(&app_name) {
+        return Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: "Invalid app name".to_owned(),
+        });
+    }
+    ensure_session_allowed_from_parts(
+        &state.config,
+        &headers,
+        Some(peer_addr),
+        &format!("/deploy/{app_name}"),
+    )?;
+    let Some(actor_email) =
+        request_actor_email_from_parts(&state.config, &headers, Some(peer_addr))
+    else {
+        return Err(ApiError::Auth {
+            status: StatusCode::UNAUTHORIZED,
+            detail: "Authentication required",
+            login_url: None,
+        });
+    };
+
+    let mut file_bytes: Option<Vec<u8>> = None;
+    let mut version_code: Option<i64> = None;
+    let mut version_name: Option<String> = None;
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|error| ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: format!("Expected multipart form upload: {error}"),
+        })?
+    {
+        let name = field.name().unwrap_or("").to_owned();
+        match name.as_str() {
+            "file" => {
+                let bytes = field.bytes().await.map_err(|error| ApiError::Status {
+                    status: StatusCode::BAD_REQUEST,
+                    detail: format!("Failed to read multipart file: {error}"),
+                })?;
+                if bytes.len() > APP_ARTIFACT_MAX_SIZE_BYTES {
+                    return Err(ApiError::Status {
+                        status: StatusCode::PAYLOAD_TOO_LARGE,
+                        detail: "Artifact exceeds 100 MB limit".to_owned(),
+                    });
+                }
+                file_bytes = Some(bytes.to_vec());
+            }
+            "version_code" => {
+                let value = field.text().await.unwrap_or_default();
+                let value = value.trim();
+                if !value.is_empty() {
+                    version_code = Some(value.parse().map_err(|_| ApiError::Status {
+                        status: StatusCode::BAD_REQUEST,
+                        detail: "version_code must be an integer".to_owned(),
+                    })?);
+                }
+            }
+            "version_name" => {
+                let value = field.text().await.unwrap_or_default();
+                let value = value.trim();
+                if !value.is_empty() {
+                    version_name = Some(value.to_owned());
+                }
+            }
+            _ => {}
+        }
+    }
+    let Some(file_bytes) = file_bytes else {
+        return Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: "Missing multipart field 'file'".to_owned(),
+        });
+    };
+    if file_bytes.is_empty() {
+        return Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: "Uploaded artifact is empty".to_owned(),
+        });
+    }
+
+    let root = expand_home(&state.config.app_artifacts.root_dir);
+    let stored = store_artifact(
+        &root,
+        &app_name,
+        &file_bytes,
+        Some(actor_email),
+        version_code,
+        version_name,
+    )
+    .map_err(|error| ApiError::Status {
+        status: StatusCode::INTERNAL_SERVER_ERROR,
+        detail: format!("Failed to store artifact: {error}"),
+    })?;
+    Ok(Json(AppArtifactDeployResponse {
+        ok: true,
+        app: app_name.clone(),
+        size_bytes: stored.size_bytes,
+        download_url: format!("/apps/{app_name}/latest.apk"),
+        artifact_hash: stored.artifact_hash,
+    }))
+}
+
+async fn get_latest_app_artifact(
+    State(state): State<Arc<AppState>>,
+    Path(app_name): Path<String>,
+    request: Request,
+) -> Result<Response, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    if !valid_app_name(&app_name) {
+        return Err(ApiError::NotFound("Artifact not found"));
+    }
+    let root = expand_home(&state.config.app_artifacts.root_dir);
+    let metadata =
+        read_metadata(&root, &app_name).map_err(|_| ApiError::NotFound("Artifact not found"))?;
+    if !valid_artifact_hash(&metadata.artifact_hash) {
+        return Err(ApiError::NotFound("Artifact not found"));
+    }
+    Ok((
+        StatusCode::FOUND,
+        [
+            (
+                LOCATION,
+                format!("/apps/{app_name}/{}.apk", metadata.artifact_hash),
+            ),
+            (CACHE_CONTROL, "no-cache".to_owned()),
+        ],
+    )
+        .into_response())
+}
+
+async fn get_hashed_app_artifact(
+    State(state): State<Arc<AppState>>,
+    Path((app_name, artifact_file)): Path<(String, String)>,
+    request: Request,
+) -> Result<Response, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    let Some(artifact_hash) = artifact_file.strip_suffix(".apk") else {
+        return Err(ApiError::NotFound("Artifact not found"));
+    };
+    if !valid_app_name(&app_name) || !valid_artifact_hash(artifact_hash) {
+        return Err(ApiError::NotFound("Artifact not found"));
+    }
+    let root = expand_home(&state.config.app_artifacts.root_dir);
+    let path = hashed_path(&root, &app_name, artifact_hash);
+    let bytes = fs::read(&path).map_err(|_| ApiError::NotFound("Artifact not found"))?;
+    Ok((
+        StatusCode::OK,
+        [
+            (CONTENT_TYPE, "application/vnd.android.package-archive"),
+            (CACHE_CONTROL, "public, max-age=31536000, immutable"),
+        ],
+        Body::from(bytes),
+    )
+        .into_response())
+}
+
+async fn get_app_artifact_metadata(
+    State(state): State<Arc<AppState>>,
+    Path(app_name): Path<String>,
+    request: Request,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    if !valid_app_name(&app_name) {
+        return Err(ApiError::NotFound("Artifact metadata not found"));
+    }
+    let root = expand_home(&state.config.app_artifacts.root_dir);
+    let metadata = read_metadata(&root, &app_name)
+        .map_err(|_| ApiError::NotFound("Artifact metadata not found"))?;
+    Ok(Json(serde_json::to_value(metadata)?))
+}
+
+async fn get_legacy_apk_download(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+) -> Result<Response, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    Ok((
+        StatusCode::FOUND,
+        [(LOCATION, "/apps/session-manager-android/latest.apk")],
+    )
+        .into_response())
 }
 
 async fn events_state(
@@ -1885,6 +2252,12 @@ fn is_static_sessions_path(path: &str) -> bool {
 }
 
 fn is_retained_write_surface(method: &str, path: &str) -> bool {
+    if method == "POST" && (path == "/client/request-status" || path == "/client/bug-reports") {
+        return true;
+    }
+    if method == "POST" && path.starts_with("/deploy/") {
+        return true;
+    }
     if method == "POST" && (path == "/sessions" || path == "/sessions/input-batch") {
         return true;
     }
@@ -1916,12 +2289,14 @@ fn is_protected_read_surface(method: &str, path: &str) -> bool {
     }
     path == "/events"
         || path == "/events/state"
+        || path == "/apk"
         || path == "/client/analytics/summary"
         || path == "/codex-review-requests"
         || path == "/queue-jobs"
         || path == "/nodes"
         || path == "/sessions"
         || path == "/client/sessions"
+        || path.starts_with("/apps/")
         || path.starts_with("/sessions/")
         || path.starts_with("/client/sessions/")
 }
@@ -2194,6 +2569,77 @@ fn authenticated_user(headers: &HeaderMap, config: &AppConfig) -> Option<Authent
     browser_session_user(headers, config)
 }
 
+fn request_actor_email_from_parts(
+    config: &AppConfig,
+    headers: &HeaderMap,
+    peer_addr: Option<SocketAddr>,
+) -> Option<String> {
+    if let Some(user) = authenticated_user(headers, config) {
+        return Some(user.email.trim().to_ascii_lowercase());
+    }
+    if is_local_bypass_request(headers, peer_addr, config) {
+        return Some("local_bypass".to_owned());
+    }
+    None
+}
+
+fn validate_json_payload_size(
+    field_name: &str,
+    payload: Option<Value>,
+    max_chars: usize,
+) -> Result<Option<Value>, ApiError> {
+    let Some(payload) = payload else {
+        return Ok(None);
+    };
+    let raw = serde_json::to_string(&payload).map_err(|_| ApiError::Status {
+        status: StatusCode::BAD_REQUEST,
+        detail: format!("{field_name} must be JSON serializable"),
+    })?;
+    if raw.chars().count() > max_chars {
+        return Err(ApiError::Status {
+            status: StatusCode::PAYLOAD_TOO_LARGE,
+            detail: format!("{field_name} exceeds {max_chars} serialized characters"),
+        });
+    }
+    Ok(Some(payload))
+}
+
+fn bug_report_server_state(
+    state: &AppState,
+    selected_session_id: Option<&str>,
+) -> Result<Value, ApiError> {
+    let sessions = state
+        .session_store
+        .list_sessions(false)?
+        .into_iter()
+        .map(SessionResponse::from)
+        .map(serde_json::to_value)
+        .collect::<Result<Vec<_>, _>>()?;
+    let selected_session = if let Some(session_id) = selected_session_id {
+        match state.session_store.get_session(session_id)? {
+            Some(session) => json!({
+                "found": true,
+                "session": ClientSessionResponse::from(session),
+            }),
+            None => json!({
+                "id": session_id,
+                "found": false,
+            }),
+        }
+    } else {
+        Value::Null
+    };
+    Ok(json!({
+        "captured_at": now_rfc3339(),
+        "bootstrap": client_bootstrap_response(&state.config),
+        "health": {
+            "status": "healthy",
+        },
+        "sessions": sessions,
+        "selected_session": selected_session,
+    }))
+}
+
 fn device_auth_user(headers: &HeaderMap, config: &AppConfig) -> Option<AuthenticatedUser> {
     let token = request_bearer_token(headers)?;
     let secret = trimmed(&config.google_auth.session_cookie_secret)?;
@@ -2432,6 +2878,52 @@ struct SessionOutputQuery {
 struct KillSessionRequest {
     #[serde(default)]
     requester_session_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct ClientRequestStatusResponse {
+    status: &'static str,
+    prompt: &'static str,
+    targeted_count: usize,
+    delivered_count: usize,
+    queued_count: usize,
+    failed_count: usize,
+    targeted_session_ids: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ClientBugReportRequest {
+    report_text: String,
+    #[serde(default = "default_true")]
+    include_debug_state: bool,
+    #[serde(default)]
+    selected_session_id: Option<String>,
+    #[serde(default)]
+    client_state: Option<Value>,
+    #[serde(default)]
+    app_version: Option<String>,
+    #[serde(default)]
+    artifact_hash: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+#[derive(Debug, Serialize)]
+struct ClientBugReportResponse {
+    status: &'static str,
+    bug_id: String,
+    maintainer_notified: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct AppArtifactDeployResponse {
+    ok: bool,
+    app: String,
+    size_bytes: u64,
+    download_url: String,
+    artifact_hash: String,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/sm-server/src/lib.rs
+++ b/crates/sm-server/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod app_artifacts;
+pub mod bug_reports;
 pub mod config;
 pub mod http;
 pub mod mobile_analytics;

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -456,25 +456,38 @@ impl TmuxRuntime {
     }
 
     fn attach_session_log(&self, spec: &TmuxSessionSpec, prompt_mode: &str) -> Result<()> {
+        let initial_stdin_prompt = (prompt_mode == "stdin")
+            .then(|| {
+                spec.initial_message
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+            })
+            .flatten();
         let pipe_command = format!("cat >> {}", shell_quote_path(&spec.log_file));
-        self.run_tmux([
+        if let Err(error) = self.run_tmux([
             "pipe-pane",
             "-t",
             spec.tmux_session.as_str(),
             pipe_command.as_str(),
-        ])?;
+        ]) {
+            if initial_stdin_prompt.is_some() && is_tmux_session_gone_error(&error) {
+                bail!("tmux session exited before initial prompt could be delivered");
+            }
+            return Err(error);
+        }
 
-        if prompt_mode == "stdin" {
-            if let Some(initial_message) = spec
-                .initial_message
-                .as_deref()
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-            {
-                thread::sleep(Duration::from_millis(self.start_settle_ms));
-                if !self.send_input(&spec.tmux_session, initial_message)? {
+        if let Some(initial_message) = initial_stdin_prompt {
+            thread::sleep(Duration::from_millis(self.start_settle_ms));
+            match self.send_input(&spec.tmux_session, initial_message) {
+                Ok(true) => {}
+                Ok(false) => {
                     bail!("tmux session exited before initial prompt could be delivered");
                 }
+                Err(error) if is_tmux_session_gone_error(&error) => {
+                    bail!("tmux session exited before initial prompt could be delivered");
+                }
+                Err(error) => return Err(error),
             }
         }
         Ok(())
@@ -542,6 +555,11 @@ fn finite_nonnegative_or_default(value: Option<f64>, default: f64) -> f64 {
 
 fn duration_from_millis(millis: f64) -> Duration {
     Duration::from_secs_f64((millis.max(0.0)) / 1000.0)
+}
+
+fn is_tmux_session_gone_error(error: &anyhow::Error) -> bool {
+    let message = error.to_string();
+    message.contains("no server running") || message.contains("can't find session")
 }
 
 fn shell_quote_path(path: &Path) -> String {

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -645,6 +645,7 @@ async fn client_request_status_prompts_live_sessions() {
     let state_file = unique_temp_path();
     let first_log = unique_temp_path();
     let second_log = unique_temp_path();
+    let codex_app_log = unique_temp_path();
     fs::write(
         &state_file,
         json!({
@@ -666,6 +667,17 @@ async fn client_request_status_prompts_live_sessions() {
                     "tmux_session": "claude-mobiletwo",
                     "log_file": second_log.display().to_string(),
                     "status": "waiting_permission",
+                    "created_at": "2026-06-01T00:00:00",
+                    "last_activity": "2026-06-01T00:01:00"
+                },
+                {
+                    "id": "mobilecodexapp",
+                    "name": "codex-app-mobile",
+                    "working_dir": "/repo",
+                    "tmux_session": "codex-app-mobile",
+                    "provider": "codex-app",
+                    "log_file": codex_app_log.display().to_string(),
+                    "status": "running",
                     "created_at": "2026-06-01T00:00:00",
                     "last_activity": "2026-06-01T00:01:00"
                 },
@@ -695,18 +707,20 @@ async fn client_request_status_prompts_live_sessions() {
         payload["prompt"],
         "[sm] user requests status, please update now using sm status"
     );
-    assert_eq!(payload["targeted_count"], 2);
+    assert_eq!(payload["targeted_count"], 3);
     assert_eq!(payload["delivered_count"], 2);
     assert_eq!(payload["queued_count"], 0);
-    assert_eq!(payload["failed_count"], 0);
+    assert_eq!(payload["failed_count"], 1);
     assert_eq!(
         payload["targeted_session_ids"],
-        json!(["mobileone", "mobiletwo"])
+        json!(["mobileone", "mobiletwo", "mobilecodexapp"])
     );
     let first_output = fs::read_to_string(first_log).unwrap();
     assert!(first_output.contains("[sm] user requests status"));
     let second_output = fs::read_to_string(second_log).unwrap();
     assert!(second_output.contains("[sm] user requests status"));
+    let codex_app_output = fs::read_to_string(codex_app_log).unwrap_or_default();
+    assert!(!codex_app_output.contains("[sm] user requests status"));
 }
 
 #[tokio::test]
@@ -1038,6 +1052,41 @@ async fn app_artifact_upload_metadata_and_downloads_are_auth_gated() {
             .and_then(|value| value.to_str().ok()),
         Some("/apps/session-manager-android/latest.apk")
     );
+    let _ = fs::remove_dir_all(artifact_root);
+}
+
+#[tokio::test]
+async fn app_artifact_upload_rejects_encoded_whitespace_app_name() {
+    let artifact_root = unique_short_temp_dir("sm-rust-app-artifacts-invalid");
+    let state_file = unique_temp_path();
+    fs::write(&state_file, json!({ "sessions": [] }).to_string()).unwrap();
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        app_artifacts: AppArtifactsConfig {
+            root_dir: artifact_root.display().to_string(),
+        },
+        ..AppConfig::default()
+    }));
+    let boundary = "sm-rust-boundary-invalid";
+    let body = multipart_app_upload(boundary, b"apk-bytes", None, None);
+
+    let (status, _headers, response_body) = post_multipart_with_host_and_peer(
+        app,
+        "/deploy/session-manager-android%20",
+        "localhost",
+        body,
+        boundary,
+        &[],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let payload: Value = serde_json::from_slice(&response_body).unwrap();
+    assert_eq!(payload["detail"], "Invalid app name");
+    assert!(!artifact_root.join("session-manager-android ").exists());
     let _ = fs::remove_dir_all(artifact_root);
 }
 

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -744,11 +744,20 @@ async fn client_bug_report_persists_sqlite_row_and_debug_state() {
     let bug_id = payload["bug_id"].as_str().unwrap();
     assert!(bug_id.starts_with("BR-"));
     let conn = Connection::open(&bug_db).unwrap();
-    let row: (String, Option<String>, String, String, i64, String, String) = conn
+    let row: (
+        String,
+        Option<String>,
+        String,
+        String,
+        i64,
+        String,
+        String,
+        Option<String>,
+    ) = conn
         .query_row(
             r#"
             SELECT report_text, reported_by, route, app_version, include_debug_state,
-                   client_state_json, server_state_json
+                   client_state_json, server_state_json, maintainer_delivery_result
             FROM bug_reports
             WHERE id = ?
             "#,
@@ -762,6 +771,7 @@ async fn client_bug_report_persists_sqlite_row_and_debug_state() {
                     row.get(4)?,
                     row.get(5)?,
                     row.get(6)?,
+                    row.get(7)?,
                 ))
             },
         )
@@ -773,6 +783,98 @@ async fn client_bug_report_persists_sqlite_row_and_debug_state() {
     assert_eq!(row.4, 1);
     assert!(row.5.contains("\"screen\":\"sessions\""));
     assert!(row.6.contains("\"selected_session\""));
+    assert_eq!(row.7.as_deref(), Some("maintainer_not_found"));
+}
+
+#[tokio::test]
+async fn client_bug_report_notifies_registered_maintainer() {
+    let state_file = unique_temp_path();
+    let maintainer_log = unique_temp_path();
+    let selected_log = unique_temp_path();
+    let bug_db = unique_temp_path();
+    fs::write(&maintainer_log, "").unwrap();
+    fs::write(&selected_log, "").unwrap();
+    fs::write(
+        &state_file,
+        json!({
+            "sessions": [
+                {
+                    "id": "maint01",
+                    "name": "claude-maint01",
+                    "working_dir": "/repo",
+                    "tmux_session": "claude-maint01",
+                    "tmux_socket_name": null,
+                    "node": "primary",
+                    "provider": "claude",
+                    "log_file": maintainer_log.display().to_string(),
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00",
+                    "last_activity": "2026-06-01T00:01:00",
+                    "friendly_name": "maintainer"
+                },
+                {
+                    "id": "run12345",
+                    "name": "claude-run12345",
+                    "working_dir": "/repo",
+                    "tmux_session": "claude-run12345",
+                    "node": "primary",
+                    "provider": "claude",
+                    "log_file": selected_log.display().to_string(),
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00",
+                    "last_activity": "2026-06-01T00:01:00"
+                }
+            ],
+            "agent_registrations": [
+                {
+                    "role": "maintainer",
+                    "session_id": "maint01",
+                    "created_at": "2026-06-01T00:02:00"
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        bug_reports: BugReportsConfig {
+            db_path: bug_db.display().to_string(),
+            max_reports: 30,
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = post_json(
+        app,
+        "/client/bug-reports",
+        json!({
+            "report_text": "important   mobile\nfailure",
+            "include_debug_state": false,
+            "selected_session_id": "run12345"
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["maintainer_notified"], true);
+    let bug_id = payload["bug_id"].as_str().unwrap();
+    let maintainer_output = fs::read_to_string(&maintainer_log).unwrap();
+    assert!(maintainer_output.contains(&format!("[app bug] {bug_id}")));
+    assert!(maintainer_output.contains("report: important mobile failure"));
+    assert!(maintainer_output.contains("session: run12345"));
+    assert!(maintainer_output.contains(&format!("db: {}", bug_db.display())));
+    let conn = Connection::open(&bug_db).unwrap();
+    let delivery_result: String = conn
+        .query_row(
+            "SELECT maintainer_delivery_result FROM bug_reports WHERE id = ?",
+            [bug_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(delivery_result, "delivered");
 }
 
 #[tokio::test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -17,9 +17,9 @@ use sm_server::config::RustShadowConfig;
 use sm_server::queue::RetainedQueueStore;
 use sm_server::{
     config::{
-        AppConfig, CodexForkLaunchConfig, ExternalAccessConfig, GoogleAuthConfig,
-        MobileAnalyticsConfig, MobileTerminalConfig, PathsConfig, QueueRunnerConfig,
-        RustCoreConfig, SmSendConfig,
+        AppArtifactsConfig, AppConfig, BugReportsConfig, CodexForkLaunchConfig,
+        ExternalAccessConfig, GoogleAuthConfig, MobileAnalyticsConfig, MobileTerminalConfig,
+        PathsConfig, QueueRunnerConfig, RustCoreConfig, SmSendConfig,
     },
     http::{router, AppState},
 };
@@ -129,6 +129,72 @@ async fn json_request_with_headers_and_peer(
     let status = response.status();
     let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
     (status, serde_json::from_slice(&body).unwrap())
+}
+
+async fn post_multipart_with_host_and_peer(
+    app: axum::Router,
+    uri: &str,
+    host: &str,
+    body: Vec<u8>,
+    boundary: &str,
+    headers: &[(&str, String)],
+    peer_addr: Option<SocketAddr>,
+) -> (StatusCode, HeaderMap, Vec<u8>) {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("host", host)
+        .header(
+            "content-type",
+            format!("multipart/form-data; boundary={boundary}"),
+        );
+    for (name, value) in headers {
+        builder = builder.header(*name, value);
+    }
+    let mut request = builder.body(Body::from(body)).unwrap();
+    if let Some(peer_addr) = peer_addr {
+        request.extensions_mut().insert(ConnectInfo(peer_addr));
+    }
+    let response = app.oneshot(request).await.unwrap();
+    let status = response.status();
+    let headers = response.headers().clone();
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    (status, headers, body.to_vec())
+}
+
+fn multipart_app_upload(
+    boundary: &str,
+    file_bytes: &[u8],
+    version_code: Option<&str>,
+    version_name: Option<&str>,
+) -> Vec<u8> {
+    let mut body = Vec::new();
+    body.extend_from_slice(
+        format!(
+            "--{boundary}\r\nContent-Disposition: form-data; name=\"file\"; filename=\"app-debug.apk\"\r\nContent-Type: application/vnd.android.package-archive\r\n\r\n"
+        )
+        .as_bytes(),
+    );
+    body.extend_from_slice(file_bytes);
+    body.extend_from_slice(b"\r\n");
+    if let Some(version_code) = version_code {
+        body.extend_from_slice(
+            format!(
+                "--{boundary}\r\nContent-Disposition: form-data; name=\"version_code\"\r\n\r\n{version_code}\r\n"
+            )
+            .as_bytes(),
+        );
+    }
+    if let Some(version_name) = version_name {
+        body.extend_from_slice(
+            format!(
+                "--{boundary}\r\nContent-Disposition: form-data; name=\"version_name\"\r\n\r\n{version_name}\r\n"
+            )
+            .as_bytes(),
+        );
+    }
+    body.extend_from_slice(format!("--{boundary}--\r\n").as_bytes());
+    body
 }
 
 async fn get_json_with_host(app: axum::Router, uri: &str, host: &str) -> (StatusCode, Value) {
@@ -572,6 +638,358 @@ async fn client_analytics_summary_rejects_public_host_without_auth() {
         payload["login_url"],
         "/auth/google/login?next=%2Fclient%2Fanalytics%2Fsummary"
     );
+}
+
+#[tokio::test]
+async fn client_request_status_prompts_live_sessions() {
+    let state_file = unique_temp_path();
+    let first_log = unique_temp_path();
+    let second_log = unique_temp_path();
+    fs::write(
+        &state_file,
+        json!({
+            "sessions": [
+                {
+                    "id": "mobileone",
+                    "name": "claude-mobileone",
+                    "working_dir": "/repo",
+                    "tmux_session": "claude-mobileone",
+                    "log_file": first_log.display().to_string(),
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00",
+                    "last_activity": "2026-06-01T00:01:00"
+                },
+                {
+                    "id": "mobiletwo",
+                    "name": "claude-mobiletwo",
+                    "working_dir": "/repo",
+                    "tmux_session": "claude-mobiletwo",
+                    "log_file": second_log.display().to_string(),
+                    "status": "waiting_permission",
+                    "created_at": "2026-06-01T00:00:00",
+                    "last_activity": "2026-06-01T00:01:00"
+                },
+                {
+                    "id": "mobilestopped",
+                    "name": "claude-mobilestopped",
+                    "working_dir": "/repo",
+                    "tmux_session": "claude-mobilestopped",
+                    "status": "stopped",
+                    "created_at": "2026-06-01T00:00:00",
+                    "last_activity": "2026-06-01T00:01:00"
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let mut config = config_with_state_file(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, payload) = post_json(app, "/client/request-status", json!({})).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "requested");
+    assert_eq!(
+        payload["prompt"],
+        "[sm] user requests status, please update now using sm status"
+    );
+    assert_eq!(payload["targeted_count"], 2);
+    assert_eq!(payload["delivered_count"], 2);
+    assert_eq!(payload["queued_count"], 0);
+    assert_eq!(payload["failed_count"], 0);
+    assert_eq!(
+        payload["targeted_session_ids"],
+        json!(["mobileone", "mobiletwo"])
+    );
+    let first_output = fs::read_to_string(first_log).unwrap();
+    assert!(first_output.contains("[sm] user requests status"));
+    let second_output = fs::read_to_string(second_log).unwrap();
+    assert!(second_output.contains("[sm] user requests status"));
+}
+
+#[tokio::test]
+async fn client_bug_report_persists_sqlite_row_and_debug_state() {
+    let state_file = write_session_fixture();
+    let bug_db = unique_temp_path();
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        bug_reports: BugReportsConfig {
+            db_path: bug_db.display().to_string(),
+            max_reports: 30,
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = post_json(
+        app,
+        "/client/bug-reports",
+        json!({
+            "report_text": "mobile bug report",
+            "include_debug_state": true,
+            "selected_session_id": "run12345",
+            "client_state": {"route": "/watch/", "screen": "sessions"},
+            "app_version": "0.3.0",
+            "artifact_hash": "deadbeef"
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "submitted");
+    assert_eq!(payload["maintainer_notified"], false);
+    let bug_id = payload["bug_id"].as_str().unwrap();
+    assert!(bug_id.starts_with("BR-"));
+    let conn = Connection::open(&bug_db).unwrap();
+    let row: (String, Option<String>, String, String, i64, String, String) = conn
+        .query_row(
+            r#"
+            SELECT report_text, reported_by, route, app_version, include_debug_state,
+                   client_state_json, server_state_json
+            FROM bug_reports
+            WHERE id = ?
+            "#,
+            [bug_id],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                    row.get(6)?,
+                ))
+            },
+        )
+        .unwrap();
+    assert_eq!(row.0, "mobile bug report");
+    assert_eq!(row.1, None);
+    assert_eq!(row.2, "/watch/");
+    assert_eq!(row.3, "0.3.0");
+    assert_eq!(row.4, 1);
+    assert!(row.5.contains("\"screen\":\"sessions\""));
+    assert!(row.6.contains("\"selected_session\""));
+}
+
+#[tokio::test]
+async fn client_bug_report_enforces_auth_and_payload_bounds() {
+    let state_file = write_session_fixture();
+    let bug_db = unique_temp_path();
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        bug_reports: BugReportsConfig {
+            db_path: bug_db.display().to_string(),
+            max_reports: 30,
+        },
+        google_auth: GoogleAuthConfig {
+            enabled: true,
+            public_host: Some("sm.example.com".to_owned()),
+            client_id: Some("web-client-id".to_owned()),
+            android_client_id: Some("android-client-id".to_owned()),
+            client_secret: Some("web-client-secret".to_owned()),
+            redirect_uri: Some("https://sm.example.com/auth/google/callback".to_owned()),
+            allowlist_emails: vec!["rajesh@example.com".to_owned()],
+            session_cookie_secret: Some("session-cookie-secret".to_owned()),
+            ..GoogleAuthConfig::default()
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/client/bug-reports",
+        json!({ "report_text": "public unauth" }),
+        &[("host", "sm.example.com")],
+        Some(SocketAddr::from(([203, 0, 113, 10], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(payload["detail"], "Authentication required");
+
+    let token = device_access_token("session-cookie-secret", "rajesh@example.com", "Rajesh");
+    let (status, payload) = post_json_with_headers_and_peer(
+        app,
+        "/client/bug-reports",
+        json!({
+            "report_text": "ok",
+            "include_debug_state": true,
+            "client_state": {"blob": "x".repeat(100_001)}
+        }),
+        &[
+            ("host", "sm.example.com"),
+            ("authorization", &format!("Bearer {token}")),
+        ],
+        Some(SocketAddr::from(([203, 0, 113, 10], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE);
+    assert!(payload["detail"]
+        .as_str()
+        .unwrap()
+        .contains("client_state exceeds"));
+}
+
+#[tokio::test]
+async fn app_artifact_upload_metadata_and_downloads_are_auth_gated() {
+    let artifact_root = unique_short_temp_dir("sm-rust-app-artifacts");
+    let state_file = unique_temp_path();
+    fs::write(&state_file, json!({ "sessions": [] }).to_string()).unwrap();
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        app_artifacts: AppArtifactsConfig {
+            root_dir: artifact_root.display().to_string(),
+        },
+        ..AppConfig::default()
+    }));
+    let boundary = "sm-rust-boundary";
+    let body = multipart_app_upload(boundary, b"apk-bytes", Some("7"), Some("0.1.7"));
+
+    let (status, _headers, response_body) = post_multipart_with_host_and_peer(
+        app.clone(),
+        "/deploy/session-manager-android",
+        "localhost",
+        body,
+        boundary,
+        &[],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let payload: Value = serde_json::from_slice(&response_body).unwrap();
+    let artifact_hash = Sha256::digest(b"apk-bytes")
+        .iter()
+        .take(4)
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    assert_eq!(
+        payload,
+        json!({
+            "ok": true,
+            "app": "session-manager-android",
+            "size_bytes": 9,
+            "download_url": "/apps/session-manager-android/latest.apk",
+            "artifact_hash": artifact_hash
+        })
+    );
+    let app_dir = artifact_root.join("session-manager-android");
+    assert_eq!(fs::read(app_dir.join("latest.apk")).unwrap(), b"apk-bytes");
+    assert_eq!(
+        fs::read(app_dir.join(format!("{artifact_hash}.apk"))).unwrap(),
+        b"apk-bytes"
+    );
+    let metadata: Value =
+        serde_json::from_str(&fs::read_to_string(app_dir.join("meta.json")).unwrap()).unwrap();
+    assert_eq!(metadata["artifact_hash"], artifact_hash);
+    assert_eq!(metadata["uploaded_by"], "local_bypass");
+    assert_eq!(metadata["version_code"], 7);
+    assert_eq!(metadata["version_name"], "0.1.7");
+
+    let (status, headers, body) =
+        get_response(app.clone(), "/apps/session-manager-android/latest.apk").await;
+    assert_eq!(status, StatusCode::FOUND);
+    assert_eq!(
+        headers
+            .get("location")
+            .and_then(|value| value.to_str().ok()),
+        Some(format!("/apps/session-manager-android/{artifact_hash}.apk").as_str())
+    );
+    assert_eq!(
+        headers
+            .get("cache-control")
+            .and_then(|value| value.to_str().ok()),
+        Some("no-cache")
+    );
+    assert!(body.is_empty());
+
+    let (status, headers, body) = get_response(
+        app.clone(),
+        &format!("/apps/session-manager-android/{artifact_hash}.apk"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body, b"apk-bytes");
+    assert_eq!(
+        headers
+            .get("cache-control")
+            .and_then(|value| value.to_str().ok()),
+        Some("public, max-age=31536000, immutable")
+    );
+
+    let (status, metadata_payload) =
+        get_json(app.clone(), "/apps/session-manager-android/meta.json").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(metadata_payload["artifact_hash"], artifact_hash);
+
+    let (status, headers, _) = get_response(app, "/apk").await;
+    assert_eq!(status, StatusCode::FOUND);
+    assert_eq!(
+        headers
+            .get("location")
+            .and_then(|value| value.to_str().ok()),
+        Some("/apps/session-manager-android/latest.apk")
+    );
+    let _ = fs::remove_dir_all(artifact_root);
+}
+
+#[tokio::test]
+async fn app_artifacts_reject_public_unauthenticated_access_when_auth_enabled() {
+    let artifact_root = unique_short_temp_dir("sm-rust-app-artifacts-auth");
+    let state_file = unique_temp_path();
+    fs::write(&state_file, json!({ "sessions": [] }).to_string()).unwrap();
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        app_artifacts: AppArtifactsConfig {
+            root_dir: artifact_root.display().to_string(),
+        },
+        google_auth: GoogleAuthConfig {
+            enabled: true,
+            public_host: Some("sm.example.com".to_owned()),
+            client_id: Some("web-client-id".to_owned()),
+            android_client_id: Some("android-client-id".to_owned()),
+            client_secret: Some("web-client-secret".to_owned()),
+            redirect_uri: Some("https://sm.example.com/auth/google/callback".to_owned()),
+            allowlist_emails: vec!["rajesh@example.com".to_owned()],
+            session_cookie_secret: Some("session-cookie-secret".to_owned()),
+            ..GoogleAuthConfig::default()
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = get_json_with_host(
+        app.clone(),
+        "/apps/session-manager-android/meta.json",
+        "sm.example.com",
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(payload["detail"], "Authentication required");
+
+    let boundary = "sm-rust-boundary-denied";
+    let body = multipart_app_upload(boundary, b"apk-bytes", None, None);
+    let (status, _headers, body) = post_multipart_with_host_and_peer(
+        app,
+        "/deploy/session-manager-android",
+        "sm.example.com",
+        body,
+        boundary,
+        &[],
+        Some(SocketAddr::from(([203, 0, 113, 10], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    let payload: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(payload["detail"], "Authentication required");
+    let _ = fs::remove_dir_all(artifact_root);
 }
 
 #[tokio::test]
@@ -1171,6 +1589,75 @@ async fn shadow_http_classifies_core_writes_without_side_effects() {
         .as_str()
         .unwrap()
         .contains("never performs retained write side effects"));
+}
+
+#[tokio::test]
+async fn shadow_http_classifies_native_mobile_writes_without_side_effects() {
+    let app = router(AppState::new(AppConfig::default()));
+    for path in [
+        "/client/request-status",
+        "/client/bug-reports",
+        "/deploy/session-manager-android",
+    ] {
+        let (status, payload) = post_json(
+            app.clone(),
+            "/__shadow/http",
+            json!({
+                "schema_version": 1,
+                "request": {
+                    "method": "POST",
+                    "path": path,
+                    "query_string": "",
+                    "headers": {},
+                    "body_sha256": sha256_hex(b"{}")
+                },
+                "python_response": {
+                    "status": 200,
+                    "body_sha256": sha256_hex(b"{\"status\":\"python-owned\"}")
+                }
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK, "{path}");
+        assert_eq!(
+            payload["support_status"], "unsupported_retained_write",
+            "{path}"
+        );
+        assert_eq!(payload["comparison"], "not_compared", "{path}");
+        assert_eq!(payload["would_write"], false, "{path}");
+    }
+}
+
+#[tokio::test]
+async fn shadow_http_preserves_python_auth_denial_for_app_artifact_reads() {
+    let app = router(AppState::new(AppConfig::default()));
+
+    for path in ["/apk", "/apps/session-manager-android/meta.json"] {
+        let (status, payload) = post_json(
+            app.clone(),
+            "/__shadow/http",
+            json!({
+                "schema_version": 1,
+                "request": {
+                    "method": "GET",
+                    "path": path,
+                    "query_string": "",
+                    "headers": {}
+                },
+                "python_response": {
+                    "status": 401,
+                    "body_sha256": sha256_hex(b"{\"detail\":\"Authentication required\"}")
+                }
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK, "{path}");
+        assert_eq!(payload["support_status"], "python_auth_denial", "{path}");
+        assert_eq!(payload["comparison"], "status_match", "{path}");
+        assert_eq!(payload["would_write"], false, "{path}");
+    }
 }
 
 #[tokio::test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -1038,6 +1038,12 @@ async fn app_artifact_upload_metadata_and_downloads_are_auth_gated() {
             .and_then(|value| value.to_str().ok()),
         Some("public, max-age=31536000, immutable")
     );
+    assert_eq!(
+        headers
+            .get("content-disposition")
+            .and_then(|value| value.to_str().ok()),
+        Some("attachment; filename=\"session-manager-android.apk\"")
+    );
 
     let (status, metadata_payload) =
         get_json(app.clone(), "/apps/session-manager-android/meta.json").await;

--- a/scripts/rust_migration/contracts_manifest.json
+++ b/scripts/rust_migration/contracts_manifest.json
@@ -332,6 +332,46 @@
       "source": "specs/762_stage5_artifacts/gate_matrix.md:74"
     },
     {
+      "id": "http.client_request_status",
+      "surface": "http",
+      "classification": "retained",
+      "target": "python_and_rust",
+      "safety": "mutating",
+      "method": "POST",
+      "path": "/client/request-status",
+      "body": {},
+      "expected_status": [200],
+      "expected_json": [
+        {"path": "/status", "equals": "requested"},
+        {"path": "/targeted_count", "type": "number"},
+        {"path": "/delivered_count", "type": "number"},
+        {"path": "/queued_count", "type": "number"},
+        {"path": "/failed_count", "type": "number"}
+      ],
+      "preconditions": ["live_server", "mutating_opt_in"],
+      "source": "https://github.com/rajeshgoli/session-manager/issues/837"
+    },
+    {
+      "id": "http.client_bug_report",
+      "surface": "http",
+      "classification": "retained",
+      "target": "python_and_rust",
+      "safety": "mutating",
+      "method": "POST",
+      "path": "/client/bug-reports",
+      "body": {
+        "report_text": "Rust migration contract smoke bug report",
+        "include_debug_state": false
+      },
+      "expected_status": [200],
+      "expected_json": [
+        {"path": "/bug_id", "type": "string"},
+        {"path": "/maintainer_notified", "type": "boolean"}
+      ],
+      "preconditions": ["live_server", "mutating_opt_in"],
+      "source": "https://github.com/rajeshgoli/session-manager/issues/837"
+    },
+    {
       "id": "http.session_detail_fixture",
       "surface": "http",
       "classification": "retained",

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -226,6 +226,31 @@ def test_manifest_has_json_shape_assertions_for_core_http_surfaces():
     )
 
 
+def test_manifest_covers_native_mobile_support_http_surfaces():
+    manifest = ContractManifest.load()
+    checks = {check.id: check for check in manifest.checks}
+
+    request_status = checks["http.client_request_status"]
+    assert request_status.classification == "retained"
+    assert request_status.target == "python_and_rust"
+    assert request_status.safety == "mutating"
+    assert request_status.path == "/client/request-status"
+    assert "mutating_opt_in" in request_status.preconditions
+
+    bug_report = checks["http.client_bug_report"]
+    assert bug_report.classification == "retained"
+    assert bug_report.target == "python_and_rust"
+    assert bug_report.safety == "mutating"
+    assert bug_report.path == "/client/bug-reports"
+    assert "mutating_opt_in" in bug_report.preconditions
+
+    app_metadata = checks["http.app_artifact_metadata"]
+    assert app_metadata.classification == "retained"
+    assert app_metadata.target == "python_and_rust"
+    assert app_metadata.path == "/apps/{app_name}/meta.json"
+    assert "fixture:app_name" in app_metadata.preconditions
+
+
 def test_python_target_does_not_run_rust_only_retirement_checks():
     manifest = ContractManifest.load()
     selected = checks_for_target(manifest.checks, target="python", include_mutating=False)


### PR DESCRIPTION
## Summary
- add Rust request-status, bug-report, and app artifact endpoints for the retained native mobile slice
- add app artifact and bug-report persistence helpers plus config parsing
- extend shadow/contract coverage for the new mobile support surfaces
- notify the registered maintainer role for accepted Rust bug reports
- harden app artifact name/hash validation against path escape
- preserve request-status input gates for retired codex-app sessions
- anchor default mobile app artifact and bug-report paths to the repo data directory
- preserve Python-compatible APK download filename headers

## Validation
- cargo check -p sm-server
- cargo test -p sm-server
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py
- ./venv/bin/python -m scripts.rust_migration.mvp_rehearsal --output-dir .local/rust-mvp-rehearsals/issue-837-disposition-20260611T075537Z

Fixes #837