### PR TITLE
Add Rust validation routes for retained auth and hook surfaces

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -247,6 +247,8 @@ pub fn router(state: AppState) -> Router {
         .route("/health", get(health))
         .route("/health/detailed", get(health_detailed))
         .route("/auth/session", get(auth_session))
+        .route("/auth/device/google", post(auth_device_google))
+        .route("/hooks/tmux-client", post(tmux_client_hook))
         .route("/client/bootstrap", get(client_bootstrap))
         .route("/client/analytics/summary", get(client_analytics_summary))
         .route("/client/request-status", post(client_request_status))
@@ -437,6 +439,51 @@ async fn auth_session(
         auth_type: None,
         error: None,
     })
+}
+
+async fn auth_device_google(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<DeviceGoogleAuthRequest>,
+) -> Result<Json<Value>, ApiError> {
+    if !state.config.google_auth.ready() {
+        return Err(ApiError::Status {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            detail: "Google auth is not configured".to_owned(),
+        });
+    }
+    let _id_token = payload.id_token.trim();
+    Err(ApiError::Status {
+        status: StatusCode::UNAUTHORIZED,
+        detail: "Invalid Google ID token".to_owned(),
+    })
+}
+
+async fn tmux_client_hook(
+    State(state): State<Arc<AppState>>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Query(query): Query<TmuxClientHookQuery>,
+) -> Result<Json<Value>, ApiError> {
+    if !is_local_bypass_request(&headers, Some(peer_addr), &state.config) {
+        return Err(ApiError::Status {
+            status: StatusCode::FORBIDDEN,
+            detail: "tmux client hooks must originate locally".to_owned(),
+        });
+    }
+    let event_name = query.event.trim();
+    if !matches!(
+        event_name,
+        "client-attached" | "client-detached" | "client-session-changed"
+    ) {
+        return Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: "unsupported tmux client event".to_owned(),
+        });
+    }
+    Ok(Json(json!({
+        "status": "ok",
+        "tmux_client_event_version": 0,
+    })))
 }
 
 async fn client_bootstrap(
@@ -6694,6 +6741,16 @@ fn decoded_last_query_value(query_string: &str, key: &str) -> Result<Option<Stri
 struct KillSessionRequest {
     #[serde(default)]
     requester_session_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeviceGoogleAuthRequest {
+    id_token: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct TmuxClientHookQuery {
+    event: String,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -1894,6 +1894,83 @@ async fn auth_session_reports_disabled_bypass_when_google_auth_not_requested() {
 }
 
 #[tokio::test]
+async fn device_google_auth_route_preserves_validation_and_config_errors() {
+    let app = router(AppState::new(AppConfig::default()));
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/auth/device/google")
+                .header("content-type", "application/json")
+                .body(Body::from(b"{}".to_vec()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert!(
+        String::from_utf8_lossy(&body).contains("id_token"),
+        "body={}",
+        String::from_utf8_lossy(&body)
+    );
+
+    let (status, payload) = post_json(
+        app,
+        "/auth/device/google",
+        json!({"id_token": "google-id-token"}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(payload["detail"], "Google auth is not configured");
+}
+
+#[tokio::test]
+async fn tmux_client_hook_preserves_local_only_and_event_validation() {
+    let app = router(AppState::new(AppConfig::default()));
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/hooks/tmux-client?event=unsupported",
+        json!({}),
+        &[("host", "127.0.0.1:8421")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(payload["detail"], "unsupported tmux client event");
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/hooks/tmux-client?event=client-session-changed&session=tmux-test",
+        json!({}),
+        &[("host", "127.0.0.1:8421")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "ok");
+    assert_eq!(payload["tmux_client_event_version"], 0);
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app,
+        "/hooks/tmux-client?event=client-session-changed",
+        json!({}),
+        &[("host", "127.0.0.1:8421")],
+        Some(SocketAddr::from(([203, 0, 113, 10], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(
+        payload["detail"],
+        "tmux client hooks must originate locally"
+    );
+}
+
+#[tokio::test]
 async fn shadow_http_reports_match_for_stable_read_only_route() {
     let app = router(AppState::new(AppConfig::default()));
     let python_body = serde_json::to_vec(&json!({ "status": "healthy" })).unwrap();


### PR DESCRIPTION
## Summary
- add retained Rust route coverage for `POST /auth/device/google` validation/config-failure behavior
- add retained Rust route coverage for local-only `POST /hooks/tmux-client` event validation
- add Rust HTTP tests for missing `id_token`, Google-auth-not-configured, local hook validation, valid hook acknowledgement, and non-local hook rejection

## Scope notes
- successful Google device-token issuance is intentionally out of scope for this slice; this PR only closes the retained validation-route gaps found by the fixture-backed manifest run
- the fuller manifest subset failed 2/21 on Rust before this slice and passed 21/21 after these routes were added

## Validation
- `git diff --check`
- `cargo fmt --check`
- `cargo test -p sm-server --test read_only_http device_google_auth_route_preserves_validation_and_config_errors -- --nocapture`
- `cargo test -p sm-server --test read_only_http tmux_client_hook_preserves -- --nocapture`
- Rust sidecar retained subset: 21/21 passed
- `cargo test -p sm-server`
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py`

Fixes #881
