### PR TITLE
Rust MVP: create retained Codex review requests

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -10,6 +10,7 @@ use std::{
         atomic::{AtomicBool, Ordering},
         Arc, Mutex,
     },
+    thread,
     time::{Duration, Instant},
 };
 
@@ -60,7 +61,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha1::{Digest, Sha1};
 use sha2::Sha256;
-use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+use time::{format_description::well_known::Rfc3339, Duration as TimeDuration, OffsetDateTime};
 use tokio::sync::{mpsc, Mutex as AsyncMutex};
 use tokio::time::timeout;
 
@@ -89,8 +90,9 @@ use crate::email::{
 };
 use crate::mobile_analytics::build_mobile_analytics_summary;
 use crate::queue::{
-    CodexReviewRequestFilters, CodexReviewRequestRegistration, CreateCodexReviewRequest,
-    CreateQueueJob, QueueAdmissionPolicy, QueueJobFilters, QueueJobRecord, RetainedQueueStore,
+    CodexReviewRequestFilters, CodexReviewRequestRegistration, CompleteCodexReviewRequest,
+    CreateCodexReviewRequest, CreateQueueJob, QueueAdmissionPolicy, QueueJobFilters,
+    QueueJobRecord, RetainedQueueStore, RetryCodexReviewRequest,
 };
 use crate::runtime::TmuxRuntime;
 use crate::sessions::{
@@ -229,6 +231,14 @@ pub struct GitHubReviewComment {
     pub posted_at: String,
 }
 
+#[derive(Debug, Clone)]
+pub struct GitHubReviewMatch {
+    pub source: String,
+    pub created_at: String,
+    pub id: Option<Value>,
+    pub url: Option<String>,
+}
+
 pub trait GitHubReviewPoster: Send + Sync {
     fn post_initial_review_request(
         &self,
@@ -236,6 +246,19 @@ pub trait GitHubReviewPoster: Send + Sync {
         pr_number: i64,
         steer: Option<&str>,
     ) -> Result<GitHubReviewComment, String>;
+
+    fn detect_codex_pickup(&self, _repo: &str, _comment_id: i64) -> Result<bool, String> {
+        Ok(false)
+    }
+
+    fn find_fresh_codex_review_or_comment(
+        &self,
+        _repo: &str,
+        _pr_number: i64,
+        _since: &str,
+    ) -> Result<Option<GitHubReviewMatch>, String> {
+        Ok(None)
+    }
 }
 
 #[derive(Debug)]
@@ -250,6 +273,19 @@ impl GitHubReviewPoster for GhCliReviewPoster {
     ) -> Result<GitHubReviewComment, String> {
         validate_open_pr_with_gh(repo, pr_number)?;
         post_pr_review_comment_with_gh(repo, pr_number, steer)
+    }
+
+    fn detect_codex_pickup(&self, repo: &str, comment_id: i64) -> Result<bool, String> {
+        detect_codex_pickup_with_gh(repo, comment_id)
+    }
+
+    fn find_fresh_codex_review_or_comment(
+        &self,
+        repo: &str,
+        pr_number: i64,
+        since: &str,
+    ) -> Result<Option<GitHubReviewMatch>, String> {
+        find_fresh_codex_review_or_comment_with_gh(repo, pr_number, since)
     }
 }
 
@@ -304,17 +340,17 @@ struct GhPrViewPayload {
 }
 
 fn validate_open_pr_with_gh(repo: &str, pr_number: i64) -> Result<(), String> {
-    let output = Command::new("gh")
-        .args([
-            "pr",
-            "view",
-            &pr_number.to_string(),
-            "--repo",
-            repo,
-            "--json",
-            "number,state,title,url",
-        ])
-        .output()
+    let mut command = Command::new("gh");
+    command.args([
+        "pr",
+        "view",
+        &pr_number.to_string(),
+        "--repo",
+        repo,
+        "--json",
+        "number,state,title,url",
+    ]);
+    let output = command_output_with_timeout(command, Duration::from_secs(10))
         .map_err(|error| format!("gh pr view failed: {error}"))?;
     if !output.status.success() {
         return Err(format!(
@@ -345,17 +381,17 @@ fn post_pr_review_comment_with_gh(
         Some(steer) => format!("@codex review for {steer}"),
         None => "@codex review".to_owned(),
     };
-    let output = Command::new("gh")
-        .args([
-            "pr",
-            "comment",
-            &pr_number.to_string(),
-            "--repo",
-            repo,
-            "--body",
-            &body,
-        ])
-        .output()
+    let mut command = Command::new("gh");
+    command.args([
+        "pr",
+        "comment",
+        &pr_number.to_string(),
+        "--repo",
+        repo,
+        "--body",
+        &body,
+    ]);
+    let output = command_output_with_timeout(command, Duration::from_secs(30))
         .map_err(|error| format!("gh pr comment failed: {error}"))?;
     if !output.status.success() {
         return Err(format!("gh pr comment failed: {}", command_stderr(&output)));
@@ -371,6 +407,276 @@ fn post_pr_review_comment_with_gh(
         comment_url,
         posted_at: now_rfc3339(),
     })
+}
+
+fn command_output_with_timeout(
+    mut command: Command,
+    timeout_duration: Duration,
+) -> Result<Output, String> {
+    let mut child = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| error.to_string())?;
+    let start = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => return child.wait_with_output().map_err(|error| error.to_string()),
+            Ok(None) => {}
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error.to_string());
+            }
+        }
+        if start.elapsed() >= timeout_duration {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(format!("timed out after {}s", timeout_duration.as_secs()));
+        }
+        thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn gh_api_json(repo: &str, endpoint: &str, paginate: bool) -> Result<Value, String> {
+    let (owner, repo_name) = split_github_repo(repo)?;
+    let mut command = Command::new("gh");
+    command.args([
+        "api",
+        &format!(
+            "repos/{}/{}/{}",
+            owner,
+            repo_name,
+            endpoint.trim_start_matches('/')
+        ),
+        "-H",
+        "Accept: application/vnd.github+json",
+    ]);
+    if paginate {
+        command.args(["--paginate", "--slurp"]);
+    }
+    let output = command_output_with_timeout(command, Duration::from_secs(30))
+        .map_err(|error| format!("gh api failed: {error}"))?;
+    if !output.status.success() {
+        return Err(format!("gh api failed: {}", command_stderr(&output)));
+    }
+    let raw = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    if raw.is_empty() {
+        return Ok(Value::Null);
+    }
+    let decoded: Value = serde_json::from_str(&raw)
+        .map_err(|error| format!("gh api returned invalid JSON: {error}"))?;
+    if paginate {
+        let mut flattened = Vec::new();
+        if let Some(pages) = decoded.as_array() {
+            for page in pages {
+                if let Some(items) = page.as_array() {
+                    flattened.extend(items.iter().cloned());
+                } else {
+                    flattened.push(page.clone());
+                }
+            }
+            return Ok(Value::Array(flattened));
+        }
+    }
+    Ok(decoded)
+}
+
+fn split_github_repo(repo: &str) -> Result<(String, String), String> {
+    let mut normalized = repo.trim();
+    if let Some(rest) = normalized.strip_prefix("https://") {
+        if let Some((_, path)) = rest.split_once('/') {
+            normalized = path;
+        }
+    } else if let Some(rest) = normalized.strip_prefix("http://") {
+        if let Some((_, path)) = rest.split_once('/') {
+            normalized = path;
+        }
+    }
+    let parts = normalized
+        .trim_matches('/')
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>();
+    match parts.as_slice() {
+        [owner, repo] => Ok(((*owner).to_owned(), (*repo).to_owned())),
+        [_host, owner, repo] => Ok(((*owner).to_owned(), (*repo).to_owned())),
+        _ => Err(format!(
+            "Invalid repo {repo:?}; expected owner/repo or host/owner/repo"
+        )),
+    }
+}
+
+fn detect_codex_pickup_with_gh(repo: &str, comment_id: i64) -> Result<bool, String> {
+    if comment_id <= 0 {
+        return Ok(false);
+    }
+    let reactions = gh_api_json(
+        repo,
+        &format!("issues/comments/{comment_id}/reactions"),
+        true,
+    )?;
+    Ok(reactions.as_array().is_some_and(|items| {
+        items.iter().any(|item| {
+            item.get("content").and_then(Value::as_str) == Some("eyes")
+                && github_actor_is_codex(item)
+        })
+    }))
+}
+
+fn find_fresh_codex_review_or_comment_with_gh(
+    repo: &str,
+    pr_number: i64,
+    since: &str,
+) -> Result<Option<GitHubReviewMatch>, String> {
+    let Some(since_dt) = parse_github_datetime(since) else {
+        return Ok(None);
+    };
+    let mut candidates = Vec::<GitHubReviewMatch>::new();
+    if let Some(review) = latest_codex_review_snapshot(repo, pr_number)? {
+        if let Some(created_at) = review
+            .get("submittedAt")
+            .and_then(Value::as_str)
+            .and_then(parse_github_datetime)
+            .filter(|created_at| *created_at > since_dt)
+        {
+            candidates.push(GitHubReviewMatch {
+                source: "review".to_owned(),
+                created_at: created_at
+                    .format(&Rfc3339)
+                    .unwrap_or_else(|_| now_rfc3339()),
+                id: review.get("id").cloned(),
+                url: review
+                    .get("url")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned),
+            });
+        }
+    }
+
+    let comments = gh_api_json(
+        repo,
+        &format!(
+            "issues/{pr_number}/comments?since={}",
+            since_dt
+                .format(&Rfc3339)
+                .unwrap_or_else(|_| since.to_owned())
+        ),
+        true,
+    )?;
+    if let Some(items) = comments.as_array() {
+        for comment in items {
+            let Some(created_at) = comment
+                .get("created_at")
+                .and_then(Value::as_str)
+                .and_then(parse_github_datetime)
+            else {
+                continue;
+            };
+            if created_at > since_dt && github_actor_is_codex(comment) {
+                candidates.push(GitHubReviewMatch {
+                    source: "comment".to_owned(),
+                    created_at: created_at
+                        .format(&Rfc3339)
+                        .unwrap_or_else(|_| now_rfc3339()),
+                    id: comment.get("id").cloned(),
+                    url: comment
+                        .get("html_url")
+                        .and_then(Value::as_str)
+                        .map(ToOwned::to_owned),
+                });
+            }
+        }
+    }
+    candidates.sort_by(|left, right| left.created_at.cmp(&right.created_at));
+    Ok(candidates.into_iter().next())
+}
+
+fn latest_codex_review_snapshot(repo: &str, pr_number: i64) -> Result<Option<Value>, String> {
+    let mut command = Command::new("gh");
+    command.args([
+        "pr",
+        "view",
+        &pr_number.to_string(),
+        "--repo",
+        repo,
+        "--json",
+        "url,latestReviews",
+    ]);
+    let output = command_output_with_timeout(command, Duration::from_secs(30))
+        .map_err(|error| format!("gh pr view failed: {error}"))?;
+    if !output.status.success() {
+        return Err(format!("gh pr view failed: {}", command_stderr(&output)));
+    }
+    let payload: Value = serde_json::from_slice(&output.stdout)
+        .map_err(|error| format!("gh pr view returned invalid JSON: {error}"))?;
+    let pr_url = payload.get("url").cloned();
+    let mut newest: Option<(OffsetDateTime, Value)> = None;
+    for review in payload
+        .get("latestReviews")
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+    {
+        let author = review
+            .get("author")
+            .and_then(|author| author.get("login"))
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        if !author.to_ascii_lowercase().contains("codex") {
+            continue;
+        }
+        let Some(submitted_at) = review
+            .get("submittedAt")
+            .and_then(Value::as_str)
+            .and_then(parse_github_datetime)
+        else {
+            continue;
+        };
+        let mut review = review.clone();
+        if review.get("url").is_none() {
+            if let Some(url) = pr_url.clone() {
+                review["url"] = url;
+            }
+        }
+        if newest
+            .as_ref()
+            .is_none_or(|(current, _)| submitted_at > *current)
+        {
+            newest = Some((submitted_at, review));
+        }
+    }
+    Ok(newest.map(|(_, review)| review))
+}
+
+fn github_actor_is_codex(payload: &Value) -> bool {
+    let user_login = payload
+        .get("user")
+        .and_then(|user| user.get("login"))
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_ascii_lowercase();
+    if user_login.contains("codex") {
+        return true;
+    }
+    let app = payload
+        .get("performed_via_github_app")
+        .unwrap_or(&Value::Null);
+    ["slug", "name"].iter().any(|field| {
+        app.get(*field)
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_ascii_lowercase()
+            .contains("codex")
+    })
+}
+
+fn parse_github_datetime(value: &str) -> Option<OffsetDateTime> {
+    let normalized = value
+        .strip_suffix('Z')
+        .map(|value| format!("{value}+00:00"))
+        .unwrap_or_else(|| value.to_owned());
+    OffsetDateTime::parse(&normalized, &Rfc3339).ok()
 }
 
 fn command_stderr(output: &Output) -> String {
@@ -2252,7 +2558,9 @@ async fn create_codex_review_request(
             },
         )
         .map_err(codex_review_store_error)?;
