### PR TITLE
Record post-938 MVP rehearsal evidence

### DIFF
--- a/specs/762_stage5_artifacts/mvp_progress.md
+++ b/specs/762_stage5_artifacts/mvp_progress.md
@@ -1,6 +1,6 @@
 # Rust MVP Progress Snapshot
 
-Status: implementation snapshot after PR #932 merged and the state-gated MVP rehearsal passed.
+Status: implementation snapshot after PR #938 merged and the full MVP rehearsal passed.
 
 This file is a handoff aid for the Rust cutover implementation track. It does
 not change retained or removed scope. Binding scope remains
@@ -55,6 +55,9 @@ not change retained or removed scope. Binding scope remains
 | #928 | freeze/drain plan ledger scaffold |
 | #930 | backup verification and restore rehearsal |
 | #932 | MVP rehearsal runs state preflight, backup, restore, and freeze/drain evidence |
+| #934 | handoff update after the state-gated rehearsal |
+| #936 | live session detail shadow comparison moved to status-only |
+| #938 | MVP rehearsal runs synthetic read-only fixture contracts in a dedicated sidecar |
 
 ## Implemented Capability Groups
 
@@ -62,7 +65,7 @@ The Rust sidecar now has executable coverage for:
 
 | Group | Current state |
 | --- | --- |
-| Harness and baselines | Contract manifest, fixture assertions, minimal value baseline runner, shadow comparison, MVP rehearsal, disposable mutating fixtures, Rust CLI build gating, state preflight/backup/restore, and freeze/drain evidence gates exist. |
+| Harness and baselines | Contract manifest, fixture assertions, minimal value baseline runner, shadow comparison, MVP rehearsal, synthetic read-only fixture sidecar, disposable mutating fixtures, Rust CLI build gating, state preflight/backup/restore, and freeze/drain evidence gates exist. |
 | Retired-surface checks | Retired public/watch/summary/remind/job-watch/queue-policy checks are represented as Rust-target absence or denial fixtures. |
 | Core reads | Health, auth session, bootstrap, session list/detail, client session list/detail, output, events state, SSE hello, nodes list, queue jobs list/detail, Codex review requests list/detail, and tool/audit read projections are implemented. |
 | Core runtime | Session/tmux/spawn/session-graph/message-queue/task-complete/input-batch/subagent slices are merged, with shadow and contract fixtures covering the early cutover path. |
@@ -107,7 +110,7 @@ the expected safety behavior for a live-state read run.
 ## Latest Real-State Rehearsal
 
 Report:
-`.local/rust-mvp-rehearsals/20260612T051529Z-state-gated-reuse/mvp-rehearsal-report.json`
+`.local/rust-mvp-rehearsals/20260612T-full-after-938/mvp-rehearsal-report.json`
 
 Summary:
 
@@ -118,33 +121,36 @@ Summary:
 | State ownership gate | Passed: 17 stores checked, 13 existing, 13 copied, 13 verified, 13 restored, freeze/drain ledger written |
 | Rust sidecar health | Passed using explicit `--reuse-rust-sidecar` because port 8421 was already healthy |
 | Isolated runtime smoke | Passed |
-| Rust read-only sidecar contracts | 17 passed, 0 failed, 0 skipped |
+| Rust live core sidecar contracts | 17 passed, 0 failed, 0 skipped |
+| Rust synthetic read-only fixture contracts | 10 passed, 0 failed, 0 skipped |
 | Rust mutating fixture contracts | 30 passed, 0 failed, 0 skipped |
 | Gap probes | 0 failed |
 | Python baseline | Passed |
 | Rust baseline | Passed |
 | Shadow read summary | 8 passed, 0 failed |
 
-The previous blocker was a body mismatch for `GET /events/state` in shadow
+The earlier blocker was a body mismatch for `GET /events/state` in shadow
 comparison. PR #898 reclassified that route as status-only because Python
 carries live tmux-client event state that a fresh Rust sidecar does not own.
-The clean run now passes the shadow summary for `/health`, `/health/detailed`,
-`/auth/session`, `/client/bootstrap`, `/sessions`, `/client/sessions`,
-`/nodes`, and `/events/state`.
+After PR #936, live session detail is also status-only for shadow comparison to
+avoid lifecycle TOCTOU noise while fixture-backed deterministic session detail
+checks remain body/assertion based. The clean run now passes the shadow summary
+for `/health`, `/health/detailed`, `/auth/session`, `/client/bootstrap`,
+`/sessions`, `/client/sessions`, `/nodes`, and `/events/state`.
 
 Measured baseline snapshot from the same run:
 
 | Metric | Python | Rust |
 | --- | ---: | ---: |
