### PR TITLE
Recover Rust queue runtime jobs on startup

### DIFF
--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -758,6 +758,10 @@ pub struct QueueRunnerConfig {
     pub state_dir: String,
     #[serde(default = "default_queue_runner_cancel_grace_seconds")]
     pub cancel_grace_seconds: u64,
+    #[serde(default = "default_queue_runner_max_running_jobs")]
+    pub max_running_jobs: i64,
+    #[serde(default = "default_queue_runner_perf_cooldown_seconds")]
+    pub perf_cooldown_seconds: i64,
     #[serde(skip)]
     pub configured: bool,
 }
@@ -767,6 +771,8 @@ impl Default for QueueRunnerConfig {
         Self {
             state_dir: default_queue_runner_state_dir(),
             cancel_grace_seconds: default_queue_runner_cancel_grace_seconds(),
+            max_running_jobs: default_queue_runner_max_running_jobs(),
+            perf_cooldown_seconds: default_queue_runner_perf_cooldown_seconds(),
             configured: false,
         }
     }
@@ -780,6 +786,14 @@ fn default_queue_runner_cancel_grace_seconds() -> u64 {
     10
 }
 
+fn default_queue_runner_max_running_jobs() -> i64 {
+    2
+}
+
+fn default_queue_runner_perf_cooldown_seconds() -> i64 {
+    30
+}
+
 fn queue_runner_config_for_state_file(state_file: &str) -> QueueRunnerConfig {
     if state_file == default_state_file() {
         return QueueRunnerConfig::default();
@@ -789,6 +803,8 @@ fn queue_runner_config_for_state_file(state_file: &str) -> QueueRunnerConfig {
             .to_string_lossy()
             .into_owned(),
         cancel_grace_seconds: default_queue_runner_cancel_grace_seconds(),
+        max_running_jobs: default_queue_runner_max_running_jobs(),
+        perf_cooldown_seconds: default_queue_runner_perf_cooldown_seconds(),
         configured: false,
     }
 }
@@ -1868,6 +1884,8 @@ cloudflare_access:
 queue_runner:
   state_dir: /tmp/custom-queue-runner
   cancel_grace_seconds: 3
+  max_running_jobs: 1
+  perf_cooldown_seconds: 7
 "#,
         )
         .unwrap();
@@ -1875,6 +1893,8 @@ queue_runner:
 
         assert_eq!(config.queue_runner.state_dir, "/tmp/custom-queue-runner");
         assert_eq!(config.queue_runner.cancel_grace_seconds, 3);
+        assert_eq!(config.queue_runner.max_running_jobs, 1);
+        assert_eq!(config.queue_runner.perf_cooldown_seconds, 7);
     }
 
     #[test]
@@ -1893,6 +1913,8 @@ paths:
             "/tmp/sm-fixture/queue-runner"
         );
         assert_eq!(config.queue_runner.cancel_grace_seconds, 10);
