### PR TITLE
Rust MVP: expose codex events endpoint

### DIFF
--- a/crates/sm-server/src/codex_events.rs
+++ b/crates/sm-server/src/codex_events.rs
@@ -1,0 +1,154 @@
+use std::path::Path;
+
+use anyhow::Result;
+use rusqlite::{Connection, OpenFlags};
+use serde::Serialize;
+use serde_json::{json, Value};
+
+const DEFAULT_PAYLOAD_PREVIEW_CHARS: usize = 1500;
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct CodexEventsResponse {
+    pub events: Vec<CodexEventRow>,
+    pub earliest_seq: Option<i64>,
+    pub latest_seq: Option<i64>,
+    pub next_seq: i64,
+    pub history_gap: bool,
+    pub gap_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct CodexEventRow {
+    pub session_id: String,
+    pub seq: i64,
+    pub timestamp: String,
+    pub event_type: String,
+    pub turn_id: Option<String>,
+    pub payload_preview: Option<Value>,
+    pub persisted: bool,
+}
+
+pub fn list_codex_events_from_path(
+    db_path: &Path,
+    session_id: &str,
+    since_seq: Option<i64>,
+    limit: usize,
+) -> Result<CodexEventsResponse> {
+    if !db_path.exists() {
+        return Ok(empty_response(since_seq));
+    }
+    let conn = match Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY) {
+        Ok(conn) => conn,
+        Err(_) => return Ok(empty_response(since_seq)),
+    };
+    list_codex_events_conn(&conn, session_id, since_seq, limit)
+}
+
+fn list_codex_events_conn(
+    conn: &Connection,
+    session_id: &str,
+    since_seq: Option<i64>,
+    limit: usize,
+) -> Result<CodexEventsResponse> {
+    let limit = limit.clamp(1, 500);
+    let (earliest_seq, latest_seq) = match conn.query_row(
+        "SELECT MIN(seq), MAX(seq) FROM codex_session_events WHERE session_id = ?1",
+        [session_id],
+        |row| Ok((row.get::<_, Option<i64>>(0)?, row.get::<_, Option<i64>>(1)?)),
+    ) {
+        Ok(value) => value,
+        Err(rusqlite::Error::SqliteFailure(_, Some(message)))
+            if message.contains("no such table") =>
+        {
+            return Ok(empty_response(since_seq));
+        }
+        Err(_) => return Ok(empty_response(since_seq)),
+    };
+
+    let (Some(earliest_seq), Some(latest_seq)) = (earliest_seq, latest_seq) else {
+        return Ok(empty_response(since_seq));
+    };
+
+    let mut history_gap = false;
+    let mut gap_reason = None;
+    let start_seq = match since_seq {
+        None => earliest_seq.max(latest_seq.saturating_sub(limit as i64 - 1)),
+        Some(seq) if seq < earliest_seq.checked_sub(1).unwrap_or(i64::MIN) => {
+            history_gap = true;
+            gap_reason = Some("retention".to_owned());
+            earliest_seq
+        }
+        Some(seq) => next_seq_value(seq),
+    };
+
+    let mut statement = match conn.prepare(
+        r#"
+        SELECT seq, timestamp, event_type, turn_id, payload_preview_json
+        FROM codex_session_events
+        WHERE session_id = ?1 AND seq >= ?2
+        ORDER BY seq ASC
+        LIMIT ?3
+        "#,
+    ) {
+        Ok(statement) => statement,
+        Err(_) => return Ok(empty_response(since_seq)),
+    };
+    let rows = match statement.query_map((session_id, start_seq, limit as i64), |row| {
+        let seq: i64 = row.get(0)?;
+        let timestamp: String = row.get(1)?;
+        let event_type: String = row.get(2)?;
+        let turn_id: Option<String> = row.get(3)?;
+        let payload_preview_json: Option<String> = row.get(4)?;
+        Ok(CodexEventRow {
+            session_id: session_id.to_owned(),
+            seq,
+            timestamp,
+            event_type,
+            turn_id,
+            payload_preview: payload_preview_json.as_deref().map(parse_payload_preview),
+            persisted: true,
+        })
+    }) {
+        Ok(rows) => rows,
+        Err(_) => return Ok(empty_response(since_seq)),
+    };
+    let events = rows
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .unwrap_or_else(|_| Vec::new());
+
+    let next_seq = events
+        .last()
+        .map(|event| next_seq_value(event.seq))
+        .or_else(|| since_seq.map(next_seq_value))
+        .unwrap_or(earliest_seq);
+
+    Ok(CodexEventsResponse {
+        events,
+        earliest_seq: Some(earliest_seq),
+        latest_seq: Some(latest_seq),
+        next_seq,
+        history_gap,
+        gap_reason,
+    })
+}
+
+fn empty_response(since_seq: Option<i64>) -> CodexEventsResponse {
+    CodexEventsResponse {
+        events: Vec::new(),
+        earliest_seq: None,
+        latest_seq: None,
+        next_seq: since_seq.map(next_seq_value).unwrap_or(1),
+        history_gap: false,
+        gap_reason: None,
+    }
+}
+
+fn next_seq_value(seq: i64) -> i64 {
+    seq.checked_add(1).unwrap_or(i64::MAX)
+}
+
+fn parse_payload_preview(raw: &str) -> Value {
+    serde_json::from_str::<Value>(raw).unwrap_or_else(
+        |_| json!({ "raw": raw.chars().take(DEFAULT_PAYLOAD_PREVIEW_CHARS).collect::<String>() }),
+    )
+}

