### PR TITLE
Make live session detail shadow status-only

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -4514,7 +4514,7 @@ fn shadow_predict_session_read(
         .strip_prefix("/sessions/")
         .filter(|value| !value.contains('/'))
     {
-        let Some(session) = state.session_store.get_session(session_id)? else {
+        let Some(_session) = state.session_store.get_session(session_id)? else {
             let body = serde_json::to_vec(&json!({ "detail": "Session not found" }))?;
             return Ok(Some(ShadowPrediction {
                 status: StatusCode::NOT_FOUND.as_u16(),
@@ -4522,11 +4522,10 @@ fn shadow_predict_session_read(
                 support_status: "implemented_read",
             }));
         };
-        let body = serde_json::to_vec(&SessionResponse::from(session))?;
         return Ok(Some(ShadowPrediction {
             status: StatusCode::OK.as_u16(),
-            body_sha256: Some(sha256_hex(&body)),
-            support_status: "implemented_read",
+            body_sha256: None,
+            support_status: "implemented_read_status_only",
         }));
     }
 

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -2110,6 +2110,39 @@ async fn shadow_http_treats_live_session_lists_as_status_only() {
 }
 
 #[tokio::test]
+async fn shadow_http_treats_live_session_detail_as_status_only() {
+    let app = router(AppState::new(config_with_state_file(
+        &write_session_fixture(),
+    )));
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/sessions/run12345",
+                "query_string": "",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 200,
+                "body_sha256": sha256_hex(b"{\"id\":\"run12345\",\"activity_state\":\"working\"}")
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read_status_only");
+    assert_eq!(payload["comparison"], "status_match");
+    assert_eq!(payload["predicted_status"], 200);
+    assert_eq!(payload["predicted_body_sha256"], Value::Null);
+    assert_eq!(payload["body_sha256_match"], Value::Null);
+}
+
+#[tokio::test]
 async fn shadow_http_reports_codex_review_request_detail_200_as_status_only() {
     let state_file = unique_temp_path();
     let queue_db = state_file.with_extension("codex-review-requests.db");


### PR DESCRIPTION
## Summary
- make successful GET /sessions/{session_id} shadow predictions status-only to avoid live state TOCTOU body mismatches
- keep missing-session 404 exact-body prediction intact
- add regression coverage for live session-detail status-only shadow behavior

## Validation
- cargo test -p sm-server --test read_only_http shadow_http_treats_live_session -- --nocapture
- cargo test -p sm-server
- ./venv/bin/python -m pytest tests/unit/test_rust_shadow_report.py tests/unit/test_rust_shadow_middleware.py -q
- cargo fmt --check
- git diff --check

Fixes #935