### PR TITLE
Add Rust shadow config activation helper

### DIFF
--- a/scripts/rust_migration/README.md
+++ b/scripts/rust_migration/README.md
@@ -169,6 +169,22 @@ is already healthy, and prints the exact sidecar command, local Python
 `--reuse-rust-sidecar` when intentionally observing against an already-running
 Rust sidecar.
 
+After reviewing the planner output, prepare the local Python config with the
+dry-run-first activation helper:
+
+```bash
+./venv/bin/python -m scripts.rust_migration.shadow_config \
+  --config config.yaml \
+  --endpoint http://127.0.0.1:8421/__shadow/http \
+  --ledger ~/.local/share/claude-sessions/rust_shadow.jsonl
+```
+
+By default this only prints a unified diff. Re-run with `--write` after
+reviewing the diff to replace or append only the top-level `rust_shadow`
+section. A timestamped `.shadow-backup-*` copy is created before any write.
+The helper does not restart Session Manager or start Rust; restart Python
+deliberately after accepting the local config change.
+
 The ledger is JSONL. Each row includes method/path, redacted query metadata,
 Python status and body hash, Rust comparison result, Rust support status,
 latency, and any shadow transport error. Raw request and response bodies are not

--- a/scripts/rust_migration/shadow_config.py
+++ b/scripts/rust_migration/shadow_config.py
@@ -1,0 +1,274 @@
+"""Prepare local Python config for Rust shadow observation."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import re
+import shutil
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+DEFAULT_CONFIG = Path("config.yaml")
+DEFAULT_RUST_ENDPOINT = "http://127.0.0.1:8421/__shadow/http"
+DEFAULT_LEDGER_PATH = "~/.local/share/claude-sessions/rust_shadow.jsonl"
+DEFAULT_TIMEOUT_SECONDS = 0.5
+DEFAULT_MAX_BODY_BYTES = 65536
+
+
+def prepare_shadow_config(
+    *,
+    config_path: Path = DEFAULT_CONFIG,
+    endpoint: str = DEFAULT_RUST_ENDPOINT,
+    ledger_path: str = DEFAULT_LEDGER_PATH,
+    secret: str = "",
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    max_body_bytes: int = DEFAULT_MAX_BODY_BYTES,
+    write: bool = False,
+) -> dict[str, Any]:
+    config_path = config_path.expanduser()
+    original = config_path.read_text(encoding="utf-8") if config_path.exists() else ""
+    rust_shadow_block = _render_rust_shadow_block(
+        endpoint=endpoint,
+        ledger_path=ledger_path,
+        secret=secret,
+        timeout_seconds=timeout_seconds,
+        max_body_bytes=max_body_bytes,
+    )
+    updated, action = _replace_top_level_block(
+        original,
+        section_name="rust_shadow",
+        replacement=rust_shadow_block,
+    )
+    _validate_yaml(updated)
+    changed = original != updated
+    diff = "".join(
+        difflib.unified_diff(
+            original.splitlines(keepends=True),
+            updated.splitlines(keepends=True),
+            fromfile=str(config_path),
+            tofile=f"{config_path} (rust_shadow)",
+        )
+    )
+
+    backup_path: Path | None = None
+    if write and changed:
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        if config_path.exists():
+            backup_path = config_path.with_suffix(
+                config_path.suffix
+                + f".shadow-backup-{datetime.now(timezone.utc).strftime('%Y%m%dT%H%M%SZ')}"
+            )
+            shutil.copy2(config_path, backup_path)
+        config_path.write_text(updated, encoding="utf-8")
+
+    return {
+        "schema_version": 1,
+        "config_path": str(config_path),
+        "status": "written" if write and changed else "unchanged" if not changed else "dry_run",
+        "action": action,
+        "changed": changed,
+        "write": write,
+        "backup_path": str(backup_path) if backup_path else None,
+        "diff": diff,
+        "rust_shadow": {
+            "enabled": True,
+            "endpoint": endpoint,
+            "ledger_path": ledger_path,
+            "secret_configured": bool(secret),
+            "timeout_seconds": timeout_seconds,
+            "max_body_bytes": max_body_bytes,
+        },
+    }
+
+
+def render_text_result(result: dict[str, Any]) -> str:
+    lines = [
+        "Rust shadow config activation",
+        f"config: {result['config_path']}",
+        f"status: {result['status']}",
+        f"action: {result['action']}",
+        f"changed: {result['changed']}",
+    ]
+    if result["backup_path"]:
+        lines.append(f"backup: {result['backup_path']}")
+    if result["diff"]:
+        lines.extend(["", "Diff:", result["diff"].rstrip()])
+    else:
+        lines.extend(["", "Diff: none"])
+    if not result["write"] and result["changed"]:
+        lines.extend(
+            [
+                "",
+                "Dry run only. Re-run with --write to update the config file.",
+            ]
+        )
+    if result["write"]:
+        lines.extend(
+            [
+                "",
+                "No service was restarted. Restart Python Session Manager deliberately after reviewing the diff.",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def _render_rust_shadow_block(
+    *,
+    endpoint: str,
+    ledger_path: str,
+    secret: str,
+    timeout_seconds: float,
+    max_body_bytes: int,
+) -> str:
+    lines = [
+        "rust_shadow:",
+        "  enabled: true",
+        f"  endpoint: {_quote_yaml(endpoint)}",
+    ]
+    if secret:
+        lines.append(f"  secret: {_quote_yaml(secret)}")
+    lines.extend(
+        [
+            f"  ledger_path: {_quote_yaml(ledger_path)}",
+            f"  timeout_seconds: {timeout_seconds:g}",
+            f"  max_body_bytes: {int(max_body_bytes)}",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def _quote_yaml(value: str) -> str:
+    return json.dumps(value)
+
+
+def _replace_top_level_block(
+    original: str, *, section_name: str, replacement: str
+) -> tuple[str, str]:
+    lines = original.splitlines(keepends=True)
+    starts = [
+        index
+        for index, line in enumerate(lines)
+        if _is_top_level_section_line(line, section_name=section_name)
+    ]
+    if len(starts) > 1:
+        raise ValueError(
+            f"config contains multiple top-level {section_name} sections; "
+            "remove duplicates before using the shadow config helper"
+        )
+    if not starts:
+        prefix = original
+        if prefix and not prefix.endswith("\n"):
+            prefix += "\n"
+        if prefix and not prefix.endswith("\n\n"):
+            prefix += "\n"
+        return prefix + replacement, "append"
+
+    start = starts[0]
+    end = _find_top_level_block_end(lines, start)
+    updated = "".join(lines[:start]) + replacement + "".join(lines[end:])
+    return updated, "replace"
+
+
+def _find_top_level_block_end(lines: list[str], start: int) -> int:
+    end = start + 1
+    while end < len(lines):
+        line = lines[end]
+        stripped = line.strip()
+        if line.startswith((" ", "\t")):
+            end += 1
+            continue
+        if not stripped or stripped.startswith("#"):
+            next_content = _next_content_line_index(lines, end + 1)
+            if next_content is not None and lines[next_content].startswith((" ", "\t")):
+                end += 1
+                continue
+            break
+        break
+    return end
+
+
+def _next_content_line_index(lines: list[str], start: int) -> int | None:
+    for index in range(start, len(lines)):
+        stripped = lines[index].strip()
+        if stripped and not stripped.startswith("#"):
+            return index
+    return None
+
+
+def _is_top_level_section_line(line: str, *, section_name: str) -> bool:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#") or line.startswith((" ", "\t")):
+        return False
+    key_pattern = rf"(?:{re.escape(section_name)}|['\"]{re.escape(section_name)}['\"])"
+    return re.match(rf"^{key_pattern}\s*:", stripped) is not None
+
+
+def _validate_yaml(content: str) -> None:
+    parsed = yaml.safe_load(content) if content.strip() else {}
+    if parsed is not None and not isinstance(parsed, dict):
+        raise ValueError("config YAML must be a mapping")
+    rust_shadow = (parsed or {}).get("rust_shadow")
+    if not isinstance(rust_shadow, dict):
+        raise ValueError("rendered rust_shadow section is not a mapping")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Safely prepare config.yaml for Rust shadow observation."
+    )
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--endpoint", default=DEFAULT_RUST_ENDPOINT)
+    parser.add_argument("--ledger", default=DEFAULT_LEDGER_PATH)
+    parser.add_argument("--secret", default="")
+    parser.add_argument("--timeout-seconds", type=float, default=DEFAULT_TIMEOUT_SECONDS)
+    parser.add_argument("--max-body-bytes", type=int, default=DEFAULT_MAX_BODY_BYTES)
+    parser.add_argument("--write", action="store_true")
+    parser.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        result = prepare_shadow_config(
+            config_path=args.config,
+            endpoint=args.endpoint,
+            ledger_path=args.ledger,
+            secret=args.secret,
+            timeout_seconds=args.timeout_seconds,
+            max_body_bytes=args.max_body_bytes,
+            write=args.write,
+        )
+    except ValueError as exc:
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "status": "error",
+                        "config_path": str(args.config.expanduser()),
+                        "error": str(exc),
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+        else:
+            print(f"error: {exc}", file=sys.stderr)
+        return 2
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(render_text_result(result))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_rust_shadow_config.py
+++ b/tests/unit/test_rust_shadow_config.py
@@ -1,0 +1,188 @@
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.rust_migration.shadow_config import (
+    main,
+    prepare_shadow_config,
+    render_text_result,
+)
+
+
+def test_shadow_config_dry_run_appends_block_without_writing(tmp_path):
+    config = tmp_path / "config.yaml"
+    original = "server:\n  host: 127.0.0.1\n"
+    config.write_text(original, encoding="utf-8")
+
+    result = prepare_shadow_config(config_path=config)
+
+    assert result["status"] == "dry_run"
+    assert result["action"] == "append"
+    assert result["changed"] is True
+    assert result["backup_path"] is None
+    assert config.read_text(encoding="utf-8") == original
+    assert "+rust_shadow:" in result["diff"]
+    assert "+  enabled: true" in result["diff"]
+    assert "Dry run only" in render_text_result(result)
+
+
+def test_shadow_config_write_creates_backup_and_preserves_unrelated_content(tmp_path):
+    config = tmp_path / "config.yaml"
+    original = "# keep this comment\nserver:\n  port: 8420\n"
+    config.write_text(original, encoding="utf-8")
+
+    result = prepare_shadow_config(
+        config_path=config,
+        endpoint="http://127.0.0.1:8421/__shadow/http",
+        ledger_path=str(tmp_path / "rust_shadow.jsonl"),
+        secret="shared-secret",
+        write=True,
+    )
+
+    assert result["status"] == "written"
+    assert result["backup_path"]
+    backup_path = Path(result["backup_path"])
+    assert backup_path.exists()
+    assert backup_path.read_text(encoding="utf-8") == original
+    updated = config.read_text(encoding="utf-8")
+    assert "# keep this comment" in updated
+    parsed = yaml.safe_load(updated)
+    assert parsed["server"]["port"] == 8420
+    assert parsed["rust_shadow"] == {
+        "enabled": True,
+        "endpoint": "http://127.0.0.1:8421/__shadow/http",
+        "ledger_path": str(tmp_path / "rust_shadow.jsonl"),
+        "secret": "shared-secret",
+        "timeout_seconds": 0.5,
+        "max_body_bytes": 65536,
+    }
+
+
+def test_shadow_config_replaces_existing_top_level_block(tmp_path):
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        "server:\n"
+        "  port: 8420\n"
+        "rust_shadow:\n"
+        "  enabled: false\n"
+        "  endpoint: \"http://old-shadow\"\n"
+        "  timeout_seconds: 9\n"
+        "# keep top-level comment\n"
+        "after:\n"
+        "  value: true\n",
+        encoding="utf-8",
+    )
+
+    result = prepare_shadow_config(
+        config_path=config,
+        endpoint="http://new-shadow/__shadow/http",
+        ledger_path="/tmp/new-shadow.jsonl",
+        write=True,
+    )
+
+    assert result["action"] == "replace"
+    parsed = yaml.safe_load(config.read_text(encoding="utf-8"))
+    assert parsed["server"]["port"] == 8420
+    assert parsed["after"]["value"] is True
+    assert "# keep top-level comment" in config.read_text(encoding="utf-8")
+    assert parsed["rust_shadow"]["enabled"] is True
+    assert parsed["rust_shadow"]["endpoint"] == "http://new-shadow/__shadow/http"
+    assert parsed["rust_shadow"]["ledger_path"] == "/tmp/new-shadow.jsonl"
+    assert "secret" not in parsed["rust_shadow"]
+
+
+def test_shadow_config_replaces_inline_or_commented_top_level_rust_shadow(tmp_path):
+    cases = {
+        "commented": "server: {}\nrust_shadow: # existing shadow config\n  enabled: false\nafter: {}\n",
+        "inline": "server: {}\nrust_shadow: {enabled: false}\nafter: {}\n",
+        "quoted": 'server: {}\n"rust_shadow": {enabled: false}\nafter: {}\n',
+    }
+
+    for name, original in cases.items():
+        config = tmp_path / f"{name}.yaml"
+        config.write_text(original, encoding="utf-8")
+
+        result = prepare_shadow_config(config_path=config, write=True)
+
+        updated = config.read_text(encoding="utf-8")
+        parsed = yaml.safe_load(updated)
+        assert result["action"] == "replace"
+        assert parsed["server"] == {}
+        assert parsed["after"] == {}
+        assert parsed["rust_shadow"]["enabled"] is True
+        assert parsed["rust_shadow"]["endpoint"] == "http://127.0.0.1:8421/__shadow/http"
+        assert updated.count("rust_shadow:") == 1
+
+
+def test_shadow_config_replaces_comments_that_resume_rust_shadow_mapping(tmp_path):
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        "server: {}\n"
+        "rust_shadow:\n"
+        "  enabled: false\n"
+        "# comment between rust_shadow child keys\n"
+        "  endpoint: \"http://old-shadow\"\n"
+        "  ledger_path: \"/tmp/old-shadow.jsonl\"\n"
+        "# keep top-level comment\n"
+        "after: {}\n",
+        encoding="utf-8",
+    )
+
+    result = prepare_shadow_config(config_path=config, write=True)
+
+    updated = config.read_text(encoding="utf-8")
+    parsed = yaml.safe_load(updated)
+    assert result["action"] == "replace"
+    assert parsed["server"] == {}
+    assert parsed["after"] == {}
+    assert parsed["rust_shadow"]["endpoint"] == "http://127.0.0.1:8421/__shadow/http"
+    assert parsed["rust_shadow"]["ledger_path"] == "~/.local/share/claude-sessions/rust_shadow.jsonl"
+    assert "old-shadow" not in updated
+    assert "# comment between rust_shadow child keys" not in updated
+    assert "# keep top-level comment" in updated
+
+
+def test_shadow_config_rejects_duplicate_top_level_rust_shadow_sections(tmp_path):
+    config = tmp_path / "config.yaml"
+    original = (
+        "server: {}\n"
+        "rust_shadow:\n"
+        "  endpoint: \"http://first-shadow\"\n"
+        "after: {}\n"
+        "rust_shadow: {endpoint: \"http://later-shadow\"}\n"
+    )
+    config.write_text(original, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="multiple top-level rust_shadow sections"):
+        prepare_shadow_config(config_path=config, write=True)
+
+    assert config.read_text(encoding="utf-8") == original
+    assert not list(tmp_path.glob("config.yaml.shadow-backup-*"))
+
+
+def test_shadow_config_cli_json_reports_duplicate_section_error(tmp_path, capsys):
+    config = tmp_path / "config.yaml"
+    original = "rust_shadow: {}\nserver: {}\nrust_shadow: {}\n"
+    config.write_text(original, encoding="utf-8")
+
+    assert main(["--config", str(config), "--write", "--json"]) == 2
+    output = json.loads(capsys.readouterr().out)
+
+    assert output["status"] == "error"
+    assert "multiple top-level rust_shadow sections" in output["error"]
+    assert config.read_text(encoding="utf-8") == original
+
+
+def test_shadow_config_cli_json_dry_run(tmp_path, capsys):
+    config = tmp_path / "config.yaml"
+    config.write_text("server: {}\n", encoding="utf-8")
+
+    assert main(["--config", str(config), "--json"]) == 0
+    output = json.loads(capsys.readouterr().out)
+
+    assert output["status"] == "dry_run"
+    assert output["write"] is False
+    assert output["config_path"] == str(config)
+    assert config.read_text(encoding="utf-8") == "server: {}\n"


### PR DESCRIPTION
## Summary
- add a dry-run-first helper to prepare local `rust_shadow` config
- replace or append only the top-level `rust_shadow` block and validate the resulting YAML
- require `--write` for file changes and create a timestamped backup before writing
- document the helper in the shadow observation workflow

## Validation
- `./venv/bin/python -m pytest tests/unit/test_rust_shadow_config.py`
- `./venv/bin/python -m pytest tests/unit/test_rust_shadow_config.py tests/unit/test_rust_shadow_observation.py tests/unit/test_rust_shadow_report.py tests/unit/test_rust_shadow_middleware.py`
- `./venv/bin/python -m scripts.rust_migration.shadow_config --config <temp>/config.yaml --json`
- `git diff --check`

Fixes #905