### PR TITLE
Default Rust contract CLI checks to Rust binary

### DIFF
--- a/scripts/rust_migration/README.md
+++ b/scripts/rust_migration/README.md
@@ -67,6 +67,10 @@ python -m scripts.rust_migration.contracts \
   --check-id http.queue_policy_runs_retired
 ```
 
+For `--target rust`, CLI checks default to `target/debug/sm` so retired or
+Rust-only CLI contracts do not accidentally exercise the Python `sm` on PATH.
+Pass `--sm-binary <path>` when testing another Rust CLI build.
+
 Fixture-backed checks assert concrete session projection and output behavior:
 
 ```bash

--- a/scripts/rust_migration/contracts.py
+++ b/scripts/rust_migration/contracts.py
@@ -23,6 +23,8 @@ from typing import Any, Iterable
 
 MANIFEST_PATH = Path(__file__).with_name("contracts_manifest.json")
 DEFAULT_TIMEOUT_SECONDS = 5.0
+DEFAULT_PYTHON_SM_BINARY = "sm"
+DEFAULT_RUST_SM_BINARY = "target/debug/sm"
 
 
 @dataclass(frozen=True)
@@ -567,7 +569,14 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--manifest", type=Path, default=MANIFEST_PATH)
     parser.add_argument("--target", choices=("python", "rust"), default="python")
     parser.add_argument("--base-url", default=None)
-    parser.add_argument("--sm-binary", default="sm")
+    parser.add_argument(
+        "--sm-binary",
+        default=None,
+        help=(
+            "CLI binary for CLI checks. Defaults to 'sm' for --target python "
+            "and 'target/debug/sm' for --target rust."
+        ),
+    )
     parser.add_argument("--session-id", default=None)
     parser.add_argument(
         "--check-id",
@@ -593,12 +602,13 @@ def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
     manifest = ContractManifest.load(args.manifest)
     fixtures = _parse_fixtures(args.fixture)
+    sm_binary = _resolve_sm_binary(args.target, args.sm_binary)
     try:
         results = run_checks(
             manifest,
             target=args.target,
             base_url=args.base_url,
-            sm_binary=args.sm_binary,
+            sm_binary=sm_binary,
             session_id=args.session_id,
             fixtures=fixtures,
             check_ids=set(args.check_id) if args.check_id else None,
@@ -627,6 +637,14 @@ def main(argv: list[str] | None = None) -> int:
             print(f"{result.status.upper():7} {result.id}{elapsed}: {result.detail}")
         print(f"Summary: {summary}")
     return 1 if summary.get("failed", 0) else 0
+
+
+def _resolve_sm_binary(target: str, sm_binary: str | None) -> str:
+    if sm_binary:
+        return sm_binary
+    if target == "rust":
+        return DEFAULT_RUST_SM_BINARY
+    return DEFAULT_PYTHON_SM_BINARY
 
 
 def _parse_fixtures(raw_items: list[str]) -> dict[str, str]:

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -15,8 +15,10 @@ from scripts.rust_migration.contracts import (
     ContractCheck,
     ContractManifest,
     JsonExpectation,
+    _build_parser as _build_contracts_parser,
     _json_expectation_error,
     _parse_fixtures,
+    _resolve_sm_binary,
     _run_cli_check,
     _run_http_check,
     _render_template,
@@ -256,6 +258,15 @@ def test_mvp_rehearsal_defaults_to_rust_cli_binary():
     args = _build_parser().parse_args([])
 
     assert args.sm_binary == DEFAULT_RUST_SM_BINARY
+
+
+def test_contract_harness_resolves_target_specific_cli_defaults():
+    args = _build_contracts_parser().parse_args([])
+
+    assert args.sm_binary is None
+    assert _resolve_sm_binary("python", args.sm_binary) == "sm"
+    assert _resolve_sm_binary("rust", args.sm_binary) == "target/debug/sm"
+    assert _resolve_sm_binary("rust", "/tmp/custom-sm") == "/tmp/custom-sm"
 
 
 def test_mvp_rehearsal_does_not_build_custom_cli_binary():


### PR DESCRIPTION
## Summary
- resolve the standalone contract harness `--sm-binary` default from `--target`
- keep Python target using `sm`, while Rust target uses `target/debug/sm` unless explicitly overridden
- document the Rust CLI default for Rust-target contract checks

## Validation
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py`
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py tests/unit/test_rust_shadow_report.py`
- `./venv/bin/python -m scripts.rust_migration.contracts --target rust --base-url http://127.0.0.1:8421 --check-id cli.what_retired --check-id cli.kill_alias_retired --check-id cli.dispatch_retired --check-id cli.telegram_retired --json`
- `git diff --check`

Fixes #909