### PR TITLE
Refresh Rust MVP handoff after review slices

### DIFF
--- a/specs/762_stage5_artifacts/mvp_progress.md
+++ b/specs/762_stage5_artifacts/mvp_progress.md
@@ -1,10 +1,11 @@
 # Rust MVP Progress Snapshot
 
-Status: implementation snapshot after PR #950 merged. The last clean full MVP
-rehearsal remains the post-#938 run; post-#942 full rehearsal is currently
-blocked by Python-origin availability during baseline/shadow. PRs #946, #948,
-and #950 added the Rust-side Cloudflare Access origin gate; public cutover still
-needs Cloudflare policy setup and mobile/browser smoke evidence.
+Status: implementation snapshot after the post-#984 review-route fixture line.
+The last clean full real-state MVP rehearsal remains the post-#938 run; the
+post-#984 focused rehearsal proves state gates, live core contracts, read-only
+fixtures, and mutating fixtures on isolated sidecars, but intentionally skips
+Python baseline and shadow. Public cutover still needs Cloudflare policy setup,
+mobile/browser smoke evidence, and a stable Python-authoritative shadow window.
 
 This file is a handoff aid for the Rust cutover implementation track. It does
 not change retained or removed scope. Binding scope remains
@@ -68,6 +69,23 @@ not change retained or removed scope. Binding scope remains
 | #946 | Cloudflare Access auth model for browser, mobile app, node fallback, and email worker route classes |
 | #948 | Rust Cloudflare Access config parsing and JWT/audience/context classification |
 | #950 | Rust origin route gates for mobile/app surfaces, app artifacts, device-token exchange, JWKS cache behavior, and mobile device actor binding |
+| #952 | Cloudflare Access cutover evidence snapshot |
+| #954 | Rust queue list/status CLI reads |
+| #956 | Pending queue job submission |
+| #958 | Simple queue job execute/cancel runtime |
+| #960 | Queue runtime recovery |
+| #962 | Node HTTP routes |
+| #964 | Codex review request cancel |
+| #966 | `request-codex-review` CLI list/status/cancel wiring |
+| #968 | Retained Codex review request creation |
+| #970 | `request-codex-review create` CLI wiring |
+| #972 | Active Codex review watch recovery |
+| #974 | Retained `sm review` CLI wiring |
+| #976 | Retained `/reviews/pr` PR review route |
+| #979 | PR review wait observes actual review events before completion |
+| #980 | Retained session review runtime routes |
+| #983 | Follow-up session review wait timeout and spawned-child startup settle fixes |
+| #984 | Review-route mutating fixture contracts |
 
 ## Implemented Capability Groups
 
@@ -78,12 +96,12 @@ The Rust sidecar now has executable coverage for:
 | Harness and baselines | Contract manifest, fixture assertions, minimal value baseline runner, shadow comparison, MVP rehearsal, synthetic read-only fixture sidecar, disposable mutating fixtures, Rust CLI build gating, state preflight/backup/restore, freeze/drain evidence gates, and mobile-aware shadow observation gates exist. |
 | Retired-surface checks | Retired public/watch/summary/remind/job-watch/queue-policy checks are represented as Rust-target absence or denial fixtures. |
 | Core reads | Health, auth session, bootstrap, session list/detail, client session list/detail, output, events state, SSE hello, nodes list, queue jobs list/detail, Codex review requests list/detail, and tool/audit read projections are implemented. |
-| Core runtime | Session/tmux/spawn/session-graph/message-queue/task-complete/input-batch/subagent slices are merged, with shadow and contract fixtures covering the early cutover path. |
+| Core runtime | Session/tmux/spawn/session-graph/message-queue/task-complete/input-batch/subagent and retained review-route slices are merged, with shadow and contract fixtures covering the early cutover path. |
 | Codex retained reads | Codex event stream, pending request ledger reads, activity actions, review detail/list, and Claude/Codex tool-call projections are implemented and covered by manifest checks. |
 | Mobile | Native bootstrap/session support, attach-ticket proofing, terminal WebSocket auth/bridge, runtime disable, device revoke/list CLI support, and public-edge assertion validation are merged. |
 | Cloudflare Access origin gate | Config parsing, JWT/audience classification, host/app separation, public-host fail-closed behavior, mobile/app route gating, app artifact gating, device-token exchange gating, JWKS cache refresh/TTL behavior, and mobile Access CN actor binding are merged. |
 | External fallback | Email/human fallback delivery and inbound email validation path are retained in the Rust track. |
