### PR TITLE
Support Rust CLI restore --node fixture

### DIFF
--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -39,7 +39,7 @@ enum Command {
     Children(ChildrenArgs),
     Tail(TailArgs),
     Retire(SessionIdArgs),
-    Restore(SessionIdArgs),
+    Restore(RestoreArgs),
     Attach(SessionIdArgs),
     Output(OutputArgs),
     Clear(ClearArgs),
@@ -155,6 +155,13 @@ struct ChildrenArgs {
 #[derive(Args)]
 struct SessionIdArgs {
     session_id: String,
+}
+
+#[derive(Args)]
+struct RestoreArgs {
+    session_id: String,
+    #[arg(long)]
+    node: Option<String>,
 }
 
 #[derive(Args)]
@@ -641,12 +648,7 @@ fn run() -> Result<()> {
             println!("{}", payload["status"].as_str().unwrap_or("stopped"));
         }
         Command::Restore(args) => {
-            let payload =
-                client.post_json(&format!("/sessions/{}/restore", args.session_id), json!({}))?;
-            println!(
-                "Session restored: {}",
-                payload["id"].as_str().unwrap_or(&args.session_id)
-            );
+            restore_session(&client, args)?;
         }
         Command::Attach(args) => attach_session(&client, &args.session_id)?,
         Command::Clear(args) => {
@@ -2406,6 +2408,142 @@ fn attach_session(client: &ApiClient, session_id: &str) -> Result<()> {
     Ok(())
 }
 
+fn restore_session(client: &ApiClient, args: RestoreArgs) -> Result<()> {
+    let node = args
+        .node
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let restore_session_id =
+        if let Some(node) = node.filter(|value| !is_primary_restore_node(value)) {
+            resolve_node_restore_candidate_id(client, node, &args.session_id)?
+                .ok_or_else(|| anyhow!("Session '{}' not found", args.session_id))?
+        } else {
+            args.session_id.clone()
+        };
+    let path = restore_session_path(&restore_session_id, node);
+    let payload = client.post_json(&path, json!({}))?;
+    let restored_id = payload["id"].as_str().unwrap_or(&restore_session_id);
+    if let Some(node) = node.filter(|value| !is_primary_restore_node(value)) {
+        println!("Session restored: {restored_id} on node {node}");
+    } else {
+        println!("Session restored: {restored_id}");
+    }
+    Ok(())
+}
+
+fn restore_session_path(session_id: &str, node: Option<&str>) -> String {
+    if let Some(node) = node.filter(|value| !is_primary_restore_node(value)) {
+        format!(
+            "/nodes/{}/restore-candidates/{}/restore",
+            encode_path_segment(node),
+            encode_path_segment(session_id)
+        )
+    } else {
+        format!("/sessions/{}/restore", encode_path_segment(session_id))
+    }
+}
+
+fn is_primary_restore_node(node: &str) -> bool {
+    matches!(node.trim(), "" | "primary")
+}
+
+fn resolve_node_restore_candidate_id(
+    client: &ApiClient,
+    node: &str,
+    identifier: &str,
+) -> Result<Option<String>> {
+    let payload = client.get_json(&node_restore_candidates_path(node))?;
+    let sessions = payload["sessions"].as_array().cloned().unwrap_or_default();
+    resolve_node_restore_candidate_id_from_sessions(identifier, &sessions)
+}
+
+fn node_restore_candidates_path(node: &str) -> String {
+    format!(
+        "/nodes/{}/restore-candidates?refresh=true",
+        encode_path_segment(node)
+    )
+}
+
+fn resolve_node_restore_candidate_id_from_sessions(
+    identifier: &str,
+    sessions: &[Value],
+) -> Result<Option<String>> {
+    let direct_matches = sessions
+        .iter()
+        .filter(|session| {
+            ["id", "source_session_id"].iter().any(|field| {
+                session[*field]
+                    .as_str()
+                    .is_some_and(|value| value == identifier)
+            })
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    match direct_matches.len() {
+        1 => return Ok(non_empty_json_string(&direct_matches[0], "id")),
+        count if count > 1 => {
+            let matched_ids = node_restore_candidate_ids(&direct_matches);
+            bail!(
+                "Multiple node restore candidates match '{}': {}. Use a session ID.",
+                identifier,
+                matched_ids
+            );
+        }
+        _ => {}
+    }
+
+    let alias_matches = sessions
+        .iter()
+        .filter(|session| {
+            session["aliases"].as_array().is_some_and(|aliases| {
+                aliases
+                    .iter()
+                    .any(|alias| alias.as_str() == Some(identifier))
+            })
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    let name_matches = sessions
+        .iter()
+        .filter(|session| session["friendly_name"].as_str() == Some(identifier))
+        .cloned()
+        .collect::<Vec<_>>();
+    let candidates = if alias_matches.is_empty() {
+        name_matches
+    } else {
+        alias_matches
+    };
+    match candidates.len() {
+        0 => Ok(None),
+        1 => Ok(non_empty_json_string(&candidates[0], "id")),
+        _ => {
+            let candidate_ids = node_restore_candidate_ids(&candidates);
+            bail!(
+                "Multiple node restore candidates match '{}': {}. Use a session ID.",
+                identifier,
+                candidate_ids
+            );
+        }
+    }
+}
+
+fn node_restore_candidate_ids(candidates: &[Value]) -> String {
+    candidates
+        .iter()
+        .filter_map(|candidate| non_empty_json_string(candidate, "id"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn non_empty_json_string(value: &Value, key: &str) -> Option<String> {
+    value[key]
+        .as_str()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
 fn ensure_clear_authorized(
     client: &ApiClient,
     target_session_id: &str,
@@ -3618,6 +3756,116 @@ mod tests {
         assert_eq!(
             resolve_launch_working_dir(Some(remote_path.to_owned()), Some("worker")).unwrap(),
             remote_path
+        );
+    }
+
+    #[test]
+    fn restore_session_path_uses_node_inventory_for_non_primary_nodes() {
+        assert_eq!(
+            restore_session_path("abc123", None),
+            "/sessions/abc123/restore"
+        );
+        assert_eq!(
+            restore_session_path("abc123", Some("primary")),
+            "/sessions/abc123/restore"
+        );
+        assert_eq!(
+            restore_session_path("abc123", Some("local")),
+            "/nodes/local/restore-candidates/abc123/restore"
+        );
+        assert_eq!(
+            restore_session_path("abc123", Some("localhost")),
+            "/nodes/localhost/restore-candidates/abc123/restore"
+        );
+        assert_eq!(
+            restore_session_path("abc123", Some("studio")),
+            "/nodes/studio/restore-candidates/abc123/restore"
+        );
+        assert_eq!(
+            restore_session_path("abc123", Some("macbook")),
+            "/nodes/macbook/restore-candidates/abc123/restore"
+        );
+        assert_eq!(
+            restore_session_path("id/with space", Some("node/with space")),
+            "/nodes/node%2Fwith%20space/restore-candidates/id%2Fwith%20space/restore"
+        );
+    }
+
+    #[test]
+    fn node_restore_candidates_path_forces_inventory_refresh() {
+        assert_eq!(
+            node_restore_candidates_path("macbook"),
+            "/nodes/macbook/restore-candidates?refresh=true"
+        );
+        assert_eq!(
+            node_restore_candidates_path("node/with space"),
+            "/nodes/node%2Fwith%20space/restore-candidates?refresh=true"
+        );
+    }
+
+    #[test]
+    fn node_restore_candidate_resolution_matches_python_order() {
+        let sessions = vec![
+            json!({
+                "id": "candidate-a",
+                "source_session_id": "source-a",
+                "aliases": ["alias-a"],
+                "friendly_name": "shared-name"
+            }),
+            json!({
+                "id": "candidate-b",
+                "source_session_id": "source-b",
+                "aliases": ["alias-b"],
+                "friendly_name": "friendly-b"
+            }),
+        ];
+
+        assert_eq!(
+            resolve_node_restore_candidate_id_from_sessions("candidate-a", &sessions).unwrap(),
+            Some("candidate-a".to_owned())
+        );
+        assert_eq!(
+            resolve_node_restore_candidate_id_from_sessions("source-b", &sessions).unwrap(),
+            Some("candidate-b".to_owned())
+        );
+        assert_eq!(
+            resolve_node_restore_candidate_id_from_sessions("alias-a", &sessions).unwrap(),
+            Some("candidate-a".to_owned())
+        );
+        assert_eq!(
+            resolve_node_restore_candidate_id_from_sessions("friendly-b", &sessions).unwrap(),
+            Some("candidate-b".to_owned())
+        );
+        assert_eq!(
+            resolve_node_restore_candidate_id_from_sessions("missing", &sessions).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn node_restore_candidate_resolution_reports_ambiguity() {
+        let sessions = vec![
+            json!({
+                "id": "candidate-a",
+                "source_session_id": "source-a",
+                "aliases": ["shared-alias"],
+                "friendly_name": "friendly-a"
+            }),
+            json!({
+                "id": "candidate-b",
+                "source_session_id": "source-b",
+                "aliases": ["shared-alias"],
+                "friendly_name": "friendly-b"
+            }),
+        ];
+
+        let error = resolve_node_restore_candidate_id_from_sessions("shared-alias", &sessions)
+            .unwrap_err()
+            .to_string();
+
+        assert_eq!(
+            error,
+            "Multiple node restore candidates match 'shared-alias': candidate-a, candidate-b. Use a session ID."
         );
     }
 

--- a/scripts/rust_migration/contracts_manifest.json
+++ b/scripts/rust_migration/contracts_manifest.json
@@ -1626,6 +1626,18 @@
       "source": "https://github.com/rajeshgoli/session-manager/issues/797"
     },
     {
+      "id": "cli.rust_core_restore_node_primary_fixture",
+      "surface": "cli",
+      "classification": "retained",
+      "target": "rust_only",
+      "safety": "mutating",
+      "command": ["--api-url", "{base_url}", "restore", "{cli_restore_session_id}", "--node", "primary"],
+      "expected_exit": [0],
+      "expected_output_contains_all": ["Session restored", "{cli_restore_session_id}"],
+      "preconditions": ["sm_cli", "fixture:base_url", "fixture:cli_restore_session_id", "mutating_opt_in"],
+      "source": "https://github.com/rajeshgoli/session-manager/issues/989"
+    },
+    {
       "id": "cli.rust_core_retire_restored_fixture",
       "surface": "cli",
       "classification": "retained",

--- a/scripts/rust_migration/mutating_fixture.py
+++ b/scripts/rust_migration/mutating_fixture.py
@@ -28,6 +28,7 @@ DEFAULT_CHILD_SESSION_NAME = "FixtureChild"
 DEFAULT_EM_SESSION_ID = "fixture-em"
 DEFAULT_NOTIFY_CHILD_SESSION_ID = "fixture-notify-child"
 DEFAULT_STOPPED_SESSION_ID = "fixture-stop"
+DEFAULT_CLI_RESTORE_SESSION_ID = "fixture-cli-restore"
 
 
 @dataclass(frozen=True)
@@ -90,6 +91,7 @@ def create_mutating_fixture_workspace(output_dir: Path | None = None) -> Mutatin
         "em_session_id": DEFAULT_EM_SESSION_ID,
         "notify_child_session_id": DEFAULT_NOTIFY_CHILD_SESSION_ID,
         "stopped_session_id": DEFAULT_STOPPED_SESSION_ID,
+        "cli_restore_session_id": DEFAULT_CLI_RESTORE_SESSION_ID,
         "queue_job_id": "job-fixture",
     }
     return MutatingFixtureWorkspace(
@@ -106,11 +108,29 @@ def _seed_em_notify_sessions(state_file: Path, log_dir: Path, working_dir: Path)
     state = json.loads(state_file.read_text())
     sessions = list(state.get("sessions", []))
     _relocate_existing_session_logs(sessions, log_dir)
-    seeded_ids = {DEFAULT_EM_SESSION_ID, DEFAULT_NOTIFY_CHILD_SESSION_ID}
+    seeded_ids = {
+        DEFAULT_EM_SESSION_ID,
+        DEFAULT_NOTIFY_CHILD_SESSION_ID,
+        DEFAULT_CLI_RESTORE_SESSION_ID,
+    }
     sessions = [session for session in sessions if session.get("id") not in seeded_ids]
     created_at = "2026-06-01T00:10:00"
     sessions.extend(
         [
+            {
+                "id": DEFAULT_CLI_RESTORE_SESSION_ID,
+                "name": "fixture-cli-restore",
+                "working_dir": str(working_dir),
+                "tmux_session": "fixture-cli-restore",
+                "node": "primary",
+                "provider": "claude",
+                "log_file": str(log_dir / "fixture-cli-restore.log"),
+                "status": "stopped",
+                "created_at": created_at,
+                "last_activity": created_at,
+                "stopped_at": "2026-06-01T00:11:00",
+                "friendly_name": "Fixture CLI Restore",
+            },
             {
                 "id": DEFAULT_EM_SESSION_ID,
                 "name": "fixture-em",

--- a/scripts/rust_migration/mvp_rehearsal.py
+++ b/scripts/rust_migration/mvp_rehearsal.py
@@ -95,6 +95,7 @@ CORE_MUTATING_CHECK_IDS = (
     "http.rust_queue_job_create_fixture",
     "http.rust_node_primary_restore_fixture",
     "cli.rust_core_restore_fixture",
+    "cli.rust_core_restore_node_primary_fixture",
     "cli.rust_core_retire_restored_fixture",
     "cli.rust_core_wait_retired_fixture",
 )

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -28,6 +28,7 @@ from scripts.rust_migration.contracts import (
 )
 from scripts.rust_migration.mutating_fixture import (
     DEFAULT_CHILD_SESSION_ID,
+    DEFAULT_CLI_RESTORE_SESSION_ID,
     DEFAULT_EM_SESSION_ID,
     DEFAULT_NOTIFY_CHILD_SESSION_ID,
     DEFAULT_SESSION_ID,
@@ -248,17 +249,18 @@ def test_cloudflare_access_cutover_evidence_pins_policy_and_origin_gates():
         assert required in evidence
 
 
-def test_handoff_and_progress_are_current_through_cloudflare_access_pr950():
+def test_handoff_and_progress_are_current_through_review_route_pr984():
     progress = (STAGE5_DIR / "mvp_progress.md").read_text(encoding="utf-8")
     handoff = (STAGE5_DIR / "resume_handoff.md").read_text(encoding="utf-8")
 
     for text in [progress, handoff]:
-        assert "PR #950" in text
+        assert "#950" in text
+        assert "#984" in text
         assert "Cloudflare Access" in text
         assert "cloudflare_access_cutover_evidence.md" in text
 
-    assert "Latest merged commit: `d8f97c0`" in handoff
-    assert "records the PR lineage through #950" in handoff
+    assert "Latest merged commit before this docs refresh: `8c261ee`" in handoff
+    assert "records the PR lineage through #984" in handoff
 
 
 def test_manifest_covers_rust_only_retired_http_surfaces():
@@ -303,6 +305,7 @@ def test_manifest_covers_rust_core_fixture_lifecycle_cli_checks():
         "cli.rust_core_tail_fixture",
         "cli.rust_core_retire_fixture",
         "cli.rust_core_restore_fixture",
+        "cli.rust_core_restore_node_primary_fixture",
         "cli.rust_core_retire_restored_fixture",
         "cli.rust_core_wait_retired_fixture",
     }
@@ -411,6 +414,26 @@ def test_manifest_covers_rust_node_restore_fixture_check():
     assert expectations["/id"].equals == "{stopped_session_id}"
     assert expectations["/status"].equals == "running"
     assert expectations["/stopped_at"].value_type == "null"
+
+
+def test_manifest_covers_rust_cli_restore_node_fixture_check():
+    manifest = ContractManifest.load()
+    checks = {check.id: check for check in manifest.checks}
+
+    restore_check = checks["cli.rust_core_restore_node_primary_fixture"]
+    assert restore_check.classification == "retained"
+    assert restore_check.target == "rust_only"
+    assert restore_check.safety == "mutating"
+    assert restore_check.command == (
+        "--api-url",
+        "{base_url}",
+        "restore",
+        "{cli_restore_session_id}",
+        "--node",
+        "primary",
+    )
+    assert "fixture:cli_restore_session_id" in restore_check.preconditions
+    assert "mutating_opt_in" in restore_check.preconditions
 
 
 def test_mvp_rehearsal_mutating_check_ids_match_manifest():
@@ -979,6 +1002,7 @@ def test_mutating_fixture_workspace_creates_disposable_config_and_seed(tmp_path)
     assert workspace.fixtures["em_session_id"] == DEFAULT_EM_SESSION_ID
     assert workspace.fixtures["notify_child_session_id"] == DEFAULT_NOTIFY_CHILD_SESSION_ID
     assert workspace.fixtures["stopped_session_id"] == DEFAULT_STOPPED_SESSION_ID
+    assert workspace.fixtures["cli_restore_session_id"] == DEFAULT_CLI_RESTORE_SESSION_ID
     assert workspace.fixtures["queue_job_id"] == "job-fixture"
 
     config_text = workspace.config_path.read_text()
@@ -993,6 +1017,7 @@ def test_mutating_fixture_workspace_creates_disposable_config_and_seed(tmp_path)
     state = json.loads(workspace.state_file.read_text())
     sessions = {session["id"]: session for session in state["sessions"]}
     assert sessions[DEFAULT_STOPPED_SESSION_ID]["status"] == "stopped"
+    assert sessions[DEFAULT_CLI_RESTORE_SESSION_ID]["status"] == "stopped"
     for session in sessions.values():
         assert Path(session["log_file"]).is_relative_to(workspace.log_dir)
     assert sessions[DEFAULT_EM_SESSION_ID]["is_em"] is True
@@ -1010,6 +1035,7 @@ def test_mutating_fixture_workspace_creates_disposable_config_and_seed(tmp_path)
     read_only_ids = {session["id"] for session in read_only_state["sessions"]}
     assert DEFAULT_EM_SESSION_ID not in read_only_ids
     assert DEFAULT_NOTIFY_CHILD_SESSION_ID not in read_only_ids
+    assert DEFAULT_CLI_RESTORE_SESSION_ID not in read_only_ids
 
 
 def test_mutating_fixture_workspace_refuses_non_empty_output_dir(tmp_path):


### PR DESCRIPTION
Fixes #989

## Summary
- add `--node` to the Rust `sm restore` command
- preserve `/sessions/{id}/restore` for omitted/primary node values and route non-primary values through the node restore endpoint
- add path-selection unit coverage for non-primary node restore routing
- add a dedicated stopped fixture and Rust-only mutating CLI contract for `restore --node primary`

## Validation
- `cargo fmt --check`
- `cargo test -p sm-server --bin sm restore_session_path_uses_node_inventory_for_non_primary_nodes -- --nocapture`
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py -q`
- `./venv/bin/python -m json.tool scripts/rust_migration/contracts_manifest.json >/dev/null`
- `git diff --check`
- `./venv/bin/python -m scripts.rust_migration.mvp_rehearsal --output-dir /tmp/session-manager-pr989-rehearsal --rust-base-url http://127.0.0.1:18426 --skip-python-health --skip-baseline --skip-shadow --core-only`