### PR TITLE
Add Codex-app read fixture for Rust migration manifest

### DIFF
--- a/scripts/rust_migration/fixtures/read_only/sessions.json
+++ b/scripts/rust_migration/fixtures/read_only/sessions.json
@@ -33,6 +33,19 @@
       "created_at": "2026-06-01T00:00:00",
       "last_activity": "2026-06-01T00:01:00",
       "stopped_at": "2026-06-01T00:02:00"
+    },
+    {
+      "id": "fixture-codex",
+      "name": "codex-app-fixture",
+      "working_dir": "/tmp/sm-fixture-workspace",
+      "tmux_session": "",
+      "node": "primary",
+      "provider": "codex-app",
+      "status": "running",
+      "created_at": "2026-06-01T00:00:00",
+      "last_activity": "2026-06-01T00:03:00",
+      "friendly_name": "Codex App Fixture",
+      "current_task": "Codex-app read fixture"
     }
   ]
 }

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -1,5 +1,7 @@
+import json
 import subprocess
 import urllib.error
+from pathlib import Path
 from unittest.mock import patch
 
 from scripts.rust_migration.baseline import (
@@ -268,6 +270,17 @@ def test_manifest_covers_retained_codex_read_http_surfaces():
         expectation.path == "/actions" and expectation.value_type == "array"
         for expectation in checks["http.codex_activity_actions"].expected_json
     )
+
+
+def test_read_only_fixture_provides_codex_app_session_for_retained_reads():
+    fixture_path = Path("scripts/rust_migration/fixtures/read_only/sessions.json")
+    fixture = json.loads(fixture_path.read_text())
+    sessions = {session["id"]: session for session in fixture["sessions"]}
+
+    codex_fixture = sessions["fixture-codex"]
+    assert codex_fixture["provider"] == "codex-app"
+    assert codex_fixture["status"] == "running"
+    assert codex_fixture["tmux_session"] == ""
 
 
 def test_manifest_covers_implemented_detail_http_surfaces():


### PR DESCRIPTION
## Summary
- add a synthetic `fixture-codex` Codex-app session to the read-only Rust migration fixture state
- add manifest-unit coverage that the fixture exists and is parseable as a Codex-app session
- unlock fixture-backed Rust manifest checks for Codex events, activity actions, and pending requests without relying on live Codex-app state

## Validation
- `./venv/bin/python -m json.tool scripts/rust_migration/fixtures/read_only/sessions.json >/dev/null`
- `git diff --check`
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py`
- Rust fixture sidecar on `http://127.0.0.1:8422`, then:
  - `./venv/bin/python -m scripts.rust_migration.contracts --target rust --base-url http://127.0.0.1:8422 --fixture codex_app_session_id=fixture-codex --check-id http.codex_events --check-id http.codex_activity_actions --check-id http.codex_pending_requests --json`
  - `./venv/bin/python -m scripts.rust_migration.contracts --target rust --base-url http://127.0.0.1:8422 --session-id fixture001 --fixture codex_app_session_id=fixture-codex --check-id http.session_detail_fixture --check-id http.client_session_detail_fixture --check-id http.session_output_fixture --check-id http.codex_events --check-id http.codex_activity_actions --check-id http.codex_pending_requests --json`

Fixes #885
