### PR TITLE
Add MVP rehearsal state backup/restore gate

### DIFF
--- a/scripts/rust_migration/README.md
+++ b/scripts/rust_migration/README.md
@@ -407,6 +407,9 @@ python -m scripts.rust_migration.mvp_rehearsal
 By default this:
 
 - checks Python `/health` on `http://127.0.0.1:8420`;
+- runs the state ownership gate: preflight, backup copy, backup verification,
+  disposable restore rehearsal, and freeze/drain plan ledger under the report
+  directory;
 - starts Rust `sm-server` on `http://127.0.0.1:8421` with `config.yaml`;
 - runs `scripts/rust-mvp-smoke.sh` for isolated mutating runtime coverage;
 - runs core read/retired-surface contracts against Rust;
@@ -425,7 +428,11 @@ state.
 
 Reports are written under `.local/rust-mvp-rehearsals/<timestamp>/` unless
 `--output-dir` is supplied. `.local/` is ignored; do not commit host-local
-reports.
+reports. The state gate writes detailed artifacts under
+`<report-dir>/state-gate/`, including `state-backup-manifest.json`,
+`state-restore-report.json`, and `freeze-drain-ledger.jsonl`. If this gate
+blocks, the rehearsal exits before Rust sidecar startup because the run cannot
+serve as cutover evidence.
 
 Useful variants:
 
@@ -437,6 +444,7 @@ python -m scripts.rust_migration.mvp_rehearsal --reuse-rust-sidecar
 python -m scripts.rust_migration.mvp_rehearsal \
   --config scripts/rust_migration/fixtures/read_only/config.yaml \
   --skip-python-health \
+  --skip-state-gate \
   --skip-smoke \
   --skip-baseline \
   --skip-shadow \

--- a/scripts/rust_migration/mvp_rehearsal.py
+++ b/scripts/rust_migration/mvp_rehearsal.py
@@ -24,7 +24,11 @@ from urllib.parse import urlparse
 
 from .baseline import run_baseline
 from .contracts import ContractManifest, run_checks, summarize
+from .freeze_drain_plan import build_freeze_drain_plan
 from .mutating_fixture import create_mutating_fixture_workspace
+from .state_backup import build_backup_plan
+from .state_preflight import build_state_preflight_report
+from .state_restore import build_restore_report
 
 
 PYTHON_BASE_URL = "http://127.0.0.1:8420"
@@ -126,6 +130,7 @@ def run_rehearsal(args: argparse.Namespace) -> dict[str, Any]:
             "include_gap_probes": not args.core_only,
             "skip_python_health": args.skip_python_health,
             "skip_smoke": args.skip_smoke,
+            "skip_state_gate": args.skip_state_gate,
             "skip_baseline": args.skip_baseline,
             "baseline_repetitions": args.baseline_repetitions,
             "skip_shadow": args.skip_shadow,
@@ -148,6 +153,32 @@ def run_rehearsal(args: argparse.Namespace) -> dict[str, Any]:
             report["steps"].append({"name": "python_health", **python_health})
             if python_health["status"] != "passed":
                 _add_blocker(report, "python_health", python_health["detail"])
+
+        if args.skip_state_gate:
+            report["steps"].append(
+                {
+                    "name": "state_ownership_backup_restore_gate",
+                    "status": "skipped",
+                    "detail": "state gate skipped by flag",
+                }
+            )
+        else:
+            state_gate = _run_state_gate(args, output_dir)
+            report["steps"].append(state_gate)
+            for name, path in state_gate.get("artifacts", {}).items():
+                report["artifacts"][f"state_gate_{name}"] = path
+            if state_gate["status"] != "passed":
+                _add_state_gate_blockers(report, state_gate)
+                if not any(
+                    blocker["kind"] == "state_ownership_gate"
+                    for blocker in report["blockers"]
+                ):
+                    _add_blocker(
+                        report,
+                        "state_ownership_gate",
+                        state_gate.get("detail", "state ownership gate failed"),
+                    )
+                return _finalize_report(report, output_dir, started_at)
 
         if args.reuse_rust_sidecar:
             rust_health = _probe_health(args.rust_base_url, args.timeout)
