### PR TITLE
Rust MVP: mobile terminal WebSocket auth consume

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -102,8 +103,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -252,7 +255,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
@@ -266,6 +269,12 @@ dependencies = [
  "generic-array",
  "typenum",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "der"
@@ -327,7 +336,7 @@ dependencies = [
  "group",
  "pem-rfc7468",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
@@ -376,7 +385,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -422,6 +431,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
 name = "futures-task"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,6 +450,7 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-macro",
+ "futures-sink",
  "futures-task",
  "pin-project-lite",
  "slab",
@@ -463,13 +479,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -766,6 +794,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,12 +830,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -819,7 +891,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1018,7 +1090,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1038,7 +1110,7 @@ dependencies = [
  "futures-util",
  "hmac",
  "p256",
- "rand_core",
+ "rand_core 0.6.4",
  "rusqlite",
  "serde",
  "serde_json",
@@ -1113,6 +1185,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
 
 [[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1151,6 +1243,7 @@ version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
+ "bytes",
  "libc",
  "mio",
  "pin-project-lite",
@@ -1169,6 +1262,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
 ]
 
 [[package]]
@@ -1217,6 +1322,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
 ]
 
 [[package]]
@@ -1300,6 +1421,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "webpki-roots"
@@ -1397,6 +1527,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"

--- a/crates/sm-server/Cargo.toml
+++ b/crates/sm-server/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
-axum = { workspace = true, features = ["multipart"] }
+axum = { workspace = true, features = ["multipart", "ws"] }
 base64 = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 futures-util = { workspace = true }
@@ -21,7 +21,7 @@ serde_yaml = { workspace = true }
 sha1 = { workspace = true }
 sha2 = { workspace = true }
 time = { workspace = true, features = ["formatting", "local-offset", "macros", "parsing"] }
-tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "signal"] }
+tokio = { workspace = true, features = ["macros", "net", "rt-multi-thread", "signal", "time"] }
 ureq = { workspace = true }
 
 [dev-dependencies]

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -9,7 +9,10 @@ use std::{
 
 use axum::{
     body::{to_bytes, Body},
-    extract::{ConnectInfo, DefaultBodyLimit, Multipart, Path, Query, Request, State},
+    extract::{
+        ws::{CloseFrame, Message, WebSocket, WebSocketUpgrade},
+        ConnectInfo, DefaultBodyLimit, FromRequestParts, Multipart, Path, Query, Request, State,
+    },
     http::{
         header::{
             AUTHORIZATION, CACHE_CONTROL, CONNECTION, CONTENT_DISPOSITION, CONTENT_TYPE, COOKIE,
@@ -40,6 +43,7 @@ use serde_json::{json, Value};
 use sha1::{Digest, Sha1};
 use sha2::Sha256;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+use tokio::time::timeout;
 
 use crate::app_artifacts::{
     hashed_path, read_metadata, store_artifact, valid_app_name, valid_artifact_hash,
@@ -80,10 +84,12 @@ const REQUEST_STATUS_PROMPT: &str = "[sm] user requests status, please update no
 const BUG_REPORT_MAX_TEXT_CHARS: usize = 4000;
 const BUG_REPORT_MAX_CLIENT_STATE_CHARS: usize = 100_000;
 const BUG_REPORT_MAX_SERVER_STATE_CHARS: usize = 200_000;
+const MOBILE_TERMINAL_UNIMPLEMENTED_CLOSE_CODE: u16 = 1011;
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 struct MobileTerminalTicket {
+    ticket_id: String,
     secret_hash: String,
     user_id: String,
     actor_email: String,
@@ -97,6 +103,16 @@ struct MobileTerminalTicket {
     expires_at_unix: i64,
 }
 
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct MobileTerminalActiveAttach {
+    user_id: String,
+    session_id: String,
+    provider: String,
+    device_key_id: String,
+    started_at_unix: i64,
+}
+
 #[derive(Debug, Serialize)]
 struct MobileAttachTicketResponse {
     ticket_id: String,
@@ -106,11 +122,23 @@ struct MobileAttachTicketResponse {
     expires_at: String,
 }
 
+#[derive(Debug, Deserialize)]
+struct MobileTerminalAuthFrame {
+    #[serde(rename = "type")]
+    frame_type: Option<String>,
+    ticket_id: Option<String>,
+    ticket_secret: Option<String>,
+    device_key_id: Option<String>,
+    nonce: Option<String>,
+    signature: Option<String>,
+}
+
 #[derive(Clone)]
 pub struct AppState {
     config: AppConfig,
     session_store: SessionStore,
     mobile_terminal_tickets: Arc<Mutex<BTreeMap<String, MobileTerminalTicket>>>,
+    mobile_terminal_active_attaches: Arc<Mutex<BTreeMap<String, MobileTerminalActiveAttach>>>,
     mobile_terminal_proof_nonces: Arc<Mutex<BTreeMap<String, i64>>>,
     mobile_terminal_secret: [u8; 32],
 }
@@ -126,6 +154,7 @@ impl AppState {
             config,
             session_store,
             mobile_terminal_tickets: Arc::new(Mutex::new(BTreeMap::new())),
+            mobile_terminal_active_attaches: Arc::new(Mutex::new(BTreeMap::new())),
             mobile_terminal_proof_nonces: Arc::new(Mutex::new(BTreeMap::new())),
             mobile_terminal_secret,
         }
@@ -145,7 +174,7 @@ pub fn router(state: AppState) -> Router {
         .route("/client/analytics/summary", get(client_analytics_summary))
         .route("/client/request-status", post(client_request_status))
         .route("/client/bug-reports", post(submit_client_bug_report))
-        .route("/client/terminal", get(mobile_terminal_upgrade_required))
+        .route("/client/terminal", get(mobile_terminal_endpoint))
         .route("/deploy/{app_name}", post(deploy_app_artifact))
         .route("/apps/{app_name}/latest.apk", get(get_latest_app_artifact))
         .route("/apps/{app_name}/meta.json", get(get_app_artifact_metadata))
@@ -1732,6 +1761,7 @@ async fn create_mobile_attach_ticket(
     tickets.insert(
         ticket_id.clone(),
         MobileTerminalTicket {
+            ticket_id: ticket_id.clone(),
             secret_hash,
             user_id,
             actor_email,
@@ -1759,19 +1789,34 @@ async fn create_mobile_attach_ticket(
     }))
 }
 
-async fn mobile_terminal_upgrade_required(
+async fn mobile_terminal_endpoint(
     State(state): State<Arc<AppState>>,
     request: Request,
-) -> Result<impl IntoResponse, ApiError> {
-    let peer_addr = request
-        .extensions()
+) -> Result<Response, ApiError> {
+    let (mut parts, _body) = request.into_parts();
+    let headers = parts.headers.clone();
+    let peer_addr = parts
+        .extensions
         .get::<ConnectInfo<SocketAddr>>()
         .map(|value| value.0);
-    let actor_email = request_actor_email_from_parts(&state.config, request.headers(), peer_addr)
+    if let Ok(ws) = WebSocketUpgrade::from_request_parts(&mut parts, &state).await {
+        return Ok(ws
+            .on_upgrade(move |socket| mobile_terminal_websocket(socket, state))
+            .into_response());
+    }
+    mobile_terminal_upgrade_required(&state, &headers, peer_addr)
+}
+
+fn mobile_terminal_upgrade_required(
+    state: &AppState,
+    headers: &HeaderMap,
+    peer_addr: Option<SocketAddr>,
+) -> Result<Response, ApiError> {
+    let actor_email = request_actor_email_from_parts(&state.config, headers, peer_addr)
         .ok_or_else(|| ApiError::Status {
-        status: StatusCode::UNAUTHORIZED,
-        detail: "Authentication required".to_owned(),
-    })?;
+            status: StatusCode::UNAUTHORIZED,
+            detail: "Authentication required".to_owned(),
+        })?;
     let Some((_user_id, user_config)) = mobile_terminal_visible_user(&state.config, &actor_email)
     else {
         return Err(ApiError::Status {
@@ -1792,7 +1837,112 @@ async fn mobile_terminal_upgrade_required(
         StatusCode::UPGRADE_REQUIRED,
         headers,
         Json(json!({ "detail": "mobile terminal requires a WebSocket upgrade" })),
-    ))
+    )
+        .into_response())
+}
+
+async fn mobile_terminal_websocket(mut socket: WebSocket, state: Arc<AppState>) {
+    if !state.config.mobile_terminal.enabled {
+        send_mobile_terminal_error(&mut socket, "mobile terminal attach is disabled").await;
+        close_mobile_terminal_socket(&mut socket, 1008, "mobile_terminal_disabled").await;
+        return;
+    }
+
+    let auth_timeout = Duration::from_secs(clamp_u64(3, 1, 30, 3));
+    let auth_frame = match timeout(auth_timeout, socket.recv()).await {
+        Ok(Some(Ok(message))) => match parse_mobile_terminal_auth_message(message) {
+            Ok(frame) => frame,
+            Err(detail) => {
+                send_mobile_terminal_error(&mut socket, detail).await;
+                close_mobile_terminal_socket(&mut socket, 1008, detail).await;
+                return;
+            }
+        },
+        Ok(Some(Err(_))) | Ok(None) => return,
+        Err(_) => {
+            send_mobile_terminal_error(&mut socket, "terminal auth timed out").await;
+            close_mobile_terminal_socket(&mut socket, 1008, "terminal_auth_timed_out").await;
+            return;
+        }
+    };
+
+    match consume_mobile_terminal_ticket(&state, &auth_frame) {
+        Ok((_ticket, attach_id)) => {
+            send_mobile_terminal_error(&mut socket, "mobile terminal bridge is not implemented")
+                .await;
+            let _ = send_mobile_terminal_json(
+                &mut socket,
+                json!({
+                    "type": "exit",
+                    "code": MOBILE_TERMINAL_UNIMPLEMENTED_CLOSE_CODE,
+                    "reason": "mobile_terminal_bridge_unimplemented",
+                }),
+            )
+            .await;
+            remove_mobile_terminal_active_attach(&state, &attach_id);
+            close_mobile_terminal_socket(
+                &mut socket,
+                MOBILE_TERMINAL_UNIMPLEMENTED_CLOSE_CODE,
+                "mobile_terminal_bridge_unimplemented",
+            )
+            .await;
+        }
+        Err(error) => {
+            let detail = api_error_detail(&error);
+            send_mobile_terminal_error(&mut socket, &detail).await;
+            close_mobile_terminal_socket(&mut socket, 1008, &detail).await;
+        }
+    }
+}
+
+fn parse_mobile_terminal_auth_message(
+    message: Message,
+) -> Result<MobileTerminalAuthFrame, &'static str> {
+    let text = match message {
+        Message::Text(text) => text.to_string(),
+        Message::Binary(bytes) => {
+            String::from_utf8(bytes.to_vec()).map_err(|_| "Invalid terminal auth frame")?
+        }
+        Message::Close(_) => return Err("Invalid terminal auth frame"),
+        _ => return Err("First terminal frame must be auth"),
+    };
+    let frame: MobileTerminalAuthFrame =
+        serde_json::from_str(&text).map_err(|_| "Invalid terminal auth frame")?;
+    if frame.frame_type.as_deref().map(str::trim) != Some("auth") {
+        return Err("First terminal frame must be auth");
+    }
+    Ok(frame)
+}
+
+async fn send_mobile_terminal_error(socket: &mut WebSocket, message: &str) {
+    let _ = send_mobile_terminal_json(
+        socket,
+        json!({
+            "type": "error",
+            "message": message,
+        }),
+    )
+    .await;
+}
+
+async fn send_mobile_terminal_json(socket: &mut WebSocket, payload: Value) -> Result<(), ()> {
+    let text = match serde_json::to_string(&payload) {
+        Ok(text) => text,
+        Err(_) => return Err(()),
+    };
+    socket
+        .send(Message::Text(text.into()))
+        .await
+        .map_err(|_| ())
+}
+
+async fn close_mobile_terminal_socket(socket: &mut WebSocket, code: u16, reason: &str) {
+    let _ = socket
+        .send(Message::Close(Some(CloseFrame {
+            code,
+            reason: reason.to_owned().into(),
+        })))
+        .await;
 }
 
 async fn get_attach_descriptor(
@@ -3436,6 +3586,316 @@ fn mobile_terminal_proof_nonce_key(
     [user_id, device_key_id, session_id, nonce].join("\u{1f}")
 }
 
+fn consume_mobile_terminal_ticket(
+    state: &AppState,
+    frame: &MobileTerminalAuthFrame,
+) -> Result<(MobileTerminalTicket, String), ApiError> {
+    if !state.config.mobile_terminal.enabled {
+        return Err(ApiError::Status {
+            status: StatusCode::FORBIDDEN,
+            detail: "mobile terminal attach is disabled".to_owned(),
+        });
+    }
+    let ticket_id = nonempty_frame_field(&frame.ticket_id);
+    let ticket_secret = nonempty_frame_field(&frame.ticket_secret);
+    let device_key_id = nonempty_frame_field(&frame.device_key_id);
+    let nonce = nonempty_frame_field(&frame.nonce);
+    let signature = nonempty_frame_field(&frame.signature);
+    if ticket_id.is_none()
+        || ticket_secret.is_none()
+        || device_key_id.is_none()
+        || nonce.is_none()
+        || signature.is_none()
+    {
+        return Err(ApiError::Status {
+            status: StatusCode::UNAUTHORIZED,
+            detail: "Invalid terminal auth frame".to_owned(),
+        });
+    }
+    let ticket_id = ticket_id.unwrap();
+    let ticket_secret = ticket_secret.unwrap();
+    let device_key_id = device_key_id.unwrap();
+    let nonce = nonce.unwrap();
+    let signature = signature.unwrap();
+    let now = OffsetDateTime::now_utc().unix_timestamp();
+
+    let ticket =
+        mobile_terminal_ticket_for_consume(state, &ticket_id, &ticket_secret, &device_key_id, now)?;
+    let Some((user_id, user_config)) =
+        mobile_terminal_visible_user(&state.config, &ticket.actor_email)
+    else {
+        return Err(ApiError::Status {
+            status: StatusCode::FORBIDDEN,
+            detail: "User is no longer allowed to attach".to_owned(),
+        });
+    };
+    if user_id != ticket.user_id {
+        return Err(ApiError::Status {
+            status: StatusCode::FORBIDDEN,
+            detail: "User is no longer allowed to attach".to_owned(),
+        });
+    }
+    let Some(device_config) = mobile_terminal_device_config(user_config, &device_key_id) else {
+        return Err(ApiError::Status {
+            status: StatusCode::UNAUTHORIZED,
+            detail: "Device key is no longer registered".to_owned(),
+        });
+    };
+    let message = mobile_terminal_ws_message(
+        &ticket.ticket_id,
+        &ticket.session_id,
+        &ticket.actor_email,
+        &device_key_id,
+        &nonce,
+    );
+    verify_mobile_terminal_p256_signature(&device_config.public_key, &signature, &message)?;
+
+    let Some(session) = state.session_store.get_session(&ticket.session_id)? else {
+        return Err(ApiError::Status {
+            status: StatusCode::CONFLICT,
+            detail: "Session is no longer attachable".to_owned(),
+        });
+    };
+    if matches!(
+        session.status.trim().to_ascii_lowercase().as_str(),
+        "stopped" | "killed"
+    ) {
+        return Err(ApiError::Status {
+            status: StatusCode::CONFLICT,
+            detail: "Session is no longer attachable".to_owned(),
+        });
+    }
+    let attach = attach_descriptor_payload(session);
+    if attach
+        .get("attach_supported")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+        != true
+    {
+        return Err(ApiError::Status {
+            status: StatusCode::FORBIDDEN,
+            detail: attach
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("Session is no longer attachable")
+                .to_owned(),
+        });
+    }
+    validate_mobile_terminal_tmux_target(&ticket.tmux_session, ticket.tmux_socket_name.as_deref())?;
+
+    let mut tickets = state
+        .mobile_terminal_tickets
+        .lock()
+        .map_err(|_| ApiError::Status {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            detail: "Mobile terminal ticket store is unavailable".to_owned(),
+        })?;
+    let Some(current_ticket) = tickets.get(&ticket_id).cloned() else {
+        return Err(ApiError::Status {
+            status: StatusCode::UNAUTHORIZED,
+            detail: "Attach ticket is invalid or expired".to_owned(),
+        });
+    };
+    validate_mobile_terminal_ticket_secret(
+        state,
+        &current_ticket,
+        &ticket_id,
+        &ticket_secret,
+        &device_key_id,
+    )?;
+    if current_ticket.expires_at_unix <= now {
+        tickets.remove(&ticket_id);
+        return Err(ApiError::Status {
+            status: StatusCode::UNAUTHORIZED,
+            detail: "Attach ticket is expired or consumed".to_owned(),
+        });
+    }
+    let mut active =
+        state
+            .mobile_terminal_active_attaches
+            .lock()
+            .map_err(|_| ApiError::Status {
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+                detail: "Mobile terminal active attach store is unavailable".to_owned(),
+            })?;
+    enforce_mobile_terminal_active_limits(&state.config, active.values(), &current_ticket)?;
+    let ticket = tickets.remove(&ticket_id).expect("ticket checked above");
+    let attach_id = random_urlsafe_token(16);
+    active.insert(
+        attach_id.clone(),
+        MobileTerminalActiveAttach {
+            user_id: ticket.user_id.clone(),
+            session_id: ticket.session_id.clone(),
+            provider: ticket.provider.clone(),
+            device_key_id: ticket.device_key_id.clone(),
+            started_at_unix: now,
+        },
+    );
+    Ok((ticket, attach_id))
+}
+
+fn mobile_terminal_ticket_for_consume(
+    state: &AppState,
+    ticket_id: &str,
+    ticket_secret: &str,
+    device_key_id: &str,
+    now_unix: i64,
+) -> Result<MobileTerminalTicket, ApiError> {
+    let mut tickets = state
+        .mobile_terminal_tickets
+        .lock()
+        .map_err(|_| ApiError::Status {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            detail: "Mobile terminal ticket store is unavailable".to_owned(),
+        })?;
+    let Some(ticket) = tickets.get(ticket_id).cloned() else {
+        return Err(ApiError::Status {
+            status: StatusCode::UNAUTHORIZED,
+            detail: "Attach ticket is invalid or expired".to_owned(),
+        });
+    };
+    validate_mobile_terminal_ticket_secret(
+        state,
+        &ticket,
+        ticket_id,
+        ticket_secret,
+        device_key_id,
+    )?;
+    if ticket.expires_at_unix <= now_unix {
+        tickets.remove(ticket_id);
+        return Err(ApiError::Status {
+            status: StatusCode::UNAUTHORIZED,
+            detail: "Attach ticket is expired or consumed".to_owned(),
+        });
+    }
+    Ok(ticket)
+}
+
+fn validate_mobile_terminal_ticket_secret(
+    state: &AppState,
+    ticket: &MobileTerminalTicket,
+    ticket_id: &str,
+    ticket_secret: &str,
+    device_key_id: &str,
+) -> Result<(), ApiError> {
+    if ticket.ticket_id != ticket_id {
+        return Err(ApiError::Status {
+            status: StatusCode::UNAUTHORIZED,
+            detail: "Attach ticket is invalid or expired".to_owned(),
+        });
+    }
+    if ticket.device_key_id != device_key_id {
+        return Err(ApiError::Status {
+            status: StatusCode::UNAUTHORIZED,
+            detail: "Attach ticket device mismatch".to_owned(),
+        });
+    }
+    let expected = mobile_terminal_secret_hash(&state.mobile_terminal_secret, ticket_secret)?;
+    if !constant_time_eq(ticket.secret_hash.as_bytes(), expected.as_bytes()) {
+        return Err(ApiError::Status {
+            status: StatusCode::UNAUTHORIZED,
+            detail: "Attach ticket secret mismatch".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn enforce_mobile_terminal_active_limits<'a>(
+    config: &AppConfig,
+    active: impl Iterator<Item = &'a MobileTerminalActiveAttach>,
+    ticket: &MobileTerminalTicket,
+) -> Result<(), ApiError> {
+    let active = active.collect::<Vec<_>>();
+    let max_global = clamp_usize(
+        config.mobile_terminal.max_concurrent_attaches_global,
+        1,
+        64,
+        4,
+    );
+    let max_user = clamp_usize(
+        config.mobile_terminal.max_concurrent_attaches_per_user,
+        1,
+        16,
+        1,
+    );
+    let max_session = clamp_usize(
+        config.mobile_terminal.max_concurrent_attaches_per_session,
+        1,
+        16,
+        1,
+    );
+    if active.len() >= max_global {
+        return Err(ApiError::Status {
+            status: StatusCode::TOO_MANY_REQUESTS,
+            detail: "Too many active mobile attaches".to_owned(),
+        });
+    }
+    if active
+        .iter()
+        .filter(|item| item.user_id == ticket.user_id)
+        .count()
+        >= max_user
+    {
+        return Err(ApiError::Status {
+            status: StatusCode::TOO_MANY_REQUESTS,
+            detail: "Too many active mobile attaches for user".to_owned(),
+        });
+    }
+    if active
+        .iter()
+        .filter(|item| item.session_id == ticket.session_id)
+        .count()
+        >= max_session
+    {
+        return Err(ApiError::Status {
+            status: StatusCode::TOO_MANY_REQUESTS,
+            detail: "Session already has an active mobile attach".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn remove_mobile_terminal_active_attach(state: &AppState, attach_id: &str) {
+    if let Ok(mut active) = state.mobile_terminal_active_attaches.lock() {
+        active.remove(attach_id);
+    }
+}
+
+fn nonempty_frame_field(value: &Option<String>) -> Option<String> {
+    value
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_owned)
+}
+
+fn mobile_terminal_ws_message(
+    ticket_id: &str,
+    session_id: &str,
+    actor_email: &str,
+    device_key_id: &str,
+    nonce: &str,
+) -> String {
+    [
+        "SM-MOBILE-TERMINAL-WS-V1",
+        ticket_id,
+        session_id,
+        &actor_email.to_ascii_lowercase(),
+        device_key_id,
+        nonce,
+    ]
+    .join("\n")
+}
+
+fn api_error_detail(error: &ApiError) -> String {
+    match error {
+        ApiError::Status { detail, .. } => detail.clone(),
+        ApiError::NotFound(detail) => (*detail).to_owned(),
+        ApiError::Auth { detail, .. } => (*detail).to_owned(),
+        ApiError::Internal(error) => error.to_string(),
+    }
+}
+
 fn clamp_u64(value: u64, minimum: u64, maximum: u64, fallback: u64) -> u64 {
     if value == 0 {
         fallback.clamp(minimum, maximum)
@@ -4596,6 +5056,48 @@ mod tests {
         (status, serde_json::from_slice(&body).unwrap())
     }
 
+    async fn mint_mobile_attach_ticket(
+        state: &AppState,
+        signing_key: &SigningKey,
+        nonce: &str,
+    ) -> Value {
+        let response = router(state.clone())
+            .oneshot(attach_ticket_request(signing_key, nonce))
+            .await
+            .unwrap();
+        let (status, body) = response_json(response).await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        body
+    }
+
+    fn signed_mobile_terminal_auth_frame(
+        signing_key: &SigningKey,
+        ticket: &Value,
+        nonce: &str,
+    ) -> MobileTerminalAuthFrame {
+        let ticket_id = ticket["ticket_id"].as_str().unwrap();
+        let message =
+            mobile_terminal_ws_message(ticket_id, "fork1001", "local_bypass", "test-device", nonce);
+        let signature: Signature = signing_key.sign(message.as_bytes());
+        MobileTerminalAuthFrame {
+            frame_type: Some("auth".to_owned()),
+            ticket_id: Some(ticket_id.to_owned()),
+            ticket_secret: Some(ticket["ticket_secret"].as_str().unwrap().to_owned()),
+            device_key_id: Some("test-device".to_owned()),
+            nonce: Some(nonce.to_owned()),
+            signature: Some(STANDARD.encode(signature.to_der().as_bytes())),
+        }
+    }
+
+    fn api_error_status_detail(error: ApiError) -> (StatusCode, String) {
+        match error {
+            ApiError::Status { status, detail } => (status, detail),
+            ApiError::NotFound(detail) => (StatusCode::NOT_FOUND, detail.to_owned()),
+            ApiError::Auth { status, detail, .. } => (status, detail.to_owned()),
+            ApiError::Internal(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()),
+        }
+    }
+
     #[tokio::test]
     async fn mobile_attach_ticket_requires_registered_device_signature() {
         let signing_key = SigningKey::random(&mut OsRng);
@@ -4896,5 +5398,137 @@ mod tests {
             body["detail"],
             "User is not allowed to use mobile terminal attach"
         );
+    }
+
+    #[tokio::test]
+    async fn mobile_terminal_auth_consumes_ticket_and_tracks_active_attach() {
+        let signing_key = SigningKey::random(&mut OsRng);
+        let state = AppState::new(mobile_ticket_config(&signing_key));
+        let ticket = mint_mobile_attach_ticket(&state, &signing_key, "ticket-nonce-1").await;
+        let frame = signed_mobile_terminal_auth_frame(&signing_key, &ticket, "ws-nonce-1");
+
+        let (consumed_ticket, attach_id) = consume_mobile_terminal_ticket(&state, &frame).unwrap();
+
+        assert_eq!(consumed_ticket.ticket_id, ticket["ticket_id"]);
+        assert_eq!(consumed_ticket.session_id, "fork1001");
+        assert_eq!(consumed_ticket.device_key_id, "test-device");
+        assert!(!state
+            .mobile_terminal_tickets
+            .lock()
+            .unwrap()
+            .contains_key(ticket["ticket_id"].as_str().unwrap()));
+        {
+            let active = state.mobile_terminal_active_attaches.lock().unwrap();
+            let attach = active.get(&attach_id).unwrap();
+            assert_eq!(attach.user_id, "local_bypass");
+            assert_eq!(attach.session_id, "fork1001");
+            assert_eq!(attach.provider, "codex-fork");
+            assert_eq!(attach.device_key_id, "test-device");
+        }
+
+        remove_mobile_terminal_active_attach(&state, &attach_id);
+        assert!(state
+            .mobile_terminal_active_attaches
+            .lock()
+            .unwrap()
+            .is_empty());
+
+        let replay = consume_mobile_terminal_ticket(&state, &frame).unwrap_err();
+        let (status, detail) = api_error_status_detail(replay);
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(detail, "Attach ticket is invalid or expired");
+    }
+
+    #[tokio::test]
+    async fn mobile_terminal_auth_rejects_secret_mismatch_without_consuming_ticket() {
+        let signing_key = SigningKey::random(&mut OsRng);
+        let state = AppState::new(mobile_ticket_config(&signing_key));
+        let ticket = mint_mobile_attach_ticket(&state, &signing_key, "ticket-nonce-1").await;
+        let mut frame = signed_mobile_terminal_auth_frame(&signing_key, &ticket, "ws-nonce-1");
+        frame.ticket_secret = Some("wrong-secret".to_owned());
+
+        let error = consume_mobile_terminal_ticket(&state, &frame).unwrap_err();
+        let (status, detail) = api_error_status_detail(error);
+
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(detail, "Attach ticket secret mismatch");
+        assert!(state
+            .mobile_terminal_tickets
+            .lock()
+            .unwrap()
+            .contains_key(ticket["ticket_id"].as_str().unwrap()));
+    }
+
+    #[tokio::test]
+    async fn mobile_terminal_auth_rejects_device_mismatch_without_consuming_ticket() {
+        let signing_key = SigningKey::random(&mut OsRng);
+        let state = AppState::new(mobile_ticket_config(&signing_key));
+        let ticket = mint_mobile_attach_ticket(&state, &signing_key, "ticket-nonce-1").await;
+        let mut frame = signed_mobile_terminal_auth_frame(&signing_key, &ticket, "ws-nonce-1");
+        frame.device_key_id = Some("other-device".to_owned());
+
+        let error = consume_mobile_terminal_ticket(&state, &frame).unwrap_err();
+        let (status, detail) = api_error_status_detail(error);
+
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(detail, "Attach ticket device mismatch");
+        assert!(state
+            .mobile_terminal_tickets
+            .lock()
+            .unwrap()
+            .contains_key(ticket["ticket_id"].as_str().unwrap()));
+    }
+
+    #[tokio::test]
+    async fn mobile_terminal_auth_rejects_invalid_signature_without_consuming_ticket() {
+        let signing_key = SigningKey::random(&mut OsRng);
+        let state = AppState::new(mobile_ticket_config(&signing_key));
+        let ticket = mint_mobile_attach_ticket(&state, &signing_key, "ticket-nonce-1").await;
+        let mut frame = signed_mobile_terminal_auth_frame(&signing_key, &ticket, "ws-nonce-1");
+        frame.nonce = Some("tampered-nonce".to_owned());
+
+        let error = consume_mobile_terminal_ticket(&state, &frame).unwrap_err();
+        let (status, detail) = api_error_status_detail(error);
+
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(detail, "Invalid device signature");
+        assert!(state
+            .mobile_terminal_tickets
+            .lock()
+            .unwrap()
+            .contains_key(ticket["ticket_id"].as_str().unwrap()));
+    }
+
+    #[tokio::test]
+    async fn mobile_terminal_auth_rechecks_active_limits_without_consuming_ticket() {
+        let signing_key = SigningKey::random(&mut OsRng);
+        let state = AppState::new(mobile_ticket_config(&signing_key));
+        let ticket = mint_mobile_attach_ticket(&state, &signing_key, "ticket-nonce-1").await;
+        let frame = signed_mobile_terminal_auth_frame(&signing_key, &ticket, "ws-nonce-1");
+        state
+            .mobile_terminal_active_attaches
+            .lock()
+            .unwrap()
+            .insert(
+                "existing".to_owned(),
+                MobileTerminalActiveAttach {
+                    user_id: "local_bypass".to_owned(),
+                    session_id: "fork1001".to_owned(),
+                    provider: "codex-fork".to_owned(),
+                    device_key_id: "test-device".to_owned(),
+                    started_at_unix: OffsetDateTime::now_utc().unix_timestamp(),
+                },
+            );
+
+        let error = consume_mobile_terminal_ticket(&state, &frame).unwrap_err();
+        let (status, detail) = api_error_status_detail(error);
+
+        assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(detail, "Too many active mobile attaches for user");
+        assert!(state
+            .mobile_terminal_tickets
+            .lock()
+            .unwrap()
+            .contains_key(ticket["ticket_id"].as_str().unwrap()));
     }
 }

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -1705,6 +1705,13 @@ async fn create_mobile_attach_ticket(
     cleanup_mobile_terminal_tickets(&mut tickets, now.unix_timestamp());
     tickets
         .retain(|_, ticket| !(ticket.user_id == user_id && ticket.device_key_id == device_key_id));
+    let active = state
+        .mobile_terminal_active_attaches
+        .lock()
+        .map_err(|_| ApiError::Status {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            detail: "Mobile terminal active attach store is unavailable".to_owned(),
+        })?;
     let max_global = clamp_usize(
         state.config.mobile_terminal.max_concurrent_attaches_global,
         1,
@@ -1729,7 +1736,7 @@ async fn create_mobile_attach_ticket(
         16,
         1,
     );
-    if tickets.len() >= max_global {
+    if tickets.len() + active.len() >= max_global {
         return Err(ApiError::Status {
             status: StatusCode::TOO_MANY_REQUESTS,
             detail: "Too many active mobile attaches".to_owned(),
@@ -1739,6 +1746,10 @@ async fn create_mobile_attach_ticket(
         .values()
         .filter(|ticket| ticket.user_id == user_id)
         .count()
+        + active
+            .values()
+            .filter(|attach| attach.user_id == user_id)
+            .count()
         >= max_user
     {
         return Err(ApiError::Status {
@@ -1750,6 +1761,10 @@ async fn create_mobile_attach_ticket(
         .values()
         .filter(|ticket| ticket.session_id == session.id)
         .count()
+        + active
+            .values()
+            .filter(|attach| attach.session_id == session.id)
+            .count()
         >= max_session
     {
         return Err(ApiError::Status {
@@ -1757,6 +1772,7 @@ async fn create_mobile_attach_ticket(
             detail: "Session already has an active mobile attach".to_owned(),
         });
     }
+    drop(active);
 
     tickets.insert(
         ticket_id.clone(),
@@ -5155,6 +5171,37 @@ mod tests {
         let tickets = state.mobile_terminal_tickets.lock().unwrap();
         assert_eq!(tickets.len(), 1);
         assert!(tickets.contains_key(second_body["ticket_id"].as_str().unwrap()));
+    }
+
+    #[tokio::test]
+    async fn mobile_attach_ticket_rejects_active_attach_quota_at_mint_time() {
+        let signing_key = SigningKey::random(&mut OsRng);
+        let state = AppState::new(mobile_ticket_config(&signing_key));
+        state
+            .mobile_terminal_active_attaches
+            .lock()
+            .unwrap()
+            .insert(
+                "existing".to_owned(),
+                MobileTerminalActiveAttach {
+                    user_id: "local_bypass".to_owned(),
+                    session_id: "fork1001".to_owned(),
+                    provider: "codex-fork".to_owned(),
+                    device_key_id: "test-device".to_owned(),
+                    started_at_unix: OffsetDateTime::now_utc().unix_timestamp(),
+                },
+            );
+        let app = router(state.clone());
+
+        let response = app
+            .oneshot(attach_ticket_request(&signing_key, "nonce-1"))
+            .await
+            .unwrap();
+        let (status, body) = response_json(response).await;
+
+        assert_eq!(status, StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(body["detail"], "Too many active mobile attaches for user");
+        assert!(state.mobile_terminal_tickets.lock().unwrap().is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- enable Axum WebSocket handling for `/client/terminal` while preserving the Python-compatible plain HTTP 426 diagnostic
- require first-frame mobile terminal auth, verify/consume attach tickets, revalidate session/user/device state, and enforce active attach quotas at consume time
- track process-local active attaches and return an explicit unimplemented bridge error/exit until PTY streaming lands

Fixes #843

## Validation
- `cargo fmt --check`
- `cargo test -p sm-server`
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py`
- `git diff --check`