### PR TITLE
Rust MVP: expose codex pending requests endpoint

### DIFF
--- a/crates/sm-server/src/codex_requests.rs
+++ b/crates/sm-server/src/codex_requests.rs
@@ -1,0 +1,121 @@
+use std::path::Path;
+
+use anyhow::Result;
+use rusqlite::{params, Connection, OpenFlags};
+use serde::Serialize;
+use serde_json::Value;
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct CodexPendingRequestsResponse {
+    pub requests: Vec<CodexPendingRequestRow>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct CodexPendingRequestRow {
+    pub request_id: String,
+    pub session_id: String,
+    pub thread_id: Option<String>,
+    pub turn_id: Option<String>,
+    pub item_id: Option<String>,
+    pub request_type: String,
+    pub request_method: String,
+    pub status: String,
+    pub requested_at: String,
+    pub expires_at: Option<String>,
+    pub resolved_payload: Option<Value>,
+    pub resolved_at: Option<String>,
+    pub resolution_source: Option<String>,
+    pub error_code: Option<String>,
+    pub error_message: Option<String>,
+}
+
+pub fn list_codex_pending_requests_from_path(
+    db_path: &Path,
+    session_id: &str,
+    include_orphaned: bool,
+) -> Result<CodexPendingRequestsResponse> {
+    if !db_path.exists() {
+        return Ok(CodexPendingRequestsResponse {
+            requests: Vec::new(),
+        });
+    }
+    let conn = match Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY) {
+        Ok(conn) => conn,
+        Err(_) => {
+            return Ok(CodexPendingRequestsResponse {
+                requests: Vec::new(),
+            })
+        }
+    };
+    list_codex_pending_requests_conn(&conn, session_id, include_orphaned)
+}
+
+fn list_codex_pending_requests_conn(
+    conn: &Connection,
+    session_id: &str,
+    include_orphaned: bool,
+) -> Result<CodexPendingRequestsResponse> {
+    let status_clause = if include_orphaned {
+        "status IN ('pending', 'orphaned')"
+    } else {
+        "status = 'pending'"
+    };
+    let query = format!(
+        r#"
+        SELECT request_id, session_id, thread_id, turn_id, item_id,
+               request_type, request_method, status, requested_at, expires_at,
+               resolved_payload_json, resolved_at, resolution_source, error_code, error_message
+        FROM codex_pending_requests
+        WHERE session_id = ?1 AND {status_clause}
+        ORDER BY requested_at ASC
+        "#
+    );
+    let mut statement = match conn.prepare(&query) {
+        Ok(statement) => statement,
+        Err(rusqlite::Error::SqliteFailure(_, Some(message)))
+            if message.contains("no such table") =>
+        {
+            return Ok(CodexPendingRequestsResponse {
+                requests: Vec::new(),
+            });
+        }
+        Err(error) => return Err(error.into()),
+    };
+    let rows = statement.query_map(params![session_id], codex_pending_request_row_from_sql)?;
+    Ok(CodexPendingRequestsResponse {
+        requests: rows.collect::<std::result::Result<Vec<_>, _>>()?,
+    })
+}
+
+fn codex_pending_request_row_from_sql(
+    row: &rusqlite::Row<'_>,
+) -> rusqlite::Result<CodexPendingRequestRow> {
+    let resolved_payload_json: Option<String> = row.get(10)?;
+    let resolved_payload = match resolved_payload_json {
+        Some(value) => Some(serde_json::from_str(&value).map_err(|error| {
+            rusqlite::Error::FromSqlConversionFailure(
+                10,
+                rusqlite::types::Type::Text,
+                Box::new(error),
+            )
+        })?),
+        None => None,
+    };
+    Ok(CodexPendingRequestRow {
+        request_id: row.get(0)?,
+        session_id: row.get(1)?,
+        thread_id: row.get(2)?,
+        turn_id: row.get(3)?,
+        item_id: row.get(4)?,
+        request_type: row.get(5)?,
+        request_method: row.get(6)?,
+        status: row.get(7)?,
+        requested_at: row.get(8)?,
+        expires_at: row.get(9)?,
+        resolved_payload,
+        resolved_at: row.get(11)?,
+        resolution_source: row.get(12)?,
+        error_code: row.get(13)?,
+        error_message: row.get(14)?,
+    })
+}