@@ -694,6 +725,205 @@ def _run_mutating_contract_group(
             _terminate_process_group(mutating_process)
 
 
+def _run_state_gate(args: argparse.Namespace, output_dir: Path) -> dict[str, Any]:
+    step_name = "state_ownership_backup_restore_gate"
+    started_at = time.perf_counter()
+    root = output_dir / "state-gate"
+    root.mkdir(parents=True, exist_ok=True)
+    artifacts = {
+        "preflight_report": str(root / "state-preflight-report.json"),
+        "backup_report": str(root / "state-backup-report.json"),
+        "backup_manifest": str(root / "backup" / "state-backup-manifest.json"),
+        "restore_verify_report": str(root / "state-restore-verify-report.json"),
+        "restore_report": str(root / "restore" / "state-restore-report.json"),
+        "restore_root": str(root / "restore"),
+        "freeze_drain_report": str(root / "freeze-drain-report.json"),
+        "freeze_drain_ledger": str(root / "freeze-drain-ledger.jsonl"),
+    }
+    reports: dict[str, dict[str, Any] | None] = {
+        "preflight": None,
+        "backup": None,
+        "restore_verify": None,
+        "restore_execute": None,
+        "freeze_drain": None,
+    }
+
+    try:
+        preflight = build_state_preflight_report(
+            config_path=args.config,
+            local_env_path=args.local_env,
+        )
+        reports["preflight"] = preflight
+        _write_json(Path(artifacts["preflight_report"]), preflight)
+
+        backup = build_backup_plan(
+            config_path=args.config,
+            local_env_path=args.local_env,
+            output_dir=root / "backup",
+            execute=True,
+        )
+        reports["backup"] = backup
+        _write_json(Path(artifacts["backup_report"]), backup)
+
+        if backup["status"] == "copied":
+            restore_verify = build_restore_report(
+                manifest_path=Path(backup["manifest_path"]),
+            )
+            reports["restore_verify"] = restore_verify
+            _write_json(Path(artifacts["restore_verify_report"]), restore_verify)
+
+            restore_execute = build_restore_report(
+                manifest_path=Path(backup["manifest_path"]),
+                restore_dir=root / "restore",
+                execute_restore=True,
+            )
+            reports["restore_execute"] = restore_execute
+            # build_restore_report writes this file on success. Write it here too so
+            # blocked/error reports still have an artifact at the advertised path.
+            _write_json(Path(artifacts["restore_report"]), restore_execute)
+
+        freeze_drain = build_freeze_drain_plan(
+            config_path=args.config,
+            local_env_path=args.local_env,
+            ledger_path=root / "freeze-drain-ledger.jsonl",
+            record_plan=True,
+        )
+        reports["freeze_drain"] = freeze_drain
+        _write_json(Path(artifacts["freeze_drain_report"]), freeze_drain)
+    except Exception as exc:  # noqa: BLE001 - preserve concrete tool failure in report.
+        return {
+            "name": step_name,
+            "status": "failed",
+            "elapsed_ms": _elapsed_ms(started_at),
+            "detail": f"state gate raised {type(exc).__name__}: {exc}",
+            "summary": _state_gate_summary(reports),
+            "blockers": [
+                {
+                    "substep": "state_gate",
+                    "kind": "exception",
+                    "detail": f"{type(exc).__name__}: {exc}",
+                }
+            ],
+            "artifacts": _existing_artifacts(artifacts),
+        }
+
+    blockers = _state_gate_report_blockers(reports)
+    expected_statuses = {
+        "preflight": "passed",
+        "backup": "copied",
+        "restore_verify": "verified",
+        "restore_execute": "restored",
+        "freeze_drain": "planned",
+    }
+    missing_or_bad = [
+        f"{name}={report.get('status') if report else 'skipped'}"
+        for name, expected in expected_statuses.items()
+        if not (report := reports.get(name)) or report.get("status") != expected
+    ]
+    if missing_or_bad and not blockers:
+        blockers.append(
+            {
+                "substep": "state_gate",
+                "kind": "unexpected_status",
+                "detail": "expected successful state gate statuses; got "
+                + ", ".join(missing_or_bad),
+            }
+        )
+
+    return {
+        "name": step_name,
+        "status": "passed" if not blockers else "failed",
+        "elapsed_ms": _elapsed_ms(started_at),
+        "detail": "state backup/restore gate completed" if not blockers else "state backup/restore gate blocked",
+        "summary": _state_gate_summary(reports),
+        "blockers": blockers,
+        "artifacts": _existing_artifacts(artifacts),
+    }
+
+
+def _existing_artifacts(artifacts: dict[str, str]) -> dict[str, str]:
+    return {
+        name: path
+        for name, path in artifacts.items()
+        if Path(path).exists()
+    }
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _state_gate_summary(
+    reports: dict[str, dict[str, Any] | None],
+) -> dict[str, Any]:
+    preflight = reports.get("preflight") or {}
+    backup = reports.get("backup") or {}
+    restore_verify = reports.get("restore_verify") or {}
+    restore_execute = reports.get("restore_execute") or {}
+    freeze_drain = reports.get("freeze_drain") or {}
+    return {
+        "preflight_status": preflight.get("status"),
+        "preflight_stores": (preflight.get("summary") or {}).get("stores"),
+        "preflight_existing": (preflight.get("summary") or {}).get("existing"),
+        "backup_status": backup.get("status"),
+        "backup_copied": (backup.get("summary") or {}).get("copied"),
+        "backup_skipped": (backup.get("summary") or {}).get("skipped"),
+        "restore_verify_status": restore_verify.get("status"),
+        "restore_verified": (restore_verify.get("summary") or {}).get("verified"),
+        "restore_execute_status": restore_execute.get("status"),
+        "restore_restored": (restore_execute.get("summary") or {}).get("restored"),
+        "freeze_drain_status": freeze_drain.get("status"),
+        "freeze_drain_ledger_written": (freeze_drain.get("ledger") or {}).get("written"),
+        "writer_families": (freeze_drain.get("summary") or {}).get("writer_families"),
+    }
+
+
+def _state_gate_report_blockers(
+    reports: dict[str, dict[str, Any] | None],
+) -> list[dict[str, Any]]:
+    blockers: dict[tuple[str | None, str, str], dict[str, Any]] = {}
+    for substep, report in reports.items():
+        if not report:
+            continue
+        for blocker in report.get("blockers", []):
+            store_id = blocker.get("store_id")
+            kind = blocker.get("kind", "blocker")
+            detail = blocker.get("detail", str(blocker))
+            key = (store_id, kind, detail)
+            entry = blockers.setdefault(
+                key,
+                {
+                    "substeps": [],
+                    "store_id": store_id,
+                    "kind": kind,
+                    "detail": detail,
+                },
+            )
+            entry["substeps"].append(substep)
+    return list(blockers.values())
+
+
+def _add_state_gate_blockers(report: dict[str, Any], step: dict[str, Any]) -> None:
+    for blocker in step.get("blockers", []):
+        detail_parts = []
+        if blocker.get("substeps"):
+            detail_parts.append("/".join(str(substep) for substep in blocker["substeps"]))
+        elif blocker.get("substep"):
+            detail_parts.append(str(blocker["substep"]))
+        if blocker.get("store_id"):
+            detail_parts.append(str(blocker["store_id"]))
+        if blocker.get("kind"):
+            detail_parts.append(str(blocker["kind"]))
+        prefix = ": ".join(detail_parts)
+        detail = blocker.get("detail", "state gate blocker")
+        _add_blocker(
+            report,
+            "state_ownership_gate",
+            f"{prefix} - {detail}" if prefix else str(detail),
+        )
+
+
 def _run_shadow_summary(
     *,
     python_base_url: str,
@@ -926,6 +1156,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--output-dir", type=Path, default=None)
     parser.add_argument("--reuse-rust-sidecar", action="store_true")
     parser.add_argument("--skip-python-health", action="store_true")
+    parser.add_argument("--skip-state-gate", action="store_true")
     parser.add_argument("--skip-smoke", action="store_true")
     parser.add_argument("--skip-baseline", action="store_true")
     parser.add_argument("--skip-shadow", action="store_true")

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -40,6 +40,8 @@ from scripts.rust_migration.mvp_rehearsal import (
     _default_mutating_rust_base_url,
     _ensure_rust_cli_available,
     _run_contract_group,
+    _run_state_gate,
+    run_rehearsal,
 )
 
 
@@ -336,6 +338,133 @@ def test_mvp_rehearsal_mutating_group_fails_on_skipped_checks():
 
     assert step["status"] == "failed"
     assert step["summary"]["skipped"] == 1
+
+
+def test_mvp_rehearsal_state_gate_copies_restores_and_records_plan(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("SM_CLIENT_CONFIG", str(tmp_path / "missing-client.yaml"))
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    (state_dir / "sessions.json").write_text("[]\n", encoding="utf-8")
+    (state_dir / "message_queue.db").write_text("queue\n", encoding="utf-8")
+    (state_dir / "logs").mkdir()
+    (state_dir / "logs/server.log").write_text("log\n", encoding="utf-8")
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        f"""
+paths:
+  state_file: "{state_dir / 'sessions.json'}"
+  log_dir: "{state_dir / 'logs'}"
+  server_log_file: "{state_dir / 'server.log'}"
+  app_artifacts_dir: "{state_dir / 'apps'}"
+  bug_reports_db: "{state_dir / 'bug_reports.db'}"
+sm_send:
+  db_path: "{state_dir / 'message_queue.db'}"
+response_relay:
+  db_path: "{state_dir / 'response_relay.db'}"
+tool_logging:
+  db_path: "{state_dir / 'tool_usage.db'}"
+telegram:
+  topic_registry:
+    path: "{state_dir / 'telegram_topics.json'}"
+email:
+  bridge_config: "{state_dir / 'email_send.yaml'}"
+queue_runner:
+  state_dir: "{state_dir / 'queue-runner'}"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    args = _build_parser().parse_args(["--config", str(config)])
+    output_dir = tmp_path / "rehearsal"
+
+    step = _run_state_gate(args, output_dir)
+
+    assert step["status"] == "passed"
+    assert step["summary"]["preflight_status"] == "passed"
+    assert step["summary"]["backup_status"] == "copied"
+    assert step["summary"]["restore_verify_status"] == "verified"
+    assert step["summary"]["restore_execute_status"] == "restored"
+    assert step["summary"]["freeze_drain_status"] == "planned"
+    assert step["summary"]["freeze_drain_ledger_written"] is True
+    for path in step["artifacts"].values():
+        if path.endswith("restore"):
+            assert Path(path).is_dir()
+        else:
+            assert Path(path).exists()
+    manifest = json.loads(
+        Path(step["artifacts"]["backup_manifest"]).read_text(encoding="utf-8")
+    )
+    assert manifest["status"] == "copied"
+    restore_report = json.loads(
+        Path(step["artifacts"]["restore_report"]).read_text(encoding="utf-8")
+    )
+    assert restore_report["status"] == "restored"
+    assert (
+        Path(step["artifacts"]["restore_root"]) / "stores/sessions_state"
+    ).read_text(encoding="utf-8") == "[]\n"
+    ledger_rows = Path(step["artifacts"]["freeze_drain_ledger"]).read_text(
+        encoding="utf-8"
+    ).splitlines()
+    assert len(ledger_rows) == 1
+    assert json.loads(ledger_rows[0])["kind"] == "freeze_drain_plan"
+
+
+def test_mvp_rehearsal_stops_after_state_gate_blocker(tmp_path, monkeypatch):
+    monkeypatch.setenv("SM_CLIENT_CONFIG", str(tmp_path / "missing-client.yaml"))
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    config = tmp_path / "config.yaml"
+    config.write_text(
+        f"""
+paths:
+  state_file: "{state_dir / 'sessions.json'}"
+  log_dir: "{state_dir / 'logs'}"
+sm_send:
+  db_path: "{state_dir / 'message_queue.db'}"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    args = _build_parser().parse_args(
+        [
+            "--skip-python-health",
+            "--config",
+            str(config),
+            "--output-dir",
+            str(tmp_path / "rehearsal"),
+        ]
+    )
+
+    report = run_rehearsal(args)
+
+    assert report["summary"]["status"] == "blocked"
+    state_blockers = [
+        blocker
+        for blocker in report["blockers"]
+        if blocker["kind"] == "state_ownership_gate"
+    ]
+    assert len(state_blockers) == 1
+    assert "preflight/backup/freeze_drain" in state_blockers[0]["detail"]
+    assert "sessions_state" in state_blockers[0]["detail"]
+    step_names = [step["name"] for step in report["steps"]]
+    assert step_names == ["state_ownership_backup_restore_gate"]
+    state_step = report["steps"][0]
+    assert len(state_step["blockers"]) == 1
+    assert state_step["blockers"][0]["substeps"] == [
+        "preflight",
+        "backup",
+        "freeze_drain",
+    ]
+    for name, path in report["artifacts"].items():
+        if name.startswith("state_gate_"):
+            assert Path(path).exists()
+    assert "state_gate_backup_manifest" not in report["artifacts"]
+    assert "state_gate_restore_verify_report" not in report["artifacts"]
+    assert "state_gate_restore_report" not in report["artifacts"]
+    assert "state_gate_restore_root" not in report["artifacts"]
+    assert "state_gate_freeze_drain_ledger" not in report["artifacts"]
 
 
 def test_manifest_has_json_shape_assertions_for_core_http_surfaces():


### PR DESCRIPTION
## Summary
- run the Stage 5 state ownership gate inside the MVP rehearsal by default
- write state preflight, backup, restore verification, restore rehearsal, and freeze/drain artifacts under the rehearsal output directory
- stop the rehearsal before Rust sidecar startup when the state gate blocks

## Validation
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py tests/unit/test_rust_state_preflight.py tests/unit/test_rust_state_backup.py tests/unit/test_rust_state_restore.py tests/unit/test_rust_freeze_drain_plan.py -q
- ./venv/bin/python -m py_compile scripts/rust_migration/mvp_rehearsal.py
- git diff --check

Fixes #931