### PR TITLE
Correct Rust migration client-session attach fixture contract

### DIFF
--- a/scripts/rust_migration/contracts_manifest.json
+++ b/scripts/rust_migration/contracts_manifest.json
@@ -431,7 +431,7 @@
       "expected_json": [
         {"path": "/id", "equals": "{session_id}"},
         {"path": "/attach_descriptor", "type": "object"},
-        {"path": "/attach_descriptor/attach_supported", "equals": false},
+        {"path": "/attach_descriptor/attach_supported", "type": "boolean"},
         {"path": "/termux_attach", "type": "null"},
         {"path": "/mobile_terminal", "type": "object"},
         {"path": "/mobile_terminal/supported", "equals": false},

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -219,6 +219,18 @@ def test_manifest_has_json_shape_assertions_for_core_http_surfaces():
         for expectation in checks["http.session_detail_fixture"].expected_json
     )
     assert checks["http.client_session_detail_fixture"].expected_json
+    client_session_expectations = {
+        expectation.path: expectation
+        for expectation in checks["http.client_session_detail_fixture"].expected_json
+    }
+    assert (
+        client_session_expectations["/attach_descriptor/attach_supported"].value_type
+        == "boolean"
+    )
+    assert client_session_expectations["/termux_attach"].value_type == "null"
+    assert (
+        client_session_expectations["/mobile_terminal/supported"].equals is False
+    )
     assert checks["http.session_output_fixture"].expected_json
     assert any(
         expectation.path == "/tmux_client_event_version" and expectation.value_type == "number"


### PR DESCRIPTION
## Summary
- update `http.client_session_detail_fixture` to assert `attach_descriptor.attach_supported` is a boolean instead of always `false`
- keep the retained cutover assertions that Termux attach is absent and mobile terminal is unsupported unless configured
- add unit coverage so the manifest remains shape-focused for the synthetic running fixture session

## Context
The fuller fixture-backed manifest run after PR #882 exposed that `fixture001` is a running Claude/tmux-backed session, so classic attach support is correctly `true`. The stale manifest expectation was asserting an unsupported attach state while using the running fixture.

## Validation
- `./venv/bin/python -m scripts.rust_migration.contracts --target rust --base-url http://127.0.0.1:8422 --session-id fixture001 --check-id http.client_session_detail_fixture --json`
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py`
- `./venv/bin/python -m json.tool scripts/rust_migration/contracts_manifest.json >/dev/null`
- `git diff --check`

Fixes #883
