### PR TITLE
Add contract harness fixture-check filter

### DIFF
--- a/scripts/rust_migration/README.md
+++ b/scripts/rust_migration/README.md
@@ -35,6 +35,17 @@ python -m scripts.rust_migration.contracts \
   --fixture codex_app_session_id=<codex-app-session-id>
 ```
 
+For broad live-state checks with a real session id, skip synthetic fixture
+contracts so fixture-specific names/output do not create false failures:
+
+```bash
+python -m scripts.rust_migration.contracts \
+  --target rust \
+  --base-url http://127.0.0.1:8421 \
+  --session-id <real-session-id> \
+  --skip-fixture-checks
+```
+
 Mutating checks never run unless `--include-mutating` is present. Use only
 disposable fixture sessions for checks such as retained mobile/API session stop.
 

--- a/scripts/rust_migration/contracts.py
+++ b/scripts/rust_migration/contracts.py
@@ -159,13 +159,19 @@ class CheckResult:
 
 
 def checks_for_target(
-    checks: Iterable[ContractCheck], target: str, include_mutating: bool
+    checks: Iterable[ContractCheck],
+    target: str,
+    include_mutating: bool,
+    *,
+    skip_fixture_checks: bool = False,
 ) -> list[ContractCheck]:
     selected: list[ContractCheck] = []
     for check in checks:
         if check.target == "rust_only" and target != "rust":
             continue
         if check.target == "python_only" and target != "python":
+            continue
+        if skip_fixture_checks and _is_fixture_check(check):
             continue
         if check.safety == "mutating" and not include_mutating:
             selected.append(check)
@@ -183,6 +189,7 @@ def run_checks(
     session_id: str | None,
     fixtures: dict[str, str] | None = None,
     include_mutating: bool,
+    skip_fixture_checks: bool = False,
     check_ids: set[str] | None = None,
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
 ) -> list[CheckResult]:
@@ -190,7 +197,12 @@ def run_checks(
     fixture_values = dict(fixtures or {})
     if session_id:
         fixture_values.setdefault("session_id", session_id)
-    selected_checks = checks_for_target(manifest.checks, target, include_mutating)
+    selected_checks = checks_for_target(
+        manifest.checks,
+        target,
+        include_mutating,
+        skip_fixture_checks=skip_fixture_checks,
+    )
     if check_ids is not None:
         known_ids = {check.id for check in selected_checks}
         unknown_ids = sorted(check_ids - known_ids)
@@ -235,6 +247,12 @@ def summarize(results: Iterable[CheckResult]) -> dict[str, int]:
     for result in results:
         summary[result.status] = summary.get(result.status, 0) + 1
     return summary
+
+
+def _is_fixture_check(check: ContractCheck) -> bool:
+    if check.id.endswith("_fixture") or "_fixture_" in check.id:
+        return True
+    return any(precondition.startswith("fixture:") for precondition in check.preconditions)
 
 
 def _skip_reason(
@@ -593,6 +611,14 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Fixture value for manifest substitutions; repeatable",
     )
     parser.add_argument("--include-mutating", action="store_true")
+    parser.add_argument(
+        "--skip-fixture-checks",
+        action="store_true",
+        help=(
+            "Exclude synthetic fixture-bound checks for broad live-state runs. "
+            "Fixture checks still run by default."
+        ),
+    )
     parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT_SECONDS)
     parser.add_argument("--json", action="store_true", help="Emit JSON report")
     return parser
@@ -613,6 +639,7 @@ def main(argv: list[str] | None = None) -> int:
             fixtures=fixtures,
             check_ids=set(args.check_id) if args.check_id else None,
             include_mutating=args.include_mutating,
+            skip_fixture_checks=args.skip_fixture_checks,
             timeout_seconds=args.timeout,
         )
     except ValueError as exc:

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -564,6 +564,75 @@ def test_mutating_checks_are_reported_as_skipped_without_opt_in():
     assert result_by_id["http.mobile_session_stop"].detail
 
 
+def test_skip_fixture_checks_excludes_synthetic_fixture_checks_only():
+    manifest = ContractManifest.load()
+    selected = checks_for_target(
+        manifest.checks,
+        target="rust",
+        include_mutating=False,
+        skip_fixture_checks=True,
+    )
+    ids = {check.id for check in selected}
+
+    assert "http.session_detail_fixture" not in ids
+    assert "http.session_output_fixture" not in ids
+    assert "http.queue_job_detail" not in ids
+    assert "http.health" in ids
+    assert "http.sessions" in ids
+    assert "http.session_tool_calls" in ids
+    assert "cli.what_retired" in ids
+
+
+def test_run_checks_skip_fixture_checks_allows_live_session_id_without_fixture_assertions():
+    manifest = ContractManifest(
+        schema_version=1,
+        source_spec="test",
+        artifacts=(),
+        checks=(
+            ContractCheck(
+                id="http.live",
+                surface="http",
+                classification="retained",
+                target="python_and_rust",
+                safety="read_only",
+                method="GET",
+                path="/health",
+                expected_status=(200,),
+                preconditions=("live_server",),
+                source="test",
+            ),
+            ContractCheck(
+                id="http.session_detail_fixture",
+                surface="http",
+                classification="retained",
+                target="python_and_rust",
+                safety="read_only",
+                method="GET",
+                path="/sessions/{session_id}",
+                expected_status=(200,),
+                preconditions=("live_server", "session_id"),
+                source="test",
+            ),
+        ),
+    )
+
+    with patch("scripts.rust_migration.contracts.urllib.request.urlopen") as urlopen:
+        response = urlopen.return_value.__enter__.return_value
+        response.status = 200
+        response.read.return_value = b"{}"
+        results = run_checks(
+            manifest,
+            target="rust",
+            base_url="http://127.0.0.1:8421",
+            sm_binary="target/debug/sm",
+            session_id="live-session",
+            include_mutating=False,
+            skip_fixture_checks=True,
+        )
+
+    assert [result.id for result in results] == ["http.live"]
+
+
 def test_existing_session_precondition_fails_for_stale_session_fixture():
     manifest = ContractManifest.load()
     not_found = urllib.error.HTTPError(


### PR DESCRIPTION
## Summary
- add `--skip-fixture-checks` for broad live-state Rust contract runs
- filter synthetic fixture-bound checks by fixture naming or `fixture:*` preconditions while preserving default behavior
- document the live-state invocation and add unit coverage for selection and runtime behavior

## Validation
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py`
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py tests/unit/test_rust_shadow_report.py`
- `git diff --check`
- `./venv/bin/python -m scripts.rust_migration.contracts --target rust --base-url http://127.0.0.1:8421 --session-id 007c6275 --skip-fixture-checks --json` -> 71 passed, 3 skipped, 0 failed

Fixes #911