### PR TITLE
Rust MVP: execute and cancel simple queue jobs

### DIFF
--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -844,9 +844,7 @@ fn run_queue(client: &ApiClient, args: QueueArgs) -> Result<()> {
         QueueCommand::List(args) => run_queue_list(client, args),
         QueueCommand::Status(args) => run_queue_status(client, args),
         QueueCommand::Run(args) => run_queue_run(client, args),
-        QueueCommand::Cancel(_) => bail!(
-            "sm queue cancel is not implemented in the Rust cutover slice yet; use Python sm until queue writer ownership lands"
-        ),
+        QueueCommand::Cancel(args) => run_queue_cancel(client, args),
     }
 }
 
@@ -1009,6 +1007,23 @@ fn run_queue_status(client: &ApiClient, args: QueueStatusArgs) -> Result<()> {
             .unwrap_or_else(|| "-".to_owned())
     );
     println!("Log: {}", payload["log_path"].as_str().unwrap_or("-"));
+    Ok(())
+}
+
+fn run_queue_cancel(client: &ApiClient, args: QueueCancelArgs) -> Result<()> {
+    let job_id = args.job_id.trim();
+    if job_id.is_empty() {
+        bail!("job id is required");
+    }
+    let payload = client.delete_json(
+        &format!("/queue-jobs/{}", encode_path_segment(job_id)),
+        json!({}),
+    )?;
+    println!(
+        "Cancelled queue job: {} ({})",
+        payload["id"].as_str().unwrap_or(job_id),
+        payload["state"].as_str().unwrap_or("-")
+    );
     Ok(())
 }
 
@@ -2409,6 +2424,18 @@ mod tests {
         assert_eq!(parse_duration_seconds("10m").unwrap(), 600);
         assert_eq!(parse_duration_seconds("2h30m").unwrap(), 9000);
         assert_eq!(parse_duration_seconds("1d").unwrap(), 86400);
+    }
+
+    #[test]
+    fn queue_cancel_cli_parses_retained_runtime_command() {
+        let cli = Cli::try_parse_from(["sm", "queue", "cancel", "job_123abc"]).unwrap();
+        let Command::Queue(queue_args) = cli.command else {
+            panic!("expected queue command");
+        };
+        let QueueCommand::Cancel(cancel_args) = queue_args.command else {
+            panic!("expected queue cancel command");
+        };
+        assert_eq!(cancel_args.job_id, "job_123abc");
     }
 
     #[test]

--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -756,6 +756,8 @@ fn default_codex_observability_db_path() -> String {
 pub struct QueueRunnerConfig {
     #[serde(default = "default_queue_runner_state_dir")]
     pub state_dir: String,
+    #[serde(default = "default_queue_runner_cancel_grace_seconds")]
+    pub cancel_grace_seconds: u64,
     #[serde(skip)]
     pub configured: bool,
 }
@@ -764,6 +766,7 @@ impl Default for QueueRunnerConfig {
     fn default() -> Self {
         Self {
             state_dir: default_queue_runner_state_dir(),
+            cancel_grace_seconds: default_queue_runner_cancel_grace_seconds(),
             configured: false,
         }
     }
@@ -771,6 +774,10 @@ impl Default for QueueRunnerConfig {
 
 fn default_queue_runner_state_dir() -> String {
     "~/.local/share/claude-sessions/queue-runner".to_owned()
+}
+
+fn default_queue_runner_cancel_grace_seconds() -> u64 {
+    10
 }
 
 fn queue_runner_config_for_state_file(state_file: &str) -> QueueRunnerConfig {
@@ -781,6 +788,7 @@ fn queue_runner_config_for_state_file(state_file: &str) -> QueueRunnerConfig {
         state_dir: queue_runner_state_dir_for_state_file(state_file)
             .to_string_lossy()
             .into_owned(),
+        cancel_grace_seconds: default_queue_runner_cancel_grace_seconds(),
         configured: false,
     }
 }
@@ -1859,12 +1867,14 @@ cloudflare_access:
             r#"
 queue_runner:
   state_dir: /tmp/custom-queue-runner
+  cancel_grace_seconds: 3
 "#,
         )
         .unwrap();
         let config = AppConfig::from(raw);
 
         assert_eq!(config.queue_runner.state_dir, "/tmp/custom-queue-runner");
+        assert_eq!(config.queue_runner.cancel_grace_seconds, 3);
     }
 
     #[test]
@@ -1882,6 +1892,7 @@ paths:
             config.queue_runner.state_dir,
             "/tmp/sm-fixture/queue-runner"
         );
+        assert_eq!(config.queue_runner.cancel_grace_seconds, 10);
     }
 
     #[test]

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -298,7 +298,10 @@ pub fn router(state: AppState) -> Router {
         .route("/events", get(events_stream))
         .route("/__shadow/http", post(shadow_http))
         .route("/queue-jobs", get(list_queue_jobs).post(create_queue_job))
-        .route("/queue-jobs/{job_id}", get(get_queue_job))
+        .route(
+            "/queue-jobs/{job_id}",
+            get(get_queue_job).delete(cancel_queue_job),
+        )
         .route("/codex-review-requests", get(list_codex_review_requests))
         .route(
             "/codex-review-requests/{request_id}",
@@ -1984,6 +1987,46 @@ async fn create_queue_job(
             timeout_seconds,
         },
     )?;
+    let job = if state.config.rust_core.runtime_enabled {
+        let message_queue_db_path = expand_home(&state.config.sm_send.db_path);
+        RetainedQueueStore::start_queue_job_in_state_dir(
+            &queue_state_dir,
+            &message_queue_db_path,
+            &job.id,
+            state.config.queue_runner.cancel_grace_seconds,
+        )?
+        .unwrap_or(job)
+    } else {
+        job
+    };
+    Ok(Json(queue_job_response(&state, job)?))
+}
+
+async fn cancel_queue_job(
+    State(state): State<Arc<AppState>>,
+    Path(job_id): Path<String>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_allowed_from_parts(
+        &state.config,
+        &headers,
+        Some(peer_addr),
+        &format!("/queue-jobs/{job_id}"),
+    )?;
+    ensure_core_writes_enabled(&state)?;
+    let queue_state_dir_config = state.config.queue_runner_state_dir();
+    let queue_state_dir = expand_home(&queue_state_dir_config.to_string_lossy());
+    let message_queue_db_path = expand_home(&state.config.sm_send.db_path);
+    let Some(job) = RetainedQueueStore::cancel_queue_job_in_state_dir(
+        &queue_state_dir,
+        &message_queue_db_path,
+        &job_id,
+        state.config.queue_runner.cancel_grace_seconds,
+    )?
+    else {
+        return Err(ApiError::NotFound("Queue job not found"));
+    };
     Ok(Json(queue_job_response(&state, job)?))
 }
 

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -1,6 +1,13 @@
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 use std::{
     collections::BTreeMap,
+    fs::{self, OpenOptions},
+    io::{Read, Seek, SeekFrom},
     path::{Path, PathBuf},
+    process::{Child, Command, Stdio},
+    thread,
+    time::{Duration as StdDuration, Instant},
 };
 
 use anyhow::{Context, Result};
