### PR TITLE
Add mobile routes to Rust shadow gates

### DIFF
--- a/scripts/rust_migration/README.md
+++ b/scripts/rust_migration/README.md
@@ -281,6 +281,7 @@ Generate the non-destructive local plan before touching the running service:
   --ledger ~/.local/share/claude-sessions/rust_shadow.jsonl \
   --report-last-minutes 60 \
   --report-min-rows 1000 \
+  --mobile-sm-app-profile \
   --report-require-route 'GET /sessions' \
   --report-require-route 'GET /events/state' \
   --report-min-route-rows 'GET /sessions=100' \
@@ -296,7 +297,11 @@ is already healthy, and prints the exact sidecar command, local Python
 `--reuse-rust-sidecar` when intentionally observing against an already-running
 Rust sidecar. `--report-*` options are copied into the generated
 `shadow_report` command so the operator-reviewed plan and the final observation
-gate use the same window and coverage thresholds.
+gate use the same window and coverage thresholds. `--mobile-sm-app-profile`
+adds native app read coverage gates for `/auth/session`, `/client/bootstrap`,
+`/client/sessions`, `/client/analytics/summary`, `/client/sessions/{id}`, and
+`/sessions/{id}/attach-descriptor`; exercise the sm app during that observation
+window or the gate should block.
 
 After reviewing the planner output, prepare the local Python config with the
 dry-run-first activation helper:
@@ -381,15 +386,24 @@ coverage. Quote route arguments because they contain spaces:
   --min-rows 1000 \
   --require-route 'GET /sessions' \
   --require-route 'GET /events/state' \
