### PR TITLE
Rust MVP: port node HTTP routes

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -308,6 +308,15 @@ pub fn router(state: AppState) -> Router {
             get(get_codex_review_request),
         )
         .route("/nodes", get(list_nodes))
+        .route("/nodes/{node_id}/ping", post(ping_node))
+        .route(
+            "/nodes/{node_id}/restore-candidates",
+            get(list_node_restore_candidates),
+        )
+        .route(
+            "/nodes/{node_id}/restore-candidates/{session_id}/restore",
+            post(restore_node_restore_candidate),
+        )
         .route("/humans", get(list_humans))
         .route("/humans/{identifier}", get(get_human))
         .route("/humans/{identifier}/email", post(send_human_email))
@@ -1787,6 +1796,129 @@ async fn list_nodes(
 ) -> Result<Json<NodesListResponse>, ApiError> {
     ensure_session_read_allowed(&state, &request)?;
     Ok(Json(nodes_list_response(&state.config)))
+}
+
+async fn ping_node(
+    State(state): State<Arc<AppState>>,
+    Path(node_id): Path<String>,
+    request: Request,
+) -> Result<Json<NodePingResponse>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    let node_id = normalize_node_id(&node_id);
+    let Some(node) = state.config.nodes.registry.get(&node_id) else {
+        return Err(unknown_node_error(&node_id));
+    };
+    if is_primary_node(&node.id) {
+        return Ok(Json(NodePingResponse {
+            node: node_id,
+            ok: true,
+            error: None,
+        }));
+    }
+    Err(ApiError::Status {
+        status: StatusCode::SERVICE_UNAVAILABLE,
+        detail: format!("node-agent not connected for node {node_id}"),
+    })
+}
+
+async fn list_node_restore_candidates(
+    State(state): State<Arc<AppState>>,
+    Path(node_id): Path<String>,
+    Query(query): Query<NodeRestoreCandidatesQuery>,
+    request: Request,
+) -> Result<Json<NodeRestoreCandidatesResponse>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    let node_id = normalize_node_id(&node_id);
+    let Some(node) = state.config.nodes.registry.get(&node_id) else {
+        return Err(unknown_node_error(&node_id));
+    };
+    if !is_primary_node(&node.id) {
+        return Err(ApiError::Status {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            detail: format!("node-agent not connected for node {node_id}"),
+        });
+    }
+    let _force_refresh = query.refresh;
+    let sessions = state
+        .session_store
+        .list_sessions(true)?
+        .into_iter()
+        .filter(|session| session.status.trim() == "stopped")
+        .filter(|session| is_primary_node(&session.node))
+        .map(|session| node_restore_candidate_value(session, &node_id))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(Json(NodeRestoreCandidatesResponse {
+        node: node_id,
+        sessions,
+    }))
+}
+
+async fn restore_node_restore_candidate(
+    State(state): State<Arc<AppState>>,
+    Path((node_id, session_id)): Path<(String, String)>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+) -> Result<Json<SessionResponse>, ApiError> {
+    ensure_session_allowed_from_parts(
+        &state.config,
+        &headers,
+        Some(peer_addr),
+        &format!("/nodes/{node_id}/restore-candidates/{session_id}/restore"),
+    )?;
+    ensure_core_writes_enabled(&state)?;
+    let node_id = normalize_node_id(&node_id);
+    if !state.config.nodes.registry.contains_key(&node_id) {
+        return Err(unknown_node_error(&node_id));
+    }
+    if !is_primary_node(&node_id) {
+        return Err(ApiError::Status {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            detail: format!("node-agent not connected for node {node_id}"),
+        });
+    }
+    let Some(session) = state.session_store.get_session(&session_id)? else {
+        return Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: "Session not found".to_owned(),
+        });
+    };
+    if session.status.trim() != "stopped" {
+        return Err(ApiError::Status {
+            status: StatusCode::CONFLICT,
+            detail: "Session is not stopped".to_owned(),
+        });
+    }
+    let outcome = if state.config.rust_core.runtime_enabled {
+        let runtime = TmuxRuntime::from_app_config(&state.config);
+        state
+            .session_store
+            .restore_core_session_with_runtime(&session_id, &runtime)?
+    } else {
+        state.session_store.restore_core_session(&session_id)?
+    };
+    match outcome {
+        Some(CoreRestoreOutcome::Restored(session)) => Ok(Json(SessionResponse::from(session))),
+        Some(CoreRestoreOutcome::NotStopped) => Err(ApiError::Status {
+            status: StatusCode::CONFLICT,
+            detail: "Session is not stopped".to_owned(),
+        }),
+        Some(CoreRestoreOutcome::UnsupportedNode(node)) => Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: format!("Rust runtime does not support remote node {node}"),
+        }),
+        Some(CoreRestoreOutcome::UnsupportedProvider(provider)) => Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: format!("Rust runtime does not support provider {provider}"),
+        }),
+        Some(CoreRestoreOutcome::MissingProviderResumeId(provider)) => Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: format!("Cannot restore {provider} session without provider_resume_id"),
+        }),
+        None => Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: "Session not found".to_owned(),
+        }),
+    }
 }
 
 async fn list_codex_review_requests(
@@ -4335,6 +4467,29 @@ fn shadow_predict_read(
     path: &str,
     query_string: &str,
 ) -> anyhow::Result<Option<ShadowPrediction>> {
+    if method == "POST" {
+        if let Some(node_id) = node_ping_path_node_id(path) {
+            let node_id = normalize_node_id(node_id);
+            if !state.config.nodes.registry.contains_key(&node_id) {
+                let body =
+                    serde_json::to_vec(&json!({ "detail": format!("Unknown node: {node_id}") }))?;
+                return Ok(Some(ShadowPrediction {
+                    status: StatusCode::NOT_FOUND.as_u16(),
+                    body_sha256: Some(sha256_hex(&body)),
+                    support_status: "implemented_read",
+                }));
+            }
+            return Ok(Some(ShadowPrediction {
+                status: if is_primary_node(&node_id) {
+                    StatusCode::OK.as_u16()
+                } else {
+                    StatusCode::SERVICE_UNAVAILABLE.as_u16()
+                },
+                body_sha256: None,
+                support_status: "implemented_read_status_only",
+            }));
+        }
+    }
     if method != "GET" {
         return Ok(None);
     }
@@ -4386,6 +4541,32 @@ fn shadow_predict_read(
                 }))
             }
         };