-| Queue and nodes | Narrow queue list/detail, queue fixture coverage, and registered-node read paths are implemented; retained node and queue writer behavior still needs final cutover verification. |
+| Queue and nodes | Queue list/detail, CLI list/status, pending submit, simple execute/cancel, queue recovery, queue fixtures, node reads, and node HTTP routes are implemented; remaining work is final live/recovery cutover evidence and any retained node-agent remote-control gaps. |
 
 ## Current Live Shadow And Contract State
 
@@ -124,6 +142,38 @@ fixture false failures:
 
 The skipped checks are mutating checks without `--include-mutating`, which is
 the expected safety behavior for a live-state read run.
+
+Current executable manifest size after the review-route fixture line:
+
+| Metric | Count |
+| --- | ---: |
+| Total checks | 131 |
+| `python_and_rust` checks | 73 |
+| `rust_only` checks | 58 |
+| Read-only checks | 92 |
+| Mutating checks | 39 |
+
+The latest focused isolated-sidecar rehearsal for the current fixture set is:
+
+```bash
+/tmp/session-manager-pr981-rehearsal-ports/mvp-rehearsal-report.json
+```
+
+It was run with `--skip-python-health --skip-baseline --skip-shadow --core-only`
+and `--rust-base-url http://127.0.0.1:18421` to avoid an existing local sidecar
+on port `8421`. Results:
+
+| Area | Result |
+| --- | --- |
+| Overall status | Passed with 0 blockers |
+| State ownership gate | Passed: 17 stores checked, 13 existing, 13 copied, 13 verified, 13 restored, freeze/drain ledger written |
+| Rust live core sidecar contracts | 17 passed, 0 failed, 0 skipped |
+| Rust synthetic read-only fixture contracts | 14 passed, 0 failed, 0 skipped |
+| Rust mutating fixture contracts | 35 passed, 0 failed, 0 skipped |
+
+This is not a full cutover rehearsal because it skips Python baseline and
+shadow. It is the current best fixture/state-gate evidence for the post-#984
+contract set.
 
 ## Latest Real-State Rehearsal
 
@@ -209,11 +259,11 @@ These are the next practical buckets before an MVP cutover trial:
 | Bucket | Why it remains |
 | --- | --- |
 | Shadow observation window | Python-authoritative shadow mode is enabled and a short clean window has been recorded, but mobile gates from PR #942 still need real app/operator traffic. Continue it for a longer agreed window and triage any unexplained retained-core mismatches before Rust becomes the writer. |
-| Full fixture manifest execution | The MVP rehearsal now runs the current synthetic read-only and mutating fixture sets. Remaining work is final live mobile/device fixture evidence and any additional retained fixture rows added by later slices. |
+| Full fixture manifest execution | The MVP rehearsal now runs the current synthetic read-only and mutating fixture sets, including review-route fixtures. Remaining work is final live mobile/device fixture evidence and any additional retained fixture rows added by later slices. |
 | CLI cutover audit | Verify every retained CLI command in [cutover_scope.md](cutover_scope.md) is native Rust or intentionally routed, and every removed command is absent or explicitly retired. |
 | State ownership and migration tooling | Initial preflight, backup, restore, and freeze/drain evidence tools are merged and exercised by the rehearsal. Remaining work is live write-admission freeze/journal ownership and rollback accounting from [state_ownership_and_migration.md](state_ownership_and_migration.md). |
 | Cloudflare Access deployment integration | Pair the merged Rust origin gate with the actual Cloudflare Access apps, mTLS/service-auth policies, device Common Name enrollment/revocation, app-host native auth smoke, browser OAuth smoke, and later node fallback tests. Current evidence lives in [cloudflare_access_cutover_evidence.md](cloudflare_access_cutover_evidence.md). |
