### PR TITLE
Integrate final backup gate into MVP rehearsal

### DIFF
--- a/scripts/rust_migration/README.md
+++ b/scripts/rust_migration/README.md
@@ -272,6 +272,23 @@ and a `final_backup` ledger row only after the stopped-origin check and backup
 copy both pass. The ledger row includes the manifest SHA-256 and per-store
 backup evidence needed for rollback audits.
 
+To record the same stopped-origin final-backup gate inside the MVP rehearsal
+artifact, opt in explicitly after stopping Python:
+
+```bash
+python -m scripts.rust_migration.mvp_rehearsal \
+  --config config.yaml \
+  --output-dir /tmp/sm-rust-cutover-rehearsal-$(date -u +%Y%m%dT%H%M%SZ) \
+  --run-final-backup-gate \
+  --skip-baseline \
+  --skip-shadow
+```
+
+The rehearsal gate records `final_backup_*` artifacts only when the underlying
+files exist. It skips the normal Python liveness probe because the final-backup
+gate requires stopped-origin evidence instead. Keep using the default rehearsal
+mode for ordinary sidecar validation where Python remains authoritative.
+
 ## Shadow Comparison Mode
 
 Shadow mode lets Python stay authoritative while Rust observes bounded
@@ -481,6 +498,10 @@ reports. The state gate writes detailed artifacts under
 `state-restore-report.json`, and `freeze-drain-ledger.jsonl`. If this gate
 blocks, the rehearsal exits before Rust sidecar startup because the run cannot
 serve as cutover evidence.
+
+For a stopped-origin cutover rehearsal, add `--run-final-backup-gate` after
+stopping Python; this records `final_backup_*` artifacts and skips the normal
+Python liveness probe.
 
 Useful variants:
 

--- a/scripts/rust_migration/mvp_rehearsal.py
+++ b/scripts/rust_migration/mvp_rehearsal.py
@@ -24,6 +24,7 @@ from urllib.parse import urlparse
 
 from .baseline import run_baseline
 from .contracts import ContractManifest, run_checks, summarize
+from .final_backup import build_final_backup_report, configured_python_health_url
 from .freeze_drain_plan import build_freeze_drain_plan
 from .mutating_fixture import create_mutating_fixture_workspace
 from .state_backup import build_backup_plan
@@ -166,6 +167,10 @@ def run_rehearsal(args: argparse.Namespace) -> dict[str, Any]:
             "skip_python_health": args.skip_python_health,
             "skip_smoke": args.skip_smoke,
             "skip_state_gate": args.skip_state_gate,
+            "run_final_backup_gate": args.run_final_backup_gate,
+            "final_backup_python_health_url": args.final_backup_python_health_url,
+            "final_backup_stopped_hold_seconds": args.final_backup_stopped_hold_seconds,
+            "final_backup_stopped_probe_count": args.final_backup_stopped_probe_count,
             "skip_baseline": args.skip_baseline,
             "baseline_repetitions": args.baseline_repetitions,
             "skip_shadow": args.skip_shadow,
@@ -186,11 +191,19 @@ def run_rehearsal(args: argparse.Namespace) -> dict[str, Any]:
     rust_process: subprocess.Popen[str] | None = None
     rust_ready = False
     try:
-        if not args.skip_python_health:
+        if not args.skip_python_health and not args.run_final_backup_gate:
             python_health = _probe_health(args.python_base_url, args.timeout)
             report["steps"].append({"name": "python_health", **python_health})
             if python_health["status"] != "passed":
                 _add_blocker(report, "python_health", python_health["detail"])
+        elif args.run_final_backup_gate and not args.skip_python_health:
+            report["steps"].append(
+                {
+                    "name": "python_health",
+                    "status": "skipped",
+                    "detail": "Python liveness probe is superseded by stopped-origin final backup gate",
+                }
+            )
 
         if args.skip_state_gate:
             report["steps"].append(
@@ -215,6 +228,26 @@ def run_rehearsal(args: argparse.Namespace) -> dict[str, Any]:
                         report,
                         "state_ownership_gate",
                         state_gate.get("detail", "state ownership gate failed"),
+                    )
+                return _finalize_report(report, output_dir, started_at)
+
+        if args.run_final_backup_gate:
+            final_backup = _run_final_backup_gate(args, output_dir)
+            report["steps"].append(final_backup)
+            for name, path in final_backup.get("artifacts", {}).items():
+                report["artifacts"][f"final_backup_{name}"] = path
+            if final_backup["status"] != "passed":
+                for blocker in final_backup.get("blockers", []):
+                    _add_blocker(
+                        report,
+                        "final_backup_gate",
+                        blocker.get("detail", str(blocker)),
+                    )
+                if not final_backup.get("blockers"):
+                    _add_blocker(
+                        report,
+                        "final_backup_gate",
+                        final_backup.get("detail", "final backup gate failed"),
                     )
                 return _finalize_report(report, output_dir, started_at)
 
