### PR TITLE
Add stopped-service final backup gate

### DIFF
--- a/scripts/rust_migration/README.md
+++ b/scripts/rust_migration/README.md
@@ -246,6 +246,32 @@ a missing/non-directory parent. The entry records the planned coverage only; it
 does not claim write admission is frozen, writers are drained, or Rust owns any
 store.
 
+For the MVP cutover path, the final rollback restore point is copied only after
+the Python origin is stopped. Generate the stopped-service final backup with:
+
+```bash
+python -m scripts.rust_migration.final_backup \
+  --config config.yaml \
+  --output-dir /tmp/sm-rust-final-backup-$(date -u +%Y%m%dT%H%M%SZ) \
+  --execute \
+  --record-ledger \
+  --ledger /tmp/sm-rust-migration-ledger.jsonl \
+  --fail-on-blockers
+```
+
+This command fails closed if any HTTP service answers the Python health URL, if
+the health probe times out, or if the backup/ledger paths are unsafe. A
+connection-refused health probe held across multiple checks is the required
+stopped-service evidence for this MVP path. By default `--execute` requires two
+refused probes over `--stopped-hold-seconds 5`; increase that hold window if the
+launchd/watchdog restart gap can be longer locally. By default the health URL
+is derived from `server.host` and `server.port` in `--config`; use
+`--python-health-url` only when the operator intentionally needs to probe a
+different origin. The command writes the normal `state-backup-manifest.json`
+and a `final_backup` ledger row only after the stopped-origin check and backup
+copy both pass. The ledger row includes the manifest SHA-256 and per-store
+backup evidence needed for rollback audits.
+
 ## Shadow Comparison Mode
 
 Shadow mode lets Python stay authoritative while Rust observes bounded