-| Node and queue writer completion | Finish retained node-control and narrow queue writer fixtures, including audit, policy, recovery, and rollback semantics. |
+| Node and queue writer completion | Basic node HTTP routes and narrow queue writer/recovery are implemented. Remaining work is final live/recovery cutover evidence, audit/rollback accounting, and any retained node-agent remote-control gaps. |
 | Service packaging and rollback | Exercise launchd/service cutover, non-destructive port ownership, health checks, rollback, and operator diagnostics. |
 | Final native mobile smoke | Run bootstrap/session/attach/request-status/analytics/bug-report/app-artifact smoke checks against Rust using real mobile assumptions. |
 | Python-origin availability during evidence runs | Post-#942 full rehearsal is blocked because Python watchdog-restarted during baseline/shadow. This does not call for broad Python hardening, but the cutover evidence path needs a stable Python authority for the observation window. |

--- a/specs/762_stage5_artifacts/resume_handoff.md
+++ b/specs/762_stage5_artifacts/resume_handoff.md
@@ -1,7 +1,7 @@
 # Rust Port Resume Handoff
 
-Status: handoff snapshot from 2026-06-13 after PR #950 and a blocked
-post-mobile-shadow rehearsal.
+Status: handoff snapshot from 2026-06-14 after the post-#984 review-route
+fixture line.
 
 Use this file to resume the Rust cutover track without reconstructing state from
 chat history. Binding scope still lives in [cutover_scope.md](cutover_scope.md),
@@ -11,9 +11,10 @@ coverage in
 
 ## Current Repository State
 
-- Branch: `main`
-- Latest merged commit: `d8f97c0` (`Merge pull request #950`)
-- Open PRs at handoff: none
+- Branch: `main` after PR #984.
+- Latest merged commit before this docs refresh: `8c261ee` (`Merge pull
+  request #984`)
+- Open PRs at handoff: none before this docs refresh PR.
 - Dirty worktree at handoff: only pre-existing untracked `.claude/settings.local.json`
   and the local `config.yaml.shadow-backup-20260612T023248Z` created when
   enabling shadow mode.
@@ -46,10 +47,12 @@ Merged Rust slices cover:
   rehearsal tooling;
 - core health/auth/bootstrap/session list/detail/output/events/SSE reads;
 - core runtime slices for session/tmux/spawn/session graph/message queue/task
-  complete/input batch/subagents;
-- nodes list;
-- queue jobs list/detail;
-- Codex review requests list/detail;
+  complete/input batch/subagents and retained review routes;
+- nodes list and node HTTP routes;
+- queue jobs list/detail, CLI reads, pending submit, simple execute/cancel, and
+  recovery;
+- Codex review requests list/detail/create/cancel/recovery and retained
+  `sm review` / PR review routes;
 - tool-call projections for Claude and Codex fork;
 - Codex events, pending requests, activity actions;
 - mobile bootstrap/session support, attach-ticket proof, terminal WebSocket
@@ -60,7 +63,7 @@ Merged Rust slices cover:
 
 ### Documentation And Manifest
 
-- [mvp_progress.md](mvp_progress.md) records the PR lineage through #950.
+- [mvp_progress.md](mvp_progress.md) records the PR lineage through #984.
 - [cloudflare_access_cutover_evidence.md](cloudflare_access_cutover_evidence.md)
   records the current Cloudflare Access origin-gate behavior and remaining
   operator setup/smoke evidence.
@@ -119,10 +122,29 @@ Merged Rust slices cover:
 - PR #950 added Rust origin route gates for native mobile/app routes, app
   artifacts, `/auth/device/google`, JWKS cache refresh/TTL behavior, public-host
   fail-closed behavior, and mobile device Common Name actor binding.
