### PR TITLE
Treat events state shadow comparison as status-only

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -4185,7 +4185,13 @@ fn shadow_predict_read(
                 support_status: "implemented_read_status_only",
             }));
         }
-        "/events/state" => Some(serde_json::to_vec(&event_state_payload())?),
+        "/events/state" => {
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::OK.as_u16(),
+                body_sha256: None,
+                support_status: "implemented_read_status_only",
+            }));
+        }
         "/nodes" => {
             return Ok(Some(ShadowPrediction {
                 status: StatusCode::OK.as_u16(),

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -2003,6 +2003,48 @@ async fn shadow_http_reports_match_for_stable_read_only_route() {
 }
 
 #[tokio::test]
+async fn shadow_http_treats_events_state_as_status_only() {
+    let app = router(AppState::new(AppConfig::default()));
+    let python_body = serde_json::to_vec(&json!({
+        "tmux_client_event_version": 42,
+        "last_tmux_client_event": {
+            "type": "tmux_client_event",
+            "event": "client-attached",
+            "tmux_session": "codex-fork-live",
+            "version": 42
+        }
+    }))
+    .unwrap();
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/events/state",
+                "query_string": "",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 200,
+                "body_sha256": sha256_hex(&python_body)
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read_status_only");
+    assert_eq!(payload["comparison"], "status_match");
+    assert_eq!(payload["would_write"], false);
+    assert_eq!(payload["predicted_status"], 200);
+    assert_eq!(payload["predicted_body_sha256"], Value::Null);
+    assert_eq!(payload["body_sha256_match"], Value::Null);
+}
+
+#[tokio::test]
 async fn shadow_http_treats_nodes_as_status_only_until_node_agents_are_ported() {
     let app = router(AppState::new(AppConfig::default()));
     let python_body = br#"{"default":"primary","nodes":[{"id":"primary","primary":true,"ssh":null,"api_url":null,"hook_base_url":null,"projects_root":null,"log_dir":null,"codex_fork_node_agent":true}]}"#;


### PR DESCRIPTION
## Summary\n- make /events/state shadow prediction status-only because Python carries live tmux-client event state that a fresh Rust sidecar does not own\n- add a regression test for non-default Python tmux event state comparing as status_match instead of body_mismatch\n\n## Validation\n- cargo fmt --check\n- cargo test -p sm-server --test read_only_http shadow_http_treats_events_state_as_status_only -- --nocapture\n- cargo test -p sm-server\n- git diff --check\n- ./venv/bin/python -m scripts.rust_migration.mvp_rehearsal --output-dir .local/rust-mvp-rehearsals/20260612T013237Z-events-state-shadow\n\nRehearsal result: 0 blockers; read-only contracts 17/17 passed; mutating fixture contracts 30/30 passed; shadow read summary 8/8 passed.\n\nFixes #897