--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -23,6 +23,8 @@ pub struct AppConfig {
     pub tmux: TmuxConfig,
     pub sm_send: SmSendConfig,
     pub tool_logging: ToolLoggingConfig,
+    pub codex_rollout: CodexRolloutConfig,
+    pub codex_events: CodexEventsConfig,
     pub codex_observability: CodexObservabilityConfig,
     pub claude: ProviderLaunchConfig,
     pub codex: ProviderLaunchConfig,
@@ -48,6 +50,8 @@ impl Default for AppConfig {
             tmux: TmuxConfig::default(),
             sm_send: SmSendConfig::default(),
             tool_logging: ToolLoggingConfig::default(),
+            codex_rollout: CodexRolloutConfig::default(),
+            codex_events: CodexEventsConfig::default(),
             codex_observability: CodexObservabilityConfig::default(),
             claude: ProviderLaunchConfig::new(
                 "claude".to_owned(),
@@ -577,6 +581,85 @@ fn default_tool_usage_db_path() -> String {
     "~/.local/share/claude-sessions/tool_usage.db".to_owned()
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct CodexRolloutConfig {
+    #[serde(
+        default = "default_true",
+        deserialize_with = "deserialize_rollout_bool"
+    )]
+    pub enable_durable_events: bool,
+    #[serde(
+        default = "default_true",
+        deserialize_with = "deserialize_rollout_bool"
+    )]
+    pub enable_structured_requests: bool,
+    #[serde(
+        default = "default_true",
+        deserialize_with = "deserialize_rollout_bool"
+    )]
+    pub enable_observability_projection: bool,
+    #[serde(
+        default = "default_true",
+        deserialize_with = "deserialize_rollout_bool"
+    )]
+    pub enable_codex_tui: bool,
+}
+
+impl Default for CodexRolloutConfig {
+    fn default() -> Self {
+        Self {
+            enable_durable_events: true,
+            enable_structured_requests: true,
+            enable_observability_projection: true,
+            enable_codex_tui: true,
+        }
+    }
+}
+
+fn deserialize_rollout_bool<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = YamlValue::deserialize(deserializer)?;
+    Ok(coerce_rollout_flag(Some(&value), true))
+}
+
+fn coerce_rollout_flag(value: Option<&YamlValue>, default: bool) -> bool {
+    match value {
+        None | Some(YamlValue::Null) => default,
+        Some(YamlValue::Bool(value)) => *value,
+        Some(YamlValue::Number(value)) => value
+            .as_i64()
+            .map(|value| value != 0)
+            .or_else(|| value.as_u64().map(|value| value != 0))
+            .or_else(|| value.as_f64().map(|value| value != 0.0))
+            .unwrap_or(default),
+        Some(YamlValue::String(value)) => match value.trim().to_ascii_lowercase().as_str() {
+            "true" | "1" | "yes" | "on" => true,
+            "false" | "0" | "no" | "off" => false,
+            _ => default,
+        },
+        Some(_) => default,
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CodexEventsConfig {
+    pub db_path: String,
+}
+
+impl Default for CodexEventsConfig {
+    fn default() -> Self {
+        Self {
+            db_path: default_codex_events_db_path(),
+        }
+    }
+}
+
+fn default_codex_events_db_path() -> String {
+    "~/.local/share/claude-sessions/codex_events.db".to_owned()
+}
+
 #[derive(Debug, Clone)]
 pub struct CodexObservabilityConfig {
     pub db_path: String,
@@ -647,6 +730,20 @@ fn codex_observability_config_for_state_file(state_file: &str) -> CodexObservabi
     }
 }
 
+fn codex_events_config_for_state_file(state_file: &str) -> CodexEventsConfig {
+    if state_file == default_state_file() {
+        return CodexEventsConfig::default();
+    }
+    let state_file = Path::new(state_file);
+    let parent = state_file.parent().unwrap_or_else(|| Path::new("."));
+    CodexEventsConfig {
+        db_path: parent
+            .join("codex_events.db")
+            .to_string_lossy()
+            .into_owned(),
+    }
+}
+
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct RustShadowConfig {
     #[serde(default)]
@@ -704,6 +801,10 @@ struct RawConfig {
     #[serde(default)]
     tool_logging: ToolLoggingConfig,
     #[serde(default)]
+    codex_rollout: CodexRolloutConfig,
+    #[serde(default)]
+    codex_events: Option<RawCodexEventsConfig>,
+    #[serde(default)]
     codex_observability: Option<RawCodexObservabilityConfig>,
     #[serde(default)]
     claude: RawProviderLaunchConfig,
@@ -736,6 +837,7 @@ impl From<RawConfig> for AppConfig {
             .unwrap_or_else(|| queue_runner_config_for_state_file(&paths.state_file));
         let codex_observability =
             codex_observability_config(raw.codex_observability, &paths.state_file);
+        let codex_events = codex_events_config(raw.codex_events, &paths.state_file);
         let claude = provider_launch_config(raw.claude, "claude", Some("sonnet"), Vec::new());
         let codex = provider_launch_config(raw.codex, "codex", None, Vec::new());
         let codex_fork = codex_fork_launch_config(raw.codex_fork, &codex);
@@ -785,6 +887,8 @@ impl From<RawConfig> for AppConfig {
             tmux: raw.tmux,
             sm_send: raw.sm_send,
             tool_logging: raw.tool_logging,
+            codex_rollout: raw.codex_rollout,
+            codex_events,
             codex_observability,
             claude,
             codex,
@@ -868,6 +972,12 @@ struct RawCodexObservabilityConfig {
 }
 
 #[derive(Debug, Default, Deserialize)]
+struct RawCodexEventsConfig {
+    #[serde(default)]
+    db_path: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
 struct RawTimeoutsConfig {
     #[serde(default)]
     tmux: RawTmuxTimeoutsConfig,
@@ -940,6 +1050,16 @@ fn codex_observability_config(
     state_file: &str,
 ) -> CodexObservabilityConfig {
     let mut config = codex_observability_config_for_state_file(state_file);
+    if let Some(raw) = raw {
+        if let Some(db_path) = raw.db_path {
+            config.db_path = db_path;
+        }
+    }
+    config
+}
+
+fn codex_events_config(raw: Option<RawCodexEventsConfig>, state_file: &str) -> CodexEventsConfig {
+    let mut config = codex_events_config_for_state_file(state_file);
     if let Some(raw) = raw {
         if let Some(db_path) = raw.db_path {
             config.db_path = db_path;
@@ -1307,6 +1427,59 @@ codex_observability:
         assert_eq!(
             config.codex_observability.db_path,
             "/tmp/custom-codex-observability.db"
+        );
+    }
+
+    #[test]
+    fn raw_config_reads_codex_events_db_path() {
+        let raw: RawConfig = serde_yaml::from_str(
+            r#"
+codex_events:
+  db_path: /tmp/custom-codex-events.db
+"#,
+        )
+        .unwrap();
+        let config = AppConfig::from(raw);
+
+        assert_eq!(config.codex_events.db_path, "/tmp/custom-codex-events.db");
+    }
+
+    #[test]
+    fn raw_config_reads_codex_rollout_flags() {
+        let raw: RawConfig = serde_yaml::from_str(
+            r#"
+codex_rollout:
+  enable_durable_events: "false"
+  enable_structured_requests: "off"
+  enable_observability_projection: 0
+  enable_codex_tui: "yes"
+"#,
+        )
+        .unwrap();
+        let config = AppConfig::from(raw);
+
+        assert!(!config.codex_rollout.enable_durable_events);
+        assert!(!config.codex_rollout.enable_structured_requests);
+        assert!(!config.codex_rollout.enable_observability_projection);
+        assert!(config.codex_rollout.enable_codex_tui);
+    }
+
+    #[test]
+    fn raw_config_derives_codex_events_db_path_from_custom_state_file() {
+        let raw: RawConfig = serde_yaml::from_str(
+            r#"
+paths:
+  state_file: /tmp/sm-fixture/sessions.json
+codex_events:
+  ring_size: 25
+"#,
+        )
+        .unwrap();
+        let config = AppConfig::from(raw);
+
+        assert_eq!(
+            config.codex_events.db_path,
+            "/tmp/sm-fixture/codex_events.db"
         );
     }
 

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -67,6 +67,7 @@ use crate::app_artifacts::{
     APP_ARTIFACT_MAX_SIZE_BYTES,
 };
 use crate::bug_reports::{BugReportStore, CreateBugReport};
+use crate::codex_events::{list_codex_events_from_path, CodexEventsResponse};
 use crate::config::{
     trimmed, AppConfig, MobileTerminalDeviceKeyConfig, MobileTerminalUserConfig, PublicNodeConfig,
 };
@@ -337,6 +338,10 @@ pub fn router(state: AppState) -> Router {
         .route("/registry/{role}", get(lookup_agent_registry))
         .route("/sessions/{session_id}/output", get(session_output))
         .route("/sessions/{session_id}/tool-calls", get(session_tool_calls))
+        .route(
+            "/sessions/{session_id}/codex-events",
+            get(session_codex_events),
+        )
         .route("/client/sessions", get(list_client_sessions))
         .route(
             "/client/sessions/{session_id}/attach-ticket",
@@ -3781,6 +3786,35 @@ async fn session_tool_calls(
     }))
 }
 
+async fn session_codex_events(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+    uri: Uri,
+    request: Request,
+) -> Result<Json<CodexEventsResponse>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    let query = SessionCodexEventsQuery::parse(uri.query().unwrap_or(""))?;
+    let Some(session) = state.session_store.get_session(&session_id)? else {
+        return Err(ApiError::NotFound("Session not found"));
+    };
+    if session.provider != "codex-app" {
+        return Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: "codex-events supported only for provider=codex-app".to_owned(),
+        });
+    }
+    if !state.config.codex_rollout.enable_durable_events {
+        return Err(ApiError::Status {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            detail: "codex durable events disabled by rollout flag".to_owned(),
+        });
+    }
+    let db_path = expand_home(&state.config.codex_events.db_path);
+    let response =
+        list_codex_events_from_path(&db_path, &session_id, query.since_seq, query.limit)?;
+    Ok(Json(response))
+}
+
 async fn shadow_http(
     State(state): State<Arc<AppState>>,
     request: Request,
@@ -4188,6 +4222,53 @@ fn shadow_predict_session_read(
                 support_status: "implemented_read",
             }));
         };
+        return Ok(Some(ShadowPrediction {
+            status: StatusCode::OK.as_u16(),
+            body_sha256: None,
+            support_status: "implemented_read_status_only",
+        }));
+    }
+
+    if let Some(session_id) = path
+        .strip_prefix("/sessions/")
+        .and_then(|value| value.strip_suffix("/codex-events"))
+        .filter(|value| !value.is_empty() && !value.contains('/'))
+    {
+        if SessionCodexEventsQuery::parse(query_string).is_err() {
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::UNPROCESSABLE_ENTITY.as_u16(),
+                body_sha256: None,
+                support_status: "implemented_read_status_only",
+            }));
+        }
+        let Some(session) = state.session_store.get_session(session_id)? else {
+            let body = serde_json::to_vec(&json!({ "detail": "Session not found" }))?;
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::NOT_FOUND.as_u16(),
+                body_sha256: Some(sha256_hex(&body)),
+                support_status: "implemented_read",
+            }));
+        };
+        if session.provider != "codex-app" {
+            let body = serde_json::to_vec(
+                &json!({ "detail": "codex-events supported only for provider=codex-app" }),
+            )?;
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::BAD_REQUEST.as_u16(),
+                body_sha256: Some(sha256_hex(&body)),
+                support_status: "implemented_read",
+            }));
+        }
+        if !state.config.codex_rollout.enable_durable_events {
+            let body = serde_json::to_vec(
+                &json!({ "detail": "codex durable events disabled by rollout flag" }),
+            )?;
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::SERVICE_UNAVAILABLE.as_u16(),
+                body_sha256: Some(sha256_hex(&body)),
+                support_status: "implemented_read",
+            }));
+        }
         return Ok(Some(ShadowPrediction {
             status: StatusCode::OK.as_u16(),
             body_sha256: None,
@@ -6168,6 +6249,41 @@ fn percent_encode_path(path: &str) -> String {
     encoded
 }
 
+fn percent_decode_query_component(value: &str) -> Option<String> {
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'+' => {
+                decoded.push(b' ');
+                index += 1;
+            }
+            b'%' if index + 2 < bytes.len() => {
+                let high = hex_value(bytes[index + 1])?;
+                let low = hex_value(bytes[index + 2])?;
+                decoded.push((high << 4) | low);
+                index += 3;
+            }
+            b'%' => return None,
+            byte => {
+                decoded.push(byte);
+                index += 1;
+            }
+        }
+    }
+    String::from_utf8(decoded).ok()
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
 fn is_local_bypass_request(
     headers: &HeaderMap,
     peer_addr: Option<SocketAddr>,
@@ -6288,6 +6404,76 @@ impl SessionToolCallsQuery {
 
 fn default_tool_calls_limit() -> i64 {
     10
+}
+
+#[derive(Debug)]
+struct SessionCodexEventsQuery {
+    since_seq: Option<i64>,
+    limit: usize,
+}
+
+impl SessionCodexEventsQuery {
+    fn parse(query_string: &str) -> Result<Self, ApiError> {
+        let since_seq_value = decoded_last_query_value(query_string, "since_seq")?;
+        let limit_value = decoded_last_query_value(query_string, "limit")?;
+        let since_seq = match since_seq_value.as_deref() {
+            None => None,
+            Some(value) => {
+                let parsed = value.parse::<i64>().map_err(|_| ApiError::Status {
+                    status: StatusCode::UNPROCESSABLE_ENTITY,
+                    detail: "since_seq must be >= 0 and less than 9223372036854775807".to_owned(),
+                })?;
+                if !(0..i64::MAX).contains(&parsed) {
+                    return Err(ApiError::Status {
+                        status: StatusCode::UNPROCESSABLE_ENTITY,
+                        detail: "since_seq must be >= 0 and less than 9223372036854775807"
+                            .to_owned(),
+                    });
+                }
+                Some(parsed)
+            }
+        };
+        let limit = match limit_value.as_deref() {
+            None => 200,
+            Some(value) => {
+                let parsed = value.parse::<i64>().map_err(|_| ApiError::Status {
+                    status: StatusCode::UNPROCESSABLE_ENTITY,
+                    detail: "limit must be between 1 and 500".to_owned(),
+                })?;
+                if !(1..=500).contains(&parsed) {
+                    return Err(ApiError::Status {
+                        status: StatusCode::UNPROCESSABLE_ENTITY,
+                        detail: "limit must be between 1 and 500".to_owned(),
+                    });
+                }
+                parsed as usize
+            }
+        };
+        Ok(Self { since_seq, limit })
+    }
+}
+
+fn decoded_last_query_value(query_string: &str, key: &str) -> Result<Option<String>, ApiError> {
+    let mut value = None;
+    for part in query_string.split('&') {
+        let (raw_name, raw_value) = part.split_once('=').unwrap_or((part, ""));
+        let Some(name) = percent_decode_query_component(raw_name) else {
+            return Err(ApiError::Status {
+                status: StatusCode::UNPROCESSABLE_ENTITY,
+                detail: "invalid query encoding".to_owned(),
+            });
+        };
+        if name == key {
+            let Some(decoded_value) = percent_decode_query_component(raw_value) else {
+                return Err(ApiError::Status {
+                    status: StatusCode::UNPROCESSABLE_ENTITY,
+                    detail: "invalid query encoding".to_owned(),
+                });
+            };
+            value = Some(decoded_value);
+        }
+    }
+    Ok(value)
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/sm-server/src/lib.rs
+++ b/crates/sm-server/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod app_artifacts;
 pub mod bug_reports;
+pub mod codex_events;
 pub mod config;
 pub mod email;
 pub mod http;

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -17,11 +17,11 @@ use sm_server::config::RustShadowConfig;
 use sm_server::queue::RetainedQueueStore;
 use sm_server::{
     config::{
-        AppArtifactsConfig, AppConfig, BugReportsConfig, CodexForkLaunchConfig,
-        CodexObservabilityConfig, EmailConfig, ExternalAccessConfig, GoogleAuthConfig,
-        MobileAnalyticsConfig, MobileTerminalConfig, MobileTerminalDeviceKeyConfig,
-        MobileTerminalUserConfig, PathsConfig, QueueRunnerConfig, RustCoreConfig, SmSendConfig,
-        ToolLoggingConfig,
+        AppArtifactsConfig, AppConfig, BugReportsConfig, CodexEventsConfig, CodexForkLaunchConfig,
+        CodexObservabilityConfig, CodexRolloutConfig, EmailConfig, ExternalAccessConfig,
+        GoogleAuthConfig, MobileAnalyticsConfig, MobileTerminalConfig,
+        MobileTerminalDeviceKeyConfig, MobileTerminalUserConfig, PathsConfig, QueueRunnerConfig,
+        RustCoreConfig, SmSendConfig, ToolLoggingConfig,
     },
     http::{router, AppState},
 };
@@ -2145,6 +2145,159 @@ async fn shadow_http_reports_tool_calls_404() {
 }
 
 #[tokio::test]
+async fn shadow_http_reports_codex_events_200_as_status_only() {
+    let state_file = write_codex_app_session_fixture("codexapp1");
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+    let python_body = br#"{"events":[{"session_id":"codexapp1","seq":1,"timestamp":"2026-06-01T00:01:00+00:00","event_type":"turn_started","turn_id":"turn-a","payload_preview":{"message":"start"},"persisted":true}],"earliest_seq":1,"latest_seq":1,"next_seq":2,"history_gap":false,"gap_reason":null}"#;
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/sessions/codexapp1/codex-events",
+                "query_string": "limit=200",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 200,
+                "body_sha256": sha256_hex(python_body)
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read_status_only");
+    assert_eq!(payload["comparison"], "status_match");
+    assert_eq!(payload["predicted_status"], 200);
+    assert_eq!(payload["predicted_body_sha256"], Value::Null);
+    assert_eq!(payload["body_sha256_match"], Value::Null);
+}
+
+#[tokio::test]
+async fn shadow_http_reports_codex_events_404() {
+    let state_file = write_codex_app_session_fixture("codexapp1");
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+    let python_body = serde_json::to_vec(&json!({ "detail": "Session not found" })).unwrap();
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/sessions/missing/codex-events",
+                "query_string": "",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 404,
+                "body_sha256": sha256_hex(&python_body)
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read");
+    assert_eq!(payload["comparison"], "match");
+    assert_eq!(payload["predicted_status"], 404);
+    assert_eq!(payload["body_sha256_match"], true);
+}
+
+#[tokio::test]
+async fn shadow_http_reports_codex_events_invalid_query_as_status_only_422() {
+    let state_file = write_codex_app_session_fixture("codexapp1");
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+    let python_body = br#"{"detail":[{"type":"greater_than_equal","loc":["query","limit"],"msg":"Input should be greater than or equal to 1","input":"0","ctx":{"ge":1}}]}"#;
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/sessions/codexapp1/codex-events",
+                "query_string": "limit=0",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 422,
+                "body_sha256": sha256_hex(python_body)
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read_status_only");
+    assert_eq!(payload["comparison"], "status_match");
+    assert_eq!(payload["predicted_status"], 422);
+    assert_eq!(payload["predicted_body_sha256"], Value::Null);
+    assert_eq!(payload["body_sha256_match"], Value::Null);
+}
+
+#[tokio::test]
+async fn shadow_http_uses_decoded_last_codex_events_query_value() {
+    let state_file = write_codex_app_session_fixture("codexapp1");
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+    let python_body = br#"{"events":[],"earliest_seq":null,"latest_seq":null,"next_seq":1,"history_gap":false,"gap_reason":null}"#;
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/sessions/codexapp1/codex-events",
+                "query_string": "limit=0&limit=%32",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 200,
+                "body_sha256": sha256_hex(python_body)
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read_status_only");
+    assert_eq!(payload["comparison"], "status_match");
+    assert_eq!(payload["predicted_status"], 200);
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/sessions/codexapp1/codex-events",
+                "query_string": "limit=2&limit=0",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 422,
+                "body_sha256": sha256_hex(b"{}")
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read_status_only");
+    assert_eq!(payload["comparison"], "status_match");
+    assert_eq!(payload["predicted_status"], 422);
+}
+
+#[tokio::test]
 async fn shadow_http_reports_queue_job_detail_404() {
     let state_file = unique_temp_path();
     fs::write(&state_file, json!({ "sessions": [] }).to_string()).unwrap();
@@ -3308,6 +3461,232 @@ async fn session_tool_calls_codex_fork_missing_observability_db_returns_empty_ro
         payload,
         json!({ "session_id": "forktools", "tool_calls": [] })
     );
+}
+
+#[tokio::test]
+async fn session_codex_events_reads_recent_events_with_python_cursor_shape() {
+    let state_file = write_codex_app_session_fixture("codexapp1");
+    let events_db = unique_temp_path();
+    create_codex_events_fixture_db(&events_db);
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        codex_events: CodexEventsConfig {
+            db_path: events_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = get_json(app, "/sessions/codexapp1/codex-events?limit=2").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["earliest_seq"], 1);
+    assert_eq!(payload["latest_seq"], 4);
+    assert_eq!(payload["next_seq"], 5);
+    assert_eq!(payload["history_gap"], false);
+    assert_eq!(payload["gap_reason"], Value::Null);
+    assert_eq!(
+        payload["events"],
+        json!([
+            {
+                "session_id": "codexapp1",
+                "seq": 3,
+                "timestamp": "2026-06-01T00:03:00+00:00",
+                "event_type": "item_completed",
+                "turn_id": "turn-a",
+                "payload_preview": {"raw": "not-json"},
+                "persisted": true
+            },
+            {
+                "session_id": "codexapp1",
+                "seq": 4,
+                "timestamp": "2026-06-01T00:04:00+00:00",
+                "event_type": "turn_completed",
+                "turn_id": null,
+                "payload_preview": null,
+                "persisted": true
+            }
+        ])
+    );
+}
+
+#[tokio::test]
+async fn session_codex_events_since_seq_reports_retention_gap() {
+    let state_file = write_codex_app_session_fixture("codexapp1");
+    let events_db = unique_temp_path();
+    create_codex_events_fixture_db(&events_db);
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        codex_events: CodexEventsConfig {
+            db_path: events_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) =
+        get_json(app, "/sessions/codexapp1/codex-events?since_seq=0&limit=2").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["history_gap"], false);
+    assert_eq!(payload["gap_reason"], Value::Null);
+    assert_eq!(payload["events"][0]["seq"], 1);
+    assert_eq!(payload["next_seq"], 3);
+
+    let state_file = write_codex_app_session_fixture("retainedgap");
+    let events_db = unique_temp_path();
+    create_codex_events_retention_gap_fixture_db(&events_db);
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        codex_events: CodexEventsConfig {
+            db_path: events_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    }));
+    let (status, payload) = get_json(app, "/sessions/retainedgap/codex-events?since_seq=1").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["earliest_seq"], 4);
+    assert_eq!(payload["latest_seq"], 5);
+    assert_eq!(payload["history_gap"], true);
+    assert_eq!(payload["gap_reason"], "retention");
+    assert_eq!(payload["events"][0]["seq"], 4);
+}
+
+#[tokio::test]
+async fn session_codex_events_handles_missing_db_session_and_provider_errors() {
+    let state_file = write_codex_app_session_fixture("codexapp1");
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        codex_events: CodexEventsConfig {
+            db_path: state_file
+                .with_extension("missing-codex-events.db")
+                .display()
+                .to_string(),
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = get_json(app.clone(), "/sessions/codexapp1/codex-events").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        payload,
+        json!({
+            "events": [],
+            "earliest_seq": null,
+            "latest_seq": null,
+            "next_seq": 1,
+            "history_gap": false,
+            "gap_reason": null
+        })
+    );
+
+    let (status, payload) = get_json(app.clone(), "/sessions/missing/codex-events").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(payload["detail"], "Session not found");
+
+    let state_file = write_session_fixture();
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+    let (status, payload) = get_json(app, "/sessions/run12345/codex-events").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        payload["detail"],
+        "codex-events supported only for provider=codex-app"
+    );
+
+    let state_file = write_codex_app_session_fixture("codexapp1");
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        codex_rollout: CodexRolloutConfig {
+            enable_durable_events: false,
+            ..CodexRolloutConfig::default()
+        },
+        ..AppConfig::default()
+    }));
+    let (status, payload) = get_json(app, "/sessions/codexapp1/codex-events").await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(
+        payload["detail"],
+        "codex durable events disabled by rollout flag"
+    );
+}
+
+#[tokio::test]
+async fn session_codex_events_rejects_invalid_query_values_before_session_lookup() {
+    let state_file = write_codex_app_session_fixture("codexapp1");
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+
+    for (uri, detail) in [
+        (
+            "/sessions/codexapp1/codex-events?limit=0",
+            "limit must be between 1 and 500",
+        ),
+        (
+            "/sessions/codexapp1/codex-events?limit=abc",
+            "limit must be between 1 and 500",
+        ),
+        (
+            "/sessions/codexapp1/codex-events?since_seq=-1",
+            "since_seq must be >= 0 and less than 9223372036854775807",
+        ),
+        (
+            "/sessions/codexapp1/codex-events?since_seq=9223372036854775807",
+            "since_seq must be >= 0 and less than 9223372036854775807",
+        ),
+        (
+            "/sessions/missing/codex-events?limit=0",
+            "limit must be between 1 and 500",
+        ),
+    ] {
+        let (status, payload) = get_json(app.clone(), uri).await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "uri={uri}");
+        assert_eq!(payload["detail"], detail, "uri={uri}");
+    }
+}
+
+#[tokio::test]
+async fn session_codex_events_decodes_query_and_uses_last_duplicate_value() {
+    let state_file = write_codex_app_session_fixture("codexapp1");
+    let events_db = unique_temp_path();
+    create_codex_events_fixture_db(&events_db);
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        codex_events: CodexEventsConfig {
+            db_path: events_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = get_json(
+        app.clone(),
+        "/sessions/codexapp1/codex-events?limit=%32&since_seq=%31",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["events"][0]["seq"], 2);
+    assert_eq!(payload["events"].as_array().unwrap().len(), 2);
+
+    let (status, payload) = get_json(
+        app.clone(),
+        "/sessions/codexapp1/codex-events?limit=0&limit=2",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["events"].as_array().unwrap().len(), 2);
+
+    let (status, payload) = get_json(app, "/sessions/codexapp1/codex-events?limit=2&limit=0").await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(payload["detail"], "limit must be between 1 and 500");
 }
 
 #[tokio::test]
@@ -8013,6 +8392,55 @@ fn create_tool_usage_fixture_db(path: &PathBuf) {
     .unwrap();
 }
 
+fn create_codex_events_fixture_db(path: &PathBuf) {
+    let conn = Connection::open(path).unwrap();
+    conn.execute_batch(
+        r#"
+        CREATE TABLE codex_session_events (
+            session_id TEXT NOT NULL,
+            seq INTEGER NOT NULL,
+            timestamp TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            turn_id TEXT,
+            payload_preview_json TEXT,
+            PRIMARY KEY (session_id, seq)
+        );
+        INSERT INTO codex_session_events
+            (session_id, seq, timestamp, event_type, turn_id, payload_preview_json)
+        VALUES
+            ('codexapp1', 1, '2026-06-01T00:01:00+00:00', 'turn_started', 'turn-a', '{"message":"start"}'),
+            ('codexapp1', 2, '2026-06-01T00:02:00+00:00', 'item_started', 'turn-a', '{"tool_name":"Read"}'),
+            ('codexapp1', 3, '2026-06-01T00:03:00+00:00', 'item_completed', 'turn-a', 'not-json'),
+            ('codexapp1', 4, '2026-06-01T00:04:00+00:00', 'turn_completed', NULL, NULL),
+            ('othercodex', 1, '2026-06-01T00:05:00+00:00', 'turn_started', 'turn-b', '{"ignored":true}');
+        "#,
+    )
+    .unwrap();
+}
+
+fn create_codex_events_retention_gap_fixture_db(path: &PathBuf) {
+    let conn = Connection::open(path).unwrap();
+    conn.execute_batch(
+        r#"
+        CREATE TABLE codex_session_events (
+            session_id TEXT NOT NULL,
+            seq INTEGER NOT NULL,
+            timestamp TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            turn_id TEXT,
+            payload_preview_json TEXT,
+            PRIMARY KEY (session_id, seq)
+        );
+        INSERT INTO codex_session_events
+            (session_id, seq, timestamp, event_type, turn_id, payload_preview_json)
+        VALUES
+            ('retainedgap', 4, '2026-06-01T00:04:00+00:00', 'item_completed', 'turn-r', '{"tool_name":"Bash"}'),
+            ('retainedgap', 5, '2026-06-01T00:05:00+00:00', 'turn_completed', 'turn-r', '{"ok":true}');
+        "#,
+    )
+    .unwrap();
+}
+
 fn create_codex_observability_fixture_db(path: &PathBuf) {
     let conn = Connection::open(path).unwrap();
     conn.execute_batch(
@@ -8143,6 +8571,33 @@ fn write_session_fixture() -> PathBuf {
                     "created_at": "2026-06-01T00:00:00",
                     "last_activity": "2026-06-01T00:01:00",
                     "stopped_at": "2026-06-01T00:02:00"
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    path
+}
+
+fn write_codex_app_session_fixture(session_id: &str) -> PathBuf {
+    let path = unique_temp_path();
+    fs::write(
+        &path,
+        json!({
+            "sessions": [
+                {
+                    "id": session_id,
+                    "name": format!("codex-app-{session_id}"),
+                    "working_dir": "/repo",
+                    "tmux_session": format!("codex-app-{session_id}"),
+                    "tmux_socket_name": null,
+                    "node": "primary",
+                    "provider": "codex-app",
+                    "log_file": format!("/tmp/{session_id}.log"),
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00",
+                    "last_activity": "2026-06-01T00:01:00"
                 }
             ]
         })


### PR DESCRIPTION
## Summary
- add retained `codex_events.db` config parsing with Python-compatible state-file sibling defaults
- implement `GET /sessions/{session_id}/codex-events` for codex-app sessions, including rollout gate and Python cursor response shape
- add shadow-mode status-only prediction for 200 event reads and deterministic error predictions

Fixes #869
Part of #762

## Validation
- cargo fmt --check
- cargo test -p sm-server
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py
- git diff --check