+    }
+
+    if let Some(node_id) = path
+        .strip_prefix("/nodes/")
+        .and_then(|value| value.strip_suffix("/restore-candidates"))
+        .filter(|value| !value.is_empty() && !value.contains('/'))
+    {
+        let node_id = normalize_node_id(node_id);
+        if !state.config.nodes.registry.contains_key(&node_id) {
+            let body =
+                serde_json::to_vec(&json!({ "detail": format!("Unknown node: {node_id}") }))?;
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::NOT_FOUND.as_u16(),
+                body_sha256: Some(sha256_hex(&body)),
+                support_status: "implemented_read",
+            }));
+        }
+        return Ok(Some(ShadowPrediction {
+            status: if is_primary_node(&node_id) {
+                StatusCode::OK.as_u16()
+            } else {
+                StatusCode::SERVICE_UNAVAILABLE.as_u16()
+            },
+            body_sha256: None,
+            support_status: "implemented_read_status_only",
+        }));
     }
 
     let body = match path {
@@ -6583,6 +6764,9 @@ fn is_retained_write_surface(method: &str, path: &str) -> bool {
     if path.starts_with("/queue-jobs/") {
         return matches!(method, "POST" | "DELETE");
     }
+    if method == "POST" && is_node_restore_post_path(path) {
+        return true;
+    }
     false
 }
 
@@ -6591,6 +6775,9 @@ fn is_auth_denial_status(status: u16) -> bool {
 }
 
 fn is_protected_read_surface(method: &str, path: &str) -> bool {
+    if method == "POST" {
+        return node_ping_path_node_id(path).is_some();
+    }
     if method != "GET" {
         return false;
     }
@@ -6603,11 +6790,32 @@ fn is_protected_read_surface(method: &str, path: &str) -> bool {
         || path == "/queue-jobs"
         || path.starts_with("/queue-jobs/")
         || path == "/nodes"
+        || path.starts_with("/nodes/")
         || path == "/sessions"
         || path == "/client/sessions"
         || path.starts_with("/apps/")
         || path.starts_with("/sessions/")
         || path.starts_with("/client/sessions/")
+}
+
+fn node_ping_path_node_id(path: &str) -> Option<&str> {
+    path.strip_prefix("/nodes/")
+        .and_then(|value| value.strip_suffix("/ping"))
+        .filter(|value| !value.is_empty() && !value.contains('/'))
+}
+
+fn is_node_restore_post_path(path: &str) -> bool {
+    let Some(rest) = path.strip_prefix("/nodes/") else {
+        return false;
+    };
+    let Some((node_id, rest)) = rest.split_once("/restore-candidates/") else {
+        return false;
+    };
+    !node_id.is_empty()
+        && !node_id.contains('/')
+        && rest
+            .strip_suffix("/restore")
+            .is_some_and(|session_id| !session_id.is_empty() && !session_id.contains('/'))
 }
 
 fn ensure_shadow_allowed(
@@ -7422,6 +7630,25 @@ struct TmuxClientHookQuery {
     event: String,
 }
 
+#[derive(Debug, Deserialize)]
+struct NodeRestoreCandidatesQuery {
+    #[serde(default)]
+    refresh: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct NodePingResponse {
+    node: String,
+    ok: bool,
+    error: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct NodeRestoreCandidatesResponse {
+    node: String,
+    sessions: Vec<Value>,
+}
+
 #[derive(Debug, Serialize)]
 struct ClientRequestStatusResponse {
     status: &'static str,
@@ -7601,6 +7828,55 @@ fn nodes_list_response(config: &AppConfig) -> NodesListResponse {
         default: config.nodes.default_node.clone(),
         nodes: config.nodes.redacted_nodes(),
     }
+}
+
+fn normalize_node_id(node_id: &str) -> String {
+    let node_id = node_id.trim();
+    if node_id.is_empty() {
+        "primary".to_owned()
+    } else {
+        node_id.to_owned()
+    }
+}
+
+fn unknown_node_error(node_id: &str) -> ApiError {
+    ApiError::Status {
+        status: StatusCode::NOT_FOUND,
+        detail: format!("Unknown node: {node_id}"),
+    }
+}
+
+fn node_restore_candidate_value(session: SessionRecord, node_id: &str) -> Result<Value, ApiError> {
+    let source_session_id = session.id.clone();
+    let mut value = serde_json::to_value(session)?;
+    let Some(object) = value.as_object_mut() else {
+        return Err(ApiError::Status {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            detail: "failed to project node restore candidate".to_owned(),
+        });
+    };
+    object.insert("node".to_owned(), Value::String(node_id.to_owned()));
+    object.insert("origin_node".to_owned(), Value::String(node_id.to_owned()));
+    object.insert(
+        "source_session_id".to_owned(),
+        Value::String(source_session_id),
+    );
+    object.insert(
+        "restore_source".to_owned(),
+        Value::String(
+            if is_primary_node(node_id) {
+                "server_state"
+            } else {
+                "node_agent"
+            }
+            .to_owned(),
+        ),
+    );
+    object.insert(
+        "activity_state".to_owned(),
+        Value::String("stopped".to_owned()),
+    );
+    Ok(value)
 }
 
 fn codex_review_request_response(

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -435,6 +435,140 @@ nodes:
 }
 
 #[tokio::test]
+async fn node_ping_preserves_primary_unknown_and_remote_error_contracts() {
+    let config_path = unique_temp_path();
+    let local_env_path = unique_temp_path();
+    fs::write(
+        &config_path,
+        r#"
+nodes:
+  registry:
+    macbook:
+      ssh: macbook.local
+      node_token: secret-node-token
+"#,
+    )
+    .unwrap();
+    let config =
+        AppConfig::load_from_path_with_local_env(&config_path, Some(&local_env_path)).unwrap();
+    let app = router(AppState::new(config));
+
+    let (status, payload) = post_json(app.clone(), "/nodes/primary/ping", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        payload,
+        json!({
+            "node": "primary",
+            "ok": true,
+            "error": null
+        })
+    );
+
+    let (status, payload) = post_json(app.clone(), "/nodes/missing/ping", json!({})).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(payload["detail"], "Unknown node: missing");
+
+    let (status, payload) = post_json(app, "/nodes/macbook/ping", json!({})).await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(
+        payload["detail"],
+        "node-agent not connected for node macbook"
+    );
+    assert!(!payload.to_string().contains("secret-node-token"));
+}
+
+#[tokio::test]
+async fn node_restore_candidates_project_primary_stopped_sessions() {
+    let state_file = write_session_fixture();
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+
+    let (status, payload) = get_json(app, "/nodes/primary/restore-candidates?refresh=true").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["node"], "primary");
+    let sessions = payload["sessions"].as_array().unwrap();
+    assert_eq!(sessions.len(), 1);
+    let candidate = &sessions[0];
+    assert_eq!(candidate["id"], "stop1234");
+    assert_eq!(candidate["status"], "stopped");
+    assert_eq!(candidate["node"], "primary");
+    assert_eq!(candidate["origin_node"], "primary");
+    assert_eq!(candidate["source_session_id"], "stop1234");
+    assert_eq!(candidate["restore_source"], "server_state");
+    assert_eq!(candidate["activity_state"], "stopped");
+    assert_eq!(candidate["provider"], "claude");
+}
+
+#[tokio::test]
+async fn node_restore_candidates_preserve_unknown_and_remote_errors() {
+    let config_path = unique_temp_path();
+    let local_env_path = unique_temp_path();
+    fs::write(
+        &config_path,
+        r#"
+nodes:
+  registry:
+    macbook:
+      ssh: macbook.local
+      node_token: secret-node-token
+"#,
+    )
+    .unwrap();
+    let config =
+        AppConfig::load_from_path_with_local_env(&config_path, Some(&local_env_path)).unwrap();
+    let app = router(AppState::new(config));
+
+    let (status, payload) = get_json(app.clone(), "/nodes/missing/restore-candidates").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(payload["detail"], "Unknown node: missing");
+
+    let (status, payload) = get_json(app, "/nodes/macbook/restore-candidates").await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(
+        payload["detail"],
+        "node-agent not connected for node macbook"
+    );
+    assert!(!payload.to_string().contains("secret-node-token"));
+}
+
+#[tokio::test]
+async fn node_restore_candidate_restore_round_trips_primary_fixture() {
+    let state_file = write_session_fixture();
+    let mut config = config_with_state_file(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/nodes/primary/restore-candidates/stop1234/restore",
+        json!({}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["id"], "stop1234");
+    assert_eq!(payload["status"], "running");
+    assert_eq!(payload["stopped_at"], Value::Null);
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/nodes/primary/restore-candidates/run12345/restore",
+        json!({}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert_eq!(payload["detail"], "Session is not stopped");
+
+    let (status, payload) = post_json(
+        app,
+        "/nodes/primary/restore-candidates/missing/restore",
+        json!({}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(payload["detail"], "Session not found");
+}
+
+#[tokio::test]
 async fn client_analytics_summary_reports_live_metrics_from_state_queue_and_logs() {
     let state_file = unique_temp_path();
     let queue_db = state_file.with_extension("analytics-message-queue.db");
@@ -2600,7 +2734,7 @@ async fn shadow_http_reports_match_for_stable_read_only_route() {
     let python_body = serde_json::to_vec(&json!({ "status": "healthy" })).unwrap();
 
     let (status, payload) = post_json(
-        app,
+        app.clone(),
         "/__shadow/http",
         json!({
             "schema_version": 1,
@@ -2641,7 +2775,7 @@ async fn shadow_http_treats_events_state_as_status_only() {
     .unwrap();
 
     let (status, payload) = post_json(
-        app,
+        app.clone(),
         "/__shadow/http",
         json!({
             "schema_version": 1,
@@ -2674,13 +2808,40 @@ async fn shadow_http_treats_nodes_as_status_only_until_node_agents_are_ported() 
     let python_body = br#"{"default":"primary","nodes":[{"id":"primary","primary":true,"ssh":null,"api_url":null,"hook_base_url":null,"projects_root":null,"log_dir":null,"codex_fork_node_agent":true}]}"#;
 
     let (status, payload) = post_json(
-        app,
+        app.clone(),
         "/__shadow/http",
         json!({
             "schema_version": 1,
             "request": {
                 "method": "GET",
                 "path": "/nodes",
+                "query_string": "",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 200,
+                "body_sha256": sha256_hex(python_body)
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read_status_only");
+    assert_eq!(payload["comparison"], "status_match");
+    assert_eq!(payload["would_write"], false);
+    assert_eq!(payload["predicted_status"], 200);
+    assert_eq!(payload["predicted_body_sha256"], Value::Null);
+
+    let python_body = br#"{"node":"primary","ok":true,"error":null}"#;
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "POST",
+                "path": "/nodes/primary/ping",
                 "query_string": "",
                 "headers": {}
             },
@@ -3428,7 +3589,7 @@ async fn shadow_http_classifies_core_writes_without_side_effects() {
     let app = router(AppState::new(AppConfig::default()));
 
     let (status, payload) = post_json(
-        app,
+        app.clone(),
         "/__shadow/http",
         json!({
             "schema_version": 1,
@@ -3442,6 +3603,34 @@ async fn shadow_http_classifies_core_writes_without_side_effects() {
             "python_response": {
                 "status": 200,
                 "body_sha256": sha256_hex(b"{\"id\":\"python-owned\"}")
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "unsupported_retained_write");
+    assert_eq!(payload["comparison"], "not_compared");
+    assert_eq!(payload["would_write"], false);
+    assert!(payload["detail"]
+        .as_str()
+        .unwrap()
+        .contains("never performs retained write side effects"));
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "POST",
+                "path": "/nodes/primary/restore-candidates/stop1234/restore",
+                "query_string": "",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 200,
+                "body_sha256": sha256_hex(b"{\"id\":\"stop1234\"}")
             }
         }),
     )

--- a/scripts/rust_migration/contracts_manifest.json
+++ b/scripts/rust_migration/contracts_manifest.json
@@ -171,6 +171,40 @@
       "source": "specs/762_stage5_artifacts/gate_matrix.md:73"
     },
     {
+      "id": "http.node_primary_ping",
+      "surface": "http",
+      "classification": "retained",
+      "target": "python_and_rust",
+      "safety": "read_only",
+      "method": "POST",
+      "path": "/nodes/primary/ping",
+      "body": {},
+      "expected_status": [200],
+      "expected_json": [
+        {"path": "/node", "equals": "primary"},
+        {"path": "/ok", "equals": true},
+        {"path": "/error", "type": "null"}
+      ],
+      "preconditions": ["live_server"],
+      "source": "specs/762_stage2_artifacts/route_manifest.md:POST /nodes/{node_id}/ping"
+    },
+    {
+      "id": "http.node_primary_restore_candidates",
+      "surface": "http",
+      "classification": "retained",
+      "target": "python_and_rust",
+      "safety": "read_only",
+      "method": "GET",
+      "path": "/nodes/primary/restore-candidates",
+      "expected_status": [200],
+      "expected_json": [
+        {"path": "/node", "equals": "primary"},
+        {"path": "/sessions", "type": "array"}
+      ],
+      "preconditions": ["live_server"],
+      "source": "specs/762_stage2_artifacts/route_manifest.md:GET /nodes/{node_id}/restore-candidates"
+    },
+    {
       "id": "http.queue_jobs_list",
       "surface": "http",
       "classification": "retained",


### PR DESCRIPTION
## Summary

- port retained node HTTP routes for ping and restore-candidate listing/restore
- preserve auth/read gating, primary-node fixture behavior, remote-node no-agent errors, and secret redaction
- add read-only contract manifest checks for primary node ping and restore-candidates

## Validation

- cargo fmt --check
- ./venv/bin/python -m json.tool scripts/rust_migration/contracts_manifest.json >/dev/null
- git diff --check
- cargo test -p sm-server --test read_only_http node_ -- --nocapture
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py -q
- cargo test -p sm-server

Fixes #961