### PR TITLE
Rust MVP: retain email and human fallback delivery

### DIFF
--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -195,10 +195,17 @@ enum ContextMonitorCommand {
 #[derive(Args)]
 struct EmailArgs {
     recipient: Option<String>,
+    message: Option<String>,
     #[arg(long)]
     subject: Option<String>,
     #[arg(long)]
     body: Option<String>,
+    #[arg(long)]
+    text: Option<String>,
+    #[arg(long)]
+    html: Option<String>,
+    #[arg(long)]
+    cc: Option<String>,
 }
 
 #[derive(Args)]
@@ -649,6 +656,7 @@ fn run() -> Result<()> {
         Command::ContextMonitor(args) => {
             run_context_monitor(&client, args)?;
         }
+        Command::Email(args) => run_email(&client, args)?,
         Command::Maintainer(args) => {
             let session_id = current_session_id()?;
             let body = json!({ "requester_session_id": session_id });
@@ -710,6 +718,192 @@ fn required_positional(value: Option<String>, label: &str) -> Result<String> {
         .map(|value| value.trim().to_owned())
         .filter(|value| !value.is_empty())
         .ok_or_else(|| anyhow!("{label} is required"))
+}
+
+fn run_email(client: &ApiClient, args: EmailArgs) -> Result<()> {
+    let requester_session_id = current_session_id()?;
+    let recipient_raw = required_positional(args.recipient, "recipient")?;
+    let recipients = split_email_targets(&recipient_raw);
+    if recipients.is_empty() {
+        bail!("at least one recipient is required");
+    }
+    let cc = split_email_targets(args.cc.as_deref().unwrap_or(""));
+    let body = email_body_from_args(args.message, args.body, args.text, args.html)?;
+    let subject = args.subject;
+
+    let mut human_match = None;
+    for target in recipients.iter().chain(cc.iter()) {
+        let human_response = client.request(
+            "GET",
+            &format!("/humans/{}", encode_path_segment(target)),
+            None,
+        )?;
+        if (200..300).contains(&human_response.status) {
+            human_match = Some((target.clone(), human_response.into_json()?));
+            break;
+        }
+        if human_response.status != 404 {
+            return Err(human_response.into_status_error());
+        }
+    }
+
+    if let Some((target, human)) = human_match {
+        if recipients.len() != 1 || !cc.is_empty() {
+            bail!("sm email to human recipients supports exactly one recipient and no --cc");
+        }
+        let Some(text) = body.text.clone() else {
+            bail!("sm email to human recipients supports plain text or markdown bodies only");
+        };
+        if body.html.is_some() {
+            bail!("sm email to human recipients supports plain text or markdown bodies only");
+        }
+        let canonical = human["recipient"].as_str().unwrap_or(&target);
+        let payload = client.post_json(
+            &format!("/humans/{}/email", encode_path_segment(canonical)),
+            json!({
+                "requester_session_id": requester_session_id,
+                "text": text,
+                "subject": subject,
+                "body_markdown": body.markdown,
+            }),
+        )?;
+        println!(
+            "Email sent to {}",
+            payload["recipient"].as_str().unwrap_or(canonical)
+        );
+        return Ok(());
+    }
+    let request_payload =
+        registered_email_payload(requester_session_id, recipients, cc, subject, body)?;
+    let payload = client.post_json("/email/send", request_payload)?;
+    let to_summary = payload["to"]
+        .as_array()
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item["username"].as_str().or_else(|| item["email"].as_str()))
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| "recipient".to_owned());
+    println!("Email sent to {to_summary}");
+    Ok(())
+}
+
+fn split_email_targets(raw_value: &str) -> Vec<String> {
+    let mut identifiers = Vec::new();
+    let mut seen = std::collections::BTreeSet::new();
+    for part in raw_value.split(',') {
+        let identifier = part.trim();
+        if identifier.is_empty() || !seen.insert(identifier.to_owned()) {
+            continue;
+        }
+        identifiers.push(identifier.to_owned());
+    }
+    identifiers
+}
+
+fn registered_email_payload(
+    requester_session_id: String,
+    recipients: Vec<String>,
+    cc: Vec<String>,
+    subject: Option<String>,
+    body: EmailBody,
+) -> Result<Value> {
+    if subject
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .is_none()
+    {
+        bail!("--subject is required for non-human registered email");
+    }
+    Ok(json!({
+        "requester_session_id": requester_session_id,
+        "recipients": recipients,
+        "cc": cc,
+        "subject": subject,
+        "body_text": body.text,
+        "body_html": body.html,
+        "body_markdown": body.markdown,
+    }))
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct EmailBody {
+    text: Option<String>,
+    html: Option<String>,
+    markdown: bool,
+}
+
+fn email_body_from_args(
+    message: Option<String>,
+    body: Option<String>,
+    text_file: Option<String>,
+    html_file: Option<String>,
+) -> Result<EmailBody> {
+    if message.is_some() && body.is_some() {
+        bail!("use either positional message or --body, not both");
+    }
+
+    let source_count = usize::from(message.is_some())
+        + usize::from(body.is_some())
+        + usize::from(text_file.is_some())
+        + usize::from(html_file.is_some());
+    if source_count > 1 {
+        bail!("Provide exactly one of positional message, --body, --text, --html, or stdin");
+    }
+
+    if let Some(body) = body
+        .or(message)
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+    {
+        return Ok(EmailBody {
+            text: Some(body),
+            html: None,
+            markdown: false,
+        });
+    }
+    if let Some(text_file) = text_file {
+        let path = Path::new(&text_file);
+        let text = fs::read_to_string(path)
+            .with_context(|| format!("failed to read email text file {}", path.display()))?;
+        let markdown = path
+            .extension()
+            .and_then(|value| value.to_str())
+            .map(|value| matches!(value.to_ascii_lowercase().as_str(), "md" | "markdown"))
+            .unwrap_or(false);
+        return Ok(EmailBody {
+            text: Some(text),
+            html: None,
+            markdown,
+        });
+    }
+    if let Some(html_file) = html_file {
+        let path = Path::new(&html_file);
+        let html = fs::read_to_string(path)
+            .with_context(|| format!("failed to read email HTML file {}", path.display()))?;
+        return Ok(EmailBody {
+            text: None,
+            html: Some(html),
+            markdown: false,
+        });
+    }
+    if !io::stdin().is_terminal() {
+        let mut input = String::new();
+        io::stdin().read_to_string(&mut input)?;
+        let input = input.trim().to_owned();
+        if !input.is_empty() {
+            return Ok(EmailBody {
+                text: Some(input),
+                html: None,
+                markdown: true,
+            });
+        }
+    }
+    bail!("Email body is required");
 }
 
 fn print_output(client: &ApiClient, session_id: &str, lines: usize) -> Result<()> {
@@ -1760,6 +1954,145 @@ mod tests {
     }
 
     #[test]
+    fn email_cli_accepts_positional_message_and_cc() {
+        let cli = Cli::try_parse_from([
+            "sm",
+            "email",
+            "alice,bob",
+            "hello from rust",
+            "--subject",
+            "Status",
+            "--cc",
+            "carol,dave",
+        ])
+        .unwrap();
+
+        let Command::Email(args) = cli.command else {
+            panic!("expected email command");
+        };
+        assert_eq!(args.recipient.as_deref(), Some("alice,bob"));
+        assert_eq!(args.message.as_deref(), Some("hello from rust"));
+        assert_eq!(args.subject.as_deref(), Some("Status"));
+        assert_eq!(args.cc.as_deref(), Some("carol,dave"));
+    }
+
+    #[test]
+    fn email_cli_accepts_file_backed_body_flags() {
+        let text_cli = Cli::try_parse_from([
+            "sm",
+            "email",
+            "alice",
+            "--subject",
+            "Status",
+            "--text",
+            "body.md",
+        ])
+        .unwrap();
+        let Command::Email(text_args) = text_cli.command else {
+            panic!("expected email command");
+        };
+        assert_eq!(text_args.text.as_deref(), Some("body.md"));
+
+        let html_cli = Cli::try_parse_from([
+            "sm",
+            "email",
+            "alice",
+            "--subject",
+            "Status",
+            "--html",
+            "body.html",
+        ])
+        .unwrap();
+        let Command::Email(html_args) = html_cli.command else {
+            panic!("expected email command");
+        };
+        assert_eq!(html_args.html.as_deref(), Some("body.html"));
+    }
+
+    #[test]
+    fn split_email_targets_dedupes_comma_lists() {
+        assert_eq!(
+            split_email_targets(" alice, bob ,,alice,carol "),
+            vec!["alice", "bob", "carol"]
+        );
+    }
+
+    #[test]
+    fn registered_email_payload_preserves_recipient_and_cc_lists() {
+        let payload = registered_email_payload(
+            "sender001".to_owned(),
+            vec!["alice".to_owned(), "bob".to_owned()],
+            vec!["carol".to_owned()],
+            Some("Status".to_owned()),
+            EmailBody {
+                text: Some("hello".to_owned()),
+                html: None,
+                markdown: false,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(payload["requester_session_id"], "sender001");
+        assert_eq!(payload["recipients"], json!(["alice", "bob"]));
+        assert_eq!(payload["cc"], json!(["carol"]));
+        assert_eq!(payload["subject"], "Status");
+        assert_eq!(payload["body_text"], "hello");
+        assert_eq!(payload["body_html"], Value::Null);
+        assert_eq!(payload["body_markdown"], false);
+    }
+
+    #[test]
+    fn registered_email_payload_preserves_html_body() {
+        let payload = registered_email_payload(
+            "sender001".to_owned(),
+            vec!["alice".to_owned()],
+            Vec::new(),
+            Some("Status".to_owned()),
+            EmailBody {
+                text: None,
+                html: Some("<p>hello</p>".to_owned()),
+                markdown: false,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(payload["body_text"], Value::Null);
+        assert_eq!(payload["body_html"], "<p>hello</p>");
+    }
+
+    #[test]
+    fn email_body_rejects_positional_message_with_body_flag() {
+        let error = email_body_from_args(
+            Some("positional".to_owned()),
+            Some("flag".to_owned()),
+            None,
+            None,
+        )
+        .unwrap_err()
+        .to_string();
+
+        assert!(error.contains("use either positional message or --body"));
+    }
+
+    #[test]
+    fn email_body_loads_text_and_html_files() {
+        let markdown_path = write_temp_file("sm-rust-email-body", ".md", "# Summary\n\n- one\n");
+        let markdown_body =
+            email_body_from_args(None, None, Some(markdown_path.display().to_string()), None)
+                .unwrap();
+        assert_eq!(markdown_body.text.as_deref(), Some("# Summary\n\n- one\n"));
+        assert_eq!(markdown_body.html, None);
+        assert!(markdown_body.markdown);
+
+        let html_path = write_temp_file("sm-rust-email-body", ".html", "<p>Summary</p>\n");
+        let html_body =
+            email_body_from_args(None, None, None, Some(html_path.display().to_string())).unwrap();
+        assert_eq!(html_body.text, None);
+        assert_eq!(html_body.html.as_deref(), Some("<p>Summary</p>\n"));
+        assert!(!html_body.markdown);
+    }
+
+    #[test]
     fn subagent_stop_summary_prefers_current_hook_field() {
         let payload = json!({
             "last_assistant_message": "done from hook",
@@ -1840,14 +2173,15 @@ mod tests {
     }
 
     fn write_temp_config(content: &str) -> PathBuf {
+        write_temp_file("sm-rust-client-config", ".yaml", content)
+    }
+
+    fn write_temp_file(prefix: &str, suffix: &str, content: &str) -> PathBuf {
         let nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        let path = env::temp_dir().join(format!(
-            "sm-rust-client-config-{}-{nonce}.yaml",
-            std::process::id()
-        ));
+        let path = env::temp_dir().join(format!("{prefix}-{}-{nonce}{suffix}", std::process::id()));
         fs::write(&path, content).unwrap();
         path
     }

--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -12,6 +12,7 @@ use sha2::{Digest, Sha256};
 #[derive(Debug, Clone)]
 pub struct AppConfig {
     pub paths: PathsConfig,
+    pub email: EmailConfig,
     pub mobile_analytics: MobileAnalyticsConfig,
     pub app_artifacts: AppArtifactsConfig,
     pub bug_reports: BugReportsConfig,
@@ -33,6 +34,7 @@ impl Default for AppConfig {
     fn default() -> Self {
         Self {
             paths: PathsConfig::default(),
+            email: EmailConfig::default(),
             mobile_analytics: MobileAnalyticsConfig::default(),
             app_artifacts: AppArtifactsConfig::default(),
             bug_reports: BugReportsConfig::default(),
@@ -136,6 +138,24 @@ fn repo_data_path(name: &str) -> String {
         .join(name)
         .display()
         .to_string()
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct EmailConfig {
+    #[serde(default = "default_email_bridge_config")]
+    pub bridge_config: String,
+}
+
+impl Default for EmailConfig {
+    fn default() -> Self {
+        Self {
+            bridge_config: default_email_bridge_config(),
+        }
+    }
+}
+
+fn default_email_bridge_config() -> String {
+    "config/email_send.yaml".to_owned()
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -476,6 +496,8 @@ struct RawConfig {
     #[serde(default)]
     paths: RawPathsConfig,
     #[serde(default)]
+    email: EmailConfig,
+    #[serde(default)]
     auth: RawAuthConfig,
     #[serde(default)]
     external_access: ExternalAccessConfig,
@@ -546,6 +568,7 @@ impl From<RawConfig> for AppConfig {
             paths: PathsConfig {
                 state_file: paths.state_file,
             },
+            email: raw.email,
             mobile_analytics: MobileAnalyticsConfig {
                 message_queue_db: paths.message_queue_db,
                 server_log_file: paths.server_log_file,

--- a/crates/sm-server/src/email.rs
+++ b/crates/sm-server/src/email.rs
@@ -1,0 +1,1198 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    env, fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{anyhow, bail, Context, Result};
+use base64::{engine::general_purpose::STANDARD, Engine as _};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+
+use crate::config::{trimmed, AppConfig};
+
+pub const DEFAULT_EMAIL_WEBHOOK_PATH: &str = "/api/email-inbound";
+pub const DEFAULT_EMAIL_WORKER_SECRET_HEADER: &str = "x-email-worker-secret";
+pub const DEFAULT_EMAIL_SESSION_ID_HEADER: &str = "x-email-session-id";
+const MAX_EMAIL_SUBJECT_LENGTH: usize = 140;
+
+#[derive(Debug)]
+pub struct EmailBridge {
+    path: PathBuf,
+    config: BridgeFileConfig,
+}
+
+impl EmailBridge {
+    pub fn load(config: &AppConfig) -> Result<Self> {
+        let path = expand_email_config_path(&config.email.bridge_config);
+        let config = match fs::read_to_string(&path) {
+            Ok(content) => serde_yaml::from_str(&content).with_context(|| {
+                format!("failed to parse email bridge config {}", path.display())
+            })?,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                BridgeFileConfig::default()
+            }
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("failed to read email bridge config {}", path.display())
+                })
+            }
+        };
+        Ok(Self { path, config })
+    }
+
+    pub fn bridge_is_available(&self) -> bool {
+        self.api_key().is_some() && self.domain().is_some()
+    }
+
+    pub fn webhook_path(&self) -> String {
+        normalize_webhook_path(
+            self.config
+                .email_bridge
+                .webhook_path
+                .as_deref()
+                .unwrap_or(DEFAULT_EMAIL_WEBHOOK_PATH),
+        )
+    }
+
+    pub fn worker_secret_header(&self) -> String {
+        self.config
+            .email_bridge
+            .worker_secret_header
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(DEFAULT_EMAIL_WORKER_SECRET_HEADER)
+            .to_ascii_lowercase()
+    }
+
+    pub fn worker_secret(&self) -> Option<String> {
+        trimmed(&self.config.email_bridge.worker_secret)
+    }
+
+    pub fn session_id_header(&self) -> String {
+        self.config
+            .email_bridge
+            .session_id_header
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(DEFAULT_EMAIL_SESSION_ID_HEADER)
+            .to_ascii_lowercase()
+    }
+
+    pub fn is_authorized_sender(&self, sender: &str) -> bool {
+        let sender = sender.trim().to_ascii_lowercase();
+        !sender.is_empty() && self.authorized_senders().contains(&sender)
+    }
+
+    pub fn list_humans(&self) -> Vec<HumanRecipient> {
+        let mut recipients = self
+            .config
+            .humans
+            .iter()
+            .filter_map(|(name, spec)| HumanRecipient::from_spec(name, spec))
+            .collect::<Vec<_>>();
+        recipients.sort_by(|left, right| left.name.cmp(&right.name));
+        recipients
+    }
+
+    pub fn lookup_human(&self, identifier: &str) -> Result<Option<HumanRecipient>> {
+        let needle = identifier.trim().to_ascii_lowercase();
+        if needle.is_empty() {
+            return Ok(None);
+        }
+        let mut matches = self
+            .list_humans()
+            .into_iter()
+            .filter(|human| human.aliases.iter().any(|alias| alias == &needle))
+            .collect::<Vec<_>>();
+        matches.sort_by(|left, right| left.name.cmp(&right.name));
+        if matches.len() > 1 {
+            let names = matches
+                .iter()
+                .map(|human| human.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            bail!(
+                "Human recipient alias \"{identifier}\" is configured for multiple humans: {names}"
+            );
+        }
+        Ok(matches.pop())
+    }
+
+    pub fn lookup_human_email_user(&self, identifier: &str) -> Result<Option<RegisteredEmailUser>> {
+        let Some(human) = self.lookup_human(identifier)? else {
+            return Ok(None);
+        };
+        let Some(channel) = human.channel("email") else {
+            return Ok(None);
+        };
+        let email = channel
+            .resolved_address()
+            .or_else(|| self.lookup_user(&human.name).map(|user| user.email))
+            .filter(|value| !value.trim().is_empty());
+        let Some(email) = email else {
+            return Ok(None);
+        };
+        Ok(Some(RegisteredEmailUser {
+            username: human.name.clone(),
+            email,
+            display_name: human.display_name.clone(),
+            aliases: human.aliases.iter().cloned().collect(),
+        }))
+    }
+
+    pub fn lookup_user(&self, identifier: &str) -> Option<RegisteredEmailUser> {
+        let needle = identifier.trim().to_ascii_lowercase();
+        if needle.is_empty() {
+            return None;
+        }
+        self.config
+            .users
+            .iter()
+            .filter_map(|(username, spec)| RegisteredEmailUser::from_spec(username, spec))
+            .find(|user| user.aliases.contains(&needle))
+    }
+
+    pub fn resolve_users(&self, identifiers: &[String]) -> Result<Vec<RegisteredEmailUser>> {
+        let mut users = Vec::new();
+        let mut seen = BTreeSet::new();
+        for identifier in identifiers {
+            let Some(user) = self.lookup_user(identifier) else {
+                bail!("No registered email user found for '{identifier}'");
+            };
+            let key = user.email.to_ascii_lowercase();
+            if seen.insert(key) {
+                users.push(user);
+            }
+        }
+        if users.is_empty() {
+            bail!("No registered email users were provided");
+        }
+        Ok(users)
+    }
+
+    pub fn send_agent_email(&self, request: SendAgentEmailRequest) -> Result<SentEmail> {
+        if !self.bridge_is_available() {
+            bail!(
+                "Email bridge config is unavailable at {}",
+                self.path.display()
+            );
+        }
+        let sender_session_id = request.sender_session_id.trim();
+        if sender_session_id.is_empty() {
+            bail!("Managed sender session is required for agent email delivery");
+        }
+        let sender_name = if request.sender_name.trim().is_empty() {
+            sender_session_id
+        } else {
+            request.sender_name.trim()
+        };
+        let sender_provider = if request.sender_provider.trim().is_empty() {
+            "unknown"
+        } else {
+            request.sender_provider.trim()
+        };
+
+        let mut text_payload = request.body_text.trim().to_owned();
+        let mut html_payload = request.body_html.trim().to_owned();
+        if text_payload.is_empty() && html_payload.is_empty() {
+            bail!("Email body is required");
+        }
+        if request.body_markdown && !text_payload.is_empty() && html_payload.is_empty() {
+            html_payload = render_markdown_to_html(&text_payload);
+        } else if !text_payload.is_empty() && html_payload.is_empty() {
+            html_payload = plain_text_to_html(&text_payload);
+        } else if !html_payload.is_empty() && text_payload.is_empty() {
+            text_payload = strip_html(&html_payload);
+        }
+
+        let subject = match request
+            .subject
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            Some(subject) => subject.to_owned(),
+            None if request.auto_subject => default_subject(sender_name, &text_payload),
+            None => bail!("Email subject is required"),
+        };
+        let footer = build_routing_footer(sender_name, sender_session_id, sender_provider);
+        let (text_payload, html_payload) =
+            append_routing_footer(&text_payload, &html_payload, &footer);
+        let from_address = self.reply_address(sender_session_id)?;
+        let from_header = format!("{sender_name} <{from_address}>");
+        let api_key = self
+            .api_key()
+            .ok_or_else(|| anyhow!("Email bridge is missing resend.api_key"))?;
+        let endpoint = format!("{}/emails", self.api_base_url());
+
+        let mut payload = json!({
+            "from": from_header,
+            "to": request.to_users.iter().map(|user| user.email.clone()).collect::<Vec<_>>(),
+            "subject": subject,
+            "text": text_payload,
+            "reply_to": from_address,
+            "headers": {
+                "X-SM-Session-ID": sender_session_id,
+            },
+        });
+        if !request.cc_users.is_empty() {
+            payload["cc"] = json!(request
+                .cc_users
+                .iter()
+                .map(|user| user.email.clone())
+                .collect::<Vec<_>>());
+        }
+        if !html_payload.is_empty() {
+            payload["html"] = Value::String(html_payload);
+        }
+
+        let body_bytes = serde_json::to_vec(&payload)?;
+        let agent: ureq::Agent = ureq::Agent::config_builder()
+            .http_status_as_error(false)
+            .build()
+            .into();
+        let mut response = agent
+            .post(&endpoint)
+            .header("Authorization", format!("Bearer {api_key}"))
+            .header("Content-Type", "application/json")
+            .send(body_bytes.as_slice())
+            .with_context(|| format!("failed to request {endpoint}"))?;
+        let status = response.status().as_u16();
+        let response_body = response.body_mut().read_to_string()?;
+        if status >= 400 {
+            bail!("Resend email send failed ({status}): {response_body}");
+        }
+        let response_payload = serde_json::from_str::<Value>(&response_body).unwrap_or(Value::Null);
+        Ok(SentEmail {
+            subject: payload["subject"].as_str().unwrap_or("").to_owned(),
+            to: request.to_users,
+            cc: request.cc_users,
+            message_id: response_payload
+                .get("id")
+                .and_then(Value::as_str)
+                .map(ToOwned::to_owned),
+            from: payload["from"].as_str().unwrap_or("").to_owned(),
+            reply_to: payload["reply_to"].as_str().unwrap_or("").to_owned(),
+        })
+    }
+
+    fn authorized_senders(&self) -> BTreeSet<String> {
+        string_list(&self.config.email_bridge.authorized_senders)
+            .into_iter()
+            .map(|value| value.to_ascii_lowercase())
+            .collect()
+    }
+
+    fn api_key(&self) -> Option<String> {
+        trimmed(&self.config.resend.api_key)
+    }
+
+    fn domain(&self) -> Option<String> {
+        trimmed(&self.config.resend.domain)
+    }
+
+    fn reply_address(&self, sender_session_id: &str) -> Result<String> {
+        if let Some(value) = trimmed(&self.config.resend.reply_address)
+            .or_else(|| trimmed(&self.config.resend.from_address))
+        {
+            return Ok(value);
+        }
+        let domain = trimmed(&self.config.resend.reply_domain)
+            .or_else(|| self.domain())
+            .ok_or_else(|| anyhow!("Email bridge is missing resend.domain"))?;
+        Ok(format!("{sender_session_id}@{domain}"))
+    }
+
+    fn api_base_url(&self) -> String {
+        trimmed(&self.config.resend.api_base_url)
+            .unwrap_or_else(|| "https://api.resend.com".to_owned())
+            .trim_end_matches('/')
+            .to_owned()
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HumanRecipientResponse {
+    pub recipient: String,
+    pub display_name: String,
+    pub aliases: Vec<String>,
+    pub default_channel: String,
+    pub available_channels: Vec<String>,
+    pub telegram_delivery: Option<String>,
+    pub email_use: Option<String>,
+}
+
+impl From<HumanRecipient> for HumanRecipientResponse {
+    fn from(human: HumanRecipient) -> Self {
+        let telegram_delivery = human
+            .channel("telegram")
+            .and_then(|channel| channel.delivery);
+        let email_use = human.channel("email").and_then(|channel| channel.use_);
+        let available_channels = human.available_channels();
+        Self {
+            recipient: human.name,
+            display_name: human.display_name,
+            aliases: human.aliases,
+            default_channel: human.default_channel,
+            available_channels,
+            telegram_delivery,
+            email_use,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct HumanRecipient {
+    pub name: String,
+    pub display_name: String,
+    pub aliases: Vec<String>,
+    pub default_channel: String,
+    pub channels: BTreeMap<String, HumanChannel>,
+}
+
+impl HumanRecipient {
+    fn from_spec(raw_name: &str, raw_spec: &HumanSpec) -> Option<Self> {
+        let name = raw_name.trim().to_ascii_lowercase();
+        if name.is_empty() {
+            return None;
+        }
+        let display_name = trimmed(&raw_spec.display_name)
+            .or_else(|| trimmed(&raw_spec.name))
+            .unwrap_or_else(|| name.clone());
+        let default_channel = trimmed(&raw_spec.default_channel)
+            .unwrap_or_else(|| "telegram".to_owned())
+            .to_ascii_lowercase();
+        let mut aliases = vec![name.clone()];
+        aliases.extend(
+            string_list(&raw_spec.aliases)
+                .into_iter()
+                .map(|value| value.to_ascii_lowercase()),
+        );
+        aliases = dedupe_nonempty(aliases);
+        let channels = raw_spec
+            .channels
+            .iter()
+            .filter_map(|(channel_name, spec)| {
+                HumanChannel::from_spec(channel_name, spec)
+                    .map(|channel| (channel.name.clone(), channel))
+            })
+            .collect();
+        Some(Self {
+            name,
+            display_name,
+            aliases,
+            default_channel,
+            channels,
+        })
+    }
+
+    pub fn channel(&self, name: &str) -> Option<HumanChannel> {
+        self.channels
+            .get(name)
+            .filter(|channel| channel.enabled)
+            .cloned()
+    }
+
+    fn available_channels(&self) -> Vec<String> {
+        self.channels
+            .values()
+            .filter(|channel| channel.enabled)
+            .map(|channel| channel.name.clone())
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct HumanChannel {
+    pub name: String,
+    pub enabled: bool,
+    pub delivery: Option<String>,
+    pub address: Option<String>,
+    pub address_env: Option<String>,
+    pub use_: Option<String>,
+}
+
+impl HumanChannel {
+    fn from_spec(raw_name: &str, raw_spec: &ChannelSpec) -> Option<Self> {
+        let name = raw_name.trim().to_ascii_lowercase();
+        if name.is_empty() {
+            return None;
+        }
+        Some(Self {
+            name,
+            enabled: raw_spec.enabled(),
+            delivery: trimmed(&raw_spec.delivery()).map(|value| value.to_ascii_lowercase()),
+            address: trimmed(&raw_spec.address()),
+            address_env: trimmed(&raw_spec.address_env()),
+            use_: trimmed(&raw_spec.use_()).map(|value| value.to_ascii_lowercase()),
+        })
+    }
+
+    fn resolved_address(&self) -> Option<String> {
+        trimmed(&self.address).or_else(|| {
+            self.address_env
+                .as_deref()
+                .and_then(|key| env::var(key).ok())
+                .map(|value| value.trim().to_owned())
+                .filter(|value| !value.is_empty())
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RegisteredEmailUser {
+    pub username: String,
+    pub email: String,
+    pub display_name: String,
+    pub aliases: BTreeSet<String>,
+}
+
+impl RegisteredEmailUser {
+    fn from_spec(username: &str, spec: &UserSpec) -> Option<Self> {
+        let username = username.trim().to_owned();
+        if username.is_empty() {
+            return None;
+        }
+        let email = match spec {
+            UserSpec::Address(value) => value.trim().to_owned(),
+            UserSpec::Details(details) => trimmed(&details.email).unwrap_or_default(),
+        };
+        if email.is_empty() {
+            return None;
+        }
+        let display_name = match spec {
+            UserSpec::Address(_) => username.clone(),
+            UserSpec::Details(details) => {
+                trimmed(&details.name).unwrap_or_else(|| username.clone())
+            }
+        };
+        let mut aliases = BTreeSet::from([username.to_ascii_lowercase()]);
+        if let UserSpec::Details(details) = spec {
+            aliases.extend(
+                string_list(&details.aliases)
+                    .into_iter()
+                    .map(|value| value.to_ascii_lowercase()),
+            );
+        }
+        Some(Self {
+            username,
+            email,
+            display_name,
+            aliases,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SendAgentEmailRequest {
+    pub sender_session_id: String,
+    pub sender_name: String,
+    pub sender_provider: String,
+    pub to_users: Vec<RegisteredEmailUser>,
+    pub cc_users: Vec<RegisteredEmailUser>,
+    pub subject: Option<String>,
+    pub body_text: String,
+    pub body_html: String,
+    pub body_markdown: bool,
+    pub auto_subject: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SentEmail {
+    pub subject: String,
+    pub to: Vec<RegisteredEmailUser>,
+    pub cc: Vec<RegisteredEmailUser>,
+    pub message_id: Option<String>,
+    pub from: String,
+    pub reply_to: String,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct BridgeFileConfig {
+    #[serde(default)]
+    resend: ResendConfig,
+    #[serde(default)]
+    humans: BTreeMap<String, HumanSpec>,
+    #[serde(default)]
+    users: BTreeMap<String, UserSpec>,
+    #[serde(default)]
+    email_bridge: EmailBridgeConfig,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ResendConfig {
+    #[serde(default)]
+    api_key: Option<String>,
+    #[serde(default)]
+    domain: Option<String>,
+    #[serde(default)]
+    reply_domain: Option<String>,
+    #[serde(default)]
+    reply_address: Option<String>,
+    #[serde(default)]
+    from_address: Option<String>,
+    #[serde(default)]
+    api_base_url: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct EmailBridgeConfig {
+    #[serde(default)]
+    authorized_senders: StringList,
+    #[serde(default)]
+    worker_secret: Option<String>,
+    #[serde(default)]
+    worker_secret_header: Option<String>,
+    #[serde(default)]
+    session_id_header: Option<String>,
+    #[serde(default)]
+    webhook_path: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct HumanSpec {
+    #[serde(default)]
+    display_name: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    aliases: StringList,
+    #[serde(default)]
+    default_channel: Option<String>,
+    #[serde(default)]
+    channels: BTreeMap<String, ChannelSpec>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(untagged)]
+enum ChannelSpec {
+    Bool(bool),
+    Details(ChannelDetails),
+    #[default]
+    Invalid,
+}
+
+impl ChannelSpec {
+    fn enabled(&self) -> bool {
+        match self {
+            Self::Bool(value) => *value,
+            Self::Details(details) => details.enabled,
+            Self::Invalid => false,
+        }
+    }
+
+    fn delivery(&self) -> Option<String> {
+        match self {
+            Self::Details(details) => details.delivery.clone(),
+            _ => None,
+        }
+    }
+
+    fn address(&self) -> Option<String> {
+        match self {
+            Self::Details(details) => details.address.clone(),
+            _ => None,
+        }
+    }
+
+    fn address_env(&self) -> Option<String> {
+        match self {
+            Self::Details(details) => details.address_env.clone(),
+            _ => None,
+        }
+    }
+
+    fn use_(&self) -> Option<String> {
+        match self {
+            Self::Details(details) => details.use_.clone(),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct ChannelDetails {
+    #[serde(default)]
+    enabled: bool,
+    #[serde(default)]
+    delivery: Option<String>,
+    #[serde(default)]
+    address: Option<String>,
+    #[serde(default)]
+    address_env: Option<String>,
+    #[serde(default, rename = "use")]
+    use_: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum UserSpec {
+    Address(String),
+    Details(UserDetails),
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct UserDetails {
+    #[serde(default)]
+    email: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    aliases: StringList,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(untagged)]
+enum StringList {
+    One(String),
+    Many(Vec<String>),
+    #[default]
+    Empty,
+}
+
+fn string_list(value: &StringList) -> Vec<String> {
+    match value {
+        StringList::One(value) => vec![value.trim().to_owned()],
+        StringList::Many(values) => values.iter().map(|value| value.trim().to_owned()).collect(),
+        StringList::Empty => Vec::new(),
+    }
+    .into_iter()
+    .filter(|value| !value.is_empty())
+    .collect()
+}
+
+fn dedupe_nonempty(values: Vec<String>) -> Vec<String> {
+    let mut seen = BTreeSet::new();
+    let mut result = Vec::new();
+    for value in values {
+        if !value.trim().is_empty() && seen.insert(value.clone()) {
+            result.push(value);
+        }
+    }
+    result
+}
+
+fn expand_email_config_path(path: &str) -> PathBuf {
+    if path == "~" {
+        return env::var("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from(path));
+    }
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Ok(home) = env::var("HOME") {
+            return PathBuf::from(home).join(rest);
+        }
+    }
+    Path::new(path).to_path_buf()
+}
+
+pub fn normalize_webhook_path(path: &str) -> String {
+    let path = path.trim();
+    if path.is_empty() {
+        return DEFAULT_EMAIL_WEBHOOK_PATH.to_owned();
+    }
+    if path.starts_with('/') {
+        path.to_owned()
+    } else {
+        format!("/{path}")
+    }
+}
+
+pub fn normalize_explicit_session_id(value: &str) -> Option<String> {
+    let value = value.trim().to_ascii_lowercase();
+    if value.len() < 6
+        || !value
+            .chars()
+            .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit())
+    {
+        return None;
+    }
+    Some(value)
+}
+
+pub fn extract_routed_session_id(body_text: &str) -> Option<String> {
+    body_text
+        .replace("\r\n", "\n")
+        .lines()
+        .rev()
+        .find_map(routed_session_from_line)
+}
+
+fn routed_session_from_line(line: &str) -> Option<String> {
+    let line = line.trim().trim_start_matches('>').trim();
+    let rest = line.strip_prefix("SM:")?.trim();
+    let parts = rest.split_whitespace().collect::<Vec<_>>();
+    if parts.len() < 3 {
+        return None;
+    }
+    normalize_explicit_session_id(parts[parts.len() - 2])
+}
+
+pub fn extract_reply_message_body(body_text: &str) -> String {
+    let normalized = body_text.replace("\r\n", "\n");
+    let mut body_lines = Vec::new();
+    for line in normalized.trim().lines() {
+        let trimmed = line.trim();
+        if line.starts_with('>')
+            || (trimmed.starts_with("On ") && trimmed.ends_with("wrote:"))
+            || line.starts_with("From:")
+            || line.starts_with("Sent:")
+            || line.starts_with("Subject:")
+            || line.starts_with("To:")
+        {
+            break;
+        }
+        body_lines.push(line.to_owned());
+    }
+    while body_lines.last().is_some_and(|line| line.trim().is_empty()) {
+        body_lines.pop();
+    }
+    if body_lines
+        .last()
+        .and_then(|line| routed_session_from_line(line))
+        .is_some()
+    {
+        body_lines.pop();
+        while body_lines.last().is_some_and(|line| line.trim().is_empty()) {
+            body_lines.pop();
+        }
+        if body_lines.last().is_some_and(|line| line.trim() == "--") {
+            body_lines.pop();
+        }
+    }
+    body_lines.join("\n").trim().to_owned()
+}
+
+pub fn extract_text_from_raw_email(raw_email: &str) -> String {
+    let normalized = raw_email.trim();
+    if normalized.is_empty() {
+        return String::new();
+    }
+    let (_, fallback_body) = split_headers_body(normalized);
+    extract_mime_text(normalized)
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or_else(|| fallback_body.trim().to_owned())
+}
+
+pub fn extract_subject_from_raw_email(raw_email: &str) -> Option<String> {
+    for line in raw_email.lines() {
+        if line.trim().is_empty() {
+            break;
+        }
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        if name.trim().eq_ignore_ascii_case("subject") {
+            let subject = value.split_whitespace().collect::<Vec<_>>().join(" ");
+            return (!subject.is_empty()).then_some(subject);
+        }
+    }
+    None
+}
+
+fn extract_mime_text(raw_email: &str) -> Option<String> {
+    let (headers, body) = split_headers_body(raw_email);
+    let headers = parse_headers(headers);
+    if header_contains(&headers, "content-disposition", "attachment") {
+        return None;
+    }
+
+    let content_type = headers
+        .get("content-type")
+        .map(String::as_str)
+        .unwrap_or("text/plain");
+    let media_type = content_type
+        .split(';')
+        .next()
+        .unwrap_or("text/plain")
+        .trim()
+        .to_ascii_lowercase();
+    if media_type.starts_with("multipart/") {
+        return extract_multipart_text(body, content_type);
+    }
+
+    let decoded = decode_transfer_encoded_body(
+        body,
+        headers
+            .get("content-transfer-encoding")
+            .map(String::as_str)
+            .unwrap_or(""),
+    );
+    if media_type == "text/html" {
+        return Some(strip_html(&decoded));
+    }
+    Some(decoded.trim().to_owned())
+}
+
+fn extract_multipart_text(body: &str, content_type: &str) -> Option<String> {
+    let boundary = content_type_param(content_type, "boundary")?;
+    let mut html_fallback = None;
+    for part in multipart_parts(body, &boundary) {
+        let (part_headers_raw, part_body) = split_headers_body(&part);
+        let part_headers = parse_headers(part_headers_raw);
+        if header_contains(&part_headers, "content-disposition", "attachment") {
+            continue;
+        }
+        let part_content_type = part_headers
+            .get("content-type")
+            .map(String::as_str)
+            .unwrap_or("text/plain");
+        let media_type = part_content_type
+            .split(';')
+            .next()
+            .unwrap_or("text/plain")
+            .trim()
+            .to_ascii_lowercase();
+        if media_type.starts_with("multipart/") {
+            let nested = extract_mime_text(&part);
+            if nested
+                .as_deref()
+                .is_some_and(|value| !value.trim().is_empty())
+            {
+                return nested;
+            }
+            continue;
+        }
+        let decoded = decode_transfer_encoded_body(
+            part_body,
+            part_headers
+                .get("content-transfer-encoding")
+                .map(String::as_str)
+                .unwrap_or(""),
+        );
+        if media_type == "text/plain" {
+            let decoded = decoded.trim().to_owned();
+            if !decoded.is_empty() {
+                return Some(decoded);
+            }
+        } else if media_type == "text/html" && html_fallback.is_none() {
+            let html = strip_html(&decoded);
+            if !html.trim().is_empty() {
+                html_fallback = Some(html);
+            }
+        }
+    }
+    html_fallback
+}
+
+fn split_headers_body(raw: &str) -> (&str, &str) {
+    raw.split_once("\r\n\r\n")
+        .or_else(|| raw.split_once("\n\n"))
+        .unwrap_or(("", raw))
+}
+
+fn parse_headers(raw: &str) -> BTreeMap<String, String> {
+    let mut headers = BTreeMap::new();
+    let mut current_name: Option<String> = None;
+    for line in raw.lines() {
+        if line.starts_with(' ') || line.starts_with('\t') {
+            if let Some(name) = current_name.as_ref() {
+                let value = headers.entry(name.clone()).or_insert_with(String::new);
+                value.push(' ');
+                value.push_str(line.trim());
+            }
+            continue;
+        }
+        let Some((name, value)) = line.split_once(':') else {
+            continue;
+        };
+        let name = name.trim().to_ascii_lowercase();
+        if name.is_empty() {
+            continue;
+        }
+        headers.insert(name.clone(), value.trim().to_owned());
+        current_name = Some(name);
+    }
+    headers
+}
+
+fn header_contains(headers: &BTreeMap<String, String>, name: &str, needle: &str) -> bool {
+    headers
+        .get(name)
+        .is_some_and(|value| value.to_ascii_lowercase().contains(needle))
+}
+
+fn content_type_param(content_type: &str, name: &str) -> Option<String> {
+    for part in content_type.split(';').skip(1) {
+        let Some((key, value)) = part.split_once('=') else {
+            continue;
+        };
+        if key.trim().eq_ignore_ascii_case(name) {
+            return Some(value.trim().trim_matches('"').to_owned());
+        }
+    }
+    None
+}
+
+fn multipart_parts(body: &str, boundary: &str) -> Vec<String> {
+    let delimiter = format!("--{boundary}");
+    let closing = format!("--{boundary}--");
+    let normalized = body.replace("\r\n", "\n");
+    let mut parts = Vec::new();
+    let mut current = Vec::new();
+    let mut in_part = false;
+    for line in normalized.lines() {
+        let marker = line.trim_end();
+        if marker == closing {
+            if in_part && !current.is_empty() {
+                parts.push(current.join("\n"));
+            }
+            break;
+        }
+        if marker == delimiter {
+            if in_part && !current.is_empty() {
+                parts.push(current.join("\n"));
+                current.clear();
+            }
+            in_part = true;
+            continue;
+        }
+        if in_part {
+            current.push(line.to_owned());
+        }
+    }
+    parts
+}
+
+fn decode_transfer_encoded_body(body: &str, encoding: &str) -> String {
+    match encoding.trim().to_ascii_lowercase().as_str() {
+        "base64" => {
+            let compact = body.split_whitespace().collect::<String>();
+            STANDARD
+                .decode(compact.as_bytes())
+                .ok()
+                .map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+                .unwrap_or_else(|| body.trim().to_owned())
+        }
+        "quoted-printable" => decode_quoted_printable(body),
+        _ => body.trim().to_owned(),
+    }
+}
+
+fn decode_quoted_printable(body: &str) -> String {
+    let bytes = body.as_bytes();
+    let mut output = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'=' {
+            if index + 1 < bytes.len() && bytes[index + 1] == b'\n' {
+                index += 2;
+                continue;
+            }
+            if index + 2 < bytes.len() && bytes[index + 1] == b'\r' && bytes[index + 2] == b'\n' {
+                index += 3;
+                continue;
+            }
+            if index + 2 < bytes.len() {
+                if let (Some(high), Some(low)) =
+                    (hex_value(bytes[index + 1]), hex_value(bytes[index + 2]))
+                {
+                    output.push((high << 4) | low);
+                    index += 3;
+                    continue;
+                }
+            }
+        }
+        output.push(bytes[index]);
+        index += 1;
+    }
+    String::from_utf8_lossy(&output).trim().to_owned()
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn build_routing_footer(
+    sender_name: &str,
+    sender_session_id: &str,
+    sender_provider: &str,
+) -> String {
+    format!(
+        "SM: {} {} {}",
+        collapse_whitespace(sender_name).unwrap_or_else(|| "session".to_owned()),
+        sender_session_id,
+        collapse_whitespace(sender_provider).unwrap_or_else(|| "unknown".to_owned())
+    )
+}
+
+fn append_routing_footer(body_text: &str, body_html: &str, footer: &str) -> (String, String) {
+    let text = if body_text.trim().is_empty() {
+        format!("--\n{footer}")
+    } else {
+        format!("{}\n\n--\n{footer}", body_text.trim_end())
+    };
+    let html_footer = format!("<hr/>\n<p>{}</p>", escape_html(footer));
+    let html = if body_html.trim().is_empty() {
+        html_footer
+    } else {
+        format!("{}\n{html_footer}", body_html.trim_end())
+    };
+    (text, html)
+}
+
+fn default_subject(sender_name: &str, body_text: &str) -> String {
+    let mut subject = String::new();
+    for line in body_text.lines() {
+        let line = line.split_whitespace().collect::<Vec<_>>().join(" ");
+        let line = line.trim().trim_start_matches(['#', '*', '-', ' ']).trim();
+        if !line.is_empty() {
+            subject = line.to_owned();
+            break;
+        }
+    }
+    if subject.is_empty() {
+        subject = format!(
+            "Message from {}",
+            if sender_name.is_empty() {
+                "Session Manager"
+            } else {
+                sender_name
+            }
+        );
+    }
+    subject.chars().take(MAX_EMAIL_SUBJECT_LENGTH).collect()
+}
+
+fn collapse_whitespace(value: &str) -> Option<String> {
+    let collapsed = value.split_whitespace().collect::<Vec<_>>().join(" ");
+    (!collapsed.is_empty()).then_some(collapsed)
+}
+
+fn plain_text_to_html(body_text: &str) -> String {
+    let paragraphs = body_text
+        .split("\n\n")
+        .map(str::trim)
+        .filter(|chunk| !chunk.is_empty())
+        .map(|paragraph| format!("<p>{}</p>", escape_html(paragraph).replace('\n', "<br/>")))
+        .collect::<Vec<_>>();
+    if paragraphs.is_empty() {
+        "<p></p>".to_owned()
+    } else {
+        paragraphs.join("\n")
+    }
+}
+
+fn render_markdown_to_html(body_text: &str) -> String {
+    plain_text_to_html(body_text)
+}
+
+fn strip_html(body_html: &str) -> String {
+    let mut result = String::new();
+    let mut in_tag = false;
+    let mut tag = String::new();
+    for ch in body_html.chars() {
+        match ch {
+            '<' => {
+                in_tag = true;
+                tag.clear();
+            }
+            '>' => {
+                in_tag = false;
+                if html_tag_breaks_text(&tag) && !result.ends_with('\n') {
+                    result.push('\n');
+                }
+            }
+            _ if in_tag => tag.push(ch),
+            _ if !in_tag => result.push(ch),
+            _ => {}
+        }
+    }
+    result
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&amp;", "&")
+        .trim()
+        .to_owned()
+}
+
+fn html_tag_breaks_text(tag: &str) -> bool {
+    let tag = tag
+        .trim()
+        .trim_start_matches('/')
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    matches!(
+        tag.as_str(),
+        "br" | "div" | "p" | "li" | "tr" | "table" | "hr"
+    )
+}
+
+fn escape_html(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_last_routing_footer_session_id() {
+        let body = "hello\n\n--\nSM: Agent Name abc123 codex-fork\n\n> SM: old old123 claude";
+        assert_eq!(extract_routed_session_id(body).as_deref(), Some("old123"));
+    }
+
+    #[test]
+    fn strips_footer_and_quoted_reply() {
+        let body = "Thanks\n\n--\nSM: Agent abc123 claude\n\n> older";
+        assert_eq!(extract_reply_message_body(body), "Thanks");
+    }
+
+    #[test]
+    fn extracts_text_plain_from_multipart_raw_email() {
+        let raw = concat!(
+            "Subject: Re: status\r\n",
+            "Content-Type: multipart/alternative; boundary=\"sm-boundary\"\r\n",
+            "\r\n",
+            "--sm-boundary\r\n",
+            "Content-Type: text/html; charset=utf-8\r\n",
+            "\r\n",
+            "<p>html should not win</p>\r\n",
+            "--sm-boundary\r\n",
+            "Content-Type: text/plain; charset=utf-8\r\n",
+            "Content-Transfer-Encoding: quoted-printable\r\n",
+            "\r\n",
+            "Here=20is=20the=20reply=0A=0A--=0ASM:=20Runner=20run12345=20claude\r\n",
+            "--sm-boundary--\r\n",
+        );
+
+        let text = extract_text_from_raw_email(raw);
+
+        assert_eq!(
+            extract_routed_session_id(&text).as_deref(),
+            Some("run12345")
+        );
+        assert_eq!(extract_reply_message_body(&text), "Here is the reply");
+        assert!(!text.contains("html should not win"));
+    }
+
+    #[test]
+    fn decodes_base64_html_raw_email_when_no_text_part_exists() {
+        let html = "<p>Fallback reply</p><p>SM: Runner run12345 claude</p>";
+        let raw = format!(
+            "Content-Type: text/html; charset=utf-8\r\nContent-Transfer-Encoding: base64\r\n\r\n{}",
+            STANDARD.encode(html.as_bytes())
+        );
+
+        let text = extract_text_from_raw_email(&raw);
+
+        assert!(text.contains("Fallback reply"));
+        assert_eq!(
+            extract_routed_session_id(&text).as_deref(),
+            Some("run12345")
+        );
+    }
+}

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -41,6 +41,11 @@ use crate::app_artifacts::{
 };
 use crate::bug_reports::{BugReportStore, CreateBugReport};
 use crate::config::{trimmed, AppConfig, PublicNodeConfig};
+use crate::email::{
+    extract_reply_message_body, extract_routed_session_id, extract_subject_from_raw_email,
+    extract_text_from_raw_email, normalize_explicit_session_id, EmailBridge,
+    HumanRecipientResponse, SendAgentEmailRequest, DEFAULT_EMAIL_WEBHOOK_PATH,
+};
 use crate::mobile_analytics::build_mobile_analytics_summary;
 use crate::queue::{
     CodexReviewRequestFilters, CodexReviewRequestRegistration, QueueJobFilters, QueueJobRecord,
@@ -87,7 +92,11 @@ impl AppState {
 }
 
 pub fn router(state: AppState) -> Router {
-    Router::new()
+    let inbound_email_alias = EmailBridge::load(&state.config)
+        .ok()
+        .map(|bridge| bridge.webhook_path())
+        .unwrap_or_else(|| DEFAULT_EMAIL_WEBHOOK_PATH.to_owned());
+    let mut app = Router::new()
         .route("/health", get(health))
         .route("/health/detailed", get(health_detailed))
         .route("/auth/session", get(auth_session))
@@ -109,6 +118,11 @@ pub fn router(state: AppState) -> Router {
         .route("/queue-jobs", get(list_queue_jobs))
         .route("/codex-review-requests", get(list_codex_review_requests))
         .route("/nodes", get(list_nodes))
+        .route("/humans", get(list_humans))
+        .route("/humans/{identifier}", get(get_human))
+        .route("/humans/{identifier}/email", post(send_human_email))
+        .route("/email/send", post(send_registered_email))
+        .route(DEFAULT_EMAIL_WEBHOOK_PATH, post(inbound_email_webhook))
         .route("/sessions", get(list_sessions).post(create_session))
         .route("/sessions/input-batch", post(send_session_input_batch))
         .route("/sessions/spawn", post(spawn_session))
@@ -162,11 +176,14 @@ pub fn router(state: AppState) -> Router {
         .route("/sessions/{session_id}/output", get(session_output))
         .route("/client/sessions", get(list_client_sessions))
         .route("/client/sessions/{session_id}", get(get_client_session))
-        .fallback(not_found)
-        .layer(DefaultBodyLimit::max(
-            APP_ARTIFACT_MAX_SIZE_BYTES + 1024 * 1024,
-        ))
-        .with_state(Arc::new(state))
+        .fallback(not_found);
+    if inbound_email_alias != DEFAULT_EMAIL_WEBHOOK_PATH {
+        app = app.route(&inbound_email_alias, post(inbound_email_webhook));
+    }
+    app.layer(DefaultBodyLimit::max(
+        APP_ARTIFACT_MAX_SIZE_BYTES + 1024 * 1024,
+    ))
+    .with_state(Arc::new(state))
 }
 
 async fn health() -> Json<Value> {
@@ -421,6 +438,344 @@ async fn submit_client_bug_report(
     }))
 }
 
+async fn list_humans(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    let bridge = email_bridge(&state.config)?;
+    let humans = bridge
+        .list_humans()
+        .into_iter()
+        .map(HumanRecipientResponse::from)
+        .collect::<Vec<_>>();
+    Ok(Json(json!({ "humans": humans })))
+}
+
+async fn get_human(
+    State(state): State<Arc<AppState>>,
+    Path(identifier): Path<String>,
+    request: Request,
+) -> Result<Json<HumanRecipientResponse>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    let bridge = email_bridge(&state.config)?;
+    let Some(human) = bridge
+        .lookup_human(&identifier)
+        .map_err(email_config_error)?
+    else {
+        return Err(ApiError::NotFound("Human recipient not configured"));
+    };
+    Ok(Json(HumanRecipientResponse::from(human)))
+}
+
+async fn send_human_email(
+    State(state): State<Arc<AppState>>,
+    Path(identifier): Path<String>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(payload): Json<HumanDeliveryRequest>,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_allowed_from_parts(
+        &state.config,
+        &headers,
+        Some(peer_addr),
+        &format!("/humans/{identifier}/email"),
+    )?;
+    let bridge = email_bridge_or_503(&state.config)?;
+    let Some(human) = bridge
+        .lookup_human(&identifier)
+        .map_err(email_config_error)?
+    else {
+        return Err(ApiError::NotFound("Human recipient not configured"));
+    };
+    if human.channel("email").is_none() {
+        return Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: format!(
+                "Human recipient \"{}\" has no enabled email channel",
+                human.name
+            ),
+        });
+    }
+    let Some(resolved_email_user) = bridge
+        .lookup_human_email_user(&human.name)
+        .map_err(email_config_error)?
+    else {
+        return Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: format!(
+                "Human recipient \"{}\" has no resolved email address",
+                human.name
+            ),
+        });
+    };
+    let sender_session_id = required_sender_session_id(payload.requester_session_id.as_deref())?;
+    let sender_session = state
+        .session_store
+        .get_session(&sender_session_id)?
+        .ok_or(ApiError::NotFound("Sender session not found"))?;
+    let sent = bridge
+        .send_agent_email(SendAgentEmailRequest {
+            sender_session_id: sender_session.id.clone(),
+            sender_name: session_display_name(sender_session.clone()),
+            sender_provider: sender_session.provider,
+            to_users: vec![resolved_email_user],
+            cc_users: Vec::new(),
+            subject: payload.subject,
+            body_text: payload.text,
+            body_html: String::new(),
+            body_markdown: payload.body_markdown,
+            auto_subject: payload.auto_subject,
+        })
+        .map_err(email_send_error)?;
+    Ok(Json(json!({
+        "status": "sent",
+        "recipient": human.name,
+        "channel": "email",
+        "subject": sent.subject,
+        "to": [{"username": human.name}],
+    })))
+}
+
+async fn send_registered_email(
+    State(state): State<Arc<AppState>>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(payload): Json<SendEmailRequest>,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_allowed_from_parts(&state.config, &headers, Some(peer_addr), "/email/send")?;
+    let bridge = email_bridge_or_503(&state.config)?;
+    let sender_session_id = required_sender_session_id(payload.requester_session_id.as_deref())?;
+    let sender_session = state
+        .session_store
+        .get_session(&sender_session_id)?
+        .ok_or(ApiError::NotFound("Sender session not found"))?;
+    let recipients = unique_identifiers(&payload.recipients);
+    let cc = unique_identifiers(&payload.cc);
+    if recipients.is_empty() {
+        return Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: "At least one email recipient is required".to_owned(),
+        });
+    }
+    for identifier in recipients.iter().chain(cc.iter()) {
+        if let Some(human) = bridge
+            .lookup_human(identifier)
+            .map_err(email_config_error)?
+        {
+            return Err(ApiError::Status {
+                status: StatusCode::BAD_REQUEST,
+                detail: format!(
+                    "Human recipient \"{}\" must use explicit human email delivery; generic email routing is not allowed",
+                    human.name
+                ),
+            });
+        }
+    }
+    let to_users = bridge
+        .resolve_users(&recipients)
+        .map_err(email_lookup_error)?;
+    let cc_users = if cc.is_empty() {
+        Vec::new()
+    } else {
+        bridge.resolve_users(&cc).map_err(email_lookup_error)?
+    };
+    let sent = bridge
+        .send_agent_email(SendAgentEmailRequest {
+            sender_session_id: sender_session.id.clone(),
+            sender_name: session_display_name(sender_session.clone()),
+            sender_provider: sender_session.provider,
+            to_users,
+            cc_users,
+            subject: payload.subject,
+            body_text: payload.body_text.unwrap_or_default(),
+            body_html: payload.body_html.unwrap_or_default(),
+            body_markdown: payload.body_markdown,
+            auto_subject: payload.auto_subject,
+        })
+        .map_err(email_send_error)?;
+    Ok(Json(serde_json::to_value(sent)?))
+}
+
+async fn inbound_email_webhook(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(payload): Json<InboundEmailRequest>,
+) -> Result<Json<Value>, ApiError> {
+    let bridge = email_bridge_or_503(&state.config)?;
+    let configured_secret = bridge.worker_secret().ok_or_else(|| ApiError::Status {
+        status: StatusCode::SERVICE_UNAVAILABLE,
+        detail: "Email worker secret is required".to_owned(),
+    })?;
+    let provided_secret = headers
+        .get(bridge.worker_secret_header())
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .unwrap_or("");
+    if provided_secret != configured_secret {
+        return Err(ApiError::Status {
+            status: StatusCode::UNAUTHORIZED,
+            detail: "Invalid email worker secret".to_owned(),
+        });
+    }
+    if !bridge.is_authorized_sender(&payload.from_address) {
+        return Err(ApiError::Status {
+            status: StatusCode::FORBIDDEN,
+            detail: "Inbound sender is not authorized".to_owned(),
+        });
+    }
+    ensure_core_writes_enabled(&state)?;
+
+    let parsed_body = payload.body.unwrap_or_default();
+    let raw_email = payload.raw_email.as_deref().unwrap_or("").trim();
+    let (mut raw_body, subject) = if raw_email.is_empty() {
+        (parsed_body.clone(), None)
+    } else {
+        (
+            extract_text_from_raw_email(raw_email),
+            extract_subject_from_raw_email(raw_email),
+        )
+    };
+    if !parsed_body.trim().is_empty()
+        && (raw_body.trim().is_empty()
+            || (extract_routed_session_id(&raw_body).is_none()
+                && extract_routed_session_id(&parsed_body).is_some()))
+    {
+        raw_body = parsed_body;
+    }
+    let raw_body = raw_body.trim().to_owned();
+    if raw_body.is_empty() {
+        return Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: "body or raw_email is required".to_owned(),
+        });
+    }
+
+    let trusted_session_id = headers
+        .get(bridge.session_id_header())
+        .and_then(|value| value.to_str().ok())
+        .and_then(normalize_explicit_session_id);
+    let session_id = trusted_session_id
+        .or_else(|| {
+            payload
+                .session_id
+                .as_deref()
+                .and_then(normalize_explicit_session_id)
+        })
+        .or_else(|| extract_routed_session_id(&raw_body));
+    let Some(session_id) = session_id else {
+        return Ok(Json(json!({
+            "status": "ignored",
+            "reason": "missing_routing_footer",
+        })));
+    };
+    let reply_body = extract_reply_message_body(&raw_body);
+    if reply_body.trim().is_empty() {
+        return Ok(Json(json!({
+            "status": "ignored",
+            "session_id": session_id,
+            "reason": "empty_reply_body",
+        })));
+    }
+    let mut body = format!("{{sm email from {}}}", payload.from_address.trim());
+    if let Some(subject) = subject
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        body = format!(
+            "{{sm email from {} subj: {subject}}}",
+            payload.from_address.trim()
+        );
+    }
+    body.push('\n');
+    body.push_str(&reply_body);
+
+    let Some(mut session) = state.session_store.get_session(&session_id)? else {
+        return Err(ApiError::NotFound("Session not found"));
+    };
+    let mut restored = false;
+    if matches!(session.status.as_str(), "stopped" | "killed") {
+        let outcome = if state.config.rust_core.runtime_enabled {
+            let runtime = TmuxRuntime::from_app_config(&state.config);
+            state
+                .session_store
+                .restore_core_session_with_runtime(&session_id, &runtime)?
+        } else {
+            state.session_store.restore_core_session(&session_id)?
+        };
+        match outcome {
+            Some(CoreRestoreOutcome::Restored(restored_session)) => {
+                session = restored_session;
+                restored = true;
+            }
+            Some(CoreRestoreOutcome::NotStopped) => {}
+            Some(CoreRestoreOutcome::UnsupportedNode(node)) => {
+                return Err(ApiError::Status {
+                    status: StatusCode::BAD_REQUEST,
+                    detail: format!("Rust runtime does not support remote node {node}"),
+                })
+            }
+            Some(CoreRestoreOutcome::UnsupportedProvider(provider)) => {
+                return Err(ApiError::Status {
+                    status: StatusCode::BAD_REQUEST,
+                    detail: format!("Rust runtime does not support provider {provider}"),
+                })
+            }
+            Some(CoreRestoreOutcome::MissingProviderResumeId(provider)) => {
+                return Err(ApiError::Status {
+                    status: StatusCode::CONFLICT,
+                    detail: format!("Cannot restore {provider} session without provider_resume_id"),
+                })
+            }
+            None => return Err(ApiError::NotFound("Session not found")),
+        }
+    }
+    let input = SendCoreInputRequest {
+        text: body,
+        delivery_mode: "sequential".to_owned(),
+        sender_session_id: None,
+        from_sm_send: false,
+        timeout_seconds: None,
+        notify_on_delivery: false,
+        notify_after_seconds: None,
+        notify_on_stop: false,
+        remind_soft_threshold: None,
+        remind_hard_threshold: None,
+        remind_cancel_on_reply_session_id: None,
+        parent_session_id: None,
+    };
+    let outcome = if state.config.rust_core.runtime_enabled {
+        if !is_primary_node(&session.node) {
+            return Err(ApiError::Status {
+                status: StatusCode::BAD_REQUEST,
+                detail: format!("Rust runtime does not support remote node {}", session.node),
+            });
+        }
+        let runtime = TmuxRuntime::from_app_config(&state.config);
+        state
+            .session_store
+            .send_core_input_with_runtime(&session_id, input, &runtime)?
+    } else {
+        state.session_store.send_core_input(&session_id, input)?
+    };
+    let Some(outcome) = outcome else {
+        return Err(ApiError::NotFound("Session not found"));
+    };
+    if !outcome.delivered && matches!(outcome.status.as_str(), "stopped" | "killed") {
+        return Err(ApiError::Status {
+            status: StatusCode::CONFLICT,
+            detail: "Failed to deliver inbound email to session".to_owned(),
+        });
+    }
+    Ok(Json(json!({
+        "status": "sent",
+        "session_id": session_id,
+        "restored": restored,
+        "delivery_result": if outcome.delivered { "delivered" } else { "queued" },
+    })))
+}
+
 fn notify_maintainer_of_bug_report(
     state: &AppState,
     bug_id: &str,
@@ -503,6 +858,61 @@ fn error_name(error: &ApiError) -> &'static str {
         ApiError::Status { .. } => "status",
         ApiError::Auth { .. } => "auth",
     }
+}
+
+fn email_bridge(config: &AppConfig) -> Result<EmailBridge, ApiError> {
+    EmailBridge::load(config).map_err(email_config_error)
+}
+
+fn email_bridge_or_503(config: &AppConfig) -> Result<EmailBridge, ApiError> {
+    let bridge = EmailBridge::load(config).map_err(email_config_error)?;
+    if !bridge.bridge_is_available() {
+        return Err(ApiError::Status {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            detail: "Email bridge is unavailable".to_owned(),
+        });
+    }
+    Ok(bridge)
+}
+
+fn email_config_error(error: anyhow::Error) -> ApiError {
+    ApiError::Status {
+        status: StatusCode::CONFLICT,
+        detail: error.to_string(),
+    }
+}
+
+fn email_lookup_error(error: anyhow::Error) -> ApiError {
+    ApiError::Status {
+        status: StatusCode::NOT_FOUND,
+        detail: error.to_string(),
+    }
+}
+
+fn email_send_error(error: anyhow::Error) -> ApiError {
+    let detail = error.to_string();
+    let status = if detail.contains("Email body is required")
+        || detail.contains("Email subject is required")
+        || detail.contains("Managed sender session is required")
+    {
+        StatusCode::BAD_REQUEST
+    } else if detail.contains("No registered email user found") {
+        StatusCode::NOT_FOUND
+    } else {
+        StatusCode::BAD_GATEWAY
+    };
+    ApiError::Status { status, detail }
+}
+
+fn required_sender_session_id(value: Option<&str>) -> Result<String, ApiError> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .ok_or_else(|| ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: "Managed sender session is required for email delivery".to_owned(),
+        })
 }
 
 async fn deploy_app_artifact(
@@ -3024,6 +3434,49 @@ struct ClientBugReportResponse {
     status: &'static str,
     bug_id: String,
     maintainer_notified: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct SendEmailRequest {
+    #[serde(default)]
+    requester_session_id: Option<String>,
+    recipients: Vec<String>,
+    #[serde(default)]
+    cc: Vec<String>,
+    #[serde(default)]
+    subject: Option<String>,
+    #[serde(default)]
+    body_text: Option<String>,
+    #[serde(default)]
+    body_html: Option<String>,
+    #[serde(default)]
+    body_markdown: bool,
+    #[serde(default)]
+    auto_subject: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct HumanDeliveryRequest {
+    #[serde(default)]
+    requester_session_id: Option<String>,
+    text: String,
+    #[serde(default)]
+    subject: Option<String>,
+    #[serde(default)]
+    body_markdown: bool,
+    #[serde(default = "default_true")]
+    auto_subject: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct InboundEmailRequest {
+    #[serde(default)]
+    session_id: Option<String>,
+    #[serde(default)]
+    body: Option<String>,
+    #[serde(default)]
+    raw_email: Option<String>,
+    from_address: String,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/sm-server/src/lib.rs
+++ b/crates/sm-server/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod app_artifacts;
 pub mod bug_reports;
 pub mod config;
+pub mod email;
 pub mod http;
 pub mod mobile_analytics;
 pub mod queue;

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -17,7 +17,7 @@ use sm_server::config::RustShadowConfig;
 use sm_server::queue::RetainedQueueStore;
 use sm_server::{
     config::{
-        AppArtifactsConfig, AppConfig, BugReportsConfig, CodexForkLaunchConfig,
+        AppArtifactsConfig, AppConfig, BugReportsConfig, CodexForkLaunchConfig, EmailConfig,
         ExternalAccessConfig, GoogleAuthConfig, MobileAnalyticsConfig, MobileTerminalConfig,
         PathsConfig, QueueRunnerConfig, RustCoreConfig, SmSendConfig,
     },
@@ -29,8 +29,8 @@ use std::os::unix::fs::PermissionsExt;
 use std::os::unix::net::UnixListener;
 use std::{
     fs,
-    io::{BufRead, BufReader, Write},
-    net::SocketAddr,
+    io::{BufRead, BufReader, Read, Write},
+    net::{SocketAddr, TcpListener},
     path::PathBuf,
     process::Command,
     sync::{
@@ -949,6 +949,235 @@ async fn client_bug_report_enforces_auth_and_payload_bounds() {
         .as_str()
         .unwrap()
         .contains("client_state exceeds"));
+}
+
+#[tokio::test]
+async fn human_lookup_lists_capabilities_without_email_addresses() {
+    let state_file = write_session_fixture();
+    let bridge_config = write_email_bridge_config(None, None);
+    let app = router(AppState::new(config_with_state_file_and_email(
+        &state_file,
+        &bridge_config,
+        false,
+    )));
+
+    let (status, payload) = get_json(app.clone(), "/humans").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["humans"][0]["recipient"], "operator");
+    assert_eq!(payload["humans"][0]["available_channels"], json!(["email"]));
+    assert_eq!(payload["humans"][0]["email_use"], "fallback_only");
+    assert!(
+        !serde_json::to_string(&payload)
+            .unwrap()
+            .contains("operator@example.com"),
+        "human listing must not expose private email addresses"
+    );
+
+    let (status, payload) = get_json(app, "/humans/owner").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["recipient"], "operator");
+    assert!(
+        !serde_json::to_string(&payload)
+            .unwrap()
+            .contains("operator@example.com"),
+        "human lookup must not expose private email addresses"
+    );
+}
+
+#[tokio::test]
+async fn registered_email_send_posts_resend_payload_with_routing_footer() {
+    let (resend_url, request_rx) = spawn_resend_server(200, r#"{"id":"email_123"}"#);
+    let state_file = write_session_fixture();
+    let bridge_config = write_email_bridge_config(Some(&resend_url), None);
+    let app = router(AppState::new(config_with_state_file_and_email(
+        &state_file,
+        &bridge_config,
+        false,
+    )));
+
+    let (status, payload) = post_json(
+        app,
+        "/email/send",
+        json!({
+            "requester_session_id": "run12345",
+            "recipients": ["teammate"],
+            "subject": "Status",
+            "body_text": "hello from rust"
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["message_id"], "email_123");
+    assert_eq!(payload["to"][0]["username"], "teammate");
+    assert_eq!(payload["to"][0]["email"], "teammate@example.com");
+    let request = request_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+    assert_eq!(request["path"], "/emails");
+    assert_eq!(request["authorization"], "Bearer test-api-key");
+    assert_eq!(request["body"]["to"], json!(["teammate@example.com"]));
+    assert_eq!(request["body"]["reply_to"], "reply@example.com");
+    assert!(request["body"]["text"]
+        .as_str()
+        .unwrap()
+        .contains("SM: Runner Native run12345 claude"));
+    assert_eq!(request["body"]["headers"]["X-SM-Session-ID"], "run12345");
+}
+
+#[tokio::test]
+async fn explicit_human_email_is_required_for_human_recipients() {
+    let state_file = write_session_fixture();
+    let bridge_config = write_email_bridge_config(None, None);
+    let app = router(AppState::new(config_with_state_file_and_email(
+        &state_file,
+        &bridge_config,
+        false,
+    )));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/email/send",
+        json!({
+            "requester_session_id": "run12345",
+            "recipients": ["owner"],
+            "subject": "Status",
+            "body_text": "hello"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(payload["detail"]
+        .as_str()
+        .unwrap()
+        .contains("must use explicit human email delivery"));
+
+    let (resend_url, request_rx) = spawn_resend_server(200, r#"{"id":"human_123"}"#);
+    fs::write(&bridge_config, email_bridge_yaml(Some(&resend_url), None)).unwrap();
+    let (status, payload) = post_json(
+        app,
+        "/humans/operator/email",
+        json!({
+            "requester_session_id": "run12345",
+            "text": "human fallback body"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "sent");
+    assert_eq!(payload["recipient"], "operator");
+    assert_eq!(payload["to"], json!([{ "username": "operator" }]));
+    let request = request_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+    assert_eq!(request["body"]["to"], json!(["operator@example.com"]));
+    assert_eq!(request["body"]["subject"], "human fallback body");
+}
+
+#[tokio::test]
+async fn inbound_email_requires_worker_proof_and_delivers_to_session() {
+    let state_file = write_session_fixture();
+    let bridge_config = write_email_bridge_config(None, Some("worker-secret"));
+    let app = router(AppState::new(config_with_state_file_and_email(
+        &state_file,
+        &bridge_config,
+        true,
+    )));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/api/email-inbound",
+        json!({
+            "from_address": "operator@example.com",
+            "body": "reply\n\n--\nSM: Runner run12345 claude"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(payload["detail"], "Invalid email worker secret");
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/api/email-inbound",
+        json!({
+            "from_address": "intruder@example.com",
+            "body": "reply\n\n--\nSM: Runner run12345 claude"
+        }),
+        &[("x-email-worker-secret", "worker-secret")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(payload["detail"], "Inbound sender is not authorized");
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/api/email-inbound",
+        json!({
+            "from_address": "operator@example.com",
+            "body": "no routing footer"
+        }),
+        &[("x-email-worker-secret", "worker-secret")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "ignored");
+    assert_eq!(payload["reason"], "missing_routing_footer");
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/api/email-inbound",
+        json!({
+            "from_address": "operator@example.com",
+            "raw_email": concat!(
+                "Subject: Re: status\r\n",
+                "Content-Type: multipart/alternative; boundary=\"sm-reply-boundary\"\r\n",
+                "\r\n",
+                "--sm-reply-boundary\r\n",
+                "Content-Type: text/html; charset=utf-8\r\n",
+                "\r\n",
+                "<p>html fallback should not be delivered</p>\r\n",
+                "--sm-reply-boundary\r\n",
+                "Content-Type: text/plain; charset=utf-8\r\n",
+                "Content-Transfer-Encoding: quoted-printable\r\n",
+                "\r\n",
+                "Here=20is=20the=20reply=0A=0A--=0ASM:=20Runner=20run12345=20claude\r\n",
+                "--sm-reply-boundary--\r\n",
+            )
+        }),
+        &[("x-email-worker-secret", "worker-secret")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "sent");
+    assert_eq!(payload["session_id"], "run12345");
+    assert_eq!(payload["restored"], false);
+    assert_eq!(payload["delivery_result"], "delivered");
+
+    let (_status, output) = get_json(app.clone(), "/sessions/run12345/output?lines=5").await;
+    assert!(output["output"]
+        .as_str()
+        .unwrap()
+        .contains("{sm email from operator@example.com subj: Re: status}\nHere is the reply"));
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/api/email-inbound",
+        json!({
+            "from_address": "operator@example.com",
+            "raw_email": "Subject: Re: parsed fallback\r\n\r\n",
+            "body": "Parsed fallback body\n\n--\nSM: Runner run12345 claude"
+        }),
+        &[("x-email-worker-secret", "worker-secret")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "sent");
+    assert_eq!(payload["session_id"], "run12345");
+
+    let (_status, output) = get_json(app, "/sessions/run12345/output?lines=10").await;
+    assert!(output["output"].as_str().unwrap().contains(
+        "{sm email from operator@example.com subj: Re: parsed fallback}\nParsed fallback body"
+    ));
 }
 
 #[tokio::test]
@@ -6920,6 +7149,26 @@ fn config_with_state_file(state_file: &PathBuf) -> AppConfig {
     }
 }
 
+fn config_with_state_file_and_email(
+    state_file: &PathBuf,
+    bridge_config: &PathBuf,
+    fixture_writes_enabled: bool,
+) -> AppConfig {
+    AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        email: EmailConfig {
+            bridge_config: bridge_config.display().to_string(),
+        },
+        rust_core: RustCoreConfig {
+            fixture_writes_enabled,
+            ..RustCoreConfig::default()
+        },
+        ..AppConfig::default()
+    }
+}
+
 fn config_with_state_file_and_queue(state_file: &PathBuf) -> AppConfig {
     AppConfig {
         paths: PathsConfig {
@@ -7336,6 +7585,105 @@ fn write_registry_fixture() -> PathBuf {
     )
     .unwrap();
     path
+}
+
+fn write_email_bridge_config(api_base_url: Option<&str>, worker_secret: Option<&str>) -> PathBuf {
+    let path = unique_temp_path();
+    fs::write(&path, email_bridge_yaml(api_base_url, worker_secret)).unwrap();
+    path
+}
+
+fn email_bridge_yaml(api_base_url: Option<&str>, worker_secret: Option<&str>) -> String {
+    let api_base_url = api_base_url.unwrap_or("http://127.0.0.1:9");
+    let worker_secret_yaml = worker_secret
+        .map(|secret| format!("  worker_secret: \"{secret}\"\n"))
+        .unwrap_or_default();
+    format!(
+        r#"resend:
+  api_key: "test-api-key"
+  domain: "example.com"
+  reply_address: "reply@example.com"
+  api_base_url: "{api_base_url}"
+humans:
+  operator:
+    display_name: "Human operator"
+    aliases: ["owner"]
+    default_channel: "email"
+    channels:
+      email:
+        enabled: true
+        address: "operator@example.com"
+        use: "fallback_only"
+users:
+  operator:
+    email: "operator@example.com"
+    name: "Human operator"
+    aliases: ["owner"]
+  teammate:
+    email: "teammate@example.com"
+    name: "Team Mate"
+    aliases: ["tm"]
+email_bridge:
+  authorized_senders: ["operator@example.com"]
+{worker_secret_yaml}  worker_secret_header: "x-email-worker-secret"
+  session_id_header: "x-email-session-id"
+  webhook_path: "/api/email-inbound"
+"#
+    )
+}
+
+fn spawn_resend_server(
+    status: u16,
+    response_body: &'static str,
+) -> (String, mpsc::Receiver<Value>) {
+    let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let address = listener.local_addr().unwrap();
+    let (sender, receiver) = mpsc::channel();
+    thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        let mut request_line = String::new();
+        reader.read_line(&mut request_line).unwrap();
+        let path = request_line
+            .split_whitespace()
+            .nth(1)
+            .unwrap_or("")
+            .to_owned();
+        let mut authorization = String::new();
+        let mut content_length = 0_usize;
+        loop {
+            let mut line = String::new();
+            reader.read_line(&mut line).unwrap();
+            let trimmed = line.trim_end_matches(['\r', '\n']);
+            if trimmed.is_empty() {
+                break;
+            }
+            if let Some((name, value)) = trimmed.split_once(':') {
+                if name.eq_ignore_ascii_case("authorization") {
+                    authorization = value.trim().to_owned();
+                }
+                if name.eq_ignore_ascii_case("content-length") {
+                    content_length = value.trim().parse::<usize>().unwrap();
+                }
+            }
+        }
+        let mut body = vec![0_u8; content_length];
+        reader.read_exact(&mut body).unwrap();
+        let body_json: Value = serde_json::from_slice(&body).unwrap();
+        sender
+            .send(json!({
+                "path": path,
+                "authorization": authorization,
+                "body": body_json,
+            }))
+            .unwrap();
+        let response = format!(
+            "HTTP/1.1 {status} OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{response_body}",
+            response_body.len()
+        );
+        stream.write_all(response.as_bytes()).unwrap();
+    });
+    (format!("http://{address}"), receiver)
 }
 
 fn unique_temp_path() -> PathBuf {


### PR DESCRIPTION
## Summary
- add Rust email bridge config parsing, human recipient lookup, privacy-safe /humans responses, and retained email HTTP routes
- add outbound registered/human email delivery through Resend-compatible payloads with routing footers
- add inbound /api/email-inbound worker-proof/sender-allowlist handling that routes replies into Rust core session input
- wire retained Rust CLI `sm email` to generic or explicit human email delivery while Telegram remains retired

## Validation
- cargo fmt --check
- cargo test -p sm-server
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py
- git diff --check

Fixes #839