--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -24,6 +24,7 @@ pub struct AppConfig {
     pub sm_send: SmSendConfig,
     pub tool_logging: ToolLoggingConfig,
     pub codex_rollout: CodexRolloutConfig,
+    pub codex_requests: CodexRequestsConfig,
     pub codex_events: CodexEventsConfig,
     pub codex_observability: CodexObservabilityConfig,
     pub claude: ProviderLaunchConfig,
@@ -51,6 +52,7 @@ impl Default for AppConfig {
             sm_send: SmSendConfig::default(),
             tool_logging: ToolLoggingConfig::default(),
             codex_rollout: CodexRolloutConfig::default(),
+            codex_requests: CodexRequestsConfig::default(),
             codex_events: CodexEventsConfig::default(),
             codex_observability: CodexObservabilityConfig::default(),
             claude: ProviderLaunchConfig::new(
@@ -661,6 +663,23 @@ fn default_codex_events_db_path() -> String {
 }
 
 #[derive(Debug, Clone)]
+pub struct CodexRequestsConfig {
+    pub db_path: String,
+}
+
+impl Default for CodexRequestsConfig {
+    fn default() -> Self {
+        Self {
+            db_path: default_codex_requests_db_path(),
+        }
+    }
+}
+
+fn default_codex_requests_db_path() -> String {
+    "~/.local/share/claude-sessions/codex_requests.db".to_owned()
+}
+
+#[derive(Debug, Clone)]
 pub struct CodexObservabilityConfig {
     pub db_path: String,
 }
@@ -744,6 +763,20 @@ fn codex_events_config_for_state_file(state_file: &str) -> CodexEventsConfig {
     }
 }
 
+fn codex_requests_config_for_state_file(state_file: &str) -> CodexRequestsConfig {
+    if state_file == default_state_file() {
+        return CodexRequestsConfig::default();
+    }
+    let state_file = Path::new(state_file);
+    let parent = state_file.parent().unwrap_or_else(|| Path::new("."));
+    CodexRequestsConfig {
+        db_path: parent
+            .join("codex_requests.db")
+            .to_string_lossy()
+            .into_owned(),
+    }
+}
+
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct RustShadowConfig {
     #[serde(default)]
@@ -803,6 +836,8 @@ struct RawConfig {
     #[serde(default)]
     codex_rollout: CodexRolloutConfig,
     #[serde(default)]
+    codex_requests: Option<RawCodexRequestsConfig>,
+    #[serde(default)]
     codex_events: Option<RawCodexEventsConfig>,
     #[serde(default)]
     codex_observability: Option<RawCodexObservabilityConfig>,
@@ -837,6 +872,7 @@ impl From<RawConfig> for AppConfig {
             .unwrap_or_else(|| queue_runner_config_for_state_file(&paths.state_file));
         let codex_observability =
             codex_observability_config(raw.codex_observability, &paths.state_file);
+        let codex_requests = codex_requests_config(raw.codex_requests, &paths.state_file);
         let codex_events = codex_events_config(raw.codex_events, &paths.state_file);
         let claude = provider_launch_config(raw.claude, "claude", Some("sonnet"), Vec::new());
         let codex = provider_launch_config(raw.codex, "codex", None, Vec::new());
@@ -888,6 +924,7 @@ impl From<RawConfig> for AppConfig {
             sm_send: raw.sm_send,
             tool_logging: raw.tool_logging,
             codex_rollout: raw.codex_rollout,
+            codex_requests,
             codex_events,
             codex_observability,
             claude,
@@ -978,6 +1015,12 @@ struct RawCodexEventsConfig {
 }
 
 #[derive(Debug, Default, Deserialize)]
+struct RawCodexRequestsConfig {
+    #[serde(default)]
+    db_path: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
 struct RawTimeoutsConfig {
     #[serde(default)]
     tmux: RawTmuxTimeoutsConfig,
@@ -1060,6 +1103,19 @@ fn codex_observability_config(
 
 fn codex_events_config(raw: Option<RawCodexEventsConfig>, state_file: &str) -> CodexEventsConfig {
     let mut config = codex_events_config_for_state_file(state_file);
+    if let Some(raw) = raw {
+        if let Some(db_path) = raw.db_path {
+            config.db_path = db_path;
+        }
+    }
+    config
+}
+
+fn codex_requests_config(
+    raw: Option<RawCodexRequestsConfig>,
+    state_file: &str,
+) -> CodexRequestsConfig {
+    let mut config = codex_requests_config_for_state_file(state_file);
     if let Some(raw) = raw {
         if let Some(db_path) = raw.db_path {
             config.db_path = db_path;
@@ -1445,6 +1501,23 @@ codex_events:
     }
 
     #[test]
+    fn raw_config_reads_codex_requests_db_path() {
+        let raw: RawConfig = serde_yaml::from_str(
+            r#"
+codex_requests:
+  db_path: /tmp/custom-codex-requests.db
+"#,
+        )
+        .unwrap();
+        let config = AppConfig::from(raw);
+
+        assert_eq!(
+            config.codex_requests.db_path,
+            "/tmp/custom-codex-requests.db"
+        );
+    }
+
+    #[test]
     fn raw_config_reads_codex_rollout_flags() {
         let raw: RawConfig = serde_yaml::from_str(
             r#"
@@ -1480,6 +1553,25 @@ codex_events:
         assert_eq!(
             config.codex_events.db_path,
             "/tmp/sm-fixture/codex_events.db"
+        );
+    }
+
+    #[test]
+    fn raw_config_derives_codex_requests_db_path_from_custom_state_file() {
+        let raw: RawConfig = serde_yaml::from_str(
+            r#"
+paths:
+  state_file: /tmp/sm-fixture/sessions.json
+codex_requests:
+  timeout_seconds: 60
+"#,
+        )
+        .unwrap();
+        let config = AppConfig::from(raw);
+
+        assert_eq!(
+            config.codex_requests.db_path,
+            "/tmp/sm-fixture/codex_requests.db"
         );
     }
 

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -68,6 +68,7 @@ use crate::app_artifacts::{
 };
 use crate::bug_reports::{BugReportStore, CreateBugReport};
 use crate::codex_events::{list_codex_events_from_path, CodexEventsResponse};
+use crate::codex_requests::{list_codex_pending_requests_from_path, CodexPendingRequestsResponse};
 use crate::config::{
     trimmed, AppConfig, MobileTerminalDeviceKeyConfig, MobileTerminalUserConfig, PublicNodeConfig,
 };
@@ -341,6 +342,10 @@ pub fn router(state: AppState) -> Router {
         .route(
             "/sessions/{session_id}/codex-events",
             get(session_codex_events),
+        )
+        .route(
+            "/sessions/{session_id}/codex-pending-requests",
+            get(session_codex_pending_requests),
         )
         .route("/client/sessions", get(list_client_sessions))
         .route(
@@ -3815,6 +3820,35 @@ async fn session_codex_events(
     Ok(Json(response))
 }
 
+async fn session_codex_pending_requests(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+    uri: Uri,
+    request: Request,
+) -> Result<Json<CodexPendingRequestsResponse>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    let query = SessionCodexPendingRequestsQuery::parse(uri.query().unwrap_or(""))?;
+    let Some(session) = state.session_store.get_session(&session_id)? else {
+        return Err(ApiError::NotFound("Session not found"));
+    };
+    if session.provider != "codex-app" {
+        return Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: "codex requests supported only for provider=codex-app".to_owned(),
+        });
+    }
+    if !state.config.codex_rollout.enable_structured_requests {
+        return Err(ApiError::Status {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            detail: "codex structured requests disabled by rollout flag".to_owned(),
+        });
+    }
+    let db_path = expand_home(&state.config.codex_requests.db_path);
+    let response =
+        list_codex_pending_requests_from_path(&db_path, &session_id, query.include_orphaned)?;
+    Ok(Json(response))
+}
+
 async fn shadow_http(
     State(state): State<Arc<AppState>>,
     request: Request,
@@ -4262,6 +4296,53 @@ fn shadow_predict_session_read(
         if !state.config.codex_rollout.enable_durable_events {
             let body = serde_json::to_vec(
                 &json!({ "detail": "codex durable events disabled by rollout flag" }),
+            )?;
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::SERVICE_UNAVAILABLE.as_u16(),
+                body_sha256: Some(sha256_hex(&body)),
+                support_status: "implemented_read",
+            }));
+        }
+        return Ok(Some(ShadowPrediction {
+            status: StatusCode::OK.as_u16(),
+            body_sha256: None,
+            support_status: "implemented_read_status_only",
+        }));
+    }
+
+    if let Some(session_id) = path
+        .strip_prefix("/sessions/")
+        .and_then(|value| value.strip_suffix("/codex-pending-requests"))
+        .filter(|value| !value.is_empty() && !value.contains('/'))
+    {
+        if SessionCodexPendingRequestsQuery::parse(query_string).is_err() {
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::UNPROCESSABLE_ENTITY.as_u16(),
+                body_sha256: None,
+                support_status: "implemented_read_status_only",
+            }));
+        }
+        let Some(session) = state.session_store.get_session(session_id)? else {
+            let body = serde_json::to_vec(&json!({ "detail": "Session not found" }))?;
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::NOT_FOUND.as_u16(),
+                body_sha256: Some(sha256_hex(&body)),
+                support_status: "implemented_read",
+            }));
+        };
+        if session.provider != "codex-app" {
+            let body = serde_json::to_vec(
+                &json!({ "detail": "codex requests supported only for provider=codex-app" }),
+            )?;
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::BAD_REQUEST.as_u16(),
+                body_sha256: Some(sha256_hex(&body)),
+                support_status: "implemented_read",
+            }));
+        }
+        if !state.config.codex_rollout.enable_structured_requests {
+            let body = serde_json::to_vec(
+                &json!({ "detail": "codex structured requests disabled by rollout flag" }),
             )?;
             return Ok(Some(ShadowPrediction {
                 status: StatusCode::SERVICE_UNAVAILABLE.as_u16(),
@@ -6450,6 +6531,32 @@ impl SessionCodexEventsQuery {
             }
         };
         Ok(Self { since_seq, limit })
+    }
+}
+
+struct SessionCodexPendingRequestsQuery {
+    include_orphaned: bool,
+}
+
+impl SessionCodexPendingRequestsQuery {
+    fn parse(query_string: &str) -> Result<Self, ApiError> {
+        let include_orphaned =
+            match decoded_last_query_value(query_string, "include_orphaned")?.as_deref() {
+                None => false,
+                Some(value) => parse_python_bool_query(value).ok_or_else(|| ApiError::Status {
+                    status: StatusCode::UNPROCESSABLE_ENTITY,
+                    detail: "include_orphaned must be a boolean".to_owned(),
+                })?,
+            };
+        Ok(Self { include_orphaned })
+    }
+}
+
+fn parse_python_bool_query(value: &str) -> Option<bool> {
+    match value.to_ascii_lowercase().as_str() {
+        "true" | "1" | "on" | "yes" | "t" | "y" => Some(true),
+        "false" | "0" | "off" | "no" | "f" | "n" => Some(false),
+        _ => None,
     }
 }
 

--- a/crates/sm-server/src/lib.rs
+++ b/crates/sm-server/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod app_artifacts;
 pub mod bug_reports;
 pub mod codex_events;
+pub mod codex_requests;
 pub mod config;
 pub mod email;
 pub mod http;

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -18,8 +18,8 @@ use sm_server::queue::RetainedQueueStore;
 use sm_server::{
     config::{
         AppArtifactsConfig, AppConfig, BugReportsConfig, CodexEventsConfig, CodexForkLaunchConfig,
-        CodexObservabilityConfig, CodexRolloutConfig, EmailConfig, ExternalAccessConfig,
-        GoogleAuthConfig, MobileAnalyticsConfig, MobileTerminalConfig,
+        CodexObservabilityConfig, CodexRequestsConfig, CodexRolloutConfig, EmailConfig,
+        ExternalAccessConfig, GoogleAuthConfig, MobileAnalyticsConfig, MobileTerminalConfig,
         MobileTerminalDeviceKeyConfig, MobileTerminalUserConfig, PathsConfig, QueueRunnerConfig,
         RustCoreConfig, SmSendConfig, ToolLoggingConfig,
     },
@@ -2295,6 +2295,117 @@ async fn shadow_http_uses_decoded_last_codex_events_query_value() {
     assert_eq!(payload["support_status"], "implemented_read_status_only");
     assert_eq!(payload["comparison"], "status_match");
     assert_eq!(payload["predicted_status"], 422);
+
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/sessions/codexpending/codex-pending-requests",
+                "query_string": "include_orphaned=%20true%20",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 422,
+                "body_sha256": sha256_hex(b"{}")
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read_status_only");
+    assert_eq!(payload["comparison"], "status_match");
+    assert_eq!(payload["predicted_status"], 422);
+}
+
+#[tokio::test]
+async fn shadow_http_reports_codex_pending_requests_200_as_status_only() {
+    let state_file = write_codex_app_session_fixture("codexpending");
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+    let python_body = br#"{"requests":[]}"#;
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/sessions/codexpending/codex-pending-requests",
+                "query_string": "include_orphaned=%74&include_orphaned=true",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 200,
+                "body_sha256": sha256_hex(python_body)
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read_status_only");
+    assert_eq!(payload["comparison"], "status_match");
+    assert_eq!(payload["predicted_status"], 200);
+    assert_eq!(payload["body_sha256"], Value::Null);
+}
+
+#[tokio::test]
+async fn shadow_http_reports_codex_pending_requests_stable_failures() {
+    let state_file = write_codex_app_session_fixture("codexpending");
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/sessions/missing/codex-pending-requests",
+                "query_string": "",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 404,
+                "body_sha256": sha256_hex(br#"{"detail":"Session not found"}"#)
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read");
+    assert_eq!(payload["comparison"], "match");
+    assert_eq!(payload["predicted_status"], 404);
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/sessions/codexpending/codex-pending-requests",
+                "query_string": "include_orphaned=maybe",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 422,
+                "body_sha256": sha256_hex(b"{}")
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read_status_only");
+    assert_eq!(payload["comparison"], "status_match");
+    assert_eq!(payload["predicted_status"], 422);
 }
 
 #[tokio::test]
@@ -3687,6 +3798,126 @@ async fn session_codex_events_decodes_query_and_uses_last_duplicate_value() {
     let (status, payload) = get_json(app, "/sessions/codexapp1/codex-events?limit=2&limit=0").await;
     assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
     assert_eq!(payload["detail"], "limit must be between 1 and 500");
+}
+
+#[tokio::test]
+async fn session_codex_pending_requests_reads_pending_and_optional_orphaned_rows() {
+    let state_file = write_codex_app_session_fixture("codexpending");
+    let requests_db = unique_temp_path();
+    create_codex_pending_requests_fixture_db(&requests_db);
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        codex_requests: CodexRequestsConfig {
+            db_path: requests_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) =
+        get_json(app.clone(), "/sessions/codexpending/codex-pending-requests").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        payload,
+        json!({
+            "requests": [
+                {
+                    "request_id": "req-pending",
+                    "session_id": "codexpending",
+                    "thread_id": "thread-a",
+                    "turn_id": "turn-a",
+                    "item_id": "item-a",
+                    "request_type": "request_approval",
+                    "request_method": "item/commandExecution/requestApproval",
+                    "status": "pending",
+                    "requested_at": "2026-06-01T00:00:00+00:00",
+                    "expires_at": "2026-06-01T00:05:00+00:00",
+                    "resolved_payload": null,
+                    "resolved_at": null,
+                    "resolution_source": null,
+                    "error_code": null,
+                    "error_message": null
+                }
+            ]
+        })
+    );
+
+    let (status, payload) = get_json(
+        app,
+        "/sessions/codexpending/codex-pending-requests?include_orphaned=false&include_orphaned=%74",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let requests = payload["requests"].as_array().unwrap();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[0]["request_id"], "req-pending");
+    assert_eq!(requests[1]["request_id"], "req-orphaned");
+    assert_eq!(requests[1]["status"], "orphaned");
+    assert_eq!(requests[1]["resolution_source"], "policy");
+    assert_eq!(requests[1]["error_code"], "server_restarted");
+}
+
+#[tokio::test]
+async fn session_codex_pending_requests_handles_empty_and_gating_errors() {
+    let state_file = write_codex_app_session_fixture("codexpending");
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+
+    let (status, payload) =
+        get_json(app.clone(), "/sessions/codexpending/codex-pending-requests").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload, json!({ "requests": [] }));
+
+    let (status, payload) = get_json(app.clone(), "/sessions/missing/codex-pending-requests").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(payload["detail"], "Session not found");
+
+    let non_codex_state = write_session_fixture();
+    let non_codex_app = router(AppState::new(config_with_state_file(&non_codex_state)));
+    let (status, payload) =
+        get_json(non_codex_app, "/sessions/run12345/codex-pending-requests").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        payload["detail"],
+        "codex requests supported only for provider=codex-app"
+    );
+
+    let disabled_app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        codex_rollout: CodexRolloutConfig {
+            enable_structured_requests: false,
+            ..CodexRolloutConfig::default()
+        },
+        ..AppConfig::default()
+    }));
+    let (status, payload) = get_json(
+        disabled_app,
+        "/sessions/codexpending/codex-pending-requests",
+    )
+    .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(
+        payload["detail"],
+        "codex structured requests disabled by rollout flag"
+    );
+
+    let (status, payload) = get_json(
+        app.clone(),
+        "/sessions/codexpending/codex-pending-requests?include_orphaned=maybe",
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(payload["detail"], "include_orphaned must be a boolean");
+
+    let (status, payload) = get_json(
+        app,
+        "/sessions/codexpending/codex-pending-requests?include_orphaned=%20true%20",
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(payload["detail"], "include_orphaned must be a boolean");
 }
 
 #[tokio::test]
@@ -8436,6 +8667,66 @@ fn create_codex_events_retention_gap_fixture_db(path: &PathBuf) {
         VALUES
             ('retainedgap', 4, '2026-06-01T00:04:00+00:00', 'item_completed', 'turn-r', '{"tool_name":"Bash"}'),
             ('retainedgap', 5, '2026-06-01T00:05:00+00:00', 'turn_completed', 'turn-r', '{"ok":true}');
+        "#,
+    )
+    .unwrap();
+}
+
+fn create_codex_pending_requests_fixture_db(path: &PathBuf) {
+    let conn = Connection::open(path).unwrap();
+    conn.execute_batch(
+        r#"
+        CREATE TABLE codex_pending_requests (
+            request_id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            process_generation TEXT NOT NULL,
+            rpc_request_id INTEGER,
+            thread_id TEXT,
+            turn_id TEXT,
+            item_id TEXT,
+            request_type TEXT NOT NULL,
+            request_method TEXT NOT NULL,
+            requested_at TEXT NOT NULL,
+            expires_at TEXT,
+            status TEXT NOT NULL,
+            request_payload_json TEXT,
+            resolved_payload_json TEXT,
+            resolved_at TEXT,
+            resolution_source TEXT,
+            error_code TEXT,
+            error_message TEXT
+        );
+        INSERT INTO codex_pending_requests
+            (request_id, session_id, process_generation, rpc_request_id, thread_id,
+             turn_id, item_id, request_type, request_method, requested_at, expires_at,
+             status, request_payload_json, resolved_payload_json, resolved_at,
+             resolution_source, error_code, error_message)
+        VALUES
+            ('req-pending', 'codexpending', 'gen-a', 7, 'thread-a',
+             'turn-a', 'item-a', 'request_approval', 'item/commandExecution/requestApproval',
+             '2026-06-01T00:00:00+00:00', '2026-06-01T00:05:00+00:00',
+             'pending', '{"turnId":"turn-a"}', NULL, NULL,
+             NULL, NULL, NULL),
+            ('req-orphaned', 'codexpending', 'gen-old', 8, 'thread-b',
+             'turn-b', 'item-b', 'request_user_input', 'item/tool/requestUserInput',
+             '2026-06-01T00:01:00+00:00', '2026-06-01T00:06:00+00:00',
+             'orphaned', '{"turnId":"turn-b"}', NULL, '2026-06-01T00:02:00+00:00',
+             'policy', 'server_restarted', 'server restarted before request resolution'),
+            ('req-resolved', 'codexpending', 'gen-a', 9, NULL,
+             NULL, NULL, 'request_approval', 'item/fileChange/requestApproval',
+             '2026-06-01T00:02:00+00:00', '2026-06-01T00:07:00+00:00',
+             'resolved', '{}', '{"decision":"accept"}', '2026-06-01T00:03:00+00:00',
+             'api', NULL, NULL),
+            ('req-expired', 'codexpending', 'gen-a', 10, NULL,
+             NULL, NULL, 'request_user_input', 'item/tool/requestUserInput',
+             '2026-06-01T00:03:00+00:00', '2026-06-01T00:08:00+00:00',
+             'expired', '{}', NULL, '2026-06-01T00:04:00+00:00',
+             'policy', 'request_expired', 'request expired before explicit response'),
+            ('req-other', 'othercodex', 'gen-a', 11, NULL,
+             NULL, NULL, 'request_approval', 'item/commandExecution/requestApproval',
+             '2026-06-01T00:04:00+00:00', '2026-06-01T00:09:00+00:00',
+             'pending', '{}', NULL, NULL,
+             NULL, NULL, NULL);
         "#,
     )
     .unwrap();


### PR DESCRIPTION
Fixes #871

## Summary
- Add Rust read parity for GET /sessions/{session_id}/codex-pending-requests backed by retained codex_requests.db.
- Preserve codex-app/provider and codex_rollout.enable_structured_requests gating, plus missing-session/provider/rollout error details.
- Add codex_requests.db config with Python-compatible default and custom state-file sibling behavior.
- Add shadow prediction for the retained read surface: status-only 200, deterministic stable failures, and status-only invalid-query 422.

## Validation
- cargo fmt --check
- cargo test -p sm-server
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py
- git diff --check