@@ -85,6 +92,23 @@ pub struct QueueJobRecord {
     pub process_group_id: Option<i64>,
     pub exit_code: Option<i64>,
     pub log_path: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct QueueJobRuntimeRecord {
+    id: String,
+    state: String,
+    notify_session_id: Option<String>,
+    queued_at: String,
+    started_at: Option<String>,
+    holding_reason: Option<String>,
+    wrapper_path: Option<String>,
+    log_path: Option<String>,
+    exit_code_path: Option<String>,
+    timeout_seconds: i64,
+    pid: Option<i64>,
+    process_group_id: Option<i64>,
+    completion_notified_at: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -249,6 +273,90 @@ impl RetainedQueueStore {
         conn.pragma_update(None, "busy_timeout", 5000)?;
         init_queue_jobs_schema(&conn)?;
         create_queue_job_conn(&conn, state_dir, request)
+    }
+
+    pub fn start_queue_job_in_state_dir(
+        state_dir: &Path,
+        message_queue_db_path: &Path,
+        job_id: &str,
+        cancel_grace_seconds: u64,
+    ) -> Result<Option<QueueJobRecord>> {
+        let db_path = state_dir.join("queue_runner.db");
+        let conn = open_queue_jobs_connection(&db_path)?;
+        init_queue_jobs_schema(&conn)?;
+        let Some(job) = get_queue_job_runtime_conn(&conn, job_id)? else {
+            return Ok(None);
+        };
+        if job.state != "pending" {
+            return get_queue_job_conn(&conn, job_id);
+        }
+        let child = match spawn_queue_job_process(&job) {
+            Ok(child) => child,
+            Err(error) => {
+                finish_queue_job_conn(&conn, &job, "failed", None, Some(message_queue_db_path))?;
+                return Err(error);
+            }
+        };
+        let pid = i64::from(child.id());
+        conn.execute(
+            r#"
+            UPDATE queue_jobs
+            SET state = 'running',
+                holding_reason = NULL,
+                started_at = ?2,
+                pid = ?3,
+                process_group_id = ?3
+            WHERE id = ?1 AND state = 'pending'
+            "#,
+            params![job_id, now_rfc3339(), pid],
+        )?;
+        let monitor_state_dir = state_dir.to_path_buf();
+        let monitor_message_queue_db_path = message_queue_db_path.to_path_buf();
+        let monitor_job_id = job_id.to_owned();
+        let timeout_seconds = job.timeout_seconds.max(1) as u64;
+        thread::spawn(move || {
+            monitor_queue_job_completion(
+                monitor_state_dir,
+                monitor_message_queue_db_path,
+                monitor_job_id,
+                child,
+                timeout_seconds,
+                cancel_grace_seconds,
+            );
+        });
+        get_queue_job_conn(&conn, job_id)
+    }
+
+    pub fn cancel_queue_job_in_state_dir(
+        state_dir: &Path,
+        message_queue_db_path: &Path,
+        job_id: &str,
+        cancel_grace_seconds: u64,
+    ) -> Result<Option<QueueJobRecord>> {
+        let db_path = state_dir.join("queue_runner.db");
+        let conn = open_queue_jobs_connection(&db_path)?;
+        init_queue_jobs_schema(&conn)?;
+        let Some(job) = get_queue_job_runtime_conn(&conn, job_id)? else {
+            return Ok(None);
+        };
+        if is_terminal_queue_state(&job.state) {
+            return get_queue_job_conn(&conn, job_id);
+        }
+        if job.state == "running" {
+            mark_queue_job_cancelling_conn(&conn, job_id)?;
+            if let Some(pgid) = job.process_group_id.or(job.pid) {
+                terminate_process_group_with_grace(pgid, cancel_grace_seconds);
+            }
+        }
+        let exit_code = read_exit_code(job.exit_code_path.as_deref());
+        finish_queue_job_conn(
+            &conn,
+            &job,
+            "cancelled",
+            exit_code,
+            Some(message_queue_db_path),
+        )?;
+        get_queue_job_conn(&conn, job_id)
     }
 
     pub fn ensure_schema(&self) -> Result<()> {
@@ -1115,6 +1223,444 @@ fn shell_quote(value: &str) -> String {
         return "''".to_owned();
     }
     format!("'{}'", value.replace('\'', "'\"'\"'"))
+}
+
+fn open_queue_jobs_connection(db_path: &Path) -> Result<Connection> {
+    if let Some(parent) = db_path.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "failed to create queue runner db directory {}",
+                parent.display()
+            )
+        })?;
+    }
+    let conn = Connection::open(db_path)
+        .with_context(|| format!("failed to open queue runner db {}", db_path.display()))?;
+    conn.pragma_update(None, "journal_mode", "WAL")?;
+    conn.pragma_update(None, "busy_timeout", 5000)?;
+    Ok(conn)
+}
+
+fn get_queue_job_runtime_conn(
+    conn: &Connection,
+    job_id: &str,
+) -> Result<Option<QueueJobRuntimeRecord>> {
+    let mut statement = match conn.prepare(
+        r#"
+        SELECT id, state, notify_session_id, queued_at, started_at, holding_reason, wrapper_path,
+               log_path, exit_code_path, timeout_seconds, pid, process_group_id,
+               completion_notified_at
+        FROM queue_jobs
+        WHERE id = ?1
+        LIMIT 1
+        "#,
+    ) {
+        Ok(statement) => statement,
+        Err(rusqlite::Error::SqliteFailure(_, Some(message)))
+            if message.contains("no such table") =>
+        {
+            return Ok(None);
+        }
+        Err(error) => return Err(error.into()),
+    };
+    statement
+        .query_row(params![job_id], |row| {
+            Ok(QueueJobRuntimeRecord {
+                id: row.get(0)?,
+                state: row.get(1)?,
+                notify_session_id: row.get(2)?,
+                queued_at: row.get(3)?,
+                started_at: row.get(4)?,
+                holding_reason: row.get(5)?,
+                wrapper_path: row.get(6)?,
+                log_path: row.get(7)?,
+                exit_code_path: row.get(8)?,
+                timeout_seconds: row.get(9)?,
+                pid: row.get(10)?,
+                process_group_id: row.get(11)?,
+                completion_notified_at: row.get(12)?,
+            })
+        })
+        .optional()
+        .map_err(Into::into)
+}
+
+fn spawn_queue_job_process(job: &QueueJobRuntimeRecord) -> Result<Child> {
+    let wrapper_path = job
+        .wrapper_path
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .context("queue job has no wrapper path")?;
+    let log_path = job
+        .log_path
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .context("queue job has no log path")?;
+    if let Some(parent) = Path::new(log_path).parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create queue log dir {}", parent.display()))?;
+    }
+    let log = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)
+        .with_context(|| format!("failed to open queue job log {log_path}"))?;
+    let stderr = log
+        .try_clone()
+        .with_context(|| format!("failed to clone queue job log {log_path}"))?;
+    let mut command = Command::new("/bin/zsh");
+    command
+        .arg(wrapper_path)
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(log))
+        .stderr(Stdio::from(stderr))
+        .env_clear()
+        .env("PATH", "/usr/bin:/bin:/usr/sbin:/sbin");
+    #[cfg(unix)]
+    {
+        command.process_group(0);
+    }
+    command
+        .spawn()
+        .with_context(|| format!("failed to start queue job {}", job.id))
+}
+
+fn monitor_queue_job_completion(
+    state_dir: PathBuf,
+    message_queue_db_path: PathBuf,
+    job_id: String,
+    mut child: Child,
+    timeout_seconds: u64,
+    cancel_grace_seconds: u64,
+) {
+    let started = Instant::now();
+    let timeout = StdDuration::from_secs(timeout_seconds.max(1));
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let exit_code = status.code().map(i64::from);
+                let state = if exit_code == Some(0) {
+                    "succeeded"
+                } else {
+                    "failed"
+                };
+                let _ = finish_queue_job_in_state_dir_if_running(
+                    &state_dir,
+                    &message_queue_db_path,
+                    &job_id,
+                    state,
+                    exit_code,
+                );
+                return;
+            }
+            Ok(None) if queue_job_is_cancelled_in_state_dir(&state_dir, &job_id) => {
+                let pgid = i64::from(child.id());
+                terminate_process_group(pgid, false);
+                let grace_deadline = Instant::now() + StdDuration::from_secs(cancel_grace_seconds);
+                loop {
+                    match child.try_wait() {
+                        Ok(Some(_status)) => break,
+                        Ok(None) if Instant::now() >= grace_deadline => {
+                            terminate_process_group(pgid, true);
+                            let _ = child.wait();
+                            break;
+                        }
+                        Ok(None) => thread::sleep(StdDuration::from_millis(100)),
+                        Err(_) => break,
+                    }
+                }
+                return;
+            }
+            Ok(None) if started.elapsed() >= timeout => {
+                let pgid = i64::from(child.id());
+                terminate_process_group(pgid, false);
+                let grace_deadline = Instant::now() + StdDuration::from_secs(cancel_grace_seconds);
+                loop {
+                    match child.try_wait() {
+                        Ok(Some(_status)) => break,
+                        Ok(None) if Instant::now() >= grace_deadline => {
+                            terminate_process_group(pgid, true);
+                            let _ = child.wait();
+                            break;
+                        }
+                        Ok(None) => thread::sleep(StdDuration::from_millis(100)),
+                        Err(_) => break,
+                    }
+                }
+                let exit_code = read_queue_job_exit_code_from_state_dir(&state_dir, &job_id);
+                let _ = finish_queue_job_in_state_dir_if_running(
+                    &state_dir,
+                    &message_queue_db_path,
+                    &job_id,
+                    "timed_out",
+                    exit_code,
+                );
+                return;
+            }
+            Ok(None) => thread::sleep(StdDuration::from_millis(100)),
+            Err(_) => {
+                let _ = finish_queue_job_in_state_dir_if_running(
+                    &state_dir,
+                    &message_queue_db_path,
+                    &job_id,
+                    "failed",
+                    None,
+                );
+                return;
+            }
+        }
+    }
+}
+
+fn queue_job_is_cancelled_in_state_dir(state_dir: &Path, job_id: &str) -> bool {
+    let db_path = state_dir.join("queue_runner.db");
+    let Ok(conn) = open_queue_jobs_connection(&db_path) else {
+        return false;
+    };
+    let Ok(Some(job)) = get_queue_job_runtime_conn(&conn, job_id) else {
+        return false;
+    };
+    job.state == "cancelled"
+}
+
+fn mark_queue_job_cancelling_conn(conn: &Connection, job_id: &str) -> Result<()> {
+    conn.execute(
+        r#"
+        UPDATE queue_jobs
+        SET holding_reason = 'cancelling'
+        WHERE id = ?1 AND state = 'running'
+        "#,
+        params![job_id],
+    )?;
+    Ok(())
+}
+
+fn finish_queue_job_in_state_dir_if_running(
+    state_dir: &Path,
+    message_queue_db_path: &Path,
+    job_id: &str,
+    state: &str,
+    exit_code: Option<i64>,
+) -> Result<()> {
+    let db_path = state_dir.join("queue_runner.db");
+    let conn = open_queue_jobs_connection(&db_path)?;
+    init_queue_jobs_schema(&conn)?;
+    let Some(job) = get_queue_job_runtime_conn(&conn, job_id)? else {
+        return Ok(());
+    };
+    if job.state != "running" {
+        return Ok(());
+    }
+    let final_state = if job.holding_reason.as_deref() == Some("cancelling") {
+        "cancelled"
+    } else {
+        state
+    };
+    finish_queue_job_conn(
+        &conn,
+        &job,
+        final_state,
+        exit_code,
+        Some(message_queue_db_path),
+    )?;
+    Ok(())
+}
+
+fn finish_queue_job_conn(
+    conn: &Connection,
+    job: &QueueJobRuntimeRecord,
+    state: &str,
+    exit_code: Option<i64>,
+    message_queue_db_path: Option<&Path>,
+) -> Result<()> {
+    let finished_at = now_rfc3339();
+    let changed = conn.execute(
+        r#"
+        UPDATE queue_jobs
+        SET state = ?2,
+            holding_reason = NULL,
+            finished_at = ?3,
+            exit_code = ?4
+        WHERE id = ?1 AND state NOT IN ('succeeded', 'failed', 'timed_out', 'cancelled', 'displaced')
+        "#,
+        params![job.id, state, finished_at, exit_code],
+    )?;
+    if changed == 0 {
+        return Ok(());
+    }
+    if let Some(completion_notified_at) =
+        queue_job_completion_notified_at(job, state, exit_code, &finished_at, message_queue_db_path)
+    {
+        conn.execute(
+            r#"
+            UPDATE queue_jobs
+            SET completion_notified_at = COALESCE(completion_notified_at, ?2)
+            WHERE id = ?1
+            "#,
+            params![job.id, completion_notified_at],
+        )?;
+    }
+    Ok(())
+}
+
+fn queue_job_completion_notified_at(
+    job: &QueueJobRuntimeRecord,
+    state: &str,
+    exit_code: Option<i64>,
+    finished_at: &str,
+    message_queue_db_path: Option<&Path>,
+) -> Option<String> {
+    if job.completion_notified_at.is_some() {
+        return None;
+    }
+    let Some(target_session_id) = job
+        .notify_session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Some(now_rfc3339());
+    };
+    let Some(message_queue_db_path) = message_queue_db_path else {
+        return None;
+    };
+    let text = queue_job_completion_text(job, state, exit_code, finished_at);
+    let queue = RetainedQueueStore::new(message_queue_db_path.to_path_buf());
+    match queue.enqueue_message(target_session_id, &text, "sequential", None) {
+        Ok(_) => Some(now_rfc3339()),
+        Err(_) => None,
+    }
+}
+
+fn queue_job_completion_text(
+    job: &QueueJobRuntimeRecord,
+    state: &str,
+    exit_code: Option<i64>,
+    finished_at: &str,
+) -> String {
+    let runtime = queue_duration_text(job.started_at.as_deref(), Some(finished_at));
+    let queue_end = job.started_at.as_deref().unwrap_or(finished_at);
+    let queued = queue_duration_text(Some(&job.queued_at), Some(queue_end));
+    let exit_text = exit_code
+        .map(|code| format!(" exit={code}"))
+        .unwrap_or_default();
+    let mut text = format!(
+        "[sm queue] {} completed: {}{} runtime={} queue={}. Log: {}",
+        job.id,
+        state,
+        exit_text,
+        runtime,
+        queued,
+        job.log_path.as_deref().unwrap_or("-")
+    );
+    let stderr_tail = tail_queue_job_log(job.log_path.as_deref(), 8192);
+    if !stderr_tail.is_empty() {
+        text.push_str("\nlog tail:\n");
+        text.push_str(&stderr_tail);
+    }
+    text
+}
+
+fn queue_duration_text(start: Option<&str>, end: Option<&str>) -> String {
+    let Some(start) = start.and_then(parse_queue_datetime) else {
+        return "-".to_owned();
+    };
+    let Some(end) = end.and_then(parse_queue_datetime) else {
+        return "-".to_owned();
+    };
+    format!("{}s", (end - start).whole_seconds().max(0))
+}
+
+fn parse_queue_datetime(value: &str) -> Option<OffsetDateTime> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    OffsetDateTime::parse(value, &Rfc3339)
+        .ok()
+        .or_else(|| parse_python_naive_datetime(value).map(PrimitiveDateTime::assume_utc))
+}
+
+fn tail_queue_job_log(path: Option<&str>, max_bytes: usize) -> String {
+    let Some(path) = path else {
+        return String::new();
+    };
+    let Ok(mut file) = fs::File::open(path) else {
+        return String::new();
+    };
+    let Ok(metadata) = file.metadata() else {
+        return String::new();
+    };
+    let start = metadata.len().saturating_sub(max_bytes as u64);
+    if file.seek(SeekFrom::Start(start)).is_err() {
+        return String::new();
+    }
+    let mut bytes = Vec::new();
+    if file.read_to_end(&mut bytes).is_err() {
+        return String::new();
+    }
+    String::from_utf8_lossy(&bytes).trim().to_owned()
+}
+
+fn read_queue_job_exit_code_from_state_dir(state_dir: &Path, job_id: &str) -> Option<i64> {
+    let db_path = state_dir.join("queue_runner.db");
+    let conn = open_queue_jobs_connection(&db_path).ok()?;
+    init_queue_jobs_schema(&conn).ok()?;
+    let exit_code_path = get_queue_job_runtime_conn(&conn, job_id)
+        .ok()
+        .flatten()
+        .and_then(|job| job.exit_code_path)?;
+    read_exit_code(Some(&exit_code_path))
+}
+
+fn read_exit_code(path: Option<&str>) -> Option<i64> {
+    let path = path?;
+    fs::read_to_string(path).ok()?.trim().parse::<i64>().ok()
+}
+
+fn terminate_process_group(pgid: i64, force: bool) {
+    if pgid <= 0 {
+        return;
+    }
+    let signal = if force { "-KILL" } else { "-TERM" };
+    let _ = Command::new("/bin/kill")
+        .arg(signal)
+        .arg(format!("-{pgid}"))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+}
+
+fn terminate_process_group_with_grace(pgid: i64, grace_seconds: u64) {
+    terminate_process_group(pgid, false);
+    let deadline = Instant::now() + StdDuration::from_secs(grace_seconds);
+    while process_group_exists(pgid) {
+        if Instant::now() >= deadline {
+            terminate_process_group(pgid, true);
+            return;
+        }
+        thread::sleep(StdDuration::from_millis(100));
+    }
+}
+
+fn process_group_exists(pgid: i64) -> bool {
+    if pgid <= 0 {
+        return false;
+    }
+    Command::new("/bin/kill")
+        .arg("-0")
+        .arg(format!("-{pgid}"))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+fn is_terminal_queue_state(state: &str) -> bool {
+    matches!(
+        state,
+        "succeeded" | "failed" | "timed_out" | "cancelled" | "displaced"
+    )
 }
 
 fn list_codex_review_requests_conn(

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -29,6 +29,8 @@ use sm_server::{
 use std::os::unix::fs::PermissionsExt;
 #[cfg(unix)]
 use std::os::unix::net::UnixListener;
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 use std::{
     fs,
     io::{BufRead, BufReader, Read, Write},
@@ -104,6 +106,45 @@ async fn delete_json(app: axum::Router, uri: &str, payload: Value) -> (StatusCod
         Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
     )
     .await
+}
+
+async fn wait_for_queue_job_state(app: axum::Router, job_id: &str, states: &[&str]) -> Value {
+    for _ in 0..80 {
+        let (status, payload) = get_json(app.clone(), &format!("/queue-jobs/{job_id}")).await;
+        assert_eq!(status, StatusCode::OK);
+        if payload["state"]
+            .as_str()
+            .is_some_and(|state| states.contains(&state))
+        {
+            return payload;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    panic!("queue job {job_id} did not reach one of {states:?}");
+}
+
+fn queued_message_texts(db_path: &PathBuf, target_session_id: &str) -> Vec<String> {
+    let conn = Connection::open(db_path).unwrap();
+    let mut statement = conn
+        .prepare(
+            "SELECT text FROM message_queue WHERE target_session_id = ?1 ORDER BY queued_at, id",
+        )
+        .unwrap();
+    statement
+        .query_map([target_session_id], |row| row.get::<_, String>(0))
+        .unwrap()
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+}
+
+fn queue_job_completion_notified_at(queue_state_dir: &PathBuf, job_id: &str) -> Option<String> {
+    let conn = Connection::open(queue_state_dir.join("queue_runner.db")).unwrap();
+    conn.query_row(
+        "SELECT completion_notified_at FROM queue_jobs WHERE id = ?1",
+        [job_id],
+        |row| row.get::<_, Option<String>>(0),
+    )
+    .unwrap()
 }
 
 async fn json_request_with_headers_and_peer(
@@ -1604,6 +1645,7 @@ async fn queue_jobs_missing_db_returns_empty_jobs() {
         },
         queue_runner: QueueRunnerConfig {
             state_dir: queue_state_dir.display().to_string(),
+            cancel_grace_seconds: 0,
             configured: true,
         },
         ..AppConfig::default()
@@ -1620,6 +1662,7 @@ async fn queue_jobs_missing_db_returns_empty_jobs() {
         },
         queue_runner: QueueRunnerConfig {
             state_dir: queue_state_dir.display().to_string(),
+            cancel_grace_seconds: 0,
             configured: true,
         },
         ..AppConfig::default()
@@ -1692,6 +1735,7 @@ async fn queue_jobs_lists_rows_with_filters_and_session_names() {
         },
         queue_runner: QueueRunnerConfig {
             state_dir: queue_state_dir.display().to_string(),
+            cancel_grace_seconds: 0,
             configured: true,
         },
         ..AppConfig::default()
@@ -1836,6 +1880,7 @@ async fn queue_jobs_unknown_notify_target_returns_404() {
         },
         queue_runner: QueueRunnerConfig {
             state_dir: queue_state_dir.display().to_string(),
+            cancel_grace_seconds: 0,
             configured: true,
         },
         ..AppConfig::default()
@@ -1886,6 +1931,7 @@ async fn queue_job_create_is_disabled_by_default() {
         },
         queue_runner: QueueRunnerConfig {
             state_dir: queue_state_dir.display().to_string(),
+            cancel_grace_seconds: 0,
             configured: true,
         },
         ..AppConfig::default()
@@ -1921,6 +1967,7 @@ async fn queue_job_create_persists_pending_job_and_files() {
         },
         queue_runner: QueueRunnerConfig {
             state_dir: queue_state_dir.display().to_string(),
+            cancel_grace_seconds: 0,
             configured: true,
         },
         ..AppConfig::default()
@@ -2023,6 +2070,7 @@ async fn queue_job_create_validates_request_shape() {
         },
         queue_runner: QueueRunnerConfig {
             state_dir: queue_state_dir.display().to_string(),
+            cancel_grace_seconds: 0,
             configured: true,
         },
         ..AppConfig::default()
@@ -2094,6 +2142,360 @@ async fn queue_job_create_validates_request_shape() {
         .as_str()
         .unwrap()
         .starts_with("cwd does not exist or is not a directory:"));
+}
+
+#[tokio::test]
+async fn queue_job_create_runs_when_runtime_enabled() {
+    let state_file = write_session_fixture();
+    let queue_state_dir = state_file.with_extension("queue-runner-runtime");
+    let message_queue_db = state_file.with_extension("queue-runtime-message-queue.db");
+    let working_dir = unique_temp_path().with_extension("queue-cwd");
+    fs::create_dir_all(&working_dir).unwrap();
+    let mut config = AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        queue_runner: QueueRunnerConfig {
+            state_dir: queue_state_dir.display().to_string(),
+            cancel_grace_seconds: 0,
+            configured: true,
+        },
+        sm_send: SmSendConfig {
+            db_path: message_queue_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    };
+    config.rust_core.runtime_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/queue-jobs",
+        json!({
+            "type": "tests",
+            "label": "runtime queue",
+            "argv": ["/bin/zsh", "-lc", "printf queue-runtime-ok"],
+            "cwd": working_dir.display().to_string(),
+            "notify_target": "run12345",
+            "requester_session_id": "run12345",
+            "timeout_seconds": 5
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let job_id = payload["id"].as_str().unwrap().to_owned();
+    assert!(matches!(
+        payload["state"].as_str(),
+        Some("running" | "succeeded")
+    ));
+    let final_payload = wait_for_queue_job_state(app, &job_id, &["succeeded"]).await;
+    assert_eq!(final_payload["exit_code"], 0);
+    assert!(final_payload["started_at"].as_str().is_some());
+    assert!(final_payload["finished_at"].as_str().is_some());
+    assert!(final_payload["pid"].as_i64().unwrap_or_default() > 0);
+    assert_eq!(
+        fs::read_to_string(queue_state_dir.join(format!("logs/{job_id}.log"))).unwrap(),
+        "queue-runtime-ok"
+    );
+    assert!(queue_job_completion_notified_at(&queue_state_dir, &job_id).is_some());
+    let notifications = queued_message_texts(&message_queue_db, "run12345");
+    assert_eq!(notifications.len(), 1);
+    assert!(notifications[0].contains(&format!("[sm queue] {job_id} completed: succeeded")));
+    assert!(notifications[0].contains(" exit=0 "));
+    assert!(notifications[0].contains("log tail:\nqueue-runtime-ok"));
+}
+
+#[tokio::test]
+async fn queue_job_runtime_persists_failure_and_timeout() {
+    let state_file = write_session_fixture();
+    let queue_state_dir = state_file.with_extension("queue-runner-terminal");
+    let message_queue_db = state_file.with_extension("queue-terminal-message-queue.db");
+    let working_dir = unique_temp_path().with_extension("queue-cwd");
+    fs::create_dir_all(&working_dir).unwrap();
+    let mut config = AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        queue_runner: QueueRunnerConfig {
+            state_dir: queue_state_dir.display().to_string(),
+            cancel_grace_seconds: 0,
+            configured: true,
+        },
+        sm_send: SmSendConfig {
+            db_path: message_queue_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    };
+    config.rust_core.runtime_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, failed) = post_json(
+        app.clone(),
+        "/queue-jobs",
+        json!({
+            "type": "tests",
+            "label": "runtime failure",
+            "argv": ["/bin/zsh", "-lc", "printf failed-output; exit 7"],
+            "cwd": working_dir.display().to_string(),
+            "notify_target": "run12345",
+            "requester_session_id": "run12345",
+            "timeout_seconds": 5
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let failed_id = failed["id"].as_str().unwrap().to_owned();
+    let failed_final = wait_for_queue_job_state(app.clone(), &failed_id, &["failed"]).await;
+    assert_eq!(failed_final["exit_code"], 7);
+    assert!(failed_final["finished_at"].as_str().is_some());
+    assert_eq!(
+        fs::read_to_string(queue_state_dir.join(format!("logs/{failed_id}.log"))).unwrap(),
+        "failed-output"
+    );
+    assert!(queue_job_completion_notified_at(&queue_state_dir, &failed_id).is_some());
+
+    let (status, timed_out) = post_json(
+        app.clone(),
+        "/queue-jobs",
+        json!({
+            "type": "tests",
+            "label": "runtime timeout",
+            "script": "printf 'before-timeout\\n'; sleep 5; printf 'after-timeout\\n'",
+            "cwd": working_dir.display().to_string(),
+            "notify_target": "run12345",
+            "requester_session_id": "run12345",
+            "timeout_seconds": 1
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let timeout_id = timed_out["id"].as_str().unwrap().to_owned();
+    let timeout_final = wait_for_queue_job_state(app.clone(), &timeout_id, &["timed_out"]).await;
+    assert!(timeout_final["finished_at"].as_str().is_some());
+    let log = fs::read_to_string(queue_state_dir.join(format!("logs/{timeout_id}.log"))).unwrap();
+    assert!(log.contains("before-timeout"));
+    assert!(!log.contains("after-timeout"));
+    assert!(queue_job_completion_notified_at(&queue_state_dir, &timeout_id).is_some());
+    let notifications = queued_message_texts(&message_queue_db, "run12345");
+    assert_eq!(notifications.len(), 2);
+    assert!(notifications[0].contains(&format!("[sm queue] {failed_id} completed: failed")));
+    assert!(notifications[0].contains(" exit=7 "));
+    assert!(notifications[1].contains(&format!("[sm queue] {timeout_id} completed: timed_out")));
+}
+
+#[tokio::test]
+async fn queue_job_cancel_persists_pending_cancel() {
+    let state_file = write_session_fixture();
+    let queue_state_dir = state_file.with_extension("queue-runner-cancel");
+    let message_queue_db = state_file.with_extension("queue-cancel-message-queue.db");
+    let working_dir = unique_temp_path().with_extension("queue-cwd");
+    fs::create_dir_all(&working_dir).unwrap();
+    let mut config = AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        queue_runner: QueueRunnerConfig {
+            state_dir: queue_state_dir.display().to_string(),
+            cancel_grace_seconds: 0,
+            configured: true,
+        },
+        sm_send: SmSendConfig {
+            db_path: message_queue_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    };
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/queue-jobs",
+        json!({
+            "type": "tests",
+            "label": "cancel queue",
+            "argv": ["echo", "cancel"],
+            "cwd": working_dir.display().to_string(),
+            "notify_target": "run12345",
+            "requester_session_id": "run12345",
+            "timeout_seconds": 5
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["state"], "pending");
+    let job_id = payload["id"].as_str().unwrap();
+
+    let (status, cancelled) =
+        delete_json(app.clone(), &format!("/queue-jobs/{job_id}"), json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(cancelled["id"], job_id);
+    assert_eq!(cancelled["state"], "cancelled");
+    assert!(cancelled["finished_at"].as_str().is_some());
+
+    let (status, detail) = get_json(app, &format!("/queue-jobs/{job_id}")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(detail["state"], "cancelled");
+    assert!(queue_job_completion_notified_at(&queue_state_dir, job_id).is_some());
+    let notifications = queued_message_texts(&message_queue_db, "run12345");
+    assert_eq!(notifications.len(), 1);
+    assert!(notifications[0].contains(&format!("[sm queue] {job_id} completed: cancelled")));
+}
+
+#[tokio::test]
+async fn queue_job_cancel_terminates_running_job() {
+    let state_file = write_session_fixture();
+    let queue_state_dir = state_file.with_extension("queue-runner-cancel-running");
+    let message_queue_db = state_file.with_extension("queue-cancel-running-message-queue.db");
+    let working_dir = unique_temp_path().with_extension("queue-cwd");
+    fs::create_dir_all(&working_dir).unwrap();
+    let mut config = AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        queue_runner: QueueRunnerConfig {
+            state_dir: queue_state_dir.display().to_string(),
+            cancel_grace_seconds: 0,
+            configured: true,
+        },
+        sm_send: SmSendConfig {
+            db_path: message_queue_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    };
+    config.rust_core.runtime_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/queue-jobs",
+        json!({
+            "type": "tests",
+            "label": "cancel running queue",
+            "script": "printf 'before-cancel\\n'; sleep 5; printf 'after-cancel\\n'",
+            "cwd": working_dir.display().to_string(),
+            "notify_target": "run12345",
+            "requester_session_id": "run12345",
+            "timeout_seconds": 20
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let job_id = payload["id"].as_str().unwrap().to_owned();
+    let running = wait_for_queue_job_state(app.clone(), &job_id, &["running"]).await;
+    assert!(running["pid"].as_i64().unwrap_or_default() > 0);
+    let log_path = queue_state_dir.join(format!("logs/{job_id}.log"));
+    let log = wait_for_file_contains(&log_path, "before-cancel").await;
+    assert!(!log.contains("after-cancel"));
+
+    let (status, cancelled) =
+        delete_json(app.clone(), &format!("/queue-jobs/{job_id}"), json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(cancelled["state"], "cancelled");
+    tokio::time::sleep(Duration::from_millis(300)).await;
+    let (status, detail) = get_json(app, &format!("/queue-jobs/{job_id}")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(detail["state"], "cancelled");
+    let log = fs::read_to_string(log_path).unwrap();
+    assert!(log.contains("before-cancel"));
+    assert!(!log.contains("after-cancel"));
+    assert!(queue_job_completion_notified_at(&queue_state_dir, &job_id).is_some());
+    let notifications = queued_message_texts(&message_queue_db, "run12345");
+    assert_eq!(notifications.len(), 1);
+    assert!(notifications[0].contains(&format!("[sm queue] {job_id} completed: cancelled")));
+    assert!(notifications[0].contains("log tail:\nbefore-cancel"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn queue_job_cancel_force_stops_unmonitored_running_process_group() {
+    let state_file = write_session_fixture();
+    let queue_state_dir = state_file.with_extension("queue-runner-cancel-unmonitored");
+    let message_queue_db = state_file.with_extension("queue-cancel-unmonitored-message-queue.db");
+    let working_dir = unique_temp_path().with_extension("queue-cwd");
+    fs::create_dir_all(&working_dir).unwrap();
+    let mut config = AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        queue_runner: QueueRunnerConfig {
+            state_dir: queue_state_dir.display().to_string(),
+            cancel_grace_seconds: 0,
+            configured: true,
+        },
+        sm_send: SmSendConfig {
+            db_path: message_queue_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    };
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/queue-jobs",
+        json!({
+            "type": "tests",
+            "label": "cancel unmonitored queue",
+            "argv": ["echo", "cancel"],
+            "cwd": working_dir.display().to_string(),
+            "notify_target": "run12345",
+            "requester_session_id": "run12345",
+            "timeout_seconds": 30
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let job_id = payload["id"].as_str().unwrap().to_owned();
+    let ready_path = queue_state_dir.join("unmonitored.ready");
+    let mut child = Command::new("/bin/zsh")
+        .arg("-lc")
+        .arg("trap '' TERM; printf ready > \"$READY_PATH\"; while true; do sleep 1; done")
+        .env("READY_PATH", &ready_path)
+        .process_group(0)
+        .spawn()
+        .unwrap();
+    let _ready = wait_for_file_contains(&ready_path, "ready").await;
+    let pid = i64::from(child.id());
+    let conn = Connection::open(queue_state_dir.join("queue_runner.db")).unwrap();
+    conn.execute(
+        r#"
+        UPDATE queue_jobs
+        SET state = 'running',
+            started_at = '2026-06-14T00:00:00Z',
+            pid = ?2,
+            process_group_id = ?2
+        WHERE id = ?1
+        "#,
+        (&job_id, pid),
+    )
+    .unwrap();
+
+    let (status, cancelled) =
+        delete_json(app.clone(), &format!("/queue-jobs/{job_id}"), json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(cancelled["state"], "cancelled");
+
+    let mut exited = false;
+    for _ in 0..50 {
+        if child.try_wait().unwrap().is_some() {
+            exited = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    if !exited {
+        let _ = Command::new("/bin/kill")
+            .arg("-KILL")
+            .arg(format!("-{pid}"))
+            .status();
+        let _ = child.wait();
+    }
+    assert!(exited, "unmonitored queue process was not force-stopped");
+    assert!(queue_job_completion_notified_at(&queue_state_dir, &job_id).is_some());
+    let notifications = queued_message_texts(&message_queue_db, "run12345");
+    assert_eq!(notifications.len(), 1);
+    assert!(notifications[0].contains(&format!("[sm queue] {job_id} completed: cancelled")));
 }
 
 #[tokio::test]
@@ -2881,6 +3283,7 @@ async fn shadow_http_reports_queue_job_detail_404() {
                 .with_extension("missing-queue-runner")
                 .display()
                 .to_string(),
+            cancel_grace_seconds: 0,
             configured: true,
         },
         ..AppConfig::default()
@@ -2925,6 +3328,7 @@ async fn shadow_http_reports_queue_job_detail_200_as_status_only() {
         },
         queue_runner: QueueRunnerConfig {
             state_dir: queue_state_dir.display().to_string(),
+            cancel_grace_seconds: 0,
             configured: true,
         },
         ..AppConfig::default()

--- a/scripts/rust_migration/contracts_manifest.json
+++ b/scripts/rust_migration/contracts_manifest.json
@@ -1081,6 +1081,18 @@
       "source": "specs/762_stage5_artifacts/implementation_workstreams.md:21"
     },
     {
+      "id": "cli.rust_queue_cancel_fixture",
+      "surface": "cli",
+      "classification": "retained",
+      "target": "rust_only",
+      "safety": "mutating",
+      "command": ["--api-url", "{base_url}", "queue", "cancel", "{queue_job_id}"],
+      "expected_exit": [0],
+      "expected_output_contains_all": ["Cancelled queue job: {queue_job_id}", "(cancelled)"],
+      "preconditions": ["sm_cli", "fixture:base_url", "fixture:queue_job_id", "mutating_opt_in"],
+      "source": "https://github.com/rajeshgoli/session-manager/issues/957"
+    },
+    {
       "id": "cli.rust_core_send_fixture",
       "surface": "cli",
       "classification": "retained",

--- a/scripts/rust_migration/mutating_fixture.py
+++ b/scripts/rust_migration/mutating_fixture.py
@@ -88,6 +88,7 @@ def create_mutating_fixture_workspace(output_dir: Path | None = None) -> Mutatin
         "clear_prompt_text": "new task after clear",
         "em_session_id": DEFAULT_EM_SESSION_ID,
         "notify_child_session_id": DEFAULT_NOTIFY_CHILD_SESSION_ID,
+        "queue_job_id": "job-fixture",
     }
     return MutatingFixtureWorkspace(
         root=root,

--- a/scripts/rust_migration/mvp_rehearsal.py
+++ b/scripts/rust_migration/mvp_rehearsal.py
@@ -86,6 +86,7 @@ CORE_MUTATING_CHECK_IDS = (
     "cli.rust_core_maintainer_clear_fixture",
     "cli.rust_core_retire_fixture",
     "cli.rust_queue_run_fixture",
+    "cli.rust_queue_cancel_fixture",
     "http.rust_core_task_complete_fixture",
     "http.rust_core_turn_complete_fixture",
     "http.rust_core_notify_on_stop_fixture",

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -325,6 +325,14 @@ def test_manifest_covers_rust_queue_writer_fixture_checks():
     assert "fixture:working_dir" in cli_check.preconditions
     assert cli_check.command[:4] == ("--api-url", "{base_url}", "queue", "run")
 
+    cancel_check = checks["cli.rust_queue_cancel_fixture"]
+    assert cancel_check.classification == "retained"
+    assert cancel_check.target == "rust_only"
+    assert cancel_check.safety == "mutating"
+    assert "mutating_opt_in" in cancel_check.preconditions
+    assert "fixture:queue_job_id" in cancel_check.preconditions
+    assert cancel_check.command[:4] == ("--api-url", "{base_url}", "queue", "cancel")
+
     http_check = checks["http.rust_queue_job_create_fixture"]
     assert http_check.classification == "retained"
     assert http_check.target == "rust_only"
@@ -900,6 +908,7 @@ def test_mutating_fixture_workspace_creates_disposable_config_and_seed(tmp_path)
     assert workspace.fixtures["child_session_id"] == DEFAULT_CHILD_SESSION_ID
     assert workspace.fixtures["em_session_id"] == DEFAULT_EM_SESSION_ID
     assert workspace.fixtures["notify_child_session_id"] == DEFAULT_NOTIFY_CHILD_SESSION_ID
+    assert workspace.fixtures["queue_job_id"] == "job-fixture"
 
     config_text = workspace.config_path.read_text()
     assert "fixture_writes_enabled: true" in config_text


### PR DESCRIPTION
## Summary

- run newly created simple queue jobs when `rust_core.runtime_enabled` is enabled
- persist queue runtime transitions for running, succeeded, failed, timed_out, and cancelled jobs
- add `DELETE /queue-jobs/{job_id}` and `sm queue cancel` support
- extend the disposable mutating fixture rehearsal with a Rust queue cancel check

## Scope

This keeps policy-run / CI queue helpers retired and does not port the broader resource-sampling or advanced scheduling policy paths.

Fixes #957

## Validation

- `cargo fmt --check`
- `cargo test -p sm-server --test read_only_http queue_job_`
- `cargo test -p sm-server --bin sm queue_`
- `cargo test -p sm-server`
- `./venv/bin/python -m json.tool scripts/rust_migration/contracts_manifest.json >/dev/null`
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py -q`
- `./venv/bin/python -m py_compile scripts/rust_migration/mvp_rehearsal.py scripts/rust_migration/mutating_fixture.py`
- `git diff --check`
- disposable rehearsal: `./venv/bin/python -m scripts.rust_migration.mvp_rehearsal --output-dir /tmp/session-manager-queue-runtime-rehearsal-pr --skip-python-health --skip-baseline --skip-shadow --core-only --rust-base-url http://127.0.0.1:18421 --mutating-rust-base-url http://127.0.0.1:18422 --read-only-fixture-rust-base-url http://127.0.0.1:18423`
  - result: 0 blockers; state gate passed; core read checks 17/17; read-only fixture checks 14/14; mutating fixture checks 33/33
