### PR TITLE
Rust MVP: expose codex activity actions endpoint

### DIFF
--- a/crates/sm-server/src/codex_activity.rs
+++ b/crates/sm-server/src/codex_activity.rs
@@ -1,0 +1,275 @@
+use std::path::Path;
+
+use anyhow::Result;
+use rusqlite::{params, Connection, OpenFlags};
+use serde::Serialize;
+use time::{format_description::well_known::Rfc3339, Duration, OffsetDateTime};
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct CodexActivityActionsResponse {
+    pub actions: Vec<CodexActivityAction>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct CodexActivityAction {
+    pub source_provider: String,
+    pub action_kind: String,
+    pub summary_text: String,
+    pub status: String,
+    pub started_at: Option<String>,
+    pub ended_at: Option<String>,
+    pub session_id: String,
+    pub turn_id: Option<String>,
+    pub item_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct CodexToolEventRow {
+    session_id: String,
+    turn_id: Option<String>,
+    item_id: Option<String>,
+    event_type: String,
+    item_type: Option<String>,
+    command: Option<String>,
+    file_path: Option<String>,
+    approval_decision: Option<String>,
+    latency_ms: Option<i64>,
+    final_status: Option<String>,
+    error_message: Option<String>,
+    created_at: Option<String>,
+}
+
+pub fn list_codex_activity_actions_from_path(
+    db_path: &Path,
+    session_id: &str,
+    limit: usize,
+) -> Result<CodexActivityActionsResponse> {
+    if !db_path.exists() {
+        return Ok(CodexActivityActionsResponse {
+            actions: Vec::new(),
+        });
+    }
+    let conn = match Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY) {
+        Ok(conn) => conn,
+        Err(_) => {
+            return Ok(CodexActivityActionsResponse {
+                actions: Vec::new(),
+            })
+        }
+    };
+    list_codex_activity_actions_conn(&conn, session_id, limit)
+}
+
+fn list_codex_activity_actions_conn(
+    conn: &Connection,
+    session_id: &str,
+    limit: usize,
+) -> Result<CodexActivityActionsResponse> {
+    let limit = limit.clamp(1, 200);
+    let mut statement = match conn.prepare(
+        r#"
+        SELECT session_id, turn_id, item_id, event_type, item_type,
+               command, file_path, approval_decision, latency_ms, final_status,
+               error_message, created_at
+        FROM codex_tool_events
+        WHERE session_id = ?1
+        ORDER BY id DESC
+        LIMIT ?2
+        "#,
+    ) {
+        Ok(statement) => statement,
+        Err(rusqlite::Error::SqliteFailure(_, Some(message)))
+            if message.contains("no such table") =>
+        {
+            return Ok(CodexActivityActionsResponse {
+                actions: Vec::new(),
+            });
+        }
+        Err(_) => {
+            return Ok(CodexActivityActionsResponse {
+                actions: Vec::new(),
+            })
+        }
+    };
+    let rows = match statement.query_map(params![session_id, limit as i64], |row| {
+        Ok(CodexToolEventRow {
+            session_id: row.get(0)?,
+            turn_id: row.get(1)?,
+            item_id: row.get(2)?,
+            event_type: row.get(3)?,
+            item_type: row.get(4)?,
+            command: row.get(5)?,
+            file_path: row.get(6)?,
+            approval_decision: row.get(7)?,
+            latency_ms: row.get(8)?,
+            final_status: row.get(9)?,
+            error_message: row.get(10)?,
+            created_at: row.get(11)?,
+        })
+    }) {
+        Ok(rows) => rows,
+        Err(_) => {
+            return Ok(CodexActivityActionsResponse {
+                actions: Vec::new(),
+            })
+        }
+    };
+    let mut rows = rows.collect::<std::result::Result<Vec<_>, _>>()?;
+    rows.reverse();
+    Ok(CodexActivityActionsResponse {
+        actions: rows.iter().map(project_row).collect(),
+    })
+}
+
+fn project_row(row: &CodexToolEventRow) -> CodexActivityAction {
+    CodexActivityAction {
+        source_provider: "codex-app".to_owned(),
+        action_kind: action_kind(&row.event_type, row.item_type.as_deref()).to_owned(),
+        summary_text: summary_text(row),
+        status: status(&row.event_type, row.final_status.as_deref()),
+        started_at: derive_started_at(row.created_at.as_deref(), row.latency_ms),
+        ended_at: if is_terminal_event(&row.event_type) {
+            row.created_at.clone()
+        } else {
+            None
+        },
+        session_id: row.session_id.clone(),
+        turn_id: row.turn_id.clone(),
+        item_id: row.item_id.clone(),
+    }
+}
+
+fn derive_started_at(created_at: Option<&str>, latency_ms: Option<i64>) -> Option<String> {
+    let created_at = created_at?;
+    let Some(latency_ms) = latency_ms.filter(|value| *value != 0) else {
+        return Some(created_at.to_owned());
+    };
+    let Ok(ended_at) = OffsetDateTime::parse(created_at, &Rfc3339) else {
+        return Some(created_at.to_owned());
+    };
+    Some(format_python_datetime(
+        ended_at - Duration::milliseconds(latency_ms),
+    ))
+}
+
+fn format_python_datetime(value: OffsetDateTime) -> String {
+    let offset_seconds = value.offset().whole_seconds();
+    let sign = if offset_seconds < 0 { '-' } else { '+' };
+    let offset_abs = offset_seconds.unsigned_abs();
+    let offset_hours = offset_abs / 3600;
+    let offset_minutes = (offset_abs % 3600) / 60;
+    let base = format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}",
+        value.year(),
+        u8::from(value.month()),
+        value.day(),
+        value.hour(),
+        value.minute(),
+        value.second()
+    );
+    let fraction = if value.nanosecond() == 0 {
+        String::new()
+    } else {
+        format!(".{:06}", value.nanosecond() / 1_000)
+    };
+    format!("{base}{fraction}{sign}{offset_hours:02}:{offset_minutes:02}")
+}
+
+fn action_kind(event_type: &str, item_type: Option<&str>) -> &'static str {
+    if matches!(event_type, "request_approval" | "approval_decision") {
+        return "approval";
+    }
+    if matches!(event_type, "request_user_input" | "user_input_submitted") {
+        return "user_input";
+    }
+    match item_type {
+        Some("commandExecution") => "command",
+        Some("fileChange") => "file_change",
+        _ => "tool",
+    }
+}
+
+fn status(event_type: &str, final_status: Option<&str>) -> String {
+    if matches!(event_type, "request_approval" | "request_user_input") {
+        return "pending".to_owned();
+    }
+    if matches!(
+        event_type,
+        "completed" | "failed" | "interrupted" | "cancelled" | "timeout"
+    ) {
+        return final_status.unwrap_or(event_type).to_owned();
+    }
+    if matches!(event_type, "approval_decision" | "user_input_submitted") {
+        return "completed".to_owned();
+    }
+    "running".to_owned()
+}
+
+fn summary_text(row: &CodexToolEventRow) -> String {
+    let item_type = row.item_type.as_deref().unwrap_or("tool");
+    let command = row.command.as_deref();
+    let file_path = row.file_path.as_deref();
+    match row.event_type.as_str() {
+        "request_approval" => format!("Approval requested ({item_type})"),
+        "approval_decision" => row
+            .approval_decision
+            .as_deref()
+            .map(|decision| format!("Approval decision: {decision}"))
+            .unwrap_or_else(|| "Approval decision submitted".to_owned()),
+        "request_user_input" => "User input requested".to_owned(),
+        "user_input_submitted" => "User input submitted".to_owned(),
+        "started" => {
+            if let Some(command) = command {
+                return format!("Started: {}", truncate_chars(command, 80));
+            }
+            if let Some(file_path) = file_path {
+                return format!("Started file change: {file_path}");
+            }
+            format!("Started {item_type}")
+        }
+        "output_delta" => {
+            if let Some(command) = command {
+                return format!("Output update: {}", truncate_chars(command, 60));
+            }
+            if let Some(file_path) = file_path {
+                return format!("File update: {file_path}");
+            }
+            "Output update".to_owned()
+        }
+        "completed" | "failed" | "interrupted" | "cancelled" | "timeout" => {
+            let target = command.or(file_path).unwrap_or(item_type);
+            if row.event_type == "failed" {
+                if let Some(error_message) = row.error_message.as_deref() {
+                    return format!("Failed {target}: {}", truncate_chars(error_message, 120));
+                }
+            }
+            format!("{} {target}", capitalize_ascii(&row.event_type))
+        }
+        event_type => format!("{event_type} ({item_type})"),
+    }
+}
+
+fn is_terminal_event(event_type: &str) -> bool {
+    matches!(
+        event_type,
+        "completed"
+            | "failed"
+            | "interrupted"
+            | "cancelled"
+            | "timeout"
+            | "approval_decision"
+            | "user_input_submitted"
+    )
+}
+
+fn truncate_chars(value: &str, limit: usize) -> String {
+    value.chars().take(limit).collect()
+}
+
+fn capitalize_ascii(value: &str) -> String {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return String::new();
+    };
+    format!("{}{}", first.to_ascii_uppercase(), chars.as_str())
+}

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -67,6 +67,7 @@ use crate::app_artifacts::{
     APP_ARTIFACT_MAX_SIZE_BYTES,
 };
 use crate::bug_reports::{BugReportStore, CreateBugReport};
