### PR TITLE
Add Rust shadow observation report

### DIFF
--- a/scripts/rust_migration/README.md
+++ b/scripts/rust_migration/README.md
@@ -180,6 +180,21 @@ For a cutover trial, run shadow mode for the agreed observation window and treat
 unexplained mismatches on retained core surfaces as blockers before Rust becomes
 the writer.
 
+Summarize the ledger during or after the observation window:
+
+```bash
+./venv/bin/python -m scripts.rust_migration.shadow_report \
+  --ledger ~/.local/share/claude-sessions/rust_shadow.jsonl \
+  --fail-on-blockers
+```
+
+Use `--json` to produce automation-friendly output with route summaries,
+comparison counts, support-status counts, and a blocker list. Blockers include
+status/body mismatches, shadow transport errors, non-JSON shadow responses, and
+invalid ledger rows. `not_compared` rows are summarized but are not blockers by
+default because retained writes may be intentionally observed without Rust side
+effects before cutover.
+
 ## MVP Sidecar Rehearsal
 
 The MVP rehearsal gate starts Rust as a sidecar, keeps Python authoritative, and

--- a/scripts/rust_migration/shadow_report.py
+++ b/scripts/rust_migration/shadow_report.py
@@ -1,0 +1,308 @@
+"""Summarize Rust shadow comparison ledgers for cutover observation."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_LEDGER_PATH = Path("~/.local/share/claude-sessions/rust_shadow.jsonl")
+BLOCKING_COMPARISONS = {
+    "body_mismatch",
+    "shadow_endpoint_non_json",
+    "status_mismatch",
+}
+
+
+def summarize_ledger(ledger_path: Path) -> dict[str, Any]:
+    ledger_path = ledger_path.expanduser()
+    route_stats: dict[str, dict[str, Any]] = defaultdict(_route_summary)
+    comparison_counts: Counter[str] = Counter()
+    support_status_counts: Counter[str] = Counter()
+    blockers: list[dict[str, Any]] = []
+    invalid_rows: list[dict[str, Any]] = []
+    row_count = 0
+
+    if ledger_path.exists():
+        with ledger_path.open("r", encoding="utf-8") as handle:
+            for line_number, line in enumerate(handle, start=1):
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                try:
+                    record = json.loads(stripped)
+                except json.JSONDecodeError as exc:
+                    blocker = {
+                        "kind": "invalid_json",
+                        "line": line_number,
+                        "detail": str(exc),
+                    }
+                    invalid_rows.append(blocker)
+                    blockers.append(blocker)
+                    continue
+                if not isinstance(record, dict):
+                    blocker = {
+                        "kind": "invalid_row_shape",
+                        "line": line_number,
+                        "detail": (
+                            f"expected JSON object, got {type(record).__name__}"
+                        ),
+                    }
+                    invalid_rows.append(blocker)
+                    blockers.append(blocker)
+                    continue
+                row_count += 1
+                _record_row(
+                    record=record,
+                    line_number=line_number,
+                    route_stats=route_stats,
+                    comparison_counts=comparison_counts,
+                    support_status_counts=support_status_counts,
+                    blockers=blockers,
+                )
+
+    route_summaries = []
+    for route, summary in sorted(route_stats.items()):
+        route_summaries.append(
+            {
+                "route": route,
+                "rows": summary["rows"],
+                "comparisons": dict(sorted(summary["comparisons"].items())),
+                "support_statuses": dict(sorted(summary["support_statuses"].items())),
+                "blockers": summary["blockers"],
+            }
+        )
+
+    status = "passed"
+    if blockers:
+        status = "blocked"
+    elif row_count == 0:
+        status = "no_data"
+
+    return {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "ledger_path": str(ledger_path),
+        "status": status,
+        "row_count": row_count,
+        "invalid_row_count": len(invalid_rows),
+        "comparison_counts": dict(sorted(comparison_counts.items())),
+        "support_status_counts": dict(sorted(support_status_counts.items())),
+        "route_summaries": route_summaries,
+        "blockers": blockers,
+    }
+
+
+def render_text_report(report: dict[str, Any]) -> str:
+    lines = [
+        "Rust shadow observation report",
+        f"ledger: {report['ledger_path']}",
+        f"status: {report['status']}",
+        f"rows: {report['row_count']}",
+        f"blockers: {len(report['blockers'])}",
+        "",
+        "Comparisons:",
+    ]
+    if report["comparison_counts"]:
+        for comparison, count in report["comparison_counts"].items():
+            lines.append(f"  {comparison}: {count}")
+    else:
+        lines.append("  none")
+
+    lines.extend(["", "Routes:"])
+    if report["route_summaries"]:
+        for route in report["route_summaries"]:
+            comparisons = ", ".join(
+                f"{key}={value}" for key, value in route["comparisons"].items()
+            )
+            support = ", ".join(
+                f"{key}={value}" for key, value in route["support_statuses"].items()
+            )
+            lines.append(
+                f"  {route['route']}: rows={route['rows']}; "
+                f"comparisons={comparisons or 'none'}; "
+                f"support={support or 'none'}; blockers={len(route['blockers'])}"
+            )
+    else:
+        lines.append("  none")
+
+    if report["blockers"]:
+        lines.extend(["", "Blockers:"])
+        for blocker in report["blockers"]:
+            route = blocker.get("route", "ledger")
+            line = blocker.get("line", "?")
+            detail = blocker.get("detail")
+            suffix = f" - {detail}" if detail else ""
+            lines.append(f"  line {line} {route}: {blocker['kind']}{suffix}")
+
+    return "\n".join(lines)
+
+
+def _route_summary() -> dict[str, Any]:
+    return {
+        "rows": 0,
+        "comparisons": Counter(),
+        "support_statuses": Counter(),
+        "blockers": [],
+    }
+
+
+def _record_row(
+    *,
+    record: dict[str, Any],
+    line_number: int,
+    route_stats: dict[str, dict[str, Any]],
+    comparison_counts: Counter[str],
+    support_status_counts: Counter[str],
+    blockers: list[dict[str, Any]],
+) -> None:
+    route = _route_key(record)
+    summary = route_stats[route]
+    summary["rows"] += 1
+
+    rust_result = record.get("rust_result")
+    comparison = _comparison_for(record)
+    comparison_counts[comparison] += 1
+    summary["comparisons"][comparison] += 1
+
+    support_status = None
+    if isinstance(rust_result, dict):
+        support_status = rust_result.get("support_status")
+    if support_status:
+        support_status = str(support_status)
+        support_status_counts[support_status] += 1
+        summary["support_statuses"][support_status] += 1
+
+    blocker = _blocker_for(
+        record=record,
+        line_number=line_number,
+        route=route,
+        comparison=comparison,
+        support_status=support_status,
+    )
+    if blocker:
+        blockers.append(blocker)
+        summary["blockers"].append(blocker)
+
+
+def _route_key(record: dict[str, Any]) -> str:
+    method = str(record.get("method") or "?").upper()
+    path = str(record.get("path") or "?")
+    return f"{method} {path}"
+
+
+def _comparison_for(record: dict[str, Any]) -> str:
+    if record.get("shadow_error"):
+        return "shadow_error"
+    rust_result = record.get("rust_result")
+    if not isinstance(rust_result, dict):
+        return "missing_rust_result"
+    comparison = rust_result.get("comparison")
+    return str(comparison or "missing_comparison")
+
+
+def _blocker_for(
+    *,
+    record: dict[str, Any],
+    line_number: int,
+    route: str,
+    comparison: str,
+    support_status: str | None,
+) -> dict[str, Any] | None:
+    if record.get("shadow_error"):
+        return {
+            "kind": "shadow_error",
+            "line": line_number,
+            "route": route,
+            "detail": record.get("shadow_error_message") or record.get("shadow_error"),
+        }
+    rust_http_status = _optional_int(record.get("rust_http_status"))
+    if rust_http_status == "invalid":
+        return {
+            "kind": "invalid_rust_http_status",
+            "line": line_number,
+            "route": route,
+            "detail": str(record.get("rust_http_status")),
+        }
+    if rust_http_status is not None and rust_http_status != 200:
+        return {
+            "kind": "shadow_http_status",
+            "line": line_number,
+            "route": route,
+            "detail": f"shadow endpoint returned HTTP {rust_http_status}",
+        }
+    if comparison in BLOCKING_COMPARISONS:
+        blocker = {
+            "kind": comparison,
+            "line": line_number,
+            "route": route,
+        }
+        if support_status:
+            blocker["support_status"] = support_status
+        predicted_status = _rust_result_value(record, "predicted_status")
+        if predicted_status is not None:
+            blocker["predicted_status"] = predicted_status
+        blocker["python_status"] = record.get("python_status")
+        return blocker
+    if comparison in {"missing_comparison", "missing_rust_result"}:
+        return {
+            "kind": comparison,
+            "line": line_number,
+            "route": route,
+        }
+    return None
+
+
+def _rust_result_value(record: dict[str, Any], key: str) -> Any:
+    rust_result = record.get("rust_result")
+    if isinstance(rust_result, dict):
+        return rust_result.get(key)
+    return None
+
+
+def _optional_int(value: Any) -> int | str | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return "invalid"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Summarize a Rust shadow JSONL ledger."
+    )
+    parser.add_argument(
+        "--ledger",
+        type=Path,
+        default=DEFAULT_LEDGER_PATH,
+        help=f"Shadow ledger path (default: {DEFAULT_LEDGER_PATH})",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON report")
+    parser.add_argument(
+        "--fail-on-blockers",
+        action="store_true",
+        help="Exit non-zero when mismatches, shadow errors, or invalid rows exist",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    report = summarize_ledger(args.ledger)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_text_report(report))
+    if args.fail_on_blockers and (report["blockers"] or report["status"] == "no_data"):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_rust_shadow_report.py
+++ b/tests/unit/test_rust_shadow_report.py
@@ -1,0 +1,222 @@
+import json
+
+from scripts.rust_migration.shadow_report import (
+    main,
+    render_text_report,
+    summarize_ledger,
+)
+
+
+def _write_jsonl(path, rows):
+    path.write_text(
+        "\n".join(json.dumps(row, sort_keys=True) for row in rows) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_shadow_report_summarizes_clean_status_and_body_matches(tmp_path):
+    ledger = tmp_path / "rust_shadow.jsonl"
+    _write_jsonl(
+        ledger,
+        [
+            {
+                "schema_version": 1,
+                "observed_at": "2026-06-12T01:00:00Z",
+                "method": "GET",
+                "path": "/health",
+                "query_string": "",
+                "python_status": 200,
+                "python_body_sha256": "python-health",
+                "rust_http_status": 200,
+                "rust_result": {
+                    "comparison": "match",
+                    "support_status": "implemented_read",
+                    "predicted_status": 200,
+                    "body_sha256_match": True,
+                },
+            },
+            {
+                "schema_version": 1,
+                "observed_at": "2026-06-12T01:00:01Z",
+                "method": "GET",
+                "path": "/sessions",
+                "query_string": "",
+                "python_status": 200,
+                "python_body_sha256": "python-sessions",
+                "rust_http_status": 200,
+                "rust_result": {
+                    "comparison": "status_match",
+                    "support_status": "implemented_read_status_only",
+                    "predicted_status": 200,
+                    "body_sha256_match": None,
+                },
+            },
+        ],
+    )
+
+    report = summarize_ledger(ledger)
+
+    assert report["status"] == "passed"
+    assert report["row_count"] == 2
+    assert report["comparison_counts"] == {"match": 1, "status_match": 1}
+    assert report["support_status_counts"] == {
+        "implemented_read": 1,
+        "implemented_read_status_only": 1,
+    }
+    assert report["blockers"] == []
+    assert [row["route"] for row in report["route_summaries"]] == [
+        "GET /health",
+        "GET /sessions",
+    ]
+
+
+def test_shadow_report_marks_mismatches_and_shadow_errors_as_blockers(tmp_path):
+    ledger = tmp_path / "rust_shadow.jsonl"
+    _write_jsonl(
+        ledger,
+        [
+            {
+                "schema_version": 1,
+                "observed_at": "2026-06-12T01:00:00Z",
+                "method": "GET",
+                "path": "/events/state",
+                "query_string": "",
+                "python_status": 200,
+                "python_body_sha256": "python-events",
+                "rust_http_status": 200,
+                "rust_result": {
+                    "comparison": "body_mismatch",
+                    "support_status": "implemented_read",
+                    "predicted_status": 200,
+                    "body_sha256_match": False,
+                },
+            },
+            {
+                "schema_version": 1,
+                "observed_at": "2026-06-12T01:00:01Z",
+                "method": "GET",
+                "path": "/nodes",
+                "query_string": "",
+                "python_status": 200,
+                "python_body_sha256": "python-nodes",
+                "shadow_error": "ConnectError",
+                "shadow_error_message": "connection refused",
+            },
+        ],
+    )
+
+    report = summarize_ledger(ledger)
+
+    assert report["status"] == "blocked"
+    assert report["comparison_counts"] == {"body_mismatch": 1, "shadow_error": 1}
+    assert [blocker["kind"] for blocker in report["blockers"]] == [
+        "body_mismatch",
+        "shadow_error",
+    ]
+    assert report["blockers"][0]["route"] == "GET /events/state"
+    assert report["blockers"][0]["support_status"] == "implemented_read"
+    assert report["blockers"][0]["python_status"] == 200
+    assert report["blockers"][0]["predicted_status"] == 200
+    assert report["blockers"][1]["detail"] == "connection refused"
+
+
+def test_shadow_report_tracks_invalid_json_as_blocker(tmp_path):
+    ledger = tmp_path / "rust_shadow.jsonl"
+    ledger.write_text(
+        '{"method":"GET","path":"/health","python_status":200,'
+        '"rust_http_status":200,"rust_result":{"comparison":"match"}}\n'
+        "{not-json}\n",
+        encoding="utf-8",
+    )
+
+    report = summarize_ledger(ledger)
+
+    assert report["status"] == "blocked"
+    assert report["row_count"] == 1
+    assert report["invalid_row_count"] == 1
+    assert report["blockers"][-1]["kind"] == "invalid_json"
+    assert report["blockers"][-1]["line"] == 2
+
+
+def test_shadow_report_tracks_non_object_json_rows_as_blockers(tmp_path):
+    ledger = tmp_path / "rust_shadow.jsonl"
+    ledger.write_text(
+        '{"method":"GET","path":"/health","python_status":200,'
+        '"rust_http_status":200,"rust_result":{"comparison":"match"}}\n'
+        "[]\n",
+        encoding="utf-8",
+    )
+
+    report = summarize_ledger(ledger)
+
+    assert report["status"] == "blocked"
+    assert report["row_count"] == 1
+    assert report["invalid_row_count"] == 1
+    assert report["blockers"][-1] == {
+        "kind": "invalid_row_shape",
+        "line": 2,
+        "detail": "expected JSON object, got list",
+    }
+
+
+def test_shadow_report_renders_text_and_fail_on_blockers_exit(tmp_path, capsys):
+    ledger = tmp_path / "rust_shadow.jsonl"
+    _write_jsonl(
+        ledger,
+        [
+            {
+                "method": "GET",
+                "path": "/health",
+                "python_status": 200,
+                "rust_http_status": 503,
+                "rust_result": {"comparison": "match"},
+            }
+        ],
+    )
+
+    report = summarize_ledger(ledger)
+    text = render_text_report(report)
+
+    assert "status: blocked" in text
+    assert "GET /health" in text
+    assert "shadow_http_status" in text
+    assert main(["--ledger", str(ledger), "--fail-on-blockers"]) == 1
+    rendered = capsys.readouterr().out
+    assert "Rust shadow observation report" in rendered
+
+
+def test_shadow_report_fail_on_blockers_exits_nonzero_for_no_data(tmp_path, capsys):
+    missing_ledger = tmp_path / "missing-rust-shadow.jsonl"
+
+    assert main(["--ledger", str(missing_ledger), "--fail-on-blockers"]) == 1
+    rendered = capsys.readouterr().out
+    assert "status: no_data" in rendered
+    assert "rows: 0" in rendered
+
+
+def test_shadow_report_marks_non_numeric_http_status_as_blocker(tmp_path):
+    ledger = tmp_path / "rust_shadow.jsonl"
+    _write_jsonl(
+        ledger,
+        [
+            {
+                "method": "GET",
+                "path": "/health",
+                "python_status": 200,
+                "rust_http_status": "not-a-status",
+                "rust_result": {"comparison": "match"},
+            }
+        ],
+    )
+
+    report = summarize_ledger(ledger)
+
+    assert report["status"] == "blocked"
+    assert report["blockers"] == [
+        {
+            "kind": "invalid_rust_http_status",
+            "line": 1,
+            "route": "GET /health",
+            "detail": "not-a-status",
+        }
+    ]


### PR DESCRIPTION
## Summary\n- add a JSONL shadow-ledger summarizer for the Rust observation window\n- report route-level comparison/support counts and blocker rows\n- document human and JSON usage in the Rust migration README\n\n## Validation\n- ./venv/bin/python -m pytest tests/unit/test_rust_shadow_report.py\n- ./venv/bin/python -m pytest tests/unit/test_rust_shadow_report.py tests/unit/test_rust_shadow_middleware.py\n- ./venv/bin/python -m scripts.rust_migration.shadow_report --ledger /tmp/session-manager-shadow-report-missing.jsonl --json\n- git diff --check origin/main...HEAD\n\nFixes #901