### PR TITLE
Add disposable mutating Rust fixture workspace

### DIFF
--- a/scripts/rust_migration/contracts_manifest.json
+++ b/scripts/rust_migration/contracts_manifest.json
@@ -1343,15 +1343,15 @@
       "target": "rust_only",
       "safety": "mutating",
       "method": "POST",
-      "path": "/sessions/{child_session_id}/notify-on-stop",
+      "path": "/sessions/{notify_child_session_id}/notify-on-stop",
       "body": {"sender_session_id": "{em_session_id}", "requester_session_id": "{em_session_id}", "delay_seconds": 0},
       "expected_status": [200],
       "expected_json": [
         {"path": "/status", "equals": "ok"},
-        {"path": "/session_id", "equals": "{child_session_id}"},
+        {"path": "/session_id", "equals": "{notify_child_session_id}"},
         {"path": "/sender_session_id", "equals": "{em_session_id}"}
       ],
-      "preconditions": ["live_server", "fixture:em_session_id", "fixture:child_session_id", "mutating_opt_in"],
+      "preconditions": ["live_server", "fixture:em_session_id", "fixture:notify_child_session_id", "mutating_opt_in"],
       "source": "https://github.com/rajeshgoli/session-manager/issues/803"
     },
     {

--- a/scripts/rust_migration/mutating_fixture.py
+++ b/scripts/rust_migration/mutating_fixture.py
@@ -1,0 +1,214 @@
+"""Create a disposable fixture workspace for Rust mutating contract checks.
+
+The checked-in migration fixtures are intentionally read-only. Rust-core
+contract checks that create sessions, enqueue messages, or arm stop
+notifications need a writable copy plus a small EM/child seed. This helper
+builds that workspace without touching repository fixture files or live
+Session Manager state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+READ_ONLY_FIXTURE_DIR = REPO_ROOT / "scripts/rust_migration/fixtures/read_only"
+
+DEFAULT_SESSION_ID = "fixture-parent"
+DEFAULT_SESSION_NAME = "FixtureParent"
+DEFAULT_CHILD_SESSION_ID = "fixture-child"
+DEFAULT_CHILD_SESSION_NAME = "FixtureChild"
+DEFAULT_EM_SESSION_ID = "fixture-em"
+DEFAULT_NOTIFY_CHILD_SESSION_ID = "fixture-notify-child"
+DEFAULT_WORKING_DIR = "/tmp/sm-fixture-workspace"
+
+
+@dataclass(frozen=True)
+class MutatingFixtureWorkspace:
+    root: Path
+    fixture_dir: Path
+    config_path: Path
+    state_file: Path
+    log_dir: Path
+    fixtures: dict[str, str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "root": str(self.root),
+            "fixture_dir": str(self.fixture_dir),
+            "config_path": str(self.config_path),
+            "state_file": str(self.state_file),
+            "log_dir": str(self.log_dir),
+            "fixtures": self.fixtures,
+        }
+
+
+def create_mutating_fixture_workspace(output_dir: Path | None = None) -> MutatingFixtureWorkspace:
+    """Create a writable copy of the migration fixtures and return its config.
+
+    If ``output_dir`` is supplied it must be empty or absent. Refusing to reuse a
+    populated directory keeps the helper from overwriting ad hoc rehearsal state.
+    """
+
+    root = output_dir or Path(tempfile.mkdtemp(prefix="sm-rust-mutating-fixture-"))
+    root = root.expanduser().resolve()
+    if root.exists() and any(root.iterdir()):
+        raise FileExistsError(f"output directory is not empty: {root}")
+    root.mkdir(parents=True, exist_ok=True)
+
+    fixture_dir = root / "read_only"
+    shutil.copytree(READ_ONLY_FIXTURE_DIR, fixture_dir)
+
+    log_dir = root / "logs"
+    log_dir.mkdir()
+    state_file = fixture_dir / "sessions.json"
+    _seed_em_notify_sessions(state_file, log_dir)
+
+    config_path = root / "config.yaml"
+    _write_config(config_path, root, fixture_dir, state_file, log_dir)
+
+    fixtures = {
+        "session_id": DEFAULT_SESSION_ID,
+        "session_name": DEFAULT_SESSION_NAME,
+        "child_session_id": DEFAULT_CHILD_SESSION_ID,
+        "child_session_name": DEFAULT_CHILD_SESSION_NAME,
+        "working_dir": DEFAULT_WORKING_DIR,
+        "message_text": "hello from rust fixture",
+        "status_text": "writing Rust status",
+        "urgent_message_text": "urgent fixture note",
+        "wait_message_text": "wait fixture note",
+        "clear_prompt_text": "new task after clear",
+        "em_session_id": DEFAULT_EM_SESSION_ID,
+        "notify_child_session_id": DEFAULT_NOTIFY_CHILD_SESSION_ID,
+    }
+    return MutatingFixtureWorkspace(
+        root=root,
+        fixture_dir=fixture_dir,
+        config_path=config_path,
+        state_file=state_file,
+        log_dir=log_dir,
+        fixtures=fixtures,
+    )
+
+
+def _seed_em_notify_sessions(state_file: Path, log_dir: Path) -> None:
+    state = json.loads(state_file.read_text())
+    sessions = list(state.get("sessions", []))
+    seeded_ids = {DEFAULT_EM_SESSION_ID, DEFAULT_NOTIFY_CHILD_SESSION_ID}
+    sessions = [session for session in sessions if session.get("id") not in seeded_ids]
+    created_at = "2026-06-01T00:10:00"
+    sessions.extend(
+        [
+            {
+                "id": DEFAULT_EM_SESSION_ID,
+                "name": "fixture-em",
+                "working_dir": DEFAULT_WORKING_DIR,
+                "tmux_session": "",
+                "node": "primary",
+                "provider": "claude",
+                "log_file": str(log_dir / "fixture-em.log"),
+                "status": "running",
+                "created_at": created_at,
+                "last_activity": created_at,
+                "friendly_name": "Fixture EM",
+                "is_em": True,
+            },
+            {
+                "id": DEFAULT_NOTIFY_CHILD_SESSION_ID,
+                "name": "fixture-notify-child",
+                "working_dir": DEFAULT_WORKING_DIR,
+                "tmux_session": "",
+                "node": "primary",
+                "provider": "claude",
+                "log_file": str(log_dir / "fixture-notify-child.log"),
+                "status": "running",
+                "created_at": created_at,
+                "last_activity": created_at,
+                "friendly_name": "Fixture Notify Child",
+                "parent_session_id": DEFAULT_EM_SESSION_ID,
+                "is_em": False,
+            },
+        ]
+    )
+    state["sessions"] = sessions
+    state_file.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n")
+
+
+def _write_config(
+    config_path: Path, root: Path, fixture_dir: Path, state_file: Path, log_dir: Path
+) -> None:
+    config_path.write_text(
+        "\n".join(
+            [
+                "paths:",
+                f"  state_file: {_yaml_string(state_file)}",
+                f"  app_artifacts_dir: {_yaml_string(fixture_dir / 'apps')}",
+                f"  message_queue_db: {_yaml_string(root / 'message_queue.db')}",
+                f"  server_log_file: {_yaml_string(root / 'session-manager.log')}",
+                f"  bug_reports_db: {_yaml_string(root / 'bug_reports.db')}",
+                "",
+                "queue_runner:",
+                f"  state_dir: {_yaml_string(fixture_dir / 'queue-runner')}",
+                "",
+                "sm_send:",
+                f"  db_path: {_yaml_string(root / 'message_queue.db')}",
+                "",
+                "tool_logging:",
+                f"  db_path: {_yaml_string(root / 'tool_usage.db')}",
+                "",
+                "codex_events:",
+                f"  db_path: {_yaml_string(root / 'codex_events.db')}",
+                "",
+                "codex_requests:",
+                f"  db_path: {_yaml_string(root / 'codex_requests.db')}",
+                "",
+                "codex_observability:",
+                f"  db_path: {_yaml_string(root / 'codex_observability.db')}",
+                "",
+                "rust_core:",
+                "  fixture_writes_enabled: true",
+                f"  log_dir: {_yaml_string(log_dir)}",
+                "",
+            ]
+        )
+    )
+
+
+def _yaml_string(value: Path | str) -> str:
+    return json.dumps(str(value))
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Optional empty directory for the fixture workspace; defaults to mkdtemp",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable metadata")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    workspace = create_mutating_fixture_workspace(args.output_dir)
+    payload = workspace.to_dict()
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(f"config_path={payload['config_path']}")
+        for key, value in payload["fixtures"].items():
+            print(f"fixture:{key}={value}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -24,6 +24,13 @@ from scripts.rust_migration.contracts import (
     run_checks,
     summarize,
 )
+from scripts.rust_migration.mutating_fixture import (
+    DEFAULT_CHILD_SESSION_ID,
+    DEFAULT_EM_SESSION_ID,
+    DEFAULT_NOTIFY_CHILD_SESSION_ID,
+    DEFAULT_SESSION_ID,
+    create_mutating_fixture_workspace,
+)
 
 
 def test_manifest_preserves_mobile_kill_route_while_retiring_cli_alias():
@@ -203,6 +210,18 @@ def test_manifest_covers_rust_core_fixture_lifecycle_cli_checks():
         assert "fixture:base_url" in check.preconditions
 
 
+def test_manifest_uses_dedicated_notify_child_for_stop_notification_fixture():
+    manifest = ContractManifest.load()
+    checks = {check.id: check for check in manifest.checks}
+
+    notify = checks["http.rust_core_notify_on_stop_fixture"]
+    assert notify.path == "/sessions/{notify_child_session_id}/notify-on-stop"
+    assert "fixture:notify_child_session_id" in notify.preconditions
+    assert "fixture:child_session_id" not in notify.preconditions
+    expectations = {expectation.path: expectation for expectation in notify.expected_json}
+    assert expectations["/session_id"].equals == "{notify_child_session_id}"
+
+
 def test_manifest_has_json_shape_assertions_for_core_http_surfaces():
     manifest = ContractManifest.load()
     checks = {check.id: check for check in manifest.checks}
@@ -372,6 +391,57 @@ def test_read_only_fixture_provides_queue_job_detail_row():
         ).fetchone()
 
     assert row == ("job-fixture", "tests", "fixture queue job", "pending")
+
+
+def test_mutating_fixture_workspace_creates_disposable_config_and_seed(tmp_path):
+    workspace = create_mutating_fixture_workspace(tmp_path)
+
+    assert workspace.root == tmp_path.resolve()
+    assert workspace.config_path.exists()
+    assert workspace.state_file.exists()
+    assert workspace.log_dir.exists()
+    assert workspace.fixtures["session_id"] == DEFAULT_SESSION_ID
+    assert workspace.fixtures["child_session_id"] == DEFAULT_CHILD_SESSION_ID
+    assert workspace.fixtures["em_session_id"] == DEFAULT_EM_SESSION_ID
+    assert workspace.fixtures["notify_child_session_id"] == DEFAULT_NOTIFY_CHILD_SESSION_ID
+
+    config_text = workspace.config_path.read_text()
+    assert "fixture_writes_enabled: true" in config_text
+    assert str(workspace.state_file) in config_text
+    assert str(workspace.fixture_dir / "apps") in config_text
+    assert str(workspace.fixture_dir / "queue-runner") in config_text
+    assert str(workspace.root / "message_queue.db") in config_text
+    assert str(workspace.root / "tool_usage.db") in config_text
+    assert "~/.local/share/claude-sessions" not in config_text
+
+    state = json.loads(workspace.state_file.read_text())
+    sessions = {session["id"]: session for session in state["sessions"]}
+    assert sessions[DEFAULT_EM_SESSION_ID]["is_em"] is True
+    assert sessions[DEFAULT_EM_SESSION_ID]["status"] == "running"
+    assert (
+        sessions[DEFAULT_NOTIFY_CHILD_SESSION_ID]["parent_session_id"]
+        == DEFAULT_EM_SESSION_ID
+    )
+    assert sessions[DEFAULT_NOTIFY_CHILD_SESSION_ID]["is_em"] is False
+    assert sessions[DEFAULT_NOTIFY_CHILD_SESSION_ID]["status"] == "running"
+
+    read_only_state = json.loads(
+        Path("scripts/rust_migration/fixtures/read_only/sessions.json").read_text()
+    )
+    read_only_ids = {session["id"] for session in read_only_state["sessions"]}
+    assert DEFAULT_EM_SESSION_ID not in read_only_ids
+    assert DEFAULT_NOTIFY_CHILD_SESSION_ID not in read_only_ids
+
+
+def test_mutating_fixture_workspace_refuses_non_empty_output_dir(tmp_path):
+    (tmp_path / "leftover.txt").write_text("do not overwrite\n")
+
+    try:
+        create_mutating_fixture_workspace(tmp_path)
+    except FileExistsError as exc:
+        assert str(tmp_path) in str(exc)
+    else:
+        raise AssertionError("expected non-empty output directory to be rejected")
 
 
 def test_python_target_does_not_run_rust_only_retirement_checks():


### PR DESCRIPTION
## Summary
- add a helper that creates a disposable writable copy of the read-only Rust migration fixtures
- isolate writable config paths for state, queue, tool logging, Codex DBs, bug reports, app artifacts, and logs
- seed an EM/child pair for the notify-on-stop mutating contract and split that manifest row from the spawned child fixture

## Validation
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py
- ./venv/bin/python -m json.tool scripts/rust_migration/contracts_manifest.json >/dev/null
- git diff --check
- cargo fmt --check
- helper-generated sidecar mutating Rust-core manifest run: 27 passed, 0 failed, 0 skipped

Fixes #891