-| RSS | 151.906 MiB | 21.516 MiB |
-| Physical footprint | 64.8 MiB | 6.891 MiB |
-| `GET /health` median | 4.994 ms | 0.350 ms |
-| `GET /health/detailed` median | 203.143 ms | 0.350 ms |
-| `GET /auth/session` median | 6.793 ms | 0.302 ms |
-| `GET /client/bootstrap` median | 5.511 ms | 0.359 ms |
-| `GET /events/state` median | 6.002 ms | 0.349 ms |
-| `GET /sessions` median | 33.644 ms | 8.662 ms |
-| `GET /client/sessions` median | 69.850 ms | 9.196 ms |
+| RSS | 154.672 MiB | 19.797 MiB |
+| Physical footprint | 66.4 MiB | 6.688 MiB |
+| `GET /health` median | 4.167 ms | 0.275 ms |
+| `GET /health/detailed` median | 1078.139 ms | 0.294 ms |
+| `GET /auth/session` median | 18.825 ms | 0.268 ms |
+| `GET /client/bootstrap` median | 6.622 ms | 0.298 ms |
+| `GET /events/state` median | 5.017 ms | 0.288 ms |
+| `GET /sessions` median | 25.746 ms | 7.972 ms |
+| `GET /client/sessions` median | 58.486 ms | 7.946 ms |
 
 ## Near-Term Remaining Work
 
@@ -153,7 +159,7 @@ These are the next practical buckets before an MVP cutover trial:
 | Bucket | Why it remains |
 | --- | --- |
 | Shadow observation window | Python-authoritative shadow mode is enabled and a short clean window has been recorded. Continue it for a longer agreed window and triage any unexplained retained-core mismatches before Rust becomes the writer. |
-| Full fixture manifest execution | Run the broader retained manifest with the current synthetic fixture set plus any live mobile/device fixtures needed for final evidence. |
+| Full fixture manifest execution | The MVP rehearsal now runs the current synthetic read-only and mutating fixture sets. Remaining work is final live mobile/device fixture evidence and any additional retained fixture rows added by later slices. |
 | CLI cutover audit | Verify every retained CLI command in [cutover_scope.md](cutover_scope.md) is native Rust or intentionally routed, and every removed command is absent or explicitly retired. |
 | State ownership and migration tooling | Initial preflight, backup, restore, and freeze/drain evidence tools are merged and exercised by the rehearsal. Remaining work is live write-admission freeze/journal ownership and rollback accounting from [state_ownership_and_migration.md](state_ownership_and_migration.md). |
 | Public-edge deployment integration | Pair the Rust origin gate with the actual edge signer/proxy/device enrollment flow, including revoked-device and node fallback tests. |

--- a/specs/762_stage5_artifacts/resume_handoff.md
+++ b/specs/762_stage5_artifacts/resume_handoff.md
@@ -1,6 +1,6 @@
 # Rust Port Resume Handoff
 
-Status: handoff snapshot from 2026-06-12 after PR #932 and the state-gated MVP rehearsal passed.
+Status: handoff snapshot from 2026-06-12 after PR #938 and the full MVP rehearsal passed.
 
 Use this file to resume the Rust cutover track without reconstructing state from
 chat history. Binding scope still lives in [cutover_scope.md](cutover_scope.md),
@@ -11,7 +11,7 @@ coverage in
 ## Current Repository State
 
 - Branch: `main`
-- Latest merged commit: `14b54e7` (`Merge pull request #932`)
+- Latest merged commit: `43eb722` (`Merge pull request #938`)
 - Open PRs at handoff: none
 - Dirty worktree at handoff: only pre-existing untracked `.claude/settings.local.json`
   and the local `config.yaml.shadow-backup-20260612T023248Z` created when
@@ -59,7 +59,7 @@ Merged Rust slices cover:
 
 ### Documentation And Manifest
 
-- [mvp_progress.md](mvp_progress.md) records the PR lineage through #932.
+- [mvp_progress.md](mvp_progress.md) records the PR lineage through #938.
 - PR #880 added fixture-gated manifest checks for already-implemented detail
   endpoints:
   - `GET /queue-jobs/{queue_job_id}`
