### PR TITLE
Add mobile device CLI contract checks

### DIFF
--- a/scripts/rust_migration/contracts_manifest.json
+++ b/scripts/rust_migration/contracts_manifest.json
@@ -874,6 +874,30 @@
       "source": "specs/762_stage5_artifacts/cutover_scope.md:42"
     },
     {
+      "id": "cli.list_devices_help",
+      "surface": "cli",
+      "classification": "retained",
+      "target": "rust_only",
+      "safety": "read_only",
+      "command": ["list-devices", "--help"],
+      "expected_exit": [0],
+      "expected_output_contains_all": ["--json"],
+      "preconditions": ["sm_cli"],
+      "source": "specs/762_stage5_artifacts/cutover_scope.md:33"
+    },
+    {
+      "id": "cli.remove_device_help",
+      "surface": "cli",
+      "classification": "retained",
+      "target": "rust_only",
+      "safety": "read_only",
+      "command": ["remove-device", "--help"],
+      "expected_exit": [0],
+      "expected_output_contains_all": ["DEVICE_ID", "--user-id"],
+      "preconditions": ["sm_cli"],
+      "source": "specs/762_stage5_artifacts/cutover_scope.md:33"
+    },
+    {
       "id": "cli.review_help",
       "surface": "cli",
       "classification": "retained",

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -163,6 +163,33 @@ def test_manifest_covers_rust_only_retired_cli_surfaces():
         assert "removed" in check.expected_output_contains_any
 
 
+def test_manifest_covers_rust_only_mobile_device_cli_surfaces():
+    manifest = ContractManifest.load()
+    checks = {check.id: check for check in manifest.checks}
+    required_ids = {
+        "cli.list_devices_help",
+        "cli.remove_device_help",
+    }
+
+    missing = required_ids - set(checks)
+    assert not missing
+
+    list_devices = checks["cli.list_devices_help"]
+    assert list_devices.classification == "retained"
+    assert list_devices.target == "rust_only"
+    assert list_devices.command == ("list-devices", "--help")
+    assert list_devices.expected_exit == (0,)
+    assert "--json" in list_devices.expected_output_contains_all
+
+    remove_device = checks["cli.remove_device_help"]
+    assert remove_device.classification == "retained"
+    assert remove_device.target == "rust_only"
+    assert remove_device.command == ("remove-device", "--help")
+    assert remove_device.expected_exit == (0,)
+    assert "DEVICE_ID" in remove_device.expected_output_contains_all
+    assert "--user-id" in remove_device.expected_output_contains_all
+
+
 def test_manifest_covers_rust_only_retired_http_surfaces():
     manifest = ContractManifest.load()
     checks = {check.id: check for check in manifest.checks}


### PR DESCRIPTION
## Summary
- add retained Rust CLI manifest checks for `list-devices --help` and `remove-device --help`
- assert device inventory/revocation help exposes `--json`, `DEVICE_ID`, and `--user-id`
- extend migration contract unit coverage for the retained Rust-only mobile CLI surfaces

## Validation
- `./venv/bin/python -m json.tool scripts/rust_migration/contracts_manifest.json >/dev/null`
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py`
- `./venv/bin/python -m scripts.rust_migration.contracts --target rust --check-id cli.list_devices_help --check-id cli.remove_device_help --json` -> 2 passed, 0 failed
- `git diff --check`

Fixes #919
