### PR TITLE
Rust MVP: add Codex review request detail endpoint

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -272,6 +272,10 @@ pub fn router(state: AppState) -> Router {
         .route("/queue-jobs", get(list_queue_jobs))
         .route("/queue-jobs/{job_id}", get(get_queue_job))
         .route("/codex-review-requests", get(list_codex_review_requests))
+        .route(
+            "/codex-review-requests/{request_id}",
+            get(get_codex_review_request),
+        )
         .route("/nodes", get(list_nodes))
         .route("/humans", get(list_humans))
         .route("/humans/{identifier}", get(get_human))
@@ -1671,6 +1675,21 @@ async fn list_codex_review_requests(
         requests.push(codex_review_request_response(&state, registration)?);
     }
     Ok(Json(json!({ "requests": requests })))
+}
+
+async fn get_codex_review_request(
+    State(state): State<Arc<AppState>>,
+    Path(request_id): Path<String>,
+    request: Request,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    let queue_db_path = expand_home(&state.config.sm_send.db_path);
+    let Some(registration) =
+        RetainedQueueStore::get_codex_review_request_from_path(&queue_db_path, &request_id)?
+    else {
+        return Err(ApiError::NotFound("Codex review request not found"));
+    };
+    Ok(Json(codex_review_request_response(&state, registration)?))
 }
 
 async fn list_queue_jobs(
@@ -3889,6 +3908,32 @@ fn shadow_predict_read(
         return Ok(None);
     }
 
+    if let Some(request_id) = path
+        .strip_prefix("/codex-review-requests/")
+        .filter(|value| !value.is_empty() && !value.contains('/'))
+    {
+        let queue_db_path = expand_home(&state.config.sm_send.db_path);
+        return match RetainedQueueStore::get_codex_review_request_from_path(
+            &queue_db_path,
+            request_id,
+        )? {
+            Some(_) => Ok(Some(ShadowPrediction {
+                status: StatusCode::OK.as_u16(),
+                body_sha256: None,
+                support_status: "implemented_read_status_only",
+            })),
+            None => {
+                let body =
+                    serde_json::to_vec(&json!({ "detail": "Codex review request not found" }))?;
+                Ok(Some(ShadowPrediction {
+                    status: StatusCode::NOT_FOUND.as_u16(),
+                    body_sha256: Some(sha256_hex(&body)),
+                    support_status: "implemented_read",
+                }))
+            }
+        };
+    }
+
     if let Some(job_id) = path
         .strip_prefix("/queue-jobs/")
         .filter(|value| !value.is_empty() && !value.contains('/'))
@@ -5574,6 +5619,7 @@ fn is_protected_read_surface(method: &str, path: &str) -> bool {
         || path == "/apk"
         || path == "/client/analytics/summary"
         || path == "/codex-review-requests"
+        || path.starts_with("/codex-review-requests/")
         || path == "/queue-jobs"
         || path.starts_with("/queue-jobs/")
         || path == "/nodes"

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -170,6 +170,20 @@ impl RetainedQueueStore {
         list_codex_review_requests_conn(&conn, filters)
     }
 
+    pub fn get_codex_review_request_from_path(
+        db_path: &Path,
+        request_id: &str,
+    ) -> Result<Option<CodexReviewRequestRegistration>> {
+        if !db_path.exists() {
+            return Ok(None);
+        }
+        let conn = match Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY) {
+            Ok(conn) => conn,
+            Err(_) => return Ok(None),
+        };
+        get_codex_review_request_conn(&conn, request_id)
+    }
+
     pub fn list_queue_jobs_from_path(
         db_path: &Path,
         filters: QueueJobFilters,
@@ -927,35 +941,76 @@ fn list_codex_review_requests_conn(
         }
         Err(error) => return Err(error.into()),
     };
-    let rows = statement.query_map(rusqlite::params_from_iter(values), |row| {
-        Ok(CodexReviewRequestRegistration {
-            id: row.get(0)?,
-            repo: row.get(1)?,
-            pr_number: row.get(2)?,
-            requester_session_id: row.get(3)?,
-            notify_session_id: row.get(4)?,
-            steer: row.get(5)?,
-            requested_at: row.get(6)?,
-            latest_request_comment_id: row.get(7)?,
-            latest_request_comment_url: row.get(8)?,
-            latest_request_posted_at: row.get(9)?,
-            attempt_count: row.get(10)?,
-            next_retry_at: row.get(11)?,
-            poll_interval_seconds: row.get(12)?,
-            retry_interval_seconds: row.get(13)?,
-            pickup_detected_at: row.get(14)?,
-            pickup_source: row.get(15)?,
-            review_landed_at: row.get(16)?,
-            review_source: row.get(17)?,
-            review_comment_id: optional_sqlite_json_scalar(row.get_ref(18)?),
-            review_url: row.get(19)?,
-            last_polled_at: row.get(20)?,
-            last_error: row.get(21)?,
-            state: row.get(22)?,
-            is_active: row.get::<_, Option<i64>>(23)?.unwrap_or(1) != 0,
-        })
-    })?;
+    let rows = statement.query_map(
+        rusqlite::params_from_iter(values),
+        codex_review_request_registration_from_row,
+    )?;
     Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
+}
+
+fn get_codex_review_request_conn(
+    conn: &Connection,
+    request_id: &str,
+) -> Result<Option<CodexReviewRequestRegistration>> {
+    let mut statement = match conn.prepare(
+        r#"
+        SELECT id, repo, pr_number, requester_session_id, notify_session_id, steer,
+               requested_at, latest_request_comment_id, latest_request_comment_url,
+               latest_request_posted_at, attempt_count, next_retry_at,
+               poll_interval_seconds, retry_interval_seconds, pickup_detected_at,
+               pickup_source, review_landed_at, review_source, review_comment_id,
+               review_url, last_polled_at, last_error, state, is_active
+        FROM codex_review_request_registrations
+        WHERE id = ?1
+        LIMIT 1
+        "#,
+    ) {
+        Ok(statement) => statement,
+        Err(rusqlite::Error::SqliteFailure(_, Some(message)))
+            if message.contains("no such table") =>
+        {
+            return Ok(None);
+        }
+        Err(error) => return Err(error.into()),
+    };
+    statement
+        .query_row(
+            params![request_id],
+            codex_review_request_registration_from_row,
+        )
+        .optional()
+        .map_err(Into::into)
+}
+
+fn codex_review_request_registration_from_row(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<CodexReviewRequestRegistration> {
+    Ok(CodexReviewRequestRegistration {
+        id: row.get(0)?,
+        repo: row.get(1)?,
+        pr_number: row.get(2)?,
+        requester_session_id: row.get(3)?,
+        notify_session_id: row.get(4)?,
+        steer: row.get(5)?,
+        requested_at: row.get(6)?,
+        latest_request_comment_id: row.get(7)?,
+        latest_request_comment_url: row.get(8)?,
+        latest_request_posted_at: row.get(9)?,
+        attempt_count: row.get(10)?,
+        next_retry_at: row.get(11)?,
+        poll_interval_seconds: row.get(12)?,
+        retry_interval_seconds: row.get(13)?,
+        pickup_detected_at: row.get(14)?,
+        pickup_source: row.get(15)?,
+        review_landed_at: row.get(16)?,
+        review_source: row.get(17)?,
+        review_comment_id: optional_sqlite_json_scalar(row.get_ref(18)?),
+        review_url: row.get(19)?,
+        last_polled_at: row.get(20)?,
+        last_error: row.get(21)?,
+        state: row.get(22)?,
+        is_active: row.get::<_, Option<i64>>(23)?.unwrap_or(1) != 0,
+    })
 }
 
 fn list_queue_jobs_conn(

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -1396,10 +1396,14 @@ async fn codex_review_requests_missing_db_returns_empty_requests() {
         ..AppConfig::default()
     }));
 