@@ -99,6 +99,11 @@ Merged Rust slices cover:
 - PR #930 added backup verification and restore rehearsal.
 - PR #932 made the MVP rehearsal run state preflight, backup, restore
   verification, disposable restore, and freeze/drain evidence by default.
+- PR #934 refreshed the handoff after the state-gated rehearsal.
+- PR #936 made live session detail shadow prediction status-only while keeping
+  fixture-backed deterministic session detail checks body/assertion based.
+- PR #938 made the MVP rehearsal run synthetic read-only fixture contracts in a
+  dedicated sidecar.
 - Current contract manifest size:
   - `117` checks total
   - `68` `python_and_rust`
@@ -109,7 +114,7 @@ Merged Rust slices cover:
 The latest real-state MVP rehearsal is:
 
 ```bash
-.local/rust-mvp-rehearsals/20260612T051529Z-state-gated-reuse/mvp-rehearsal-report.json
+.local/rust-mvp-rehearsals/20260612T-full-after-938/mvp-rehearsal-report.json
 ```
 
 Observed results from that run:
@@ -123,22 +128,25 @@ Observed results from that run:
   - `13` backup entries verified;
   - `13` backup entries restored into the disposable restore root;
   - freeze/drain ledger plan written;
-- Rust read-only sidecar contracts: `17` passed, `0` failed, `0` skipped;
+- Rust live core sidecar contracts: `17` passed, `0` failed, `0` skipped;
+- Rust synthetic read-only fixture contracts: `10` passed, `0` failed, `0`
+  skipped;
 - Rust mutating fixture contracts: `30` passed, `0` failed, `0` skipped;
 - gap probes: `0` failed;
 - Python and Rust baseline measurements completed;
 - shadow read summary: `8` passed, `0` failed.
 
-The previous blocker was `GET /events/state` shadow comparison. Python and Rust
+The earlier blocker was `GET /events/state` shadow comparison. Python and Rust
 both returned status `200`, but the predicted Rust body hash did not match
 Python because Python carries live tmux-client event state. PR #898 made that
-shadow prediction status-only. The clean run now passes `/health`,
-`/health/detailed`, `/auth/session`, `/client/bootstrap`, `/sessions`,
-`/client/sessions`, `/nodes`, and `/events/state`.
+shadow prediction status-only. PR #936 also made live session detail
+status-only for shadow to avoid lifecycle TOCTOU noise. The clean run now
+passes `/health`, `/health/detailed`, `/auth/session`, `/client/bootstrap`,
+`/sessions`, `/client/sessions`, `/nodes`, and `/events/state`.
 
-The same run measured the current Python process at `151.906 MiB` RSS and
-`64.8 MiB` physical footprint, while the Rust sidecar measured `21.516 MiB`
-RSS and `6.891 MiB` physical footprint.
+The same run measured the current Python process at `154.672 MiB` RSS and
+`66.4 MiB` physical footprint, while the Rust sidecar measured `19.797 MiB`
+RSS and `6.688 MiB` physical footprint.
 
 ## Live Observation
 
@@ -207,8 +215,10 @@ needed for final cutover evidence.
 
 1. Continue Python-authoritative shadow mode for a longer real observation
    window and triage unexplained mismatches.
-2. Run the full retained manifest against Python and Rust with the current
-   synthetic fixture set plus any live fixtures needed for mobile/device flows.
+2. Continue expanding fixture/live evidence as new retained rows land.
+   - The MVP rehearsal already runs the current synthetic read-only and
+     mutating fixture sets.
+   - Final live mobile/device fixture evidence is still needed.
 3. Audit retained CLI commands against [cutover_scope.md](cutover_scope.md).
    - Retained commands should be native Rust or intentionally routed.
    - Removed commands should be absent or explicitly retired.


### PR DESCRIPTION
## Summary
- update the Stage 5 MVP progress snapshot through PR #938
- record the clean full rehearsal at `.local/rust-mvp-rehearsals/20260612T-full-after-938/mvp-rehearsal-report.json`
- refresh the resume handoff with current merge point, fixture counts, and baseline metrics

## Validation
- git diff --check specs/762_stage5_artifacts/mvp_progress.md specs/762_stage5_artifacts/resume_handoff.md
- stale #932-era wording search across the updated docs

Fixes #939