### PR TITLE
Record Cloudflare Access cutover evidence

### DIFF
--- a/scripts/rust_migration/contracts_manifest.json
+++ b/scripts/rust_migration/contracts_manifest.json
@@ -5,7 +5,9 @@
     "specs/762_stage2_artifacts/route_auth_matrix.md",
     "specs/762_stage2_artifacts/external_client_manifest.md",
     "specs/762_stage5_artifacts/cutover_scope.md",
-    "specs/762_stage5_artifacts/gate_matrix.md"
+    "specs/762_stage5_artifacts/gate_matrix.md",
+    "specs/945_cloudflare_access_auth_model.md",
+    "specs/762_stage5_artifacts/cloudflare_access_cutover_evidence.md"
   ],
   "checks": [
     {

--- a/specs/762_stage5_artifacts/cloudflare_access_cutover_evidence.md
+++ b/specs/762_stage5_artifacts/cloudflare_access_cutover_evidence.md
@@ -1,0 +1,87 @@
+# Cloudflare Access Cutover Evidence
+
+Status: implementation evidence after PR #950 merged.
+
+This artifact records the current Rust-side Cloudflare Access boundary for the
+Rust cutover track. It complements the design in
+[`../945_cloudflare_access_auth_model.md`](../945_cloudflare_access_auth_model.md)
+and does not replace the rollout gates in [gate_matrix.md](gate_matrix.md).
+
+## Merged Runtime Boundary
+
+Rust `main` now includes the Cloudflare Access origin gate through PR #950:
+
+| PR | Evidence added |
+| --- | --- |
+| #946 | Design artifact for the SM Cloudflare Access model. |
+| #948 | Rust config parsing and Cloudflare Access JWT/audience/context classification. |
+| #950 | Origin route gates, JWKS caching/refresh, public-host fail-closed behavior, app artifact gating, device-token exchange gating, and mobile device identity binding. |
+
+Current origin behavior:
+
+- Cloudflare Access is disabled by default for existing local configs.
+- If any Cloudflare Access app is enabled, public requests to unknown hosts fail
+  closed instead of falling through to local/session auth.
+- Enabled Access apps with missing host/audience config fail closed as
+  incomplete config.
+- Browser, mobile app, node fallback, and email worker hostnames are classified
+  as separate Access applications.
+- `/client/*`, `/auth/device/google`, `/apps/*`, and `/apk` require the
+  `MobileApp` Access application class before route-specific SM auth.
+- `MobileApp` Access assertions require a verified JWT/audience and an enrolled,
+  enabled, non-revoked device Common Name.
+- Actor-bearing mobile/app routes additionally require that Access device
+  Common Name to be registered under the same mobile user resolved from the SM session or bearer actor.
+- `/client/bootstrap` remains pre-SM-auth and proves only enrolled mobile
+  device identity before returning native bootstrap metadata.
+- Local loopback plus trusted local host still preserves local operator bypass.
+- Non-mobile Access contexts are not accepted for native app routes.
+
+The merged Rust tests currently cover:
+
+```bash
+cargo test -p sm-server cloudflare_access -- --nocapture
+cargo test -p sm-server --test read_only_http \
+  device_google_auth_route_preserves_validation_and_config_errors -- --nocapture
+cargo test -p sm-server
+```
+
+## Required Cloudflare Applications
+
+Use separate Cloudflare Access applications unless an explicit owner-reviewed
+Cloudflare config proves equivalent host/path separation.
+
+| Access application | Hostname | Required policy | Origin expectation |
+| --- | --- | --- | --- |
+| `sm-browser` | `sm.rajeshgo.li` | Interactive Access login allowlisted to the owner email. No bypass policy. | Existing SM Google OAuth/session cookie remains required for operational browser data. |
+| `sm-mobile-app` | `sm-app.rajeshgo.li` | Service Auth or mTLS policy with Common Name include entries for enrolled SM mobile devices. No broad Valid Certificate policy. | Rust verifies Access JWT/audience, enrolled device Common Name, then SM Google/device bearer auth and route capabilities. |
+| `sm-node-fallback` | node fallback hostname | Service Auth or mTLS policy with Common Name include entries for registered SM nodes. No broad Valid Certificate policy. | Rust must verify node Access context plus node credentials/capabilities when node fallback is ported. |
+| `sm-email-worker` | email ingress hostname/path if split out | Worker/service identity or service token, exact route allowlist, no generic app/node/browser access. | Rust/Python still require route-local worker secret, trusted session header handling, authorized sender, and delivery checks. |
+
+Cloudflare tunnel requirements:
+
+- route only exact SM hostnames to loopback/private origin;
+- do not expose wildcard DNS, private-network catchalls, or Access bypass;
+- strip any incoming spoofed `CF-Access-*` / edge assertion headers before
+  injecting trusted headers;
+- deny or 404 unmatched ingress;
+- record each Access application audience in SM config.
+
+## Remaining Cutover Evidence
+
+The Rust origin gate is merged, but public cutover still needs operator-side
+Cloudflare and native-app evidence:
+
+| Evidence | Required before public mobile cutover |
+| --- | --- |
+| Cloudflare policy setup | Prove each Access app exists with the expected hostname, audience, and no bypass/broad-certificate policy. |
+| Mobile device enrollment | Prove an enrolled phone certificate Common Name appears in the `sm-mobile-app` policy and in SM mobile device config. |
+| Revoked-device denial | Prove a removed/revoked device Common Name is denied by Cloudflare or origin and cannot use `/client/*`, `/apps/*`, `/apk`, or `/auth/device/google`. |
+| Native app smoke | Exercise `/client/bootstrap`, `/auth/device/google`, `/client/sessions`, `/client/sessions/{id}`, attach ticket, WebSocket auth, request-status, analytics, bug report, and app artifact metadata/download through the app hostname. |
+| Browser smoke | Exercise browser Access owner email login, SM Google OAuth callback, `/auth/session`, and authenticated/proofed watch diagnostics through the browser hostname. |
+| Node fallback smoke | Once node fallback is ported, prove LAN-first behavior and Cloudflare node certificate fallback for a registered node. |
+| Shadow/rehearsal | Record a clean shadow/rehearsal window that includes native app traffic or an explicit operator-driven mobile route exercise. |
+
+Do not treat the Cloudflare Access design as complete cutover evidence until
+these setup and smoke checks are recorded. The revoked-device denial and native
+app smoke checks are release gates, not optional diagnostics.

--- a/specs/762_stage5_artifacts/index.md
+++ b/specs/762_stage5_artifacts/index.md
@@ -11,8 +11,9 @@ This bundle supports Stage 5 of [762_rust_migration_and_ruggedization.md](../762
 | [state_ownership_and_migration.md](state_ownership_and_migration.md) | Store-by-store ownership, backup, migration, rollback, and downgrade rules. |
 | [gate_matrix.md](gate_matrix.md) | Falsifiable value gate, compatibility/security/ops gates, and observability requirements. |
 | [implementation_workstreams.md](implementation_workstreams.md) | Epic split and sequencing for implementation tickets after this spec converges. |
-| [mvp_progress.md](mvp_progress.md) | Dated implementation snapshot for the Rust MVP track after merged PR #898 and the clean real-state rehearsal. |
+| [mvp_progress.md](mvp_progress.md) | Dated implementation snapshot for the Rust MVP track after merged PR #950 and the clean real-state rehearsal. |
 | [resume_handoff.md](resume_handoff.md) | Current resume point, validation state, known fixtures, and next slices for the Rust port. |
+| [cloudflare_access_cutover_evidence.md](cloudflare_access_cutover_evidence.md) | Current Cloudflare Access origin-gate evidence, required policies, and remaining public/mobile setup checks. |
 
 The owner has approved the cutover scope reductions in [cutover_scope.md](cutover_scope.md). Future breaking changes outside that artifact still require explicit owner approval.
 

--- a/specs/762_stage5_artifacts/mvp_progress.md
+++ b/specs/762_stage5_artifacts/mvp_progress.md
@@ -1,8 +1,10 @@
 # Rust MVP Progress Snapshot
 
-Status: implementation snapshot after PR #942 merged. The last clean full MVP
+Status: implementation snapshot after PR #950 merged. The last clean full MVP
 rehearsal remains the post-#938 run; post-#942 full rehearsal is currently
-blocked by Python-origin availability during baseline/shadow.
+blocked by Python-origin availability during baseline/shadow. PRs #946, #948,
+and #950 added the Rust-side Cloudflare Access origin gate; public cutover still
+needs Cloudflare policy setup and mobile/browser smoke evidence.
 
 This file is a handoff aid for the Rust cutover implementation track. It does
 not change retained or removed scope. Binding scope remains
@@ -62,6 +64,10 @@ not change retained or removed scope. Binding scope remains
 | #938 | MVP rehearsal runs synthetic read-only fixture contracts in a dedicated sidecar |
 | #940 | handoff update after the post-#938 clean rehearsal |
 | #942 | mobile/sm-app routes added to active rehearsal shadow probes and passive shadow coverage gates |
+| #944 | handoff update after the post-#942 mobile shadow evidence |
+| #946 | Cloudflare Access auth model for browser, mobile app, node fallback, and email worker route classes |
+| #948 | Rust Cloudflare Access config parsing and JWT/audience/context classification |
+| #950 | Rust origin route gates for mobile/app surfaces, app artifacts, device-token exchange, JWKS cache behavior, and mobile device actor binding |
 
 ## Implemented Capability Groups
 
@@ -75,6 +81,7 @@ The Rust sidecar now has executable coverage for:
 | Core runtime | Session/tmux/spawn/session-graph/message-queue/task-complete/input-batch/subagent slices are merged, with shadow and contract fixtures covering the early cutover path. |
 | Codex retained reads | Codex event stream, pending request ledger reads, activity actions, review detail/list, and Claude/Codex tool-call projections are implemented and covered by manifest checks. |
 | Mobile | Native bootstrap/session support, attach-ticket proofing, terminal WebSocket auth/bridge, runtime disable, device revoke/list CLI support, and public-edge assertion validation are merged. |
+| Cloudflare Access origin gate | Config parsing, JWT/audience classification, host/app separation, public-host fail-closed behavior, mobile/app route gating, app artifact gating, device-token exchange gating, JWKS cache refresh/TTL behavior, and mobile Access CN actor binding are merged. |
 | External fallback | Email/human fallback delivery and inbound email validation path are retained in the Rust track. |
 | Queue and nodes | Narrow queue list/detail, queue fixture coverage, and registered-node read paths are implemented; retained node and queue writer behavior still needs final cutover verification. |
 
@@ -103,7 +110,8 @@ The latest clean short-window shadow report after #942 used
 
 This passive window did not satisfy the new mobile route/pattern coverage gates
 from PR #942; those gates need real native app traffic or explicit operator
-exercise.
+exercise. It also predates the Cloudflare Access origin-gate implementation from
+PRs #948 and #950, so it is not public-edge cutover evidence.
 
 The fixture-filtered broad live Rust contract run now passes without synthetic
 fixture false failures:
@@ -204,7 +212,7 @@ These are the next practical buckets before an MVP cutover trial:
 | Full fixture manifest execution | The MVP rehearsal now runs the current synthetic read-only and mutating fixture sets. Remaining work is final live mobile/device fixture evidence and any additional retained fixture rows added by later slices. |
 | CLI cutover audit | Verify every retained CLI command in [cutover_scope.md](cutover_scope.md) is native Rust or intentionally routed, and every removed command is absent or explicitly retired. |
 | State ownership and migration tooling | Initial preflight, backup, restore, and freeze/drain evidence tools are merged and exercised by the rehearsal. Remaining work is live write-admission freeze/journal ownership and rollback accounting from [state_ownership_and_migration.md](state_ownership_and_migration.md). |
-| Public-edge deployment integration | Pair the Rust origin gate with the actual edge signer/proxy/device enrollment flow, including revoked-device and node fallback tests. |
+| Cloudflare Access deployment integration | Pair the merged Rust origin gate with the actual Cloudflare Access apps, mTLS/service-auth policies, device Common Name enrollment/revocation, app-host native auth smoke, browser OAuth smoke, and later node fallback tests. Current evidence lives in [cloudflare_access_cutover_evidence.md](cloudflare_access_cutover_evidence.md). |
 | Node and queue writer completion | Finish retained node-control and narrow queue writer fixtures, including audit, policy, recovery, and rollback semantics. |
 | Service packaging and rollback | Exercise launchd/service cutover, non-destructive port ownership, health checks, rollback, and operator diagnostics. |
 | Final native mobile smoke | Run bootstrap/session/attach/request-status/analytics/bug-report/app-artifact smoke checks against Rust using real mobile assumptions. |
@@ -218,5 +226,6 @@ Do not start an MVP cutover until:
 - shadow mode shows no unexplained mismatches on retained core reads for the agreed observation window;
 - final backup happens after write admission is frozen or journaled;
 - public traffic has proof-of-possession before origin plus origin auth/capability checks;
+- Cloudflare Access browser/mobile/node/email route classes are configured with no bypass/broad-certificate policy and verified against Rust origin gates;
 - mobile attach, request-status, bug reports, and app artifacts pass smoke checks;
 - rollback restores or explicitly journals every accepted write after the restore point.

--- a/specs/762_stage5_artifacts/resume_handoff.md
+++ b/specs/762_stage5_artifacts/resume_handoff.md
@@ -1,6 +1,6 @@
 # Rust Port Resume Handoff
 
-Status: handoff snapshot from 2026-06-12 after PR #942 and a blocked
+Status: handoff snapshot from 2026-06-13 after PR #950 and a blocked
 post-mobile-shadow rehearsal.
 
 Use this file to resume the Rust cutover track without reconstructing state from
@@ -12,7 +12,7 @@ coverage in
 ## Current Repository State
 
 - Branch: `main`
-- Latest merged commit: `e8fae11` (`Merge pull request #942`)
+- Latest merged commit: `d8f97c0` (`Merge pull request #950`)
 - Open PRs at handoff: none
 - Dirty worktree at handoff: only pre-existing untracked `.claude/settings.local.json`
   and the local `config.yaml.shadow-backup-20260612T023248Z` created when
@@ -60,7 +60,10 @@ Merged Rust slices cover:
 
 ### Documentation And Manifest
 
-- [mvp_progress.md](mvp_progress.md) records the PR lineage through #942.
+- [mvp_progress.md](mvp_progress.md) records the PR lineage through #950.
+- [cloudflare_access_cutover_evidence.md](cloudflare_access_cutover_evidence.md)
+  records the current Cloudflare Access origin-gate behavior and remaining
+  operator setup/smoke evidence.
 - PR #880 added fixture-gated manifest checks for already-implemented detail
   endpoints:
   - `GET /queue-jobs/{queue_job_id}`
@@ -108,6 +111,14 @@ Merged Rust slices cover:
 - PR #940 refreshed the handoff after the post-#938 clean rehearsal.
 - PR #942 added native mobile/sm-app read paths to rehearsal shadow probes and
   mobile route/pattern gates to the shadow observation planner/report.
+- PR #944 refreshed the handoff after the post-#942 mobile shadow evidence.
+- PR #946 added the Cloudflare Access auth model for browser, mobile app, node
+  fallback, and email worker route classes.
+- PR #948 added Rust Cloudflare Access config parsing and JWT/audience/context
+  classification.
+- PR #950 added Rust origin route gates for native mobile/app routes, app
+  artifacts, `/auth/device/google`, JWKS cache refresh/TTL behavior, public-host
+  fail-closed behavior, and mobile device Common Name actor binding.
 - Current contract manifest size:
   - `117` checks total
   - `68` `python_and_rust`
@@ -263,9 +274,13 @@ needed for final cutover evidence.
      final backup.
    - Prove rollback restores or accounts for every accepted write after the
      restore point.
-5. Complete public-edge deployment integration.
-   - Edge signer/proxy, device enrollment/list/remove, revoked-device denial,
-     and node fallback proof.
+5. Complete Cloudflare Access deployment integration.
+   - Configure the browser, mobile app, node fallback, and email worker Access
+     apps/policies from [cloudflare_access_cutover_evidence.md](cloudflare_access_cutover_evidence.md).
+   - Prove app-host requests require an enrolled mobile device certificate,
+     then SM Google/device bearer auth at origin.
+   - Prove revoked-device denial, browser OAuth callback behavior, and later
+     node fallback proof.
 6. Finish retained node-control and narrow queue writer fixtures.
    - Include audit, policy, recovery, and rollback semantics.
 7. Exercise service packaging and cutover.
@@ -284,6 +299,8 @@ Do not start Rust writer ownership or MVP cutover until:
 - final backup happens after write admission is frozen or journaled;
 - public traffic has proof-of-possession before origin plus origin
   auth/capability checks;
+- Cloudflare Access browser/mobile/node/email route classes are configured with
+  no bypass/broad-certificate policy and verified against Rust origin gates;
 - mobile attach, request-status, bug reports, and app artifacts pass smoke
   checks;
 - rollback restores or explicitly journals every accepted write after the
@@ -291,15 +308,20 @@ Do not start Rust writer ownership or MVP cutover until:
 
 ## Recommended Resume Point
 
-Continue with the shadow observation gate:
+Continue with Cloudflare Access deployment evidence, then return to the shadow
+observation gate:
 
-1. Keep Python-authoritative Rust shadow mode running for retained reads against
+1. Configure or verify the Cloudflare Access apps/policies described in
+   [cloudflare_access_cutover_evidence.md](cloudflare_access_cutover_evidence.md).
+2. Exercise the native app route class through the app hostname so mobile gates
+   collect real traffic and smoke evidence.
+3. Keep Python-authoritative Rust shadow mode running for retained reads against
    the local Rust sidecar.
-2. Let it observe real traffic for the agreed window.
-3. Summarize the shadow ledger by route, comparison class, and unexplained
+4. Let it observe real traffic for the agreed window.
+5. Summarize the shadow ledger by route, comparison class, and unexplained
    mismatch.
-4. Convert any unexplained retained-surface mismatch into a bounded Rust slice.
+6. Convert any unexplained retained-surface mismatch into a bounded Rust slice.
 
-This is the highest-signal next step because the latest rehearsal passed both
-the read-only sidecar contracts and the mutating Rust-core fixture contracts;
-the next risk is sustained live-traffic drift, not single-run rehearsal drift.
+This is the highest-signal next step because the Rust origin gate is now merged,
+but the public edge still needs actual Cloudflare policy and mobile/browser
+smoke evidence before it can count as cutover-ready.

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -49,6 +49,10 @@ from scripts.rust_migration.mvp_rehearsal import (
 )
 
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STAGE5_DIR = REPO_ROOT / "specs" / "762_stage5_artifacts"
+
+
 def test_manifest_preserves_mobile_kill_route_while_retiring_cli_alias():
     manifest = ContractManifest.load()
     checks = {check.id: check for check in manifest.checks}
@@ -194,6 +198,50 @@ def test_manifest_covers_rust_only_mobile_device_cli_surfaces():
     assert remove_device.expected_exit == (0,)
     assert "DEVICE_ID" in remove_device.expected_output_contains_all
     assert "--user-id" in remove_device.expected_output_contains_all
+
+
+def test_manifest_links_cloudflare_access_cutover_evidence():
+    manifest = ContractManifest.load()
+
+    assert "specs/945_cloudflare_access_auth_model.md" in manifest.artifacts
+    assert (
+        "specs/762_stage5_artifacts/cloudflare_access_cutover_evidence.md"
+        in manifest.artifacts
+    )
+
+
+def test_cloudflare_access_cutover_evidence_pins_policy_and_origin_gates():
+    evidence = (STAGE5_DIR / "cloudflare_access_cutover_evidence.md").read_text(
+        encoding="utf-8"
+    )
+    index = (STAGE5_DIR / "index.md").read_text(encoding="utf-8")
+
+    assert "cloudflare_access_cutover_evidence.md" in index
+    for required in [
+        "PR #950",
+        "sm-browser",
+        "sm-mobile-app",
+        "sm-node-fallback",
+        "sm-email-worker",
+        "No broad Valid Certificate policy",
+        "same mobile user resolved from the SM session or bearer actor",
+        "revoked-device denial",
+        "Native app smoke",
+    ]:
+        assert required in evidence
+
+
+def test_handoff_and_progress_are_current_through_cloudflare_access_pr950():
+    progress = (STAGE5_DIR / "mvp_progress.md").read_text(encoding="utf-8")
+    handoff = (STAGE5_DIR / "resume_handoff.md").read_text(encoding="utf-8")
+
+    for text in [progress, handoff]:
+        assert "PR #950" in text
+        assert "Cloudflare Access" in text
+        assert "cloudflare_access_cutover_evidence.md" in text
+
+    assert "Latest merged commit: `d8f97c0`" in handoff
+    assert "records the PR lineage through #950" in handoff
 
 
 def test_manifest_covers_rust_only_retired_http_surfaces():


### PR DESCRIPTION
## Summary
- add Stage 5 Cloudflare Access cutover evidence for the merged #946/#948/#950 origin gate
- refresh Stage 5 handoff/progress/index docs through PR #950
- link the Access evidence from the contract manifest provenance and add tests that pin the policy/origin-gate language

## Validation
- `./venv/bin/python -m json.tool scripts/rust_migration/contracts_manifest.json >/dev/null`
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py -q`
- `git diff --check`

Fixes #951