+  --require-route 'GET /client/analytics/summary' \
+  --require-route-pattern 'GET /client/sessions/*' \
+  --require-route-pattern 'GET /sessions/*/attach-descriptor' \
   --min-route-rows 'GET /sessions=100' \
   --min-route-rows 'GET /events/state=100' \
   --fail-on-blockers
 ```
 
 Coverage gate failures are reported as blockers (`insufficient_rows`,
-`missing_required_route`, or `insufficient_route_rows`) so the same
-`--fail-on-blockers` automation path handles mismatches and insufficient
+`missing_required_route`, `insufficient_route_rows`,
+`missing_required_route_pattern`, or `insufficient_route_pattern_rows`) so the
+same `--fail-on-blockers` automation path handles mismatches and insufficient
 observation evidence.
+
+Passive shadow observation is read-only. Native app side-effect flows such as
+attach-ticket minting, request-status prompts, bug-report submission, and device
+revocation/list changes should be covered by disposable fixture or smoke
+rehearsal gates, not by executing Rust against live state from shadow mode.
 
 ## MVP Sidecar Rehearsal
 
@@ -428,7 +442,11 @@ own yet. `/nodes` includes live node-agent connectivity that the sidecar does
 not own yet. `/client/bootstrap` can advertise Python-only mobile-terminal
 attach support until Rust owns the terminal/ticket routes. The shadow summary
 treats those paths as status-only until Rust owns the corresponding runtime
-state.
+state. The active rehearsal shadow summary also probes
+`/client/analytics/summary` and, when Python has at least one live session,
+`/client/sessions/{id}` plus `/sessions/{id}/attach-descriptor`, so native app
+read prediction is exercised before a longer passive mobile observation window
+is collected.
 
 Reports are written under `.local/rust-mvp-rehearsals/<timestamp>/` unless
 `--output-dir` is supplied. `.local/` is ignored; do not commit host-local

--- a/scripts/rust_migration/mvp_rehearsal.py
+++ b/scripts/rust_migration/mvp_rehearsal.py
@@ -129,6 +129,7 @@ SHADOW_COMPARE_PATHS = (
     "/health/detailed",
     "/auth/session",
     "/client/bootstrap",
+    "/client/analytics/summary",
     "/sessions",
     "/client/sessions",
     "/nodes",
@@ -444,10 +445,16 @@ def run_rehearsal(args: argparse.Namespace) -> dict[str, Any]:
                     _add_blocker(report, step["name"], step["detail"])
 
         if not args.skip_shadow:
+            shadow_paths = _resolve_shadow_compare_paths(
+                python_base_url=args.python_base_url,
+                base_paths=SHADOW_COMPARE_PATHS,
+                timeout_seconds=args.timeout,
+            )
+            report["steps"].append(shadow_paths)
             shadow = _run_shadow_summary(
                 python_base_url=args.python_base_url,
                 rust_base_url=args.rust_base_url,
-                paths=SHADOW_COMPARE_PATHS,
+                paths=tuple(shadow_paths["paths"]),
                 timeout_seconds=args.timeout,
                 shadow_secret=args.shadow_secret,
             )
@@ -1148,6 +1155,65 @@ def _run_shadow_summary(
         "summary": {"passed": len(results) - failed, "failed": failed},
         "results": results,
     }
+
+
+def _resolve_shadow_compare_paths(
+    *,
+    python_base_url: str,
+    base_paths: tuple[str, ...],
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    started_at = time.perf_counter()
+    paths = list(base_paths)
+    detail = "mobile session detail probes skipped: no live session id resolved"
+    status = "passed"
+    session_id = None
+    try:
+        response_status, response_body, _headers = _http_request(
+            "GET",
+            python_base_url.rstrip("/") + "/sessions",
+            timeout_seconds=timeout_seconds,
+        )
+        if response_status != 200:
+            status = "skipped"
+            detail = f"mobile session detail probes skipped: /sessions returned HTTP {response_status}"
+        else:
+            session_id = _first_shadow_session_id(response_body)
+            if session_id:
+                paths.extend(
+                    [
+                        f"/client/sessions/{session_id}",
+                        f"/sessions/{session_id}/attach-descriptor",
+                    ]
+                )
+                detail = f"mobile session detail probes use session_id={session_id}"
+            else:
+                status = "skipped"
+    except Exception as exc:  # noqa: BLE001 - report should preserve the concrete transport/parsing error.
+        status = "skipped"
+        detail = f"mobile session detail probes skipped: {type(exc).__name__}: {exc}"
+    return {
+        "name": "shadow_mobile_path_resolution",
+        "status": status,
+        "elapsed_ms": _elapsed_ms(started_at),
+        "detail": detail,
+        "session_id": session_id,
+        "paths": paths,
+    }
+
+
+def _first_shadow_session_id(response_body: bytes) -> str | None:
+    payload = json.loads(response_body.decode("utf-8"))
+    sessions = payload.get("sessions") if isinstance(payload, dict) else payload
+    if not isinstance(sessions, list):
+        return None
+    for session in sessions:
+        if not isinstance(session, dict):
+            continue
+        session_id = session.get("id")
+        if isinstance(session_id, str) and session_id:
+            return session_id
+    return None
 
 
 def _baseline_step(name: str, report: dict[str, Any]) -> dict[str, Any]:

--- a/scripts/rust_migration/shadow_observation.py
+++ b/scripts/rust_migration/shadow_observation.py
@@ -20,6 +20,16 @@ RUST_BASE_URL = "http://127.0.0.1:8421"
 DEFAULT_LEDGER_PATH = Path("~/.local/share/claude-sessions/rust_shadow.jsonl")
 DEFAULT_CONFIG = Path("config.yaml")
 DEFAULT_TIMEOUT_SECONDS = 1.0
+MOBILE_SM_APP_REQUIRED_ROUTES = (
+    "GET /auth/session",
+    "GET /client/bootstrap",
+    "GET /client/sessions",
+    "GET /client/analytics/summary",
+)
+MOBILE_SM_APP_REQUIRED_ROUTE_PATTERNS = (
+    "GET /client/sessions/*",
+    "GET /sessions/*/attach-descriptor",
+)
 
 
 @dataclass(frozen=True)
@@ -44,6 +54,9 @@ def build_observation_plan(
     report_min_rows: int | None = None,
     report_required_routes: list[str] | None = None,
     report_min_route_rows: list[str] | None = None,
+    report_required_route_patterns: list[str] | None = None,
+    report_min_route_pattern_rows: list[str] | None = None,
+    mobile_sm_app_profile: bool = False,
     probe_health: Callable[[str, float], HealthProbe] = None,
     cargo_resolver: Callable[[str], str | None] = shutil.which,
 ) -> dict[str, Any]:
@@ -55,6 +68,15 @@ def build_observation_plan(
     python_health = probe_health(python_base_url, timeout_seconds)
     rust_health = probe_health(rust_base_url, timeout_seconds)
     cargo_path = cargo_resolver(cargo)
+    resolved_required_routes = list(report_required_routes or ())
+    resolved_required_route_patterns = list(report_required_route_patterns or ())
+    if mobile_sm_app_profile:
+        resolved_required_routes = _append_unique(
+            resolved_required_routes, MOBILE_SM_APP_REQUIRED_ROUTES
+        )
+        resolved_required_route_patterns = _append_unique(
+            resolved_required_route_patterns, MOBILE_SM_APP_REQUIRED_ROUTE_PATTERNS
+        )
 
     blockers: list[dict[str, str]] = []
     warnings: list[dict[str, str]] = []
@@ -123,10 +145,14 @@ def build_observation_plan(
         report_command.extend(["--last-minutes", str(report_last_minutes)])
     if report_min_rows is not None:
         report_command.extend(["--min-rows", str(report_min_rows)])
-    for route in report_required_routes or ():
+    for route in resolved_required_routes:
         report_command.extend(["--require-route", route])
     for route_minimum in report_min_route_rows or ():
         report_command.extend(["--min-route-rows", route_minimum])
+    for pattern in resolved_required_route_patterns:
+        report_command.extend(["--require-route-pattern", pattern])
+    for pattern_minimum in report_min_route_pattern_rows or ():
+        report_command.extend(["--min-route-pattern-rows", pattern_minimum])
 
     return {
         "schema_version": 1,
@@ -142,8 +168,11 @@ def build_observation_plan(
             "reuse_rust_sidecar": reuse_rust_sidecar,
             "report_last_minutes": report_last_minutes,
             "report_min_rows": report_min_rows,
-            "report_required_routes": list(report_required_routes or ()),
+            "mobile_sm_app_profile": mobile_sm_app_profile,
+            "report_required_routes": resolved_required_routes,
             "report_min_route_rows": list(report_min_route_rows or ()),
+            "report_required_route_patterns": resolved_required_route_patterns,
+            "report_min_route_pattern_rows": list(report_min_route_pattern_rows or ()),
         },
         "checks": {
             "python_health": python_health.__dict__,
@@ -172,6 +201,7 @@ def build_observation_plan(
             "Start the Rust sidecar command in a separate terminal, unless reusing an existing sidecar.",
             "Add the rust_shadow snippet to local config and restart Python Session Manager deliberately.",
             "Let normal traffic run for the agreed observation window.",
+            "Exercise the native sm app during the window when using the mobile profile.",
             "Run the shadow ledger report command and treat blockers as cutover blockers.",
         ],
     }
@@ -268,6 +298,16 @@ def _python_config_snippet(
         ]
     )
     return "\n".join(lines)
+
+
+def _append_unique(existing: list[str], additions: tuple[str, ...]) -> list[str]:
+    values = list(existing)
+    seen = set(values)
+    for value in additions:
+        if value not in seen:
+            values.append(value)
+            seen.add(value)
+    return values
 
 
 def _probe_health(base_url: str, timeout_seconds: float) -> HealthProbe:
@@ -371,6 +411,32 @@ def _build_parser() -> argparse.ArgumentParser:
             "command. Format as 'METHOD /path=N'. Repeatable."
         ),
     )
+    parser.add_argument(
+        "--report-require-route-pattern",
+        action="append",
+        default=[],
+        help=(
+            "Include a --require-route-pattern value in the generated "
+            "shadow_report command. Format as 'METHOD /path/*'. Repeatable."
+        ),
+    )
+    parser.add_argument(
+        "--report-min-route-pattern-rows",
+        action="append",
+        default=[],
+        help=(
+            "Include a --min-route-pattern-rows value in the generated "
+            "shadow_report command. Format as 'METHOD /path/*=N'. Repeatable."
+        ),
+    )
+    parser.add_argument(
+        "--mobile-sm-app-profile",
+        action="store_true",
+        help=(
+            "Add native sm app/mobile read coverage gates to the generated "
+            "shadow_report command."
+        ),
+    )
     parser.add_argument("--json", action="store_true")
     parser.add_argument("--fail-on-blockers", action="store_true")
     return parser
@@ -392,6 +458,9 @@ def main(argv: list[str] | None = None) -> int:
         report_min_rows=args.report_min_rows,
         report_required_routes=args.report_require_route,
         report_min_route_rows=args.report_min_route_rows,
+        report_required_route_patterns=args.report_require_route_pattern,
+        report_min_route_pattern_rows=args.report_min_route_pattern_rows,
+        mobile_sm_app_profile=args.mobile_sm_app_profile,
     )
     if args.json:
         print(json.dumps(plan, indent=2, sort_keys=True))

--- a/scripts/rust_migration/shadow_report.py
+++ b/scripts/rust_migration/shadow_report.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import fnmatch
 import json
 from collections import Counter, defaultdict
 from collections.abc import Mapping, Sequence
@@ -28,6 +29,8 @@ def summarize_ledger(
     min_rows: int | None = None,
     required_routes: Sequence[str] | None = None,
     min_route_rows: Mapping[str, int] | None = None,
+    required_route_patterns: Sequence[str] | None = None,
+    min_route_pattern_rows: Mapping[str, int] | None = None,
 ) -> dict[str, Any]:
     ledger_path = ledger_path.expanduser()
     since_filter = _resolve_since_filter(
@@ -110,6 +113,8 @@ def summarize_ledger(
             min_rows=min_rows,
             required_routes=required_routes or (),
             min_route_rows=min_route_rows or {},
+            required_route_patterns=required_route_patterns or (),
+            min_route_pattern_rows=min_route_pattern_rows or {},
         )
     )
 
@@ -131,6 +136,8 @@ def summarize_ledger(
             "min_rows": min_rows,
             "required_routes": list(required_routes or ()),
             "min_route_rows": dict(sorted((min_route_rows or {}).items())),
+            "required_route_patterns": list(required_route_patterns or ()),
+            "min_route_pattern_rows": dict(sorted((min_route_pattern_rows or {}).items())),
         },
         "status": status,
         "row_count": row_count,
@@ -185,6 +192,10 @@ def render_text_report(report: dict[str, Any]) -> str:
             lines.append(f"  required route: {route}")
         for route, count in (gates.get("min_route_rows") or {}).items():
             lines.append(f"  min route rows: {route} >= {count}")
+        for pattern in gates.get("required_route_patterns") or ():
+            lines.append(f"  required route pattern: {pattern}")
+        for pattern, count in (gates.get("min_route_pattern_rows") or {}).items():
+            lines.append(f"  min route pattern rows: {pattern} >= {count}")
 
     if report["blockers"]:
         lines.extend(["", "Blockers:"])
@@ -396,6 +407,8 @@ def _coverage_gate_blockers(
     min_rows: int | None,
     required_routes: Sequence[str],
     min_route_rows: Mapping[str, int],
+    required_route_patterns: Sequence[str],
+    min_route_pattern_rows: Mapping[str, int],
 ) -> list[dict[str, Any]]:
     blockers: list[dict[str, Any]] = []
     if min_rows is not None and row_count < min_rows:
@@ -424,7 +437,34 @@ def _coverage_gate_blockers(
                     "detail": f"observed {observed}, required {minimum}",
                 }
             )
+    for pattern in required_route_patterns:
+        if _route_pattern_count(route_row_counts, pattern) == 0:
+            blockers.append(
+                {
+                    "kind": "missing_required_route_pattern",
+                    "route": pattern,
+                    "detail": "required route pattern not observed",
+                }
+            )
+    for pattern, minimum in min_route_pattern_rows.items():
+        observed = _route_pattern_count(route_row_counts, pattern)
+        if observed < minimum:
+            blockers.append(
+                {
+                    "kind": "insufficient_route_pattern_rows",
+                    "route": pattern,
+                    "detail": f"observed {observed}, required {minimum}",
+                }
+            )
     return blockers
+
+
+def _route_pattern_count(route_row_counts: Mapping[str, int], pattern: str) -> int:
+    return sum(
+        count
+        for route, count in route_row_counts.items()
+        if fnmatch.fnmatchcase(route, pattern)
+    )
 
 
 def _normalize_route_requirement(value: str) -> str:
@@ -510,6 +550,24 @@ def _build_parser() -> argparse.ArgumentParser:
             "'METHOD /path=N'. Repeatable."
         ),
     )
+    parser.add_argument(
+        "--require-route-pattern",
+        action="append",
+        default=[],
+        help=(
+            "Require at least one observation matching a shell-style route "
+            "pattern, formatted as 'METHOD /path/*'. Repeatable."
+        ),
+    )
+    parser.add_argument(
+        "--min-route-pattern-rows",
+        action="append",
+        default=[],
+        help=(
+            "Require at least N observations matching a shell-style route "
+            "pattern, formatted as 'METHOD /path/*=N'. Repeatable."
+        ),
+    )
     return parser
 
 
@@ -525,6 +583,14 @@ def main(argv: list[str] | None = None) -> int:
             _parse_route_minimum(requirement)
             for requirement in args.min_route_rows
         )
+        required_route_patterns = [
+            _normalize_route_requirement(pattern)
+            for pattern in args.require_route_pattern
+        ]
+        min_route_pattern_rows = dict(
+            _parse_route_minimum(requirement)
+            for requirement in args.min_route_pattern_rows
+        )
         report = summarize_ledger(
             args.ledger,
             since=since,
@@ -532,6 +598,8 @@ def main(argv: list[str] | None = None) -> int:
             min_rows=args.min_rows,
             required_routes=required_routes,
             min_route_rows=min_route_rows,
+            required_route_patterns=required_route_patterns,
+            min_route_pattern_rows=min_route_pattern_rows,
         )
     except ValueError as exc:
         parser.error(str(exc))

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -42,6 +42,7 @@ from scripts.rust_migration.mvp_rehearsal import (
     _default_read_only_fixture_rust_base_url,
     _default_mutating_rust_base_url,
     _ensure_rust_cli_available,
+    _resolve_shadow_compare_paths,
     _run_contract_group,
     _run_state_gate,
     run_rehearsal,
@@ -433,6 +434,58 @@ def test_mvp_rehearsal_records_read_only_fixture_skip_step(tmp_path, monkeypatch
     )
     assert step["status"] == "skipped"
     assert report["summary"]["status"] == "passed"
+
+
+def test_mvp_rehearsal_resolves_mobile_shadow_paths(monkeypatch):
+    def fake_http_request(method, url, *, timeout_seconds, **_kwargs):
+        assert method == "GET"
+        assert url == "http://python.test/sessions"
+        assert timeout_seconds == 0.5
+        return (
+            200,
+            json.dumps({"sessions": [{"id": "mobile-session"}]}).encode(),
+            {},
+        )
+
+    monkeypatch.setattr(
+        "scripts.rust_migration.mvp_rehearsal._http_request",
+        fake_http_request,
+    )
+
+    step = _resolve_shadow_compare_paths(
+        python_base_url="http://python.test",
+        base_paths=("/health", "/client/analytics/summary"),
+        timeout_seconds=0.5,
+    )
+
+    assert step["status"] == "passed"
+    assert step["session_id"] == "mobile-session"
+    assert step["paths"] == [
+        "/health",
+        "/client/analytics/summary",
+        "/client/sessions/mobile-session",
+        "/sessions/mobile-session/attach-descriptor",
+    ]
+
+
+def test_mvp_rehearsal_mobile_shadow_paths_skip_without_session(monkeypatch):
+    def fake_http_request(method, url, *, timeout_seconds, **_kwargs):
+        return 200, b'{"sessions":[]}', {}
+
+    monkeypatch.setattr(
+        "scripts.rust_migration.mvp_rehearsal._http_request",
+        fake_http_request,
+    )
+
+    step = _resolve_shadow_compare_paths(
+        python_base_url="http://python.test",
+        base_paths=("/health",),
+        timeout_seconds=0.5,
+    )
+
+    assert step["status"] == "skipped"
+    assert step["session_id"] is None
+    assert step["paths"] == ["/health"]
 
 
 def test_mvp_rehearsal_state_gate_copies_restores_and_records_plan(

--- a/tests/unit/test_rust_shadow_observation.py
+++ b/tests/unit/test_rust_shadow_observation.py
@@ -147,6 +147,67 @@ def test_shadow_observation_plan_includes_report_coverage_gates(tmp_path):
     assert "'GET /sessions'" in rendered
 
 
+def test_shadow_observation_mobile_profile_adds_native_app_gates(tmp_path):
+    config = tmp_path / "config.yaml"
+    config.write_text("server: {}\n", encoding="utf-8")
+    ledger = tmp_path / "rust_shadow.jsonl"
+
+    plan = build_observation_plan(
+        config=config,
+        ledger=ledger,
+        probe_health=_python_healthy_rust_unreachable_probe,
+        cargo_resolver=lambda _cargo: "/usr/bin/cargo",
+        report_required_routes=["GET /sessions"],
+        mobile_sm_app_profile=True,
+    )
+
+    assert plan["inputs"]["mobile_sm_app_profile"] is True
+    assert plan["inputs"]["report_required_routes"] == [
+        "GET /sessions",
+        "GET /auth/session",
+        "GET /client/bootstrap",
+        "GET /client/sessions",
+        "GET /client/analytics/summary",
+    ]
+    assert plan["inputs"]["report_required_route_patterns"] == [
+        "GET /client/sessions/*",
+        "GET /sessions/*/attach-descriptor",
+    ]
+    assert "--require-route-pattern" in plan["commands"]["summarize_shadow_ledger"]
+    assert "GET /client/sessions/*" in plan["commands"]["summarize_shadow_ledger"]
+    rendered = render_text_plan(plan)
+    assert "--require-route 'GET /client/analytics/summary'" in rendered
+    assert "--require-route-pattern 'GET /sessions/*/attach-descriptor'" in rendered
+    assert "Exercise the native sm app" in rendered
+
+
+def test_shadow_observation_cli_json_includes_mobile_profile_gates(tmp_path, capsys):
+    config = tmp_path / "config.yaml"
+    config.write_text("server: {}\n", encoding="utf-8")
+
+    exit_code = main(
+        [
+            "--config",
+            str(config),
+            "--python-base-url",
+            "http://127.0.0.1:1",
+            "--rust-base-url",
+            "http://127.0.0.1:2",
+            "--reuse-rust-sidecar",
+            "--mobile-sm-app-profile",
+            "--json",
+            "--fail-on-blockers",
+        ]
+    )
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert '"mobile_sm_app_profile": true' in output
+    assert '"GET /client/analytics/summary"' in output
+    assert '"GET /sessions/*/attach-descriptor"' in output
+    assert '"--require-route-pattern"' in output
+
+
 def test_shadow_observation_plan_blocks_when_rust_port_already_healthy(tmp_path):
     config = tmp_path / "config.yaml"
     config.write_text("server: {}\n", encoding="utf-8")

--- a/tests/unit/test_rust_shadow_report.py
+++ b/tests/unit/test_rust_shadow_report.py
@@ -456,6 +456,8 @@ def test_shadow_report_route_coverage_gates_block_missing_or_sparse_routes(tmp_p
             "GET /events/state": 1,
             "GET /sessions": 2,
         },
+        "required_route_patterns": [],
+        "min_route_pattern_rows": {},
     }
     assert report["blockers"] == [
         {
@@ -466,6 +468,65 @@ def test_shadow_report_route_coverage_gates_block_missing_or_sparse_routes(tmp_p
         {
             "kind": "insufficient_route_rows",
             "route": "GET /sessions",
+            "detail": "observed 1, required 2",
+        },
+    ]
+
+
+def test_shadow_report_route_pattern_gates_cover_mobile_detail_routes(tmp_path):
+    ledger = tmp_path / "rust_shadow.jsonl"
+    _write_jsonl(
+        ledger,
+        [
+            {
+                "observed_at": "2026-06-12T02:00:00Z",
+                "method": "GET",
+                "path": "/client/sessions/fixture001",
+                "rust_http_status": 200,
+                "rust_result": {"comparison": "status_match"},
+            },
+            {
+                "observed_at": "2026-06-12T02:00:01Z",
+                "method": "GET",
+                "path": "/sessions/fixture001/attach-descriptor",
+                "rust_http_status": 200,
+                "rust_result": {"comparison": "match"},
+            },
+        ],
+    )
+
+    report = summarize_ledger(
+        ledger,
+        required_route_patterns=(
+            "GET /client/sessions/*",
+            "GET /sessions/*/attach-descriptor",
+            "GET /client/bug-reports/*",
+        ),
+        min_route_pattern_rows={
+            "GET /client/sessions/*": 2,
+            "GET /sessions/*/attach-descriptor": 1,
+        },
+    )
+
+    assert report["status"] == "blocked"
+    assert report["gates"]["required_route_patterns"] == [
+        "GET /client/sessions/*",
+        "GET /sessions/*/attach-descriptor",
+        "GET /client/bug-reports/*",
+    ]
+    assert report["gates"]["min_route_pattern_rows"] == {
+        "GET /client/sessions/*": 2,
+        "GET /sessions/*/attach-descriptor": 1,
+    }
+    assert report["blockers"] == [
+        {
+            "kind": "missing_required_route_pattern",
+            "route": "GET /client/bug-reports/*",
+            "detail": "required route pattern not observed",
+        },
+        {
+            "kind": "insufficient_route_pattern_rows",
+            "route": "GET /client/sessions/*",
             "detail": "observed 1, required 2",
         },
     ]
@@ -483,6 +544,13 @@ def test_shadow_report_cli_accepts_coverage_gates(tmp_path, capsys):
                 "rust_http_status": 200,
                 "rust_result": {"comparison": "status_match"},
             },
+            {
+                "observed_at": "2026-06-12T02:00:01Z",
+                "method": "GET",
+                "path": "/client/sessions/fixture001",
+                "rust_http_status": 200,
+                "rust_result": {"comparison": "status_match"},
+            },
         ],
     )
 
@@ -497,6 +565,10 @@ def test_shadow_report_cli_accepts_coverage_gates(tmp_path, capsys):
                 "get /sessions",
                 "--min-route-rows",
                 "get /sessions=1",
+                "--require-route-pattern",
+                "get /client/sessions/*",
+                "--min-route-pattern-rows",
+                "get /client/sessions/*=1",
                 "--json",
                 "--fail-on-blockers",
             ]
@@ -510,6 +582,8 @@ def test_shadow_report_cli_accepts_coverage_gates(tmp_path, capsys):
         "min_rows": 1,
         "required_routes": ["GET /sessions"],
         "min_route_rows": {"GET /sessions": 1},
+        "required_route_patterns": ["GET /client/sessions/*"],
+        "min_route_pattern_rows": {"GET /client/sessions/*": 1},
     }
 
 


### PR DESCRIPTION
## Summary
- add active MVP rehearsal shadow probes for native app mobile read paths: analytics summary, client session detail, and attach descriptor
- add route-pattern coverage gates to `shadow_report` for dynamic paths like `/client/sessions/{id}`
- add `--mobile-sm-app-profile` to the shadow observation planner and document read-only shadow versus mutating mobile rehearsal boundaries

## Validation
- ./venv/bin/python -m pytest tests/unit/test_rust_shadow_report.py tests/unit/test_rust_shadow_observation.py tests/unit/test_rust_migration_contracts.py -q
- ./venv/bin/python -m py_compile scripts/rust_migration/shadow_report.py scripts/rust_migration/shadow_observation.py scripts/rust_migration/mvp_rehearsal.py
- git diff --check
- ./venv/bin/python -m scripts.rust_migration.shadow_observation --config config.yaml --reuse-rust-sidecar --mobile-sm-app-profile --report-last-minutes 60 --report-min-rows 1000 --json --fail-on-blockers
- ./venv/bin/python -m scripts.rust_migration.mvp_rehearsal --python-base-url http://127.0.0.1:8421 --rust-base-url http://127.0.0.1:8421 --reuse-rust-sidecar --skip-python-health --skip-state-gate --skip-smoke --skip-baseline --skip-mutating-contracts --skip-read-only-fixture-contracts --output-dir .local/rust-mvp-rehearsals/mobile-shadow-rust-loopback

Note: a live Python-backed fast rehearsal was not run because local Python on :8420 was refusing connections during this slice; the Rust-loopback rehearsal verifies the shadow path mechanics without live Python state.

Fixes #941