### PR TITLE
Add Rust migration state backup plan

### DIFF
--- a/scripts/rust_migration/README.md
+++ b/scripts/rust_migration/README.md
@@ -170,6 +170,29 @@ directory sizes without writing to live state. Missing optional stores are
 warnings; missing required session state or unreadable/wrong-kind paths are
 blockers for cutover tooling.
 
+Plan a copyable backup manifest without writing:
+
+```bash
+python -m scripts.rust_migration.state_backup \
+  --config config.yaml \
+  --output-dir /tmp/sm-rust-state-backup-plan
+```
+
+Copy the planned stores only after reviewing the dry-run output:
+
+```bash
+python -m scripts.rust_migration.state_backup \
+  --config config.yaml \
+  --output-dir /tmp/sm-rust-state-backup-$(date -u +%Y%m%dT%H%M%SZ) \
+  --execute \
+  --fail-on-blockers
+```
+
+Execution creates a fresh output directory, copies existing copyable stores, and
+writes `state-backup-manifest.json` inside it. Missing optional stores remain
+warnings. Preflight blockers, top-level symlink stores, and pre-existing backup
+roots block execution. Directory copies do not follow symlink children.
+
 ## Shadow Comparison Mode
 
 Shadow mode lets Python stay authoritative while Rust observes bounded