--- a/scripts/rust_migration/final_backup.py
+++ b/scripts/rust_migration/final_backup.py
@@ -1,0 +1,482 @@
+"""Create a stopped-service final Rust migration state backup.
+
+This tool is the MVP cutover version of the write-admission freeze gate: Python
+must be stopped before the final rollback restore point is copied. By default it
+is a dry run. With ``--execute`` it fails closed unless the configured Python
+health URL is connection-refused, then delegates to the existing state backup
+tool and can append final-backup evidence to the migration ledger.
+"""
+
+from __future__ import annotations
+
+import argparse
+import errno
+import hashlib
+import json
+import socket
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from scripts.rust_migration.state_backup import build_backup_plan, render_text_report
+from scripts.rust_migration.state_preflight import DEFAULT_CONFIG, _get, _load_yaml_config
+
+
+DEFAULT_PYTHON_HEALTH_URL = "http://127.0.0.1:8420/health"
+DEFAULT_STOPPED_HOLD_SECONDS = 5.0
+DEFAULT_STOPPED_PROBE_COUNT = 2
+
+
+def build_final_backup_report(
+    *,
+    config_path: Path = DEFAULT_CONFIG,
+    local_env_path: Path | None = None,
+    output_dir: Path | None = None,
+    python_health_url: str | None = None,
+    health_timeout_seconds: float = 1.0,
+    stopped_hold_seconds: float = DEFAULT_STOPPED_HOLD_SECONDS,
+    stopped_probe_count: int = DEFAULT_STOPPED_PROBE_COUNT,
+    execute: bool = False,
+    ledger_path: Path | None = None,
+    record_ledger: bool = False,
+    urlopen: Callable[..., Any] = urllib.request.urlopen,
+    sleep: Callable[[float], None] = time.sleep,
+) -> dict[str, Any]:
+    if execute and output_dir is None:
+        raise ValueError("--execute requires --output-dir")
+    if health_timeout_seconds <= 0:
+        raise ValueError("--health-timeout-seconds must be positive")
+    if stopped_hold_seconds < 0:
+        raise ValueError("--stopped-hold-seconds must be non-negative")
+    if stopped_probe_count < 1:
+        raise ValueError("--stopped-probe-count must be at least 1")
+    if execute and stopped_probe_count < 2:
+        raise ValueError("--execute requires --stopped-probe-count >= 2")
+    generated_at = datetime.now(timezone.utc).isoformat()
+    resolved_health_url = python_health_url or configured_python_health_url(config_path)
+    if execute:
+        health = probe_python_origin_stopped_durably(
+            resolved_health_url,
+            timeout_seconds=health_timeout_seconds,
+            hold_seconds=stopped_hold_seconds,
+            probe_count=stopped_probe_count,
+            urlopen=urlopen,
+            sleep=sleep,
+        )
+    else:
+        health = probe_python_origin_stopped(
+            resolved_health_url,
+            timeout_seconds=health_timeout_seconds,
+            urlopen=urlopen,
+        )
+    ledger = _ledger_info(ledger_path, record_ledger=record_ledger)
+    blockers = [*health["blockers"], *ledger["blockers"]]
+
+    backup: dict[str, Any] | None = None
+    if not execute or not blockers:
+        backup = build_backup_plan(
+            config_path=config_path,
+            local_env_path=local_env_path,
+            output_dir=output_dir,
+            execute=execute,
+        )
+        blockers.extend(backup["blockers"])
+
+    status = "blocked" if blockers else "copied" if execute else "planned"
+    report: dict[str, Any] = {
+        "schema_version": 1,
+        "generated_at": generated_at,
+        "status": status,
+        "mode": "execute" if execute else "dry_run",
+        "python_origin": health,
+        "backup": backup,
+        "ledger": {
+            "path": str(ledger_path.expanduser()) if ledger_path else None,
+            "record_ledger": record_ledger,
+            "written": False,
+            "entry_kind": "final_backup",
+        },
+        "summary": {
+            "python_origin_stopped": health["stopped"],
+            "backup_status": backup.get("status") if backup else None,
+            "copied": (backup.get("summary") or {}).get("copied") if backup else 0,
+            "planned": (backup.get("summary") or {}).get("planned") if backup else 0,
+            "blockers": len(blockers),
+            "warnings": len((backup or {}).get("warnings", [])),
+        },
+        "blockers": blockers,
+        "warnings": (backup or {}).get("warnings", []),
+    }
+    if execute and record_ledger and not blockers:
+        _append_ledger_entry(report, Path(ledger_path).expanduser())
+        report["ledger"]["written"] = True
+    return report
+
+
+def configured_python_health_url(config_path: Path = DEFAULT_CONFIG) -> str:
+    config = _load_yaml_config(config_path.expanduser())
+    host = str(_get(config, ("server", "host"), "127.0.0.1")).strip()
+    if not host:
+        host = "127.0.0.1"
+    port = _coerce_port(_get(config, ("server", "port"), 8420))
+    if host == "0.0.0.0":
+        host = "127.0.0.1"
+    elif host in {"::", "[::]"}:
+        host = "[::1]"
+    if ":" in host and not host.startswith("["):
+        host = f"[{host}]"
+    return f"http://{host}:{port}/health"
+
+
+def probe_python_origin_stopped(
+    url: str,
+    *,
+    timeout_seconds: float,
+    urlopen: Callable[..., Any] = urllib.request.urlopen,
+) -> dict[str, Any]:
+    blockers: list[dict[str, str]] = []
+    try:
+        with urlopen(url, timeout=timeout_seconds) as response:
+            status = getattr(response, "status", None) or response.getcode()
+        blockers.append(
+            _issue(
+                "python_origin",
+                "python_origin_reachable",
+                f"Python origin answered {url} with HTTP {status}",
+            )
+        )
+        return {
+            "url": url,
+            "stopped": False,
+            "status": "reachable",
+            "http_status": status,
+            "detail": f"HTTP {status}",
+            "blockers": blockers,
+        }
+    except urllib.error.HTTPError as exc:
+        blockers.append(
+            _issue(
+                "python_origin",
+                "python_origin_reachable",
+                f"Python origin answered {url} with HTTP {exc.code}",
+            )
+        )
+        return {
+            "url": url,
+            "stopped": False,
+            "status": "reachable",
+            "http_status": exc.code,
+            "detail": f"HTTP {exc.code}",
+            "blockers": blockers,
+        }
+    except urllib.error.URLError as exc:
+        if _is_connection_refused(exc.reason):
+            return {
+                "url": url,
+                "stopped": True,
+                "status": "connection_refused",
+                "http_status": None,
+                "detail": str(exc.reason),
+                "blockers": [],
+            }
+        blockers.append(
+            _issue(
+                "python_origin",
+                "python_origin_probe_failed",
+                f"Python origin probe did not prove stopped: {exc.reason}",
+            )
+        )
+        return {
+            "url": url,
+            "stopped": False,
+            "status": "probe_failed",
+            "http_status": None,
+            "detail": str(exc.reason),
+            "blockers": blockers,
+        }
+    except (TimeoutError, socket.timeout) as exc:
+        blockers.append(
+            _issue(
+                "python_origin",
+                "python_origin_probe_timeout",
+                f"Python origin probe timed out: {exc}",
+            )
+        )
+        return {
+            "url": url,
+            "stopped": False,
+            "status": "timeout",
+            "http_status": None,
+            "detail": str(exc),
+            "blockers": blockers,
+        }
+    except ValueError as exc:
+        blockers.append(
+            _issue(
+                "python_origin",
+                "python_origin_probe_invalid_url",
+                f"Python origin health URL is invalid: {exc}",
+            )
+        )
+        return {
+            "url": url,
+            "stopped": False,
+            "status": "invalid_url",
+            "http_status": None,
+            "detail": str(exc),
+            "blockers": blockers,
+        }
+
+
+def probe_python_origin_stopped_durably(
+    url: str,
+    *,
+    timeout_seconds: float,
+    hold_seconds: float,
+    probe_count: int,
+    urlopen: Callable[..., Any] = urllib.request.urlopen,
+    sleep: Callable[[float], None] = time.sleep,
+) -> dict[str, Any]:
+    attempts: list[dict[str, Any]] = []
+    interval = hold_seconds / (probe_count - 1) if probe_count > 1 else 0.0
+    for index in range(probe_count):
+        if index and interval:
+            sleep(interval)
+        probe = probe_python_origin_stopped(
+            url,
+            timeout_seconds=timeout_seconds,
+            urlopen=urlopen,
+        )
+        attempts.append(_probe_attempt(probe))
+        if not probe["stopped"]:
+            probe = dict(probe)
+            probe["attempts"] = attempts
+            probe["required_probe_count"] = probe_count
+            probe["hold_seconds"] = hold_seconds
+            return probe
+    return {
+        "url": url,
+        "stopped": True,
+        "status": "connection_refused",
+        "http_status": None,
+        "detail": f"{probe_count} refused probes over {hold_seconds:g}s",
+        "attempts": attempts,
+        "required_probe_count": probe_count,
+        "hold_seconds": hold_seconds,
+        "blockers": [],
+    }
+
+
+def _probe_attempt(probe: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "stopped": probe["stopped"],
+        "status": probe["status"],
+        "http_status": probe.get("http_status"),
+        "detail": probe.get("detail"),
+    }
+
+
+def render_final_backup_text(report: dict[str, Any]) -> str:
+    lines = [
+        "Rust final backup gate",
+        f"status: {report['status']}",
+        f"mode: {report['mode']}",
+        f"python_origin_stopped: {str(report['python_origin']['stopped']).lower()}",
+        f"python_origin_status: {report['python_origin']['status']}",
+        f"backup_status: {report['summary']['backup_status']}",
+        f"copied: {report['summary']['copied']}",
+        f"planned: {report['summary']['planned']}",
+        f"blockers: {report['summary']['blockers']}",
+        f"warnings: {report['summary']['warnings']}",
+    ]
+    if report.get("backup"):
+        lines.extend(["", render_text_report(report["backup"])])
+    if report["blockers"]:
+        lines.extend(["", "Blockers:"])
+        for blocker in report["blockers"]:
+            lines.append(f"  {blocker['store_id']}: {blocker['kind']} - {blocker['detail']}")
+    return "\n".join(lines)
+
+
+def _is_connection_refused(reason: Any) -> bool:
+    if isinstance(reason, ConnectionRefusedError):
+        return True
+    if isinstance(reason, OSError):
+        return reason.errno == errno.ECONNREFUSED
+    return False
+
+
+def _ledger_info(
+    ledger_path: Path | None,
+    *,
+    record_ledger: bool,
+) -> dict[str, Any]:
+    blockers: list[dict[str, str]] = []
+    if not record_ledger:
+        return {"blockers": blockers}
+    if ledger_path is None:
+        blockers.append(_issue("ledger", "missing_ledger_path", "--record-ledger requires --ledger"))
+        return {"blockers": blockers}
+    path = ledger_path.expanduser()
+    parent = path.parent
+    if not parent.exists():
+        blockers.append(
+            _issue("ledger", "ledger_parent_missing", f"ledger parent does not exist: {parent}")
+        )
+    elif not parent.is_dir():
+        blockers.append(
+            _issue("ledger", "ledger_parent_not_dir", f"ledger parent is not a directory: {parent}")
+        )
+    if path.exists() and path.is_dir():
+        blockers.append(_issue("ledger", "ledger_is_directory", f"ledger is a directory: {path}"))
+    if path.is_symlink():
+        blockers.append(_issue("ledger", "ledger_is_symlink", f"ledger is a symlink: {path}"))
+    return {"blockers": blockers}
+
+
+def _append_ledger_entry(report: dict[str, Any], ledger_path: Path) -> None:
+    backup = report["backup"] or {}
+    manifest_path = backup.get("manifest_path")
+    entry = {
+        "schema_version": 1,
+        "kind": "final_backup",
+        "generated_at": report["generated_at"],
+        "status": report["status"],
+        "python_origin_stopped": report["python_origin"]["stopped"],
+        "python_origin_status": report["python_origin"]["status"],
+        "backup_root": backup.get("backup_root"),
+        "manifest_path": manifest_path,
+        "manifest_sha256": _path_sha256(Path(manifest_path)) if manifest_path else None,
+        "backup_summary": backup.get("summary"),
+        "store_evidence": _store_backup_evidence(backup),
+    }
+    ledger_path.parent.mkdir(parents=True, exist_ok=True)
+    with ledger_path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, sort_keys=True) + "\n")
+
+
+def _issue(store_id: str, kind: str, detail: str) -> dict[str, str]:
+    return {
+        "store_id": store_id,
+        "kind": kind,
+        "severity": "blocker",
+        "detail": detail,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--local-env", type=Path, default=None)
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument(
+        "--python-health-url",
+        default=None,
+        help=(
+            "Override the Python origin health URL. Defaults to server.host/server.port "
+            "from --config."
+        ),
+    )
+    parser.add_argument("--health-timeout-seconds", type=float, default=1.0)
+    parser.add_argument(
+        "--stopped-hold-seconds",
+        type=float,
+        default=DEFAULT_STOPPED_HOLD_SECONDS,
+        help="Seconds over which stopped-service probes must remain connection-refused before --execute copies.",
+    )
+    parser.add_argument(
+        "--stopped-probe-count",
+        type=int,
+        default=DEFAULT_STOPPED_PROBE_COUNT,
+        help="Number of stopped-service probes required before --execute copies.",
+    )
+    parser.add_argument("--ledger", type=Path, default=None)
+    parser.add_argument(
+        "--record-ledger",
+        action="store_true",
+        help="Append final-backup JSONL evidence to --ledger",
+    )
+    parser.add_argument("--execute", action="store_true", help="Copy the final backup")
+    parser.add_argument("--json", action="store_true", help="Emit JSON report")
+    parser.add_argument(
+        "--fail-on-blockers",
+        action="store_true",
+        help="Exit nonzero when the report has blockers",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        report = build_final_backup_report(
+            config_path=args.config,
+            local_env_path=args.local_env,
+            output_dir=args.output_dir,
+            python_health_url=args.python_health_url,
+            health_timeout_seconds=args.health_timeout_seconds,
+            stopped_hold_seconds=args.stopped_hold_seconds,
+            stopped_probe_count=args.stopped_probe_count,
+            execute=args.execute,
+            ledger_path=args.ledger,
+            record_ledger=args.record_ledger,
+        )
+    except ValueError as exc:
+        raise SystemExit(str(exc)) from exc
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_final_backup_text(report))
+    if args.fail_on_blockers and report["blockers"]:
+        return 1
+    return 0
+
+
+def _coerce_port(value: Any) -> int:
+    try:
+        port = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"server.port must be an integer, got {value!r}") from exc
+    if port <= 0 or port > 65535:
+        raise ValueError(f"server.port must be in 1..65535, got {port}")
+    return port
+
+
+def _path_sha256(path: Path) -> str | None:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError:
+        return None
+    return digest.hexdigest()
+
+
+def _store_backup_evidence(backup: dict[str, Any]) -> list[dict[str, Any]]:
+    evidence: list[dict[str, Any]] = []
+    for entry in backup.get("entries") or []:
+        if entry.get("action") != "copy":
+            continue
+        evidence.append(
+            {
+                "store_id": entry.get("store_id"),
+                "kind": entry.get("kind"),
+                "source": entry.get("source"),
+                "destination": entry.get("destination"),
+                "size_bytes": entry.get("size_bytes"),
+                "sha256": entry.get("sha256"),
+                "file_count": entry.get("file_count"),
+                "backup_size_bytes": entry.get("backup_size_bytes"),
+                "backup_sha256": entry.get("backup_sha256"),
+                "backup_file_count": entry.get("backup_file_count"),
+            }
+        )
+    return evidence
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_rust_final_backup.py
+++ b/tests/unit/test_rust_final_backup.py
@@ -1,0 +1,279 @@
+import errno
+import hashlib
+import json
+import urllib.error
+
+from scripts.rust_migration.final_backup import (
+    build_final_backup_report,
+    configured_python_health_url,
+    main as final_backup_main,
+)
+
+
+def _write_config(path, state_dir, *, host="127.0.0.1", port=8420):
+    path.write_text(
+        f"""
+server:
+  host: "{host}"
+  port: {port}
+paths:
+  state_file: "{state_dir / 'sessions.json'}"
+  log_dir: "{state_dir / 'logs'}"
+sm_send:
+  db_path: "{state_dir / 'message_queue.db'}"
+response_relay:
+  db_path: "{state_dir / 'response_relay.db'}"
+tool_logging:
+  db_path: "{state_dir / 'tool_usage.db'}"
+telegram:
+  topic_registry:
+    path: "{state_dir / 'telegram_topics.json'}"
+email:
+  bridge_config: "{state_dir / 'email_send.yaml'}"
+queue_runner:
+  state_dir: "{state_dir / 'queue-runner'}"
+codex_events:
+  db_path: "{state_dir / 'codex_events.db'}"
+codex_requests:
+  db_path: "{state_dir / 'codex_requests.db'}"
+codex_observability:
+  db_path: "{state_dir / 'codex_observability.db'}"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _seed_state_tree(tmp_path):
+    config = tmp_path / "config.yaml"
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    (state_dir / "sessions.json").write_text('[{"id":"fixture"}]\n', encoding="utf-8")
+    (state_dir / "message_queue.db").write_text("queue", encoding="utf-8")
+    (state_dir / "response_relay.db").write_text("relay", encoding="utf-8")
+    (state_dir / "tool_usage.db").write_text("tools", encoding="utf-8")
+    (state_dir / "telegram_topics.json").write_text("{}\n", encoding="utf-8")
+    (state_dir / "codex_events.db").write_text("events", encoding="utf-8")
+    (state_dir / "codex_requests.db").write_text("requests", encoding="utf-8")
+    (state_dir / "codex_observability.db").write_text("observability", encoding="utf-8")
+    (state_dir / "email_send.yaml").write_text("registered_users: {}\n", encoding="utf-8")
+    (state_dir / "logs").mkdir()
+    (state_dir / "logs/server.log").write_text("log\n", encoding="utf-8")
+    (state_dir / "queue-runner").mkdir()
+    (state_dir / "queue-runner/queue_runner.db").write_text("jobs", encoding="utf-8")
+    _write_config(config, state_dir)
+    return config, state_dir
+
+
+class _FakeHttpResponse:
+    status = 200
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def getcode(self):
+        return self.status
+
+
+def _reachable_urlopen(*_args, **_kwargs):
+    return _FakeHttpResponse()
+
+
+def _refused_urlopen(*_args, **_kwargs):
+    raise urllib.error.URLError(
+        ConnectionRefusedError(errno.ECONNREFUSED, "Connection refused")
+    )
+
+
+def _sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def test_configured_python_health_url_uses_server_host_and_port(tmp_path):
+    config, state_dir = _seed_state_tree(tmp_path)
+    _write_config(config, state_dir, host="127.0.0.1", port=18420)
+
+    assert configured_python_health_url(config) == "http://127.0.0.1:18420/health"
+
+
+def test_configured_python_health_url_maps_bind_all_host_to_loopback(tmp_path):
+    config, state_dir = _seed_state_tree(tmp_path)
+    _write_config(config, state_dir, host="0.0.0.0", port=18421)
+
+    assert configured_python_health_url(config) == "http://127.0.0.1:18421/health"
+
+
+def test_configured_python_health_url_maps_ipv6_bind_all_to_ipv6_loopback(tmp_path):
+    config, state_dir = _seed_state_tree(tmp_path)
+    _write_config(config, state_dir, host="::", port=18423)
+
+    assert configured_python_health_url(config) == "http://[::1]:18423/health"
+
+
+def test_final_backup_blocks_when_python_origin_answers(tmp_path):
+    config, _state_dir = _seed_state_tree(tmp_path)
+    backup_root = tmp_path / "final-backup"
+
+    report = build_final_backup_report(
+        config_path=config,
+        output_dir=backup_root,
+        execute=True,
+        stopped_hold_seconds=0,
+        urlopen=_reachable_urlopen,
+    )
+
+    assert report["status"] == "blocked"
+    assert report["backup"] is None
+    assert not backup_root.exists()
+    assert report["python_origin"]["stopped"] is False
+    assert any(
+        blocker["store_id"] == "python_origin"
+        and blocker["kind"] == "python_origin_reachable"
+        for blocker in report["blockers"]
+    )
+
+
+def test_final_backup_default_probe_uses_configured_server_port(tmp_path):
+    config, state_dir = _seed_state_tree(tmp_path)
+    _write_config(config, state_dir, host="127.0.0.1", port=18422)
+    seen_urls = []
+
+    def record_urlopen(url, **_kwargs):
+        seen_urls.append(url)
+        return _FakeHttpResponse()
+
+    report = build_final_backup_report(
+        config_path=config,
+        output_dir=tmp_path / "final-backup",
+        execute=True,
+        stopped_hold_seconds=0,
+        urlopen=record_urlopen,
+    )
+
+    assert report["status"] == "blocked"
+    assert seen_urls == ["http://127.0.0.1:18422/health"]
+
+
+def test_final_backup_explicit_health_url_overrides_config(tmp_path):
+    config, state_dir = _seed_state_tree(tmp_path)
+    _write_config(config, state_dir, host="127.0.0.1", port=18422)
+    seen_urls = []
+
+    def record_urlopen(url, **_kwargs):
+        seen_urls.append(url)
+        return _FakeHttpResponse()
+
+    report = build_final_backup_report(
+        config_path=config,
+        output_dir=tmp_path / "final-backup",
+        python_health_url="http://127.0.0.1:19999/health",
+        execute=True,
+        stopped_hold_seconds=0,
+        urlopen=record_urlopen,
+    )
+
+    assert report["status"] == "blocked"
+    assert seen_urls == ["http://127.0.0.1:19999/health"]
+
+
+def test_final_backup_executes_after_connection_refused_and_writes_ledger(tmp_path):
+    config, state_dir = _seed_state_tree(tmp_path)
+    backup_root = tmp_path / "final-backup"
+    ledger = tmp_path / "migration-ledger.jsonl"
+    seen_urls = []
+
+    def record_refused(url, **_kwargs):
+        seen_urls.append(url)
+        return _refused_urlopen(url, **_kwargs)
+
+    report = build_final_backup_report(
+        config_path=config,
+        output_dir=backup_root,
+        execute=True,
+        ledger_path=ledger,
+        record_ledger=True,
+        stopped_hold_seconds=0,
+        urlopen=record_refused,
+    )
+
+    assert report["status"] == "copied"
+    assert report["python_origin"]["stopped"] is True
+    assert len(report["python_origin"]["attempts"]) == 2
+    assert len(seen_urls) == 2
+    assert report["backup"]["status"] == "copied"
+    assert report["ledger"]["written"] is True
+    manifest_path = backup_root / "state-backup-manifest.json"
+    assert manifest_path.exists()
+    assert (backup_root / "stores/sessions_state").read_text(encoding="utf-8") == (
+        state_dir / "sessions.json"
+    ).read_text(encoding="utf-8")
+    rows = [json.loads(line) for line in ledger.read_text(encoding="utf-8").splitlines()]
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "final_backup"
+    assert rows[0]["python_origin_stopped"] is True
+    assert rows[0]["manifest_path"] == str(manifest_path)
+    assert rows[0]["manifest_sha256"] == _sha256(manifest_path)
+    stores = {row["store_id"]: row for row in rows[0]["store_evidence"]}
+    assert stores["sessions_state"]["backup_sha256"] == _sha256(
+        backup_root / "stores/sessions_state"
+    )
+    assert stores["log_dir"]["backup_file_count"] == 1
+
+
+def test_final_backup_blocks_when_origin_reappears_during_hold(tmp_path):
+    config, _state_dir = _seed_state_tree(tmp_path)
+    backup_root = tmp_path / "final-backup"
+    calls = 0
+
+    def refused_then_reachable(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return _refused_urlopen(*args, **kwargs)
+        return _reachable_urlopen(*args, **kwargs)
+
+    report = build_final_backup_report(
+        config_path=config,
+        output_dir=backup_root,
+        execute=True,
+        stopped_hold_seconds=0,
+        urlopen=refused_then_reachable,
+    )
+
+    assert report["status"] == "blocked"
+    assert report["backup"] is None
+    assert not backup_root.exists()
+    assert report["python_origin"]["stopped"] is False
+    assert len(report["python_origin"]["attempts"]) == 2
+
+
+def test_final_backup_cli_reports_blocker_for_invalid_health_url(tmp_path, capsys):
+    config, _state_dir = _seed_state_tree(tmp_path)
+    backup_root = tmp_path / "backup"
+
+    exit_code = final_backup_main(
+        [
+            "--config",
+            str(config),
+            "--output-dir",
+            str(backup_root),
+            "--python-health-url",
+            "not a url",
+            "--execute",
+            "--json",
+            "--fail-on-blockers",
+        ]
+    )
+    rendered = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 1
+    assert rendered["status"] == "blocked"
+    assert rendered["backup"] is None
+    assert not backup_root.exists()


### PR DESCRIPTION
## Summary
- add a stopped-service final backup tool for the Rust migration cutover path
- block final backup execution unless the Python health URL is connection-refused
- append final-backup ledger evidence only after the stopped-origin check and backup copy pass
- document the MVP final rollback backup command

## Validation
- ./venv/bin/python -m pytest tests/unit/test_rust_final_backup.py tests/unit/test_rust_state_backup.py tests/unit/test_rust_freeze_drain_plan.py -q
- ./venv/bin/python -m py_compile scripts/rust_migration/final_backup.py
- git diff --check
- live probe: ./venv/bin/python -m scripts.rust_migration.final_backup --config config.yaml --output-dir /tmp/session-manager-final-backup-live-probe --execute --json --fail-on-blockers blocked because Python answered /health with HTTP 200 and did not create the backup directory

Fixes #991