### PR TITLE
Rust MVP: advertise native mobile terminal metadata

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -1528,15 +1528,16 @@ fn short_session_id(session_id: &str) -> String {
 async fn list_client_sessions(
     State(state): State<Arc<AppState>>,
     request: Request,
-) -> Result<Json<SessionsEnvelope<ClientSessionResponse>>, ApiError> {
+) -> Result<Json<Value>, ApiError> {
     ensure_session_read_allowed(&state, &request)?;
+    let actor_email = request_actor_email(&state.config, &request);
     let sessions = state
         .session_store
         .list_sessions(false)?
         .into_iter()
-        .map(ClientSessionResponse::from)
+        .map(|session| client_session_value(&state.config, session, actor_email.as_deref(), None))
         .collect::<Vec<_>>();
-    Ok(Json(SessionsEnvelope::from(sessions)))
+    Ok(Json(json!({ "sessions": sessions })))
 }
 
 async fn list_nodes(
@@ -1659,12 +1660,18 @@ async fn get_client_session(
     State(state): State<Arc<AppState>>,
     Path(session_id): Path<String>,
     request: Request,
-) -> Result<Json<ClientSessionResponse>, ApiError> {
+) -> Result<Json<Value>, ApiError> {
     ensure_session_read_allowed(&state, &request)?;
+    let actor_email = request_actor_email(&state.config, &request);
     let Some(session) = state.session_store.get_session(&session_id)? else {
         return Err(ApiError::NotFound("Session not found"));
     };
-    Ok(Json(ClientSessionResponse::from(session)))
+    Ok(Json(client_session_value(
+        &state.config,
+        session,
+        actor_email.as_deref(),
+        None,
+    )))
 }
 
 async fn create_mobile_attach_ticket(
@@ -3702,7 +3709,7 @@ fn shadow_predict_session_read(
         .strip_prefix("/client/sessions/")
         .filter(|value| !value.contains('/'))
     {
-        let Some(session) = state.session_store.get_session(session_id)? else {
+        let Some(_session) = state.session_store.get_session(session_id)? else {
             let body = serde_json::to_vec(&json!({ "detail": "Session not found" }))?;
             return Ok(Some(ShadowPrediction {
                 status: StatusCode::NOT_FOUND.as_u16(),
@@ -3710,11 +3717,10 @@ fn shadow_predict_session_read(
                 support_status: "implemented_read",
             }));
         };
-        let body = serde_json::to_vec(&ClientSessionResponse::from(session))?;
         return Ok(Some(ShadowPrediction {
             status: StatusCode::OK.as_u16(),
-            body_sha256: Some(sha256_hex(&body)),
-            support_status: "implemented_read",
+            body_sha256: None,
+            support_status: "implemented_read_status_only",
         }));
     }
 
@@ -3790,6 +3796,12 @@ fn shadow_predict_session_read(
 fn client_bootstrap_response(config: &AppConfig) -> ClientBootstrapResponse {
     let auth = &config.google_auth;
     let external = &config.external_access;
+    let mobile_terminal_ws_url = if config.mobile_terminal.enabled {
+        mobile_terminal_ws_url(config, None)
+    } else {
+        None
+    };
+    let mobile_terminal_supported = mobile_terminal_ws_url.is_some();
 
     ClientBootstrapResponse {
         auth: BootstrapAuth {
@@ -3806,11 +3818,15 @@ fn client_bootstrap_response(config: &AppConfig) -> ClientBootstrapResponse {
             public_ssh_host: trimmed(&external.public_ssh_host),
             ssh_username: trimmed(&external.ssh_username),
             termux_attach_supported: false,
-            mobile_terminal_supported: false,
-            mobile_terminal_ws_url: None,
+            mobile_terminal_supported,
+            mobile_terminal_ws_url,
         },
         session_open_defaults: SessionOpenDefaults {
-            preferred_action: "details",
+            preferred_action: if mobile_terminal_supported {
+                "mobile_terminal"
+            } else {
+                "details"
+            },
             termux_package: "com.termux",
         },
     }
@@ -3850,6 +3866,147 @@ fn attach_descriptor_payload(session: SessionRecord) -> Value {
 fn attach_descriptor_response(session: SessionRecord) -> Value {
     json!({
         "attach": attach_descriptor_payload(session),
+    })
+}
+
+fn client_session_value(
+    config: &AppConfig,
+    session: SessionRecord,
+    actor_email: Option<&str>,
+    route_prefix: Option<&str>,
+) -> Value {
+    let mut value = serde_json::to_value(ClientSessionResponse::from(session.clone()))
+        .unwrap_or_else(|_| json!({}));
+    let attach_descriptor = attach_descriptor_payload(session.clone());
+    value["attach_descriptor"] = attach_descriptor.clone();
+    value["termux_attach"] = Value::Null;
+    let mobile_terminal = mobile_terminal_metadata(
+        config,
+        &session,
+        &attach_descriptor,
+        actor_email,
+        route_prefix,
+    );
+    value["mobile_terminal"] = mobile_terminal.clone();
+    value["primary_action"] = mobile_primary_action(&mobile_terminal, &attach_descriptor);
+    value
+}
+
+fn mobile_primary_action(mobile_terminal: &Value, attach_descriptor: &Value) -> Value {
+    if mobile_terminal
+        .get("supported")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        json!({
+            "type": "mobile_terminal",
+            "label": "Attach",
+        })
+    } else if attach_descriptor
+        .get("attach_supported")
+        .and_then(Value::as_bool)
+        .unwrap_or(true)
+        != true
+    {
+        json!({
+            "type": "details",
+            "label": "View details",
+            "reason": attach_descriptor
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("attach not supported"),
+        })
+    } else {
+        json!({
+            "type": "details",
+            "label": "View details",
+        })
+    }
+}
+
+fn mobile_terminal_metadata(
+    config: &AppConfig,
+    session: &SessionRecord,
+    attach_descriptor: &Value,
+    actor_email: Option<&str>,
+    route_prefix: Option<&str>,
+) -> Value {
+    if !config.mobile_terminal.enabled {
+        return json!({
+            "supported": false,
+            "reason": "mobile terminal attach is disabled",
+        });
+    }
+    let Some(ws_url) = mobile_terminal_ws_url(config, route_prefix) else {
+        return json!({
+            "supported": false,
+            "reason": "mobile terminal public HTTPS host is not configured",
+        });
+    };
+    let Some(actor_email) = actor_email.map(str::trim).filter(|value| !value.is_empty()) else {
+        return json!({
+            "supported": false,
+            "reason": "authenticated mobile terminal user is required",
+        });
+    };
+    let Some((_user_id, user_config)) = mobile_terminal_visible_user(config, actor_email) else {
+        return json!({
+            "supported": false,
+            "reason": "mobile terminal user is not configured",
+        });
+    };
+    if !user_config.interactive_shell_access {
+        return json!({
+            "supported": false,
+            "reason": "interactive shell access is not enabled",
+        });
+    }
+    if !mobile_terminal_user_has_registered_device(user_config) {
+        return json!({
+            "supported": false,
+            "reason": "registered mobile device key is required",
+        });
+    }
+    if attach_descriptor
+        .get("attach_supported")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+        != true
+    {
+        return json!({
+            "supported": false,
+            "reason": attach_descriptor
+                .get("message")
+                .and_then(Value::as_str)
+                .unwrap_or("Session is not attachable"),
+        });
+    }
+    let tmux_session = attach_descriptor
+        .get("tmux_session")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .trim();
+    let tmux_socket_name = attach_descriptor
+        .get("tmux_socket_name")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if let Err(error) = validate_mobile_terminal_tmux_target(tmux_session, tmux_socket_name) {
+        return json!({
+            "supported": false,
+            "reason": api_error_detail(&error),
+        });
+    }
+
+    json!({
+        "supported": true,
+        "transport": "sm-https-tmux",
+        "ticket_endpoint": mobile_terminal_attach_ticket_path(config, &session.id, route_prefix),
+        "ws_url": ws_url,
+        "tmux_session": tmux_session,
+        "tmux_socket_name": tmux_socket_name,
+        "runtime_mode": "detached_runtime",
+        "requires_device_key": true,
     })
 }
 
@@ -4969,6 +5126,14 @@ fn request_actor_email_from_parts(
         return Some("local_bypass".to_owned());
     }
     None
+}
+
+fn request_actor_email(config: &AppConfig, request: &Request) -> Option<String> {
+    let peer_addr = request
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|value| value.0);
+    request_actor_email_from_parts(config, request.headers(), peer_addr)
 }
 
 fn validate_json_payload_size(
@@ -6120,7 +6285,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn mobile_terminal_routes_do_not_advertise_unimplemented_bridge() {
+    async fn mobile_terminal_routes_advertise_supported_bridge() {
         let signing_key = SigningKey::random(&mut OsRng);
         let app = router(AppState::new(mobile_ticket_config(&signing_key)));
 
@@ -6135,8 +6300,24 @@ mod tests {
         let (status, body) = response_json(response).await;
         assert_eq!(status, StatusCode::OK);
         let session = &body["sessions"][0];
-        assert_eq!(session["mobile_terminal"]["supported"], false);
-        assert_eq!(session["primary_action"]["type"], "details");
+        assert_eq!(session["mobile_terminal"]["supported"], true);
+        assert_eq!(session["mobile_terminal"]["transport"], "sm-https-tmux");
+        assert_eq!(
+            session["mobile_terminal"]["ticket_endpoint"],
+            "/client/sessions/fork1001/attach-ticket"
+        );
+        assert_eq!(
+            session["mobile_terminal"]["ws_url"],
+            "wss://sm.rajeshgo.li/client/terminal"
+        );
+        assert_eq!(
+            session["mobile_terminal"]["tmux_session"],
+            "codex-fork-fork1001"
+        );
+        assert_eq!(session["mobile_terminal"]["requires_device_key"], true);
+        assert_eq!(session["termux_attach"], Value::Null);
+        assert_eq!(session["primary_action"]["type"], "mobile_terminal");
+        assert_eq!(session["primary_action"]["label"], "Attach");
     }
 
     #[tokio::test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -19,7 +19,8 @@ use sm_server::{
     config::{
         AppArtifactsConfig, AppConfig, BugReportsConfig, CodexForkLaunchConfig, EmailConfig,
         ExternalAccessConfig, GoogleAuthConfig, MobileAnalyticsConfig, MobileTerminalConfig,
-        PathsConfig, QueueRunnerConfig, RustCoreConfig, SmSendConfig,
+        MobileTerminalDeviceKeyConfig, MobileTerminalUserConfig, PathsConfig, QueueRunnerConfig,
+        RustCoreConfig, SmSendConfig,
     },
     http::{router, AppState},
 };
@@ -2224,7 +2225,7 @@ async fn shadow_http_treats_auth_session_as_status_only() {
 }
 
 #[tokio::test]
-async fn shadow_http_treats_bootstrap_as_status_only_until_mobile_terminal_is_ported() {
+async fn shadow_http_treats_bootstrap_as_status_only_for_mobile_terminal_metadata() {
     let app = router(AppState::new(AppConfig {
         mobile_terminal: MobileTerminalConfig {
             enabled: true,
@@ -2381,7 +2382,7 @@ async fn auth_session_does_not_bypass_for_spoofed_localhost_host_from_remote_pee
 }
 
 #[tokio::test]
-async fn bootstrap_preserves_native_schema_without_termux_or_terminal_advertisement() {
+async fn bootstrap_preserves_native_schema_without_termux_or_terminal_when_disabled() {
     let app = router(AppState::new(AppConfig {
         google_auth: GoogleAuthConfig {
             client_id: Some("web-client-id".to_owned()),
@@ -2431,7 +2432,7 @@ async fn bootstrap_preserves_native_schema_without_termux_or_terminal_advertisem
 }
 
 #[tokio::test]
-async fn bootstrap_does_not_advertise_unimplemented_mobile_terminal() {
+async fn bootstrap_advertises_configured_mobile_terminal() {
     let app = router(AppState::new(AppConfig {
         google_auth: GoogleAuthConfig {
             client_id: Some("web-client-id".to_owned()),
@@ -2441,6 +2442,36 @@ async fn bootstrap_does_not_advertise_unimplemented_mobile_terminal() {
             public_http_host: Some("sm.example.com".to_owned()),
             ..ExternalAccessConfig::default()
         },
+        mobile_terminal: MobileTerminalConfig {
+            enabled: true,
+            ..MobileTerminalConfig::default()
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = get_json(app, "/client/bootstrap").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        payload["external_access"]["mobile_terminal_supported"],
+        true
+    );
+    assert_eq!(
+        payload["external_access"]["mobile_terminal_ws_url"],
+        "wss://sm.example.com/client/terminal"
+    );
+    assert_eq!(
+        payload["session_open_defaults"],
+        json!({
+            "preferred_action": "mobile_terminal",
+            "termux_package": "com.termux"
+        })
+    );
+}
+
+#[tokio::test]
+async fn bootstrap_does_not_advertise_mobile_terminal_without_public_ws_url() {
+    let app = router(AppState::new(AppConfig {
         mobile_terminal: MobileTerminalConfig {
             enabled: true,
             ..MobileTerminalConfig::default()
@@ -2598,7 +2629,7 @@ async fn sessions_can_include_stopped_sessions() {
 }
 
 #[tokio::test]
-async fn client_sessions_adds_read_only_mobile_metadata_without_termux() {
+async fn client_sessions_adds_attach_descriptor_without_termux_when_mobile_disabled() {
     let state_file = write_session_fixture();
     let app = router(AppState::new(config_with_state_file(&state_file)));
 
@@ -2607,19 +2638,65 @@ async fn client_sessions_adds_read_only_mobile_metadata_without_termux() {
     assert_eq!(status, StatusCode::OK);
     let first = &payload["sessions"][0];
     assert_eq!(first["id"], "run12345");
-    assert_eq!(first["attach_descriptor"]["attach_supported"], false);
+    assert_eq!(first["attach_descriptor"]["attach_supported"], true);
     assert_eq!(
-        first["attach_descriptor"]["message"],
-        "attach tickets are not implemented in the Rust read-only scaffold"
+        first["attach_descriptor"]["tmux_session"],
+        "claude-run12345"
     );
+    assert_eq!(first["attach_descriptor"]["message"], Value::Null);
     assert_eq!(first["termux_attach"], Value::Null);
     assert_eq!(first["mobile_terminal"]["supported"], false);
+    assert_eq!(
+        first["mobile_terminal"]["reason"],
+        "mobile terminal attach is disabled"
+    );
     assert_eq!(first["primary_action"]["type"], "details");
     assert!(payload["sessions"]
         .as_array()
         .unwrap()
         .iter()
         .all(|session| session["id"] != "stop1234"));
+}
+
+#[tokio::test]
+async fn client_sessions_advertises_mobile_terminal_for_authorized_local_user() {
+    let state_file = write_session_fixture();
+    let app = router(AppState::new(config_with_state_file_and_mobile_terminal(
+        &state_file,
+    )));
+
+    let (status, payload) = get_json_with_host_and_peer(
+        app,
+        "/client/sessions",
+        "localhost:8421",
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let first = &payload["sessions"][0];
+    assert_eq!(first["id"], "run12345");
+    assert_eq!(first["termux_attach"], Value::Null);
+    assert_eq!(
+        first["mobile_terminal"],
+        json!({
+            "supported": true,
+            "transport": "sm-https-tmux",
+            "ticket_endpoint": "/client/sessions/run12345/attach-ticket",
+            "ws_url": "wss://sm.example.com/client/terminal",
+            "tmux_session": "claude-run12345",
+            "tmux_socket_name": null,
+            "runtime_mode": "detached_runtime",
+            "requires_device_key": true
+        })
+    );
+    assert_eq!(
+        first["primary_action"],
+        json!({
+            "type": "mobile_terminal",
+            "label": "Attach"
+        })
+    );
 }
 
 #[tokio::test]
@@ -2656,10 +2733,58 @@ async fn client_session_detail_returns_mobile_metadata_for_one_session() {
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["id"], "run12345");
-    assert_eq!(payload["attach_descriptor"]["attach_supported"], false);
+    assert_eq!(payload["attach_descriptor"]["attach_supported"], true);
     assert_eq!(payload["termux_attach"], Value::Null);
     assert_eq!(payload["mobile_terminal"]["supported"], false);
+    assert_eq!(
+        payload["mobile_terminal"]["reason"],
+        "mobile terminal attach is disabled"
+    );
     assert_eq!(payload["primary_action"]["type"], "details");
+}
+
+#[tokio::test]
+async fn client_session_detail_explains_mobile_terminal_auth_gap_without_actor() {
+    let state_file = write_session_fixture();
+    let app = router(AppState::new(config_with_state_file_and_mobile_terminal(
+        &state_file,
+    )));
+
+    let (status, payload) = get_json(app, "/client/sessions/run12345").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["id"], "run12345");
+    assert_eq!(payload["attach_descriptor"]["attach_supported"], true);
+    assert_eq!(payload["mobile_terminal"]["supported"], false);
+    assert_eq!(
+        payload["mobile_terminal"]["reason"],
+        "authenticated mobile terminal user is required"
+    );
+    assert_eq!(payload["primary_action"]["type"], "details");
+}
+
+#[tokio::test]
+async fn client_session_detail_preserves_attach_unsupported_primary_action_reason() {
+    let state_file = write_session_fixture();
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+
+    let (status, payload) = get_json(app, "/client/sessions/stop1234").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["id"], "stop1234");
+    assert_eq!(payload["attach_descriptor"]["attach_supported"], false);
+    assert_eq!(
+        payload["attach_descriptor"]["message"],
+        "Session is stopped"
+    );
+    assert_eq!(
+        payload["primary_action"],
+        json!({
+            "type": "details",
+            "label": "View details",
+            "reason": "Session is stopped"
+        })
+    );
 }
 
 #[tokio::test]
@@ -7147,6 +7272,26 @@ fn config_with_state_file(state_file: &PathBuf) -> AppConfig {
         },
         ..AppConfig::default()
     }
+}
+
+fn config_with_state_file_and_mobile_terminal(state_file: &PathBuf) -> AppConfig {
+    let mut config = config_with_state_file(state_file);
+    config.external_access.public_http_host = Some("sm.example.com".to_owned());
+    config.mobile_terminal.enabled = true;
+    config.mobile_terminal.allowed_users.insert(
+        "local_bypass".to_owned(),
+        MobileTerminalUserConfig {
+            interactive_shell_access: true,
+            registered_device_keys: vec![MobileTerminalDeviceKeyConfig {
+                id: "android-1".to_owned(),
+                public_key: "-----BEGIN PUBLIC KEY-----\nfixture\n-----END PUBLIC KEY-----"
+                    .to_owned(),
+                enabled: true,
+            }],
+            ..MobileTerminalUserConfig::default()
+        },
+    );
+    config
 }
 
 fn config_with_state_file_and_email(


### PR DESCRIPTION
## Summary
- advertise configured native mobile terminal support from Rust `/client/bootstrap`
- project `/client/sessions` and `/client/sessions/{id}` through real attach descriptors, mobile terminal metadata, and primary actions
- keep Termux retired/unimplemented and keep actor-dependent shadow client-session reads status-only

## Validation
- cargo fmt --check
- cargo test -p sm-server
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py
- git diff --check

Fixes #847