### PR TITLE
Rust MVP: project codex-fork tool calls

### DIFF
--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -23,6 +23,7 @@ pub struct AppConfig {
     pub tmux: TmuxConfig,
     pub sm_send: SmSendConfig,
     pub tool_logging: ToolLoggingConfig,
+    pub codex_observability: CodexObservabilityConfig,
     pub claude: ProviderLaunchConfig,
     pub codex: ProviderLaunchConfig,
     pub codex_fork: CodexForkLaunchConfig,
@@ -47,6 +48,7 @@ impl Default for AppConfig {
             tmux: TmuxConfig::default(),
             sm_send: SmSendConfig::default(),
             tool_logging: ToolLoggingConfig::default(),
+            codex_observability: CodexObservabilityConfig::default(),
             claude: ProviderLaunchConfig::new(
                 "claude".to_owned(),
                 Vec::new(),
@@ -575,6 +577,23 @@ fn default_tool_usage_db_path() -> String {
     "~/.local/share/claude-sessions/tool_usage.db".to_owned()
 }
 
+#[derive(Debug, Clone)]
+pub struct CodexObservabilityConfig {
+    pub db_path: String,
+}
+
+impl Default for CodexObservabilityConfig {
+    fn default() -> Self {
+        Self {
+            db_path: default_codex_observability_db_path(),
+        }
+    }
+}
+
+fn default_codex_observability_db_path() -> String {
+    "~/.local/share/claude-sessions/codex_observability.db".to_owned()
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct QueueRunnerConfig {
     #[serde(default = "default_queue_runner_state_dir")]
@@ -612,6 +631,20 @@ fn queue_runner_state_dir_for_state_file(state_file: &str) -> PathBuf {
     let state_file = Path::new(state_file);
     let parent = state_file.parent().unwrap_or_else(|| Path::new("."));
     parent.join("queue-runner")
+}
+
+fn codex_observability_config_for_state_file(state_file: &str) -> CodexObservabilityConfig {
+    if state_file == default_state_file() {
+        return CodexObservabilityConfig::default();
+    }
+    let state_file = Path::new(state_file);
+    let parent = state_file.parent().unwrap_or_else(|| Path::new("."));
+    CodexObservabilityConfig {
+        db_path: parent
+            .join("codex_observability.db")
+            .to_string_lossy()
+            .into_owned(),
+    }
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -671,6 +704,8 @@ struct RawConfig {
     #[serde(default)]
     tool_logging: ToolLoggingConfig,
     #[serde(default)]
+    codex_observability: Option<RawCodexObservabilityConfig>,
+    #[serde(default)]
     claude: RawProviderLaunchConfig,
     #[serde(default)]
     codex: RawProviderLaunchConfig,
@@ -699,6 +734,8 @@ impl From<RawConfig> for AppConfig {
                 config
             })
             .unwrap_or_else(|| queue_runner_config_for_state_file(&paths.state_file));
+        let codex_observability =
+            codex_observability_config(raw.codex_observability, &paths.state_file);
         let claude = provider_launch_config(raw.claude, "claude", Some("sonnet"), Vec::new());
         let codex = provider_launch_config(raw.codex, "codex", None, Vec::new());
         let codex_fork = codex_fork_launch_config(raw.codex_fork, &codex);
@@ -748,6 +785,7 @@ impl From<RawConfig> for AppConfig {
             tmux: raw.tmux,
             sm_send: raw.sm_send,
             tool_logging: raw.tool_logging,
+            codex_observability,
             claude,
             codex,
             codex_fork,
@@ -824,6 +862,12 @@ struct RawCodexForkLaunchConfig {
 }
 
 #[derive(Debug, Default, Deserialize)]
+struct RawCodexObservabilityConfig {
+    #[serde(default)]
+    db_path: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
 struct RawTimeoutsConfig {
     #[serde(default)]
     tmux: RawTmuxTimeoutsConfig,
@@ -889,6 +933,19 @@ fn codex_fork_launch_config(
         default_model,
         event_schema_version: raw.event_schema_version.unwrap_or(2),
     }
+}
+
+fn codex_observability_config(
+    raw: Option<RawCodexObservabilityConfig>,
+    state_file: &str,
+) -> CodexObservabilityConfig {
+    let mut config = codex_observability_config_for_state_file(state_file);
+    if let Some(raw) = raw {
+        if let Some(db_path) = raw.db_path {
+            config.db_path = db_path;
+        }
+    }
+    config
 }
 
 fn codex_fork_managed_args(args: Vec<String>) -> Vec<String> {
@@ -1234,6 +1291,59 @@ tool_logging:
         let config = AppConfig::from(raw);
 
         assert_eq!(config.tool_logging.db_path, "/tmp/custom-tool-usage.db");
+    }
+
+    #[test]
+    fn raw_config_reads_codex_observability_db_path() {
+        let raw: RawConfig = serde_yaml::from_str(
+            r#"
+codex_observability:
+  db_path: /tmp/custom-codex-observability.db
+"#,
+        )
+        .unwrap();
+        let config = AppConfig::from(raw);
+
+        assert_eq!(
+            config.codex_observability.db_path,
+            "/tmp/custom-codex-observability.db"
+        );
+    }
+
+    #[test]
+    fn raw_config_derives_codex_observability_db_path_from_custom_state_file() {
+        let raw: RawConfig = serde_yaml::from_str(
+            r#"
+paths:
+  state_file: /tmp/sm-fixture/sessions.json
+"#,
+        )
+        .unwrap();
+        let config = AppConfig::from(raw);
+
+        assert_eq!(
+            config.codex_observability.db_path,
+            "/tmp/sm-fixture/codex_observability.db"
+        );
+    }
+
+    #[test]
+    fn raw_config_keeps_codex_observability_state_sibling_when_section_omits_db_path() {
+        let raw: RawConfig = serde_yaml::from_str(
+            r#"
+paths:
+  state_file: /tmp/sm-fixture/sessions.json
+codex_observability:
+  retention_max_age_days: 7
+"#,
+        )
+        .unwrap();
+        let config = AppConfig::from(raw);
+
+        assert_eq!(
+            config.codex_observability.db_path,
+            "/tmp/sm-fixture/codex_observability.db"
+        );
     }
 
     #[test]

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -92,7 +92,9 @@ use crate::sessions::{
     SubagentStopOutcome, SubagentStopRequest, TaskCompleteOutcome, TaskCompleteRequest,
     TurnCompleteOutcome,
 };
-use crate::tool_usage::{list_recent_tool_calls_from_path, ToolCallRow};
+use crate::tool_usage::{
+    list_recent_codex_fork_tool_calls_from_path, list_recent_tool_calls_from_path, ToolCallRow,
+};
 
 const SESSION_COOKIE_NAME: &str = "sm_auth";
 const SESSION_COOKIE_MAX_AGE_SECONDS: i64 = 60 * 60 * 24 * 14;
@@ -3764,9 +3766,11 @@ async fn session_tool_calls(
         });
     };
     if session.provider == "codex-fork" {
+        let db_path = expand_home(&state.config.codex_observability.db_path);
+        let tool_calls = list_recent_codex_fork_tool_calls_from_path(&db_path, &session_id, limit)?;
         return Ok(Json(ToolCallsResponse {
             session_id,
-            tool_calls: Vec::new(),
+            tool_calls,
         }));
     }
     let db_path = expand_home(&state.config.tool_logging.db_path);

--- a/crates/sm-server/src/tool_usage.rs
+++ b/crates/sm-server/src/tool_usage.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use anyhow::Result;
 use rusqlite::{Connection, OpenFlags};
 use serde::Serialize;
+use serde_json::Value;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ToolCallRow {
@@ -58,6 +59,87 @@ fn list_recent_tool_calls_conn(
         Ok(rows) => rows,
         Err(_) => return Ok(Vec::new()),
     };
-    rows.collect::<std::result::Result<Vec<_>, _>>()
-        .map_err(Into::into)
+    Ok(rows
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .unwrap_or_else(|_| Vec::new()))
+}
+
+pub fn list_recent_codex_fork_tool_calls_from_path(
+    db_path: &Path,
+    session_id: &str,
+    limit: usize,
+) -> Result<Vec<ToolCallRow>> {
+    if !db_path.exists() {
+        return Ok(Vec::new());
+    }
+    let conn = match Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY) {
+        Ok(conn) => conn,
+        Err(_) => return Ok(Vec::new()),
+    };
+    list_recent_codex_fork_tool_calls_conn(&conn, session_id, limit)
+}
+
+fn list_recent_codex_fork_tool_calls_conn(
+    conn: &Connection,
+    session_id: &str,
+    limit: usize,
+) -> Result<Vec<ToolCallRow>> {
+    let scan_limit = limit.saturating_mul(4).min(500);
+    let mut statement = match conn.prepare(
+        r#"
+        SELECT created_at, raw_payload_json
+        FROM codex_tool_events
+        WHERE session_id = ?1
+        ORDER BY id DESC
+        LIMIT ?2
+        "#,
+    ) {
+        Ok(statement) => statement,
+        Err(rusqlite::Error::SqliteFailure(_, Some(message)))
+            if message.contains("no such table") =>
+        {
+            return Ok(Vec::new());
+        }
+        Err(_) => return Ok(Vec::new()),
+    };
+    let rows = match statement.query_map((session_id, scan_limit as i64), |row| {
+        let timestamp: Option<String> = row.get(0)?;
+        let raw_payload_json: Option<String> = row.get(1)?;
+        Ok((timestamp, raw_payload_json))
+    }) {
+        Ok(rows) => rows,
+        Err(_) => return Ok(Vec::new()),
+    };
+
+    let mut selected = Vec::new();
+    for row in rows {
+        let Ok((timestamp, raw_payload_json)) = row else {
+            return Ok(Vec::new());
+        };
+        let Some(raw_payload_json) = raw_payload_json else {
+            continue;
+        };
+        let Ok(payload) = serde_json::from_str::<Value>(&raw_payload_json) else {
+            continue;
+        };
+        let Some(tool_name) = payload
+            .as_object()
+            .and_then(|payload| payload.get("tool_name"))
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+        else {
+            continue;
+        };
+        selected.push(ToolCallRow {
+            timestamp,
+            tool_name: tool_name.to_owned(),
+            hook_type: "CodexForkToolCall".to_owned(),
+        });
+        if selected.len() >= limit {
+            break;
+        }
+    }
+
+    selected.reverse();
+    Ok(selected)
 }

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -17,10 +17,11 @@ use sm_server::config::RustShadowConfig;
 use sm_server::queue::RetainedQueueStore;
 use sm_server::{
     config::{
-        AppArtifactsConfig, AppConfig, BugReportsConfig, CodexForkLaunchConfig, EmailConfig,
-        ExternalAccessConfig, GoogleAuthConfig, MobileAnalyticsConfig, MobileTerminalConfig,
-        MobileTerminalDeviceKeyConfig, MobileTerminalUserConfig, PathsConfig, QueueRunnerConfig,
-        RustCoreConfig, SmSendConfig, ToolLoggingConfig,
+        AppArtifactsConfig, AppConfig, BugReportsConfig, CodexForkLaunchConfig,
+        CodexObservabilityConfig, EmailConfig, ExternalAccessConfig, GoogleAuthConfig,
+        MobileAnalyticsConfig, MobileTerminalConfig, MobileTerminalDeviceKeyConfig,
+        MobileTerminalUserConfig, PathsConfig, QueueRunnerConfig, RustCoreConfig, SmSendConfig,
+        ToolLoggingConfig,
     },
     http::{router, AppState},
 };
@@ -3203,6 +3204,109 @@ async fn session_tool_calls_reads_pre_tool_use_rows() {
                 "hook_type": "PreToolUse"
             }
         ])
+    );
+}
+
+#[tokio::test]
+async fn session_tool_calls_projects_codex_fork_observability_rows() {
+    let state_file = unique_temp_path();
+    fs::write(
+        &state_file,
+        json!({
+            "sessions": [
+                {
+                    "id": "forktools",
+                    "name": "codex-fork-forktools",
+                    "working_dir": "/repo",
+                    "tmux_session": "codex-fork-forktools",
+                    "tmux_socket_name": null,
+                    "node": "primary",
+                    "provider": "codex-fork",
+                    "log_file": "/tmp/forktools.log",
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00",
+                    "last_activity": "2026-06-01T00:01:00"
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let observability_db = unique_temp_path();
+    create_codex_observability_fixture_db(&observability_db);
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        codex_observability: CodexObservabilityConfig {
+            db_path: observability_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = get_json(app, "/sessions/forktools/tool-calls?limit=2").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["session_id"], "forktools");
+    assert_eq!(
+        payload["tool_calls"],
+        json!([
+            {
+                "timestamp": "2026-06-01T00:03:00+00:00",
+                "tool_name": "Bash",
+                "hook_type": "CodexForkToolCall"
+            },
+            {
+                "timestamp": "2026-06-01T00:05:00+00:00",
+                "tool_name": "Edit",
+                "hook_type": "CodexForkToolCall"
+            }
+        ])
+    );
+}
+
+#[tokio::test]
+async fn session_tool_calls_codex_fork_missing_observability_db_returns_empty_rows() {
+    let state_file = unique_temp_path();
+    fs::write(
+        &state_file,
+        json!({
+            "sessions": [
+                {
+                    "id": "forktools",
+                    "name": "codex-fork-forktools",
+                    "working_dir": "/repo",
+                    "tmux_session": "codex-fork-forktools",
+                    "provider": "codex-fork",
+                    "log_file": "/tmp/forktools.log",
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00",
+                    "last_activity": "2026-06-01T00:01:00"
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        codex_observability: CodexObservabilityConfig {
+            db_path: state_file
+                .with_extension("missing-codex-observability.db")
+                .display()
+                .to_string(),
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = get_json(app, "/sessions/forktools/tool-calls").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        payload,
+        json!({ "session_id": "forktools", "tool_calls": [] })
     );
 }
 
@@ -7904,6 +8008,30 @@ fn create_tool_usage_fixture_db(path: &PathBuf) {
             ('2026-06-01 00:02:00', 'run12345', 'PreToolUse', 'Bash'),
             ('2026-06-01 00:03:00', 'run12345', 'PostToolUse', 'Bash'),
             ('2026-06-01 00:04:00', 'oldstate', 'PreToolUse', 'Glob');
+        "#,
+    )
+    .unwrap();
+}
+
+fn create_codex_observability_fixture_db(path: &PathBuf) {
+    let conn = Connection::open(path).unwrap();
+    conn.execute_batch(
+        r#"
+        CREATE TABLE codex_tool_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            raw_payload_json TEXT,
+            created_at TEXT NOT NULL
+        );
+        INSERT INTO codex_tool_events (session_id, raw_payload_json, created_at)
+        VALUES
+            ('forktools', '{"tool_name":"Read"}', '2026-06-01T00:00:00+00:00'),
+            ('forktools', '{"event_type":"no-tool"}', '2026-06-01T00:01:00+00:00'),
+            ('forktools', 'not-json', '2026-06-01T00:02:00+00:00'),
+            ('forktools', '{"tool_name":"Bash"}', '2026-06-01T00:03:00+00:00'),
+            ('otherfork', '{"tool_name":"Ignore"}', '2026-06-01T00:04:00+00:00'),
+            ('forktools', NULL, '2026-06-01T00:04:30+00:00'),
+            ('forktools', '{"tool_name":"Edit"}', '2026-06-01T00:05:00+00:00');
         "#,
     )
     .unwrap();


### PR DESCRIPTION
## Summary
- add Rust config support for the retained codex_observability DB path, including Python-compatible state-file sibling defaults
- project codex-fork /tool-calls from codex_tool_events raw_payload_json.tool_name
- keep missing/error DB behavior as an empty tool_calls list and preserve status-only shadow semantics

Fixes #867

## Validation
- cargo fmt --check
- cargo test -p sm-server
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py
- git diff --check