### PR TITLE
Rust MVP: add queue job detail endpoint

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -270,6 +270,7 @@ pub fn router(state: AppState) -> Router {
         .route("/events", get(events_stream))
         .route("/__shadow/http", post(shadow_http))
         .route("/queue-jobs", get(list_queue_jobs))
+        .route("/queue-jobs/{job_id}", get(get_queue_job))
         .route("/codex-review-requests", get(list_codex_review_requests))
         .route("/nodes", get(list_nodes))
         .route("/humans", get(list_humans))
@@ -1710,6 +1711,20 @@ async fn list_queue_jobs(
         response_jobs.push(queue_job_response(&state, job)?);
     }
     Ok(Json(json!({ "jobs": response_jobs })))
+}
+
+async fn get_queue_job(
+    State(state): State<Arc<AppState>>,
+    Path(job_id): Path<String>,
+    request: Request,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    let queue_state_dir = state.config.queue_runner_state_dir();
+    let queue_db_path = expand_home(&queue_state_dir.to_string_lossy()).join("queue_runner.db");
+    let Some(job) = RetainedQueueStore::get_queue_job_from_path(&queue_db_path, &job_id)? else {
+        return Err(ApiError::NotFound("Queue job not found"));
+    };
+    Ok(Json(queue_job_response(&state, job)?))
 }
 
 fn resolve_session_or_registry_role(
@@ -3870,6 +3885,29 @@ fn shadow_predict_read(
         return Ok(None);
     }
 
+    if let Some(job_id) = path.strip_prefix("/queue-jobs/") {
+        let queue_state_dir = state.config.queue_runner_state_dir();
+        let queue_db_path = expand_home(&queue_state_dir.to_string_lossy()).join("queue_runner.db");
+        let (status, body) =
+            match RetainedQueueStore::get_queue_job_from_path(&queue_db_path, job_id)? {
+                Some(job) => (
+                    StatusCode::OK,
+                    serde_json::to_vec(&queue_job_response(state, job).map_err(|error| {
+                        anyhow::anyhow!("queue job response failed: {error:?}")
+                    })?)?,
+                ),
+                None => (
+                    StatusCode::NOT_FOUND,
+                    serde_json::to_vec(&json!({ "detail": "Queue job not found" }))?,
+                ),
+            };
+        return Ok(Some(ShadowPrediction {
+            status: status.as_u16(),
+            body_sha256: Some(sha256_hex(&body)),
+            support_status: "implemented_read",
+        }));
+    }
+
     let body = match path {
         "/health" => Some(serde_json::to_vec(&json!({ "status": "healthy" }))?),
         "/health/detailed" => {
@@ -5531,6 +5569,7 @@ fn is_protected_read_surface(method: &str, path: &str) -> bool {
         || path == "/client/analytics/summary"
         || path == "/codex-review-requests"
         || path == "/queue-jobs"
+        || path.starts_with("/queue-jobs/")
         || path == "/nodes"
         || path == "/sessions"
         || path == "/client/sessions"

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -184,6 +184,17 @@ impl RetainedQueueStore {
         list_queue_jobs_conn(&conn, filters)
     }
 
+    pub fn get_queue_job_from_path(db_path: &Path, job_id: &str) -> Result<Option<QueueJobRecord>> {
+        if !db_path.exists() {
+            return Ok(None);
+        }
+        let conn = match Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY) {
+            Ok(conn) => conn,
+            Err(_) => return Ok(None),
+        };
+        get_queue_job_conn(&conn, job_id)
+    }
+
     pub fn ensure_schema(&self) -> Result<()> {
         self.with_connection(|_| Ok(()))
     }
@@ -996,46 +1007,77 @@ fn list_queue_jobs_conn(
         }
         Err(error) => return Err(error.into()),
     };
-    let rows = statement.query_map(rusqlite::params_from_iter(values), |row| {
-        let argv_json: Option<String> = row.get(6)?;
-        let argv = match argv_json
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-        {
-            Some(raw) => Some(serde_json::from_str::<Vec<String>>(raw).map_err(|error| {
-                rusqlite::Error::FromSqlConversionFailure(
-                    6,
-                    rusqlite::types::Type::Text,
-                    Box::new(error),
-                )
-            })?),
-            None => None,
-        };
-        Ok(QueueJobRecord {
-            id: row.get(0)?,
-            job_type: row.get(1)?,
-            label: row.get(2)?,
-            requester_session_id: row.get(3)?,
-            notify_session_id: row
-                .get::<_, Option<String>>(4)?
-                .filter(|value| !value.is_empty()),
-            cwd: row.get(5)?,
-            argv,
-            script_path: row.get(7)?,
-            timeout_seconds: row.get(8)?,
-            state: row.get(9)?,
-            holding_reason: row.get(10)?,
-            queued_at: row.get(11)?,
-            started_at: row.get(12)?,
-            finished_at: row.get(13)?,
-            pid: row.get(14)?,
-            process_group_id: row.get(15)?,
-            exit_code: row.get(16)?,
-            log_path: row.get(17)?,
-        })
-    })?;
+    let rows = statement.query_map(
+        rusqlite::params_from_iter(values),
+        queue_job_record_from_row,
+    )?;
     Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
+}
+
+fn get_queue_job_conn(conn: &Connection, job_id: &str) -> Result<Option<QueueJobRecord>> {
+    let mut statement = match conn.prepare(
+        r#"
+        SELECT id, type, label, requester_session_id, notify_session_id, cwd,
+               argv_json, script_path, timeout_seconds, state, holding_reason,
+               queued_at, started_at, finished_at, pid, process_group_id,
+               exit_code, log_path
+        FROM queue_jobs
+        WHERE id = ?1
+        LIMIT 1
+        "#,
+    ) {
+        Ok(statement) => statement,
+        Err(rusqlite::Error::SqliteFailure(_, Some(message)))
+            if message.contains("no such table") =>
+        {
+            return Ok(None);
+        }
+        Err(error) => return Err(error.into()),
+    };
+    statement
+        .query_row(params![job_id], queue_job_record_from_row)
+        .optional()
+        .map_err(Into::into)
+}
+
+fn queue_job_record_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<QueueJobRecord> {
+    let argv_json: Option<String> = row.get(6)?;
+    let argv = match argv_json
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        Some(raw) => Some(serde_json::from_str::<Vec<String>>(raw).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                6,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?),
+        None => None,
+    };
+    Ok(QueueJobRecord {
+        id: row.get(0)?,
+        job_type: row.get(1)?,
+        label: row.get(2)?,
+        requester_session_id: row.get(3)?,
+        notify_session_id: row
+            .get::<_, Option<String>>(4)?
+            .filter(|value| !value.is_empty()),
+        cwd: row.get(5)?,
+        argv,
+        script_path: row.get(7)?,
+        timeout_seconds: row.get(8)?,
+        state: row.get(9)?,
+        holding_reason: row.get(10)?,
+        queued_at: row.get(11)?,
+        started_at: row.get(12)?,
+        finished_at: row.get(13)?,
+        pid: row.get(14)?,
+        process_group_id: row.get(15)?,
+        exit_code: row.get(16)?,
+        log_path: row.get(17)?,
+    })
 }
 
 fn optional_sqlite_json_scalar(value: ValueRef<'_>) -> Option<JsonValue> {

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -1576,6 +1576,20 @@ async fn queue_jobs_missing_db_returns_empty_jobs() {
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload, json!({ "jobs": [] }));
+
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        queue_runner: QueueRunnerConfig {
+            state_dir: queue_state_dir.display().to_string(),
+            configured: true,
+        },
+        ..AppConfig::default()
+    }));
+    let (status, payload) = get_json(app, "/queue-jobs/missing").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(payload["detail"], "Queue job not found");
 }
 
 #[tokio::test]
