### PR TITLE
Rust MVP: cancel retained Codex review requests

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -305,7 +305,7 @@ pub fn router(state: AppState) -> Router {
         .route("/codex-review-requests", get(list_codex_review_requests))
         .route(
             "/codex-review-requests/{request_id}",
-            get(get_codex_review_request),
+            get(get_codex_review_request).delete(cancel_codex_review_request),
         )
         .route("/nodes", get(list_nodes))
         .route("/nodes/{node_id}/ping", post(ping_node))
@@ -1969,6 +1969,28 @@ async fn get_codex_review_request(
     let queue_db_path = expand_home(&state.config.sm_send.db_path);
     let Some(registration) =
         RetainedQueueStore::get_codex_review_request_from_path(&queue_db_path, &request_id)?
+    else {
+        return Err(ApiError::NotFound("Codex review request not found"));
+    };
+    Ok(Json(codex_review_request_response(&state, registration)?))
+}
+
+async fn cancel_codex_review_request(
+    State(state): State<Arc<AppState>>,
+    Path(request_id): Path<String>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_allowed_from_parts(
+        &state.config,
+        &headers,
+        Some(peer_addr),
+        &format!("/codex-review-requests/{request_id}"),
+    )?;
+    ensure_core_writes_enabled(&state)?;
+    let queue_db_path = expand_home(&state.config.sm_send.db_path);
+    let Some(registration) =
+        RetainedQueueStore::cancel_codex_review_request_in_path(&queue_db_path, &request_id)?
     else {
         return Err(ApiError::NotFound("Codex review request not found"));
     };
@@ -4394,6 +4416,36 @@ fn shadow_compare(
     let path = envelope.request.path.trim().to_owned();
     let python_status = envelope.python_response.status;
 
+    if let Some(prediction) = shadow_predict_retained_write(state, &method, &path)? {
+        let status_matches = prediction.status == python_status;
+        let body_matches = prediction
+            .body_sha256
+            .as_ref()
+            .map(|value| value == &envelope.python_response.body_sha256);
+        let comparison = match (status_matches, body_matches) {
+            (true, Some(true)) => "match",
+            (true, None) => "status_match",
+            (false, _) => "status_mismatch",
+            (true, Some(false)) => "body_mismatch",
+        };
+        return Ok(ShadowHttpResult {
+            schema_version: 1,
+            method,
+            path,
+            support_status: prediction.support_status,
+            comparison,
+            would_write: false,
+            python_status,
+            predicted_status: Some(prediction.status),
+            predicted_body_sha256: prediction.body_sha256,
+            body_sha256_match: body_matches,
+            detail: Some(
+                "Rust shadow mode predicts this implemented retained write without performing side effects"
+                    .to_owned(),
+            ),
+        });
+    }
+
     if is_retained_write_surface(&method, &path) {
         return Ok(ShadowHttpResult {
             schema_version: 1,
@@ -4472,6 +4524,41 @@ fn shadow_compare(
         body_sha256_match: body_matches,
         detail: None,
     })
+}
+
+fn shadow_predict_retained_write(
+    state: &AppState,
+    method: &str,
+    path: &str,
+) -> anyhow::Result<Option<ShadowPrediction>> {
+    if method == "DELETE" {
+        if let Some(request_id) = path
+            .strip_prefix("/codex-review-requests/")
+            .filter(|value| !value.is_empty() && !value.contains('/'))
+        {
+            let queue_db_path = expand_home(&state.config.sm_send.db_path);
+            return match RetainedQueueStore::get_codex_review_request_from_path(
+                &queue_db_path,
+                request_id,
+            )? {
+                Some(_) => Ok(Some(ShadowPrediction {
+                    status: StatusCode::OK.as_u16(),
+                    body_sha256: None,
+                    support_status: "implemented_retained_write_status_only",
+                })),
+                None => {
+                    let body =
+                        serde_json::to_vec(&json!({ "detail": "Codex review request not found" }))?;
+                    Ok(Some(ShadowPrediction {
+                        status: StatusCode::NOT_FOUND.as_u16(),
+                        body_sha256: Some(sha256_hex(&body)),
+                        support_status: "implemented_retained_write",
+                    }))
+                }
+            };
+        }
+    }
+    Ok(None)
 }
 
 fn shadow_predict_read(

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -263,6 +263,39 @@ impl RetainedQueueStore {
         get_codex_review_request_conn(&conn, request_id)
     }
 
+    pub fn cancel_codex_review_request_in_path(
+        db_path: &Path,
+        request_id: &str,
+    ) -> Result<Option<CodexReviewRequestRegistration>> {
+        if !db_path.exists() {
+            return Ok(None);
+        }
+        let conn = Connection::open(db_path)?;
+        let Some(mut registration) = get_codex_review_request_conn(&conn, request_id)? else {
+            return Ok(None);
+        };
+        if !registration.is_active {
+            return Ok(Some(registration));
+        }
+        registration.is_active = false;
+        registration.state = "cancelled".to_owned();
+        conn.execute(
+            r#"
+            UPDATE codex_review_request_registrations
+            SET is_active = 0,
+                state = ?2,
+                last_error = ?3
+            WHERE id = ?1 AND is_active = 1
+            "#,
+            params![
+                request_id,
+                registration.state.as_str(),
+                registration.last_error.as_deref()
+            ],
+        )?;
+        Ok(Some(registration))
+    }
+
     pub fn list_queue_jobs_from_path(
         db_path: &Path,
         filters: QueueJobFilters,

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -1913,6 +1913,102 @@ async fn codex_review_requests_lists_rows_with_filters_and_session_names() {
 }
 
 #[tokio::test]
+async fn codex_review_request_cancel_updates_active_row_and_preserves_inactive_row() {
+    let state_file = unique_temp_path();
+    let queue_db = state_file.with_extension("codex-review-cancel.db");
+    fs::write(&state_file, json!({ "sessions": [] }).to_string()).unwrap();
+    create_codex_review_request_fixture_db(&queue_db);
+    let mut config = AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        sm_send: SmSendConfig {
+            db_path: queue_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    };
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, payload) =
+        delete_json(app.clone(), "/codex-review-requests/active-old", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["id"], "active-old");
+    assert_eq!(payload["state"], "cancelled");
+    assert_eq!(payload["is_active"], false);
+    assert_eq!(payload["last_error"], Value::Null);
+
+    let conn = Connection::open(&queue_db).unwrap();
+    let (state, is_active): (String, i64) = conn
+        .query_row(
+            "SELECT state, is_active FROM codex_review_request_registrations WHERE id = 'active-old'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(state, "cancelled");
+    assert_eq!(is_active, 0);
+
+    let (status, payload) = get_json(app.clone(), "/codex-review-requests").await;
+    assert_eq!(status, StatusCode::OK);
+    let active_ids = payload["requests"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|entry| entry["id"].as_str().unwrap())
+        .collect::<Vec<_>>();
+    assert_eq!(active_ids, vec!["active-new"]);
+
+    let (status, payload) = delete_json(app, "/codex-review-requests/inactive", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["id"], "inactive");
+    assert_eq!(payload["state"], "cancelled");
+    assert_eq!(payload["is_active"], false);
+}
+
+#[tokio::test]
+async fn codex_review_request_cancel_preserves_missing_and_write_gate_errors() {
+    let state_file = unique_temp_path();
+    let queue_db = state_file.with_extension("codex-review-cancel-gates.db");
+    fs::write(&state_file, json!({ "sessions": [] }).to_string()).unwrap();
+    create_codex_review_request_fixture_db(&queue_db);
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        sm_send: SmSendConfig {
+            db_path: queue_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) =
+        delete_json(app.clone(), "/codex-review-requests/active-old", json!({})).await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(payload["detail"], "Rust core writes are disabled");
+    let (status, payload) = get_json(app.clone(), "/codex-review-requests/active-old").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["state"], "completed");
+    assert_eq!(payload["is_active"], true);
+
+    let mut write_config = AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        sm_send: SmSendConfig {
+            db_path: queue_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    };
+    write_config.rust_core.fixture_writes_enabled = true;
+    let write_app = router(AppState::new(write_config));
+    let (status, payload) =
+        delete_json(write_app, "/codex-review-requests/missing", json!({})).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(payload["detail"], "Codex review request not found");
+}
+
+#[tokio::test]
 async fn codex_review_requests_unknown_notify_target_returns_404() {
     let state_file = unique_temp_path();
     let queue_db = state_file.with_extension("codex-review-requests-empty.db");
@@ -1950,8 +2046,29 @@ async fn codex_review_requests_rejects_public_host_without_auth() {
         "/auth/google/login?next=%2Fcodex-review-requests"
     );
 
-    let (status, payload) =
-        get_json_with_host(app, "/codex-review-requests/active-old", "sm.example.com").await;
+    let (status, payload) = get_json_with_host(
+        app.clone(),
+        "/codex-review-requests/active-old",
+        "sm.example.com",
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(payload["detail"], "Authentication required");
+    assert_eq!(
+        payload["login_url"],
+        "/auth/google/login?next=%2Fcodex-review-requests%2Factive-old"
+    );
+
+    let (status, payload) = json_request_with_headers_and_peer(
+        app,
+        "DELETE",
+        "/codex-review-requests/active-old",
+        json!({}),
+        &[("host", "sm.example.com")],
+        Some(SocketAddr::from(([203, 0, 113, 10], 49152))),
+    )
+    .await;
 
     assert_eq!(status, StatusCode::UNAUTHORIZED);
     assert_eq!(payload["detail"], "Authentication required");
@@ -4246,6 +4363,59 @@ async fn shadow_http_reports_codex_review_request_detail_404() {
     assert_eq!(payload["comparison"], "match");
     assert_eq!(payload["predicted_status"], 404);
     assert_eq!(payload["body_sha256_match"], true);
+}
+
+#[tokio::test]
+async fn shadow_http_reports_codex_review_request_cancel_as_status_only_without_writing() {
+    let state_file = unique_temp_path();
+    let queue_db = state_file.with_extension("codex-review-requests-shadow-delete.db");
+    fs::write(&state_file, json!({ "sessions": [] }).to_string()).unwrap();
+    create_codex_review_request_fixture_db(&queue_db);
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        sm_send: SmSendConfig {
+            db_path: queue_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    }));
+    let python_body = br#"{"id":"active-old","state":"cancelled","is_active":false}"#;
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "DELETE",
+                "path": "/codex-review-requests/active-old",
+                "query_string": "",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 200,
+                "body_sha256": sha256_hex(python_body)
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        payload["support_status"],
+        "implemented_retained_write_status_only"
+    );
+    assert_eq!(payload["comparison"], "status_match");
+    assert_eq!(payload["would_write"], false);
+    assert_eq!(payload["predicted_status"], 200);
+    assert_eq!(payload["predicted_body_sha256"], Value::Null);
+    assert_eq!(payload["body_sha256_match"], Value::Null);
+
+    let (status, detail) = get_json(app, "/codex-review-requests/active-old").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(detail["state"], "completed");
+    assert_eq!(detail["is_active"], true);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #963

## Summary
- add DELETE /codex-review-requests/{request_id} for retained DB cancellation
- keep inactive rows unchanged and update active rows to cancelled/inactive without starting watchers
- classify the implemented DELETE path in shadow mode as status-only without performing side effects

## Validation
- cargo fmt --check
- cargo test -p sm-server
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py -q
- ./venv/bin/python -m json.tool scripts/rust_migration/contracts_manifest.json >/dev/null
- git diff --check