### PR TITLE
Add node restore mutating fixture contract

### DIFF
--- a/scripts/rust_migration/contracts_manifest.json
+++ b/scripts/rust_migration/contracts_manifest.json
@@ -205,6 +205,24 @@
       "source": "specs/762_stage2_artifacts/route_manifest.md:GET /nodes/{node_id}/restore-candidates"
     },
     {
+      "id": "http.rust_node_primary_restore_fixture",
+      "surface": "http",
+      "classification": "retained",
+      "target": "rust_only",
+      "safety": "mutating",
+      "method": "POST",
+      "path": "/nodes/primary/restore-candidates/{stopped_session_id}/restore",
+      "body": {},
+      "expected_status": [200],
+      "expected_json": [
+        {"path": "/id", "equals": "{stopped_session_id}"},
+        {"path": "/status", "equals": "running"},
+        {"path": "/stopped_at", "type": "null"}
+      ],
+      "preconditions": ["live_server", "fixture:stopped_session_id", "mutating_opt_in"],
+      "source": "https://github.com/rajeshgoli/session-manager/issues/987"
+    },
+    {
       "id": "http.queue_jobs_list",
       "surface": "http",
       "classification": "retained",

--- a/scripts/rust_migration/mutating_fixture.py
+++ b/scripts/rust_migration/mutating_fixture.py
@@ -27,6 +27,7 @@ DEFAULT_CHILD_SESSION_ID = "fixture-child"
 DEFAULT_CHILD_SESSION_NAME = "FixtureChild"
 DEFAULT_EM_SESSION_ID = "fixture-em"
 DEFAULT_NOTIFY_CHILD_SESSION_ID = "fixture-notify-child"
+DEFAULT_STOPPED_SESSION_ID = "fixture-stop"
 
 
 @dataclass(frozen=True)
@@ -88,6 +89,7 @@ def create_mutating_fixture_workspace(output_dir: Path | None = None) -> Mutatin
         "clear_prompt_text": "new task after clear",
         "em_session_id": DEFAULT_EM_SESSION_ID,
         "notify_child_session_id": DEFAULT_NOTIFY_CHILD_SESSION_ID,
+        "stopped_session_id": DEFAULT_STOPPED_SESSION_ID,
         "queue_job_id": "job-fixture",
     }
     return MutatingFixtureWorkspace(
@@ -103,6 +105,7 @@ def create_mutating_fixture_workspace(output_dir: Path | None = None) -> Mutatin
 def _seed_em_notify_sessions(state_file: Path, log_dir: Path, working_dir: Path) -> None:
     state = json.loads(state_file.read_text())
     sessions = list(state.get("sessions", []))
+    _relocate_existing_session_logs(sessions, log_dir)
     seeded_ids = {DEFAULT_EM_SESSION_ID, DEFAULT_NOTIFY_CHILD_SESSION_ID}
     sessions = [session for session in sessions if session.get("id") not in seeded_ids]
     created_at = "2026-06-01T00:10:00"
@@ -141,6 +144,24 @@ def _seed_em_notify_sessions(state_file: Path, log_dir: Path, working_dir: Path)
     )
     state["sessions"] = sessions
     state_file.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n")