--- a/scripts/rust_migration/state_backup.py
+++ b/scripts/rust_migration/state_backup.py
@@ -1,0 +1,345 @@
+"""Plan and optionally copy Rust migration state backups.
+
+By default this tool is a dry run. It consumes the non-mutating state preflight
+report and produces a deterministic backup manifest for existing copyable
+stores. Use ``--execute --output-dir <dir>`` to copy files/directories and write
+the manifest into that directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from scripts.rust_migration.state_preflight import (
+    DEFAULT_CONFIG,
+    build_state_preflight_report,
+    is_unsafe_directory_root,
+)
+
+
+DEFAULT_BACKUP_PARENT = Path(".local/rust-state-backups")
+
+
+def build_backup_plan(
+    *,
+    config_path: Path = DEFAULT_CONFIG,
+    local_env_path: Path | None = None,
+    output_dir: Path | None = None,
+    execute: bool = False,
+) -> dict[str, Any]:
+    if execute and output_dir is None:
+        raise ValueError("--execute requires --output-dir")
+    generated_at = datetime.now(timezone.utc).isoformat()
+    backup_root = _backup_root(output_dir, generated_at=generated_at)
+    preflight = build_state_preflight_report(
+        config_path=config_path,
+        local_env_path=local_env_path,
+    )
+    entries: list[dict[str, Any]] = []
+    blockers = list(preflight["blockers"])
+    warnings = list(preflight["warnings"])
+    if execute and backup_root.exists():
+        blockers.append(
+            {
+                "store_id": "backup_root",
+                "kind": "backup_root_exists",
+                "severity": "blocker",
+                "detail": f"backup root already exists: {backup_root}",
+            }
+        )
+
+    for row in preflight["stores"]:
+        entry = _plan_entry(row, backup_root)
+        entries.append(entry)
+        blockers.extend(entry["blockers"])
+        warnings.extend(entry["warnings"])
+    blockers.extend(_backup_root_inside_source_blockers(entries, backup_root))
+
+    report: dict[str, Any] = {
+        "schema_version": 1,
+        "generated_at": generated_at,
+        "status": "blocked" if blockers else "copied" if execute else "planned",
+        "mode": "execute" if execute else "dry_run",
+        "backup_root": str(backup_root),
+        "manifest_path": str(backup_root / "state-backup-manifest.json"),
+        "preflight_status": preflight["status"],
+        "preflight_summary": preflight["summary"],
+        "summary": {
+            "entries": len(entries),
+            "planned": sum(1 for entry in entries if entry["action"] == "copy"),
+            "skipped": sum(1 for entry in entries if entry["action"] == "skip"),
+            "copied": 0,
+            "blockers": len(blockers),
+            "warnings": len(warnings),
+            "planned_bytes": sum(
+                int(entry.get("size_bytes") or 0)
+                for entry in entries
+                if entry["action"] == "copy"
+            ),
+        },
+        "entries": entries,
+        "blockers": blockers,
+        "warnings": warnings,
+    }
+    if execute and not blockers:
+        copied = _execute_plan(report)
+        report["summary"]["copied"] = copied
+        report["summary"]["blockers"] = len(report["blockers"])
+        report["summary"]["warnings"] = len(report["warnings"])
+        _write_manifest(report)
+    return report
+
+
+def render_text_report(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    lines = [
+        "Rust state backup plan",
+        f"status: {report['status']}",
+        f"mode: {report['mode']}",
+        f"backup_root: {report['backup_root']}",
+        (
+            "entries: "
+            f"{summary['entries']} total, {summary['planned']} planned, "
+            f"{summary['skipped']} skipped, {summary['copied']} copied"
+        ),
+        f"planned_bytes: {summary['planned_bytes']}",
+        f"blockers: {summary['blockers']}",
+        f"warnings: {summary['warnings']}",
+        "",
+        "Stores:",
+    ]
+    for entry in report["entries"]:
+        evidence = _entry_evidence(entry)
+        if entry["action"] == "copy":
+            lines.append(
+                f"  copy  {entry['store_id']}: {entry['source']} -> {entry['destination']} ({evidence})"
+            )
+        else:
+            lines.append(
+                f"  skip  {entry['store_id']}: {entry['skip_reason']} ({evidence})"
+            )
+    if report["blockers"]:
+        lines.extend(["", "Blockers:"])
+        for blocker in report["blockers"]:
+            lines.append(f"  {blocker['store_id']}: {blocker['kind']} - {blocker['detail']}")
+    if report["warnings"]:
+        lines.extend(["", "Warnings:"])
+        for warning in report["warnings"]:
+            lines.append(f"  {warning['store_id']}: {warning['kind']} - {warning['detail']}")
+    return "\n".join(lines)
+
+
+def _backup_root(output_dir: Path | None, *, generated_at: str) -> Path:
+    if output_dir is not None:
+        return output_dir.expanduser().resolve()
+    stamp = (
+        generated_at.replace("-", "")
+        .replace(":", "")
+        .replace("+00:00", "Z")
+        .replace(".", "-")
+    )
+    return (DEFAULT_BACKUP_PARENT / stamp).resolve()
+
+
+def _plan_entry(row: dict[str, Any], backup_root: Path) -> dict[str, Any]:
+    source = Path(row["path"])
+    entry: dict[str, Any] = {
+        "store_id": row["id"],
+        "label": row["label"],
+        "category": row["category"],
+        "kind": row["kind"],
+        "source": str(source),
+        "destination": str(backup_root / "stores" / row["id"]),
+        "required": row["required"],
+        "exists": row["exists"],
+        "size_bytes": row["size_bytes"],
+        "sha256": row["sha256"],
+        "file_count": row["file_count"],
+        "action": "skip",
+        "skip_reason": None,
+        "blockers": [],
+        "warnings": [],
+    }
+    if not row["exists"]:
+        entry["skip_reason"] = "missing"
+        return entry
+    if row["issues"]:
+        entry["skip_reason"] = "preflight_issue"
+        return entry
+    if not row["copyable"]:
+        entry["skip_reason"] = "not_copyable"
+        entry["blockers"].append(
+            _issue(row["id"], "not_copyable", "path exists but is not copyable")
+        )
+        return entry
+    if source.is_symlink():
+        entry["skip_reason"] = "symlink_source"
+        entry["blockers"].append(
+            _issue(row["id"], "symlink_source", "top-level store path is a symlink")
+        )
+        return entry
+    if row["kind"] == "dir" and is_unsafe_directory_root(source):
+        entry["skip_reason"] = "unsafe_source_root"
+        entry["blockers"].append(
+            _issue(
+                row["id"],
+                "unsafe_source_root",
+                f"directory source is too broad to back up safely: {source}",
+            )
+        )
+        return entry
+    entry["action"] = "copy"
+    entry["skip_reason"] = None
+    return entry
+
+
+def _entry_evidence(entry: dict[str, Any]) -> str:
+    fields = [
+        f"kind={entry['kind']}",
+        f"size_bytes={entry['size_bytes']}",
+        f"sha256={entry['sha256']}",
+        f"file_count={entry['file_count']}",
+    ]
+    return ", ".join(fields)
+
+
+def _backup_root_inside_source_blockers(
+    entries: list[dict[str, Any]],
+    backup_root: Path,
+) -> list[dict[str, str]]:
+    blockers: list[dict[str, str]] = []
+    backup_root_resolved = backup_root.resolve()
+    for entry in entries:
+        if entry["action"] != "copy" or entry["kind"] != "dir":
+            continue
+        source = Path(entry["source"]).resolve()
+        if _is_same_or_descendant(backup_root_resolved, source):
+            blockers.append(
+                _issue(
+                    entry["store_id"],
+                    "backup_root_inside_source",
+                    f"backup root {backup_root_resolved} is inside copied directory source {source}",
+                )
+            )
+    return blockers
+
+
+def _is_same_or_descendant(path: Path, parent: Path) -> bool:
+    return path == parent or parent in path.parents
+
+
+def _execute_plan(report: dict[str, Any]) -> int:
+    backup_root = Path(report["backup_root"])
+    backup_root.mkdir(parents=True, exist_ok=False)
+    copied = 0
+    for entry in report["entries"]:
+        if entry["action"] != "copy":
+            continue
+        source = Path(entry["source"])
+        destination = Path(entry["destination"])
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if entry["kind"] == "file":
+            shutil.copy2(source, destination)
+        elif entry["kind"] == "dir":
+            _copy_directory(source, destination, entry)
+        else:
+            entry["blockers"].append(
+                _issue(entry["store_id"], "unsupported_kind", f"cannot copy kind {entry['kind']}")
+            )
+            continue
+        entry["copied"] = True
+        copied += 1
+    report["blockers"] = [
+        blocker
+        for entry in report["entries"]
+        for blocker in entry.get("blockers", [])
+    ]
+    report["warnings"].extend(
+        warning
+        for entry in report["entries"]
+        for warning in entry.get("warnings", [])
+    )
+    if report["blockers"]:
+        report["status"] = "blocked"
+    return copied
+
+
+def _copy_directory(source: Path, destination: Path, entry: dict[str, Any]) -> None:
+    destination.mkdir(parents=True, exist_ok=False)
+    for child in source.rglob("*"):
+        relative = child.relative_to(source)
+        target = destination / relative
+        if child.is_symlink():
+            entry["warnings"].append(
+                _issue(
+                    entry["store_id"],
+                    "skipped_symlink",
+                    f"skipped symlink inside directory: {child}",
+                )
+            )
+            continue
+        if child.is_dir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+        if child.is_file():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(child, target)
+
+
+def _write_manifest(report: dict[str, Any]) -> None:
+    manifest_path = Path(report["manifest_path"])
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+
+
+def _issue(store_id: str, kind: str, detail: str) -> dict[str, str]:
+    return {
+        "store_id": store_id,
+        "kind": kind,
+        "severity": "blocker" if kind not in {"skipped_symlink"} else "warning",
+        "detail": detail,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--local-env", type=Path, default=None)
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--execute", action="store_true", help="Copy planned stores")
+    parser.add_argument("--json", action="store_true", help="Emit JSON report")
+    parser.add_argument(
+        "--fail-on-blockers",
+        action="store_true",
+        help="Exit nonzero when the plan/report has blockers",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        report = build_backup_plan(
+            config_path=args.config,
+            local_env_path=args.local_env,
+            output_dir=args.output_dir,
+            execute=args.execute,
+        )
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_text_report(report))
+    if args.fail_on_blockers and report["blockers"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/rust_migration/state_preflight.py
+++ b/scripts/rust_migration/state_preflight.py
@@ -35,6 +35,17 @@ DEFAULT_BUG_REPORTS_DB = "data/bug_reports.db"
 DEFAULT_LOCAL_ENV = ".local/android-parity/values.env"
 CLIENT_CONFIG_ENV = "SM_CLIENT_CONFIG"
 CLIENT_CONFIG_SUBPATH = "session-manager/client.yaml"
+UNSAFE_DIRECTORY_ROOTS = frozenset(
+    path.resolve()
+    for path in (
+        Path("/"),
+        Path.home(),
+        REPO_ROOT,
+        Path("/tmp"),
+        Path("/private/tmp"),
+        Path("/var/tmp"),
+    )
+)
 
 
 @dataclass(frozen=True)
@@ -314,6 +325,17 @@ def _inspect_store(spec: StoreSpec) -> dict[str, Any]:
             _issue(spec, "missing", severity, f"path does not exist: {path}")
         )
         return row
+    if spec.kind == "dir" and is_unsafe_directory_root(path):
+        row["actual_kind"] = "dir" if path.is_dir() else "other"
+        row["issues"].append(
+            _issue(
+                spec,
+                "unsafe_source_root",
+                "blocker",
+                f"directory source is too broad to inspect or back up safely: {path}",
+            )
+        )
+        return row
 
     if path.is_file():
         row["actual_kind"] = "file"
@@ -369,6 +391,14 @@ def _dir_stats(path: Path) -> tuple[bool, int, int]:
     except OSError:
         return False, total_size, file_count
     return True, total_size, file_count
+
+
+def is_unsafe_directory_root(path: Path) -> bool:
+    try:
+        resolved = path.resolve()
+    except OSError:
+        resolved = path.absolute()
+    return resolved in UNSAFE_DIRECTORY_ROOTS or resolved.parent == resolved
 
 
 def _issue(spec: StoreSpec, kind: str, severity: str, detail: str) -> dict[str, str]:

--- a/tests/unit/test_rust_state_backup.py
+++ b/tests/unit/test_rust_state_backup.py
@@ -1,0 +1,240 @@
+import json
+
+from scripts.rust_migration.state_backup import (
+    build_backup_plan,
+    main as state_backup_main,
+    render_text_report,
+)
+
+
+def _write_config(path, state_dir):
+    path.write_text(
+        f"""
+paths:
+  state_file: "{state_dir / 'sessions.json'}"
+  log_dir: "{state_dir / 'logs'}"
+sm_send:
+  db_path: "{state_dir / 'message_queue.db'}"
+response_relay:
+  db_path: "{state_dir / 'response_relay.db'}"
+tool_logging:
+  db_path: "{state_dir / 'tool_usage.db'}"
+telegram:
+  topic_registry:
+    path: "{state_dir / 'telegram_topics.json'}"
+email:
+  bridge_config: "{state_dir / 'email_send.yaml'}"
+queue_runner:
+  state_dir: "{state_dir / 'queue-runner'}"
+codex_events:
+  db_path: "{state_dir / 'codex_events.db'}"
+codex_requests:
+  db_path: "{state_dir / 'codex_requests.db'}"
+codex_observability:
+  db_path: "{state_dir / 'codex_observability.db'}"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _seed_state_tree(tmp_path):
+    config = tmp_path / "config.yaml"
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    (state_dir / "sessions.json").write_text('[{"id":"fixture"}]\n', encoding="utf-8")
+    (state_dir / "message_queue.db").write_text("queue", encoding="utf-8")
+    (state_dir / "response_relay.db").write_text("relay", encoding="utf-8")
+    (state_dir / "tool_usage.db").write_text("tools", encoding="utf-8")
+    (state_dir / "telegram_topics.json").write_text("{}\n", encoding="utf-8")
+    (state_dir / "codex_events.db").write_text("events", encoding="utf-8")
+    (state_dir / "codex_requests.db").write_text("requests", encoding="utf-8")
+    (state_dir / "codex_observability.db").write_text("observability", encoding="utf-8")
+    (state_dir / "email_send.yaml").write_text("registered_users: {}\n", encoding="utf-8")
+    (state_dir / "logs").mkdir()
+    (state_dir / "logs/server.log").write_text("log\n", encoding="utf-8")
+    (state_dir / "queue-runner").mkdir()
+    (state_dir / "queue-runner/queue_runner.db").write_text("jobs", encoding="utf-8")
+    _write_config(config, state_dir)
+    return config, state_dir
+
+
+def test_state_backup_dry_run_plans_copyable_existing_stores(tmp_path):
+    config, _state_dir = _seed_state_tree(tmp_path)
+    backup_root = tmp_path / "backup"
+
+    report = build_backup_plan(config_path=config, output_dir=backup_root)
+
+    assert report["status"] == "planned"
+    assert report["mode"] == "dry_run"
+    assert report["backup_root"] == str(backup_root)
+    assert report["summary"]["blockers"] == 0
+    assert report["summary"]["planned"] > 0
+    assert not backup_root.exists()
+    entries = {entry["store_id"]: entry for entry in report["entries"]}
+    assert entries["sessions_state"]["action"] == "copy"
+    assert entries["sessions_state"]["destination"] == str(
+        backup_root / "stores/sessions_state"
+    )
+    assert entries["bug_reports_db"]["action"] == "skip"
+    assert entries["bug_reports_db"]["skip_reason"] == "missing"
+
+
+def test_state_backup_execute_copies_files_dirs_and_manifest(tmp_path):
+    config, state_dir = _seed_state_tree(tmp_path)
+    backup_root = tmp_path / "backup"
+
+    report = build_backup_plan(config_path=config, output_dir=backup_root, execute=True)
+
+    assert report["status"] == "copied"
+    assert report["summary"]["blockers"] == 0
+    assert report["summary"]["copied"] == report["summary"]["planned"]
+    assert (backup_root / "stores/sessions_state").read_text(encoding="utf-8") == (
+        state_dir / "sessions.json"
+    ).read_text(encoding="utf-8")
+    assert (backup_root / "stores/log_dir/server.log").read_text(encoding="utf-8") == "log\n"
+    manifest = json.loads((backup_root / "state-backup-manifest.json").read_text())
+    assert manifest["status"] == "copied"
+    assert manifest["backup_root"] == str(backup_root)
+
+
+def test_state_backup_blocks_missing_required_state(tmp_path):
+    config = tmp_path / "config.yaml"
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    _write_config(config, state_dir)
+
+    report = build_backup_plan(config_path=config, output_dir=tmp_path / "backup")
+
+    assert report["status"] == "blocked"
+    assert any(
+        blocker["store_id"] == "sessions_state" and blocker["kind"] == "missing"
+        for blocker in report["blockers"]
+    )
+
+
+def test_state_backup_execute_requires_new_output_dir(tmp_path):
+    config, _state_dir = _seed_state_tree(tmp_path)
+    backup_root = tmp_path / "backup"
+    backup_root.mkdir()
+
+    report = build_backup_plan(config_path=config, output_dir=backup_root, execute=True)
+
+    assert report["status"] == "blocked"
+    assert {
+        "store_id": "backup_root",
+        "kind": "backup_root_exists",
+        "severity": "blocker",
+        "detail": f"backup root already exists: {backup_root}",
+    } in report["blockers"]
+
+
+def test_state_backup_blocks_unsafe_directory_roots(tmp_path):
+    config = tmp_path / "config.yaml"
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    (state_dir / "sessions.json").write_text("[]\n", encoding="utf-8")
+    config.write_text(
+        f"""
+paths:
+  state_file: "{state_dir / 'sessions.json'}"
+  log_dir: "/"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = build_backup_plan(config_path=config, output_dir=tmp_path / "backup")
+    entries = {entry["store_id"]: entry for entry in report["entries"]}
+
+    assert report["status"] == "blocked"
+    assert entries["log_dir"]["action"] == "skip"
+    assert entries["log_dir"]["skip_reason"] == "preflight_issue"
+    assert any(
+        blocker["store_id"] == "log_dir"
+        and blocker["kind"] == "unsafe_source_root"
+        for blocker in report["blockers"]
+    )
+
+
+def test_state_backup_blocks_top_level_symlink_store(tmp_path):
+    config, state_dir = _seed_state_tree(tmp_path)
+    real_logs = state_dir / "real-logs"
+    real_logs.mkdir()
+    (real_logs / "server.log").write_text("log\n", encoding="utf-8")
+    log_link = state_dir / "log-link"
+    log_link.symlink_to(real_logs, target_is_directory=True)
+    config.write_text(
+        f"""
+paths:
+  state_file: "{state_dir / 'sessions.json'}"
+  log_dir: "{log_link}"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = build_backup_plan(config_path=config, output_dir=tmp_path / "backup")
+    entries = {entry["store_id"]: entry for entry in report["entries"]}
+
+    assert report["status"] == "blocked"
+    assert entries["log_dir"]["action"] == "skip"
+    assert entries["log_dir"]["skip_reason"] == "symlink_source"
+    assert any(
+        blocker["store_id"] == "log_dir" and blocker["kind"] == "symlink_source"
+        for blocker in report["blockers"]
+    )
+
+
+def test_state_backup_blocks_output_dir_inside_copied_directory_source(tmp_path):
+    config, state_dir = _seed_state_tree(tmp_path)
+    backup_root = state_dir / "logs/backup"
+
+    report = build_backup_plan(config_path=config, output_dir=backup_root, execute=True)
+
+    assert report["status"] == "blocked"
+    assert not backup_root.exists()
+    assert any(
+        blocker["store_id"] == "log_dir"
+        and blocker["kind"] == "backup_root_inside_source"
+        for blocker in report["blockers"]
+    )
+
+
+def test_state_backup_skips_symlink_children_without_following(tmp_path):
+    config, state_dir = _seed_state_tree(tmp_path)
+    external = tmp_path / "outside-secret"
+    external.write_text("do-not-copy\n", encoding="utf-8")
+    (state_dir / "logs/link").symlink_to(external)
+    backup_root = tmp_path / "backup"
+
+    report = build_backup_plan(config_path=config, output_dir=backup_root, execute=True)
+
+    assert report["status"] == "copied"
+    assert not (backup_root / "stores/log_dir/link").exists()
+    assert any(
+        warning["store_id"] == "log_dir" and warning["kind"] == "skipped_symlink"
+        for warning in report["warnings"]
+    )
+
+
+def test_state_backup_text_report_and_cli_json(tmp_path, capsys):
+    config, _state_dir = _seed_state_tree(tmp_path)
+    backup_root = tmp_path / "backup"
+    report = build_backup_plan(config_path=config, output_dir=backup_root)
+
+    text = render_text_report(report)
+    assert "Rust state backup plan" in text
+    assert "status: planned" in text
+    assert "copy  sessions_state" in text
+    assert "kind=file" in text
+    assert "size_bytes=" in text
+    assert "sha256=" in text
+    assert "file_count=" in text
+
+    exit_code = state_backup_main(
+        ["--config", str(config), "--output-dir", str(backup_root), "--json"]
+    )
+    rendered = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert rendered["status"] == "planned"

--- a/tests/unit/test_rust_state_preflight.py
+++ b/tests/unit/test_rust_state_preflight.py
@@ -114,6 +114,30 @@ def test_state_preflight_reports_wrong_kind_as_blocker(tmp_path):
     )
 
 
