### PR TITLE
Fix Rust session review wait semantics

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -129,6 +129,8 @@ const MOBILE_TERMINAL_INITIAL_RESIZE_WAIT_SECONDS: f64 = 2.0;
 const MOBILE_TERMINAL_MAX_ATTACH_SECONDS: u64 = 3600;
 const CLOUDFLARE_ACCESS_JWKS_TTL: Duration = Duration::from_secs(60 * 60);
 const CLOUDFLARE_ACCESS_UNKNOWN_KID_REFRESH_INTERVAL: Duration = Duration::from_secs(30);
+const REVIEW_WAIT_IDLE_THRESHOLD: Duration = Duration::from_secs(1);
+const REVIEW_WAIT_POLL_INTERVAL: Duration = Duration::from_millis(250);
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
@@ -2304,7 +2306,7 @@ async fn spawn_review_session(
             .create_core_session(create_payload, log_dir)?
     };
 
-    tokio::time::sleep(Duration::from_secs(1)).await;
+    tokio::time::sleep(runtime.startup_settle_duration()).await;
 
     let review_request = StartReviewRequest {
         mode: payload.mode.clone(),
@@ -2416,7 +2418,7 @@ fn spawn_session_wait_monitor(
         let mut idle_since = Instant::now();
         let started_at = Instant::now();
         loop {
-            tokio::time::sleep(Duration::from_millis(250)).await;
+            tokio::time::sleep(REVIEW_WAIT_POLL_INTERVAL).await;
             let elapsed = started_at.elapsed().as_secs();
             let Ok(Some(target)) = state.session_store.get_session(&target_session_id) else {
                 queue_wait_notification(
@@ -2439,10 +2441,16 @@ fn spawn_session_wait_monitor(
                 Some(format!(
                     "[sm wait] {target_name} reached stopped (waited {elapsed}s)"
                 ))
+            } else if idle_since.elapsed() >= REVIEW_WAIT_IDLE_THRESHOLD {
+                Some(format!(
+                    "[sm wait] {target_name} is now idle (waited {elapsed}s)"
+                ))
+            } else if elapsed >= wait_seconds {
+                Some(format!(
+                    "[sm wait] Timeout: {target_name} still active after {wait_seconds}s"
+                ))
             } else {
-                Some(idle_since.elapsed().as_secs())
-                    .filter(|idle_seconds| *idle_seconds >= wait_seconds)
-                    .map(|_| format!("[sm wait] {target_name} is now idle (waited {elapsed}s)"))
+                None
             };
             if let Some(notification) = notification {
                 queue_wait_notification(&state, &watcher_session_id, notification);

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -144,6 +144,10 @@ impl TmuxRuntime {
         self.socket_name.as_deref()
     }
 
+    pub fn startup_settle_duration(&self) -> Duration {
+        Duration::from_millis(self.start_settle_ms)
+    }
+
     pub fn for_socket_name(&self, socket_name: Option<&str>) -> Self {
         let mut runtime = self.clone();
         runtime.socket_name = socket_name

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -11290,6 +11290,88 @@ async fn runtime_core_starts_review_on_existing_codex_session() {
 }
 
 #[tokio::test]
+async fn runtime_core_existing_review_wait_times_out_while_session_stays_active() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let working_dir = unique_short_temp_dir("sm-rust-review-wait-timeout-repo");
+    create_git_repo(&working_dir);
+    let tmux_socket = format!(
+        "sm-rust-test-review-wait-timeout-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app(&state_file, &log_dir, &tmux_socket);
+
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "reviewtimeout",
+            "name": "review-codex-timeout",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "codex"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "reviewtimeoutwatcher",
+            "name": "review-timeout-watcher",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/reviewtimeout/review",
+        json!({
+            "mode": "custom",
+            "custom_prompt": "stay active until timeout",
+            "wait": 2,
+            "watcher_session_id": "reviewtimeoutwatcher"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "started");
+
+    let state_path = state_file.clone();
+    let activity_task = tokio::spawn(async move {
+        for tick in 0..16 {
+            touch_session_activity(&state_path, "reviewtimeout", tick);
+            tokio::time::sleep(Duration::from_millis(150)).await;
+        }
+    });
+
+    wait_for_output_contains(
+        app.clone(),
+        "reviewtimeout",
+        "runtime:/review stay active until timeout",
+    )
+    .await;
+    wait_for_output_contains(
+        app.clone(),
+        "reviewtimeoutwatcher",
+        "[sm wait] Timeout: review-codex-timeout still active after 2s",
+    )
+    .await;
+    activity_task.abort();
+}
+
+#[tokio::test]
 async fn runtime_core_starts_commit_review_with_requested_sha() {
     if !tmux_available() {
         return;
@@ -13317,6 +13399,24 @@ fn create_git_commit(path: &PathBuf, file_name: &str, contents: &str) -> String 
         .unwrap();
     assert!(output.status.success());
     String::from_utf8_lossy(&output.stdout).trim().to_owned()
+}
+
+fn touch_session_activity(state_file: &PathBuf, session_id: &str, tick: usize) {
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(state_file).unwrap()).unwrap();
+    let Some(session) = state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == session_id)
+        .and_then(Value::as_object_mut)
+    else {
+        return;
+    };
+    session.insert(
+        "last_activity".to_owned(),
+        Value::String(format!("2026-06-14T04:00:{:02}Z", tick % 60)),
+    );
+    fs::write(state_file, serde_json::to_string_pretty(&state).unwrap()).unwrap();
 }
 
 fn runtime_app(state_file: &PathBuf, log_dir: &PathBuf, tmux_socket: &str) -> axum::Router {


### PR DESCRIPTION
Fixes #982

## Summary
- treat existing-session review `wait` as an upper-bound timeout while still notifying when the session becomes idle
- replace the spawned review child hard-coded one-second delay with the configured runtime startup settle duration
- add a tmux-backed regression for active review sessions timing out instead of waiting forever

## Validation
- cargo fmt --check
- git diff --check
- cargo test -p sm-server --test read_only_http review -- --nocapture
- cargo test -p sm-server
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py