-        codex_review_request_response(&state, registration).map(Json)
+        let response = codex_review_request_response(&state, registration.clone())?;
+        spawn_codex_review_request_watcher(state.clone(), registration.id);
+        Ok(Json(response))
     }
     .await;
     state
@@ -2285,6 +2593,275 @@ fn validate_codex_review_create_payload(
         });
     }
     Ok(())
+}
+
+fn spawn_codex_review_request_watcher(state: Arc<AppState>, request_id: String) {
+    tokio::spawn(async move {
+        if let Err(error) = run_codex_review_request_watcher(state, request_id.clone()).await {
+            eprintln!("Codex review request watcher {request_id} stopped with error: {error}");
+        }
+    });
+}
+
+async fn run_codex_review_request_watcher(
+    state: Arc<AppState>,
+    request_id: String,
+) -> Result<(), String> {
+    let queue_db_path = expand_home(&state.config.sm_send.db_path);
+    loop {
+        let Some(registration) =
+            RetainedQueueStore::get_codex_review_request_from_path(&queue_db_path, &request_id)
+                .map_err(|error| error.to_string())?
+        else {
+            return Ok(());
+        };
+        if !registration.is_active {
+            return Ok(());
+        }
+        let poll_seconds = registration.poll_interval_seconds.max(1) as u64;
+        tokio::time::sleep(Duration::from_secs(poll_seconds)).await;
+        let Some(registration) =
+            RetainedQueueStore::get_codex_review_request_from_path(&queue_db_path, &request_id)
+                .map_err(|error| error.to_string())?
+        else {
+            return Ok(());
+        };
+        if !registration.is_active {
+            return Ok(());
+        }
+        if state
+            .session_store
+            .get_session(&registration.notify_session_id)
+            .map_err(|error| error.to_string())?
+            .is_none()
+        {
+            let _ = RetainedQueueStore::cancel_codex_review_request_in_path(
+                &queue_db_path,
+                &request_id,
+            )
+            .map_err(|error| error.to_string())?;
+            return Ok(());
+        }
+
+        let now = now_rfc3339();
+        if let Some(comment_id) = registration.latest_request_comment_id {
+            if registration.pickup_detected_at.is_none() {
+                match github_detect_pickup(
+                    state.github_review_poster.clone(),
+                    &registration.repo,
+                    comment_id,
+                )
+                .await
+                {
+                    Ok(true) => {
+                        let _ = RetainedQueueStore::mark_codex_review_request_pickup_in_path(
+                            &queue_db_path,
+                            &request_id,
+                            &now,
+                        )
+                        .map_err(|error| error.to_string())?;
+                    }
+                    Ok(false) => {}
+                    Err(error) => {
+                        let _ = RetainedQueueStore::mark_codex_review_request_poll_error_in_path(
+                            &queue_db_path,
+                            &request_id,
+                            &now,
+                            &format!("pickup detection failed: {error}"),
+                            None,
+                        )
+                        .map_err(|error| error.to_string())?;
+                    }
+                }
+            }
+        }
+
+        let since = registration
+            .latest_request_posted_at
+            .as_deref()
+            .unwrap_or(&registration.requested_at)
+            .to_owned();
+        match github_find_fresh_review(
+            state.github_review_poster.clone(),
+            &registration.repo,
+            registration.pr_number,
+            &since,
+        )
+        .await
+        {
+            Ok(Some(review_match)) => {
+                complete_codex_review_request(
+                    &queue_db_path,
+                    &request_id,
+                    &registration,
+                    review_match,
+                    &now,
+                )?;
+                return Ok(());
+            }
+            Ok(None) => {}
+            Err(error) => {
+                let next_retry_at = registration
+                    .next_retry_at
+                    .as_deref()
+                    .filter(|value| codex_review_datetime_due(value))
+                    .and_then(|_| {
+                        codex_review_next_retry_at(&now, registration.retry_interval_seconds.max(1))
+                    });
+                let _ = RetainedQueueStore::mark_codex_review_request_poll_error_in_path(
+                    &queue_db_path,
+                    &request_id,
+                    &now,
+                    &error,
+                    next_retry_at.as_deref(),
+                )
+                .map_err(|error| error.to_string())?;
+                continue;
+            }
+        }
+
+        if registration
+            .next_retry_at
+            .as_deref()
+            .is_some_and(codex_review_datetime_due)
+        {
+            let comment = github_post_review_request(
+                state.github_review_poster.clone(),
+                &registration.repo,
+                registration.pr_number,
+                registration.steer.as_deref(),
+            )
+            .await?;
+            let next_retry_at = codex_review_next_retry_at(
+                &comment.posted_at,
+                registration.retry_interval_seconds.max(1),
+            )
+            .unwrap_or_else(|| now_rfc3339());
+            let _ = RetainedQueueStore::retry_codex_review_request_in_path(
+                &queue_db_path,
+                &request_id,
+                RetryCodexReviewRequest {
+                    latest_request_comment_id: comment.comment_id,
+                    latest_request_comment_url: comment.comment_url,
+                    latest_request_posted_at: comment.posted_at,
+                    next_retry_at,
+                },
+                &now,
+            )
+            .map_err(|error| error.to_string())?;
+        } else {
+            let _ = RetainedQueueStore::mark_codex_review_request_polled_in_path(
+                &queue_db_path,
+                &request_id,
+                &now,
+            )
+            .map_err(|error| error.to_string())?;
+        }
+    }
+}
+
+async fn github_detect_pickup(
+    poster: Arc<dyn GitHubReviewPoster>,
+    repo: &str,
+    comment_id: i64,
+) -> Result<bool, String> {
+    let repo = repo.to_owned();
+    tokio::task::spawn_blocking(move || poster.detect_codex_pickup(&repo, comment_id))
+        .await
+        .map_err(|error| format!("pickup detection task failed: {error}"))?
+}
+
+async fn github_find_fresh_review(
+    poster: Arc<dyn GitHubReviewPoster>,
+    repo: &str,
+    pr_number: i64,
+    since: &str,
+) -> Result<Option<GitHubReviewMatch>, String> {
+    let repo = repo.to_owned();
+    let since = since.to_owned();
+    tokio::task::spawn_blocking(move || {
+        poster.find_fresh_codex_review_or_comment(&repo, pr_number, &since)
+    })
+    .await
+    .map_err(|error| format!("review poll task failed: {error}"))?
+}
+
+async fn github_post_review_request(
+    poster: Arc<dyn GitHubReviewPoster>,
+    repo: &str,
+    pr_number: i64,
+    steer: Option<&str>,
+) -> Result<GitHubReviewComment, String> {
+    let repo = repo.to_owned();
+    let steer = steer.map(ToOwned::to_owned);
+    tokio::task::spawn_blocking(move || {
+        poster.post_initial_review_request(&repo, pr_number, steer.as_deref())
+    })
+    .await
+    .map_err(|error| format!("review retry task failed: {error}"))?
+}
+
+fn complete_codex_review_request(
+    queue_db_path: &std::path::Path,
+    request_id: &str,
+    registration: &CodexReviewRequestRegistration,
+    review_match: GitHubReviewMatch,
+    last_polled_at: &str,
+) -> Result<(), String> {
+    let text = render_codex_review_landed_message(registration, &review_match);
+    let queue = RetainedQueueStore::new(queue_db_path.to_path_buf());
+    queue
+        .enqueue_message(&registration.notify_session_id, &text, "sequential", None)
+        .map_err(|error| error.to_string())?;
+    RetainedQueueStore::complete_codex_review_request_in_path(
+        queue_db_path,
+        request_id,
+        CompleteCodexReviewRequest {
+            review_landed_at: review_match.created_at,
+            review_source: Some(review_match.source),
+            review_comment_id: review_match.id,
+            review_url: review_match.url,
+            last_polled_at: last_polled_at.to_owned(),
+        },
+    )
+    .map_err(|error| error.to_string())?;
+    Ok(())
+}
+
+fn render_codex_review_landed_message(
+    registration: &CodexReviewRequestRegistration,
+    review_match: &GitHubReviewMatch,
+) -> String {
+    let noun = if review_match.source == "comment" {
+        "comment"
+    } else {
+        "review"
+    };
+    let mut message = format!(
+        "[sm review] Codex {noun} for PR #{} is here.",
+        registration.pr_number
+    );
+    if let Some(url) = review_match
+        .url
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        message.push(' ');
+        message.push_str(url);
+    }
+    message
+}
+
+fn codex_review_datetime_due(value: &str) -> bool {
+    parse_github_datetime(value).is_none_or(|value| value <= OffsetDateTime::now_utc())
+}
+
+fn codex_review_next_retry_at(posted_at: &str, retry_interval_seconds: i64) -> Option<String> {
+    let posted_at = parse_github_datetime(posted_at).unwrap_or_else(OffsetDateTime::now_utc);
+    (posted_at + TimeDuration::seconds(retry_interval_seconds.max(1)))
+        .format(&Rfc3339)
+        .ok()
 }
 
 async fn list_codex_review_requests(

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -5,7 +5,7 @@ use std::{
     convert::Infallible,
     fs,
     net::SocketAddr,
-    process::{Child, Command, Stdio},
+    process::{Child, Command, Output, Stdio},
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc, Mutex,
@@ -61,7 +61,7 @@ use serde_json::{json, Value};
 use sha1::{Digest, Sha1};
 use sha2::Sha256;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, Mutex as AsyncMutex};
 use tokio::time::timeout;
 
 use crate::app_artifacts::{
@@ -89,8 +89,8 @@ use crate::email::{
 };
 use crate::mobile_analytics::build_mobile_analytics_summary;
 use crate::queue::{
-    CodexReviewRequestFilters, CodexReviewRequestRegistration, CreateQueueJob,
-    QueueAdmissionPolicy, QueueJobFilters, QueueJobRecord, RetainedQueueStore,
+    CodexReviewRequestFilters, CodexReviewRequestRegistration, CreateCodexReviewRequest,
+    CreateQueueJob, QueueAdmissionPolicy, QueueJobFilters, QueueJobRecord, RetainedQueueStore,
 };
 use crate::runtime::TmuxRuntime;
 use crate::sessions::{
@@ -222,10 +222,43 @@ struct CloudflareAccessJwksCacheEntry {
     last_unknown_key_refresh: Option<Instant>,
 }
 
+#[derive(Debug, Clone)]
+pub struct GitHubReviewComment {
+    pub comment_id: Option<i64>,
+    pub comment_url: Option<String>,
+    pub posted_at: String,
+}
+
+pub trait GitHubReviewPoster: Send + Sync {
+    fn post_initial_review_request(
+        &self,
+        repo: &str,
+        pr_number: i64,
+        steer: Option<&str>,
+    ) -> Result<GitHubReviewComment, String>;
+}
+
+#[derive(Debug)]
+struct GhCliReviewPoster;
+
+impl GitHubReviewPoster for GhCliReviewPoster {
+    fn post_initial_review_request(
+        &self,
+        repo: &str,
+        pr_number: i64,
+        steer: Option<&str>,
+    ) -> Result<GitHubReviewComment, String> {
+        validate_open_pr_with_gh(repo, pr_number)?;
+        post_pr_review_comment_with_gh(repo, pr_number, steer)
+    }
+}
+
 #[derive(Clone)]
 pub struct AppState {
     config: AppConfig,
     session_store: SessionStore,
+    github_review_poster: Arc<dyn GitHubReviewPoster>,
+    codex_review_creation_locks: Arc<AsyncMutex<BTreeSet<String>>>,
     mobile_terminal_tickets: Arc<Mutex<BTreeMap<String, MobileTerminalTicket>>>,
     mobile_terminal_active_attaches: Arc<Mutex<BTreeMap<String, MobileTerminalActiveAttach>>>,
     mobile_terminal_proof_nonces: Arc<Mutex<BTreeMap<String, i64>>>,
@@ -246,6 +279,8 @@ impl AppState {
         Self {
             config,
             session_store,
+            github_review_poster: Arc::new(GhCliReviewPoster),
+            codex_review_creation_locks: Arc::new(AsyncMutex::new(BTreeSet::new())),
             mobile_terminal_tickets: Arc::new(Mutex::new(BTreeMap::new())),
             mobile_terminal_active_attaches: Arc::new(Mutex::new(BTreeMap::new())),
             mobile_terminal_proof_nonces: Arc::new(Mutex::new(BTreeMap::new())),
@@ -255,6 +290,169 @@ impl AppState {
             mobile_terminal_runtime_disabled: Arc::new(AtomicBool::new(false)),
             mobile_terminal_secret,
         }
+    }
+
+    pub fn with_github_review_poster(mut self, poster: Arc<dyn GitHubReviewPoster>) -> Self {
+        self.github_review_poster = poster;
+        self
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GhPrViewPayload {
+    state: Option<String>,
+}
+
+fn validate_open_pr_with_gh(repo: &str, pr_number: i64) -> Result<(), String> {
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "view",
+            &pr_number.to_string(),
+            "--repo",
+            repo,
+            "--json",
+            "number,state,title,url",
+        ])
+        .output()
+        .map_err(|error| format!("gh pr view failed: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "PR #{} not found in {}: {}",
+            pr_number,
+            repo,
+            command_stderr(&output)
+        ));
+    }
+    let payload: GhPrViewPayload = serde_json::from_slice(&output.stdout)
+        .map_err(|error| format!("gh pr view returned invalid JSON: {error}"))?;
+    if payload.state.as_deref() != Some("OPEN") {
+        return Err(format!(
+            "PR #{} is {}, not OPEN",
+            pr_number,
+            payload.state.as_deref().unwrap_or("unknown")
+        ));
+    }
+    Ok(())
+}
+
+fn post_pr_review_comment_with_gh(
+    repo: &str,
+    pr_number: i64,
+    steer: Option<&str>,
+) -> Result<GitHubReviewComment, String> {
+    let body = match steer.map(str::trim).filter(|value| !value.is_empty()) {
+        Some(steer) => format!("@codex review for {steer}"),
+        None => "@codex review".to_owned(),
+    };
+    let output = Command::new("gh")
+        .args([
+            "pr",
+            "comment",
+            &pr_number.to_string(),
+            "--repo",
+            repo,
+            "--body",
+            &body,
+        ])
+        .output()
+        .map_err(|error| format!("gh pr comment failed: {error}"))?;
+    if !output.status.success() {
+        return Err(format!("gh pr comment failed: {}", command_stderr(&output)));
+    }
+    let raw_comment_url = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+    let comment_url = (!raw_comment_url.is_empty()).then_some(raw_comment_url);
+    let comment_id = comment_url
+        .as_deref()
+        .and_then(|url| url.rsplit("#issuecomment-").next())
+        .and_then(|value| value.parse::<i64>().ok());
+    Ok(GitHubReviewComment {
+        comment_id,
+        comment_url,
+        posted_at: now_rfc3339(),
+    })
+}
+
+fn command_stderr(output: &Output) -> String {
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_owned();
+    if stderr.is_empty() {
+        String::from_utf8_lossy(&output.stdout).trim().to_owned()
+    } else {
+        stderr
+    }
+}
+
+async fn resolve_codex_review_repo(
+    state: &AppState,
+    repo: Option<&str>,
+    requester_session_id: Option<&str>,
+) -> Result<String, ApiError> {
+    if let Some(repo) = repo.map(str::trim).filter(|value| !value.is_empty()) {
+        return Ok(repo.to_owned());
+    }
+    let Some(requester_session_id) = requester_session_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Err(codex_review_repo_error());
+    };
+    let Some(requester) = state.session_store.get_session(requester_session_id)? else {
+        return Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: format!("Requester session {requester_session_id} not found"),
+        });
+    };
+    let working_dir = requester.working_dir;
+    let output = tokio::task::spawn_blocking(move || {
+        Command::new("gh")
+            .args([
+                "repo",
+                "view",
+                "--json",
+                "nameWithOwner",
+                "--jq",
+                ".nameWithOwner",
+            ])
+            .current_dir(working_dir)
+            .output()
+    })
+    .await
+    .ok()
+    .and_then(Result::ok);
+    if let Some(output) = output {
+        if output.status.success() {
+            let repo = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+            if !repo.is_empty() {
+                return Ok(repo);
+            }
+        }
+    }
+    Err(codex_review_repo_error())
+}
+
+fn codex_review_repo_error() -> ApiError {
+    ApiError::Status {
+        status: StatusCode::BAD_REQUEST,
+        detail:
+            "Could not determine GitHub repo without requester session context; pass --repo explicitly"
+                .to_owned(),
+    }
+}
+
+fn codex_review_store_error(error: anyhow::Error) -> ApiError {
+    let detail = error.to_string();
+    if detail.contains("poll_interval_seconds")
+        || detail.contains("retry_interval_seconds")
+        || detail.contains("Active Codex review request already exists")
+    {
+        return ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail,
+        };
+    }
+    ApiError::Status {
+        status: StatusCode::BAD_GATEWAY,
+        detail: format!("Failed to request Codex review: {detail}"),
     }
 }
 