+def test_state_preflight_blocks_unsafe_directory_roots_before_scanning(tmp_path):
+    config = tmp_path / "config.yaml"
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    (state_dir / "sessions.json").write_text("[]\n", encoding="utf-8")
+    config.write_text(
+        f"""
+paths:
+  state_file: "{state_dir / 'sessions.json'}"
+  log_dir: "/"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    report = build_state_preflight_report(config_path=config)
+
+    assert report["status"] == "blocked"
+    assert any(
+        issue["store_id"] == "log_dir" and issue["kind"] == "unsafe_source_root"
+        for issue in report["blockers"]
+    )
+
+
 def test_state_preflight_text_report_includes_warnings(tmp_path):
     config = tmp_path / "config.yaml"
     state_dir = tmp_path / "state"


### PR DESCRIPTION
## Summary
- add a dry-run backup plan for Rust migration state ownership
- copy existing preflight stores into a fresh output directory only with --execute
- write state-backup-manifest.json for executed backups and document the workflow

## Local dry-run result
- config.yaml report: 17 entries, 13 planned copies, 4 optional skips, 0 blockers

## Validation
- ./venv/bin/python -m pytest tests/unit/test_rust_state_backup.py tests/unit/test_rust_state_preflight.py
- ./venv/bin/python -m pytest tests/unit/test_rust_state_backup.py tests/unit/test_rust_state_preflight.py tests/unit/test_rust_cli_cutover_audit.py tests/unit/test_rust_migration_contracts.py
- ./venv/bin/python -m scripts.rust_migration.state_backup --config config.yaml --output-dir /tmp/sm-rust-state-backup-plan --fail-on-blockers
- ./venv/bin/python -m scripts.rust_migration.state_backup --config config.yaml --output-dir /tmp/sm-rust-state-backup-plan --json --fail-on-blockers | ./venv/bin/python -m json.tool >/dev/null
- ./venv/bin/python -m py_compile scripts/rust_migration/state_backup.py tests/unit/test_rust_state_backup.py
- git diff --check

Fixes #925