+use crate::codex_activity::{list_codex_activity_actions_from_path, CodexActivityActionsResponse};
 use crate::codex_events::{list_codex_events_from_path, CodexEventsResponse};
 use crate::codex_requests::{list_codex_pending_requests_from_path, CodexPendingRequestsResponse};
 use crate::config::{
@@ -339,6 +340,10 @@ pub fn router(state: AppState) -> Router {
         .route("/registry/{role}", get(lookup_agent_registry))
         .route("/sessions/{session_id}/output", get(session_output))
         .route("/sessions/{session_id}/tool-calls", get(session_tool_calls))
+        .route(
+            "/sessions/{session_id}/activity-actions",
+            get(session_activity_actions),
+        )
         .route(
             "/sessions/{session_id}/codex-events",
             get(session_codex_events),
@@ -3791,6 +3796,34 @@ async fn session_tool_calls(
     }))
 }
 
+async fn session_activity_actions(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+    uri: Uri,
+    request: Request,
+) -> Result<Json<CodexActivityActionsResponse>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    let query = SessionActivityActionsQuery::parse(uri.query().unwrap_or(""))?;
+    let Some(session) = state.session_store.get_session(&session_id)? else {
+        return Err(ApiError::NotFound("Session not found"));
+    };
+    if session.provider != "codex-app" {
+        return Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: "activity actions supported only for provider=codex-app".to_owned(),
+        });
+    }
+    if !state.config.codex_rollout.enable_observability_projection {
+        return Err(ApiError::Status {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            detail: "codex activity projection disabled by rollout flag".to_owned(),
+        });
+    }
+    let db_path = expand_home(&state.config.codex_observability.db_path);
+    let response = list_codex_activity_actions_from_path(&db_path, &session_id, query.limit)?;
+    Ok(Json(response))
+}
+
 async fn session_codex_events(
     State(state): State<Arc<AppState>>,
     Path(session_id): Path<String>,
@@ -4256,6 +4289,53 @@ fn shadow_predict_session_read(
                 support_status: "implemented_read",
             }));
         };
