### PR TITLE
Rust MVP: cover codex read endpoints in contract manifest

### DIFF
--- a/scripts/rust_migration/contracts_manifest.json
+++ b/scripts/rust_migration/contracts_manifest.json
@@ -451,6 +451,36 @@
       "source": "specs/762_stage2_artifacts/external_client_manifest.md:26"
     },
     {
+      "id": "http.codex_events",
+      "surface": "http",
+      "classification": "retained",
+      "target": "python_and_rust",
+      "safety": "read_only",
+      "method": "GET",
+      "path": "/sessions/{codex_app_session_id}/codex-events?limit=5",
+      "expected_status": [200],
+      "expected_json": [
+        {"path": "/events", "type": "array"}
+      ],
+      "preconditions": ["live_server", "fixture:codex_app_session_id"],
+      "source": "specs/762_stage2_artifacts/route_manifest.md:69"
+    },
+    {
+      "id": "http.codex_activity_actions",
+      "surface": "http",
+      "classification": "retained",
+      "target": "python_and_rust",
+      "safety": "read_only",
+      "method": "GET",
+      "path": "/sessions/{codex_app_session_id}/activity-actions?limit=5",
+      "expected_status": [200],
+      "expected_json": [
+        {"path": "/actions", "type": "array"}
+      ],
+      "preconditions": ["live_server", "fixture:codex_app_session_id"],
+      "source": "specs/762_stage2_artifacts/route_manifest.md:70"
+    },
+    {
       "id": "http.codex_pending_requests",
       "surface": "http",
       "classification": "retained",

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -226,6 +226,38 @@ def test_manifest_has_json_shape_assertions_for_core_http_surfaces():
     )
 
 
+def test_manifest_covers_retained_codex_read_http_surfaces():
+    manifest = ContractManifest.load()
+    checks = {check.id: check for check in manifest.checks}
+    required_ids = {
+        "http.session_tool_calls",
+        "http.codex_events",
+        "http.codex_activity_actions",
+        "http.codex_pending_requests",
+    }
+
+    missing = required_ids - set(checks)
+    assert not missing
+    for check_id in required_ids:
+        check = checks[check_id]
+        assert check.classification == "retained"
+        assert check.target == "python_and_rust"
+        assert check.safety == "read_only"
+        assert check.method == "GET"
+
+    assert "fixture:codex_app_session_id" in checks["http.codex_events"].preconditions
+    assert "fixture:codex_app_session_id" in checks["http.codex_activity_actions"].preconditions
+    assert "fixture:codex_app_session_id" in checks["http.codex_pending_requests"].preconditions
+    assert any(
+        expectation.path == "/events" and expectation.value_type == "array"
+        for expectation in checks["http.codex_events"].expected_json
+    )
+    assert any(
+        expectation.path == "/actions" and expectation.value_type == "array"
+        for expectation in checks["http.codex_activity_actions"].expected_json
+    )
+
+
 def test_manifest_covers_native_mobile_support_http_surfaces():
     manifest = ContractManifest.load()
     checks = {check.id: check for check in manifest.checks}


### PR DESCRIPTION
Fixes #875

## Summary
- Add migration contract-manifest checks for retained Codex read endpoints: codex events and activity actions.
- Keep checks read-only and gated on a supplied codex_app_session_id fixture.
- Add a manifest unit assertion for the retained Codex read HTTP set.

## Validation
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py
- ./venv/bin/python -m json.tool scripts/rust_migration/contracts_manifest.json
- cargo fmt --check
- git diff --check
