### PR TITLE
Cover detail endpoints in Rust contract manifest

### DIFF
--- a/scripts/rust_migration/contracts_manifest.json
+++ b/scripts/rust_migration/contracts_manifest.json
@@ -184,6 +184,21 @@
       "source": "specs/762_stage5_artifacts/gate_matrix.md:72"
     },
     {
+      "id": "http.queue_job_detail",
+      "surface": "http",
+      "classification": "retained",
+      "target": "python_and_rust",
+      "safety": "read_only",
+      "method": "GET",
+      "path": "/queue-jobs/{queue_job_id}",
+      "expected_status": [200],
+      "expected_json": [
+        {"path": "/id", "equals": "{queue_job_id}"}
+      ],
+      "preconditions": ["live_server", "fixture:queue_job_id"],
+      "source": "specs/762_stage2_artifacts/route_manifest.md:137"
+    },
+    {
       "id": "http.codex_review_requests_list",
       "surface": "http",
       "classification": "retained",
@@ -197,6 +212,21 @@
       ],
       "preconditions": ["live_server"],
       "source": "specs/762_stage5_artifacts/gate_matrix.md:72"
+    },
+    {
+      "id": "http.codex_review_request_detail",
+      "surface": "http",
+      "classification": "retained",
+      "target": "python_and_rust",
+      "safety": "read_only",
+      "method": "GET",
+      "path": "/codex-review-requests/{codex_review_request_id}",
+      "expected_status": [200],
+      "expected_json": [
+        {"path": "/id", "equals": "{codex_review_request_id}"}
+      ],
+      "preconditions": ["live_server", "fixture:codex_review_request_id"],
+      "source": "specs/762_stage2_artifacts/route_manifest.md:145"
     },
     {
       "id": "http.api_sessions_absent",

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -258,6 +258,41 @@ def test_manifest_covers_retained_codex_read_http_surfaces():
     )
 
 
+def test_manifest_covers_implemented_detail_http_surfaces():
+    manifest = ContractManifest.load()
+    checks = {check.id: check for check in manifest.checks}
+    required_ids = {
+        "http.queue_job_detail",
+        "http.codex_review_request_detail",
+    }
+
+    missing = required_ids - set(checks)
+    assert not missing
+    for check_id in required_ids:
+        check = checks[check_id]
+        assert check.classification == "retained"
+        assert check.target == "python_and_rust"
+        assert check.safety == "read_only"
+        assert check.method == "GET"
+        assert check.expected_status == (200,)
+
+    queue_job = checks["http.queue_job_detail"]
+    assert queue_job.path == "/queue-jobs/{queue_job_id}"
+    assert "fixture:queue_job_id" in queue_job.preconditions
+    assert any(
+        expectation.path == "/id" and expectation.equals == "{queue_job_id}"
+        for expectation in queue_job.expected_json
+    )
+
+    codex_review = checks["http.codex_review_request_detail"]
+    assert codex_review.path == "/codex-review-requests/{codex_review_request_id}"
+    assert "fixture:codex_review_request_id" in codex_review.preconditions
+    assert any(
+        expectation.path == "/id" and expectation.equals == "{codex_review_request_id}"
+        for expectation in codex_review.expected_json
+    )
+
+
 def test_manifest_covers_native_mobile_support_http_surfaces():
     manifest = ContractManifest.load()
     checks = {check.id: check for check in manifest.checks}


### PR DESCRIPTION
## Summary
- add fixture-gated contract checks for GET /queue-jobs/{job_id}
- add fixture-gated contract checks for GET /codex-review-requests/{request_id}
- assert both implemented detail surfaces stay retained read-only python_and_rust checks

## Validation
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py
- ./venv/bin/python -m json.tool scripts/rust_migration/contracts_manifest.json >/dev/null
- git diff --check

Fixes #879