### PR TITLE
Update Rust MVP handoff after real-state rehearsal

### DIFF
--- a/specs/762_stage5_artifacts/index.md
+++ b/specs/762_stage5_artifacts/index.md
@@ -11,7 +11,7 @@ This bundle supports Stage 5 of [762_rust_migration_and_ruggedization.md](../762
 | [state_ownership_and_migration.md](state_ownership_and_migration.md) | Store-by-store ownership, backup, migration, rollback, and downgrade rules. |
 | [gate_matrix.md](gate_matrix.md) | Falsifiable value gate, compatibility/security/ops gates, and observability requirements. |
 | [implementation_workstreams.md](implementation_workstreams.md) | Epic split and sequencing for implementation tickets after this spec converges. |
-| [mvp_progress.md](mvp_progress.md) | Dated implementation snapshot for the Rust MVP track after merged PR #876. |
+| [mvp_progress.md](mvp_progress.md) | Dated implementation snapshot for the Rust MVP track after merged PR #894 and the latest real-state rehearsal. |
 | [resume_handoff.md](resume_handoff.md) | Current resume point, validation state, known fixtures, and next slices for the Rust port. |
 
 The owner has approved the cutover scope reductions in [cutover_scope.md](cutover_scope.md). Future breaking changes outside that artifact still require explicit owner approval.

--- a/specs/762_stage5_artifacts/mvp_progress.md
+++ b/specs/762_stage5_artifacts/mvp_progress.md
@@ -1,6 +1,6 @@
 # Rust MVP Progress Snapshot
 
-Status: implementation snapshot after PR #876 merged on 2026-06-11.
+Status: implementation snapshot after PR #894 merged and the 2026-06-12 real-state MVP rehearsal.
 
 This file is a handoff aid for the Rust cutover implementation track. It does
 not change retained or removed scope. Binding scope remains
@@ -27,6 +27,15 @@ not change retained or removed scope. Binding scope remains
 | #842-#856 | mobile attach tickets, terminal WebSocket auth/bridge, disable/revoke/device CLI, public-edge assertion gate |
 | #858-#862 | queue job detail and public-edge request-target follow-up |
 | #864-#876 | Codex review detail, tool-call projections, Codex events, pending requests, activity actions, and manifest coverage |
+| #878 | progress snapshot for resuming the Rust MVP track |
+| #880 | fixture-gated manifest checks for queue job and Codex review request detail endpoints |
+| #882 | validation-only manifest coverage for device-token and tmux-client hook error paths |
+| #884 | client-session fixture assertion correction for classic attach support |
+| #886 | synthetic Codex app read fixture for retained Codex read checks |
+| #888 | synthetic app artifact metadata fixture |
+| #890 | synthetic queue-runner job fixture for list/detail checks |
+| #892 | disposable mutating fixture workspace for Rust-core CLI and HTTP checks |
+| #894 | MVP rehearsal gate runs isolated read-only and mutating Rust-core contracts |
 
 ## Implemented Capability Groups
 
@@ -34,14 +43,54 @@ The Rust sidecar now has executable coverage for:
 
 | Group | Current state |
 | --- | --- |
-| Harness and baselines | Contract manifest, fixture assertions, minimal value baseline runner, shadow comparison, and MVP rehearsal exist. |
+| Harness and baselines | Contract manifest, fixture assertions, minimal value baseline runner, shadow comparison, MVP rehearsal, disposable mutating fixtures, and Rust CLI build gating exist. |
 | Retired-surface checks | Retired public/watch/summary/remind/job-watch/queue-policy checks are represented as Rust-target absence or denial fixtures. |
 | Core reads | Health, auth session, bootstrap, session list/detail, client session list/detail, output, events state, SSE hello, nodes list, queue jobs list/detail, Codex review requests list/detail, and tool/audit read projections are implemented. |
 | Core runtime | Session/tmux/spawn/session-graph/message-queue/task-complete/input-batch/subagent slices are merged, with shadow and contract fixtures covering the early cutover path. |
 | Codex retained reads | Codex event stream, pending request ledger reads, activity actions, review detail/list, and Claude/Codex tool-call projections are implemented and covered by manifest checks. |
 | Mobile | Native bootstrap/session support, attach-ticket proofing, terminal WebSocket auth/bridge, runtime disable, device revoke/list CLI support, and public-edge assertion validation are merged. |
 | External fallback | Email/human fallback delivery and inbound email validation path are retained in the Rust track. |
-| Queue and nodes | Narrow queue list/detail and registered-node read paths are implemented; retained node and queue writer behavior still needs final cutover verification. |
+| Queue and nodes | Narrow queue list/detail, queue fixture coverage, and registered-node read paths are implemented; retained node and queue writer behavior still needs final cutover verification. |
+
+## Latest Real-State Rehearsal
+
+Report:
+`.local/rust-mvp-rehearsals/20260612T012613Z-real-state/mvp-rehearsal-report.json`
+
+Summary:
+
+| Area | Result |
+| --- | --- |
+| Overall status | Blocked by 1 rehearsal blocker |
+| Python health | Passed |
+| Fresh Rust sidecar start and health | Passed |
+| Isolated runtime smoke | Passed |
+| Rust read-only sidecar contracts | 17 passed, 0 failed, 0 skipped |
+| Rust mutating fixture contracts | 30 passed, 0 failed, 0 skipped |
+| Gap probes | 0 failed |
+| Python baseline | Passed |
+| Rust baseline | Passed |
+| Shadow read summary | 7 passed, 1 failed |
+
+The only blocker is a body mismatch for `GET /events/state` in shadow
+comparison. The status matched (`200` vs `200`), but the Rust predicted body
+hash did not match Python. The passing shadow reads were `/health`,
+`/health/detailed`, `/auth/session`, `/client/bootstrap`, `/sessions`,
+`/client/sessions`, and `/nodes`.
+
+Measured baseline snapshot from the same run:
+
+| Metric | Python | Rust |
+| --- | ---: | ---: |
+| RSS | 151.438 MiB | 17.438 MiB |
+| Physical footprint | 64.3 MiB | 6.828 MiB |
+| `GET /health` median | 0.774 ms | 0.375 ms |
+| `GET /health/detailed` median | 150.077 ms | 0.380 ms |
+| `GET /auth/session` median | 1.048 ms | 0.342 ms |
+| `GET /client/bootstrap` median | 0.923 ms | 0.402 ms |
+| `GET /events/state` median | 1.083 ms | 0.443 ms |
+| `GET /sessions` median | 31.491 ms | 7.548 ms |
+| `GET /client/sessions` median | 62.133 ms | 7.980 ms |
 
 ## Near-Term Remaining Work
 
@@ -49,7 +98,8 @@ These are the next practical buckets before an MVP cutover trial:
 
 | Bucket | Why it remains |
 | --- | --- |
-| Real-state MVP rehearsal | Run `scripts.rust_migration.mvp_rehearsal` against current local state, record blockers, and keep shrinking the retained gap list. |
+| Fix `/events/state` shadow body mismatch | This is the only blocker from the latest real-state MVP rehearsal. Determine whether the mismatch is a Rust projection bug, a volatile field that should be status-only, or a Python/Rust ordering/default mismatch, then add a fixture to prevent recurrence. |
+| Re-run real-state MVP rehearsal | After the `/events/state` shadow fix, rerun `scripts.rust_migration.mvp_rehearsal --allow-blockers` and update this handoff with the new blocker list. |
 | Shadow observation window | Enable Python-authoritative shadow mode for retained reads and triage unexplained mismatches before Rust becomes the writer. |
 | CLI cutover audit | Verify every retained CLI command in [cutover_scope.md](cutover_scope.md) is native Rust or intentionally routed, and every removed command is absent or explicitly retired. |
 | State ownership and migration tooling | Implement final freeze/drain/backup/restore ledger behavior from [state_ownership_and_migration.md](state_ownership_and_migration.md). |

--- a/specs/762_stage5_artifacts/resume_handoff.md
+++ b/specs/762_stage5_artifacts/resume_handoff.md
@@ -1,6 +1,6 @@
 # Rust Port Resume Handoff
 
-Status: handoff snapshot from 2026-06-11 after PR #880.
+Status: handoff snapshot from 2026-06-12 after PR #894 and the latest real-state MVP rehearsal.
 
 Use this file to resume the Rust cutover track without reconstructing state from
 chat history. Binding scope still lives in [cutover_scope.md](cutover_scope.md),
@@ -11,7 +11,7 @@ coverage in
 ## Current Repository State
 
 - Branch: `main`
-- Latest merged commit: `9854e0c` (`Merge pull request #880`)
+- Latest merged commit: `470b725` (`Merge pull request #894`)
 - Open PRs at handoff: none
 - Dirty worktree at handoff: only pre-existing untracked `.claude/settings.local.json`
 - Stale session-manager review agents from the overnight run were retired.
@@ -54,11 +54,21 @@ Merged Rust slices cover:
 
 ### Documentation And Manifest
 
-- [mvp_progress.md](mvp_progress.md) records the PR lineage through #876.
+- [mvp_progress.md](mvp_progress.md) records the PR lineage through #894.
 - PR #880 added fixture-gated manifest checks for already-implemented detail
   endpoints:
   - `GET /queue-jobs/{queue_job_id}`
   - `GET /codex-review-requests/{codex_review_request_id}`
+- PR #882 added validation-only manifest coverage for device-token and
+  tmux-client hook error paths.
+- PR #884 corrected the retained client-session fixture expectation for
+  classic attach support.
+- PR #886 added a synthetic Codex app read fixture.
+- PR #888 added a synthetic app artifact metadata fixture.
+- PR #890 added a synthetic queue-runner job fixture.
+- PR #892 added the disposable mutating fixture workspace.
+- PR #894 made the MVP rehearsal run both read-only and mutating Rust-core
+  contracts in isolated sidecars.
 - Current contract manifest size:
   - `115` checks total
   - `68` `python_and_rust`
@@ -66,45 +76,31 @@ Merged Rust slices cover:
 
 ## Validation At Handoff
 
-All commands below passed at handoff:
+The latest real-state MVP rehearsal is:
 
 ```bash
-cargo test -p sm-server
-./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py
+.local/rust-mvp-rehearsals/20260612T012613Z-real-state/mvp-rehearsal-report.json
 ```
 
-Observed results:
+Observed results from that run:
 
-- Rust tests: `78` lib tests, `20` CLI tests, `142` read-only HTTP tests, and
-  doctests passed.
-- Rust migration contract tests: `34` passed.
-- Latest MVP rehearsal passed with zero blockers:
-  - `.local/rust-mvp-rehearsals/20260611T142302Z/mvp-rehearsal-report.json`
+- overall status: blocked by one rehearsal blocker;
+- Python health, fresh Rust sidecar start/health, and isolated runtime smoke
+  passed;
+- Rust read-only sidecar contracts: `17` passed, `0` failed, `0` skipped;
+- Rust mutating fixture contracts: `30` passed, `0` failed, `0` skipped;
+- gap probes: `0` failed;
+- Python and Rust baseline measurements completed;
+- shadow read summary: `7` passed, `1` failed.
 
-The two new detail checks passed against live Python and a temporary Rust
-sidecar using real local fixture IDs:
+The only blocker is `GET /events/state` shadow comparison. Python and Rust both
+returned status `200`, but the predicted Rust body hash did not match Python.
+The matching shadow reads were `/health`, `/health/detailed`, `/auth/session`,
+`/client/bootstrap`, `/sessions`, `/client/sessions`, and `/nodes`.
 
-```bash
-./venv/bin/python -m scripts.rust_migration.contracts \
-  --target python \
-  --base-url http://127.0.0.1:8420 \
-  --check-id http.queue_job_detail \
-  --check-id http.codex_review_request_detail \
-  --fixture queue_job_id=job_5a66488c1b6b \
-  --fixture codex_review_request_id=255618bcc483 \
-  --json
-
-cargo run -p sm-server --bin sm-server -- --port 8421 --config config.yaml
-
-./venv/bin/python -m scripts.rust_migration.contracts \
-  --target rust \
-  --base-url http://127.0.0.1:8421 \
-  --check-id http.queue_job_detail \
-  --check-id http.codex_review_request_detail \
-  --fixture queue_job_id=job_5a66488c1b6b \
-  --fixture codex_review_request_id=255618bcc483 \
-  --json
-```
+The same run measured the current Python process at `151.438 MiB` RSS and
+`64.3 MiB` physical footprint, while the Rust sidecar measured `17.438 MiB`
+RSS and `6.828 MiB` physical footprint.
 
 ## Useful Local Fixtures Found
 
@@ -116,37 +112,45 @@ contract coverage:
 | `queue_job_id` | `job_5a66488c1b6b` | `~/.local/share/claude-sessions/queue-runner/queue_runner.db` |
 | `codex_review_request_id` | `255618bcc483` | `~/.local/share/claude-sessions/message_queue.db` |
 
-Missing or not found at handoff:
+Historical missing or not-found local fixtures from the earlier #880 handoff:
 
 - no active `provider=codex-app` sessions in `GET /sessions`;
 - no app artifact `meta.json` found in the checked default local artifact paths.
+
+Those gaps are now covered by synthetic read-only fixtures from PR #886 and
+PR #888 for Rust-side fixture execution. Real live-state fixtures are still
+needed for final cutover evidence.
 
 ## What Remains
 
 ### Near-Term Work
 
-1. Build a complete fixture set for the retained manifest.
-   - Need real or synthetic fixtures for `codex_app_session_id`, app artifact
-     metadata, mobile/device flows, disposable mutating sessions, and any
-     retained CLI fixture inputs.
-2. Run the full contract manifest against Python and Rust with those fixtures.
+1. Fix the `/events/state` shadow body mismatch from the latest real-state
+   rehearsal.
+   - Determine whether this is a Rust projection bug, a volatile field that
+     should be status-only, or a Python/Rust ordering/default mismatch.
+   - Add a focused fixture or shadow test before rerunning rehearsal.
+2. Re-run `scripts.rust_migration.mvp_rehearsal --allow-blockers` against real
+   local state and update [mvp_progress.md](mvp_progress.md) with the result.
 3. Enable Python-authoritative shadow mode for a real observation window and
    triage unexplained mismatches.
-4. Audit retained CLI commands against [cutover_scope.md](cutover_scope.md).
+4. Run the full retained manifest against Python and Rust with the current
+   synthetic fixture set plus any live fixtures needed for mobile/device flows.
+5. Audit retained CLI commands against [cutover_scope.md](cutover_scope.md).
    - Retained commands should be native Rust or intentionally routed.
    - Removed commands should be absent or explicitly retired.
-5. Implement final state ownership and migration tooling.
+6. Implement final state ownership and migration tooling.
    - Freeze or journal write admission before final backup.
    - Prove rollback restores or accounts for every accepted write after the
      restore point.
-6. Complete public-edge deployment integration.
+7. Complete public-edge deployment integration.
    - Edge signer/proxy, device enrollment/list/remove, revoked-device denial,
      and node fallback proof.
-7. Finish retained node-control and narrow queue writer fixtures.
+8. Finish retained node-control and narrow queue writer fixtures.
    - Include audit, policy, recovery, and rollback semantics.
-8. Exercise service packaging and cutover.
+9. Exercise service packaging and cutover.
    - launchd wrapper, non-destructive port ownership, health checks, rollback.
-9. Run final native mobile smoke checks.
+10. Run final native mobile smoke checks.
    - bootstrap, session list/detail, attach, request-status, analytics, bug
      reports, app artifacts.
 
@@ -167,14 +171,15 @@ Do not start Rust writer ownership or MVP cutover until:
 
 ## Recommended Resume Point
 
-Start with fixture-backed manifest execution:
+Start with the real-state rehearsal blocker:
 
-1. Create or identify a disposable retained session fixture.
-2. Create or identify a real `codex_app_session_id`.
-3. Publish or synthesize an app artifact metadata fixture.
-4. Run the manifest against Python and Rust with the fixture set.
-5. Convert any failures into the next bounded Rust implementation slice.
+1. Inspect the Python and Rust `/events/state` payloads from the latest
+   real-state run or reproduce them against local Python and a Rust sidecar.
+2. Classify the body mismatch as an implementation bug, status-only shadow
+   candidate, or stable ordering/default mismatch.
+3. Patch the Rust projection or shadow predictor, add a focused test, and run
+   the MVP rehearsal again.
 
-This is the highest-signal next step because the MVP rehearsal currently has
-zero blockers only for the core sidecar subset. The full manifest with fixtures
-will expose the next real cutover gaps.
+This is the highest-signal next step because the latest rehearsal passed both
+the read-only sidecar contracts and the mutating Rust-core fixture contracts;
+only one retained read still blocks a clean real-state MVP rehearsal.


### PR DESCRIPTION
## Summary\n- update the Stage 5 MVP progress snapshot through PR #894\n- record the latest real-state rehearsal result and measured baseline snapshot\n- make the /events/state shadow body mismatch the next explicit resume blocker\n\n## Validation\n- git diff --check\n\nFixes #895