### PR TITLE
Rust MVP: implement retained PR review route

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -818,6 +818,7 @@ pub fn router(state: AppState) -> Router {
             "/codex-review-requests/{request_id}",
             get(get_codex_review_request).delete(cancel_codex_review_request),
         )
+        .route("/reviews/pr", post(start_pr_review))
         .route("/nodes", get(list_nodes))
         .route("/nodes/{node_id}/ping", post(ping_node))
         .route(
@@ -2573,6 +2574,168 @@ async fn create_codex_review_request(
         .await
         .remove(&creation_key);
     create_result
+}
+
+async fn start_pr_review(
+    State(state): State<Arc<AppState>>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(payload): Json<PrReviewRequest>,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_allowed_from_parts(&state.config, &headers, Some(peer_addr), "/reviews/pr")?;
+    ensure_core_writes_enabled(&state)?;
+    let repo = match resolve_pr_review_repo(
+        &state,
+        payload.repo.as_deref(),
+        payload.caller_session_id.as_deref(),
+    )
+    .await
+    {
+        Ok(repo) => repo,
+        Err(error) => return Ok(Json(json!({ "error": error }))),
+    };
+    let steer = trimmed(&payload.steer);
+    let poster = state.github_review_poster.clone();
+    let comment = match github_post_review_request(
+        poster,
+        &repo,
+        payload.pr_number,
+        steer.as_deref(),
+    )
+    .await
+    {
+        Ok(comment) => comment,
+        Err(error) => return Ok(Json(json!({ "error": error }))),
+    };
+    let caller_session_id = trimmed(&payload.caller_session_id);
+    let server_polling = payload.wait.is_some_and(|wait| wait != 0) && caller_session_id.is_some();
+    if server_polling {
+        spawn_pr_review_completion_notifier(
+            state.clone(),
+            repo.clone(),
+            payload.pr_number,
+            comment.posted_at.clone(),
+            payload.wait.unwrap_or_default(),
+            caller_session_id.clone().unwrap_or_default(),
+        );
+    }
+
+    Ok(Json(json!({
+        "repo": repo,
+        "pr_number": payload.pr_number,
+        "posted_at": comment.posted_at,
+        "comment_id": comment.comment_id.unwrap_or(0),
+        "comment_body": codex_review_comment_body(steer.as_deref()),
+        "status": "posted",
+        "server_polling": server_polling,
+    })))
+}
+
+async fn resolve_pr_review_repo(
+    state: &AppState,
+    repo: Option<&str>,
+    caller_session_id: Option<&str>,
+) -> Result<String, String> {
+    if let Some(repo) = repo.map(str::trim).filter(|value| !value.is_empty()) {
+        return Ok(repo.to_owned());
+    }
+    let Some(caller_session_id) = caller_session_id
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Err(
+            "Could not determine repo. Provide --repo or run from a git directory.".to_owned(),
+        );
+    };
+    let Some(caller) = state
+        .session_store
+        .get_session(caller_session_id)
+        .map_err(|error| error.to_string())?
+    else {
+        return Err(
+            "Could not determine repo. Provide --repo or run from a git directory.".to_owned(),
+        );
+    };
+    let working_dir = caller.working_dir;
+    let output = tokio::task::spawn_blocking(move || {
+        Command::new("gh")
+            .args([
+                "repo",
+                "view",
+                "--json",
+                "nameWithOwner",
+                "--jq",
+                ".nameWithOwner",
+            ])
+            .current_dir(working_dir)
+            .output()
+    })
+    .await
+    .ok()
+    .and_then(Result::ok);
+    if let Some(output) = output {
+        if output.status.success() {
+            let repo = String::from_utf8_lossy(&output.stdout).trim().to_owned();
+            if !repo.is_empty() {
+                return Ok(repo);
+            }
+        }
+    }
+    Err("Could not determine repo. Provide --repo or run from a git directory.".to_owned())
+}
+
+fn codex_review_comment_body(steer: Option<&str>) -> String {
+    match steer.map(str::trim).filter(|value| !value.is_empty()) {
+        Some(steer) => format!("@codex review for {steer}"),
+        None => "@codex review".to_owned(),
+    }
+}
+
+fn spawn_pr_review_completion_notifier(
+    state: Arc<AppState>,
+    repo: String,
+    pr_number: i64,
+    posted_at: String,
+    wait_seconds: i64,
+    caller_session_id: String,
+) {
+    tokio::spawn(async move {
+        let wait_duration = Duration::from_secs(wait_seconds.max(0) as u64);
+        let deadline = Instant::now() + wait_duration;
+        loop {
+            if let Ok(Some(_review_match)) = github_find_fresh_review(
+                state.github_review_poster.clone(),
+                &repo,
+                pr_number,
+                &posted_at,
+            )
+            .await
+            {
+                let text =
+                    format!("Review --pr {pr_number} ({repo}) completed: Codex posted review on PR #{pr_number}");
+                enqueue_pr_review_notification(&state, &caller_session_id, &text);
+                return;
+            }
+            let now = Instant::now();
+            if now >= deadline {
+                break;
+            }
+            let sleep_for = std::cmp::min(
+                Duration::from_secs(30),
+                deadline.saturating_duration_since(now),
+            );
+            tokio::time::sleep(sleep_for).await;
+        }
+
+        let text = format!("Review --pr {pr_number} ({repo}) timed out after {wait_seconds}s");
+        enqueue_pr_review_notification(&state, &caller_session_id, &text);
+    });
+}
+
+fn enqueue_pr_review_notification(state: &AppState, caller_session_id: &str, text: &str) {
+    let queue_db_path = expand_home(&state.config.sm_send.db_path);
+    let queue = RetainedQueueStore::new(queue_db_path);
+    let _ = queue.enqueue_message(caller_session_id, text, "important", None);
 }
 
 fn validate_codex_review_create_payload(
@@ -5534,6 +5697,13 @@ fn shadow_predict_retained_write(
             support_status: "implemented_retained_write_status_only",
         }));
     }