+        return Ok(Some(ShadowPrediction {
+            status: StatusCode::OK.as_u16(),
+            body_sha256: None,
+            support_status: "implemented_read_status_only",
+        }));
+    }
+
+    if let Some(session_id) = path
+        .strip_prefix("/sessions/")
+        .and_then(|value| value.strip_suffix("/activity-actions"))
+        .filter(|value| !value.is_empty() && !value.contains('/'))
+    {
+        if SessionActivityActionsQuery::parse(query_string).is_err() {
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::UNPROCESSABLE_ENTITY.as_u16(),
+                body_sha256: None,
+                support_status: "implemented_read_status_only",
+            }));
+        }
+        let Some(session) = state.session_store.get_session(session_id)? else {
+            let body = serde_json::to_vec(&json!({ "detail": "Session not found" }))?;
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::NOT_FOUND.as_u16(),
+                body_sha256: Some(sha256_hex(&body)),
+                support_status: "implemented_read",
+            }));
+        };
+        if session.provider != "codex-app" {
+            let body = serde_json::to_vec(
+                &json!({ "detail": "activity actions supported only for provider=codex-app" }),
+            )?;
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::BAD_REQUEST.as_u16(),
+                body_sha256: Some(sha256_hex(&body)),
+                support_status: "implemented_read",
+            }));
+        }
+        if !state.config.codex_rollout.enable_observability_projection {
+            let body = serde_json::to_vec(
+                &json!({ "detail": "codex activity projection disabled by rollout flag" }),
+            )?;
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::SERVICE_UNAVAILABLE.as_u16(),
+                body_sha256: Some(sha256_hex(&body)),
+                support_status: "implemented_read",
+            }));
+        }
         return Ok(Some(ShadowPrediction {
             status: StatusCode::OK.as_u16(),
             body_sha256: None,
@@ -6531,6 +6611,33 @@ impl SessionCodexEventsQuery {
             }
         };
         Ok(Self { since_seq, limit })
+    }
+}
+
+struct SessionActivityActionsQuery {
+    limit: usize,
+}
+
+impl SessionActivityActionsQuery {
+    fn parse(query_string: &str) -> Result<Self, ApiError> {
+        let limit_value = decoded_last_query_value(query_string, "limit")?;
+        let limit = match limit_value.as_deref() {
+            None => 20,
+            Some(value) => {
+                let parsed = value.parse::<i64>().map_err(|_| ApiError::Status {
+                    status: StatusCode::UNPROCESSABLE_ENTITY,
+                    detail: "limit must be between 1 and 200".to_owned(),
+                })?;
+                if !(1..=200).contains(&parsed) {
+                    return Err(ApiError::Status {
+                        status: StatusCode::UNPROCESSABLE_ENTITY,
+                        detail: "limit must be between 1 and 200".to_owned(),
+                    });
+                }
+                parsed as usize
+            }
+        };
+        Ok(Self { limit })
     }
 }
 

