### PR TITLE
Add app artifact fixture for Rust migration manifest

### DIFF
--- a/scripts/rust_migration/fixtures/read_only/apps/session-manager-android/meta.json
+++ b/scripts/rust_migration/fixtures/read_only/apps/session-manager-android/meta.json
@@ -1,0 +1,8 @@
+{
+  "artifact_hash": "deadbeef",
+  "size_bytes": 9,
+  "uploaded_at": "2026-06-01T00:04:00+00:00",
+  "uploaded_by": "fixture@example.com",
+  "version_code": 1,
+  "version_name": "fixture"
+}

--- a/scripts/rust_migration/fixtures/read_only/config.yaml
+++ b/scripts/rust_migration/fixtures/read_only/config.yaml
@@ -1,5 +1,6 @@
 paths:
   state_file: "scripts/rust_migration/fixtures/read_only/sessions.json"
+  app_artifacts_dir: "scripts/rust_migration/fixtures/read_only/apps"
 
 queue_runner:
   state_dir: "scripts/rust_migration/fixtures/read_only/queue-runner"

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -343,6 +343,21 @@ def test_manifest_covers_native_mobile_support_http_surfaces():
     assert "fixture:app_name" in app_metadata.preconditions
 
 
+def test_read_only_fixture_provides_app_artifact_metadata():
+    config_path = Path("scripts/rust_migration/fixtures/read_only/config.yaml")
+    metadata_path = Path(
+        "scripts/rust_migration/fixtures/read_only/apps/session-manager-android/meta.json"
+    )
+
+    assert "app_artifacts_dir: \"scripts/rust_migration/fixtures/read_only/apps\"" in (
+        config_path.read_text()
+    )
+    metadata = json.loads(metadata_path.read_text())
+    assert metadata["artifact_hash"] == "deadbeef"
+    assert metadata["size_bytes"] == 9
+    assert metadata["uploaded_by"] == "fixture@example.com"
+
+
 def test_python_target_does_not_run_rust_only_retirement_checks():
     manifest = ContractManifest.load()
     selected = checks_for_target(manifest.checks, target="python", include_mutating=False)


### PR DESCRIPTION
## Summary
- add `paths.app_artifacts_dir` to the read-only Rust migration fixture config
- add synthetic `session-manager-android` artifact metadata under the fixture directory
- add unit coverage that the fixture config and metadata fields are present

## Validation
- `./venv/bin/python -m json.tool scripts/rust_migration/fixtures/read_only/apps/session-manager-android/meta.json >/dev/null`
- `git diff --check`
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py`
- Rust fixture sidecar on `http://127.0.0.1:8422`, then:
  - `./venv/bin/python -m scripts.rust_migration.contracts --target rust --base-url http://127.0.0.1:8422 --fixture app_name=session-manager-android --check-id http.app_artifact_metadata --json`
  - `./venv/bin/python -m scripts.rust_migration.contracts --target rust --base-url http://127.0.0.1:8422 --session-id fixture001 --fixture codex_app_session_id=fixture-codex --fixture app_name=session-manager-android --check-id http.session_detail_fixture --check-id http.client_session_detail_fixture --check-id http.session_output_fixture --check-id http.codex_events --check-id http.codex_activity_actions --check-id http.codex_pending_requests --check-id http.app_artifact_metadata --json`

Fixes #887
