### PR TITLE
Rust MVP: implement retained session review runtime routes

### DIFF
--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -30,6 +30,7 @@ pub struct AppConfig {
     pub codex_observability: CodexObservabilityConfig,
     pub claude: ProviderLaunchConfig,
     pub codex: ProviderLaunchConfig,
+    pub codex_review: CodexReviewConfig,
     pub codex_fork: CodexForkLaunchConfig,
     pub nodes: NodesConfig,
     pub queue_runner: QueueRunnerConfig,
@@ -63,6 +64,7 @@ impl Default for AppConfig {
                 Some("sonnet".to_owned()),
             ),
             codex: ProviderLaunchConfig::new("codex".to_owned(), Vec::new(), None),
+            codex_review: CodexReviewConfig::default(),
             codex_fork: CodexForkLaunchConfig::default(),
             nodes: NodesConfig::default(),
             queue_runner: QueueRunnerConfig::default(),
@@ -577,6 +579,45 @@ impl Default for ProviderLaunchConfig {
     }
 }
 
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+pub struct CodexReviewConfig {
+    #[serde(default = "default_codex_review_default_wait")]
+    pub default_wait: u64,
+    #[serde(default = "default_codex_review_menu_settle_seconds")]
+    pub menu_settle_seconds: f64,
+    #[serde(default = "default_codex_review_branch_settle_seconds")]
+    pub branch_settle_seconds: f64,
+    #[serde(default = "default_codex_review_steer_delay_seconds")]
+    pub steer_delay_seconds: f64,
+}
+
+impl Default for CodexReviewConfig {
+    fn default() -> Self {
+        Self {
+            default_wait: default_codex_review_default_wait(),
+            menu_settle_seconds: default_codex_review_menu_settle_seconds(),
+            branch_settle_seconds: default_codex_review_branch_settle_seconds(),
+            steer_delay_seconds: default_codex_review_steer_delay_seconds(),
+        }
+    }
+}
+
+fn default_codex_review_default_wait() -> u64 {
+    600
+}
+
+fn default_codex_review_menu_settle_seconds() -> f64 {
+    1.0
+}
+
+fn default_codex_review_branch_settle_seconds() -> f64 {
+    1.0
+}
+
+fn default_codex_review_steer_delay_seconds() -> f64 {
+    5.0
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CodexForkLaunchConfig {
     pub command: String,
@@ -926,7 +967,7 @@ struct RawConfig {
     #[serde(default)]
     claude: RawProviderLaunchConfig,
     #[serde(default)]
-    codex: RawProviderLaunchConfig,
+    codex: RawCodexConfig,
     #[serde(default)]
     codex_fork: RawCodexForkLaunchConfig,
     #[serde(default)]
@@ -957,7 +998,8 @@ impl From<RawConfig> for AppConfig {
         let codex_requests = codex_requests_config(raw.codex_requests, &paths.state_file);
         let codex_events = codex_events_config(raw.codex_events, &paths.state_file);
         let claude = provider_launch_config(raw.claude, "claude", Some("sonnet"), Vec::new());
-        let codex = provider_launch_config(raw.codex, "codex", None, Vec::new());
+        let codex_review = raw.codex.review;
+        let codex = provider_launch_config(raw.codex.provider, "codex", None, Vec::new());
         let codex_fork = codex_fork_launch_config(raw.codex_fork, &codex);
         if trimmed(&rust_core.tmux_socket_name).is_none() {
             rust_core.tmux_socket_name = trimmed(&raw.tmux.socket_name);
@@ -1012,6 +1054,7 @@ impl From<RawConfig> for AppConfig {
             codex_observability,
             claude,
             codex,
+            codex_review,
             codex_fork,
             nodes: nodes_config_from_yaml(raw.nodes),
             queue_runner,
@@ -1075,6 +1118,14 @@ struct RawProviderLaunchConfig {
     args: Option<Vec<String>>,
     #[serde(default)]
     default_model: Option<String>,
+}
+
+#[derive(Debug, Default, Clone, Deserialize)]
+struct RawCodexConfig {
+    #[serde(flatten)]
+    provider: RawProviderLaunchConfig,
+    #[serde(default)]
+    review: CodexReviewConfig,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -1944,6 +1995,36 @@ codex_fork:
         );
         assert_eq!(config.codex_fork.default_model.as_deref(), Some("gpt-5"));
         assert_eq!(config.codex_fork.event_schema_version, 7);
+    }
+
+    #[test]
+    fn raw_config_reads_codex_launch_and_review_timing() {
+        let raw: RawConfig = serde_yaml::from_str(
+            r#"
+codex:
+  command: "/opt/bin/codex"
+  args: ["--dangerously-bypass-approvals-and-sandbox"]
+  default_model: "gpt-5"
+  review:
+    default_wait: 42
+    menu_settle_seconds: 0.25
+    branch_settle_seconds: 0.5
+    steer_delay_seconds: 0.75
+"#,
+        )
+        .unwrap();
+        let config = AppConfig::from(raw);
+
+        assert_eq!(config.codex.command, "/opt/bin/codex");
+        assert_eq!(
+            config.codex.args,
+            vec!["--dangerously-bypass-approvals-and-sandbox"]
+        );
+        assert_eq!(config.codex.default_model.as_deref(), Some("gpt-5"));
+        assert_eq!(config.codex_review.default_wait, 42);
+        assert_eq!(config.codex_review.menu_settle_seconds, 0.25);
+        assert_eq!(config.codex_review.branch_settle_seconds, 0.5);
+        assert_eq!(config.codex_review.steer_delay_seconds, 0.75);
     }
 
     #[test]

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -99,12 +99,12 @@ use crate::sessions::{
     expand_home, is_primary_node, AgentStatusRequest, ArmStopNotifyOutcome, ArmStopNotifyRequest,
     ClearSessionRequest, ClientSessionResponse, ContextMonitorOutcome, ContextMonitorRequest,
     CoreClearOutcome, CoreInputBatchResponse, CoreInputBatchResult, CoreRestoreOutcome,
-    CoreRetireOutcome, CreateCoreSessionRequest, HandoffOutcome, HandoffRequest,
+    CoreRetireOutcome, CoreReviewOutcome, CreateCoreSessionRequest, HandoffOutcome, HandoffRequest,
     MaintainerMutationOutcome, RegistryMutationOutcome, RoleRegistrationRequest,
     SendCoreInputBatchRequest, SendCoreInputRequest, SessionRecord, SessionResponse, SessionStore,
-    SessionsEnvelope, SetMaintainerRequest, SubagentStartOutcome, SubagentStartRequest,
-    SubagentStopOutcome, SubagentStopRequest, TaskCompleteOutcome, TaskCompleteRequest,
-    TurnCompleteOutcome,
+    SessionsEnvelope, SetMaintainerRequest, SpawnReviewRequest, StartReviewRequest,
+    SubagentStartOutcome, SubagentStartRequest, SubagentStopOutcome, SubagentStopRequest,
+    TaskCompleteOutcome, TaskCompleteRequest, TurnCompleteOutcome,
 };
 use crate::tool_usage::{
     list_recent_codex_fork_tool_calls_from_path, list_recent_tool_calls_from_path, ToolCallRow,
@@ -877,8 +877,10 @@ pub fn router(state: AppState) -> Router {
         .route("/sessions", get(list_sessions).post(create_session))
         .route("/sessions/input-batch", post(send_session_input_batch))
         .route("/sessions/spawn", post(spawn_session))
+        .route("/sessions/review", post(spawn_review_session))
         .route("/sessions/context-monitor", get(get_context_monitor_status))
         .route("/sessions/{session_id}", get(get_session))
+        .route("/sessions/{session_id}/review", post(start_session_review))
         .route(
             "/sessions/{parent_session_id}/children",
             get(list_children_sessions),
@@ -2179,6 +2181,302 @@ async fn spawn_session(
     Ok(Json(serde_json::to_value(SpawnSessionResponse::from(
         child,
     ))?))
+}
+
+async fn start_session_review(
+    State(state): State<Arc<AppState>>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Path(session_id): Path<String>,
+    Json(payload): Json<StartReviewRequest>,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_allowed_from_parts(
+        &state.config,
+        &headers,
+        Some(peer_addr),
+        &format!("/sessions/{session_id}/review"),
+    )?;
+    ensure_core_writes_enabled(&state)?;
+    let runtime = TmuxRuntime::from_app_config(&state.config);
+    let wait_seconds = payload.wait;
+    let watcher_session_id = payload
+        .watcher_session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned);
+    match state.session_store.start_review_with_runtime(
+        &session_id,
+        payload,
+        &runtime,
+        &state.config.codex_review,
+    )? {
+        CoreReviewOutcome::Started(result) => {
+            spawn_review_steer_if_needed(state.clone(), &result, &runtime);
+            if let (Some(wait_seconds), Some(watcher_session_id)) =
+                (wait_seconds, watcher_session_id)
+            {
+                spawn_session_wait_monitor(
+                    state,
+                    result.session_id.clone(),
+                    watcher_session_id,
+                    wait_seconds,
+                );
+            }
+            Ok(Json(serde_json::to_value(result)?))
+        }
+        CoreReviewOutcome::NotFound => Err(ApiError::Status {
+            status: StatusCode::NOT_FOUND,
+            detail: "Session not found".to_owned(),
+        }),
+        CoreReviewOutcome::Error(error) => Ok(Json(json!({ "error": error }))),
+    }
+}
+
+async fn spawn_review_session(
+    State(state): State<Arc<AppState>>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(payload): Json<SpawnReviewRequest>,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_allowed_from_parts(
+        &state.config,
+        &headers,
+        Some(peer_addr),
+        "/sessions/review",
+    )?;
+    ensure_core_writes_enabled(&state)?;
+    let Some(parent) = state
+        .session_store
+        .get_session(&payload.parent_session_id)?
+    else {
+        return Err(ApiError::Status {
+            status: StatusCode::NOT_FOUND,
+            detail: "Parent session not found".to_owned(),
+        });
+    };
+    if let Some(name) = payload
+        .name
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        validate_requested_friendly_name(name)?;
+    }
+
+    let working_dir = payload
+        .working_dir
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(parent.working_dir.as_str())
+        .to_owned();
+    let create_payload = CreateCoreSessionRequest {
+        id: None,
+        name: Some(
+            payload
+                .name
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned)
+                .unwrap_or_else(|| format!("child-{}", short_session_id(&parent.id))),
+        ),
+        working_dir: Some(working_dir),
+        provider: Some("codex".to_owned()),
+        parent_session_id: Some(parent.id.clone()),
+        node: Some("primary".to_owned()),
+        initial_message: None,
+        model: payload.model.clone(),
+        wait: None,
+    };
+    let log_dir = state.config.rust_core.log_dir.as_deref().map(expand_home);
+    let runtime = TmuxRuntime::from_app_config(&state.config);
+    let child = if state.config.rust_core.runtime_enabled {
+        ensure_core_runtime_provider_supported(&create_payload)?;
+        ensure_core_runtime_request_node_supported(&state, &create_payload)?;
+        state
+            .session_store
+            .create_core_session_with_runtime(create_payload, log_dir, &runtime)?
+    } else {
+        state
+            .session_store
+            .create_core_session(create_payload, log_dir)?
+    };
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    let review_request = StartReviewRequest {
+        mode: payload.mode.clone(),
+        base_branch: payload.base_branch.clone(),
+        commit_sha: payload.commit_sha.clone(),
+        custom_prompt: payload.custom_prompt.clone(),
+        steer_text: payload.steer_text.clone(),
+        wait: None,
+        watcher_session_id: None,
+    };
+    let review_outcome = match state.session_store.start_review_with_runtime(
+        &child.id,
+        review_request,
+        &runtime,
+        &state.config.codex_review,
+    ) {
+        Ok(outcome) => outcome,
+        Err(error) => {
+            retire_spawned_review_child(&state, &child.id, &runtime);
+            return Err(error.into());
+        }
+    };
+    match review_outcome {
+        CoreReviewOutcome::Started(result) => {
+            spawn_review_steer_if_needed(state.clone(), &result, &runtime);
+            if let Some(wait_seconds) = payload.wait {
+                spawn_child_wait_monitor(state.clone(), child.clone(), wait_seconds);
+            }
+            Ok(Json(json!({
+                "session_id": child.id,
+                "name": child.name,
+                "friendly_name": child
+                    .friendly_name
+                    .as_deref()
+                    .filter(|value| !value.trim().is_empty())
+                    .unwrap_or(child.name.as_str()),
+                "review_mode": payload.mode,
+                "base_branch": payload.base_branch,
+                "status": "started"
+            })))
+        }
+        CoreReviewOutcome::NotFound => {
+            Ok(Json(json!({ "error": "Failed to spawn review session" })))
+        }
+        CoreReviewOutcome::Error(error) => {
+            retire_spawned_review_child(&state, &child.id, &runtime);
+            Ok(Json(json!({ "error": error })))
+        }
+    }
+}
+
+fn retire_spawned_review_child(state: &AppState, child_id: &str, runtime: &TmuxRuntime) {
+    let _ = if state.config.rust_core.runtime_enabled {
+        state
+            .session_store
+            .retire_core_session_with_runtime(child_id, None, runtime)
+    } else {
+        state.session_store.retire_core_session(child_id, None)
+    };
+}
+
+fn spawn_review_steer_if_needed(
+    state: Arc<AppState>,
+    result: &crate::sessions::CoreReviewResult,
+    runtime: &TmuxRuntime,
+) {
+    let Some(steer_text) = result
+        .steer_text
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+    else {
+        return;
+    };
+    let session_id = result.session_id.clone();
+    let tmux_session = result.tmux_session.clone();
+    let session_runtime = runtime.for_socket_name(result.tmux_socket_name.as_deref());
+    let delay = Duration::from_secs_f64(state.config.codex_review.steer_delay_seconds.max(0.0));
+    tokio::spawn(async move {
+        tokio::time::sleep(delay).await;
+        let delivered = tokio::task::spawn_blocking(move || {
+            session_runtime.send_steer_text(&tmux_session, &steer_text)
+        })
+        .await;
+        if matches!(delivered, Ok(Ok(true))) {
+            let _ = state.session_store.mark_review_steer_delivered(&session_id);
+        }
+    });
+}
+
+fn spawn_session_wait_monitor(
+    state: Arc<AppState>,
+    target_session_id: String,
+    watcher_session_id: String,
+    wait_seconds: u64,
+) {
+    tokio::spawn(async move {
+        let Ok(Some(initial_target)) = state.session_store.get_session(&target_session_id) else {
+            queue_wait_notification(
+                &state,
+                &watcher_session_id,
+                format!("[sm wait] {target_session_id} no longer exists (waited 0s)"),
+            );
+            return;
+        };
+        let mut last_activity = initial_target.last_activity.clone();
+        let mut last_output_size = child_output_size(&initial_target);
+        let mut idle_since = Instant::now();
+        let started_at = Instant::now();
+        loop {
+            tokio::time::sleep(Duration::from_millis(250)).await;
+            let elapsed = started_at.elapsed().as_secs();
+            let Ok(Some(target)) = state.session_store.get_session(&target_session_id) else {
+                queue_wait_notification(
+                    &state,
+                    &watcher_session_id,
+                    format!("[sm wait] {target_session_id} no longer exists (waited {elapsed}s)"),
+                );
+                break;
+            };
+            let output_size = child_output_size(&target);
+            if target.last_activity != last_activity || output_size != last_output_size {
+                last_activity = target.last_activity.clone();
+                last_output_size = output_size;
+                idle_since = Instant::now();
+            }
+            let target_name = child_display_name(&target);
+            let notification = if session_status_is_stopped(&target.status)
+                || runtime_child_session_exited(&state, &target)
+            {
+                Some(format!(
+                    "[sm wait] {target_name} reached stopped (waited {elapsed}s)"
+                ))
+            } else {
+                Some(idle_since.elapsed().as_secs())
+                    .filter(|idle_seconds| *idle_seconds >= wait_seconds)
+                    .map(|_| format!("[sm wait] {target_name} is now idle (waited {elapsed}s)"))
+            };
+            if let Some(notification) = notification {
+                queue_wait_notification(&state, &watcher_session_id, notification);
+                break;
+            }
+        }
+    });
+}
+
+fn queue_wait_notification(state: &AppState, watcher_session_id: &str, text: String) {
+    let request = SendCoreInputRequest {
+        text,
+        delivery_mode: "important".to_owned(),
+        sender_session_id: None,
+        from_sm_send: false,
+        timeout_seconds: None,
+        notify_on_delivery: false,
+        notify_after_seconds: None,
+        notify_on_stop: false,
+        remind_soft_threshold: None,
+        remind_hard_threshold: None,
+        remind_cancel_on_reply_session_id: None,
+        parent_session_id: None,
+    };
+    let _ = if state.config.rust_core.runtime_enabled {
+        let runtime = TmuxRuntime::from_app_config(&state.config);
+        state
+            .session_store
+            .send_core_input_with_runtime(watcher_session_id, request, &runtime)
+    } else {
+        state
+            .session_store
+            .send_core_input(watcher_session_id, request)
+    };
 }
 
 fn spawn_child_wait_monitor(state: Arc<AppState>, child: SessionRecord, wait_seconds: u64) {
@@ -5743,6 +6041,15 @@ fn shadow_predict_retained_write(
     method: &str,
     path: &str,
 ) -> anyhow::Result<Option<ShadowPrediction>> {
+    if method == "POST"
+        && (path == "/sessions/review" || session_review_path_session_id(path).is_some())
+    {
+        return Ok(Some(ShadowPrediction {
+            status: StatusCode::OK.as_u16(),
+            body_sha256: None,
+            support_status: "implemented_retained_write_status_only",
+        }));
+    }
     if method == "POST" && path == "/codex-review-requests" {
         return Ok(Some(ShadowPrediction {
             status: StatusCode::OK.as_u16(),
@@ -8099,6 +8406,33 @@ fn is_retained_write_surface(method: &str, path: &str) -> bool {
     false
 }
 
+fn session_review_path_session_id(path: &str) -> Option<&str> {
+    let session_id = path.strip_prefix("/sessions/")?.strip_suffix("/review")?;
+    (!session_id.is_empty() && !session_id.contains('/')).then_some(session_id)
+}
+
+fn validate_requested_friendly_name(name: &str) -> Result<(), ApiError> {
+    let detail = if name.is_empty() {
+        Some("Invalid name: Name cannot be empty")
+    } else if name.chars().count() > 32 {
+        Some("Invalid name: Name too long (max 32 chars)")
+    } else if !name
+        .chars()
+        .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+    {
+        Some("Invalid name: Name must be alphanumeric with - or _ only (no spaces)")
+    } else {
+        None
+    };
+    match detail {
+        Some(detail) => Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: detail.to_owned(),
+        }),
+        None => Ok(()),
+    }
+}
+
 fn is_auth_denial_status(status: u16) -> bool {
     matches!(status, 401 | 403 | 503)
 }
@@ -8294,7 +8628,7 @@ fn ensure_core_runtime_provider_supported(
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .unwrap_or("claude");
-    if matches!(provider, "claude" | "codex-fork") {
+    if matches!(provider, "claude" | "codex" | "codex-fork") {
         return Ok(());
     }
     Err(ApiError::Status {

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -11,7 +11,7 @@ use std::{
 use anyhow::{bail, Context, Result};
 use sha2::{Digest, Sha256};
 
-use crate::config::{AppConfig, RustCoreConfig};
+use crate::config::{AppConfig, CodexReviewConfig, RustCoreConfig};
 
 const DEFAULT_SEND_KEYS_SETTLE_MS: f64 = 300.0;
 const DEFAULT_SEND_KEYS_SETTLE_MAX_MS: f64 = 900.0;
@@ -25,6 +25,9 @@ pub struct TmuxRuntime {
     tmux_binary: String,
     claude_command: String,
     claude_args: Vec<String>,
+    codex_command: String,
+    codex_args: Vec<String>,
+    codex_default_model: Option<String>,
     codex_fork_command: String,
     codex_fork_args: Vec<String>,
     codex_fork_default_model: Option<String>,
@@ -73,6 +76,9 @@ impl TmuxRuntime {
                 .unwrap_or("claude")
                 .to_owned(),
             claude_args: Vec::new(),
+            codex_command: "codex".to_owned(),
+            codex_args: Vec::new(),
+            codex_default_model: None,
             codex_fork_command: "codex".to_owned(),
             codex_fork_args: vec![
                 "-c".to_owned(),
@@ -124,6 +130,9 @@ impl TmuxRuntime {
             runtime.claude_command = config.claude.command.clone();
             runtime.claude_args = config.claude.args.clone();
         }
+        runtime.codex_command = config.codex.command.clone();
+        runtime.codex_args = config.codex.args.clone();
+        runtime.codex_default_model = config.codex.default_model.clone();
         runtime.codex_fork_command = config.codex_fork.command.clone();
         runtime.codex_fork_args = config.codex_fork.args.clone();
         runtime.codex_fork_default_model = config.codex_fork.default_model.clone();
@@ -262,6 +271,75 @@ impl TmuxRuntime {
         Ok(true)
     }
 
+    pub fn send_review_sequence(
+        &self,
+        tmux_session: &str,
+        mode: &str,
+        base_branch: Option<&str>,
+        commit_sha: Option<&str>,
+        custom_prompt: Option<&str>,
+        branch_position: Option<usize>,
+        timing: &CodexReviewConfig,
+    ) -> Result<bool> {
+        if !self.session_exists(tmux_session)? {
+            return Ok(false);
+        }
+        let mode = mode.trim();
+        if mode == "custom" {
+            let prompt = custom_prompt.unwrap_or("").trim();
+            self.send_text_then_enter(tmux_session, &format!("/review {prompt}"))?;
+            return Ok(true);
+        }
+
+        self.send_text_then_enter(tmux_session, "/review")?;
+        thread::sleep(duration_from_seconds(timing.menu_settle_seconds));
+
+        match mode {
+            "branch" => {
+                self.send_key(tmux_session, "Enter")?;
+                thread::sleep(duration_from_seconds(timing.branch_settle_seconds));
+                if base_branch.is_some() {
+                    for _ in 0..branch_position.unwrap_or(0) {
+                        self.send_key(tmux_session, "Down")?;
+                    }
+                }
+                thread::sleep(self.compute_settle_delay(base_branch.unwrap_or("")));
+                self.send_key(tmux_session, "Enter")?;
+            }
+            "uncommitted" => {
+                self.send_key(tmux_session, "Down")?;
+                thread::sleep(self.compute_settle_delay(mode));
+                self.send_key(tmux_session, "Enter")?;
+            }
+            "commit" => {
+                self.send_key(tmux_session, "Down")?;
+                self.send_key(tmux_session, "Down")?;
+                thread::sleep(self.compute_settle_delay(mode));
+                self.send_key(tmux_session, "Enter")?;
+                thread::sleep(duration_from_seconds(timing.branch_settle_seconds));
+                if let Some(commit_sha) =
+                    commit_sha.map(str::trim).filter(|value| !value.is_empty())
+                {
+                    self.send_text(tmux_session, commit_sha)?;
+                    thread::sleep(self.compute_settle_delay(commit_sha));
+                }
+                self.send_key(tmux_session, "Enter")?;
+            }
+            _ => return Ok(false),
+        }
+        Ok(true)
+    }
+
+    pub fn send_steer_text(&self, tmux_session: &str, text: &str) -> Result<bool> {
+        if !self.session_exists(tmux_session)? {
+            return Ok(false);
+        }
+        self.send_key(tmux_session, "Enter")?;
+        thread::sleep(self.compute_settle_delay(text));
+        self.send_text_then_enter(tmux_session, text)?;
+        Ok(true)
+    }
+
     pub fn clear_session(
         &self,
         tmux_session: &str,
@@ -337,12 +415,17 @@ impl TmuxRuntime {
     }
 
     fn send_text_then_enter(&self, tmux_session: &str, text: &str) -> Result<()> {
+        self.send_text(tmux_session, text)?;
+        thread::sleep(self.compute_settle_delay(text));
+        self.send_key(tmux_session, "Enter")
+    }
+
+    fn send_text(&self, tmux_session: &str, text: &str) -> Result<()> {
         self.exit_copy_mode_if_needed(tmux_session);
         for chunk in split_send_text_chunks(text, self.send_keys_max_chunk_chars) {
             self.run_tmux(["send-keys", "-t", tmux_session, "-l", "--", chunk])?;
         }
-        thread::sleep(self.compute_settle_delay(text));
-        self.send_key(tmux_session, "Enter")
+        Ok(())
     }
 
     fn send_key(&self, tmux_session: &str, key: &str) -> Result<()> {
@@ -406,6 +489,7 @@ impl TmuxRuntime {
     fn launch_command(&self, spec: &TmuxSessionSpec, prompt_mode: &str) -> Result<String> {
         let mut parts = match spec.provider.as_str() {
             "claude" => command_parts(&self.claude_command, &self.claude_args),
+            "codex" => command_parts(&self.codex_command, &self.codex_args),
             "codex-fork" => self.codex_fork_command_parts(spec)?,
             provider => bail!("Rust runtime does not support provider {provider}"),
         };
@@ -415,11 +499,19 @@ impl TmuxRuntime {
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .or_else(|| {
-                (spec.provider == "codex-fork")
-                    .then_some(self.codex_fork_default_model.as_deref())
-                    .flatten()
-                    .map(str::trim)
-                    .filter(|value| !value.is_empty())
+                if spec.provider == "codex" {
+                    self.codex_default_model
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty())
+                } else if spec.provider == "codex-fork" {
+                    self.codex_fork_default_model
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|value| !value.is_empty())
+                } else {
+                    None
+                }
             });
         if let Some(model) = model {
             parts.push("--model".to_owned());
@@ -555,6 +647,10 @@ fn finite_nonnegative_or_default(value: Option<f64>, default: f64) -> f64 {
 
 fn duration_from_millis(millis: f64) -> Duration {
     Duration::from_secs_f64((millis.max(0.0)) / 1000.0)
+}
+
+fn duration_from_seconds(seconds: f64) -> Duration {
+    Duration::from_secs_f64(seconds.max(0.0))
 }
 
 fn is_tmux_session_gone_error(error: &anyhow::Error) -> bool {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -5,6 +5,7 @@ use std::{
     env, fs,
     io::{self, BufRead, BufReader, Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
+    process::Command,
     sync::atomic::{AtomicU64, Ordering},
     sync::{Arc, Mutex},
     thread,
@@ -21,7 +22,10 @@ use crate::queue::{
     followup_notification_text, PendingMessage, QueueMessageMetadata, RetainedQueueStore,
     StopNotifyState,
 };
-use crate::runtime::{TmuxRuntime, TmuxSessionSpec};
+use crate::{
+    config::CodexReviewConfig,
+    runtime::{TmuxRuntime, TmuxSessionSpec},
+};
 
 const DEFAULT_SESSION_STATE_FILE: &str = "~/.local/share/claude-sessions/sessions.json";
 const LEGACY_TMP_SESSION_STATE_FILE: &str = "/tmp/claude-sessions/sessions.json";
@@ -411,6 +415,195 @@ impl SessionStore {
             notify_after_seconds: request.notify_after_seconds,
             status,
         }))
+    }
+
+    pub fn start_review_with_runtime(
+        &self,
+        session_id: &str,
+        request: StartReviewRequest,
+        runtime: &TmuxRuntime,
+        timing: &CodexReviewConfig,
+    ) -> Result<CoreReviewOutcome> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let Some(session) = session_object_mut(sessions, session_id) else {
+            return Ok(CoreReviewOutcome::NotFound);
+        };
+
+        let provider = json_text(session.get("provider")).unwrap_or_else(default_provider);
+        if !matches!(provider.as_str(), "codex" | "codex-fork" | "codex-app") {
+            return Ok(CoreReviewOutcome::Error(
+                "Review requires a Codex session (provider=codex, codex-fork, or codex-app)"
+                    .to_owned(),
+            ));
+        }
+        if provider == "codex-app" {
+            return Ok(CoreReviewOutcome::Error(
+                "Rust core review does not support codex-app review/start yet".to_owned(),
+            ));
+        }
+
+        let mode = normalized_review_mode(&request.mode);
+        if !matches!(
+            mode.as_str(),
+            "branch" | "uncommitted" | "commit" | "custom"
+        ) {
+            return Ok(CoreReviewOutcome::Error(format!(
+                "Unsupported review mode: {mode}"
+            )));
+        }
+        let status = json_text(session.get("status")).unwrap_or_else(|| "running".to_owned());
+        if review_session_is_busy(session, &status) {
+            return Ok(CoreReviewOutcome::Error(
+                "Session is busy. Wait for current work to complete or use sm clear first."
+                    .to_owned(),
+            ));
+        }
+
+        let node = json_text(session.get("node")).unwrap_or_else(default_node);
+        ensure_runtime_local_node(&node)?;
+        let tmux_session = json_text(session.get("tmux_session"))
+            .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?;
+        let session_socket_name = json_text(session.get("tmux_socket_name"));
+        let session_runtime = runtime.for_socket_name(session_socket_name.as_deref());
+        if !session_runtime.session_exists(&tmux_session)? {
+            return Ok(CoreReviewOutcome::Error(
+                "Failed to send review sequence to tmux".to_owned(),
+            ));
+        }
+        let working_dir = json_text(session.get("working_dir")).unwrap_or_else(|| ".".to_owned());
+        let working_path = expand_home(&working_dir);
+
+        if !git_command_success(&working_path, ["rev-parse", "--git-dir"])? {
+            return Ok(CoreReviewOutcome::Error(format!(
+                "Working directory is not a git repo: {working_dir}"
+            )));
+        }
+
+        let branch_position = if mode == "branch" {
+            match request
+                .base_branch
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                Some(base_branch) => match git_branch_position(&working_path, base_branch)? {
+                    Some(position) => Some(position),
+                    None => {
+                        let branches = git_branch_list(&working_path)?;
+                        return Ok(CoreReviewOutcome::Error(format!(
+                            "Branch '{base_branch}' not found. Available: {}",
+                            branches.join(", ")
+                        )));
+                    }
+                },
+                None => None,
+            }
+        } else {
+            None
+        };
+        if mode == "commit" {
+            if let Some(commit_sha) = request
+                .commit_sha
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                if !git_commit_exists(&working_path, commit_sha)? {
+                    return Ok(CoreReviewOutcome::Error(format!(
+                        "Commit '{commit_sha}' not found"
+                    )));
+                }
+            }
+        }
+
+        let now = now_rfc3339();
+        session.insert(
+            "review_config".to_owned(),
+            review_config_value(&mode, &request),
+        );
+        session.insert("last_tool_call".to_owned(), Value::String(now.clone()));
+        self.write_raw_json_value(&state)?;
+
+        let delivered = match session_runtime.send_review_sequence(
+            &tmux_session,
+            &mode,
+            request.base_branch.as_deref(),
+            request.commit_sha.as_deref(),
+            request.custom_prompt.as_deref(),
+            branch_position,
+            timing,
+        ) {
+            Ok(delivered) => delivered,
+            Err(error) => {
+                let mut state = self.load_raw_json_value()?;
+                let sessions = ensure_sessions_array_mut(&mut state)?;
+                if let Some(session) = session_object_mut(sessions, session_id) {
+                    let now = now_rfc3339();
+                    mark_review_dispatch_completed(session, &now);
+                    self.write_raw_json_value(&state)?;
+                }
+                return Err(error);
+            }
+        };
+        if !delivered {
+            let mut state = self.load_raw_json_value()?;
+            let sessions = ensure_sessions_array_mut(&mut state)?;
+            if let Some(session) = session_object_mut(sessions, session_id) {
+                let now = now_rfc3339();
+                mark_review_dispatch_completed(session, &now);
+                self.write_raw_json_value(&state)?;
+            }
+            return Ok(CoreReviewOutcome::Error(
+                "Failed to send review sequence to tmux".to_owned(),
+            ));
+        }
+
+        let mut state = self.load_raw_json_value()?;
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let Some(session) = session_object_mut(sessions, session_id) else {
+            return Ok(CoreReviewOutcome::NotFound);
+        };
+        let now = now_rfc3339();
+        mark_review_dispatch_completed(session, &now);
+        session.insert("status".to_owned(), Value::String("running".to_owned()));
+        session.insert("last_activity".to_owned(), Value::String(now));
+        self.write_raw_json_value(&state)?;
+
+        Ok(CoreReviewOutcome::Started(CoreReviewResult {
+            session_id: session_id.to_owned(),
+            review_mode: mode,
+            base_branch: request.base_branch,
+            commit_sha: request.commit_sha,
+            status: "started".to_owned(),
+            steer_queued: request
+                .steer_text
+                .as_deref()
+                .map(str::trim)
+                .is_some_and(|value| !value.is_empty()),
+            tmux_session,
+            tmux_socket_name: session_socket_name,
+            steer_text: request.steer_text,
+        }))
+    }
+
+    pub fn mark_review_steer_delivered(&self, session_id: &str) -> Result<bool> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let Some(session) = session_object_mut(sessions, session_id) else {
+            return Ok(false);
+        };
+        let Some(review_config) = session
+            .get_mut("review_config")
+            .and_then(Value::as_object_mut)
+        else {
+            return Ok(false);
+        };
+        review_config.insert("steer_delivered".to_owned(), Value::Bool(true));
+        self.write_raw_json_value(&state)?;
+        Ok(true)
     }
 
     pub fn drain_runtime_pending_messages_for_session(
@@ -1681,6 +1874,7 @@ impl SessionStore {
             telegram_root_msg_id: None,
             current_task: None,
             git_remote_url: None,
+            review_config: None,
             parent_session_id: request.parent_session_id.clone(),
             last_handoff_path: None,
             agent_status_text: None,
@@ -1929,6 +2123,51 @@ pub struct CreateCoreSessionRequest {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct StartReviewRequest {
+    #[serde(default = "default_review_mode")]
+    pub mode: String,
+    #[serde(default)]
+    pub base_branch: Option<String>,
+    #[serde(default)]
+    pub commit_sha: Option<String>,
+    #[serde(default)]
+    pub custom_prompt: Option<String>,
+    #[serde(default, alias = "steer")]
+    pub steer_text: Option<String>,
+    #[serde(default)]
+    pub wait: Option<u64>,
+    #[serde(default)]
+    pub watcher_session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct SpawnReviewRequest {
+    pub parent_session_id: String,
+    #[serde(default = "default_review_mode")]
+    pub mode: String,
+    #[serde(default)]
+    pub base_branch: Option<String>,
+    #[serde(default)]
+    pub commit_sha: Option<String>,
+    #[serde(default)]
+    pub custom_prompt: Option<String>,
+    #[serde(default, alias = "steer")]
+    pub steer_text: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub wait: Option<u64>,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub working_dir: Option<String>,
+}
+
+fn default_review_mode() -> String {
+    "branch".to_owned()
+}
+
+#[derive(Debug, Clone, Deserialize)]
 pub struct SendCoreInputRequest {
     pub text: String,
     #[serde(default = "default_delivery_mode")]
@@ -2076,6 +2315,29 @@ pub struct CoreInputBatchResponse {
     pub failure_count: usize,
     pub delivery_mode: String,
     pub results: Vec<CoreInputBatchResult>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CoreReviewResult {
+    pub session_id: String,
+    pub review_mode: String,
+    pub base_branch: Option<String>,
+    pub commit_sha: Option<String>,
+    pub status: String,
+    pub steer_queued: bool,
+    #[serde(skip)]
+    pub tmux_session: String,
+    #[serde(skip)]
+    pub tmux_socket_name: Option<String>,
+    #[serde(skip)]
+    pub steer_text: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub enum CoreReviewOutcome {
+    Started(CoreReviewResult),
+    NotFound,
+    Error(String),
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -2510,6 +2772,132 @@ fn format_send_input_text_raw(
         ),
         Some(sender_name),
     )
+}
+
+fn normalized_review_mode(mode: &str) -> String {
+    let mode = mode.trim();
+    if mode.is_empty() {
+        "branch".to_owned()
+    } else {
+        mode.to_owned()
+    }
+}
+
+fn review_config_value(mode: &str, request: &StartReviewRequest) -> Value {
+    json!({
+        "mode": mode,
+        "base_branch": trimmed_value(request.base_branch.as_deref()),
+        "commit_sha": trimmed_value(request.commit_sha.as_deref()),
+        "custom_prompt": trimmed_value(request.custom_prompt.as_deref()),
+        "steer_text": trimmed_value(request.steer_text.as_deref()),
+        "steer_delivered": false,
+        "dispatch_in_progress": true,
+        "dispatch_completed_at": null,
+        "pr_number": null,
+        "pr_repo": null,
+        "pr_comment_id": null
+    })
+}
+
+fn review_session_is_busy(session: &Map<String, Value>, status: &str) -> bool {
+    if review_dispatch_in_progress(session) {
+        return true;
+    }
+    if normalized_status(status) != "running" {
+        return false;
+    }
+    let Some(last_tool_call) = json_text(session.get("last_tool_call"))
+        .map(|value| value.trim().to_owned())
+        .filter(|value| !value.is_empty())
+    else {
+        return false;
+    };
+    !review_dispatch_completed_after(session, &last_tool_call)
+}
+
+fn review_dispatch_in_progress(session: &Map<String, Value>) -> bool {
+    session
+        .get("review_config")
+        .and_then(Value::as_object)
+        .and_then(|config| config.get("dispatch_in_progress"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+fn review_dispatch_completed_after(session: &Map<String, Value>, last_tool_call: &str) -> bool {
+    session
+        .get("review_config")
+        .and_then(Value::as_object)
+        .and_then(|config| config.get("dispatch_completed_at"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .is_some_and(|completed_at| completed_at >= last_tool_call)
+}
+
+fn mark_review_dispatch_completed(session: &mut Map<String, Value>, completed_at: &str) {
+    if let Some(config) = session
+        .get_mut("review_config")
+        .and_then(Value::as_object_mut)
+    {
+        config.insert("dispatch_in_progress".to_owned(), Value::Bool(false));
+        config.insert(
+            "dispatch_completed_at".to_owned(),
+            Value::String(completed_at.to_owned()),
+        );
+    }
+}
+
+fn trimmed_value(value: Option<&str>) -> Value {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| Value::String(value.to_owned()))
+        .unwrap_or(Value::Null)
+}
+
+fn git_command_success<const N: usize>(working_path: &Path, args: [&str; N]) -> Result<bool> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(working_path)
+        .output()
+        .with_context(|| format!("failed to run git in {}", working_path.display()))?;
+    Ok(output.status.success())
+}
+
+fn git_commit_exists(working_path: &Path, commit_sha: &str) -> Result<bool> {
+    let commit_ref = format!("{commit_sha}^{{commit}}");
+    let output = Command::new("git")
+        .args(["rev-parse", "--verify", "--quiet", "--end-of-options"])
+        .arg(commit_ref)
+        .current_dir(working_path)
+        .output()
+        .with_context(|| format!("failed to verify git commit in {}", working_path.display()))?;
+    Ok(output.status.success())
+}
+
+fn git_branch_position(working_path: &Path, branch: &str) -> Result<Option<usize>> {
+    Ok(git_branch_list(working_path)?
+        .iter()
+        .position(|candidate| candidate == branch))
+}
+
+fn git_branch_list(working_path: &Path) -> Result<Vec<String>> {
+    let output = Command::new("git")
+        .args(["branch", "--list"])
+        .current_dir(working_path)
+        .output()
+        .with_context(|| format!("failed to list git branches in {}", working_path.display()))?;
+    if !output.status.success() {
+        anyhow::bail!("Failed to list git branches");
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| {
+            let branch = line.trim().trim_start_matches("* ").trim();
+            (!branch.is_empty()).then(|| branch.to_owned())
+        })
+        .collect())
 }
 
 fn pending_message_from_metadata(
@@ -3577,6 +3965,7 @@ fn reset_session_after_clear(session: &mut Map<String, Value>, now: &str) {
     session.insert("completion_message".to_owned(), Value::Null);
     session.insert("completed_at".to_owned(), Value::Null);
     session.insert("last_activity".to_owned(), Value::String(now.to_owned()));
+    mark_review_dispatch_completed(session, now);
 }
 
 fn mark_session_killed(session: &mut Map<String, Value>, now: &str) {
@@ -3970,6 +4359,8 @@ pub struct SessionRecord {
     pub current_task: Option<String>,
     #[serde(default)]
     pub git_remote_url: Option<String>,
+    #[serde(default)]
+    pub review_config: Option<Value>,
     #[serde(default)]
     pub parent_session_id: Option<String>,
     #[serde(default)]
@@ -4469,6 +4860,7 @@ mod tests {
             telegram_root_msg_id: None,
             current_task: None,
             git_remote_url: None,
+            review_config: None,
             parent_session_id: None,
             last_handoff_path: None,
             agent_status_text: None,

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -20,8 +20,8 @@ use sm_server::{
         AppArtifactsConfig, AppConfig, BugReportsConfig, CodexEventsConfig, CodexForkLaunchConfig,
         CodexObservabilityConfig, CodexRequestsConfig, CodexRolloutConfig, EmailConfig,
         ExternalAccessConfig, GoogleAuthConfig, MobileAnalyticsConfig, MobileTerminalConfig,
-        MobileTerminalDeviceKeyConfig, MobileTerminalUserConfig, PathsConfig, QueueRunnerConfig,
-        RustCoreConfig, SmSendConfig, ToolLoggingConfig,
+        MobileTerminalDeviceKeyConfig, MobileTerminalUserConfig, PathsConfig, ProviderLaunchConfig,
+        QueueRunnerConfig, RustCoreConfig, SmSendConfig, ToolLoggingConfig,
     },
     http::{router, AppState, GitHubReviewComment, GitHubReviewMatch, GitHubReviewPoster},
 };
@@ -5065,7 +5065,7 @@ async fn shadow_http_treats_nodes_as_status_only_until_node_agents_are_ported() 
 
     let python_body = br#"{"node":"primary","ok":true,"error":null}"#;
     let (status, payload) = post_json(
-        app,
+        app.clone(),
         "/__shadow/http",
         json!({
             "schema_version": 1,
@@ -5987,7 +5987,7 @@ async fn shadow_http_classifies_core_writes_without_side_effects() {
         .contains("never performs retained write side effects"));
 
     let (status, payload) = post_json(
-        app,
+        app.clone(),
         "/__shadow/http",
         json!({
             "schema_version": 1,
@@ -6013,6 +6013,37 @@ async fn shadow_http_classifies_core_writes_without_side_effects() {
         .as_str()
         .unwrap()
         .contains("never performs retained write side effects"));
+
+    for path in ["/sessions/review", "/sessions/reviewcodex/review"] {
+        let (status, payload) = post_json(
+            app.clone(),
+            "/__shadow/http",
+            json!({
+                "schema_version": 1,
+                "request": {
+                    "method": "POST",
+                    "path": path,
+                    "query_string": "",
+                    "headers": {},
+                    "body_sha256": sha256_hex(b"{\"mode\":\"custom\"}")
+                },
+                "python_response": {
+                    "status": 200,
+                    "body_sha256": sha256_hex(b"{\"status\":\"started\"}")
+                }
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            payload["support_status"],
+            "implemented_retained_write_status_only"
+        );
+        assert_eq!(payload["comparison"], "status_match");
+        assert_eq!(payload["would_write"], false);
+        assert_eq!(payload["body_sha256_match"], Value::Null);
+    }
 }
 
 #[tokio::test]
@@ -11129,7 +11160,7 @@ async fn runtime_core_rejects_unsupported_provider() {
         json!({
             "id": "runtimecodex",
             "working_dir": working_dir.display().to_string(),
-            "provider": "codex",
+            "provider": "gemini",
             "initial_message": "codex should not launch claude"
         }),
     )
@@ -11138,10 +11169,444 @@ async fn runtime_core_rejects_unsupported_provider() {
     assert_eq!(status, StatusCode::BAD_REQUEST);
     assert_eq!(
         payload,
-        json!({ "detail": "Rust runtime does not support provider codex" })
+        json!({ "detail": "Rust runtime does not support provider gemini" })
     );
     let (status, _) = get_json(app, "/sessions/runtimecodex").await;
     assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn runtime_core_starts_review_on_existing_codex_session() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let working_dir = unique_short_temp_dir("sm-rust-review-existing-repo");
+    create_git_repo(&working_dir);
+    let tmux_socket = format!(
+        "sm-rust-test-review-existing-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app(&state_file, &log_dir, &tmux_socket);
+
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "reviewcodex",
+            "name": "review-codex",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "codex"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "reviewwatcher",
+            "name": "review-watcher",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/reviewcodex/review",
+        json!({
+            "mode": "custom",
+            "custom_prompt": "inspect retained review route",
+            "wait": 1,
+            "watcher_session_id": "reviewwatcher"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["session_id"], "reviewcodex");
+    assert_eq!(payload["review_mode"], "custom");
+    assert_eq!(payload["status"], "started");
+    assert_eq!(payload["steer_queued"], false);
+    wait_for_output_contains(
+        app.clone(),
+        "reviewcodex",
+        "runtime:/review inspect retained review route",
+    )
+    .await;
+    wait_for_output_contains(
+        app.clone(),
+        "reviewwatcher",
+        "[sm wait] review-codex is now idle",
+    )
+    .await;
+
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let session = state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "reviewcodex")
+        .unwrap();
+    assert_eq!(session["review_config"]["mode"], "custom");
+    assert_eq!(
+        session["review_config"]["custom_prompt"],
+        "inspect retained review route"
+    );
+    assert_eq!(session["review_config"]["steer_delivered"], false);
+    assert_eq!(session["review_config"]["dispatch_in_progress"], false);
+    assert!(session["review_config"]["dispatch_completed_at"]
+        .as_str()
+        .is_some_and(|value| !value.is_empty()));
+    assert_eq!(session["status"], "running");
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/reviewcodex/review",
+        json!({
+            "mode": "custom",
+            "custom_prompt": "inspect retained review route again"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["session_id"], "reviewcodex");
+    assert_eq!(payload["review_mode"], "custom");
+    assert_eq!(payload["status"], "started");
+    wait_for_output_contains(
+        app.clone(),
+        "reviewcodex",
+        "runtime:/review inspect retained review route again",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn runtime_core_starts_commit_review_with_requested_sha() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let working_dir = unique_short_temp_dir("sm-rust-review-commit-repo");
+    create_git_repo(&working_dir);
+    let commit_sha = create_git_commit(&working_dir, "review-target.txt", "review target\n");
+    let tmux_socket = format!(
+        "sm-rust-test-review-commit-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app(&state_file, &log_dir, &tmux_socket);
+
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "reviewcommit",
+            "name": "review-commit",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "codex"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/reviewcommit/review",
+        json!({
+            "mode": "commit",
+            "commit_sha": commit_sha
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["session_id"], "reviewcommit");
+    assert_eq!(payload["review_mode"], "commit");
+    assert_eq!(payload["commit_sha"], commit_sha);
+    assert_eq!(payload["status"], "started");
+    wait_for_output_contains(
+        app.clone(),
+        "reviewcommit",
+        &format!("runtime:{commit_sha}"),
+    )
+    .await;
+
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let session = state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "reviewcommit")
+        .unwrap();
+    assert_eq!(session["review_config"]["mode"], "commit");
+    assert_eq!(session["review_config"]["commit_sha"], commit_sha);
+}
+
+#[tokio::test]
+async fn runtime_core_rejects_review_when_session_is_busy() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let working_dir = unique_short_temp_dir("sm-rust-review-busy-repo");
+    create_git_repo(&working_dir);
+    let tmux_socket = format!(
+        "sm-rust-test-review-busy-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app(&state_file, &log_dir, &tmux_socket);
+
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "reviewbusy",
+            "name": "review-busy",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "codex"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let session = state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "reviewbusy")
+        .unwrap()
+        .as_object_mut()
+        .unwrap();
+    session.insert(
+        "last_tool_call".to_owned(),
+        Value::String("2026-06-14T04:00:00Z".to_owned()),
+    );
+    fs::write(&state_file, serde_json::to_string_pretty(&state).unwrap()).unwrap();
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/reviewbusy/review",
+        json!({
+            "mode": "custom",
+            "custom_prompt": "should not be delivered"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        payload,
+        json!({
+            "error": "Session is busy. Wait for current work to complete or use sm clear first."
+        })
+    );
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let session = state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "reviewbusy")
+        .unwrap();
+    assert!(session.get("review_config").is_none() || session["review_config"].is_null());
+
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let session = state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "reviewbusy")
+        .unwrap()
+        .as_object_mut()
+        .unwrap();
+    session.insert(
+        "parent_session_id".to_owned(),
+        Value::String("reviewparent".to_owned()),
+    );
+    session.insert(
+        "review_config".to_owned(),
+        json!({
+            "mode": "custom",
+            "dispatch_in_progress": true,
+            "dispatch_completed_at": null
+        }),
+    );
+    fs::write(&state_file, serde_json::to_string_pretty(&state).unwrap()).unwrap();
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/reviewbusy/clear",
+        json!({ "prompt": "reset stale review dispatch" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        payload,
+        json!({ "status": "cleared", "session_id": "reviewbusy" })
+    );
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let session = state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "reviewbusy")
+        .unwrap();
+    assert_eq!(session["review_config"]["dispatch_in_progress"], false);
+    assert!(session["review_config"]["dispatch_completed_at"]
+        .as_str()
+        .is_some_and(|value| !value.is_empty()));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/reviewbusy/review",
+        json!({
+            "mode": "custom",
+            "custom_prompt": "review after stale dispatch clear"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["session_id"], "reviewbusy");
+    assert_eq!(payload["status"], "started");
+    wait_for_output_contains(
+        app.clone(),
+        "reviewbusy",
+        "runtime:/review review after stale dispatch clear",
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn runtime_core_spawns_codex_review_child() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let working_dir = unique_short_temp_dir("sm-rust-review-spawn-repo");
+    create_git_repo(&working_dir);
+    let tmux_socket = format!(
+        "sm-rust-test-review-spawn-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app(&state_file, &log_dir, &tmux_socket);
+
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "reviewparent",
+            "name": "review-parent",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/review",
+        json!({
+            "parent_session_id": "reviewparent",
+            "mode": "custom",
+            "custom_prompt": "inspect spawned child",
+            "name": "spawned-review"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["name"], "spawned-review");
+    assert_eq!(payload["friendly_name"], "spawned-review");
+    assert_eq!(payload["review_mode"], "custom");
+    assert_eq!(payload["status"], "started");
+    let child_id = payload["session_id"].as_str().unwrap();
+    wait_for_output_contains(
+        app.clone(),
+        child_id,
+        "runtime:/review inspect spawned child",
+    )
+    .await;
+
+    let (status, child) = get_json(app, &format!("/sessions/{child_id}")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(child["provider"], "codex");
+    assert_eq!(child["parent_session_id"], "reviewparent");
+}
+
+#[tokio::test]
+async fn runtime_core_spawn_review_rejects_invalid_requested_name() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let working_dir = unique_short_temp_dir("sm-rust-review-bad-name-repo");
+    create_git_repo(&working_dir);
+    let tmux_socket = format!(
+        "sm-rust-test-review-bad-name-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app(&state_file, &log_dir, &tmux_socket);
+
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "reviewparent",
+            "name": "review-parent",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/review",
+        json!({
+            "parent_session_id": "reviewparent",
+            "mode": "custom",
+            "custom_prompt": "should not spawn",
+            "name": "bad\n/clear"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        payload["detail"],
+        "Invalid name: Name must be alphanumeric with - or _ only (no spaces)"
+    );
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    assert_eq!(state["sessions"].as_array().unwrap().len(), 1);
 }
 
 #[tokio::test]
@@ -12809,6 +13274,51 @@ fn unique_short_temp_dir(prefix: &str) -> PathBuf {
     ))
 }
 
+fn create_git_repo(path: &PathBuf) {
+    fs::create_dir_all(path).unwrap();
+    let status = Command::new("git")
+        .args(["init"])
+        .current_dir(path)
+        .status()
+        .unwrap();
+    assert!(status.success());
+}
+
+fn create_git_commit(path: &PathBuf, file_name: &str, contents: &str) -> String {
+    let status = Command::new("git")
+        .args(["config", "user.email", "sm-rust-test@example.invalid"])
+        .current_dir(path)
+        .status()
+        .unwrap();
+    assert!(status.success());
+    let status = Command::new("git")
+        .args(["config", "user.name", "SM Rust Test"])
+        .current_dir(path)
+        .status()
+        .unwrap();
+    assert!(status.success());
+    fs::write(path.join(file_name), contents).unwrap();
+    let status = Command::new("git")
+        .args(["add", file_name])
+        .current_dir(path)
+        .status()
+        .unwrap();
+    assert!(status.success());
+    let status = Command::new("git")
+        .args(["commit", "-m", "add review target"])
+        .current_dir(path)
+        .status()
+        .unwrap();
+    assert!(status.success());
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(path)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    String::from_utf8_lossy(&output.stdout).trim().to_owned()
+}
+
 fn runtime_app(state_file: &PathBuf, log_dir: &PathBuf, tmux_socket: &str) -> axum::Router {
     runtime_app_with_command(
         state_file,
@@ -12844,6 +13354,11 @@ fn runtime_app_with_command(
             send_keys_settle_max_ms: Some(50.0),
             send_keys_max_chunk_chars: Some(128),
             ..RustCoreConfig::default()
+        },
+        codex: ProviderLaunchConfig {
+            command: runtime_command.to_owned(),
+            args: Vec::new(),
+            default_model: None,
         },
         ..AppConfig::default()
     }))


### PR DESCRIPTION
## Summary

- implement retained Rust runtime routes for `POST /sessions/{session_id}/review` and `POST /sessions/review`
- add Codex runtime launch/review tmux sequencing, `review_config` persistence, delayed steer delivery, and wait notifications
- classify review writes in shadow mode as retained write status-only without side effects
- keep codex-app review/start RPC out of scope with an explicit Rust-core error

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p sm-server --test read_only_http runtime_core_starts_review_on_existing_codex_session -- --nocapture`
- `cargo test -p sm-server --test read_only_http runtime_core_spawns_codex_review_child -- --nocapture`
- `cargo test -p sm-server --test read_only_http shadow_http_classifies_core_writes_without_side_effects -- --nocapture`
- `cargo test -p sm-server --bin sm review -- --nocapture`
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py`
- `cargo test -p sm-server`

Fixes #977
