### PR TITLE
Add Rust review route fixture contracts

### DIFF
--- a/scripts/rust_migration/contracts_manifest.json
+++ b/scripts/rust_migration/contracts_manifest.json
@@ -1158,6 +1158,38 @@
       "source": "https://github.com/rajeshgoli/session-manager/issues/795"
     },
     {
+      "id": "http.rust_core_review_existing_fixture",
+      "surface": "http",
+      "classification": "retained",
+      "target": "rust_only",
+      "safety": "mutating",
+      "method": "POST",
+      "path": "/sessions/{session_id}/review",
+      "body": {"mode": "custom", "custom_prompt": "fixture review request"},
+      "expected_status": [200],
+      "expected_json": [
+        {"path": "/error", "equals": "Review requires a Codex session (provider=codex, codex-fork, or codex-app)"}
+      ],
+      "preconditions": ["live_server", "session_id", "mutating_opt_in"],
+      "source": "https://github.com/rajeshgoli/session-manager/issues/981"
+    },
+    {
+      "id": "http.rust_core_spawn_review_fixture",
+      "surface": "http",
+      "classification": "retained",
+      "target": "rust_only",
+      "safety": "mutating",
+      "method": "POST",
+      "path": "/sessions/review",
+      "body": {"parent_session_id": "{session_id}", "mode": "custom", "custom_prompt": "fixture spawned review", "name": "fixture-review-child"},
+      "expected_status": [200],
+      "expected_json": [
+        {"path": "/error", "equals": "Failed to send review sequence to tmux"}
+      ],
+      "preconditions": ["live_server", "session_id", "mutating_opt_in"],
+      "source": "https://github.com/rajeshgoli/session-manager/issues/981"
+    },
+    {
       "id": "cli.rust_queue_run_fixture",
       "surface": "cli",
       "classification": "retained",

--- a/scripts/rust_migration/mvp_rehearsal.py
+++ b/scripts/rust_migration/mvp_rehearsal.py
@@ -62,6 +62,8 @@ MVP_GAP_PROBE_CHECK_IDS = ()
 
 CORE_MUTATING_CHECK_IDS = (
     "cli.rust_core_spawn_fixture",
+    "http.rust_core_review_existing_fixture",
+    "http.rust_core_spawn_review_fixture",
     "cli.rust_core_send_fixture",
     "cli.rust_core_spawn_child_inherits_parent_fixture",
     "cli.rust_core_me_fixture",

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -329,6 +329,36 @@ def test_manifest_uses_dedicated_notify_child_for_stop_notification_fixture():
     assert expectations["/session_id"].equals == "{notify_child_session_id}"
 
 
+def test_manifest_covers_rust_core_review_fixture_checks():
+    manifest = ContractManifest.load()
+    checks = {check.id: check for check in manifest.checks}
+
+    existing = checks["http.rust_core_review_existing_fixture"]
+    assert existing.classification == "retained"
+    assert existing.target == "rust_only"
+    assert existing.safety == "mutating"
+    assert existing.method == "POST"
+    assert existing.path == "/sessions/{session_id}/review"
+    assert existing.body["mode"] == "custom"
+    assert "session_id" in existing.preconditions
+    assert "mutating_opt_in" in existing.preconditions
+    expectations = {expectation.path: expectation for expectation in existing.expected_json}
+    assert expectations["/error"].equals.startswith("Review requires a Codex session")
+
+    spawned = checks["http.rust_core_spawn_review_fixture"]
+    assert spawned.classification == "retained"
+    assert spawned.target == "rust_only"
+    assert spawned.safety == "mutating"
+    assert spawned.method == "POST"
+    assert spawned.path == "/sessions/review"
+    assert spawned.body["parent_session_id"] == "{session_id}"
+    assert spawned.body["mode"] == "custom"
+    assert "session_id" in spawned.preconditions
+    assert "mutating_opt_in" in spawned.preconditions
+    expectations = {expectation.path: expectation for expectation in spawned.expected_json}
+    assert expectations["/error"].equals == "Failed to send review sequence to tmux"
+
+
 def test_manifest_covers_rust_queue_writer_fixture_checks():
     manifest = ContractManifest.load()
     checks = {check.id: check for check in manifest.checks}


### PR DESCRIPTION
Fixes #981

## Summary
- add Rust-only mutating fixture checks for retained session review HTTP routes
- include the review checks in the MVP mutating fixture rehearsal group
- add manifest unit assertions for the review route contracts

## Notes
- The disposable fixture sidecar does not own tmux runtime sessions, so these checks pin stable retained admission/error behavior for the review routes. The runtime dispatch/wait behavior is covered by the tmux-backed Rust tests merged in #980/#983.

## Validation
- ./venv/bin/python -m json.tool scripts/rust_migration/contracts_manifest.json >/dev/null
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py
- git diff --check
- ./venv/bin/python -m py_compile scripts/rust_migration/mvp_rehearsal.py scripts/rust_migration/contracts.py scripts/rust_migration/mutating_fixture.py
- ./venv/bin/python -m scripts.rust_migration.mvp_rehearsal --output-dir /tmp/session-manager-pr981-rehearsal-ports --rust-base-url http://127.0.0.1:18421 --skip-python-health --skip-baseline --skip-shadow --core-only