### PR TITLE
Wire shadow observation coverage gates

### DIFF
--- a/scripts/rust_migration/README.md
+++ b/scripts/rust_migration/README.md
@@ -173,6 +173,12 @@ Generate the non-destructive local plan before touching the running service:
 ./venv/bin/python -m scripts.rust_migration.shadow_observation \
   --config config.yaml \
   --ledger ~/.local/share/claude-sessions/rust_shadow.jsonl \
+  --report-last-minutes 60 \
+  --report-min-rows 1000 \
+  --report-require-route 'GET /sessions' \
+  --report-require-route 'GET /events/state' \
+  --report-min-route-rows 'GET /sessions=100' \
+  --report-min-route-rows 'GET /events/state=100' \
   --fail-on-blockers
 ```
 
@@ -182,7 +188,9 @@ is already healthy, and prints the exact sidecar command, local Python
 `rust_shadow` config snippet, and ledger report command. It never edits
 `config.yaml`, restarts Session Manager, or starts a process. Use
 `--reuse-rust-sidecar` when intentionally observing against an already-running
-Rust sidecar.
+Rust sidecar. `--report-*` options are copied into the generated
+`shadow_report` command so the operator-reviewed plan and the final observation
+gate use the same window and coverage thresholds.
 
 After reviewing the planner output, prepare the local Python config with the
 dry-run-first activation helper:

--- a/scripts/rust_migration/shadow_observation.py
+++ b/scripts/rust_migration/shadow_observation.py
@@ -40,6 +40,10 @@ def build_observation_plan(
     shadow_secret: str = "",
     timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
     reuse_rust_sidecar: bool = False,
+    report_last_minutes: float | None = None,
+    report_min_rows: int | None = None,
+    report_required_routes: list[str] | None = None,
+    report_min_route_rows: list[str] | None = None,
     probe_health: Callable[[str, float], HealthProbe] = None,
     cargo_resolver: Callable[[str], str | None] = shutil.which,
 ) -> dict[str, Any]:
@@ -115,6 +119,14 @@ def build_observation_plan(
         str(ledger),
         "--fail-on-blockers",
     ]
+    if report_last_minutes is not None:
+        report_command.extend(["--last-minutes", str(report_last_minutes)])
+    if report_min_rows is not None:
+        report_command.extend(["--min-rows", str(report_min_rows)])
+    for route in report_required_routes or ():
+        report_command.extend(["--require-route", route])
+    for route_minimum in report_min_route_rows or ():
+        report_command.extend(["--min-route-rows", route_minimum])
 
     return {
         "schema_version": 1,
@@ -128,6 +140,10 @@ def build_observation_plan(
             "cargo": cargo,
             "shadow_secret_configured": bool(shadow_secret),
             "reuse_rust_sidecar": reuse_rust_sidecar,
+            "report_last_minutes": report_last_minutes,
+            "report_min_rows": report_min_rows,
+            "report_required_routes": list(report_required_routes or ()),
+            "report_min_route_rows": list(report_min_route_rows or ()),
         },
         "checks": {
             "python_health": python_health.__dict__,
@@ -327,6 +343,34 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--shadow-secret", default="")
     parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT_SECONDS)
     parser.add_argument("--reuse-rust-sidecar", action="store_true")
+    parser.add_argument(
+        "--report-last-minutes",
+        type=float,
+        help="Include --last-minutes in the generated shadow_report command.",
+    )
+    parser.add_argument(
+        "--report-min-rows",
+        type=int,
+        help="Include --min-rows in the generated shadow_report command.",
+    )
+    parser.add_argument(
+        "--report-require-route",
+        action="append",
+        default=[],
+        help=(
+            "Include a --require-route value in the generated shadow_report "
+            "command. Format as 'METHOD /path'. Repeatable."
+        ),
+    )
+    parser.add_argument(
+        "--report-min-route-rows",
+        action="append",
+        default=[],
+        help=(
+            "Include a --min-route-rows value in the generated shadow_report "
+            "command. Format as 'METHOD /path=N'. Repeatable."
+        ),
+    )
     parser.add_argument("--json", action="store_true")
     parser.add_argument("--fail-on-blockers", action="store_true")
     return parser
@@ -344,6 +388,10 @@ def main(argv: list[str] | None = None) -> int:
         shadow_secret=args.shadow_secret,
         timeout_seconds=args.timeout,
         reuse_rust_sidecar=args.reuse_rust_sidecar,
+        report_last_minutes=args.report_last_minutes,
+        report_min_rows=args.report_min_rows,
+        report_required_routes=args.report_require_route,
+        report_min_route_rows=args.report_min_route_rows,
     )
     if args.json:
         print(json.dumps(plan, indent=2, sort_keys=True))

--- a/tests/unit/test_rust_shadow_observation.py
+++ b/tests/unit/test_rust_shadow_observation.py
@@ -96,6 +96,57 @@ def test_shadow_observation_plan_generates_non_destructive_commands(tmp_path):
     assert "Summarize ledger:" in rendered
 
 
+def test_shadow_observation_plan_includes_report_coverage_gates(tmp_path):
+    config = tmp_path / "config.yaml"
+    config.write_text("server: {}\n", encoding="utf-8")
+    ledger = tmp_path / "rust_shadow.jsonl"
+
+    plan = build_observation_plan(
+        config=config,
+        ledger=ledger,
+        probe_health=_python_healthy_rust_unreachable_probe,
+        cargo_resolver=lambda _cargo: "/usr/bin/cargo",
+        report_last_minutes=60,
+        report_min_rows=1000,
+        report_required_routes=["GET /sessions", "GET /events/state"],
+        report_min_route_rows=["GET /sessions=100", "GET /events/state=100"],
+    )
+
+    assert plan["inputs"]["report_last_minutes"] == 60
+    assert plan["inputs"]["report_min_rows"] == 1000
+    assert plan["inputs"]["report_required_routes"] == [
+        "GET /sessions",
+        "GET /events/state",
+    ]
+    assert plan["inputs"]["report_min_route_rows"] == [
+        "GET /sessions=100",
+        "GET /events/state=100",
+    ]
+    assert plan["commands"]["summarize_shadow_ledger"] == [
+        "./venv/bin/python",
+        "-m",
+        "scripts.rust_migration.shadow_report",
+        "--ledger",
+        str(ledger),
+        "--fail-on-blockers",
+        "--last-minutes",
+        "60",
+        "--min-rows",
+        "1000",
+        "--require-route",
+        "GET /sessions",
+        "--require-route",
+        "GET /events/state",
+        "--min-route-rows",
+        "GET /sessions=100",
+        "--min-route-rows",
+        "GET /events/state=100",
+    ]
+    rendered = render_text_plan(plan)
+    assert "--min-rows 1000" in rendered
+    assert "'GET /sessions'" in rendered
+
+
 def test_shadow_observation_plan_blocks_when_rust_port_already_healthy(tmp_path):
     config = tmp_path / "config.yaml"
     config.write_text("server: {}\n", encoding="utf-8")
@@ -182,6 +233,40 @@ def test_shadow_observation_cli_json_and_fail_on_blockers(tmp_path, capsys):
     assert '"status": "blocked"' in output
     assert "missing_config" in output
     assert "missing_cargo" in output
+
+
+def test_shadow_observation_cli_json_includes_report_coverage_gates(tmp_path, capsys):
+    config = tmp_path / "config.yaml"
+    config.write_text("server: {}\n", encoding="utf-8")
+
+    exit_code = main(
+        [
+            "--config",
+            str(config),
+            "--python-base-url",
+            "http://127.0.0.1:1",
+            "--rust-base-url",
+            "http://127.0.0.1:2",
+            "--reuse-rust-sidecar",
+            "--report-last-minutes",
+            "60",
+            "--report-min-rows",
+            "1000",
+            "--report-require-route",
+            "GET /sessions",
+            "--report-min-route-rows",
+            "GET /sessions=100",
+            "--json",
+            "--fail-on-blockers",
+        ]
+    )
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert '"report_last_minutes": 60.0' in output
+    assert '"report_min_rows": 1000' in output
+    assert '"--last-minutes"' in output
+    assert '"GET /sessions=100"' in output
 
 
 def test_shadow_observation_probe_reports_http_error_as_unhealthy(monkeypatch):


### PR DESCRIPTION
## Summary
- add `--report-*` coverage options to the shadow observation planner
- copy those options into the generated `shadow_report` command
- document the gated planner invocation and add focused unit coverage

## Validation
- `./venv/bin/python -m pytest tests/unit/test_rust_shadow_observation.py tests/unit/test_rust_shadow_report.py tests/unit/test_rust_shadow_middleware.py`
- `git diff --check`
- `./venv/bin/python -m scripts.rust_migration.shadow_observation --config config.yaml --ledger ~/.local/share/claude-sessions/rust_shadow.jsonl --reuse-rust-sidecar --report-last-minutes 1 --report-min-rows 50 --report-require-route 'GET /sessions' --report-require-route 'GET /events/state' --report-min-route-rows 'GET /sessions=20' --report-min-route-rows 'GET /events/state=20' --fail-on-blockers`

Fixes #917