+    if method == "POST" && path == "/reviews/pr" {
+        return Ok(Some(ShadowPrediction {
+            status: StatusCode::OK.as_u16(),
+            body_sha256: None,
+            support_status: "implemented_retained_write_status_only",
+        }));
+    }
     if method == "DELETE" {
         if let Some(request_id) = path
             .strip_prefix("/codex-review-requests/")
@@ -7858,6 +8028,9 @@ fn is_retained_write_surface(method: &str, path: &str) -> bool {
     if method == "POST" && path == "/codex-review-requests" {
         return true;
     }
+    if method == "POST" && path == "/reviews/pr" {
+        return true;
+    }
     if path.starts_with("/codex-review-requests/") {
         return matches!(method, "POST" | "DELETE");
     }
@@ -8526,6 +8699,19 @@ struct CodexReviewRequestCreateRequest {
     poll_interval_seconds: i64,
     #[serde(default = "default_codex_review_retry_interval_seconds")]
     retry_interval_seconds: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct PrReviewRequest {
+    pr_number: i64,
+    #[serde(default)]
+    repo: Option<String>,
+    #[serde(default)]
+    steer: Option<String>,
+    #[serde(default)]
+    wait: Option<i64>,
+    #[serde(default)]
+    caller_session_id: Option<String>,
 }
 
 fn default_codex_review_poll_interval_seconds() -> i64 {

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -2171,6 +2171,124 @@ async fn codex_review_request_create_posts_and_persists_active_row() {
 }
 
 #[tokio::test]
+async fn pr_review_route_posts_comment_and_returns_python_shape() {
+    let state_file = unique_temp_path();
+    fs::write(
+        &state_file,
+        json!({
+            "sessions": [
+                {
+                    "id": "caller1",
+                    "name": "codex-fork-caller1",
+                    "working_dir": "/repo/caller",
+                    "tmux_session": "codex-fork-caller1",
+                    "log_file": "/tmp/caller1.log",
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00Z",
+                    "last_activity": "2026-06-01T00:01:00Z",
+                    "provider": "codex-fork"
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let queue_db = state_file.with_extension("pr-review-route-message-queue.db");
+    let poster = StubGitHubReviewPoster::successful().with_fresh_review(GitHubReviewMatch {
+        source: "pull_review".to_owned(),
+        created_at: "2026-06-14T02:30:01Z".to_owned(),
+        id: Some(json!("PRR_kw123")),
+        url: Some(
+            "https://github.com/rajeshgoli/session-manager/pull/967#pullrequestreview-1".to_owned(),
+        ),
+    });
+    let mut config = AppConfig::default();
+    config.paths.state_file = state_file.display().to_string();
+    config.sm_send.db_path = queue_db.display().to_string();
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config).with_github_review_poster(Arc::new(poster.clone())));
+
+    let (status, payload) = post_json(
+        app,
+        "/reviews/pr",
+        json!({
+            "pr_number": 967,
+            "repo": "rajeshgoli/session-manager",
+            "steer": "focus create",
+            "wait": 600,
+            "caller_session_id": "caller1"
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["repo"], "rajeshgoli/session-manager");
+    assert_eq!(payload["pr_number"], 967);
+    assert_eq!(payload["posted_at"], "2026-06-14T02:30:00Z");
+    assert_eq!(payload["comment_id"], 4701290334_i64);
+    assert_eq!(payload["comment_body"], "@codex review for focus create");
+    assert_eq!(payload["status"], "posted");
+    assert_eq!(payload["server_polling"], true);
+    assert_eq!(
+        poster.calls(),
+        vec![(
+            "rajeshgoli/session-manager".to_owned(),
+            967,
+            Some("focus create".to_owned())
+        )]
+    );
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert_eq!(
+        queued_message_texts(&queue_db, "caller1"),
+        vec!["Review --pr 967 (rajeshgoli/session-manager) completed: Codex posted review on PR #967"]
+    );
+}
+
+#[tokio::test]
+async fn pr_review_route_returns_error_payloads_and_preserves_write_gate() {
+    let poster = StubGitHubReviewPoster::failing("PR #999 not found in owner/repo");
+    let mut config = AppConfig::default();
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config).with_github_review_poster(Arc::new(poster.clone())));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/reviews/pr",
+        json!({
+            "pr_number": 999,
+            "repo": "owner/repo"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["error"], "PR #999 not found in owner/repo");
+    assert_eq!(poster.calls(), vec![("owner/repo".to_owned(), 999, None)]);
+
+    let (status, payload) = post_json(app.clone(), "/reviews/pr", json!({ "pr_number": 42 })).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        payload["error"],
+        "Could not determine repo. Provide --repo or run from a git directory."
+    );
+
+    let gated_app = router(AppState::new(AppConfig::default()));
+    let (status, payload) = post_json(
+        gated_app,
+        "/reviews/pr",
+        json!({
+            "pr_number": 42,
+            "repo": "owner/repo"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    assert!(payload["detail"]
+        .as_str()
+        .unwrap()
+        .contains("Rust core writes are disabled"));
+}
+
+#[tokio::test]
 async fn codex_review_request_watcher_completes_and_queues_wake() {
     let state_file = unique_temp_path();
     let queue_db = state_file.with_extension("codex-review-create-watch.db");
@@ -5064,6 +5182,42 @@ async fn shadow_http_reports_codex_review_request_create_as_status_only_without_
     assert_eq!(payload["predicted_body_sha256"], Value::Null);
     assert_eq!(payload["body_sha256_match"], Value::Null);
     assert!(!queue_db.exists());
+}
+
+#[tokio::test]
+async fn shadow_http_reports_pr_review_create_as_status_only_without_writing() {
+    let app = router(AppState::new(AppConfig::default()));
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "POST",
+                "path": "/reviews/pr",
+                "query_string": "",
+                "headers": {},
+                "body_sha256": sha256_hex(b"{\"pr_number\":967}")
+            },
+            "python_response": {
+                "status": 200,
+                "body_sha256": sha256_hex(b"{\"status\":\"posted\"}")
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        payload["support_status"],
+        "implemented_retained_write_status_only"
+    );
+    assert_eq!(payload["comparison"], "status_match");
+    assert_eq!(payload["would_write"], false);
+    assert_eq!(payload["predicted_status"], 200);
+    assert_eq!(payload["predicted_body_sha256"], Value::Null);
+    assert_eq!(payload["body_sha256_match"], Value::Null);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #975

## Summary
- add retained `POST /reviews/pr` to the Rust server
- reuse the existing GitHub review poster abstraction to validate/post `@codex review`
- preserve Python-style 200 error payloads for repo/post failures and enqueue managed-session completion notifications when `wait` and `caller_session_id` are supplied
- classify `/reviews/pr` as an implemented retained write in shadow mode without performing side effects

## Scope note
This PR implements the immediate PR review trigger route only. `/sessions/{id}/review` and `/sessions/review` remain follow-up runtime slices because they require Codex app RPC and tmux review-sequence behavior.

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p sm-server --test read_only_http pr_review -- --nocapture`
- `cargo test -p sm-server --test read_only_http codex_review_request -- --nocapture`
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py -q`
- `cargo test -p sm-server`
