### PR TITLE
Implement Rust queue list/status CLI reads

### DIFF
--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -245,14 +245,32 @@ enum QueueCommand {
 
 #[derive(Args)]
 struct QueueRunArgs {
+    #[arg(long = "type", value_parser = ["tests", "perf", "background"], default_value = "tests")]
+    job_type: String,
+    #[arg(long)]
+    label: Option<String>,
+    #[arg(long)]
+    cwd: Option<String>,
+    #[arg(long)]
+    timeout: Option<String>,
+    #[arg(long = "env")]
+    env_pairs: Vec<String>,
     #[arg(long)]
     script_file: Option<String>,
     #[arg(long)]
     notify: Option<String>,
+    #[arg(trailing_var_arg = true)]
+    command: Vec<String>,
 }
 
 #[derive(Args)]
 struct QueueListArgs {
+    #[arg(long)]
+    notify: Option<String>,
+    #[arg(long)]
+    all: bool,
+    #[arg(long = "type", value_parser = ["tests", "perf", "background"])]
+    job_type: Option<String>,
     #[arg(long)]
     state: Option<String>,
     #[arg(long)]
@@ -727,6 +745,7 @@ fn run() -> Result<()> {
         Command::SubagentStart(_) => run_subagent_start(&client)?,
         Command::SubagentStop(_) => run_subagent_stop(&client)?,
         Command::Subagents(args) => print_subagents(&client, &args.session_id)?,
+        Command::Queue(args) => run_queue(&client, args)?,
         _ => bail!("this retained command is not implemented in the Rust core slice yet"),
     }
     Ok(())
@@ -817,6 +836,129 @@ fn run_list_devices(client: &ApiClient, args: ListDevicesArgs) -> Result<()> {
         return Ok(());
     }
     print_mobile_devices(&payload)
+}
+
+fn run_queue(client: &ApiClient, args: QueueArgs) -> Result<()> {
+    match args.command {
+        QueueCommand::List(args) => run_queue_list(client, args),
+        QueueCommand::Status(args) => run_queue_status(client, args),
+        QueueCommand::Run(_) => bail!(
+            "sm queue run is not implemented in the Rust cutover slice yet; use Python sm until queue writer ownership lands"
+        ),
+        QueueCommand::Cancel(_) => bail!(
+            "sm queue cancel is not implemented in the Rust cutover slice yet; use Python sm until queue writer ownership lands"
+        ),
+    }
+}
+
+fn run_queue_list(client: &ApiClient, args: QueueListArgs) -> Result<()> {
+    let mut query = Vec::new();
+    let effective_notify = args
+        .notify
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            if args.all {
+                None
+            } else {
+                optional_current_session_id()
+            }
+        });
+    if !args.all && effective_notify.is_none() {
+        bail!("No session context. Use --notify or --all.");
+    }
+    if let Some(notify) = effective_notify {
+        query.push(format!("notify_target={}", encode_query_component(&notify)));
+    }
+    if let Some(job_type) = args
+        .job_type
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        query.push(format!("type={}", encode_query_component(job_type)));
+    }
+    if let Some(state) = args
+        .state
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        query.push(format!("state={}", encode_query_component(state)));
+    }
+    if args.all || args.state.is_some() {
+        query.push("include_terminal=true".to_owned());
+    }
+    let path = if query.is_empty() {
+        "/queue-jobs".to_owned()
+    } else {
+        format!("/queue-jobs?{}", query.join("&"))
+    };
+    let payload = client.get_json(&path)?;
+    let jobs = payload["jobs"].as_array().cloned().unwrap_or_default();
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&jobs)?);
+        return Ok(());
+    }
+    print_queue_jobs(&jobs);
+    Ok(())
+}
+
+fn run_queue_status(client: &ApiClient, args: QueueStatusArgs) -> Result<()> {
+    let job_id = args.job_id.trim();
+    if job_id.is_empty() {
+        bail!("job id is required");
+    }
+    let payload = client.get_json(&format!("/queue-jobs/{}", encode_path_segment(job_id)))?;
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+        return Ok(());
+    }
+    println!("Job: {}", payload["id"].as_str().unwrap_or(job_id));
+    println!("Type: {}", payload["type"].as_str().unwrap_or("-"));
+    println!("State: {}", payload["state"].as_str().unwrap_or("-"));
+    println!(
+        "Holding: {}",
+        payload["holding_reason"].as_str().unwrap_or("-")
+    );
+    println!(
+        "Exit: {}",
+        payload["exit_code"]
+            .as_i64()
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "-".to_owned())
+    );
+    println!("Log: {}", payload["log_path"].as_str().unwrap_or("-"));
+    Ok(())
+}
+
+fn print_queue_jobs(jobs: &[Value]) {
+    if jobs.is_empty() {
+        println!("No queue jobs.");
+        return;
+    }
+    let headers = ["ID", "Type", "State", "Notify", "Label", "Holding", "Log"];
+    let rows = jobs
+        .iter()
+        .map(|job| {
+            vec![
+                json_string(job, "id"),
+                json_string(job, "type"),
+                json_string(job, "state"),
+                job["notify_name"]
+                    .as_str()
+                    .or_else(|| job["notify_session_id"].as_str())
+                    .unwrap_or("")
+                    .to_owned(),
+                json_string(job, "label"),
+                job["holding_reason"].as_str().unwrap_or("-").to_owned(),
+                job["log_path"].as_str().unwrap_or("-").to_owned(),
+            ]
+        })
+        .collect::<Vec<_>>();
+    print_table(&headers, &rows);
 }
 
 fn run_remove_device(client: &ApiClient, args: RemoveDeviceArgs) -> Result<()> {

--- a/scripts/rust_migration/contracts_manifest.json
+++ b/scripts/rust_migration/contracts_manifest.json
@@ -1008,6 +1008,54 @@
       "source": "specs/762_stage5_artifacts/cutover_scope.md:43"
     },
     {
+      "id": "cli.rust_queue_list_fixture",
+      "surface": "cli",
+      "classification": "retained",
+      "target": "rust_only",
+      "safety": "read_only",
+      "command": ["--api-url", "{base_url}", "queue", "list", "--all"],
+      "expected_exit": [0],
+      "expected_output_contains_all": ["job-fixture", "tests", "pending", "fixture queue job"],
+      "preconditions": ["sm_cli", "fixture:base_url", "fixture:queue_job_id"],
+      "source": "https://github.com/rajeshgoli/session-manager/issues/953"
+    },
+    {
+      "id": "cli.rust_queue_list_json_fixture",
+      "surface": "cli",
+      "classification": "retained",
+      "target": "rust_only",
+      "safety": "read_only",
+      "command": ["--api-url", "{base_url}", "queue", "list", "--all", "--json"],
+      "expected_exit": [0],
+      "expected_output_contains_all": ["job-fixture", "fixture queue job", "\"state\": \"pending\""],
+      "preconditions": ["sm_cli", "fixture:base_url", "fixture:queue_job_id"],
+      "source": "https://github.com/rajeshgoli/session-manager/issues/953"
+    },
+    {
+      "id": "cli.rust_queue_status_fixture",
+      "surface": "cli",
+      "classification": "retained",
+      "target": "rust_only",
+      "safety": "read_only",
+      "command": ["--api-url", "{base_url}", "queue", "status", "{queue_job_id}"],
+      "expected_exit": [0],
+      "expected_output_contains_all": ["Job: {queue_job_id}", "Type: tests", "State: pending"],
+      "preconditions": ["sm_cli", "fixture:base_url", "fixture:queue_job_id"],
+      "source": "https://github.com/rajeshgoli/session-manager/issues/953"
+    },
+    {
+      "id": "cli.rust_queue_status_json_fixture",
+      "surface": "cli",
+      "classification": "retained",
+      "target": "rust_only",
+      "safety": "read_only",
+      "command": ["--api-url", "{base_url}", "queue", "status", "{queue_job_id}", "--json"],
+      "expected_exit": [0],
+      "expected_output_contains_all": ["\"id\": \"{queue_job_id}\"", "\"label\": \"fixture queue job\"", "\"state\": \"pending\""],
+      "preconditions": ["sm_cli", "fixture:base_url", "fixture:queue_job_id"],
+      "source": "https://github.com/rajeshgoli/session-manager/issues/953"
+    },
+    {
       "id": "cli.rust_core_spawn_fixture",
       "surface": "cli",
       "classification": "retained",

--- a/scripts/rust_migration/mvp_rehearsal.py
+++ b/scripts/rust_migration/mvp_rehearsal.py
@@ -104,6 +104,10 @@ READ_ONLY_FIXTURE_CHECK_IDS = (
     "http.app_artifact_metadata",
     "http.queue_jobs_list",
     "http.queue_job_detail",
+    "cli.rust_queue_list_fixture",
+    "cli.rust_queue_list_json_fixture",
+    "cli.rust_queue_status_fixture",
+    "cli.rust_queue_status_json_fixture",
 )
 
 READ_ONLY_FIXTURE_VALUES = {
@@ -872,6 +876,8 @@ def _run_read_only_fixture_contract_group(
                 "artifacts": artifacts,
             }
 
+        fixtures = dict(READ_ONLY_FIXTURE_VALUES)
+        fixtures["base_url"] = fixture_base_url
         step = _run_contract_group(
             manifest,
             name=step_name,
@@ -880,7 +886,7 @@ def _run_read_only_fixture_contract_group(
             sm_binary=args.sm_binary,
             check_ids=set(READ_ONLY_FIXTURE_CHECK_IDS),
             timeout_seconds=args.timeout,
-            fixtures=dict(READ_ONLY_FIXTURE_VALUES),
+            fixtures=fixtures,
             include_mutating=False,
             fail_on_skipped=True,
         )

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -338,15 +338,23 @@ def test_mvp_rehearsal_read_only_fixture_check_ids_are_retained_reads():
         "http.app_artifact_metadata",
         "http.queue_jobs_list",
         "http.queue_job_detail",
+        "cli.rust_queue_list_fixture",
+        "cli.rust_queue_list_json_fixture",
+        "cli.rust_queue_status_fixture",
+        "cli.rust_queue_status_json_fixture",
     }
 
     assert set(READ_ONLY_FIXTURE_CHECK_IDS) == expected
     for check_id in READ_ONLY_FIXTURE_CHECK_IDS:
         check = checks[check_id]
         assert check.classification == "retained"
-        assert check.target == "python_and_rust"
+        if check.surface == "cli":
+            assert check.target == "rust_only"
+        else:
+            assert check.target == "python_and_rust"
         assert check.safety == "read_only"
-        assert check.method == "GET"
+        if check.surface == "http":
+            assert check.method == "GET"
 
 
 def test_mvp_rehearsal_read_only_fixture_values_cover_preconditions():
@@ -360,7 +368,31 @@ def test_mvp_rehearsal_read_only_fixture_values_cover_preconditions():
                 assert READ_ONLY_FIXTURE_VALUES["session_id"] == "fixture001"
             if precondition.startswith("fixture:"):
                 fixture_name = precondition.split(":", 1)[1]
+                if fixture_name == "base_url":
+                    continue
                 assert READ_ONLY_FIXTURE_VALUES[fixture_name]
+
+
+def test_manifest_covers_rust_queue_cli_read_fixtures():
+    manifest = ContractManifest.load()
+    checks = {check.id: check for check in manifest.checks}
+    required_ids = {
+        "cli.rust_queue_list_fixture",
+        "cli.rust_queue_list_json_fixture",
+        "cli.rust_queue_status_fixture",
+        "cli.rust_queue_status_json_fixture",
+    }
+
+    missing = required_ids - set(checks)
+    assert not missing
+    for check_id in required_ids:
+        check = checks[check_id]
+        assert check.classification == "retained"
+        assert check.target == "rust_only"
+        assert check.safety == "read_only"
+        assert check.surface == "cli"
+        assert "fixture:queue_job_id" in check.preconditions
+        assert "fixture:base_url" in check.preconditions
 
 
 def test_mvp_rehearsal_defaults_mutating_sidecar_to_next_port():


### PR DESCRIPTION
## Summary
- implement Rust `sm queue list` and `sm queue status` over the retained queue read endpoints
- add Python-compatible read flags for queue listing: `--notify`, `--all`, `--type`, `--state`, and `--json`
- add fixture-backed Rust CLI contract rows and include them in the synthetic read-only rehearsal group

## Validation
- `cargo fmt --check`
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py -q`
- `cargo build -p sm-server --bin sm`
- `cargo test -p sm-server`
- `./venv/bin/python -m scripts.rust_migration.mvp_rehearsal --output-dir /tmp/session-manager-queue-cli-953 --skip-python-health --skip-state-gate --skip-smoke --skip-baseline --skip-shadow --skip-mutating-contracts --reuse-rust-sidecar --allow-blockers` → 0 blockers; read-only fixture contracts 14/14 passed
- `git diff --check`

Fixes #953