--- a/crates/sm-server/src/lib.rs
+++ b/crates/sm-server/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod app_artifacts;
 pub mod bug_reports;
+pub mod codex_activity;
 pub mod codex_events;
 pub mod codex_requests;
 pub mod config;

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -2145,6 +2145,92 @@ async fn shadow_http_reports_tool_calls_404() {
 }
 
 #[tokio::test]
+async fn shadow_http_reports_activity_actions_200_as_status_only() {
+    let state_file = write_codex_app_session_fixture("codexproj");
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+    let python_body = br#"{"actions":[]}"#;
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/sessions/codexproj/activity-actions",
+                "query_string": "limit=%32&limit=3",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 200,
+                "body_sha256": sha256_hex(python_body)
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read_status_only");
+    assert_eq!(payload["comparison"], "status_match");
+    assert_eq!(payload["predicted_status"], 200);
+    assert_eq!(payload["body_sha256"], Value::Null);
+}
+
+#[tokio::test]
+async fn shadow_http_reports_activity_actions_stable_failures() {
+    let state_file = write_codex_app_session_fixture("codexproj");
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/sessions/missing/activity-actions",
+                "query_string": "",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 404,
+                "body_sha256": sha256_hex(br#"{"detail":"Session not found"}"#)
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read");
+    assert_eq!(payload["comparison"], "match");
+    assert_eq!(payload["predicted_status"], 404);
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/sessions/codexproj/activity-actions",
+                "query_string": "limit=0",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 422,
+                "body_sha256": sha256_hex(b"{}")
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read_status_only");
+    assert_eq!(payload["comparison"], "status_match");
+    assert_eq!(payload["predicted_status"], 422);
+}
+
+#[tokio::test]
 async fn shadow_http_reports_codex_events_200_as_status_only() {
     let state_file = write_codex_app_session_fixture("codexapp1");
     let app = router(AppState::new(config_with_state_file(&state_file)));
@@ -3572,6 +3658,107 @@ async fn session_tool_calls_codex_fork_missing_observability_db_returns_empty_ro
         payload,
         json!({ "session_id": "forktools", "tool_calls": [] })
     );
+}
+
+#[tokio::test]
+async fn session_activity_actions_projects_codex_observability_rows() {
+    let state_file = write_codex_app_session_fixture("codexproj");
+    let observability_db = unique_temp_path();
+    create_codex_activity_fixture_db(&observability_db);
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        codex_observability: CodexObservabilityConfig {
+            db_path: observability_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = get_json(
+        app,
+        "/sessions/codexproj/activity-actions?limit=%32&limit=3",
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["actions"].as_array().unwrap().len(), 3);
+    assert_eq!(
+        payload["actions"][0],
+        json!({
+            "source_provider": "codex-app",
+            "action_kind": "command",
+            "summary_text": "Started: pytest -q",
+            "status": "running",
+            "started_at": "2026-02-21T10:00:00+00:00",
+            "ended_at": null,
+            "session_id": "codexproj",
+            "turn_id": "turn-1",
+            "item_id": "item-1"
+        })
+    );
+    assert_eq!(
+        payload["actions"][1]["summary_text"],
+        "Failed pytest -q: non-zero exit"
+    );
+    assert_eq!(
+        payload["actions"][1]["started_at"],
+        "2026-02-21T10:00:00+00:00"
+    );
+    assert_eq!(
+        payload["actions"][1]["ended_at"],
+        "2026-02-21T10:00:05+00:00"
+    );
+    assert_eq!(payload["actions"][2]["action_kind"], "approval");
+    assert_eq!(
+        payload["actions"][2]["summary_text"],
+        "Approval decision: accept"
+    );
+    assert_eq!(payload["actions"][2]["status"], "completed");
+}
+
+#[tokio::test]
+async fn session_activity_actions_handles_empty_and_gating_errors() {
+    let state_file = write_codex_app_session_fixture("codexproj");
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+
+    let (status, payload) = get_json(app.clone(), "/sessions/codexproj/activity-actions").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload, json!({ "actions": [] }));
+
+    let (status, payload) = get_json(app.clone(), "/sessions/missing/activity-actions").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(payload["detail"], "Session not found");
+
+    let non_codex_state = write_session_fixture();
+    let non_codex_app = router(AppState::new(config_with_state_file(&non_codex_state)));
+    let (status, payload) = get_json(non_codex_app, "/sessions/run12345/activity-actions").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        payload["detail"],
+        "activity actions supported only for provider=codex-app"
+    );
+
+    let disabled_app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        codex_rollout: CodexRolloutConfig {
+            enable_observability_projection: false,
+            ..CodexRolloutConfig::default()
+        },
+        ..AppConfig::default()
+    }));
+    let (status, payload) = get_json(disabled_app, "/sessions/codexproj/activity-actions").await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(
+        payload["detail"],
+        "codex activity projection disabled by rollout flag"
+    );
+
+    let (status, payload) = get_json(app, "/sessions/codexproj/activity-actions?limit=201").await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(payload["detail"], "limit must be between 1 and 200");
 }
 
 #[tokio::test]