@@ -1661,6 +1675,19 @@ async fn queue_jobs_lists_rows_with_filters_and_session_names() {
     assert_eq!(jobs[1]["notify_name"], "codex-fork-notify2");
     assert_eq!(jobs[1]["script_path"], "/tmp/run-perf.sh");
     assert_eq!(jobs[1]["pid"], 4242);
+
+    let (status, payload) = get_json(app.clone(), "/queue-jobs/job-pending").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["id"], "job-pending");
+    assert_eq!(payload["type"], "tests");
+    assert_eq!(payload["requester_name"], "native requester");
+    assert_eq!(payload["notify_name"], "reviewer");
+    assert_eq!(payload["argv"], json!(["cargo", "test"]));
+    assert_eq!(payload["holding_reason"], "memory");
+
+    let (status, payload) = get_json(app.clone(), "/queue-jobs/missing").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(payload["detail"], "Queue job not found");
 
     let (status, payload) =
         get_json(app.clone(), "/queue-jobs?notify_target=notify1&type=tests").await;
@@ -1797,6 +1824,17 @@ async fn queue_jobs_rejects_public_host_without_auth() {
         payload["login_url"],
         "/auth/google/login?next=%2Fqueue-jobs"
     );
+
+    let app = router(AppState::new(config_with_state_file_and_auth(&state_file)));
+    let (status, payload) =
+        get_json_with_host(app, "/queue-jobs/job-pending", "sm.example.com").await;
+
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(payload["detail"], "Authentication required");
+    assert_eq!(
+        payload["login_url"],
+        "/auth/google/login?next=%2Fqueue-jobs%2Fjob-pending"
+    );
 }
 
 #[tokio::test]
@@ -1913,6 +1951,51 @@ async fn shadow_http_treats_live_session_lists_as_status_only() {
     assert_eq!(payload["predicted_status"], 200);
     assert_eq!(payload["predicted_body_sha256"], Value::Null);
     assert_eq!(payload["body_sha256_match"], Value::Null);
+}
+
+#[tokio::test]
+async fn shadow_http_reports_queue_job_detail_404() {
+    let state_file = unique_temp_path();
+    fs::write(&state_file, json!({ "sessions": [] }).to_string()).unwrap();
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        queue_runner: QueueRunnerConfig {
+            state_dir: state_file
+                .with_extension("missing-queue-runner")
+                .display()
+                .to_string(),
+            configured: true,
+        },
+        ..AppConfig::default()
+    }));
+    let python_body = serde_json::to_vec(&json!({ "detail": "Queue job not found" })).unwrap();
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/queue-jobs/missing",
+                "query_string": "",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 404,
+                "body_sha256": sha256_hex(&python_body)
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read");
+    assert_eq!(payload["comparison"], "match");
+    assert_eq!(payload["predicted_status"], 404);
+    assert_eq!(payload["body_sha256_match"], true);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add `GET /queue-jobs/{job_id}` to the Rust server
- reuse the queue job projection used by `GET /queue-jobs` so list/detail payloads stay aligned
- preserve queue state-dir resolution, auth behavior, missing DB/table handling, and 404 missing-job behavior

## Validation
- `cargo fmt --check && cargo test -p sm-server`
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py`
- `git diff --check`

Fixes #857