+- PR #952 recorded Cloudflare Access cutover evidence.
+- PR #954 added Rust queue list/status CLI reads.
+- PR #956 added pending queue job submission.
+- PR #958 added simple queue job execute/cancel runtime.
+- PR #960 added queue runtime recovery.
+- PR #962 added node HTTP routes.
+- PR #964 added Codex review request cancel.
+- PR #966 wired `request-codex-review` list/status/cancel CLI surfaces.
+- PR #968 added retained Codex review request creation.
+- PR #970 wired `request-codex-review create`.
+- PR #972 added active Codex review watch recovery.
+- PR #974 wired retained `sm review`.
+- PR #976 added retained `/reviews/pr`.
+- PR #979 made PR review wait require actual review events before completion.
+- PR #980 added retained session review runtime routes.
+- PR #983 fixed session review wait timeout semantics and spawned review
+  startup settle behavior.
+- PR #984 added mutating fixture contracts for retained session review routes.
 - Current contract manifest size:
-  - `117` checks total
-  - `68` `python_and_rust`
-  - `49` `rust_only`
+  - `131` checks total
+  - `73` `python_and_rust`
+  - `58` `rust_only`
+  - `39` mutating checks
 
 ## Validation At Handoff
 
@@ -162,6 +184,36 @@ passes `/health`, `/health/detailed`, `/auth/session`, `/client/bootstrap`,
 The same run measured the current Python process at `154.672 MiB` RSS and
 `66.4 MiB` physical footprint, while the Rust sidecar measured `19.797 MiB`
 RSS and `6.688 MiB` physical footprint.
+
+The latest focused post-#984 fixture/state-gated rehearsal is:
+
+```bash
+/tmp/session-manager-pr981-rehearsal-ports/mvp-rehearsal-report.json
+```
+
+It used alternate ports because a Rust sidecar was already healthy on `8421`:
+
+```bash
+./venv/bin/python -m scripts.rust_migration.mvp_rehearsal \
+  --output-dir /tmp/session-manager-pr981-rehearsal-ports \
+  --rust-base-url http://127.0.0.1:18421 \
+  --skip-python-health \
+  --skip-baseline \
+  --skip-shadow \
+  --core-only
+```
+
+This was not a full cutover rehearsal because it skipped Python baseline and
+shadow, but it is the current fixture/state-gate evidence for the post-#984
+manifest:
+
+- overall status: passed with zero blockers;
+- state ownership gate: `17` stores checked, `13` existing, `13` copied, `13`
+  verified, `13` restored, freeze/drain ledger written;
+- Rust live core sidecar contracts: `17` passed, `0` failed, `0` skipped;
+- Rust synthetic read-only fixture contracts: `14` passed, `0` failed, `0`
+  skipped;
+- Rust mutating fixture contracts: `35` passed, `0` failed, `0` skipped.
 
 The latest post-#942 full rehearsal attempts are blocked, not cutover evidence:
 
@@ -262,7 +314,7 @@ needed for final cutover evidence.
    window and triage unexplained mismatches.
 2. Continue expanding fixture/live evidence as new retained rows land.
    - The MVP rehearsal already runs the current synthetic read-only and
-     mutating fixture sets.
+     mutating fixture sets, including review-route fixtures.
    - Final live mobile/device fixture evidence is still needed.
 3. Audit retained CLI commands against [cutover_scope.md](cutover_scope.md).
    - Retained commands should be native Rust or intentionally routed.
@@ -281,8 +333,10 @@ needed for final cutover evidence.
      then SM Google/device bearer auth at origin.
    - Prove revoked-device denial, browser OAuth callback behavior, and later
      node fallback proof.
-6. Finish retained node-control and narrow queue writer fixtures.
-   - Include audit, policy, recovery, and rollback semantics.
+6. Finish retained node-control and narrow queue writer evidence.
+   - Basic node HTTP routes and narrow queue writer/recovery are implemented.
+   - Remaining work is final live/recovery cutover evidence, audit/rollback
+     accounting, and any retained node-agent remote-control gaps.
 7. Exercise service packaging and cutover.
    - launchd wrapper, non-destructive port ownership, health checks, rollback.
 8. Run final native mobile smoke checks.


### PR DESCRIPTION
Fixes #985

## Summary
- update Rust MVP progress/resume docs through #984
- record current manifest counts and focused post-#984 fixture/state-gate rehearsal evidence
- clarify remaining node/queue/review evidence work without changing scope or gates

## Validation
- git diff --check