@@ -8751,6 +8938,62 @@ fn create_codex_observability_fixture_db(path: &PathBuf) {
             ('otherfork', '{"tool_name":"Ignore"}', '2026-06-01T00:04:00+00:00'),
             ('forktools', NULL, '2026-06-01T00:04:30+00:00'),
             ('forktools', '{"tool_name":"Edit"}', '2026-06-01T00:05:00+00:00');
+        "#,
+    )
+    .unwrap();
+}
+
+fn create_codex_activity_fixture_db(path: &PathBuf) {
+    let conn = Connection::open(path).unwrap();
+    conn.execute_batch(
+        r#"
+        CREATE TABLE codex_tool_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            thread_id TEXT,
+            turn_id TEXT,
+            item_id TEXT,
+            request_id TEXT,
+            event_type TEXT NOT NULL,
+            item_type TEXT,
+            phase TEXT,
+            command TEXT,
+            cwd TEXT,
+            exit_code INTEGER,
+            file_path TEXT,
+            diff_summary TEXT,
+            approval_decision TEXT,
+            latency_ms INTEGER,
+            final_status TEXT,
+            error_code TEXT,
+            error_message TEXT,
+            raw_payload_json TEXT,
+            provider TEXT NOT NULL DEFAULT 'codex-app',
+            schema_version INTEGER,
+            created_at TEXT NOT NULL
+        );
+        INSERT INTO codex_tool_events
+            (session_id, thread_id, turn_id, item_id, request_id, event_type,
+             item_type, phase, command, cwd, exit_code, file_path, diff_summary,
+             approval_decision, latency_ms, final_status, error_code, error_message,
+             raw_payload_json, provider, schema_version, created_at)
+        VALUES
+            ('codexproj', 'thread-1', 'turn-1', 'item-1', NULL, 'started',
+             'commandExecution', 'pre', 'pytest -q', '/repo', NULL, NULL, NULL,
+             NULL, NULL, NULL, NULL, NULL,
+             '{}', 'codex-app', 2, '2026-02-21T10:00:00+00:00'),
+            ('codexproj', 'thread-1', 'turn-1', 'item-1', NULL, 'failed',
+             'commandExecution', 'post', 'pytest -q', '/repo', 1, NULL, NULL,
+             NULL, 5000, 'failed', 'nonzero', 'non-zero exit',
+             '{}', 'codex-app', 2, '2026-02-21T10:00:05+00:00'),
+            ('codexproj', 'thread-2', 'turn-2', 'item-2', 'req-1', 'approval_decision',
+             'fileChange', 'post', NULL, '/repo', NULL, 'src/main.py', NULL,
+             'accept', NULL, NULL, NULL, NULL,
+             '{}', 'codex-app', 2, '2026-02-21T10:01:00+00:00'),
+            ('otherproj', 'thread-x', 'turn-x', 'item-x', NULL, 'started',
+             'commandExecution', 'pre', 'ignored', '/repo', NULL, NULL, NULL,
+             NULL, NULL, NULL, NULL, NULL,
+             '{}', 'codex-app', 2, '2026-02-21T10:02:00+00:00');
         "#,
     )
     .unwrap();


### PR DESCRIPTION
Fixes #873

## Summary
- Add Rust read parity for GET /sessions/{session_id}/activity-actions backed by retained codex_observability.db.
- Preserve codex-app/provider and codex_rollout.enable_observability_projection gating, plus missing-session/provider/rollout error details.
- Project recent codex_tool_events rows into the provider-neutral activity action shape used by CLI/watch/mobile.
- Add shadow prediction for the retained read surface: status-only 200, deterministic stable failures, and status-only invalid-query 422.

## Validation
- cargo fmt --check
- cargo test -p sm-server
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py
- git diff --check
