### PR TITLE
Rust MVP: add session tool-calls audit endpoint

### DIFF
--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -22,6 +22,7 @@ pub struct AppConfig {
     pub mobile_terminal: MobileTerminalConfig,
     pub tmux: TmuxConfig,
     pub sm_send: SmSendConfig,
+    pub tool_logging: ToolLoggingConfig,
     pub claude: ProviderLaunchConfig,
     pub codex: ProviderLaunchConfig,
     pub codex_fork: CodexForkLaunchConfig,
@@ -45,6 +46,7 @@ impl Default for AppConfig {
             mobile_terminal: MobileTerminalConfig::default(),
             tmux: TmuxConfig::default(),
             sm_send: SmSendConfig::default(),
+            tool_logging: ToolLoggingConfig::default(),
             claude: ProviderLaunchConfig::new(
                 "claude".to_owned(),
                 Vec::new(),
@@ -556,6 +558,24 @@ fn default_server_log_file() -> String {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct ToolLoggingConfig {
+    #[serde(default = "default_tool_usage_db_path")]
+    pub db_path: String,
+}
+
+impl Default for ToolLoggingConfig {
+    fn default() -> Self {
+        Self {
+            db_path: default_tool_usage_db_path(),
+        }
+    }
+}
+
+fn default_tool_usage_db_path() -> String {
+    "~/.local/share/claude-sessions/tool_usage.db".to_owned()
+}
+
+#[derive(Debug, Clone, Deserialize)]
 pub struct QueueRunnerConfig {
     #[serde(default = "default_queue_runner_state_dir")]
     pub state_dir: String,
@@ -649,6 +669,8 @@ struct RawConfig {
     #[serde(default)]
     sm_send: SmSendConfig,
     #[serde(default)]
+    tool_logging: ToolLoggingConfig,
+    #[serde(default)]
     claude: RawProviderLaunchConfig,
     #[serde(default)]
     codex: RawProviderLaunchConfig,
@@ -725,6 +747,7 @@ impl From<RawConfig> for AppConfig {
             mobile_terminal: raw.mobile_terminal,
             tmux: raw.tmux,
             sm_send: raw.sm_send,
+            tool_logging: raw.tool_logging,
             claude,
             codex,
             codex_fork,
@@ -1197,6 +1220,20 @@ sm_send:
         let config = AppConfig::from(raw);
 
         assert_eq!(config.sm_send.db_path, "/tmp/custom-message-queue.db");
+    }
+
+    #[test]
+    fn raw_config_reads_tool_logging_db_path() {
+        let raw: RawConfig = serde_yaml::from_str(
+            r#"
+tool_logging:
+  db_path: /tmp/custom-tool-usage.db
+"#,
+        )
+        .unwrap();
+        let config = AppConfig::from(raw);
+
+        assert_eq!(config.tool_logging.db_path, "/tmp/custom-tool-usage.db");
     }
 
     #[test]

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -92,6 +92,7 @@ use crate::sessions::{
     SubagentStopOutcome, SubagentStopRequest, TaskCompleteOutcome, TaskCompleteRequest,
     TurnCompleteOutcome,
 };
+use crate::tool_usage::{list_recent_tool_calls_from_path, ToolCallRow};
 
 const SESSION_COOKIE_NAME: &str = "sm_auth";
 const SESSION_COOKIE_MAX_AGE_SECONDS: i64 = 60 * 60 * 24 * 14;
@@ -333,6 +334,7 @@ pub fn router(state: AppState) -> Router {
         .route("/registry", get(list_agent_registry))
         .route("/registry/{role}", get(lookup_agent_registry))
         .route("/sessions/{session_id}/output", get(session_output))
+        .route("/sessions/{session_id}/tool-calls", get(session_tool_calls))
         .route("/client/sessions", get(list_client_sessions))
         .route(
             "/client/sessions/{session_id}/attach-ticket",
@@ -3745,6 +3747,36 @@ async fn session_output(
     Ok(Json(SessionOutputResponse { session_id, output }))
 }
 
+async fn session_tool_calls(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+    Query(query): Query<SessionToolCallsQuery>,
+    request: Request,
+) -> Result<Json<ToolCallsResponse>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    let Some(session) = state.session_store.get_session(&session_id)? else {
+        return Err(ApiError::NotFound("Session not found"));
+    };
+    let Some(limit) = query.validated_limit() else {
+        return Err(ApiError::Status {
+            status: StatusCode::UNPROCESSABLE_ENTITY,
+            detail: "limit must be between 1 and 100".to_owned(),
+        });
+    };
+    if session.provider == "codex-fork" {
+        return Ok(Json(ToolCallsResponse {
+            session_id,
+            tool_calls: Vec::new(),
+        }));
+    }
+    let db_path = expand_home(&state.config.tool_logging.db_path);
+    let tool_calls = list_recent_tool_calls_from_path(&db_path, &session_id, limit)?;
+    Ok(Json(ToolCallsResponse {
+        session_id,
+        tool_calls,
+    }))
+}
+
 async fn shadow_http(
     State(state): State<Arc<AppState>>,
     request: Request,
@@ -4136,6 +4168,26 @@ fn shadow_predict_session_read(
             status: StatusCode::OK.as_u16(),
             body_sha256: Some(sha256_hex(&body)),
             support_status: "implemented_read",
+        }));
+    }
+
+    if let Some(session_id) = path
+        .strip_prefix("/sessions/")
+        .and_then(|value| value.strip_suffix("/tool-calls"))
+        .filter(|value| !value.is_empty() && !value.contains('/'))
+    {
+        let Some(_) = state.session_store.get_session(session_id)? else {
+            let body = serde_json::to_vec(&json!({ "detail": "Session not found" }))?;
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::NOT_FOUND.as_u16(),
+                body_sha256: Some(sha256_hex(&body)),
+                support_status: "implemented_read",
+            }));
+        };
+        return Ok(Some(ShadowPrediction {
+            status: StatusCode::OK.as_u16(),
+            body_sha256: None,
+            support_status: "implemented_read_status_only",
         }));
     }
 
@@ -6215,6 +6267,26 @@ struct SessionOutputQuery {
 }
 
 #[derive(Debug, Deserialize)]
+struct SessionToolCallsQuery {
+    #[serde(default = "default_tool_calls_limit")]
+    limit: i64,
+}
+
+impl SessionToolCallsQuery {
+    fn validated_limit(&self) -> Option<usize> {
+        if (1..=100).contains(&self.limit) {
+            Some(self.limit as usize)
+        } else {
+            None
+        }
+    }
+}
+
+fn default_tool_calls_limit() -> i64 {
+    10
+}
+
+#[derive(Debug, Deserialize)]
 struct KillSessionRequest {
     #[serde(default)]
     requester_session_id: Option<String>,
@@ -6380,6 +6452,12 @@ impl From<SessionRecord> for SpawnSessionResponse {
 struct SessionOutputResponse {
     session_id: String,
     output: Option<String>,
+}
+
+#[derive(Serialize)]
+struct ToolCallsResponse {
+    session_id: String,
+    tool_calls: Vec<ToolCallRow>,
 }
 
 #[derive(Serialize)]

--- a/crates/sm-server/src/lib.rs
+++ b/crates/sm-server/src/lib.rs
@@ -7,3 +7,4 @@ pub mod mobile_analytics;
 pub mod queue;
 pub mod runtime;
 pub mod sessions;
+pub mod tool_usage;

--- a/crates/sm-server/src/tool_usage.rs
+++ b/crates/sm-server/src/tool_usage.rs
@@ -1,0 +1,63 @@
+use std::path::Path;
+
+use anyhow::Result;
+use rusqlite::{Connection, OpenFlags};
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ToolCallRow {
+    pub timestamp: Option<String>,
+    pub tool_name: String,
+    pub hook_type: String,
+}
+
+pub fn list_recent_tool_calls_from_path(
+    db_path: &Path,
+    session_id: &str,
+    limit: usize,
+) -> Result<Vec<ToolCallRow>> {
+    if !db_path.exists() {
+        return Ok(Vec::new());
+    }
+    let conn = match Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY) {
+        Ok(conn) => conn,
+        Err(_) => return Ok(Vec::new()),
+    };
+    list_recent_tool_calls_conn(&conn, session_id, limit)
+}
+
+fn list_recent_tool_calls_conn(
+    conn: &Connection,
+    session_id: &str,
+    limit: usize,
+) -> Result<Vec<ToolCallRow>> {
+    let mut statement = match conn.prepare(
+        r#"
+        SELECT timestamp, tool_name, hook_type
+        FROM tool_usage
+        WHERE session_id = ?1 AND hook_type = 'PreToolUse'
+        ORDER BY id DESC
+        LIMIT ?2
+        "#,
+    ) {
+        Ok(statement) => statement,
+        Err(rusqlite::Error::SqliteFailure(_, Some(message)))
+            if message.contains("no such table") =>
+        {
+            return Ok(Vec::new());
+        }
+        Err(_) => return Ok(Vec::new()),
+    };
+    let rows = match statement.query_map((session_id, limit as i64), |row| {
+        Ok(ToolCallRow {
+            timestamp: row.get(0)?,
+            tool_name: row.get(1)?,
+            hook_type: row.get(2)?,
+        })
+    }) {
+        Ok(rows) => rows,
+        Err(_) => return Ok(Vec::new()),
+    };
+    rows.collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(Into::into)
+}

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -20,7 +20,7 @@ use sm_server::{
         AppArtifactsConfig, AppConfig, BugReportsConfig, CodexForkLaunchConfig, EmailConfig,
         ExternalAccessConfig, GoogleAuthConfig, MobileAnalyticsConfig, MobileTerminalConfig,
         MobileTerminalDeviceKeyConfig, MobileTerminalUserConfig, PathsConfig, QueueRunnerConfig,
-        RustCoreConfig, SmSendConfig,
+        RustCoreConfig, SmSendConfig, ToolLoggingConfig,
     },
     http::{router, AppState},
 };
@@ -2079,6 +2079,71 @@ async fn shadow_http_reports_codex_review_request_detail_404() {
 }
 
 #[tokio::test]
+async fn shadow_http_reports_tool_calls_200_as_status_only() {
+    let state_file = write_session_fixture();
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+    let python_body = br#"{"session_id":"run12345","tool_calls":[{"timestamp":"2026-06-01 00:02:00","tool_name":"Bash","hook_type":"PreToolUse"}]}"#;
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/sessions/run12345/tool-calls",
+                "query_string": "limit=10",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 200,
+                "body_sha256": sha256_hex(python_body)
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read_status_only");
+    assert_eq!(payload["comparison"], "status_match");
+    assert_eq!(payload["predicted_status"], 200);
+    assert_eq!(payload["predicted_body_sha256"], Value::Null);
+    assert_eq!(payload["body_sha256_match"], Value::Null);
+}
+
+#[tokio::test]
+async fn shadow_http_reports_tool_calls_404() {
+    let state_file = write_session_fixture();
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+    let python_body = serde_json::to_vec(&json!({ "detail": "Session not found" })).unwrap();
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/sessions/missing/tool-calls",
+                "query_string": "",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 404,
+                "body_sha256": sha256_hex(&python_body)
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read");
+    assert_eq!(payload["comparison"], "match");
+    assert_eq!(payload["predicted_status"], 404);
+    assert_eq!(payload["body_sha256_match"], true);
+}
+
+#[tokio::test]
 async fn shadow_http_reports_queue_job_detail_404() {
     let state_file = unique_temp_path();
     fs::write(&state_file, json!({ "sessions": [] }).to_string()).unwrap();
@@ -3103,6 +3168,74 @@ async fn session_output_tails_fixture_log_file() {
         payload["output"],
         "fixture log line 2\nfixture log line 3\n"
     );
+}
+
+#[tokio::test]
+async fn session_tool_calls_reads_pre_tool_use_rows() {
+    let state_file = write_session_fixture();
+    let tool_db = unique_temp_path();
+    create_tool_usage_fixture_db(&tool_db);
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        tool_logging: ToolLoggingConfig {
+            db_path: tool_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = get_json(app, "/sessions/run12345/tool-calls?limit=2").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["session_id"], "run12345");
+    assert_eq!(
+        payload["tool_calls"],
+        json!([
+            {
+                "timestamp": "2026-06-01 00:02:00",
+                "tool_name": "Bash",
+                "hook_type": "PreToolUse"
+            },
+            {
+                "timestamp": "2026-06-01 00:01:00",
+                "tool_name": "Read",
+                "hook_type": "PreToolUse"
+            }
+        ])
+    );
+}
+
+#[tokio::test]
+async fn session_tool_calls_handles_missing_db_and_invalid_limit() {
+    let state_file = write_session_fixture();
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        tool_logging: ToolLoggingConfig {
+            db_path: state_file
+                .with_extension("missing-tool-usage.db")
+                .display()
+                .to_string(),
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = get_json(app.clone(), "/sessions/run12345/tool-calls").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        payload,
+        json!({ "session_id": "run12345", "tool_calls": [] })
+    );
+
+    let (status, payload) = get_json(app.clone(), "/sessions/missing/tool-calls").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(payload["detail"], "Session not found");
+
+    let (status, payload) = get_json(app, "/sessions/run12345/tool-calls?limit=0").await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(payload["detail"], "limit must be between 1 and 100");
 }
 
 #[tokio::test]
@@ -7749,6 +7882,29 @@ fn create_queue_jobs_fixture_db(state_dir: &PathBuf) {
              NULL, NULL, NULL)
         "#,
         [],
+    )
+    .unwrap();
+}
+
+fn create_tool_usage_fixture_db(path: &PathBuf) {
+    let conn = Connection::open(path).unwrap();
+    conn.execute_batch(
+        r#"
+        CREATE TABLE tool_usage (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+            session_id TEXT,
+            hook_type TEXT NOT NULL,
+            tool_name TEXT NOT NULL
+        );
+        INSERT INTO tool_usage (timestamp, session_id, hook_type, tool_name)
+        VALUES
+            ('2026-06-01 00:00:00', 'run12345', 'PreToolUse', 'Write'),
+            ('2026-06-01 00:01:00', 'run12345', 'PreToolUse', 'Read'),
+            ('2026-06-01 00:02:00', 'run12345', 'PreToolUse', 'Bash'),
+            ('2026-06-01 00:03:00', 'run12345', 'PostToolUse', 'Bash'),
+            ('2026-06-01 00:04:00', 'oldstate', 'PreToolUse', 'Glob');
+        "#,
     )
     .unwrap();
 }


### PR DESCRIPTION
## Summary
- add `tool_logging.db_path` config with the Python-compatible `tool_usage.db` default
- add `GET /sessions/{session_id}/tool-calls` for regular session audit rows from `tool_usage`
- preserve session/auth checks, missing DB/table empty-list behavior, and `limit` bounds
- add shadow-mode status-only coverage for successful tool-call reads and deterministic 404 handling

## Scope note
This slice covers the `tool_usage.db` audit path used by regular Claude sessions. Codex-fork tool calls are **not body-converged in this PR**: Python production projects them from `CodexObservabilityLogger`, while Rust temporarily returns an empty list for codex-fork sessions. That follow-up is tracked in #867, and status-only shadow results for this endpoint must not be treated as codex-fork body parity.

## Validation
- `cargo fmt --check && cargo test -p sm-server tool_calls`
- `cargo test -p sm-server raw_config_reads_tool_logging_db_path`
- `cargo test -p sm-server`
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py`
- `git diff --check`

Fixes #865