@@ -1020,6 +1053,104 @@ def _run_state_gate(args: argparse.Namespace, output_dir: Path) -> dict[str, Any
     }
 
 
+def _run_final_backup_gate(args: argparse.Namespace, output_dir: Path) -> dict[str, Any]:
+    step_name = "stopped_origin_final_backup_gate"
+    started_at = time.perf_counter()
+    root = output_dir / "final-backup"
+    root.mkdir(parents=True, exist_ok=True)
+    artifacts = {
+        "report": str(root / "final-backup-report.json"),
+        "backup_manifest": str(root / "backup" / "state-backup-manifest.json"),
+        "ledger": str(root / "final-backup-ledger.jsonl"),
+    }
+
+    try:
+        final_backup = build_final_backup_report(
+            config_path=args.config,
+            local_env_path=args.local_env,
+            output_dir=root / "backup",
+            python_health_url=_final_backup_python_health_url(args),
+            health_timeout_seconds=args.final_backup_health_timeout,
+            stopped_hold_seconds=args.final_backup_stopped_hold_seconds,
+            stopped_probe_count=args.final_backup_stopped_probe_count,
+            execute=True,
+            ledger_path=root / "final-backup-ledger.jsonl",
+            record_ledger=True,
+        )
+        _write_json(Path(artifacts["report"]), final_backup)
+    except Exception as exc:  # noqa: BLE001 - preserve concrete tool failure in report.
+        return {
+            "name": step_name,
+            "status": "failed",
+            "elapsed_ms": _elapsed_ms(started_at),
+            "detail": f"final backup gate raised {type(exc).__name__}: {exc}",
+            "summary": {
+                "final_backup_status": None,
+                "python_origin_stopped": None,
+                "backup_status": None,
+                "backup_copied": None,
+                "ledger_written": None,
+            },
+            "blockers": [
+                {
+                    "substep": "final_backup",
+                    "kind": "exception",
+                    "detail": f"{type(exc).__name__}: {exc}",
+                }
+            ],
+            "artifacts": _existing_artifacts(artifacts),
+        }
+
+    blockers = [
+        {
+            "substep": blocker.get("store_id", "final_backup"),
+            "kind": blocker.get("kind", "blocker"),
+            "detail": blocker.get("detail", str(blocker)),
+        }
+        for blocker in final_backup.get("blockers", [])
+    ]
+    status = final_backup.get("status")
+    if status != "copied" and not blockers:
+        blockers.append(
+            {
+                "substep": "final_backup",
+                "kind": "unexpected_status",
+                "detail": f"expected copied final backup; got {status}",
+            }
+        )
+
+    return {
+        "name": step_name,
+        "status": "passed" if not blockers else "failed",
+        "elapsed_ms": _elapsed_ms(started_at),
+        "detail": "stopped-origin final backup completed" if not blockers else "stopped-origin final backup blocked",
+        "summary": {
+            "final_backup_status": status,
+            "python_origin_stopped": (final_backup.get("python_origin") or {}).get("stopped"),
+            "backup_status": (final_backup.get("summary") or {}).get("backup_status"),
+            "backup_copied": (final_backup.get("summary") or {}).get("copied"),
+            "ledger_written": (final_backup.get("ledger") or {}).get("written"),
+        },
+        "blockers": blockers,
+        "artifacts": _existing_artifacts(artifacts),
+    }
+
+
+def _final_backup_python_health_url(args: argparse.Namespace) -> str:
+    if args.final_backup_python_health_url:
+        return args.final_backup_python_health_url
+    config_url = configured_python_health_url(args.config)
+    rehearsal_url = args.python_base_url.rstrip("/") + "/health"
+    if rehearsal_url != config_url:
+        raise ValueError(
+            "final backup health URL is ambiguous: "
+            f"--python-base-url resolves to {rehearsal_url}, "
+            f"but --config resolves to {config_url}; pass "
+            "--final-backup-python-health-url explicitly"
+        )
+    return config_url
+
+
 def _existing_artifacts(artifacts: dict[str, str]) -> dict[str, str]:
     return {
         name: path
@@ -1420,6 +1551,34 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--reuse-rust-sidecar", action="store_true")
     parser.add_argument("--skip-python-health", action="store_true")
     parser.add_argument("--skip-state-gate", action="store_true")
+    parser.add_argument(
+        "--run-final-backup-gate",
+        action="store_true",
+        help="After state preflight/backup/restore/freeze-drain, require stopped Python evidence and create the final backup",
+    )
+    parser.add_argument(
+        "--final-backup-python-health-url",
+        default=None,
+        help="Override the Python health URL used by the stopped-origin final backup gate",
+    )
+    parser.add_argument(
+        "--final-backup-health-timeout",
+        type=float,
+        default=1.0,
+        help="Per-probe timeout for stopped-origin final backup health checks",
+    )
+    parser.add_argument(
+        "--final-backup-stopped-hold-seconds",
+        type=float,
+        default=5.0,
+        help="Hold window for durable stopped-origin final backup evidence",
+    )
+    parser.add_argument(
+        "--final-backup-stopped-probe-count",
+        type=_positive_int,
+        default=2,
+        help="Number of refused probes required for stopped-origin final backup evidence",
+    )
     parser.add_argument("--skip-smoke", action="store_true")
     parser.add_argument("--skip-baseline", action="store_true")
     parser.add_argument("--skip-shadow", action="store_true")

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -44,8 +44,10 @@ from scripts.rust_migration.mvp_rehearsal import (
     _default_read_only_fixture_rust_base_url,
     _default_mutating_rust_base_url,
     _ensure_rust_cli_available,
+    _final_backup_python_health_url,
     _resolve_shadow_compare_paths,
     _run_contract_group,
+    _run_final_backup_gate,
     _run_state_gate,
     run_rehearsal,
 )
@@ -816,6 +818,167 @@ sm_send:
     assert "state_gate_restore_report" not in report["artifacts"]
     assert "state_gate_restore_root" not in report["artifacts"]
     assert "state_gate_freeze_drain_ledger" not in report["artifacts"]
+
+
+def test_mvp_rehearsal_final_backup_gate_defaults_off():
+    args = _build_parser().parse_args([])
+
+    assert args.run_final_backup_gate is False
+
+
+def test_mvp_rehearsal_final_backup_health_url_defaults_to_config_when_unambiguous(tmp_path):
+    config = tmp_path / "config.yaml"
+    config.write_text("server:\n  host: 127.0.0.1\n  port: 18420\n", encoding="utf-8")
+    args = _build_parser().parse_args(
+        [
+            "--config",
+            str(config),
+            "--python-base-url",
+            "http://127.0.0.1:18420/",
+            "--run-final-backup-gate",
+        ]
+    )
+
+    assert _final_backup_python_health_url(args) == "http://127.0.0.1:18420/health"
+
+    override = _build_parser().parse_args(
+        [
+            "--config",
+            str(config),
+            "--python-base-url",
+            "http://127.0.0.1:18420",
+            "--run-final-backup-gate",
+            "--final-backup-python-health-url",
+            "http://127.0.0.1:19420/health",
+        ]
+    )
+    assert _final_backup_python_health_url(override) == "http://127.0.0.1:19420/health"
+
+
+def test_mvp_rehearsal_final_backup_health_url_blocks_ambiguous_default(tmp_path):
+    config = tmp_path / "config.yaml"
+    config.write_text("server:\n  host: 127.0.0.1\n  port: 8420\n", encoding="utf-8")
+    args = _build_parser().parse_args(
+        [
+            "--config",
+            str(config),
+            "--python-base-url",
+            "http://127.0.0.1:18420",
+            "--run-final-backup-gate",
+        ]
+    )
+
+    try:
+        _final_backup_python_health_url(args)
+    except ValueError as exc:
+        assert "final backup health URL is ambiguous" in str(exc)
+        assert "http://127.0.0.1:18420/health" in str(exc)
+        assert "http://127.0.0.1:8420/health" in str(exc)
+    else:
+        raise AssertionError("expected ambiguous final backup health URL to block")
+
+
+def test_mvp_rehearsal_final_backup_gate_records_artifacts(tmp_path, monkeypatch):
+    config = tmp_path / "config.yaml"
+    config.write_text("server:\n  port: 18420\n", encoding="utf-8")
+
+    def fake_final_backup_report(**kwargs):
+        output_dir = kwargs["output_dir"]
+        ledger_path = kwargs["ledger_path"]
+        assert kwargs["execute"] is True
+        assert kwargs["record_ledger"] is True
+        assert kwargs["python_health_url"] == "http://127.0.0.1:9/health"
+        assert kwargs["stopped_hold_seconds"] == 0.0
+        assert kwargs["stopped_probe_count"] == 2
+        output_dir.mkdir(parents=True)
+        manifest_path = output_dir / "state-backup-manifest.json"
+        manifest_path.write_text('{"status":"copied"}\n', encoding="utf-8")
+        ledger_path.write_text('{"kind":"final_backup"}\n', encoding="utf-8")
+        return {
+            "status": "copied",
+            "python_origin": {"stopped": True},
+            "summary": {"backup_status": "copied", "copied": 3},
+            "ledger": {"written": True},
+            "blockers": [],
+        }
+
+    monkeypatch.setattr(
+        "scripts.rust_migration.mvp_rehearsal.build_final_backup_report",
+        fake_final_backup_report,
+    )
+    args = _build_parser().parse_args(
+        [
+            "--config",
+            str(config),
+            "--run-final-backup-gate",
+            "--final-backup-python-health-url",
+            "http://127.0.0.1:9/health",
+            "--final-backup-stopped-hold-seconds",
+            "0",
+            "--final-backup-stopped-probe-count",
+            "2",
+        ]
+    )
+
+    step = _run_final_backup_gate(args, tmp_path / "rehearsal")
+
+    assert step["status"] == "passed"
+    assert step["summary"]["final_backup_status"] == "copied"
+    assert step["summary"]["python_origin_stopped"] is True
+    assert step["summary"]["ledger_written"] is True
+    assert set(step["artifacts"]) == {"report", "backup_manifest", "ledger"}
+    for path in step["artifacts"].values():
+        assert Path(path).exists()
+
+
+def test_mvp_rehearsal_final_backup_gate_blocks_without_missing_artifacts(
+    tmp_path, monkeypatch
+):
+    config = tmp_path / "config.yaml"
+    config.write_text("server:\n  port: 18420\n", encoding="utf-8")
+
+    def fake_final_backup_report(**_kwargs):
+        return {
+            "status": "blocked",
+            "python_origin": {"stopped": False},
+            "summary": {"backup_status": None, "copied": 0},
+            "ledger": {"written": False},
+            "blockers": [
+                {
+                    "store_id": "python_origin",
+                    "kind": "python_origin_reachable",
+                    "detail": "Python origin answered with HTTP 200",
+                }
+            ],
+        }
+
+    monkeypatch.setattr(
+        "scripts.rust_migration.mvp_rehearsal.build_final_backup_report",
+        fake_final_backup_report,
+    )
+    args = _build_parser().parse_args(
+        [
+            "--config",
+            str(config),
+            "--python-base-url",
+            "http://127.0.0.1:18420",
+            "--run-final-backup-gate",
+        ]
+    )
+
+    step = _run_final_backup_gate(args, tmp_path / "rehearsal")
+
+    assert step["status"] == "failed"
+    assert step["summary"]["final_backup_status"] == "blocked"
+    assert step["blockers"] == [
+        {
+            "substep": "python_origin",
+            "kind": "python_origin_reachable",
+            "detail": "Python origin answered with HTTP 200",
+        }
+    ]
+    assert set(step["artifacts"]) == {"report"}
+    assert Path(step["artifacts"]["report"]).exists()
 
 
 def test_manifest_has_json_shape_assertions_for_core_http_surfaces():


### PR DESCRIPTION
## Summary

- add an explicit `--run-final-backup-gate` MVP rehearsal option
- run stopped-origin final backup evidence after the existing state ownership gate when opted in
- record final-backup report, manifest, and ledger artifacts only when they exist
- document the cutover rehearsal command and keep normal sidecar rehearsals non-destructive

## Validation

- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py -q`
- `./venv/bin/python -m py_compile scripts/rust_migration/mvp_rehearsal.py`
- `git diff --check`

Fixes #993