-    let (status, payload) = get_json(app, "/codex-review-requests").await;
+    let (status, payload) = get_json(app.clone(), "/codex-review-requests").await;
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload, json!({ "requests": [] }));
+
+    let (status, payload) = get_json(app, "/codex-review-requests/missing").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(payload["detail"], "Codex review request not found");
 }
 
 #[tokio::test]
@@ -1484,6 +1488,21 @@ async fn codex_review_requests_lists_rows_with_filters_and_session_names() {
     assert_eq!(requests[1]["id"], "active-new");
     assert_eq!(requests[1]["review_comment_id"], "R_kw123");
 
+    let (status, payload) = get_json(app.clone(), "/codex-review-requests/active-old").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["id"], "active-old");
+    assert_eq!(payload["repo"], "rajeshgoli/session-manager");
+    assert_eq!(payload["pr_number"], 830);
+    assert_eq!(payload["requester_name"], "native requester");
+    assert_eq!(payload["notify_name"], "reviewer");
+    assert_eq!(payload["latest_request_comment_id"], 111);
+    assert_eq!(payload["review_comment_id"], 222);
+    assert_eq!(payload["is_active"], true);
+
+    let (status, payload) = get_json(app.clone(), "/codex-review-requests/missing").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(payload["detail"], "Codex review request not found");
+
     let (status, payload) = get_json(
         app.clone(),
         "/codex-review-requests?repo=rajeshgoli/session-manager&pr_number=830&notify_target=notify1",
@@ -1506,7 +1525,8 @@ async fn codex_review_requests_lists_rows_with_filters_and_session_names() {
     assert_eq!(payload["requests"].as_array().unwrap().len(), 1);
     assert_eq!(payload["requests"][0]["id"], "active-old");
 
-    let (status, payload) = get_json(app, "/codex-review-requests?include_inactive=true").await;
+    let (status, payload) =
+        get_json(app.clone(), "/codex-review-requests?include_inactive=true").await;
     assert_eq!(status, StatusCode::OK);
     let ids = payload["requests"]
         .as_array()
@@ -1515,6 +1535,12 @@ async fn codex_review_requests_lists_rows_with_filters_and_session_names() {
         .map(|entry| entry["id"].as_str().unwrap())
         .collect::<Vec<_>>();
     assert_eq!(ids, vec!["active-old", "inactive", "active-new"]);
+
+    let (status, payload) = get_json(app, "/codex-review-requests/inactive").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["id"], "inactive");
+    assert_eq!(payload["state"], "cancelled");
+    assert_eq!(payload["is_active"], false);
 }
 
 #[tokio::test]
@@ -1546,13 +1572,23 @@ async fn codex_review_requests_rejects_public_host_without_auth() {
     let app = router(AppState::new(config_with_state_file_and_auth(&state_file)));
 
     let (status, payload) =
-        get_json_with_host(app, "/codex-review-requests", "sm.example.com").await;
+        get_json_with_host(app.clone(), "/codex-review-requests", "sm.example.com").await;
 
     assert_eq!(status, StatusCode::UNAUTHORIZED);
     assert_eq!(payload["detail"], "Authentication required");
     assert_eq!(
         payload["login_url"],
         "/auth/google/login?next=%2Fcodex-review-requests"
+    );
+
+    let (status, payload) =
+        get_json_with_host(app, "/codex-review-requests/active-old", "sm.example.com").await;
+
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(payload["detail"], "Authentication required");
+    assert_eq!(
+        payload["login_url"],
+        "/auth/google/login?next=%2Fcodex-review-requests%2Factive-old"
     );
 }
 
@@ -1951,6 +1987,95 @@ async fn shadow_http_treats_live_session_lists_as_status_only() {
     assert_eq!(payload["predicted_status"], 200);
     assert_eq!(payload["predicted_body_sha256"], Value::Null);
     assert_eq!(payload["body_sha256_match"], Value::Null);
+}
+
+#[tokio::test]
+async fn shadow_http_reports_codex_review_request_detail_200_as_status_only() {
+    let state_file = unique_temp_path();
+    let queue_db = state_file.with_extension("codex-review-requests.db");
+    fs::write(&state_file, json!({ "sessions": [] }).to_string()).unwrap();
+    create_codex_review_request_fixture_db(&queue_db);
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        sm_send: SmSendConfig {
+            db_path: queue_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    }));
+    let python_body = br#"{"id":"active-old","repo":"rajeshgoli/session-manager","pr_number":830,"requester_session_id":"requester1","requester_name":"requester1","notify_session_id":"notify1","notify_name":"notify1","steer":"focus nodes","requested_at":"2026-06-01T00:00:00","latest_request_comment_id":111,"latest_request_comment_url":"https://example.com/comment/111","latest_request_posted_at":"2026-06-01T00:00:01","attempt_count":2,"next_retry_at":"2026-06-01T00:10:00","poll_interval_seconds":30,"retry_interval_seconds":600,"pickup_detected_at":"2026-06-01T00:02:00","pickup_source":"issue_comment","review_landed_at":"2026-06-01T00:03:00","review_source":"pull_review","review_comment_id":222,"review_url":"https://example.com/review/222","last_polled_at":"2026-06-01T00:04:00","last_error":null,"state":"completed","is_active":true}"#;
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/codex-review-requests/active-old",
+                "query_string": "",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 200,
+                "body_sha256": sha256_hex(python_body)
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read_status_only");
+    assert_eq!(payload["comparison"], "status_match");
+    assert_eq!(payload["predicted_status"], 200);
+    assert_eq!(payload["predicted_body_sha256"], Value::Null);
+    assert_eq!(payload["body_sha256_match"], Value::Null);
+}
+
+#[tokio::test]
+async fn shadow_http_reports_codex_review_request_detail_404() {
+    let state_file = unique_temp_path();
+    fs::write(&state_file, json!({ "sessions": [] }).to_string()).unwrap();
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        sm_send: SmSendConfig {
+            db_path: state_file
+                .with_extension("missing-codex-review.db")
+                .display()
+                .to_string(),
+        },
+        ..AppConfig::default()
+    }));
+    let python_body =
+        serde_json::to_vec(&json!({ "detail": "Codex review request not found" })).unwrap();
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/codex-review-requests/missing",
+                "query_string": "",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 404,
+                "body_sha256": sha256_hex(&python_body)
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read");
+    assert_eq!(payload["comparison"], "match");
+    assert_eq!(payload["predicted_status"], 404);
+    assert_eq!(payload["body_sha256_match"], true);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- add `GET /codex-review-requests/{request_id}` to the Rust server
- reuse the retained Codex review request row projection used by the list endpoint
- preserve missing DB/table handling, missing-request 404 behavior, inactive-record lookup, auth denial, and shadow-mode status-only 200 / deterministic 404 behavior

## Validation
- `cargo fmt --check && cargo test -p sm-server codex_review_requests`
- `cargo test -p sm-server shadow_http_reports_codex_review_request`
- `cargo test -p sm-server`
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py`
- `git diff --check`

Fixes #863