+
+
+def _relocate_existing_session_logs(sessions: list[dict[str, Any]], log_dir: Path) -> None:
+    for session in sessions:
+        session_id = str(session.get("id") or session.get("name") or "session")
+        destination = log_dir / f"{session_id}.log"
+        source = session.get("log_file")
+        if isinstance(source, str) and source:
+            source_path = Path(source).expanduser()
+            if not source_path.is_absolute():
+                source_path = REPO_ROOT / source_path
+            if source_path.exists() and source_path.is_file():
+                shutil.copyfile(source_path, destination)
+            else:
+                destination.touch()
+        else:
+            destination.touch()
+        session["log_file"] = str(destination)
 
 
 def _write_config(

--- a/scripts/rust_migration/mvp_rehearsal.py
+++ b/scripts/rust_migration/mvp_rehearsal.py
@@ -93,6 +93,7 @@ CORE_MUTATING_CHECK_IDS = (
     "http.rust_core_turn_complete_fixture",
     "http.rust_core_notify_on_stop_fixture",
     "http.rust_queue_job_create_fixture",
+    "http.rust_node_primary_restore_fixture",
     "cli.rust_core_restore_fixture",
     "cli.rust_core_retire_restored_fixture",
     "cli.rust_core_wait_retired_fixture",

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -31,6 +31,7 @@ from scripts.rust_migration.mutating_fixture import (
     DEFAULT_EM_SESSION_ID,
     DEFAULT_NOTIFY_CHILD_SESSION_ID,
     DEFAULT_SESSION_ID,
+    DEFAULT_STOPPED_SESSION_ID,
     create_mutating_fixture_workspace,
 )
 from scripts.rust_migration.mvp_rehearsal import (
@@ -387,6 +388,29 @@ def test_manifest_covers_rust_queue_writer_fixture_checks():
     assert http_check.path == "/queue-jobs"
     assert http_check.body["argv"] == ["echo", "queue http fixture"]
     assert "mutating_opt_in" in http_check.preconditions
+
+
+def test_manifest_covers_rust_node_restore_fixture_check():
+    manifest = ContractManifest.load()
+    checks = {check.id: check for check in manifest.checks}
+
+    restore_check = checks["http.rust_node_primary_restore_fixture"]
+    assert restore_check.classification == "retained"
+    assert restore_check.target == "rust_only"
+    assert restore_check.safety == "mutating"
+    assert restore_check.method == "POST"
+    assert (
+        restore_check.path
+        == "/nodes/primary/restore-candidates/{stopped_session_id}/restore"
+    )
+    assert "fixture:stopped_session_id" in restore_check.preconditions
+    assert "mutating_opt_in" in restore_check.preconditions
+    expectations = {
+        expectation.path: expectation for expectation in restore_check.expected_json
+    }
+    assert expectations["/id"].equals == "{stopped_session_id}"
+    assert expectations["/status"].equals == "running"
+    assert expectations["/stopped_at"].value_type == "null"
 
 
 def test_mvp_rehearsal_mutating_check_ids_match_manifest():
@@ -954,6 +978,7 @@ def test_mutating_fixture_workspace_creates_disposable_config_and_seed(tmp_path)
     assert workspace.fixtures["child_session_id"] == DEFAULT_CHILD_SESSION_ID
     assert workspace.fixtures["em_session_id"] == DEFAULT_EM_SESSION_ID
     assert workspace.fixtures["notify_child_session_id"] == DEFAULT_NOTIFY_CHILD_SESSION_ID
+    assert workspace.fixtures["stopped_session_id"] == DEFAULT_STOPPED_SESSION_ID
     assert workspace.fixtures["queue_job_id"] == "job-fixture"
 
     config_text = workspace.config_path.read_text()
@@ -967,6 +992,9 @@ def test_mutating_fixture_workspace_creates_disposable_config_and_seed(tmp_path)
 
     state = json.loads(workspace.state_file.read_text())
     sessions = {session["id"]: session for session in state["sessions"]}
+    assert sessions[DEFAULT_STOPPED_SESSION_ID]["status"] == "stopped"
+    for session in sessions.values():
+        assert Path(session["log_file"]).is_relative_to(workspace.log_dir)
     assert sessions[DEFAULT_EM_SESSION_ID]["is_em"] is True
     assert sessions[DEFAULT_EM_SESSION_ID]["status"] == "running"
     assert (


### PR DESCRIPTION
Fixes #987

## Summary
- add a Rust-only mutating contract for primary-node restore through `/nodes/primary/restore-candidates/{session_id}/restore`
- expose the stopped-session fixture id to disposable mutating fixture workspaces
- relocate copied fixture session logs under the disposable workspace so restore checks cannot write checked-in fixture logs
- include the node restore check in the MVP mutating fixture rehearsal set

## Validation
- `./venv/bin/python -m json.tool scripts/rust_migration/contracts_manifest.json >/dev/null`
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py -q`
- `./venv/bin/python -m py_compile scripts/rust_migration/mutating_fixture.py scripts/rust_migration/mvp_rehearsal.py`
- `git diff --check`
- `./venv/bin/python -m scripts.rust_migration.mvp_rehearsal --output-dir /tmp/session-manager-pr987-rehearsal --rust-base-url http://127.0.0.1:18423 --skip-python-health --skip-baseline --skip-shadow --core-only`