@@ -302,7 +500,10 @@ pub fn router(state: AppState) -> Router {
             "/queue-jobs/{job_id}",
             get(get_queue_job).delete(cancel_queue_job),
         )
-        .route("/codex-review-requests", get(list_codex_review_requests))
+        .route(
+            "/codex-review-requests",
+            get(list_codex_review_requests).post(create_codex_review_request),
+        )
         .route(
             "/codex-review-requests/{request_id}",
             get(get_codex_review_request).delete(cancel_codex_review_request),
@@ -1919,6 +2120,171 @@ async fn restore_node_restore_candidate(
             detail: "Session not found".to_owned(),
         }),
     }
+}
+
+async fn create_codex_review_request(
+    State(state): State<Arc<AppState>>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(payload): Json<CodexReviewRequestCreateRequest>,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_allowed_from_parts(
+        &state.config,
+        &headers,
+        Some(peer_addr),
+        "/codex-review-requests",
+    )?;
+    validate_codex_review_create_payload(&payload)?;
+    ensure_core_writes_enabled(&state)?;
+
+    let notify_identifier = payload
+        .notify_target
+        .as_deref()
+        .or(payload.requester_session_id.as_deref())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: "notify_target or requester_session_id is required".to_owned(),
+        })?;
+    let Some(notify_session) = resolve_session_or_registry_role(&state, notify_identifier)? else {
+        return Err(ApiError::NotFound("Notify target not found"));
+    };
+    if let Some(requester_session_id) = payload
+        .requester_session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        if state
+            .session_store
+            .get_session(requester_session_id)?
+            .is_none()
+        {
+            return Err(ApiError::Status {
+                status: StatusCode::BAD_REQUEST,
+                detail: format!("Requester session {requester_session_id} not found"),
+            });
+        }
+    }
+    let repo = resolve_codex_review_repo(
+        &state,
+        payload.repo.as_deref(),
+        payload.requester_session_id.as_deref(),
+    )
+    .await?;
+    let queue_db_path = expand_home(&state.config.sm_send.db_path);
+    let creation_key = format!(
+        "{}\u{1f}{}\u{1f}{}",
+        repo, payload.pr_number, notify_session.id
+    );
+    {
+        let mut locks = state.codex_review_creation_locks.lock().await;
+        if !locks.insert(creation_key.clone()) {
+            return Err(ApiError::Status {
+                status: StatusCode::BAD_REQUEST,
+                detail: format!(
+                    "Active Codex review request already exists for {} PR #{}",
+                    repo, payload.pr_number
+                ),
+            });
+        }
+    }
+
+    let create_result = async {
+        match RetainedQueueStore::active_codex_review_request_exists_from_path(
+            &queue_db_path,
+            &repo,
+            payload.pr_number,
+            &notify_session.id,
+        ) {
+            Ok(true) => {
+                return Err(ApiError::Status {
+                    status: StatusCode::BAD_REQUEST,
+                    detail: format!(
+                        "Active Codex review request already exists for {} PR #{}",
+                        repo, payload.pr_number
+                    ),
+                });
+            }
+            Ok(false) => {}
+            Err(error) => {
+                return Err(ApiError::Status {
+                    status: StatusCode::INTERNAL_SERVER_ERROR,
+                    detail: format!("Failed to inspect Codex review requests: {error}"),
+                });
+            }
+        }
+
+        let poster = state.github_review_poster.clone();
+        let repo_for_poster = repo.clone();
+        let steer_for_poster = payload.steer.clone();
+        let comment = tokio::task::spawn_blocking(move || {
+            poster.post_initial_review_request(
+                &repo_for_poster,
+                payload.pr_number,
+                steer_for_poster.as_deref(),
+            )
+        })
+        .await
+        .map_err(|error| ApiError::Status {
+            status: StatusCode::BAD_GATEWAY,
+            detail: format!("Failed to request Codex review: {error}"),
+        })?
+        .map_err(|error| ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: error,
+        })?;
+
+        let registration = RetainedQueueStore::create_codex_review_request_in_path(
+            &queue_db_path,
+            CreateCodexReviewRequest {
+                repo: repo.clone(),
+                pr_number: payload.pr_number,
+                requester_session_id: trimmed(&payload.requester_session_id),
+                notify_session_id: notify_session.id.clone(),
+                steer: trimmed(&payload.steer),
+                latest_request_comment_id: comment.comment_id,
+                latest_request_comment_url: comment.comment_url,
+                latest_request_posted_at: comment.posted_at,
+                poll_interval_seconds: payload.poll_interval_seconds,
+                retry_interval_seconds: payload.retry_interval_seconds,
+            },
+        )
+        .map_err(codex_review_store_error)?;
+        codex_review_request_response(&state, registration).map(Json)
+    }
+    .await;
+    state
+        .codex_review_creation_locks
+        .lock()
+        .await
+        .remove(&creation_key);
+    create_result
+}
+
+fn validate_codex_review_create_payload(
+    payload: &CodexReviewRequestCreateRequest,
+) -> Result<(), ApiError> {
+    if payload.pr_number <= 0 {
+        return Err(ApiError::Status {
+            status: StatusCode::UNPROCESSABLE_ENTITY,
+            detail: "pr_number must be > 0".to_owned(),
+        });
+    }
+    if payload.poll_interval_seconds <= 0 {
+        return Err(ApiError::Status {
+            status: StatusCode::UNPROCESSABLE_ENTITY,
+            detail: "poll_interval_seconds must be > 0".to_owned(),
+        });
+    }
+    if payload.retry_interval_seconds <= 0 {
+        return Err(ApiError::Status {
+            status: StatusCode::UNPROCESSABLE_ENTITY,
+            detail: "retry_interval_seconds must be > 0".to_owned(),
+        });
+    }
+    Ok(())
 }
 
 async fn list_codex_review_requests(
@@ -4531,6 +4897,13 @@ fn shadow_predict_retained_write(
     method: &str,
     path: &str,
 ) -> anyhow::Result<Option<ShadowPrediction>> {
+    if method == "POST" && path == "/codex-review-requests" {
+        return Ok(Some(ShadowPrediction {
+            status: StatusCode::OK.as_u16(),
+            body_sha256: None,
+            support_status: "implemented_retained_write_status_only",
+        }));
+    }
     if method == "DELETE" {
         if let Some(request_id) = path
             .strip_prefix("/codex-review-requests/")
@@ -7506,6 +7879,31 @@ struct ListChildrenQuery {
     status: Option<String>,
     #[serde(default)]
     include_terminated: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexReviewRequestCreateRequest {
+    pr_number: i64,
+    #[serde(default)]
+    repo: Option<String>,
+    #[serde(default)]
+    steer: Option<String>,
+    #[serde(default)]
+    notify_target: Option<String>,
+    #[serde(default)]
+    requester_session_id: Option<String>,
+    #[serde(default = "default_codex_review_poll_interval_seconds")]
+    poll_interval_seconds: i64,
+    #[serde(default = "default_codex_review_retry_interval_seconds")]
+    retry_interval_seconds: i64,
+}
+
+fn default_codex_review_poll_interval_seconds() -> i64 {
+    30
+}
+
+fn default_codex_review_retry_interval_seconds() -> i64 {
+    600
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -65,6 +65,20 @@ pub struct CodexReviewRequestRegistration {
     pub is_active: bool,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateCodexReviewRequest {
+    pub repo: String,
+    pub pr_number: i64,
+    pub requester_session_id: Option<String>,
+    pub notify_session_id: String,
+    pub steer: Option<String>,
+    pub latest_request_comment_id: Option<i64>,
+    pub latest_request_comment_url: Option<String>,
+    pub latest_request_posted_at: String,
+    pub poll_interval_seconds: i64,
+    pub retry_interval_seconds: i64,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct QueueJobFilters {
     pub notify_session_id: Option<String>,
@@ -294,6 +308,42 @@ impl RetainedQueueStore {
             ],
         )?;
         Ok(Some(registration))
+    }
+
+    pub fn create_codex_review_request_in_path(
+        db_path: &Path,
+        request: CreateCodexReviewRequest,
+    ) -> Result<CodexReviewRequestRegistration> {
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "failed to create message queue db directory {}",
+                    parent.display()
+                )
+            })?;
+        }
+        let conn = Connection::open(db_path)
+            .with_context(|| format!("failed to open message queue db {}", db_path.display()))?;
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        conn.pragma_update(None, "busy_timeout", 5000)?;
+        init_codex_review_requests_schema(&conn)?;
+        create_codex_review_request_conn(&conn, request)
+    }
+
+    pub fn active_codex_review_request_exists_from_path(
+        db_path: &Path,
+        repo: &str,
+        pr_number: i64,
+        notify_session_id: &str,
+    ) -> Result<bool> {
+        if !db_path.exists() {
+            return Ok(false);
+        }
+        let conn = match Connection::open_with_flags(db_path, OpenFlags::SQLITE_OPEN_READ_ONLY) {
+            Ok(conn) => conn,
+            Err(_) => return Ok(false),
+        };
+        active_codex_review_request_exists_conn(&conn, repo, pr_number, notify_session_id)
     }
 
     pub fn list_queue_jobs_from_path(
@@ -1343,6 +1393,40 @@ fn init_queue_jobs_schema(conn: &Connection) -> Result<()> {
     ensure_column(conn, "queue_jobs", "queued_notified_at", "TEXT")?;
     ensure_column(conn, "queue_jobs", "started_notified_at", "TEXT")?;
     ensure_column(conn, "queue_jobs", "completion_notified_at", "TEXT")?;
+    Ok(())
+}
+
+fn init_codex_review_requests_schema(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        r#"
+        CREATE TABLE IF NOT EXISTS codex_review_request_registrations (
+            id TEXT PRIMARY KEY,
+            repo TEXT NOT NULL,
+            pr_number INTEGER NOT NULL,
+            requester_session_id TEXT,
+            notify_session_id TEXT NOT NULL,
+            steer TEXT,
+            requested_at TIMESTAMP NOT NULL,
+            latest_request_comment_id INTEGER,
+            latest_request_comment_url TEXT,
+            latest_request_posted_at TIMESTAMP,
+            attempt_count INTEGER NOT NULL,
+            next_retry_at TIMESTAMP,
+            poll_interval_seconds INTEGER NOT NULL,
+            retry_interval_seconds INTEGER NOT NULL,
+            pickup_detected_at TIMESTAMP,
+            pickup_source TEXT,
+            review_landed_at TIMESTAMP,
+            review_source TEXT,
+            review_comment_id INTEGER,
+            review_url TEXT,
+            last_polled_at TIMESTAMP,
+            last_error TEXT,
+            state TEXT NOT NULL,
+            is_active INTEGER DEFAULT 1
+        );
+        "#,
+    )?;
     Ok(())
 }
 
@@ -2548,6 +2632,125 @@ fn list_codex_review_requests_conn(
     Ok(rows.collect::<std::result::Result<Vec<_>, _>>()?)
 }
 
+fn active_codex_review_request_exists_conn(
+    conn: &Connection,
+    repo: &str,
+    pr_number: i64,
+    notify_session_id: &str,
+) -> Result<bool> {
+    let count = match conn.query_row(
+        r#"
+        SELECT COUNT(*)
+        FROM codex_review_request_registrations
+        WHERE repo = ?1
+            AND pr_number = ?2
+            AND notify_session_id = ?3
+            AND is_active = 1
+        "#,
+        params![repo, pr_number, notify_session_id],
+        |row| row.get::<_, i64>(0),
+    ) {
+        Ok(count) => count,
+        Err(rusqlite::Error::SqliteFailure(_, Some(message)))
+            if message.contains("no such table") =>
+        {
+            0
+        }
+        Err(error) => return Err(error.into()),
+    };
+    Ok(count > 0)
+}
+
+fn create_codex_review_request_conn(
+    conn: &Connection,
+    request: CreateCodexReviewRequest,
+) -> Result<CodexReviewRequestRegistration> {
+    if request.poll_interval_seconds <= 0 {
+        anyhow::bail!("poll_interval_seconds must be > 0");
+    }
+    if request.retry_interval_seconds <= 0 {
+        anyhow::bail!("retry_interval_seconds must be > 0");
+    }
+    if active_codex_review_request_exists_conn(
+        conn,
+        &request.repo,
+        request.pr_number,
+        &request.notify_session_id,
+    )? {
+        anyhow::bail!(
+            "Active Codex review request already exists for {} PR #{}",
+            request.repo,
+            request.pr_number
+        );
+    }
+
+    let latest_posted_at = request.latest_request_posted_at;
+    let next_retry_at =
+        codex_review_next_retry_at(&latest_posted_at, request.retry_interval_seconds)?;
+    let registration = CodexReviewRequestRegistration {
+        id: generate_codex_review_request_id(),
+        repo: request.repo,
+        pr_number: request.pr_number,
+        requester_session_id: request.requester_session_id,
+        notify_session_id: request.notify_session_id,
+        steer: request.steer,
+        requested_at: latest_posted_at.clone(),
+        latest_request_comment_id: request.latest_request_comment_id,
+        latest_request_comment_url: request.latest_request_comment_url,
+        latest_request_posted_at: Some(latest_posted_at),
+        attempt_count: 1,
+        next_retry_at: Some(next_retry_at),
+        poll_interval_seconds: request.poll_interval_seconds,
+        retry_interval_seconds: request.retry_interval_seconds,
+        pickup_detected_at: None,
+        pickup_source: None,
+        review_landed_at: None,
+        review_source: None,
+        review_comment_id: None,
+        review_url: None,
+        last_polled_at: None,
+        last_error: None,
+        state: "active".to_owned(),
+        is_active: true,
+    };
+    conn.execute(
+        r#"
+        INSERT INTO codex_review_request_registrations
+            (id, repo, pr_number, requester_session_id, notify_session_id, steer,
+             requested_at, latest_request_comment_id, latest_request_comment_url,
+             latest_request_posted_at, attempt_count, next_retry_at,
+             poll_interval_seconds, retry_interval_seconds, pickup_detected_at,
+             pickup_source, review_landed_at, review_source, review_comment_id,
+             review_url, last_polled_at, last_error, state, is_active)
+        VALUES
+            (?1, ?2, ?3, ?4, ?5, ?6,
+             ?7, ?8, ?9,
+             ?10, ?11, ?12,
+             ?13, ?14, NULL,
+             NULL, NULL, NULL, NULL,
+             NULL, NULL, NULL, ?15, 1)
+        "#,
+        params![
+            registration.id,
+            registration.repo,
+            registration.pr_number,
+            registration.requester_session_id,
+            registration.notify_session_id,
+            registration.steer,
+            registration.requested_at,
+            registration.latest_request_comment_id,
+            registration.latest_request_comment_url,
+            registration.latest_request_posted_at,
+            registration.attempt_count,
+            registration.next_retry_at,
+            registration.poll_interval_seconds,
+            registration.retry_interval_seconds,
+            registration.state,
+        ],
+    )?;
+    Ok(registration)
+}
+
 fn get_codex_review_request_conn(
     conn: &Connection,
     request_id: &str,
@@ -2843,10 +3046,27 @@ fn generate_queue_job_id() -> String {
     format!("job_{suffix}")
 }
 
+fn generate_codex_review_request_id() -> String {
+    let mut bytes = [0u8; 6];
+    OsRng.fill_bytes(&mut bytes);
+    bytes
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>()
+}
+
 fn now_rfc3339() -> String {
     OffsetDateTime::now_utc()
         .format(&Rfc3339)
         .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned())
+}
+
+fn codex_review_next_retry_at(posted_at: &str, retry_interval_seconds: i64) -> Result<String> {
+    let posted_at = parse_queue_datetime(posted_at)
+        .or_else(|| parse_python_naive_datetime(posted_at).map(PrimitiveDateTime::assume_utc))
+        .unwrap_or_else(OffsetDateTime::now_utc);
+    let next_retry_at = posted_at + Duration::seconds(retry_interval_seconds.max(1));
+    Ok(next_retry_at.format(&Rfc3339)?)
 }
 
 fn timeout_at_rfc3339(timeout_seconds: Option<u64>) -> Result<Option<String>> {

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -79,6 +79,23 @@ pub struct CreateCodexReviewRequest {
     pub retry_interval_seconds: i64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RetryCodexReviewRequest {
+    pub latest_request_comment_id: Option<i64>,
+    pub latest_request_comment_url: Option<String>,
+    pub latest_request_posted_at: String,
+    pub next_retry_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompleteCodexReviewRequest {
+    pub review_landed_at: String,
+    pub review_source: Option<String>,
+    pub review_comment_id: Option<JsonValue>,
+    pub review_url: Option<String>,
+    pub last_polled_at: String,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct QueueJobFilters {
     pub notify_session_id: Option<String>,
@@ -344,6 +361,145 @@ impl RetainedQueueStore {
             Err(_) => return Ok(false),
         };
         active_codex_review_request_exists_conn(&conn, repo, pr_number, notify_session_id)
+    }
+
+    pub fn mark_codex_review_request_pickup_in_path(
+        db_path: &Path,
+        request_id: &str,
+        last_polled_at: &str,
+    ) -> Result<Option<CodexReviewRequestRegistration>> {
+        if !db_path.exists() {
+            return Ok(None);
+        }
+        let conn = Connection::open(db_path)?;
+        conn.execute(
+            r#"
+            UPDATE codex_review_request_registrations
+            SET pickup_detected_at = COALESCE(pickup_detected_at, ?2),
+                pickup_source = COALESCE(pickup_source, 'reaction'),
+                last_polled_at = ?2,
+                last_error = NULL
+            WHERE id = ?1 AND is_active = 1
+            "#,
+            params![request_id, last_polled_at],
+        )?;
+        get_codex_review_request_conn(&conn, request_id)
+    }
+
+    pub fn mark_codex_review_request_poll_error_in_path(
+        db_path: &Path,
+        request_id: &str,
+        last_polled_at: &str,
+        last_error: &str,
+        next_retry_at: Option<&str>,
+    ) -> Result<Option<CodexReviewRequestRegistration>> {
+        if !db_path.exists() {
+            return Ok(None);
+        }
+        let conn = Connection::open(db_path)?;
+        conn.execute(
+            r#"
+            UPDATE codex_review_request_registrations
+            SET last_polled_at = ?2,
+                last_error = ?3,
+                next_retry_at = COALESCE(?4, next_retry_at)
+            WHERE id = ?1 AND is_active = 1
+            "#,
+            params![request_id, last_polled_at, last_error, next_retry_at],
+        )?;
+        get_codex_review_request_conn(&conn, request_id)
+    }
+
+    pub fn mark_codex_review_request_polled_in_path(
+        db_path: &Path,
+        request_id: &str,
+        last_polled_at: &str,
+    ) -> Result<Option<CodexReviewRequestRegistration>> {
+        if !db_path.exists() {
+            return Ok(None);
+        }
+        let conn = Connection::open(db_path)?;
+        conn.execute(
+            r#"
+            UPDATE codex_review_request_registrations
+            SET last_polled_at = ?2,
+                last_error = NULL
+            WHERE id = ?1 AND is_active = 1
+            "#,
+            params![request_id, last_polled_at],
+        )?;
+        get_codex_review_request_conn(&conn, request_id)
+    }
+
+    pub fn retry_codex_review_request_in_path(
+        db_path: &Path,
+        request_id: &str,
+        retry: RetryCodexReviewRequest,
+        last_polled_at: &str,
+    ) -> Result<Option<CodexReviewRequestRegistration>> {
+        if !db_path.exists() {
+            return Ok(None);
+        }
+        let conn = Connection::open(db_path)?;
+        conn.execute(
+            r#"
+            UPDATE codex_review_request_registrations
+            SET attempt_count = attempt_count + 1,
+                latest_request_comment_id = ?2,
+                latest_request_comment_url = ?3,
+                latest_request_posted_at = ?4,
+                pickup_detected_at = NULL,
+                pickup_source = NULL,
+                next_retry_at = ?5,
+                last_polled_at = ?6,
+                last_error = NULL
+            WHERE id = ?1 AND is_active = 1
+            "#,
+            params![
+                request_id,
+                retry.latest_request_comment_id,
+                retry.latest_request_comment_url,
+                retry.latest_request_posted_at,
+                retry.next_retry_at,
+                last_polled_at,
+            ],
+        )?;
+        get_codex_review_request_conn(&conn, request_id)
+    }
+
+    pub fn complete_codex_review_request_in_path(
+        db_path: &Path,
+        request_id: &str,
+        completion: CompleteCodexReviewRequest,
+    ) -> Result<Option<CodexReviewRequestRegistration>> {
+        if !db_path.exists() {
+            return Ok(None);
+        }
+        let conn = Connection::open(db_path)?;
+        let review_comment_id = completion.review_comment_id.map(json_scalar_to_sql_value);
+        conn.execute(
+            r#"
+            UPDATE codex_review_request_registrations
+            SET review_landed_at = ?2,
+                review_source = ?3,
+                review_comment_id = ?4,
+                review_url = ?5,
+                state = 'completed',
+                is_active = 0,
+                last_polled_at = ?6,
+                last_error = NULL
+            WHERE id = ?1 AND is_active = 1
+            "#,
+            params![
+                request_id,
+                completion.review_landed_at,
+                completion.review_source,
+                review_comment_id,
+                completion.review_url,
+                completion.last_polled_at,
+            ],
+        )?;
+        get_codex_review_request_conn(&conn, request_id)
     }
 
     pub fn list_queue_jobs_from_path(
@@ -2949,6 +3105,26 @@ fn optional_sqlite_json_scalar(value: ValueRef<'_>) -> Option<JsonValue> {
         ValueRef::Blob(value) => Some(JsonValue::String(
             String::from_utf8_lossy(value).into_owned(),
         )),
+    }
+}
+
+fn json_scalar_to_sql_value(value: JsonValue) -> SqlValue {
+    match value {
+        JsonValue::Null => SqlValue::Null,
+        JsonValue::Bool(value) => SqlValue::Integer(i64::from(value)),
+        JsonValue::Number(value) => {
+            if let Some(value) = value.as_i64() {
+                SqlValue::Integer(value)
+            } else if let Some(value) = value.as_u64().and_then(|value| i64::try_from(value).ok()) {
+                SqlValue::Integer(value)
+            } else if let Some(value) = value.as_f64() {
+                SqlValue::Real(value)
+            } else {
+                SqlValue::Text(value.to_string())
+            }
+        }
+        JsonValue::String(value) => SqlValue::Text(value),
+        JsonValue::Array(_) | JsonValue::Object(_) => SqlValue::Text(value.to_string()),
     }
 }
 

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -23,7 +23,7 @@ use sm_server::{
         MobileTerminalDeviceKeyConfig, MobileTerminalUserConfig, PathsConfig, QueueRunnerConfig,
         RustCoreConfig, SmSendConfig, ToolLoggingConfig,
     },
-    http::{router, AppState},
+    http::{router, AppState, GitHubReviewComment, GitHubReviewPoster},
 };
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -39,7 +39,7 @@ use std::{
     process::Command,
     sync::{
         atomic::{AtomicU64, Ordering},
-        mpsc,
+        mpsc, Arc, Mutex,
     },
     thread,
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -168,6 +168,54 @@ fn queue_job_completion_notified_at(queue_state_dir: &PathBuf, job_id: &str) -> 
         thread::sleep(Duration::from_millis(50));
     }
     None
+}
+
+#[derive(Debug, Clone)]
+struct StubGitHubReviewPoster {
+    result: Arc<Mutex<Result<GitHubReviewComment, String>>>,
+    calls: Arc<Mutex<Vec<(String, i64, Option<String>)>>>,
+}
+
+impl StubGitHubReviewPoster {
+    fn successful() -> Self {
+        Self {
+            result: Arc::new(Mutex::new(Ok(GitHubReviewComment {
+                comment_id: Some(4701290334),
+                comment_url: Some(
+                    "https://github.com/rajeshgoli/session-manager/pull/967#issuecomment-4701290334"
+                        .to_owned(),
+                ),
+                posted_at: "2026-06-14T02:30:00Z".to_owned(),
+            }))),
+            calls: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn failing(message: &str) -> Self {
+        Self {
+            result: Arc::new(Mutex::new(Err(message.to_owned()))),
+            calls: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn calls(&self) -> Vec<(String, i64, Option<String>)> {
+        self.calls.lock().unwrap().clone()
+    }
+}
+
+impl GitHubReviewPoster for StubGitHubReviewPoster {
+    fn post_initial_review_request(
+        &self,
+        repo: &str,
+        pr_number: i64,
+        steer: Option<&str>,
+    ) -> Result<GitHubReviewComment, String> {
+        self.calls
+            .lock()
+            .unwrap()
+            .push((repo.to_owned(), pr_number, steer.map(ToOwned::to_owned)));
+        self.result.lock().unwrap().clone()
+    }
 }
 
 fn queue_job_text_column(queue_state_dir: &PathBuf, job_id: &str, column: &str) -> String {
@@ -1964,6 +2012,321 @@ async fn codex_review_request_cancel_updates_active_row_and_preserves_inactive_r
     assert_eq!(payload["id"], "inactive");
     assert_eq!(payload["state"], "cancelled");
     assert_eq!(payload["is_active"], false);
+}
+
+#[tokio::test]
+async fn codex_review_request_create_posts_and_persists_active_row() {
+    let state_file = unique_temp_path();
+    let queue_db = state_file.with_extension("codex-review-create.db");
+    fs::write(
+        &state_file,
+        json!({
+            "sessions": [
+                {
+                    "id": "requester1",
+                    "name": "codex-fork-requester1",
+                    "working_dir": "/repo/requester",
+                    "tmux_session": "codex-fork-requester1",
+                    "log_file": "/tmp/requester1.log",
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00Z",
+                    "last_activity": "2026-06-01T00:01:00Z",
+                    "provider": "codex-fork",
+                    "native_title": "native requester"
+                },
+                {
+                    "id": "notify1",
+                    "name": "codex-fork-notify1",
+                    "working_dir": "/repo/notify",
+                    "tmux_session": "codex-fork-notify1",
+                    "log_file": "/tmp/notify1.log",
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00Z",
+                    "last_activity": "2026-06-01T00:01:00Z"
+                }
+            ],
+            "agent_registrations": [
+                {
+                    "role": "reviewer",
+                    "session_id": "notify1",
+                    "created_at": "2026-06-01T00:02:00Z"
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let poster = StubGitHubReviewPoster::successful();
+    let mut config = AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        sm_send: SmSendConfig {
+            db_path: queue_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    };
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config).with_github_review_poster(Arc::new(poster.clone())));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/codex-review-requests",
+        json!({
+            "pr_number": 967,
+            "repo": "rajeshgoli/session-manager",
+            "steer": "focus create",
+            "requester_session_id": "requester1",
+            "notify_target": "reviewer",
+            "poll_interval_seconds": 45,
+            "retry_interval_seconds": 900
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let request_id = payload["id"].as_str().unwrap();
+    assert_eq!(request_id.len(), 12);
+    assert!(request_id.chars().all(|ch| ch.is_ascii_hexdigit()));
+    assert_eq!(payload["repo"], "rajeshgoli/session-manager");
+    assert_eq!(payload["pr_number"], 967);
+    assert_eq!(payload["requester_session_id"], "requester1");
+    assert_eq!(payload["requester_name"], "native requester");
+    assert_eq!(payload["notify_session_id"], "notify1");
+    assert_eq!(payload["notify_name"], "reviewer");
+    assert_eq!(payload["steer"], "focus create");
+    assert_eq!(payload["latest_request_comment_id"], 4701290334_i64);
+    assert_eq!(
+        payload["latest_request_comment_url"],
+        "https://github.com/rajeshgoli/session-manager/pull/967#issuecomment-4701290334"
+    );
+    assert_eq!(payload["attempt_count"], 1);
+    assert_eq!(payload["poll_interval_seconds"], 45);
+    assert_eq!(payload["retry_interval_seconds"], 900);
+    assert_eq!(payload["state"], "active");
+    assert_eq!(payload["is_active"], true);
+    assert_eq!(
+        poster.calls(),
+        vec![(
+            "rajeshgoli/session-manager".to_owned(),
+            967,
+            Some("focus create".to_owned())
+        )]
+    );
+
+    let conn = Connection::open(&queue_db).unwrap();
+    let row: (String, i64, String, i64, String, String, i64) = conn
+        .query_row(
+            r#"
+            SELECT id, latest_request_comment_id, latest_request_comment_url,
+                   attempt_count, state, next_retry_at, is_active
+            FROM codex_review_request_registrations
+            WHERE id = ?1
+            "#,
+            [request_id],
+            |row| {
+                Ok((
+                    row.get(0)?,
+                    row.get(1)?,
+                    row.get(2)?,
+                    row.get(3)?,
+                    row.get(4)?,
+                    row.get(5)?,
+                    row.get(6)?,
+                ))
+            },
+        )
+        .unwrap();
+    assert_eq!(row.0, request_id);
+    assert_eq!(row.1, 4701290334);
+    assert_eq!(
+        row.2,
+        "https://github.com/rajeshgoli/session-manager/pull/967#issuecomment-4701290334"
+    );
+    assert_eq!(row.3, 1);
+    assert_eq!(row.4, "active");
+    assert_eq!(row.5, "2026-06-14T02:45:00Z");
+    assert_eq!(row.6, 1);
+
+    let (status, payload) = get_json(app, &format!("/codex-review-requests/{request_id}")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["id"], request_id);
+}
+
+#[tokio::test]
+async fn codex_review_request_create_rejects_duplicates_before_github_post() {
+    let state_file = unique_temp_path();
+    let queue_db = state_file.with_extension("codex-review-create-duplicate.db");
+    fs::write(
+        &state_file,
+        json!({
+            "sessions": [
+                {
+                    "id": "notify1",
+                    "name": "codex-fork-notify1",
+                    "working_dir": "/repo/notify",
+                    "tmux_session": "codex-fork-notify1",
+                    "log_file": "/tmp/notify1.log",
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00Z",
+                    "last_activity": "2026-06-01T00:01:00Z"
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    create_codex_review_request_fixture_db(&queue_db);
+    let poster = StubGitHubReviewPoster::successful();
+    let mut config = AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        sm_send: SmSendConfig {
+            db_path: queue_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    };
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config).with_github_review_poster(Arc::new(poster.clone())));
+
+    let (status, payload) = post_json(
+        app,
+        "/codex-review-requests",
+        json!({
+            "pr_number": 830,
+            "repo": "rajeshgoli/session-manager",
+            "notify_target": "notify1"
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        payload["detail"],
+        "Active Codex review request already exists for rajeshgoli/session-manager PR #830"
+    );
+    assert!(poster.calls().is_empty());
+}
+
+#[tokio::test]
+async fn codex_review_request_create_preserves_validation_errors_and_write_gate() {
+    let state_file = unique_temp_path();
+    let queue_db = state_file.with_extension("codex-review-create-errors.db");
+    fs::write(
+        &state_file,
+        json!({
+            "sessions": [
+                {
+                    "id": "notify1",
+                    "name": "codex-fork-notify1",
+                    "working_dir": "/repo/notify",
+                    "tmux_session": "codex-fork-notify1",
+                    "log_file": "/tmp/notify1.log",
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00Z",
+                    "last_activity": "2026-06-01T00:01:00Z"
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let disabled_app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        sm_send: SmSendConfig {
+            db_path: queue_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    }));
+    let (status, payload) = post_json(
+        disabled_app,
+        "/codex-review-requests",
+        json!({
+            "pr_number": 967,
+            "repo": "rajeshgoli/session-manager",
+            "notify_target": "notify1"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert_eq!(payload["detail"], "Rust core writes are disabled");
+
+    let poster = StubGitHubReviewPoster::failing("gh pr comment failed: denied");
+    let mut config = AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        sm_send: SmSendConfig {
+            db_path: queue_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    };
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config).with_github_review_poster(Arc::new(poster.clone())));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/codex-review-requests",
+        json!({
+            "pr_number": 967,
+            "repo": "rajeshgoli/session-manager",
+            "notify_target": "missing"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(payload["detail"], "Notify target not found");
+    assert!(poster.calls().is_empty());
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/codex-review-requests",
+        json!({
+            "pr_number": 967,
+            "repo": "rajeshgoli/session-manager",
+            "notify_target": "notify1",
+            "poll_interval_seconds": 0
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(payload["detail"], "poll_interval_seconds must be > 0");
+    assert!(poster.calls().is_empty());
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/codex-review-requests",
+        json!({
+            "pr_number": 0,
+            "repo": "rajeshgoli/session-manager",
+            "notify_target": "notify1"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(payload["detail"], "pr_number must be > 0");
+    assert!(poster.calls().is_empty());
+
+    let (status, payload) = post_json(
+        app,
+        "/codex-review-requests",
+        json!({
+            "pr_number": 967,
+            "repo": "rajeshgoli/session-manager",
+            "notify_target": "notify1"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(payload["detail"], "gh pr comment failed: denied");
+    assert_eq!(
+        poster.calls(),
+        vec![("rajeshgoli/session-manager".to_owned(), 967, None)]
+    );
+    assert!(!queue_db.exists());
 }
 
 #[tokio::test]
@@ -4416,6 +4779,54 @@ async fn shadow_http_reports_codex_review_request_cancel_as_status_only_without_
     assert_eq!(status, StatusCode::OK);
     assert_eq!(detail["state"], "completed");
     assert_eq!(detail["is_active"], true);
+}
+
+#[tokio::test]
+async fn shadow_http_reports_codex_review_request_create_as_status_only_without_writing() {
+    let state_file = unique_temp_path();
+    let queue_db = state_file.with_extension("codex-review-requests-shadow-create.db");
+    fs::write(&state_file, json!({ "sessions": [] }).to_string()).unwrap();
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        sm_send: SmSendConfig {
+            db_path: queue_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "POST",
+                "path": "/codex-review-requests",
+                "query_string": "",
+                "headers": {},
+                "body_sha256": sha256_hex(b"{\"pr_number\":967}")
+            },
+            "python_response": {
+                "status": 200,
+                "body_sha256": sha256_hex(b"{\"id\":\"python-owned\"}")
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        payload["support_status"],
+        "implemented_retained_write_status_only"
+    );
+    assert_eq!(payload["comparison"], "status_match");
+    assert_eq!(payload["would_write"], false);
+    assert_eq!(payload["predicted_status"], 200);
+    assert_eq!(payload["predicted_body_sha256"], Value::Null);
+    assert_eq!(payload["body_sha256_match"], Value::Null);
+    assert!(!queue_db.exists());
 }
 
 #[tokio::test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -23,7 +23,7 @@ use sm_server::{
         MobileTerminalDeviceKeyConfig, MobileTerminalUserConfig, PathsConfig, QueueRunnerConfig,
         RustCoreConfig, SmSendConfig, ToolLoggingConfig,
     },
-    http::{router, AppState, GitHubReviewComment, GitHubReviewPoster},
+    http::{router, AppState, GitHubReviewComment, GitHubReviewMatch, GitHubReviewPoster},
 };
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -174,6 +174,7 @@ fn queue_job_completion_notified_at(queue_state_dir: &PathBuf, job_id: &str) -> 
 struct StubGitHubReviewPoster {
     result: Arc<Mutex<Result<GitHubReviewComment, String>>>,
     calls: Arc<Mutex<Vec<(String, i64, Option<String>)>>>,
+    fresh_review: Arc<Mutex<Option<GitHubReviewMatch>>>,
 }
 
 impl StubGitHubReviewPoster {
@@ -188,6 +189,7 @@ impl StubGitHubReviewPoster {
                 posted_at: "2026-06-14T02:30:00Z".to_owned(),
             }))),
             calls: Arc::new(Mutex::new(Vec::new())),
+            fresh_review: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -195,11 +197,17 @@ impl StubGitHubReviewPoster {
         Self {
             result: Arc::new(Mutex::new(Err(message.to_owned()))),
             calls: Arc::new(Mutex::new(Vec::new())),
+            fresh_review: Arc::new(Mutex::new(None)),
         }
     }
 
     fn calls(&self) -> Vec<(String, i64, Option<String>)> {
         self.calls.lock().unwrap().clone()
+    }
+
+    fn with_fresh_review(self, review_match: GitHubReviewMatch) -> Self {
+        *self.fresh_review.lock().unwrap() = Some(review_match);
+        self
     }
 }
 
@@ -215,6 +223,15 @@ impl GitHubReviewPoster for StubGitHubReviewPoster {
             .unwrap()
             .push((repo.to_owned(), pr_number, steer.map(ToOwned::to_owned)));
         self.result.lock().unwrap().clone()
+    }
+
+    fn find_fresh_codex_review_or_comment(
+        &self,
+        _repo: &str,
+        _pr_number: i64,
+        _since: &str,
+    ) -> Result<Option<GitHubReviewMatch>, String> {
+        Ok(self.fresh_review.lock().unwrap().clone())
     }
 }
 
@@ -2151,6 +2168,106 @@ async fn codex_review_request_create_posts_and_persists_active_row() {
     let (status, payload) = get_json(app, &format!("/codex-review-requests/{request_id}")).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["id"], request_id);
+}
+
+#[tokio::test]
+async fn codex_review_request_watcher_completes_and_queues_wake() {
+    let state_file = unique_temp_path();
+    let queue_db = state_file.with_extension("codex-review-create-watch.db");
+    fs::write(
+        &state_file,
+        json!({
+            "sessions": [
+                {
+                    "id": "notify1",
+                    "name": "codex-fork-notify1",
+                    "working_dir": "/repo/notify",
+                    "tmux_session": "codex-fork-notify1",
+                    "log_file": "/tmp/notify1.log",
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00Z",
+                    "last_activity": "2026-06-01T00:01:00Z"
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let poster = StubGitHubReviewPoster::successful().with_fresh_review(GitHubReviewMatch {
+        source: "comment".to_owned(),
+        created_at: "2026-06-14T02:31:00Z".to_owned(),
+        id: Some(json!(4701300000_i64)),
+        url: Some(
+            "https://github.com/rajeshgoli/session-manager/pull/967#issuecomment-4701300000"
+                .to_owned(),
+        ),
+    });
+    let mut config = AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        sm_send: SmSendConfig {
+            db_path: queue_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    };
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config).with_github_review_poster(Arc::new(poster)));
+
+    let (status, payload) = post_json(
+        app,
+        "/codex-review-requests",
+        json!({
+            "pr_number": 967,
+            "repo": "rajeshgoli/session-manager",
+            "notify_target": "notify1",
+            "poll_interval_seconds": 1,
+            "retry_interval_seconds": 900
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let request_id = payload["id"].as_str().unwrap().to_owned();
+
+    let mut completed = None;
+    for _ in 0..30 {
+        let conn = Connection::open(&queue_db).unwrap();
+        let row: (String, i64, Option<String>) = conn
+            .query_row(
+                r#"
+                SELECT state, is_active, review_url
+                FROM codex_review_request_registrations
+                WHERE id = ?1
+                "#,
+                [&request_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        if row.0 == "completed" {
+            completed = Some(row);
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    let completed = completed.expect("watcher should complete retained request");
+    assert_eq!(completed.1, 0);
+    assert_eq!(
+        completed.2.as_deref(),
+        Some("https://github.com/rajeshgoli/session-manager/pull/967#issuecomment-4701300000")
+    );
+
+    let conn = Connection::open(&queue_db).unwrap();
+    let message: String = conn
+        .query_row(
+            "SELECT text FROM message_queue WHERE target_session_id = 'notify1'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(
+        message,
+        "[sm review] Codex comment for PR #967 is here. https://github.com/rajeshgoli/session-manager/pull/967#issuecomment-4701300000"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #967

## Summary
- add the Rust retained `POST /codex-review-requests` create endpoint
- validate notify/requester targets, repo resolution, duplicate active requests, PR state, and initial `@codex review` posting before persisting
- create the retained `codex_review_request_registrations` row with Python-compatible fields and status-only shadow classification for the retained write

## Validation
- `cargo fmt --check`
- `cargo test -p sm-server --test read_only_http codex_review -- --nocapture`
- `cargo test -p sm-server`
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py -q`
- `./venv/bin/python -m json.tool scripts/rust_migration/contracts_manifest.json >/dev/null`
- `git diff --check`