+        assert_eq!(config.queue_runner.max_running_jobs, 2);
+        assert_eq!(config.queue_runner.perf_cooldown_seconds, 30);
     }
 
     #[test]

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -89,8 +89,8 @@ use crate::email::{
 };
 use crate::mobile_analytics::build_mobile_analytics_summary;
 use crate::queue::{
-    CodexReviewRequestFilters, CodexReviewRequestRegistration, CreateQueueJob, QueueJobFilters,
-    QueueJobRecord, RetainedQueueStore,
+    CodexReviewRequestFilters, CodexReviewRequestRegistration, CreateQueueJob,
+    QueueAdmissionPolicy, QueueJobFilters, QueueJobRecord, RetainedQueueStore,
 };
 use crate::runtime::TmuxRuntime;
 use crate::sessions::{
@@ -1989,11 +1989,15 @@ async fn create_queue_job(
     )?;
     let job = if state.config.rust_core.runtime_enabled {
         let message_queue_db_path = expand_home(&state.config.sm_send.db_path);
-        RetainedQueueStore::start_queue_job_in_state_dir(
+        RetainedQueueStore::admit_queue_jobs_in_state_dir_continuing_after_failed_start_with_policy(
             &queue_state_dir,
             &message_queue_db_path,
-            &job.id,
             state.config.queue_runner.cancel_grace_seconds,
+            queue_admission_policy(&state.config),
+        )?;
+        RetainedQueueStore::get_queue_job_from_path(
+            &queue_state_dir.join("queue_runner.db"),
+            &job.id,
         )?
         .unwrap_or(job)
     } else {
@@ -2023,6 +2027,8 @@ async fn cancel_queue_job(
         &message_queue_db_path,
         &job_id,
         state.config.queue_runner.cancel_grace_seconds,
+        queue_admission_policy(&state.config),
+        state.config.rust_core.runtime_enabled,
     )?
     else {
         return Err(ApiError::NotFound("Queue job not found"));
@@ -2041,6 +2047,13 @@ fn resolve_session_or_registry_role(
         return Ok(None);
     };
     Ok(state.session_store.get_session(&registration.session_id)?)
+}
+
+fn queue_admission_policy(config: &AppConfig) -> QueueAdmissionPolicy {
+    QueueAdmissionPolicy {
+        max_running_jobs: config.queue_runner.max_running_jobs,
+        perf_cooldown_seconds: config.queue_runner.perf_cooldown_seconds,
+    }
 }
 
 async fn get_session(

--- a/crates/sm-server/src/main.rs
+++ b/crates/sm-server/src/main.rs
@@ -1,10 +1,12 @@
-use std::{net::SocketAddr, path::PathBuf};
+use std::{net::SocketAddr, path::PathBuf, thread};
 
 use anyhow::{Context, Result};
 use clap::Parser;
 use sm_server::{
     config::AppConfig,
     http::{router, AppState},
+    queue::{QueueAdmissionPolicy, QueueRecoverySummary, RetainedQueueStore},
+    sessions::expand_home,
 };
 use tokio::net::TcpListener;
 
@@ -31,6 +33,31 @@ async fn main() -> Result<()> {
     let listener = TcpListener::bind(address)
         .await
         .with_context(|| format!("failed to bind {address}"))?;
+
+    if config.rust_core.runtime_enabled {
+        let queue_state_dir_config = config.queue_runner_state_dir();
+        let queue_state_dir = expand_home(&queue_state_dir_config.to_string_lossy());
+        let message_queue_db_path = expand_home(&config.sm_send.db_path);
+        let cancel_grace_seconds = config.queue_runner.cancel_grace_seconds;
+        let admission_policy = QueueAdmissionPolicy {
+            max_running_jobs: config.queue_runner.max_running_jobs,
+            perf_cooldown_seconds: config.queue_runner.perf_cooldown_seconds,
+        };
+        thread::spawn(
+            move || match RetainedQueueStore::recover_queue_jobs_in_state_dir_with_policy(
+                &queue_state_dir,
+                &message_queue_db_path,
+                cancel_grace_seconds,
+                admission_policy,
+            ) {
+                Ok(summary) if summary != QueueRecoverySummary::default() => {
+                    eprintln!("queue runtime recovery: {summary:?}");
+                }
+                Ok(_) => {}
+                Err(error) => eprintln!("queue runtime recovery failed: {error:#}"),
+            },
+        );
+    }
 
     eprintln!("sm-server listening on http://{address}");
     axum::serve(

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -6,6 +6,7 @@ use std::{
     io::{Read, Seek, SeekFrom},
     path::{Path, PathBuf},
     process::{Child, Command, Stdio},
+    sync::Mutex,
     thread,
     time::{Duration as StdDuration, Instant},
 };
@@ -94,13 +95,44 @@ pub struct QueueJobRecord {
     pub log_path: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct QueueAdmissionPolicy {
+    pub max_running_jobs: i64,
+    pub perf_cooldown_seconds: i64,
+}
+
+impl Default for QueueAdmissionPolicy {
+    fn default() -> Self {
+        Self {
+            max_running_jobs: DEFAULT_MAX_RUNNING_QUEUE_JOBS,
+            perf_cooldown_seconds: DEFAULT_PERF_COOLDOWN_SECONDS,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct QueueRecoverySummary {
+    pub recovered_running: usize,
+    pub started_pending: usize,
+    pub requeued_pending: usize,
+    pub held_pending: usize,
+    pub polling_running: usize,
+    pub finished_succeeded: usize,
+    pub finished_failed: usize,
+    pub finished_timed_out: usize,
+    pub finished_cancelled: usize,
+    pub finished_displaced: usize,
+}
+
 #[derive(Debug, Clone)]
 struct QueueJobRuntimeRecord {
     id: String,
+    job_type: String,
     state: String,
     notify_session_id: Option<String>,
     queued_at: String,
     started_at: Option<String>,
+    finished_at: Option<String>,
     holding_reason: Option<String>,
     wrapper_path: Option<String>,
     log_path: Option<String>,
@@ -109,6 +141,12 @@ struct QueueJobRuntimeRecord {
     pid: Option<i64>,
     process_group_id: Option<i64>,
     completion_notified_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecoveredQueueJobAction {
+    Polling,
+    Finished(&'static str),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -281,6 +319,22 @@ impl RetainedQueueStore {
         job_id: &str,
         cancel_grace_seconds: u64,
     ) -> Result<Option<QueueJobRecord>> {
+        Self::start_queue_job_in_state_dir_with_policy(
+            state_dir,
+            message_queue_db_path,
+            job_id,
+            cancel_grace_seconds,
+            QueueAdmissionPolicy::default(),
+        )
+    }
+
+    fn start_queue_job_in_state_dir_with_policy(
+        state_dir: &Path,
+        message_queue_db_path: &Path,
+        job_id: &str,
+        cancel_grace_seconds: u64,
+        admission_policy: QueueAdmissionPolicy,
+    ) -> Result<Option<QueueJobRecord>> {
         let db_path = state_dir.join("queue_runner.db");
         let conn = open_queue_jobs_connection(&db_path)?;
         init_queue_jobs_schema(&conn)?;
@@ -322,9 +376,73 @@ impl RetainedQueueStore {
                 child,
                 timeout_seconds,
                 cancel_grace_seconds,
+                admission_policy,
             );
         });
         get_queue_job_conn(&conn, job_id)
+    }
+
+    pub fn admit_queue_jobs_in_state_dir(
+        state_dir: &Path,
+        message_queue_db_path: &Path,
+        cancel_grace_seconds: u64,
+    ) -> Result<()> {
+        Self::admit_queue_jobs_in_state_dir_with_policy(
+            state_dir,
+            message_queue_db_path,
+            cancel_grace_seconds,
+            QueueAdmissionPolicy::default(),
+            false,
+        )
+    }
+
+    pub fn admit_queue_jobs_in_state_dir_continuing_after_failed_start(
+        state_dir: &Path,
+        message_queue_db_path: &Path,
+        cancel_grace_seconds: u64,
+    ) -> Result<()> {
+        Self::admit_queue_jobs_in_state_dir_continuing_after_failed_start_with_policy(
+            state_dir,
+            message_queue_db_path,
+            cancel_grace_seconds,
+            QueueAdmissionPolicy::default(),
+        )
+    }
+
+    pub fn admit_queue_jobs_in_state_dir_continuing_after_failed_start_with_policy(
+        state_dir: &Path,
+        message_queue_db_path: &Path,
+        cancel_grace_seconds: u64,
+        admission_policy: QueueAdmissionPolicy,
+    ) -> Result<()> {
+        Self::admit_queue_jobs_in_state_dir_with_policy(
+            state_dir,
+            message_queue_db_path,
+            cancel_grace_seconds,
+            admission_policy,
+            true,
+        )
+    }
+
+    fn admit_queue_jobs_in_state_dir_with_policy(
+        state_dir: &Path,
+        message_queue_db_path: &Path,
+        cancel_grace_seconds: u64,
+        admission_policy: QueueAdmissionPolicy,
+        continue_after_failed_start: bool,
+    ) -> Result<()> {
+        let db_path = state_dir.join("queue_runner.db");
+        let conn = open_queue_jobs_connection(&db_path)?;
+        init_queue_jobs_schema(&conn)?;
+        admit_pending_queue_jobs_conn(
+            &conn,
+            state_dir,
+            message_queue_db_path,
+            cancel_grace_seconds,
+            admission_policy,
+            continue_after_failed_start,
+        )?;
+        Ok(())
     }
 
     pub fn cancel_queue_job_in_state_dir(
@@ -332,6 +450,8 @@ impl RetainedQueueStore {
         message_queue_db_path: &Path,
         job_id: &str,
         cancel_grace_seconds: u64,
+        admission_policy: QueueAdmissionPolicy,
+        admit_after_cancel: bool,
     ) -> Result<Option<QueueJobRecord>> {
         let db_path = state_dir.join("queue_runner.db");
         let conn = open_queue_jobs_connection(&db_path)?;
@@ -356,7 +476,103 @@ impl RetainedQueueStore {
             exit_code,
             Some(message_queue_db_path),
         )?;
+        if admit_after_cancel {
+            let _ = admit_pending_queue_jobs_conn(
+                &conn,
+                state_dir,
+                message_queue_db_path,
+                cancel_grace_seconds,
+                admission_policy,
+                true,
+            );
+        }
         get_queue_job_conn(&conn, job_id)
+    }
+
+    pub fn recover_queue_jobs_in_state_dir(
+        state_dir: &Path,
+        message_queue_db_path: &Path,
+        cancel_grace_seconds: u64,
+    ) -> Result<QueueRecoverySummary> {
+        Self::recover_queue_jobs_in_state_dir_with_policy(
+            state_dir,
+            message_queue_db_path,
+            cancel_grace_seconds,
+            QueueAdmissionPolicy::default(),
+        )
+    }
+
+    pub fn recover_queue_jobs_in_state_dir_with_policy(
+        state_dir: &Path,
+        message_queue_db_path: &Path,
+        cancel_grace_seconds: u64,
+        admission_policy: QueueAdmissionPolicy,
+    ) -> Result<QueueRecoverySummary> {
+        let db_path = state_dir.join("queue_runner.db");
+        if !db_path.exists() {
+            return Ok(QueueRecoverySummary::default());
+        }
+        let conn = open_queue_jobs_connection(&db_path)?;
+        init_queue_jobs_schema(&conn)?;
+        let mut statement = conn.prepare(
+            r#"
+            SELECT id
+            FROM queue_jobs
+            WHERE state = 'running'
+            ORDER BY queued_at, id
+            "#,
+        )?;
+        let job_ids = statement
+            .query_map([], |row| row.get::<_, String>(0))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        drop(statement);
+
+        let mut summary = QueueRecoverySummary::default();
+        for job_id in job_ids {
+            let Some(job) = get_queue_job_runtime_conn(&conn, &job_id)? else {
+                continue;
+            };
+            if job.state.as_str() == "running" {
+                summary.recovered_running += 1;
+                match recover_running_queue_job_conn(
+                    &conn,
+                    state_dir,
+                    message_queue_db_path,
+                    &job,
+                    cancel_grace_seconds,
+                    admission_policy,
+                )? {
+                    RecoveredQueueJobAction::Polling => summary.polling_running += 1,
+                    RecoveredQueueJobAction::Finished("succeeded") => {
+                        summary.finished_succeeded += 1
+                    }
+                    RecoveredQueueJobAction::Finished("failed") => summary.finished_failed += 1,
+                    RecoveredQueueJobAction::Finished("timed_out") => {
+                        summary.finished_timed_out += 1
+                    }
+                    RecoveredQueueJobAction::Finished("cancelled") => {
+                        summary.finished_cancelled += 1
+                    }
+                    RecoveredQueueJobAction::Finished("displaced") => {
+                        summary.finished_displaced += 1
+                    }
+                    RecoveredQueueJobAction::Finished(_) => {}
+                }
+            }
+        }
+        let admission = admit_pending_queue_jobs_conn(
+            &conn,
+            state_dir,
+            message_queue_db_path,
+            cancel_grace_seconds,
+            admission_policy,
+            true,
+        )?;
+        summary.started_pending += admission.started;
+        summary.requeued_pending += admission.requeued;
+        summary.held_pending += admission.held;
+        summary.finished_failed += admission.failed_start;
+        Ok(summary)
     }
 
     pub fn ensure_schema(&self) -> Result<()> {
@@ -1247,9 +1463,9 @@ fn get_queue_job_runtime_conn(
 ) -> Result<Option<QueueJobRuntimeRecord>> {
     let mut statement = match conn.prepare(
         r#"
-        SELECT id, state, notify_session_id, queued_at, started_at, holding_reason, wrapper_path,
-               log_path, exit_code_path, timeout_seconds, pid, process_group_id,
-               completion_notified_at
+        SELECT id, type, state, notify_session_id, queued_at, started_at, finished_at,
+               holding_reason, wrapper_path, log_path, exit_code_path, timeout_seconds,
+               pid, process_group_id, completion_notified_at
         FROM queue_jobs
         WHERE id = ?1
         LIMIT 1
@@ -1267,22 +1483,350 @@ fn get_queue_job_runtime_conn(
         .query_row(params![job_id], |row| {
             Ok(QueueJobRuntimeRecord {
                 id: row.get(0)?,
-                state: row.get(1)?,
-                notify_session_id: row.get(2)?,
-                queued_at: row.get(3)?,
-                started_at: row.get(4)?,
-                holding_reason: row.get(5)?,
-                wrapper_path: row.get(6)?,
-                log_path: row.get(7)?,
-                exit_code_path: row.get(8)?,
-                timeout_seconds: row.get(9)?,
-                pid: row.get(10)?,
-                process_group_id: row.get(11)?,
-                completion_notified_at: row.get(12)?,
+                job_type: row.get(1)?,
+                state: row.get(2)?,
+                notify_session_id: row.get(3)?,
+                queued_at: row.get(4)?,
+                started_at: row.get(5)?,
+                finished_at: row.get(6)?,
+                holding_reason: row.get(7)?,
+                wrapper_path: row.get(8)?,
+                log_path: row.get(9)?,
+                exit_code_path: row.get(10)?,
+                timeout_seconds: row.get(11)?,
+                pid: row.get(12)?,
+                process_group_id: row.get(13)?,
+                completion_notified_at: row.get(14)?,
             })
         })
         .optional()
         .map_err(Into::into)
+}
+
+fn list_queue_job_runtime_records_conn(conn: &Connection) -> Result<Vec<QueueJobRuntimeRecord>> {
+    let mut statement = conn.prepare(
+        r#"
+        SELECT id, type, state, notify_session_id, queued_at, started_at, finished_at,
+               holding_reason, wrapper_path, log_path, exit_code_path, timeout_seconds,
+               pid, process_group_id, completion_notified_at
+        FROM queue_jobs
+        ORDER BY queued_at, id
+        "#,
+    )?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok(QueueJobRuntimeRecord {
+                id: row.get(0)?,
+                job_type: row.get(1)?,
+                state: row.get(2)?,
+                notify_session_id: row.get(3)?,
+                queued_at: row.get(4)?,
+                started_at: row.get(5)?,
+                finished_at: row.get(6)?,
+                holding_reason: row.get(7)?,
+                wrapper_path: row.get(8)?,
+                log_path: row.get(9)?,
+                exit_code_path: row.get(10)?,
+                timeout_seconds: row.get(11)?,
+                pid: row.get(12)?,
+                process_group_id: row.get(13)?,
+                completion_notified_at: row.get(14)?,
+            })
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    Ok(rows)
+}
+
+#[derive(Debug, Default)]
+struct QueueAdmissionSummary {
+    started: usize,
+    requeued: usize,
+    held: usize,
+    failed_start: usize,
+    retry_after_seconds: Option<u64>,
+}
+
+fn admit_pending_queue_jobs_conn(
+    conn: &Connection,
+    state_dir: &Path,
+    message_queue_db_path: &Path,
+    cancel_grace_seconds: u64,
+    admission_policy: QueueAdmissionPolicy,
+    continue_after_failed_start: bool,
+) -> Result<QueueAdmissionSummary> {
+    let _admission_guard = QUEUE_ADMISSION_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let requeued = conn.execute(
+        "UPDATE queue_jobs SET holding_reason = NULL WHERE state = 'pending' AND holding_reason IS NOT NULL",
+        [],
+    )?;
+    let mut summary = QueueAdmissionSummary {
+        requeued,
+        ..QueueAdmissionSummary::default()
+    };
+    loop {
+        let jobs = list_queue_job_runtime_records_conn(conn)?;
+        if !jobs.iter().any(|job| job.state == "pending") {
+            break;
+        }
+        if running_queue_job_count(&jobs, None) as i64 >= admission_policy.max_running_jobs {
+            if displace_background_for_perf_conn(
+                conn,
+                &jobs,
+                message_queue_db_path,
+                cancel_grace_seconds,
+                admission_policy,
+            )? {
+                continue;
+            }
+            summary.held += mark_pending_queue_jobs_holding_conn(conn, None, "concurrency_cap")?;
+            break;
+        }
+        let Some(candidate_id) =
+            next_admissible_queue_job_id_conn(conn, &jobs, admission_policy, &mut summary)?
+        else {
+            break;
+        };
+        match RetainedQueueStore::start_queue_job_in_state_dir_with_policy(
+            state_dir,
+            message_queue_db_path,
+            &candidate_id,
+            cancel_grace_seconds,
+            admission_policy,
+        ) {
+            Ok(Some(job)) if job.state == "running" => summary.started += 1,
+            Ok(_) => {}
+            Err(error) => {
+                let Some(current) = get_queue_job_conn(conn, &candidate_id)? else {
+                    return Err(error);
+                };
+                if continue_after_failed_start && current.state == "failed" {
+                    summary.failed_start += 1;
+                } else {
+                    return Err(error);
+                }
+            }
+        }
+    }
+    if let Some(seconds) = summary.retry_after_seconds {
+        schedule_queue_admission_retry(
+            state_dir.to_path_buf(),
+            message_queue_db_path.to_path_buf(),
+            cancel_grace_seconds,
+            admission_policy,
+            seconds,
+        );
+    }
+    Ok(summary)
+}
+
+fn schedule_queue_admission_retry(
+    state_dir: PathBuf,
+    message_queue_db_path: PathBuf,
+    cancel_grace_seconds: u64,
+    admission_policy: QueueAdmissionPolicy,
+    delay_seconds: u64,
+) {
+    thread::spawn(move || {
+        thread::sleep(StdDuration::from_secs(delay_seconds.max(1)));
+        let _ =
+            RetainedQueueStore::admit_queue_jobs_in_state_dir_continuing_after_failed_start_with_policy(
+                &state_dir,
+                &message_queue_db_path,
+                cancel_grace_seconds,
+                admission_policy,
+            );
+    });
+}
+
+const DEFAULT_MAX_RUNNING_QUEUE_JOBS: i64 = 2;
+const DEFAULT_PERF_COOLDOWN_SECONDS: i64 = 30;
+const QUEUE_JOB_TYPE_ORDER: [&str; 3] = ["perf", "tests", "background"];
+static QUEUE_ADMISSION_LOCK: Mutex<()> = Mutex::new(());
+
+fn next_admissible_queue_job_id_conn(
+    conn: &Connection,
+    jobs: &[QueueJobRuntimeRecord],
+    admission_policy: QueueAdmissionPolicy,
+    summary: &mut QueueAdmissionSummary,
+) -> Result<Option<String>> {
+    for job_type in QUEUE_JOB_TYPE_ORDER {
+        let Some(job) = oldest_pending_queue_job(jobs, job_type) else {
+            continue;
+        };
+        if running_queue_job_count(jobs, Some(job_type)) >= max_concurrent_queue_jobs(job_type) {
+            summary.held +=
+                mark_pending_queue_jobs_holding_conn(conn, Some(&job.id), "concurrency_cap")?;
+            continue;
+        }
+        if job_type == "perf" && perf_cooldown_active(jobs, admission_policy) {
+            summary.held +=
+                mark_pending_queue_jobs_holding_conn(conn, Some(&job.id), "perf_cooldown")?;
+            if let Some(remaining) = perf_cooldown_remaining_seconds(jobs, admission_policy) {
+                summary.retry_after_seconds = Some(
+                    summary
+                        .retry_after_seconds
+                        .map_or(remaining, |current| current.min(remaining)),
+                );
+            }
+            continue;
+        }
+        if job_type == "perf" && perf_blocked_by_tests_after_perf(jobs) {
+            summary.held +=
+                mark_pending_queue_jobs_holding_conn(conn, Some(&job.id), "awaiting_tests")?;
+            continue;
+        }
+        return Ok(Some(job.id.clone()));
+    }
+    Ok(None)
+}
+
+fn displace_background_for_perf_conn(
+    conn: &Connection,
+    jobs: &[QueueJobRuntimeRecord],
+    message_queue_db_path: &Path,
+    cancel_grace_seconds: u64,
+    admission_policy: QueueAdmissionPolicy,
+) -> Result<bool> {
+    if oldest_pending_queue_job(jobs, "perf").is_none() {
+        return Ok(false);
+    }
+    if running_queue_job_count(jobs, Some("perf")) >= max_concurrent_queue_jobs("perf") {
+        return Ok(false);
+    }
+    if perf_cooldown_active(jobs, admission_policy) || perf_blocked_by_tests_after_perf(jobs) {
+        return Ok(false);
+    }
+    let Some(background) = jobs
+        .iter()
+        .filter(|job| job.state == "running" && job.job_type == "background")
+        .min_by_key(|job| (job.started_at.as_deref().unwrap_or(&job.queued_at), &job.id))
+        .cloned()
+    else {
+        return Ok(false);
+    };
+    mark_queue_job_displacing_conn(conn, &background.id)?;
+    let mut background = background;
+    background.holding_reason = Some("displacing".to_owned());
+    if let Some(pgid) = background.process_group_id.or(background.pid) {
+        terminate_process_group_with_grace(pgid, cancel_grace_seconds);
+    }
+    let exit_code = read_exit_code(background.exit_code_path.as_deref());
+    finish_queue_job_conn(
+        conn,
+        &background,
+        "displaced",
+        exit_code,
+        Some(message_queue_db_path),
+    )?;
+    Ok(true)
+}
+
+fn oldest_pending_queue_job<'a>(
+    jobs: &'a [QueueJobRuntimeRecord],
+    job_type: &str,
+) -> Option<&'a QueueJobRuntimeRecord> {
+    jobs.iter()
+        .filter(|job| job.state == "pending" && job.job_type == job_type)
+        .min_by_key(|job| (&job.queued_at, &job.id))
+}
+
+fn running_queue_job_count(jobs: &[QueueJobRuntimeRecord], job_type: Option<&str>) -> usize {
+    jobs.iter()
+        .filter(|job| {
+            job.state == "running"
+                && match job_type {
+                    Some(expected) => job.job_type == expected,
+                    None => true,
+                }
+        })
+        .count()
+}
+
+fn max_concurrent_queue_jobs(job_type: &str) -> usize {
+    match job_type {
+        "perf" => 1,
+        "tests" | "background" => 2,
+        _ => 1,
+    }
+}
+
+fn mark_pending_queue_jobs_holding_conn(
+    conn: &Connection,
+    job_id: Option<&str>,
+    reason: &str,
+) -> Result<usize> {
+    let updated = if let Some(job_id) = job_id {
+        conn.execute(
+            r#"
+            UPDATE queue_jobs
+            SET holding_reason = ?2
+            WHERE id = ?1 AND state = 'pending' AND COALESCE(holding_reason, '') != ?2
+            "#,
+            params![job_id, reason],
+        )?
+    } else {
+        conn.execute(
+            r#"
+            UPDATE queue_jobs
+            SET holding_reason = ?1
+            WHERE state = 'pending' AND COALESCE(holding_reason, '') != ?1
+            "#,
+            params![reason],
+        )?
+    };
+    Ok(updated)
+}
+
+fn perf_cooldown_active(
+    jobs: &[QueueJobRuntimeRecord],
+    admission_policy: QueueAdmissionPolicy,
+) -> bool {
+    perf_cooldown_remaining_seconds(jobs, admission_policy).is_some()
+}
+
+fn perf_cooldown_remaining_seconds(
+    jobs: &[QueueJobRuntimeRecord],
+    admission_policy: QueueAdmissionPolicy,
+) -> Option<u64> {
+    if admission_policy.perf_cooldown_seconds <= 0 {
+        return None;
+    }
+    let now = OffsetDateTime::now_utc();
+    jobs.iter()
+        .filter(|job| matches!(job.job_type.as_str(), "perf" | "tests"))
+        .filter_map(|job| {
+            let elapsed = queue_elapsed_since(job.finished_at.as_deref()?, now)?;
+            if elapsed < 0 || elapsed >= admission_policy.perf_cooldown_seconds {
+                return None;
+            }
+            let remaining: u64 = (admission_policy.perf_cooldown_seconds - elapsed)
+                .try_into()
+                .ok()?;
+            Some(remaining.max(1))
+        })
+        .max()
+}
+
+fn perf_blocked_by_tests_after_perf(jobs: &[QueueJobRuntimeRecord]) -> bool {
+    let now = OffsetDateTime::now_utc();
+    let latest = jobs
+        .iter()
+        .filter(|job| matches!(job.job_type.as_str(), "perf" | "tests"))
+        .filter_map(|job| {
+            let finished_at = job.finished_at.as_deref()?;
+            let elapsed = queue_elapsed_since(finished_at, now)?;
+            if elapsed < 0 {
+                return None;
+            }
+            Some((elapsed, job.job_type.as_str()))
+        })
+        .min_by_key(|(elapsed, _)| *elapsed);
+    matches!(latest, Some((_, "perf")))
+        && jobs.iter().any(|job| {
+            job.job_type == "tests" && matches!(job.state.as_str(), "pending" | "running")
+        })
 }
 
 fn spawn_queue_job_process(job: &QueueJobRuntimeRecord) -> Result<Child> {
@@ -1332,6 +1876,7 @@ fn monitor_queue_job_completion(
     mut child: Child,
     timeout_seconds: u64,
     cancel_grace_seconds: u64,
+    admission_policy: QueueAdmissionPolicy,
 ) {
     let started = Instant::now();
     let timeout = StdDuration::from_secs(timeout_seconds.max(1));
@@ -1350,6 +1895,8 @@ fn monitor_queue_job_completion(
                     &job_id,
                     state,
                     exit_code,
+                    cancel_grace_seconds,
+                    admission_policy,
                 );
                 return;
             }
@@ -1394,6 +1941,8 @@ fn monitor_queue_job_completion(
                     &job_id,
                     "timed_out",
                     exit_code,
+                    cancel_grace_seconds,
+                    admission_policy,
                 );
                 return;
             }
@@ -1405,11 +1954,214 @@ fn monitor_queue_job_completion(
                     &job_id,
                     "failed",
                     None,
+                    cancel_grace_seconds,
+                    admission_policy,
                 );
                 return;
             }
         }
     }
+}
+
+fn recover_running_queue_job_conn(
+    conn: &Connection,
+    state_dir: &Path,
+    message_queue_db_path: &Path,
+    job: &QueueJobRuntimeRecord,
+    cancel_grace_seconds: u64,
+    admission_policy: QueueAdmissionPolicy,
+) -> Result<RecoveredQueueJobAction> {
+    if let Some(final_state) =
+        forced_terminal_state_for_holding_reason(job.holding_reason.as_deref())
+    {
+        if let Some(pgid) = job.process_group_id.or(job.pid) {
+            terminate_process_group_with_grace(pgid, cancel_grace_seconds);
+        }
+        let exit_code = read_exit_code(job.exit_code_path.as_deref());
+        finish_queue_job_conn(
+            conn,
+            job,
+            final_state,
+            exit_code,
+            Some(message_queue_db_path),
+        )?;
+        return Ok(RecoveredQueueJobAction::Finished(final_state));
+    }
+    if queue_job_exit_code_path_exists(job) {
+        let exit_code = read_exit_code(job.exit_code_path.as_deref());
+        let state = if exit_code == Some(0) {
+            "succeeded"
+        } else {
+            "failed"
+        };
+        finish_queue_job_conn(conn, job, state, exit_code, Some(message_queue_db_path))?;
+        return Ok(RecoveredQueueJobAction::Finished(state));
+    }
+    if queue_job_timed_out(job) {
+        if let Some(pgid) = job.process_group_id.or(job.pid) {
+            terminate_process_group_with_grace(pgid, cancel_grace_seconds);
+        }
+        let exit_code = read_exit_code(job.exit_code_path.as_deref());
+        finish_queue_job_conn(
+            conn,
+            job,
+            "timed_out",
+            exit_code,
+            Some(message_queue_db_path),
+        )?;
+        return Ok(RecoveredQueueJobAction::Finished("timed_out"));
+    }
+    let Some(pid) = job.pid else {
+        finish_queue_job_conn(conn, job, "failed", None, Some(message_queue_db_path))?;
+        return Ok(RecoveredQueueJobAction::Finished("failed"));
+    };
+    if !process_exists(pid) {
+        finish_queue_job_conn(conn, job, "failed", None, Some(message_queue_db_path))?;
+        return Ok(RecoveredQueueJobAction::Finished("failed"));
+    }
+
+    let state_dir = state_dir.to_path_buf();
+    let message_queue_db_path = message_queue_db_path.to_path_buf();
+    let job_id = job.id.clone();
+    thread::spawn(move || {
+        poll_recovered_queue_job(
+            state_dir,
+            message_queue_db_path,
+            job_id,
+            pid,
+            cancel_grace_seconds,
+            admission_policy,
+        );
+    });
+    Ok(RecoveredQueueJobAction::Polling)
+}
+
+fn poll_recovered_queue_job(
+    state_dir: PathBuf,
+    message_queue_db_path: PathBuf,
+    job_id: String,
+    pid: i64,
+    cancel_grace_seconds: u64,
+    admission_policy: QueueAdmissionPolicy,
+) {
+    loop {
+        thread::sleep(StdDuration::from_millis(100));
+        let db_path = state_dir.join("queue_runner.db");
+        let Ok(conn) = open_queue_jobs_connection(&db_path) else {
+            return;
+        };
+        let _ = init_queue_jobs_schema(&conn);
+        let Ok(Some(job)) = get_queue_job_runtime_conn(&conn, &job_id) else {
+            return;
+        };
+        if job.state != "running" {
+            return;
+        }
+        if let Some(final_state) =
+            forced_terminal_state_for_holding_reason(job.holding_reason.as_deref())
+        {
+            if let Some(pgid) = job.process_group_id.or(job.pid) {
+                terminate_process_group_with_grace(pgid, cancel_grace_seconds);
+            }
+            let exit_code = read_exit_code(job.exit_code_path.as_deref());
+            let _ = finish_queue_job_conn(
+                &conn,
+                &job,
+                final_state,
+                exit_code,
+                Some(&message_queue_db_path),
+            );
+            let _ = admit_pending_queue_jobs_conn(
+                &conn,
+                &state_dir,
+                &message_queue_db_path,
+                cancel_grace_seconds,
+                admission_policy,
+                true,
+            );
+            return;
+        }
+        if queue_job_exit_code_path_exists(&job) {
+            let exit_code = read_exit_code(job.exit_code_path.as_deref());
+            let state = if exit_code == Some(0) {
+                "succeeded"
+            } else {
+                "failed"
+            };
+            let _ =
+                finish_queue_job_conn(&conn, &job, state, exit_code, Some(&message_queue_db_path));
+            let _ = admit_pending_queue_jobs_conn(
+                &conn,
+                &state_dir,
+                &message_queue_db_path,
+                cancel_grace_seconds,
+                admission_policy,
+                true,
+            );
+            return;
+        }
+        if queue_job_timed_out(&job) {
+            if let Some(pgid) = job.process_group_id.or(job.pid) {
+                terminate_process_group_with_grace(pgid, cancel_grace_seconds);
+            }
+            let exit_code = read_exit_code(job.exit_code_path.as_deref());
+            let _ = finish_queue_job_conn(
+                &conn,
+                &job,
+                "timed_out",
+                exit_code,
+                Some(&message_queue_db_path),
+            );
+            let _ = admit_pending_queue_jobs_conn(
+                &conn,
+                &state_dir,
+                &message_queue_db_path,
+                cancel_grace_seconds,
+                admission_policy,
+                true,
+            );
+            return;
+        }
+        if !process_exists(pid) {
+            let _ =
+                finish_queue_job_conn(&conn, &job, "failed", None, Some(&message_queue_db_path));
+            let _ = admit_pending_queue_jobs_conn(
+                &conn,
+                &state_dir,
+                &message_queue_db_path,
+                cancel_grace_seconds,
+                admission_policy,
+                true,
+            );
+            return;
+        }
+    }
+}
+
+fn queue_job_timed_out(job: &QueueJobRuntimeRecord) -> bool {
+    queue_job_timed_out_at(job, OffsetDateTime::now_utc())
+}
+
+fn queue_job_timed_out_at(job: &QueueJobRuntimeRecord, now_utc: OffsetDateTime) -> bool {
+    let Some(started_at) = job.started_at.as_deref() else {
+        return false;
+    };
+    let Some(elapsed_seconds) = queue_elapsed_since(started_at, now_utc) else {
+        return false;
+    };
+    elapsed_seconds >= job.timeout_seconds.max(1)
+}
+
+fn queue_elapsed_since(value: &str, now_utc: OffsetDateTime) -> Option<i64> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    if let Ok(parsed) = OffsetDateTime::parse(value, &Rfc3339) {
+        return Some((now_utc - parsed).whole_seconds());
+    }
+    let parsed = parse_python_naive_datetime(value)?;
+    Some((local_now_naive(now_utc) - parsed).whole_seconds())
 }
 
 fn queue_job_is_cancelled_in_state_dir(state_dir: &Path, job_id: &str) -> bool {
@@ -1435,12 +2187,34 @@ fn mark_queue_job_cancelling_conn(conn: &Connection, job_id: &str) -> Result<()>
     Ok(())
 }
 
+fn mark_queue_job_displacing_conn(conn: &Connection, job_id: &str) -> Result<()> {
+    conn.execute(
+        r#"
+        UPDATE queue_jobs
+        SET holding_reason = 'displacing'
+        WHERE id = ?1 AND state = 'running'
+        "#,
+        params![job_id],
+    )?;
+    Ok(())
+}
+
+fn forced_terminal_state_for_holding_reason(holding_reason: Option<&str>) -> Option<&'static str> {
+    match holding_reason {
+        Some("cancelling") => Some("cancelled"),
+        Some("displacing") => Some("displaced"),
+        _ => None,
+    }
+}
+
 fn finish_queue_job_in_state_dir_if_running(
     state_dir: &Path,
     message_queue_db_path: &Path,
     job_id: &str,
     state: &str,
     exit_code: Option<i64>,
+    cancel_grace_seconds: u64,
+    admission_policy: QueueAdmissionPolicy,
 ) -> Result<()> {
     let db_path = state_dir.join("queue_runner.db");
     let conn = open_queue_jobs_connection(&db_path)?;
@@ -1451,11 +2225,8 @@ fn finish_queue_job_in_state_dir_if_running(
     if job.state != "running" {
         return Ok(());
     }
-    let final_state = if job.holding_reason.as_deref() == Some("cancelling") {
-        "cancelled"
-    } else {
-        state
-    };
+    let final_state =
+        forced_terminal_state_for_holding_reason(job.holding_reason.as_deref()).unwrap_or(state);
     finish_queue_job_conn(
         &conn,
         &job,
@@ -1463,6 +2234,14 @@ fn finish_queue_job_in_state_dir_if_running(
         exit_code,
         Some(message_queue_db_path),
     )?;
+    let _ = admit_pending_queue_jobs_conn(
+        &conn,
+        state_dir,
+        message_queue_db_path,
+        cancel_grace_seconds,
+        admission_policy,
+        true,
+    );
     Ok(())
 }
 
@@ -1613,6 +2392,12 @@ fn read_queue_job_exit_code_from_state_dir(state_dir: &Path, job_id: &str) -> Op
     read_exit_code(Some(&exit_code_path))
 }
 
+fn queue_job_exit_code_path_exists(job: &QueueJobRuntimeRecord) -> bool {
+    job.exit_code_path
+        .as_deref()
+        .is_some_and(|path| Path::new(path).exists())
+}
+
 fn read_exit_code(path: Option<&str>) -> Option<i64> {
     let path = path?;
     fs::read_to_string(path).ok()?.trim().parse::<i64>().ok()
@@ -1650,6 +2435,19 @@ fn process_group_exists(pgid: i64) -> bool {
     Command::new("/bin/kill")
         .arg("-0")
         .arg(format!("-{pgid}"))
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+fn process_exists(pid: i64) -> bool {
+    if pid <= 0 {
+        return false;
+    }
+    Command::new("/bin/kill")
+        .arg("-0")
+        .arg(pid.to_string())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
@@ -2176,6 +2974,35 @@ mod tests {
             )
             .unwrap();
         assert_eq!(expired_count, 0);
+    }
+
+    #[test]
+    fn queue_job_timeout_treats_python_naive_started_at_as_local_time() {
+        let now_utc = OffsetDateTime::now_utc();
+        let now_local = local_now_naive(now_utc);
+        let recent_started_at = python_naive_timestamp(now_local - Duration::seconds(30));
+        let old_started_at = python_naive_timestamp(now_local - Duration::seconds(300));
+        let mut job = QueueJobRuntimeRecord {
+            id: "job-naive-timeout".to_owned(),
+            job_type: "tests".to_owned(),
+            state: "running".to_owned(),
+            notify_session_id: None,
+            queued_at: recent_started_at.clone(),
+            started_at: Some(recent_started_at),
+            finished_at: None,
+            holding_reason: None,
+            wrapper_path: None,
+            log_path: None,
+            exit_code_path: None,
+            timeout_seconds: 120,
+            pid: None,
+            process_group_id: None,
+            completion_notified_at: None,
+        };
+
+        assert!(!queue_job_timed_out_at(&job, now_utc));
+        job.started_at = Some(old_started_at);
+        assert!(queue_job_timed_out_at(&job, now_utc));
     }
 
     fn unique_temp_path(label: &str) -> PathBuf {

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -14,7 +14,7 @@ use serde_json::{json, Value};
 use sha1::{Digest, Sha1};
 use sha2::Sha256;
 use sm_server::config::RustShadowConfig;
-use sm_server::queue::RetainedQueueStore;
+use sm_server::queue::{QueueAdmissionPolicy, RetainedQueueStore};
 use sm_server::{
     config::{
         AppArtifactsConfig, AppConfig, BugReportsConfig, CodexEventsConfig, CodexForkLaunchConfig,
@@ -124,27 +124,220 @@ async fn wait_for_queue_job_state(app: axum::Router, job_id: &str, states: &[&st
 }
 
 fn queued_message_texts(db_path: &PathBuf, target_session_id: &str) -> Vec<String> {
-    let conn = Connection::open(db_path).unwrap();
-    let mut statement = conn
-        .prepare(
-            "SELECT text FROM message_queue WHERE target_session_id = ?1 ORDER BY queued_at, id",
-        )
-        .unwrap();
-    statement
-        .query_map([target_session_id], |row| row.get::<_, String>(0))
-        .unwrap()
-        .collect::<Result<Vec<_>, _>>()
-        .unwrap()
+    let mut last_texts = Vec::new();
+    let mut stable_reads = 0;
+    for attempt in 0..50 {
+        if let Ok(conn) = Connection::open(db_path) {
+            if let Ok(mut statement) = conn.prepare(
+                "SELECT text FROM message_queue WHERE target_session_id = ?1 ORDER BY queued_at, id",
+            ) {
+                let texts = statement
+                    .query_map([target_session_id], |row| row.get::<_, String>(0))
+                    .unwrap()
+                    .collect::<Result<Vec<_>, _>>()
+                    .unwrap();
+                if texts == last_texts {
+                    stable_reads += 1;
+                } else {
+                    stable_reads = 0;
+                    last_texts = texts;
+                }
+                if (!last_texts.is_empty() && stable_reads >= 2) || attempt == 49 {
+                    return last_texts;
+                }
+            }
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    last_texts
 }
 
 fn queue_job_completion_notified_at(queue_state_dir: &PathBuf, job_id: &str) -> Option<String> {
+    for attempt in 0..50 {
+        let conn = Connection::open(queue_state_dir.join("queue_runner.db")).unwrap();
+        let completion_notified_at = conn
+            .query_row(
+                "SELECT completion_notified_at FROM queue_jobs WHERE id = ?1",
+                [job_id],
+                |row| row.get::<_, Option<String>>(0),
+            )
+            .unwrap();
+        if completion_notified_at.is_some() || attempt == 49 {
+            return completion_notified_at;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+    None
+}
+
+fn queue_job_text_column(queue_state_dir: &PathBuf, job_id: &str, column: &str) -> String {
+    assert!(matches!(column, "exit_code_path" | "log_path"));
     let conn = Connection::open(queue_state_dir.join("queue_runner.db")).unwrap();
     conn.query_row(
-        "SELECT completion_notified_at FROM queue_jobs WHERE id = ?1",
+        &format!("SELECT {column} FROM queue_jobs WHERE id = ?1"),
         [job_id],
-        |row| row.get::<_, Option<String>>(0),
+        |row| row.get::<_, String>(0),
     )
     .unwrap()
+}
+
+fn set_queue_job_text_column_null(queue_state_dir: &PathBuf, job_id: &str, column: &str) {
+    assert!(matches!(column, "wrapper_path" | "log_path"));
+    let conn = Connection::open(queue_state_dir.join("queue_runner.db")).unwrap();
+    conn.execute(
+        &format!("UPDATE queue_jobs SET {column} = NULL WHERE id = ?1"),
+        [job_id],
+    )
+    .unwrap();
+}
+
+fn set_queue_job_holding_reason(queue_state_dir: &PathBuf, job_id: &str, holding_reason: &str) {
+    let conn = Connection::open(queue_state_dir.join("queue_runner.db")).unwrap();
+    conn.execute(
+        "UPDATE queue_jobs SET holding_reason = ?2 WHERE id = ?1",
+        (job_id, holding_reason),
+    )
+    .unwrap();
+}
+
+fn mark_queue_job_terminal(
+    queue_state_dir: &PathBuf,
+    job_id: &str,
+    state: &str,
+    started_at: &str,
+    finished_at: &str,
+    exit_code: i64,
+) {
+    assert!(matches!(
+        state,
+        "succeeded" | "failed" | "cancelled" | "timed_out"
+    ));
+    let conn = Connection::open(queue_state_dir.join("queue_runner.db")).unwrap();
+    conn.execute(
+        r#"
+        UPDATE queue_jobs
+        SET state = ?2,
+            started_at = ?3,
+            finished_at = ?4,
+            exit_code = ?5,
+            holding_reason = NULL
+        WHERE id = ?1
+        "#,
+        (job_id, state, started_at, finished_at, exit_code),
+    )
+    .unwrap();
+}
+
+fn mark_queue_job_running(
+    queue_state_dir: &PathBuf,
+    job_id: &str,
+    started_at: &str,
+    pid: i64,
+    process_group_id: i64,
+) {
+    mark_queue_job_running_with_holding(
+        queue_state_dir,
+        job_id,
+        started_at,
+        pid,
+        process_group_id,
+        None,
+    );
+}
+
+fn mark_queue_job_running_with_holding(
+    queue_state_dir: &PathBuf,
+    job_id: &str,
+    started_at: &str,
+    pid: i64,
+    process_group_id: i64,
+    holding_reason: Option<&str>,
+) {
+    let conn = Connection::open(queue_state_dir.join("queue_runner.db")).unwrap();
+    conn.execute(
+        r#"
+        UPDATE queue_jobs
+        SET state = 'running',
+            started_at = ?2,
+            pid = ?3,
+            process_group_id = ?4,
+            holding_reason = ?5
+        WHERE id = ?1
+        "#,
+        (job_id, started_at, pid, process_group_id, holding_reason),
+    )
+    .unwrap();
+}
+
+fn test_now_rfc3339() -> String {
+    time::OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap()
+}
+
+fn queue_runtime_test_app(
+    state_file: &PathBuf,
+    queue_state_dir: &PathBuf,
+    message_queue_db: &PathBuf,
+    runtime_enabled: bool,
+    fixture_writes_enabled: bool,
+) -> axum::Router {
+    let mut config = AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        queue_runner: QueueRunnerConfig {
+            state_dir: queue_state_dir.display().to_string(),
+            cancel_grace_seconds: 0,
+            configured: true,
+            ..QueueRunnerConfig::default()
+        },
+        sm_send: SmSendConfig {
+            db_path: message_queue_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    };
+    config.rust_core.runtime_enabled = runtime_enabled;
+    config.rust_core.fixture_writes_enabled = fixture_writes_enabled;
+    router(AppState::new(config))
+}
+
+async fn create_pending_queue_job(
+    app: axum::Router,
+    working_dir: &PathBuf,
+    label: &str,
+    script: &str,
+    timeout_seconds: i64,
+) -> String {
+    create_pending_queue_job_of_type(app, working_dir, "tests", label, script, timeout_seconds)
+        .await
+}
+
+async fn create_pending_queue_job_of_type(
+    app: axum::Router,
+    working_dir: &PathBuf,
+    job_type: &str,
+    label: &str,
+    script: &str,
+    timeout_seconds: i64,
+) -> String {
+    let (status, payload) = post_json(
+        app,
+        "/queue-jobs",
+        json!({
+            "type": job_type,
+            "label": label,
+            "script": script,
+            "cwd": working_dir.display().to_string(),
+            "notify_target": "run12345",
+            "requester_session_id": "run12345",
+            "timeout_seconds": timeout_seconds
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["state"], "pending");
+    payload["id"].as_str().unwrap().to_owned()
 }
 
 async fn json_request_with_headers_and_peer(
@@ -1647,6 +1840,7 @@ async fn queue_jobs_missing_db_returns_empty_jobs() {
             state_dir: queue_state_dir.display().to_string(),
             cancel_grace_seconds: 0,
             configured: true,
+            ..QueueRunnerConfig::default()
         },
         ..AppConfig::default()
     }));
@@ -1664,6 +1858,7 @@ async fn queue_jobs_missing_db_returns_empty_jobs() {
             state_dir: queue_state_dir.display().to_string(),
             cancel_grace_seconds: 0,
             configured: true,
+            ..QueueRunnerConfig::default()
         },
         ..AppConfig::default()
     }));
@@ -1737,6 +1932,7 @@ async fn queue_jobs_lists_rows_with_filters_and_session_names() {
             state_dir: queue_state_dir.display().to_string(),
             cancel_grace_seconds: 0,
             configured: true,
+            ..QueueRunnerConfig::default()
         },
         ..AppConfig::default()
     }));
@@ -1882,6 +2078,7 @@ async fn queue_jobs_unknown_notify_target_returns_404() {
             state_dir: queue_state_dir.display().to_string(),
             cancel_grace_seconds: 0,
             configured: true,
+            ..QueueRunnerConfig::default()
         },
         ..AppConfig::default()
     }));
@@ -1933,6 +2130,7 @@ async fn queue_job_create_is_disabled_by_default() {
             state_dir: queue_state_dir.display().to_string(),
             cancel_grace_seconds: 0,
             configured: true,
+            ..QueueRunnerConfig::default()
         },
         ..AppConfig::default()
     }));
@@ -1969,6 +2167,7 @@ async fn queue_job_create_persists_pending_job_and_files() {
             state_dir: queue_state_dir.display().to_string(),
             cancel_grace_seconds: 0,
             configured: true,
+            ..QueueRunnerConfig::default()
         },
         ..AppConfig::default()
     };
@@ -2072,6 +2271,7 @@ async fn queue_job_create_validates_request_shape() {
             state_dir: queue_state_dir.display().to_string(),
             cancel_grace_seconds: 0,
             configured: true,
+            ..QueueRunnerConfig::default()
         },
         ..AppConfig::default()
     };
@@ -2159,6 +2359,7 @@ async fn queue_job_create_runs_when_runtime_enabled() {
             state_dir: queue_state_dir.display().to_string(),
             cancel_grace_seconds: 0,
             configured: true,
+            ..QueueRunnerConfig::default()
         },
         sm_send: SmSendConfig {
             db_path: message_queue_db.display().to_string(),
@@ -2207,6 +2408,77 @@ async fn queue_job_create_runs_when_runtime_enabled() {
 }
 
 #[tokio::test]
+async fn queue_job_runtime_respects_configured_max_running_jobs() {
+    let state_file = write_session_fixture();
+    let queue_state_dir = state_file.with_extension("queue-runner-configured-cap");
+    let message_queue_db = state_file.with_extension("queue-configured-cap-message-queue.db");
+    let working_dir = unique_temp_path().with_extension("queue-cwd");
+    fs::create_dir_all(&working_dir).unwrap();
+    let mut config = AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        queue_runner: QueueRunnerConfig {
+            state_dir: queue_state_dir.display().to_string(),
+            cancel_grace_seconds: 0,
+            max_running_jobs: 1,
+            configured: true,
+            ..QueueRunnerConfig::default()
+        },
+        sm_send: SmSendConfig {
+            db_path: message_queue_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    };
+    config.rust_core.runtime_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, first) = post_json(
+        app.clone(),
+        "/queue-jobs",
+        json!({
+            "type": "tests",
+            "label": "configured cap first",
+            "script": "printf first-start; sleep 1; printf first-end",
+            "cwd": working_dir.display().to_string(),
+            "notify_target": "run12345",
+            "requester_session_id": "run12345",
+            "timeout_seconds": 5
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let first_id = first["id"].as_str().unwrap().to_owned();
+    let first_running = wait_for_queue_job_state(app.clone(), &first_id, &["running"]).await;
+    assert_eq!(first_running["state"], "running");
+
+    let (status, second) = post_json(
+        app.clone(),
+        "/queue-jobs",
+        json!({
+            "type": "tests",
+            "label": "configured cap second",
+            "script": "printf second-started",
+            "cwd": working_dir.display().to_string(),
+            "notify_target": "run12345",
+            "requester_session_id": "run12345",
+            "timeout_seconds": 5
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let second_id = second["id"].as_str().unwrap().to_owned();
+    assert_eq!(second["state"], "pending");
+    assert_eq!(second["holding_reason"], "concurrency_cap");
+
+    let first_final = wait_for_queue_job_state(app.clone(), &first_id, &["succeeded"]).await;
+    assert_eq!(first_final["exit_code"], 0);
+    let second_final = wait_for_queue_job_state(app, &second_id, &["succeeded"]).await;
+    assert_eq!(second_final["exit_code"], 0);
+    assert_eq!(second_final["holding_reason"], Value::Null);
+}
+
+#[tokio::test]
 async fn queue_job_runtime_persists_failure_and_timeout() {
     let state_file = write_session_fixture();
     let queue_state_dir = state_file.with_extension("queue-runner-terminal");
@@ -2221,6 +2493,7 @@ async fn queue_job_runtime_persists_failure_and_timeout() {
             state_dir: queue_state_dir.display().to_string(),
             cancel_grace_seconds: 0,
             configured: true,
+            ..QueueRunnerConfig::default()
         },
         sm_send: SmSendConfig {
             db_path: message_queue_db.display().to_string(),
@@ -2285,6 +2558,823 @@ async fn queue_job_runtime_persists_failure_and_timeout() {
 }
 
 #[tokio::test]
+async fn queue_runtime_recovery_requeues_held_pending_job() {
+    let state_file = write_session_fixture();
+    let queue_state_dir = state_file.with_extension("queue-runner-recover-held-pending");
+    let message_queue_db = state_file.with_extension("queue-recover-held-pending-message-queue.db");
+    let working_dir = unique_temp_path().with_extension("queue-cwd");
+    fs::create_dir_all(&working_dir).unwrap();
+    let app = queue_runtime_test_app(
+        &state_file,
+        &queue_state_dir,
+        &message_queue_db,
+        false,
+        true,
+    );
+    let job_id = create_pending_queue_job(
+        app.clone(),
+        &working_dir,
+        "recover held pending",
+        "printf recovered-held",
+        5,
+    )
+    .await;
+    set_queue_job_holding_reason(&queue_state_dir, &job_id, "memory_pressure");
+
+    let summary =
+        RetainedQueueStore::recover_queue_jobs_in_state_dir(&queue_state_dir, &message_queue_db, 0)
+            .unwrap();
+
+    assert_eq!(summary.requeued_pending, 1);
+    assert_eq!(summary.started_pending, 1);
+    assert_eq!(summary.held_pending, 0);
+    let final_payload = wait_for_queue_job_state(app, &job_id, &["succeeded"]).await;
+    assert_eq!(final_payload["holding_reason"], Value::Null);
+    assert!(final_payload["started_at"].as_str().is_some());
+    let notifications = queued_message_texts(&message_queue_db, "run12345");
+    assert_eq!(notifications.len(), 1);
+    assert!(notifications[0].contains(&format!("[sm queue] {job_id} completed: succeeded")));
+}
+
+#[tokio::test]
+async fn queue_runtime_recovery_admits_pending_jobs_through_concurrency_cap() {
+    let state_file = write_session_fixture();
+    let queue_state_dir = state_file.with_extension("queue-runner-recover-pending-cap");
+    let message_queue_db = state_file.with_extension("queue-recover-pending-cap-message-queue.db");
+    let working_dir = unique_temp_path().with_extension("queue-cwd");
+    fs::create_dir_all(&working_dir).unwrap();
+    let app = queue_runtime_test_app(
+        &state_file,
+        &queue_state_dir,
+        &message_queue_db,
+        false,
+        true,
+    );
+    let first_id = create_pending_queue_job(
+        app.clone(),
+        &working_dir,
+        "recover cap first",
+        "sleep 0.5; printf first",
+        5,
+    )
+    .await;
+    let second_id = create_pending_queue_job(
+        app.clone(),
+        &working_dir,
+        "recover cap second",
+        "sleep 0.5; printf second",
+        5,
+    )
+    .await;
+    let third_id = create_pending_queue_job(
+        app.clone(),
+        &working_dir,
+        "recover cap third",
+        "printf third",
+        5,
+    )
+    .await;
+    set_queue_job_holding_reason(&queue_state_dir, &third_id, "memory_pressure");
+
+    let summary =
+        RetainedQueueStore::recover_queue_jobs_in_state_dir(&queue_state_dir, &message_queue_db, 0)
+            .unwrap();
+
+    assert_eq!(summary.started_pending, 2);
+    assert_eq!(summary.requeued_pending, 1);
+    assert!(summary.held_pending >= 1);
+    let (status, third_pending) = get_json(app.clone(), &format!("/queue-jobs/{third_id}")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(third_pending["state"], "pending");
+    assert_eq!(third_pending["holding_reason"], "concurrency_cap");
+
+    let first_final = wait_for_queue_job_state(app.clone(), &first_id, &["succeeded"]).await;
+    let second_final = wait_for_queue_job_state(app.clone(), &second_id, &["succeeded"]).await;
+    let third_final = wait_for_queue_job_state(app, &third_id, &["succeeded"]).await;
+    assert_eq!(first_final["exit_code"], 0);
+    assert_eq!(second_final["exit_code"], 0);
+    assert_eq!(third_final["exit_code"], 0);
+}
+
+#[tokio::test]
+async fn queue_runtime_admission_displaces_background_for_ready_perf_job() {
+    let state_file = write_session_fixture();
+    let queue_state_dir = state_file.with_extension("queue-runner-displace-background");
+    let message_queue_db = state_file.with_extension("queue-displace-background-message-queue.db");
+    let working_dir = unique_temp_path().with_extension("queue-cwd");
+    fs::create_dir_all(&working_dir).unwrap();
+    let mut config = AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        queue_runner: QueueRunnerConfig {
+            state_dir: queue_state_dir.display().to_string(),
+            cancel_grace_seconds: 2,
+            configured: true,
+            ..QueueRunnerConfig::default()
+        },
+        sm_send: SmSendConfig {
+            db_path: message_queue_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    };
+    config.rust_core.runtime_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, first_background) = post_json(
+        app.clone(),
+        "/queue-jobs",
+        json!({
+            "type": "background",
+            "label": "first background",
+            "script": "trap 'exit 0' TERM; printf first-start; while true; do sleep 1; done",
+            "cwd": working_dir.display().to_string(),
+            "notify_target": "run12345",
+            "requester_session_id": "run12345",
+            "timeout_seconds": 10
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let first_background_id = first_background["id"].as_str().unwrap().to_owned();
+    let (status, second_background) = post_json(
+        app.clone(),
+        "/queue-jobs",
+        json!({
+            "type": "background",
+            "label": "second background",
+            "script": "printf second-start; sleep 2; printf second-end",
+            "cwd": working_dir.display().to_string(),
+            "notify_target": "run12345",
+            "requester_session_id": "run12345",
+            "timeout_seconds": 10
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let second_background_id = second_background["id"].as_str().unwrap().to_owned();
+    let first_running =
+        wait_for_queue_job_state(app.clone(), &first_background_id, &["running"]).await;
+    let second_running =
+        wait_for_queue_job_state(app.clone(), &second_background_id, &["running"]).await;
+    assert!(first_running["pid"].as_i64().unwrap_or_default() > 0);
+    assert!(second_running["pid"].as_i64().unwrap_or_default() > 0);
+
+    let (status, perf) = post_json(
+        app.clone(),
+        "/queue-jobs",
+        json!({
+            "type": "perf",
+            "label": "ready perf",
+            "script": "printf perf-started",
+            "cwd": working_dir.display().to_string(),
+            "notify_target": "run12345",
+            "requester_session_id": "run12345",
+            "timeout_seconds": 10
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let perf_id = perf["id"].as_str().unwrap().to_owned();
+
+    let first_final =
+        wait_for_queue_job_state(app.clone(), &first_background_id, &["displaced"]).await;
+    assert_eq!(first_final["state"], "displaced");
+    let perf_final = wait_for_queue_job_state(app.clone(), &perf_id, &["succeeded"]).await;
+    assert_eq!(perf_final["exit_code"], 0);
+    assert_eq!(perf_final["holding_reason"], Value::Null);
+    let second_final = wait_for_queue_job_state(app, &second_background_id, &["succeeded"]).await;
+    assert_eq!(second_final["exit_code"], 0);
+    let notifications = queued_message_texts(&message_queue_db, "run12345");
+    assert!(notifications.iter().any(|text| text.contains(&format!(
+        "[sm queue] {first_background_id} completed: displaced"
+    ))));
+    assert!(notifications
+        .iter()
+        .any(|text| text.contains(&format!("[sm queue] {perf_id} completed: succeeded"))));
+}
+
+#[tokio::test]
+async fn queue_runtime_recovery_retries_perf_after_cooldown_expires() {
+    let state_file = write_session_fixture();
+    let queue_state_dir = state_file.with_extension("queue-runner-recover-perf-cooldown");
+    let message_queue_db =
+        state_file.with_extension("queue-recover-perf-cooldown-message-queue.db");
+    let working_dir = unique_temp_path().with_extension("queue-cwd");
+    fs::create_dir_all(&working_dir).unwrap();
+    let app = queue_runtime_test_app(
+        &state_file,
+        &queue_state_dir,
+        &message_queue_db,
+        false,
+        true,
+    );
+    let seed_id = create_pending_queue_job(
+        app.clone(),
+        &working_dir,
+        "cooldown seed",
+        "printf cooldown-seed",
+        5,
+    )
+    .await;
+    let now = time::OffsetDateTime::now_utc();
+    let started_at = (now - time::Duration::seconds(29))
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap();
+    let finished_at = (now - time::Duration::seconds(28))
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap();
+    mark_queue_job_terminal(
+        &queue_state_dir,
+        &seed_id,
+        "succeeded",
+        &started_at,
+        &finished_at,
+        0,
+    );
+    let perf_id = create_pending_queue_job_of_type(
+        app.clone(),
+        &working_dir,
+        "perf",
+        "perf after cooldown",
+        "printf perf-after-cooldown",
+        5,
+    )
+    .await;
+
+    RetainedQueueStore::admit_queue_jobs_in_state_dir(&queue_state_dir, &message_queue_db, 0)
+        .unwrap();
+
+    let (status, held) = get_json(app.clone(), &format!("/queue-jobs/{perf_id}")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(held["state"], "pending");
+    assert_eq!(held["holding_reason"], "perf_cooldown");
+
+    let final_payload = wait_for_queue_job_state(app, &perf_id, &["succeeded"]).await;
+    assert_eq!(final_payload["holding_reason"], Value::Null);
+    assert_eq!(final_payload["exit_code"], 0);
+    assert_eq!(
+        fs::read_to_string(queue_state_dir.join(format!("logs/{perf_id}.log"))).unwrap(),
+        "perf-after-cooldown"
+    );
+    assert!(queue_job_completion_notified_at(&queue_state_dir, &perf_id).is_some());
+}
+
+#[tokio::test]
+async fn queue_runtime_admission_respects_configured_perf_cooldown() {
+    let state_file = write_session_fixture();
+    let queue_state_dir = state_file.with_extension("queue-runner-configured-perf-cooldown");
+    let message_queue_db =
+        state_file.with_extension("queue-configured-perf-cooldown-message-queue.db");
+    let working_dir = unique_temp_path().with_extension("queue-cwd");
+    fs::create_dir_all(&working_dir).unwrap();
+    let app = queue_runtime_test_app(
+        &state_file,
+        &queue_state_dir,
+        &message_queue_db,
+        false,
+        true,
+    );
+    let seed_id = create_pending_queue_job(
+        app.clone(),
+        &working_dir,
+        "configured cooldown seed",
+        "printf configured-cooldown-seed",
+        5,
+    )
+    .await;
+    let now = time::OffsetDateTime::now_utc();
+    let started_at = (now - time::Duration::seconds(4))
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap();
+    let finished_at = (now - time::Duration::seconds(3))
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap();
+    mark_queue_job_terminal(
+        &queue_state_dir,
+        &seed_id,
+        "succeeded",
+        &started_at,
+        &finished_at,
+        0,
+    );
+    let perf_id = create_pending_queue_job_of_type(
+        app.clone(),
+        &working_dir,
+        "perf",
+        "configured cooldown perf",
+        "printf configured-perf",
+        5,
+    )
+    .await;
+
+    RetainedQueueStore::admit_queue_jobs_in_state_dir_continuing_after_failed_start_with_policy(
+        &queue_state_dir,
+        &message_queue_db,
+        0,
+        QueueAdmissionPolicy {
+            max_running_jobs: 2,
+            perf_cooldown_seconds: 5,
+        },
+    )
+    .unwrap();
+
+    let (status, held) = get_json(app.clone(), &format!("/queue-jobs/{perf_id}")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(held["state"], "pending");
+    assert_eq!(held["holding_reason"], "perf_cooldown");
+
+    RetainedQueueStore::admit_queue_jobs_in_state_dir_continuing_after_failed_start_with_policy(
+        &queue_state_dir,
+        &message_queue_db,
+        0,
+        QueueAdmissionPolicy {
+            max_running_jobs: 2,
+            perf_cooldown_seconds: 1,
+        },
+    )
+    .unwrap();
+
+    let final_payload = wait_for_queue_job_state(app, &perf_id, &["succeeded"]).await;
+    assert_eq!(final_payload["exit_code"], 0);
+    assert_eq!(final_payload["holding_reason"], Value::Null);
+}
+
+#[tokio::test]
+async fn queue_runtime_admission_serializes_concurrent_start_claims() {
+    let state_file = write_session_fixture();
+    let queue_state_dir = state_file.with_extension("queue-runner-concurrent-admission");
+    let message_queue_db = state_file.with_extension("queue-concurrent-admission-message-queue.db");
+    let working_dir = unique_temp_path().with_extension("queue-cwd");
+    fs::create_dir_all(&working_dir).unwrap();
+    let marker_path = working_dir.join("started.txt");
+    let app = queue_runtime_test_app(
+        &state_file,
+        &queue_state_dir,
+        &message_queue_db,
+        false,
+        true,
+    );
+    let job_id = create_pending_queue_job(
+        app.clone(),
+        &working_dir,
+        "concurrent admission",
+        &format!("printf started >> {}; sleep 0.1", marker_path.display()),
+        5,
+    )
+    .await;
+
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let queue_state_dir = queue_state_dir.clone();
+        let message_queue_db = message_queue_db.clone();
+        handles.push(thread::spawn(move || {
+            RetainedQueueStore::admit_queue_jobs_in_state_dir(
+                &queue_state_dir,
+                &message_queue_db,
+                0,
+            )
+            .unwrap();
+        }));
+    }
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    let final_payload = wait_for_queue_job_state(app, &job_id, &["succeeded"]).await;
+    assert_eq!(final_payload["exit_code"], 0);
+    assert_eq!(
+        fs::read_to_string(marker_path)
+            .unwrap()
+            .matches("started")
+            .count(),
+        1
+    );
+    assert!(queue_job_completion_notified_at(&queue_state_dir, &job_id).is_some());
+}
+
+#[tokio::test]
+async fn queue_runtime_recovery_starts_pending_job() {
+    let state_file = write_session_fixture();
+    let queue_state_dir = state_file.with_extension("queue-runner-recover-pending");
+    let message_queue_db = state_file.with_extension("queue-recover-pending-message-queue.db");
+    let working_dir = unique_temp_path().with_extension("queue-cwd");
+    fs::create_dir_all(&working_dir).unwrap();
+    let app = queue_runtime_test_app(
+        &state_file,
+        &queue_state_dir,
+        &message_queue_db,
+        false,
+        true,
+    );
+    let job_id = create_pending_queue_job(
+        app.clone(),
+        &working_dir,
+        "recover pending",
+        "printf recovered-pending",
+        5,
+    )
+    .await;
+
+    let summary =
+        RetainedQueueStore::recover_queue_jobs_in_state_dir(&queue_state_dir, &message_queue_db, 0)
+            .unwrap();
+
+    assert_eq!(summary.started_pending, 1);
+    let final_payload = wait_for_queue_job_state(app, &job_id, &["succeeded"]).await;
+    assert_eq!(final_payload["exit_code"], 0);
+    assert!(queue_job_completion_notified_at(&queue_state_dir, &job_id).is_some());
+    let notifications = queued_message_texts(&message_queue_db, "run12345");
+    assert_eq!(notifications.len(), 1);
+    assert!(notifications[0].contains(&format!("[sm queue] {job_id} completed: succeeded")));
+    assert!(notifications[0].contains("log tail:\nrecovered-pending"));
+}
+
+#[tokio::test]
+async fn queue_runtime_recovery_continues_after_bad_pending_job() {
+    let state_file = write_session_fixture();
+    let queue_state_dir = state_file.with_extension("queue-runner-recover-bad-pending");
+    let message_queue_db = state_file.with_extension("queue-recover-bad-pending-message-queue.db");
+    let working_dir = unique_temp_path().with_extension("queue-cwd");
+    fs::create_dir_all(&working_dir).unwrap();
+    let app = queue_runtime_test_app(
+        &state_file,
+        &queue_state_dir,
+        &message_queue_db,
+        false,
+        true,
+    );
+    let bad_job_id = create_pending_queue_job(
+        app.clone(),
+        &working_dir,
+        "recover bad pending",
+        "printf should-not-start",
+        5,
+    )
+    .await;
+    let good_job_id = create_pending_queue_job(
+        app.clone(),
+        &working_dir,
+        "recover good pending",
+        "printf recovered-after-bad-pending",
+        5,
+    )
+    .await;
+    set_queue_job_text_column_null(&queue_state_dir, &bad_job_id, "wrapper_path");
+
+    let summary =
+        RetainedQueueStore::recover_queue_jobs_in_state_dir(&queue_state_dir, &message_queue_db, 0)
+            .unwrap();
+
+    assert_eq!(summary.finished_failed, 1);
+    assert_eq!(summary.started_pending, 1);
+    let (bad_status, bad_detail) =
+        get_json(app.clone(), &format!("/queue-jobs/{bad_job_id}")).await;
+    assert_eq!(bad_status, StatusCode::OK);
+    assert_eq!(bad_detail["state"], "failed");
+    let good_final = wait_for_queue_job_state(app, &good_job_id, &["succeeded"]).await;
+    assert_eq!(good_final["exit_code"], 0);
+    let notifications = queued_message_texts(&message_queue_db, "run12345");
+    assert_eq!(notifications.len(), 2);
+    assert!(notifications[0].contains(&format!("[sm queue] {bad_job_id} completed: failed")));
+    assert!(notifications[1].contains(&format!("[sm queue] {good_job_id} completed: succeeded")));
+}
+
+#[tokio::test]
+async fn queue_job_create_continues_after_bad_existing_pending_job() {
+    let state_file = write_session_fixture();
+    let queue_state_dir = state_file.with_extension("queue-runner-create-after-bad-pending");
+    let message_queue_db = state_file.with_extension("queue-create-after-bad-message-queue.db");
+    let working_dir = unique_temp_path().with_extension("queue-cwd");
+    fs::create_dir_all(&working_dir).unwrap();
+    let seed_app = queue_runtime_test_app(
+        &state_file,
+        &queue_state_dir,
+        &message_queue_db,
+        false,
+        true,
+    );
+    let bad_job_id = create_pending_queue_job(
+        seed_app,
+        &working_dir,
+        "bad existing pending",
+        "printf should-not-start",
+        5,
+    )
+    .await;
+    set_queue_job_text_column_null(&queue_state_dir, &bad_job_id, "wrapper_path");
+
+    let app = queue_runtime_test_app(
+        &state_file,
+        &queue_state_dir,
+        &message_queue_db,
+        true,
+        false,
+    );
+    let (status, created) = post_json(
+        app.clone(),
+        "/queue-jobs",
+        json!({
+            "type": "tests",
+            "label": "created after bad pending",
+            "script": "printf created-after-bad",
+            "cwd": working_dir.display().to_string(),
+            "notify_target": "run12345",
+            "requester_session_id": "run12345",
+            "timeout_seconds": 5
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let created_id = created["id"].as_str().unwrap().to_owned();
+
+    let bad_final = wait_for_queue_job_state(app.clone(), &bad_job_id, &["failed"]).await;
+    assert_eq!(bad_final["state"], "failed");
+    let created_final = wait_for_queue_job_state(app, &created_id, &["succeeded"]).await;
+    assert_eq!(created_final["exit_code"], 0);
+    let notifications = queued_message_texts(&message_queue_db, "run12345");
+    assert_eq!(notifications.len(), 2);
+    assert!(notifications[0].contains(&format!("[sm queue] {bad_job_id} completed: failed")));
+    assert!(notifications[1].contains(&format!("[sm queue] {created_id} completed: succeeded")));
+}
+
+#[tokio::test]
+async fn queue_runtime_recovery_finishes_running_job_with_exit_code() {
+    let state_file = write_session_fixture();
+    let queue_state_dir = state_file.with_extension("queue-runner-recover-exit");
+    let message_queue_db = state_file.with_extension("queue-recover-exit-message-queue.db");
+    let working_dir = unique_temp_path().with_extension("queue-cwd");
+    fs::create_dir_all(&working_dir).unwrap();
+    let app = queue_runtime_test_app(
+        &state_file,
+        &queue_state_dir,
+        &message_queue_db,
+        false,
+        true,
+    );
+    let job_id = create_pending_queue_job(
+        app.clone(),
+        &working_dir,
+        "recover exit",
+        "printf recovered-exit",
+        5,
+    )
+    .await;
+    let exit_code_path = queue_job_text_column(&queue_state_dir, &job_id, "exit_code_path");
+    let log_path = queue_job_text_column(&queue_state_dir, &job_id, "log_path");
+    fs::write(&exit_code_path, "0\n").unwrap();
+    fs::write(&log_path, "recovered-exit").unwrap();
+    mark_queue_job_running(
+        &queue_state_dir,
+        &job_id,
+        &test_now_rfc3339(),
+        9_999_999,
+        9_999_999,
+    );
+
+    let summary =
+        RetainedQueueStore::recover_queue_jobs_in_state_dir(&queue_state_dir, &message_queue_db, 0)
+            .unwrap();
+
+    assert_eq!(summary.recovered_running, 1);
+    assert_eq!(summary.finished_succeeded, 1);
+    let (status, detail) = get_json(app, &format!("/queue-jobs/{job_id}")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(detail["state"], "succeeded");
+    assert_eq!(detail["exit_code"], 0);
+    let notifications = queued_message_texts(&message_queue_db, "run12345");
+    assert_eq!(notifications.len(), 1);
+    assert!(notifications[0].contains(&format!("[sm queue] {job_id} completed: succeeded")));
+}
+
+#[tokio::test]
+async fn queue_runtime_recovery_marks_dead_running_job_failed() {
+    let state_file = write_session_fixture();
+    let queue_state_dir = state_file.with_extension("queue-runner-recover-dead");
+    let message_queue_db = state_file.with_extension("queue-recover-dead-message-queue.db");
+    let working_dir = unique_temp_path().with_extension("queue-cwd");
+    fs::create_dir_all(&working_dir).unwrap();
+    let app = queue_runtime_test_app(
+        &state_file,
+        &queue_state_dir,
+        &message_queue_db,
+        false,
+        true,
+    );
+    let job_id = create_pending_queue_job(
+        app.clone(),
+        &working_dir,
+        "recover dead",
+        "printf never-ran",
+        5,
+    )
+    .await;
+    mark_queue_job_running(
+        &queue_state_dir,
+        &job_id,
+        &test_now_rfc3339(),
+        9_999_999,
+        9_999_999,
+    );
+
+    let summary =
+        RetainedQueueStore::recover_queue_jobs_in_state_dir(&queue_state_dir, &message_queue_db, 0)
+            .unwrap();
+
+    assert_eq!(summary.recovered_running, 1);
+    assert_eq!(summary.finished_failed, 1);
+    let (status, detail) = get_json(app, &format!("/queue-jobs/{job_id}")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(detail["state"], "failed");
+    assert!(queue_job_completion_notified_at(&queue_state_dir, &job_id).is_some());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn queue_runtime_recovery_honors_persisted_running_cancellation() {
+    let state_file = write_session_fixture();
+    let queue_state_dir = state_file.with_extension("queue-runner-recover-cancelling");
+    let message_queue_db = state_file.with_extension("queue-recover-cancelling-message-queue.db");
+    let working_dir = unique_temp_path().with_extension("queue-cwd");
+    fs::create_dir_all(&working_dir).unwrap();
+    let app = queue_runtime_test_app(
+        &state_file,
+        &queue_state_dir,
+        &message_queue_db,
+        false,
+        true,
+    );
+    let job_id = create_pending_queue_job(
+        app.clone(),
+        &working_dir,
+        "recover cancelling",
+        "printf never-completes",
+        30,
+    )
+    .await;
+    let ready_path = queue_state_dir.join("recover-cancelling.ready");
+    let mut child = Command::new("/bin/zsh")
+        .arg("-lc")
+        .arg("printf ready > \"$READY_PATH\"; while true; do sleep 1; done")
+        .env("READY_PATH", &ready_path)
+        .process_group(0)
+        .spawn()
+        .unwrap();
+    let _ready = wait_for_file_contains(&ready_path, "ready").await;
+    let pid = i64::from(child.id());
+    mark_queue_job_running_with_holding(
+        &queue_state_dir,
+        &job_id,
+        &test_now_rfc3339(),
+        pid,
+        pid,
+        Some("cancelling"),
+    );
+
+    let summary =
+        RetainedQueueStore::recover_queue_jobs_in_state_dir(&queue_state_dir, &message_queue_db, 0)
+            .unwrap();
+
+    assert_eq!(summary.recovered_running, 1);
+    assert_eq!(summary.finished_cancelled, 1);
+    let mut exited = false;
+    for _ in 0..50 {
+        if child.try_wait().unwrap().is_some() {
+            exited = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    if !exited {
+        let _ = Command::new("/bin/kill")
+            .arg("-KILL")
+            .arg(format!("-{pid}"))
+            .status();
+        let _ = child.wait();
+    }
+    assert!(exited, "recovered cancelling process was not stopped");
+    let (status, detail) = get_json(app, &format!("/queue-jobs/{job_id}")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(detail["state"], "cancelled");
+    assert!(queue_job_completion_notified_at(&queue_state_dir, &job_id).is_some());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn queue_runtime_recovery_polls_live_running_job_to_completion() {
+    let state_file = write_session_fixture();
+    let queue_state_dir = state_file.with_extension("queue-runner-recover-live");
+    let message_queue_db = state_file.with_extension("queue-recover-live-message-queue.db");
+    let working_dir = unique_temp_path().with_extension("queue-cwd");
+    fs::create_dir_all(&working_dir).unwrap();
+    let app = queue_runtime_test_app(
+        &state_file,
+        &queue_state_dir,
+        &message_queue_db,
+        false,
+        true,
+    );
+    let job_id = create_pending_queue_job(
+        app.clone(),
+        &working_dir,
+        "recover live",
+        "printf placeholder",
+        5,
+    )
+    .await;
+    let exit_code_path = queue_job_text_column(&queue_state_dir, &job_id, "exit_code_path");
+    let log_path = queue_job_text_column(&queue_state_dir, &job_id, "log_path");
+    let ready_path = queue_state_dir.join("recover-live.ready");
+    let mut child = Command::new("/bin/zsh")
+        .arg("-lc")
+        .arg("printf ready > \"$READY_PATH\"; sleep 0.3; printf recovered-live > \"$LOG_PATH\"; printf '0\\n' > \"$EXIT_CODE_PATH\"")
+        .env("READY_PATH", &ready_path)
+        .env("LOG_PATH", &log_path)
+        .env("EXIT_CODE_PATH", &exit_code_path)
+        .process_group(0)
+        .spawn()
+        .unwrap();
+    let _ready = wait_for_file_contains(&ready_path, "ready").await;
+    let pid = i64::from(child.id());
+    mark_queue_job_running(&queue_state_dir, &job_id, &test_now_rfc3339(), pid, pid);
+
+    let summary =
+        RetainedQueueStore::recover_queue_jobs_in_state_dir(&queue_state_dir, &message_queue_db, 0)
+            .unwrap();
+    assert_eq!(summary.recovered_running, 1);
+    assert_eq!(summary.polling_running, 1);
+    let final_payload = wait_for_queue_job_state(app, &job_id, &["succeeded"]).await;
+    assert_eq!(final_payload["exit_code"], 0);
+    let _ = child.wait();
+    let notifications = queued_message_texts(&message_queue_db, "run12345");
+    assert_eq!(notifications.len(), 1);
+    assert!(notifications[0].contains("log tail:\nrecovered-live"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn queue_runtime_recovery_times_out_and_stops_live_running_job() {
+    let state_file = write_session_fixture();
+    let queue_state_dir = state_file.with_extension("queue-runner-recover-timeout");
+    let message_queue_db = state_file.with_extension("queue-recover-timeout-message-queue.db");
+    let working_dir = unique_temp_path().with_extension("queue-cwd");
+    fs::create_dir_all(&working_dir).unwrap();
+    let app = queue_runtime_test_app(
+        &state_file,
+        &queue_state_dir,
+        &message_queue_db,
+        false,
+        true,
+    );
+    let job_id = create_pending_queue_job(
+        app.clone(),
+        &working_dir,
+        "recover timeout",
+        "printf never-completes",
+        1,
+    )
+    .await;
+    let ready_path = queue_state_dir.join("recover-timeout.ready");
+    let mut child = Command::new("/bin/zsh")
+        .arg("-lc")
+        .arg("trap '' TERM; printf ready > \"$READY_PATH\"; while true; do sleep 1; done")
+        .env("READY_PATH", &ready_path)
+        .process_group(0)
+        .spawn()
+        .unwrap();
+    let _ready = wait_for_file_contains(&ready_path, "ready").await;
+    let pid = i64::from(child.id());
+    mark_queue_job_running(&queue_state_dir, &job_id, "2026-06-14T00:00:00Z", pid, pid);
+
+    let summary =
+        RetainedQueueStore::recover_queue_jobs_in_state_dir(&queue_state_dir, &message_queue_db, 0)
+            .unwrap();
+
+    assert_eq!(summary.recovered_running, 1);
+    assert_eq!(summary.finished_timed_out, 1);
+    let mut exited = false;
+    for _ in 0..50 {
+        if child.try_wait().unwrap().is_some() {
+            exited = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    if !exited {
+        let _ = Command::new("/bin/kill")
+            .arg("-KILL")
+            .arg(format!("-{pid}"))
+            .status();
+        let _ = child.wait();
+    }
+    assert!(exited, "recovered timed-out process was not stopped");
+    let (status, detail) = get_json(app, &format!("/queue-jobs/{job_id}")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(detail["state"], "timed_out");
+    assert!(queue_job_completion_notified_at(&queue_state_dir, &job_id).is_some());
+}
+
+#[tokio::test]
 async fn queue_job_cancel_persists_pending_cancel() {
     let state_file = write_session_fixture();
     let queue_state_dir = state_file.with_extension("queue-runner-cancel");
@@ -2299,6 +3389,7 @@ async fn queue_job_cancel_persists_pending_cancel() {
             state_dir: queue_state_dir.display().to_string(),
             cancel_grace_seconds: 0,
             configured: true,
+            ..QueueRunnerConfig::default()
         },
         sm_send: SmSendConfig {
             db_path: message_queue_db.display().to_string(),
@@ -2343,6 +3434,63 @@ async fn queue_job_cancel_persists_pending_cancel() {
 }
 
 #[tokio::test]
+async fn queue_job_cancel_does_not_admit_pending_jobs_without_runtime_ownership() {
+    let state_file = write_session_fixture();
+    let queue_state_dir = state_file.with_extension("queue-runner-cancel-no-runtime-admission");
+    let message_queue_db = state_file.with_extension("queue-cancel-no-runtime-message-queue.db");
+    let working_dir = unique_temp_path().with_extension("queue-cwd");
+    fs::create_dir_all(&working_dir).unwrap();
+    let mut config = AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        queue_runner: QueueRunnerConfig {
+            state_dir: queue_state_dir.display().to_string(),
+            cancel_grace_seconds: 0,
+            configured: true,
+            ..QueueRunnerConfig::default()
+        },
+        sm_send: SmSendConfig {
+            db_path: message_queue_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    };
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let first_id = create_pending_queue_job(
+        app.clone(),
+        &working_dir,
+        "cancel fixture first",
+        "printf first-should-not-run",
+        5,
+    )
+    .await;
+    let second_id = create_pending_queue_job(
+        app.clone(),
+        &working_dir,
+        "cancel fixture second",
+        "printf second-should-not-run",
+        5,
+    )
+    .await;
+
+    let (status, cancelled) =
+        delete_json(app.clone(), &format!("/queue-jobs/{first_id}"), json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(cancelled["state"], "cancelled");
+
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let (status, second_detail) = get_json(app, &format!("/queue-jobs/{second_id}")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(second_detail["state"], "pending");
+    assert_eq!(second_detail["pid"], Value::Null);
+    assert!(!queue_state_dir
+        .join(format!("logs/{second_id}.log"))
+        .exists());
+}
+
+#[tokio::test]
 async fn queue_job_cancel_terminates_running_job() {
     let state_file = write_session_fixture();
     let queue_state_dir = state_file.with_extension("queue-runner-cancel-running");
@@ -2357,6 +3505,7 @@ async fn queue_job_cancel_terminates_running_job() {
             state_dir: queue_state_dir.display().to_string(),
             cancel_grace_seconds: 0,
             configured: true,
+            ..QueueRunnerConfig::default()
         },
         sm_send: SmSendConfig {
             db_path: message_queue_db.display().to_string(),
@@ -2406,6 +3555,88 @@ async fn queue_job_cancel_terminates_running_job() {
     assert!(notifications[0].contains("log tail:\nbefore-cancel"));
 }
 
+#[tokio::test]
+async fn queue_job_cancel_admits_next_pending_job() {
+    let state_file = write_session_fixture();
+    let queue_state_dir = state_file.with_extension("queue-runner-cancel-admits-next");
+    let message_queue_db = state_file.with_extension("queue-cancel-admits-next-message-queue.db");
+    let working_dir = unique_temp_path().with_extension("queue-cwd");
+    fs::create_dir_all(&working_dir).unwrap();
+    let app = queue_runtime_test_app(
+        &state_file,
+        &queue_state_dir,
+        &message_queue_db,
+        true,
+        false,
+    );
+
+    let (status, first) = post_json(
+        app.clone(),
+        "/queue-jobs",
+        json!({
+            "type": "tests",
+            "label": "cancel admits first",
+            "script": "printf first-start; sleep 2; printf first-end",
+            "cwd": working_dir.display().to_string(),
+            "notify_target": "run12345",
+            "requester_session_id": "run12345",
+            "timeout_seconds": 10
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let first_id = first["id"].as_str().unwrap().to_owned();
+    let (status, second) = post_json(
+        app.clone(),
+        "/queue-jobs",
+        json!({
+            "type": "tests",
+            "label": "cancel admits second",
+            "script": "printf second-start; sleep 2; printf second-end",
+            "cwd": working_dir.display().to_string(),
+            "notify_target": "run12345",
+            "requester_session_id": "run12345",
+            "timeout_seconds": 10
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let second_id = second["id"].as_str().unwrap().to_owned();
+    let first_running = wait_for_queue_job_state(app.clone(), &first_id, &["running"]).await;
+    let second_running = wait_for_queue_job_state(app.clone(), &second_id, &["running"]).await;
+    assert!(first_running["pid"].as_i64().unwrap_or_default() > 0);
+    assert!(second_running["pid"].as_i64().unwrap_or_default() > 0);
+
+    let third_id = create_pending_queue_job(
+        app.clone(),
+        &working_dir,
+        "cancel admits third",
+        "printf third-started",
+        10,
+    )
+    .await;
+    let (status, third_pending) = get_json(app.clone(), &format!("/queue-jobs/{third_id}")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(third_pending["state"], "pending");
+    assert_eq!(third_pending["holding_reason"], "concurrency_cap");
+
+    let (status, cancelled) =
+        delete_json(app.clone(), &format!("/queue-jobs/{first_id}"), json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(cancelled["state"], "cancelled");
+    let third_final = wait_for_queue_job_state(app.clone(), &third_id, &["succeeded"]).await;
+    assert_eq!(third_final["exit_code"], 0);
+    assert_eq!(third_final["holding_reason"], Value::Null);
+    assert_eq!(
+        fs::read_to_string(queue_state_dir.join(format!("logs/{third_id}.log"))).unwrap(),
+        "third-started"
+    );
+    let second_final = wait_for_queue_job_state(app, &second_id, &["succeeded"]).await;
+    assert_eq!(second_final["exit_code"], 0);
+    assert!(queue_job_completion_notified_at(&queue_state_dir, &first_id).is_some());
+    assert!(queue_job_completion_notified_at(&queue_state_dir, &third_id).is_some());
+}
+
 #[cfg(unix)]
 #[tokio::test]
 async fn queue_job_cancel_force_stops_unmonitored_running_process_group() {
@@ -2422,6 +3653,7 @@ async fn queue_job_cancel_force_stops_unmonitored_running_process_group() {
             state_dir: queue_state_dir.display().to_string(),
             cancel_grace_seconds: 0,
             configured: true,
+            ..QueueRunnerConfig::default()
         },
         sm_send: SmSendConfig {
             db_path: message_queue_db.display().to_string(),
@@ -3285,6 +4517,7 @@ async fn shadow_http_reports_queue_job_detail_404() {
                 .to_string(),
             cancel_grace_seconds: 0,
             configured: true,
+            ..QueueRunnerConfig::default()
         },
         ..AppConfig::default()
     }));
@@ -3330,6 +4563,7 @@ async fn shadow_http_reports_queue_job_detail_200_as_status_only() {
             state_dir: queue_state_dir.display().to_string(),
             cancel_grace_seconds: 0,
             configured: true,
+            ..QueueRunnerConfig::default()
         },
         ..AppConfig::default()
     }));


### PR DESCRIPTION
## Summary
- recover retained queue runner rows on Rust server startup when runtime ownership is enabled
- reconcile running jobs from exit-code files, timeouts, dead pids, or live pid polling
- admit retained pending jobs through the narrow simple runtime path
- cover recovery with disposable queue/message DB fixtures

## Validation
- cargo fmt --check
- cargo test -p sm-server --test read_only_http queue_runtime_recovery -- --nocapture
- cargo test -p sm-server --test read_only_http queue_
- cargo test -p sm-server
- ./venv/bin/python -m json.tool scripts/rust_migration/contracts_manifest.json >/dev/null
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py -q
- git diff --check
- ./venv/bin/python -m scripts.rust_migration.mvp_rehearsal --output-dir /tmp/session-manager-queue-recovery-rehearsal-pr959 --skip-python-health --skip-baseline --skip-shadow --core-only --rust-base-url http://127.0.0.1:18441 --mutating-rust-base-url http://127.0.0.1:18442 --read-only-fixture-rust-base-url http://127.0.0.1:18443

Fixes #959