### PR TITLE
Add Cloudflare Access mobile smoke evidence runner

### DIFF
--- a/scripts/rust_migration/README.md
+++ b/scripts/rust_migration/README.md
@@ -448,6 +448,39 @@ attach-ticket minting, request-status prompts, bug-report submission, and device
 revocation/list changes should be covered by disposable fixture or smoke
 rehearsal gates, not by executing Rust against live state from shadow mode.
 
+## Cloudflare Access Smoke Evidence
+
+After the Cloudflare Access apps and tunnel policies are configured, collect
+read-only origin-gate evidence with:
+
+```bash
+python -m scripts.rust_migration.cloudflare_access_smoke \
+  --base-url http://127.0.0.1:8421 \
+  --mobile-host sm-app.rajeshgo.li \
+  --browser-host sm.rajeshgo.li \
+  --mobile-access-jwt-env CF_MOBILE_ACCESS_JWT \
+  --browser-access-jwt-env CF_BROWSER_ACCESS_JWT \
+  --public-edge-secret-env SM_PUBLIC_EDGE_SECRET \
+  --bearer-token-env SM_DEVICE_BEARER_TOKEN \
+  --output /tmp/sm-cloudflare-access-smoke.json \
+  --fail-on-blockers
+```
+
+Sensitive Cloudflare Access, public-edge, SM bearer, and cookie values should be
+provided through `--*-env` or `--*-file` options so they do not appear in process
+arguments or shell history. File inputs strip one trailing newline.
+
+The smoke runner does not configure Cloudflare and does not perform mutating
+native app flows by default. It records missing/provided Access proof behavior,
+mobile bootstrap, app artifact metadata, the mobile Access-to-SM-auth boundary,
+and optional authenticated native session reads when an SM bearer token or
+cookie is supplied. Mobile success probes reject redirects/login HTML by
+requiring the expected JSON response shape. Browser `/auth/session` Access
+denial is enforced by Cloudflare at the edge rather than by the Rust origin, so
+the loopback smoke report records those checks as skipped edge-only evidence.
+Use the JSON output as operator evidence alongside
+`specs/762_stage5_artifacts/cloudflare_access_cutover_evidence.md`.
+
 ## MVP Sidecar Rehearsal
 
 The MVP rehearsal gate starts Rust as a sidecar, keeps Python authoritative, and

--- a/scripts/rust_migration/cloudflare_access_smoke.py
+++ b/scripts/rust_migration/cloudflare_access_smoke.py
@@ -1,0 +1,660 @@
+"""Run read-only Cloudflare Access/mobile cutover smoke checks.
+
+The script is an evidence collector, not a Cloudflare configurator. Operators
+provide the hostnames and Access assertions from the deployed policy; the script
+records which route-class checks passed, skipped, or blocked.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import hmac
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_BASE_URL = "http://127.0.0.1:8421"
+DEFAULT_APP_NAME = "session-manager-android"
+
+
+def build_smoke_report(
+    *,
+    base_url: str = DEFAULT_BASE_URL,
+    mobile_host: str | None = None,
+    browser_host: str | None = None,
+    mobile_access_jwt: str | None = None,
+    browser_access_jwt: str | None = None,
+    public_edge_secret: str | None = None,
+    bearer_token: str | None = None,
+    cookie: str | None = None,
+    session_id: str | None = None,
+    app_name: str = DEFAULT_APP_NAME,
+    timeout_seconds: float = 5.0,
+    urlopen=None,
+) -> dict[str, Any]:
+    if timeout_seconds <= 0:
+        raise ValueError("--timeout must be positive")
+    base_url = base_url.rstrip("/")
+    checks = [
+        _request_check(
+            check_id="mobile.bootstrap_requires_access",
+            description="mobile host denies bootstrap without Access assertion",
+            base_url=base_url,
+            method="GET",
+            path="/client/bootstrap",
+            host=mobile_host,
+            public_edge_secret=public_edge_secret,
+            expected_status=403,
+            expected_detail="Cloudflare Access mobile app assertion is required",
+            timeout_seconds=timeout_seconds,
+            urlopen=urlopen,
+            require_public_edge_secret=True,
+        ),
+        _request_check(
+            check_id="mobile.bootstrap_with_access",
+            description="mobile host accepts enrolled Access assertion for bootstrap",
+            base_url=base_url,
+            method="GET",
+            path="/client/bootstrap",
+            host=mobile_host,
+            access_jwt=mobile_access_jwt,
+            public_edge_secret=public_edge_secret,
+            expected_status=200,
+            expected_json_type=dict,
+            expected_json_keys=("auth",),
+            timeout_seconds=timeout_seconds,
+            urlopen=urlopen,
+            require_public_edge_secret=True,
+        ),
+        _request_check(
+            check_id="mobile.bootstrap_requires_public_edge",
+            description="mobile host denies bootstrap without public-edge proof",
+            base_url=base_url,
+            method="GET",
+            path="/client/bootstrap",
+            host=mobile_host,
+            access_jwt=mobile_access_jwt,
+            public_edge_secret=public_edge_secret,
+            expected_status=403,
+            expected_detail="Public edge assertion is required",
+            timeout_seconds=timeout_seconds,
+            urlopen=urlopen,
+            skip_without_access=True,
+            require_public_edge_secret=True,
+            send_public_edge_proof=False,
+        ),
+        _request_check(
+            check_id="mobile.sessions_require_sm_auth",
+            description="mobile host reaches SM auth boundary after Access proof",
+            base_url=base_url,
+            method="GET",
+            path="/client/sessions",
+            host=mobile_host,
+            access_jwt=mobile_access_jwt,
+            public_edge_secret=public_edge_secret,
+            expected_status=401,
+            expected_detail="Authentication required",
+            timeout_seconds=timeout_seconds,
+            urlopen=urlopen,
+            skip_without_access=True,
+            require_public_edge_secret=True,
+        ),
+        _request_check(
+            check_id="mobile.sessions_with_sm_auth",
+            description="mobile host returns native session list with Access and SM auth",
+            base_url=base_url,
+            method="GET",
+            path="/client/sessions",
+            host=mobile_host,
+            access_jwt=mobile_access_jwt,
+            public_edge_secret=public_edge_secret,
+            bearer_token=bearer_token,
+            cookie=cookie,
+            expected_status=200,
+            expected_json_type=dict,
+            expected_json_keys=("sessions",),
+            timeout_seconds=timeout_seconds,
+            urlopen=urlopen,
+            skip_without_any_auth=True,
+            skip_without_access=True,
+            require_public_edge_secret=True,
+        ),
+        _request_check(
+            check_id="mobile.app_artifact_metadata",
+            description="mobile host serves app artifact metadata with Access proof",
+            base_url=base_url,
+            method="GET",
+            path=f"/apps/{app_name}/meta.json",
+            host=mobile_host,
+            access_jwt=mobile_access_jwt,
+            public_edge_secret=public_edge_secret,
+            bearer_token=bearer_token,
+            cookie=cookie,
+            expected_status=200,
+            expected_json_type=dict,
+            expected_json_keys=("artifact_hash",),
+            timeout_seconds=timeout_seconds,
+            urlopen=urlopen,
+            skip_without_access=True,
+            skip_without_any_auth=True,
+            require_public_edge_secret=True,
+        ),
+        _browser_edge_only_check(
+            check_id="browser.auth_session_requires_access",
+            description="browser host denies auth-session without browser Access assertion",
+            host=browser_host,
+        ),
+        _browser_edge_only_check(
+            check_id="browser.auth_session_with_access",
+            description="browser host reaches SM auth-session after browser Access proof",
+            host=browser_host,
+            access_jwt=browser_access_jwt,
+        ),
+    ]
+    if session_id:
+        checks.append(
+            _request_check(
+                check_id="mobile.session_detail_with_sm_auth",
+                description="mobile host returns native session detail with Access and SM auth",
+                base_url=base_url,
+                method="GET",
+                path=f"/client/sessions/{session_id}",
+                host=mobile_host,
+                access_jwt=mobile_access_jwt,
+                public_edge_secret=public_edge_secret,
+                bearer_token=bearer_token,
+                cookie=cookie,
+                expected_status=200,
+                expected_json_type=dict,
+                expected_json_keys=("id",),
+                timeout_seconds=timeout_seconds,
+                urlopen=urlopen,
+                skip_without_any_auth=True,
+                skip_without_access=True,
+                require_public_edge_secret=True,
+            )
+        )
+
+    blockers = []
+    for check in checks:
+        if check["status"] == "blocked":
+            blockers.append(
+                {
+                    "check_id": check["id"],
+                    "kind": check["blocker_kind"],
+                    "detail": check["detail"],
+                }
+            )
+        elif check["status"] == "skipped" and check.get("required"):
+            blockers.append(
+                {
+                    "check_id": check["id"],
+                    "kind": "required_check_skipped",
+                    "detail": check["detail"],
+                }
+            )
+    return {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "inputs": {
+            "base_url": base_url,
+            "mobile_host": mobile_host,
+            "browser_host": browser_host,
+            "mobile_access_jwt_supplied": bool(mobile_access_jwt),
+            "browser_access_jwt_supplied": bool(browser_access_jwt),
+            "public_edge_secret_supplied": bool(public_edge_secret),
+            "sm_auth_supplied": bool(bearer_token or cookie),
+            "session_id_supplied": bool(session_id),
+            "app_name": app_name,
+        },
+        "status": "blocked" if blockers else "passed",
+        "summary": {
+            "passed": sum(1 for check in checks if check["status"] == "passed"),
+            "blocked": len(blockers),
+            "skipped": sum(1 for check in checks if check["status"] == "skipped"),
+        },
+        "checks": checks,
+        "blockers": blockers,
+    }
+
+
+def _request_check(
+    *,
+    check_id: str,
+    description: str,
+    base_url: str,
+    method: str,
+    path: str,
+    host: str | None,
+    expected_status: int,
+    timeout_seconds: float,
+    urlopen,
+    access_jwt: str | None = None,
+    public_edge_secret: str | None = None,
+    bearer_token: str | None = None,
+    cookie: str | None = None,
+    expected_detail: str | None = None,
+    expected_json_type: type | None = None,
+    expected_json_keys: tuple[str, ...] = (),
+    skip_without_access: bool = False,
+    skip_without_any_auth: bool = False,
+    require_public_edge_secret: bool = False,
+    send_public_edge_proof: bool = True,
+    required: bool = True,
+) -> dict[str, Any]:
+    if not host:
+        return _skipped(check_id, description, "host was not supplied", required=required)
+    if require_public_edge_secret and not public_edge_secret:
+        return _skipped(
+            check_id,
+            description,
+            "public edge secret was not supplied",
+            required=required,
+        )
+    if access_jwt is None and "with_access" in check_id:
+        return _skipped(
+            check_id,
+            description,
+            "Access assertion was not supplied",
+            required=required,
+        )
+    if access_jwt is None and skip_without_access:
+        return _skipped(
+            check_id,
+            description,
+            "Access assertion was not supplied",
+            required=required,
+        )
+    if skip_without_any_auth and not (bearer_token or cookie):
+        return _skipped(
+            check_id,
+            description,
+            "SM bearer token or cookie was not supplied",
+            required=required,
+        )
+
+    headers = {"Host": host}
+    if access_jwt:
+        headers["Cf-Access-Jwt-Assertion"] = access_jwt
+    if bearer_token:
+        headers["Authorization"] = f"Bearer {bearer_token}"
+    if cookie:
+        headers["Cookie"] = cookie
+    if public_edge_secret and send_public_edge_proof:
+        headers.update(_public_edge_headers(public_edge_secret, method, path))
+
+    request = urllib.request.Request(
+        base_url + path,
+        method=method,
+        headers=headers,
+    )
+    request_urlopen = urlopen or _urlopen_no_redirect
+    try:
+        with request_urlopen(request, timeout=timeout_seconds) as response:
+            status = response.getcode()
+            body = response.read()
+            content_type = response.headers.get("content-type")
+    except urllib.error.HTTPError as exc:
+        status = exc.code
+        body = exc.read()
+        content_type = exc.headers.get("content-type")
+    except Exception as exc:  # noqa: BLE001 - evidence report should capture probe failures.
+        return {
+            "id": check_id,
+            "description": description,
+            "status": "blocked",
+            "blocker_kind": "request_failed",
+            "detail": f"{type(exc).__name__}: {exc}",
+            "method": method,
+            "path": path,
+            "expected_status": expected_status,
+            "actual_status": None,
+            "response": None,
+        }
+
+    actual_json = _parse_json_body(body)
+    include_response_body = not (bearer_token or cookie)
+    response = _response_summary(
+        body,
+        content_type,
+        parsed_json=actual_json,
+        include_json_body=include_response_body,
+    )
+    if status != expected_status:
+        return _blocked(
+            check_id,
+            description,
+            "unexpected_status",
+            f"expected HTTP {expected_status}, got HTTP {status}",
+            method=method,
+            path=path,
+            expected_status=expected_status,
+            actual_status=status,
+            response=response,
+            )
+    if expected_detail is not None:
+        actual_detail = actual_json.get("detail") if isinstance(actual_json, dict) else None
+        if actual_detail != expected_detail:
+            return _blocked(
+                check_id,
+                description,
+                "unexpected_detail",
+                f"expected detail {expected_detail!r}, got {actual_detail!r}",
+                method=method,
+                path=path,
+                expected_status=expected_status,
+                actual_status=status,
+                response=response,
+            )
+    if expected_json_type is not None:
+        if not isinstance(actual_json, expected_json_type):
+            return _blocked(
+                check_id,
+                description,
+                "unexpected_json",
+                f"expected JSON {expected_json_type.__name__}, got non-matching response",
+                method=method,
+                path=path,
+                expected_status=expected_status,
+                actual_status=status,
+                response=response,
+            )
+        if isinstance(actual_json, dict):
+            missing_keys = [key for key in expected_json_keys if key not in actual_json]
+            if missing_keys:
+                return _blocked(
+                    check_id,
+                    description,
+                    "unexpected_json",
+                    f"missing expected JSON keys: {', '.join(missing_keys)}",
+                    method=method,
+                    path=path,
+                    expected_status=expected_status,
+                    actual_status=status,
+                    response=response,
+                )
+    return {
+        "id": check_id,
+        "description": description,
+        "status": "passed",
+        "method": method,
+        "path": path,
+        "expected_status": expected_status,
+        "actual_status": status,
+        "response": response,
+    }
+
+
+def _browser_edge_only_check(
+    *,
+    check_id: str,
+    description: str,
+    host: str | None,
+    access_jwt: str | None = None,
+) -> dict[str, Any]:
+    if not host:
+        return _skipped(check_id, description, "host was not supplied")
+    if access_jwt is None and "with_access" in check_id:
+        return _skipped(check_id, description, "Access assertion was not supplied")
+    return _skipped(
+        check_id,
+        description,
+        "browser Cloudflare Access is enforced at the edge, not by the Rust origin",
+    )
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):  # noqa: ANN001
+        return None
+
+
+_NO_REDIRECT_OPENER = urllib.request.build_opener(_NoRedirectHandler)
+
+
+def _urlopen_no_redirect(request: urllib.request.Request, *, timeout: float):
+    return _NO_REDIRECT_OPENER.open(request, timeout=timeout)
+
+
+def _public_edge_headers(secret: str, method: str, path: str) -> dict[str, str]:
+    timestamp = str(time.time())
+    nonce = uuid.uuid4().hex
+    message = "\n".join(
+        [
+            "SM-PUBLIC-EDGE-V1",
+            method.upper(),
+            path,
+            timestamp,
+            nonce,
+        ]
+    )
+    signature = hmac.new(secret.encode(), message.encode(), hashlib.sha256).digest()
+    return {
+        "X-SM-Edge-Timestamp": timestamp,
+        "X-SM-Edge-Nonce": nonce,
+        "X-SM-Edge-Signature": base64.b64encode(signature).decode("ascii"),
+    }
+
+
+def _parse_json_body(body: bytes) -> Any:
+    try:
+        return json.loads(body.decode("utf-8"))
+    except Exception:  # noqa: BLE001 - body may be non-JSON.
+        return None
+
+
+def _response_summary(
+    body: bytes,
+    content_type: str | None,
+    *,
+    parsed_json: Any,
+    include_json_body: bool,
+) -> dict[str, Any]:
+    body_sha256 = hashlib.sha256(body).hexdigest()
+    summary: dict[str, Any] = {
+        "content_type": content_type,
+        "body_sha256": body_sha256,
+        "body_bytes": len(body),
+    }
+    if parsed_json is not None:
+        if include_json_body:
+            summary["json"] = parsed_json
+        else:
+            summary["json_redacted"] = True
+            summary["json_type"] = type(parsed_json).__name__
+            if isinstance(parsed_json, dict):
+                summary["json_keys"] = sorted(str(key) for key in parsed_json.keys())
+            elif isinstance(parsed_json, list):
+                summary["json_length"] = len(parsed_json)
+    elif include_json_body:
+        summary["text_preview"] = body[:200].decode("utf-8", errors="replace")
+    else:
+        summary["body_redacted"] = True
+    return summary
+
+
+def _skipped(
+    check_id: str,
+    description: str,
+    detail: str,
+    *,
+    required: bool = False,
+) -> dict[str, Any]:
+    return {
+        "id": check_id,
+        "description": description,
+        "status": "skipped",
+        "detail": detail,
+        "required": required,
+    }
+
+
+def _blocked(
+    check_id: str,
+    description: str,
+    kind: str,
+    detail: str,
+    *,
+    method: str,
+    path: str,
+    expected_status: int,
+    actual_status: int | None,
+    response: dict[str, Any] | None,
+) -> dict[str, Any]:
+    return {
+        "id": check_id,
+        "description": description,
+        "status": "blocked",
+        "blocker_kind": kind,
+        "detail": detail,
+        "method": method,
+        "path": path,
+        "expected_status": expected_status,
+        "actual_status": actual_status,
+        "response": response,
+    }
+
+
+def render_text_report(report: dict[str, Any]) -> str:
+    lines = [
+        "Cloudflare Access mobile smoke report",
+        f"status: {report['status']}",
+        f"passed: {report['summary']['passed']}",
+        f"blocked: {report['summary']['blocked']}",
+        f"skipped: {report['summary']['skipped']}",
+    ]
+    if report["blockers"]:
+        lines.extend(["", "Blockers:"])
+        for blocker in report["blockers"]:
+            lines.append(f"  {blocker['check_id']}: {blocker['kind']} - {blocker['detail']}")
+    return "\n".join(lines)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    parser.add_argument("--mobile-host", default=None)
+    parser.add_argument("--browser-host", default=None)
+    _add_secret_source_args(
+        parser,
+        "mobile-access-jwt",
+        "Cloudflare Access JWT for the mobile app host",
+    )
+    _add_secret_source_args(
+        parser,
+        "browser-access-jwt",
+        "Cloudflare Access JWT for the browser host",
+    )
+    _add_secret_source_args(
+        parser,
+        "public-edge-secret",
+        "SM public-edge HMAC secret",
+    )
+    _add_secret_source_args(parser, "bearer-token", "SM device bearer token")
+    _add_secret_source_args(parser, "cookie", "SM browser cookie header")
+    parser.add_argument("--session-id", default=None)
+    parser.add_argument("--app-name", default=DEFAULT_APP_NAME)
+    parser.add_argument("--timeout", type=float, default=5.0)
+    parser.add_argument("--output", type=Path, default=None)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--fail-on-blockers", action="store_true")
+    return parser
+
+
+def _add_secret_source_args(parser: argparse.ArgumentParser, name: str, help_text: str) -> None:
+    parser.add_argument(
+        f"--{name}-env",
+        default=None,
+        metavar="ENV",
+        help=f"read {help_text} from ENV",
+    )
+    parser.add_argument(
+        f"--{name}-file",
+        default=None,
+        metavar="PATH",
+        help=f"read {help_text} from PATH; trailing newline is stripped",
+    )
+
+
+def _resolve_secret(
+    *,
+    parser: argparse.ArgumentParser,
+    label: str,
+    env_name: str | None,
+    file_path: str | None,
+) -> str | None:
+    if env_name and file_path:
+        parser.error(f"{label}: pass only one of --{label}-env or --{label}-file")
+    if env_name:
+        value = os.environ.get(env_name)
+        if value is None:
+            parser.error(f"{label}: environment variable {env_name!r} is not set")
+        return value
+    if file_path:
+        return Path(file_path).read_text(encoding="utf-8").rstrip("\n")
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    report = build_smoke_report(
+        base_url=args.base_url,
+        mobile_host=args.mobile_host,
+        browser_host=args.browser_host,
+        mobile_access_jwt=_resolve_secret(
+            parser=parser,
+            label="mobile-access-jwt",
+            env_name=args.mobile_access_jwt_env,
+            file_path=args.mobile_access_jwt_file,
+        ),
+        browser_access_jwt=_resolve_secret(
+            parser=parser,
+            label="browser-access-jwt",
+            env_name=args.browser_access_jwt_env,
+            file_path=args.browser_access_jwt_file,
+        ),
+        public_edge_secret=_resolve_secret(
+            parser=parser,
+            label="public-edge-secret",
+            env_name=args.public_edge_secret_env,
+            file_path=args.public_edge_secret_file,
+        ),
+        bearer_token=_resolve_secret(
+            parser=parser,
+            label="bearer-token",
+            env_name=args.bearer_token_env,
+            file_path=args.bearer_token_file,
+        ),
+        cookie=_resolve_secret(
+            parser=parser,
+            label="cookie",
+            env_name=args.cookie_env,
+            file_path=args.cookie_file,
+        ),
+        session_id=args.session_id,
+        app_name=args.app_name,
+        timeout_seconds=args.timeout,
+    )
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_text_report(report))
+    if args.fail_on_blockers and report["blockers"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_rust_cloudflare_access_smoke.py
+++ b/tests/unit/test_rust_cloudflare_access_smoke.py
@@ -1,0 +1,564 @@
+import json
+import urllib.error
+
+from scripts.rust_migration.cloudflare_access_smoke import (
+    build_smoke_report,
+    main,
+)
+
+
+class FakeResponse:
+    def __init__(self, status, body, headers=None):
+        self.status = status
+        self._body = body
+        self.headers = headers or {"content-type": "application/json"}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def getcode(self):
+        return self.status
+
+    def read(self):
+        return self._body
+
+
+def _http_error(url, status, payload):
+    body = json.dumps(payload).encode("utf-8")
+    return urllib.error.HTTPError(
+        url,
+        status,
+        "error",
+        {"content-type": "application/json"},
+        None,
+    ).__class__(
+        url,
+        status,
+        "error",
+        {"content-type": "application/json"},
+        _BytesHandle(body),
+    )
+
+
+class _BytesHandle:
+    def __init__(self, body):
+        self._body = body
+
+    def read(self):
+        return self._body
+
+    def close(self):
+        pass
+
+
+def test_cloudflare_access_smoke_blocks_when_required_inputs_are_missing():
+    report = build_smoke_report()
+
+    assert report["status"] == "blocked"
+    assert report["summary"]["skipped"] == len(report["checks"])
+    assert [blocker["check_id"] for blocker in report["blockers"]] == [
+        "mobile.bootstrap_requires_access",
+        "mobile.bootstrap_with_access",
+        "mobile.bootstrap_requires_public_edge",
+        "mobile.sessions_require_sm_auth",
+        "mobile.sessions_with_sm_auth",
+        "mobile.app_artifact_metadata",
+    ]
+    assert {blocker["kind"] for blocker in report["blockers"]} == {
+        "required_check_skipped"
+    }
+    assert all(check["status"] == "skipped" for check in report["checks"])
+
+
+def test_cloudflare_access_smoke_blocks_when_access_assertion_is_missing():
+    def fake_urlopen(request, timeout):
+        path = request.full_url.removeprefix("http://127.0.0.1:8421")
+        if path == "/client/bootstrap":
+            raise _http_error(
+                request.full_url,
+                403,
+                {"detail": "Cloudflare Access mobile app assertion is required"},
+            )
+        raise AssertionError(f"unexpected request path {path}")
+
+    report = build_smoke_report(
+        mobile_host="sm-app.example.com",
+        public_edge_secret="edge-secret",
+        timeout_seconds=2.5,
+        urlopen=fake_urlopen,
+    )
+
+    assert report["status"] == "blocked"
+    assert [blocker["check_id"] for blocker in report["blockers"]] == [
+        "mobile.bootstrap_with_access",
+        "mobile.bootstrap_requires_public_edge",
+        "mobile.sessions_require_sm_auth",
+        "mobile.sessions_with_sm_auth",
+        "mobile.app_artifact_metadata",
+    ]
+    assert {blocker["kind"] for blocker in report["blockers"]} == {
+        "required_check_skipped"
+    }
+
+
+def test_cloudflare_access_smoke_blocks_when_public_edge_secret_is_missing():
+    def fake_urlopen(request, timeout):
+        raise AssertionError(f"unexpected request to {request.full_url}")
+
+    report = build_smoke_report(
+        mobile_host="sm-app.example.com",
+        mobile_access_jwt="mobile.jwt",
+        bearer_token="smat_token",
+        timeout_seconds=2.5,
+        urlopen=fake_urlopen,
+    )
+
+    assert report["status"] == "blocked"
+    assert [blocker["check_id"] for blocker in report["blockers"]] == [
+        "mobile.bootstrap_requires_access",
+        "mobile.bootstrap_with_access",
+        "mobile.bootstrap_requires_public_edge",
+        "mobile.sessions_require_sm_auth",
+        "mobile.sessions_with_sm_auth",
+        "mobile.app_artifact_metadata",
+    ]
+    assert {blocker["kind"] for blocker in report["blockers"]} == {
+        "required_check_skipped"
+    }
+    assert {
+        check["detail"]
+        for check in report["checks"]
+        if check["id"].startswith("mobile.")
+    } == {"public edge secret was not supplied"}
+
+
+def test_cloudflare_access_smoke_records_mobile_boundary_and_headers():
+    seen = []
+
+    def fake_urlopen(request, timeout):
+        seen.append((request, timeout))
+        path = request.full_url.removeprefix("http://127.0.0.1:8421")
+        if path == "/client/bootstrap" and not request.get_header(
+            "Cf-access-jwt-assertion"
+        ):
+            raise _http_error(
+                request.full_url,
+                403,
+                {"detail": "Cloudflare Access mobile app assertion is required"},
+            )
+        if path == "/client/bootstrap" and not request.get_header(
+            "X-sm-edge-signature"
+        ):
+            raise _http_error(
+                request.full_url,
+                403,
+                {"detail": "Public edge assertion is required"},
+            )
+        if path == "/client/bootstrap":
+            return FakeResponse(200, b'{"auth":{}}')
+        if path == "/client/sessions" and not request.get_header("Authorization"):
+            raise _http_error(
+                request.full_url,
+                401,
+                {"detail": "Authentication required"},
+            )
+        if path == "/client/sessions":
+            return FakeResponse(200, b'{"sessions":[]}')
+        if path == "/apps/session-manager-android/meta.json" and request.get_header(
+            "Authorization"
+        ):
+            return FakeResponse(200, b'{"artifact_hash":"deadbeef"}')
+        raise AssertionError(f"unexpected request path {path}")
+
+    report = build_smoke_report(
+        mobile_host="sm-app.example.com",
+        mobile_access_jwt="mobile.jwt",
+        public_edge_secret="edge-secret",
+        bearer_token="smat_token",
+        timeout_seconds=2.5,
+        urlopen=fake_urlopen,
+    )
+
+    assert report["status"] == "passed"
+    assert report["blockers"] == []
+    assert report["summary"]["blocked"] == 0
+    by_id = {check["id"]: check for check in report["checks"]}
+    assert by_id["mobile.bootstrap_requires_access"]["status"] == "passed"
+    assert by_id["mobile.bootstrap_with_access"]["status"] == "passed"
+    assert by_id["mobile.bootstrap_requires_public_edge"]["status"] == "passed"
+    assert by_id["mobile.sessions_require_sm_auth"]["status"] == "passed"
+    assert by_id["mobile.sessions_with_sm_auth"]["status"] == "passed"
+    assert by_id["mobile.app_artifact_metadata"]["status"] == "passed"
+    sessions_response = by_id["mobile.sessions_with_sm_auth"]["response"]
+    assert sessions_response["json_redacted"] is True
+    assert sessions_response["json_keys"] == ["sessions"]
+    assert "json" not in sessions_response
+    metadata_response = by_id["mobile.app_artifact_metadata"]["response"]
+    assert metadata_response["json_redacted"] is True
+    assert metadata_response["json_keys"] == ["artifact_hash"]
+    assert "json" not in metadata_response
+
+    bootstrap_with_access = seen[1][0]
+    assert bootstrap_with_access.get_header("Host") == "sm-app.example.com"
+    assert bootstrap_with_access.get_header("Cf-access-jwt-assertion") == "mobile.jwt"
+    assert bootstrap_with_access.get_header("X-sm-edge-timestamp")
+    assert bootstrap_with_access.get_header("X-sm-edge-nonce")
+    assert bootstrap_with_access.get_header("X-sm-edge-signature")
+    sessions_with_auth = [
+        request
+        for request, _timeout in seen
+        if request.full_url.endswith("/client/sessions")
+        and request.get_header("Authorization")
+    ][0]
+    assert sessions_with_auth.get_header("Authorization") == "Bearer smat_token"
+    metadata_with_auth = [
+        request
+        for request, _timeout in seen
+        if request.full_url.endswith("/apps/session-manager-android/meta.json")
+    ][0]
+    assert metadata_with_auth.get_header("Authorization") == "Bearer smat_token"
+    assert {timeout for _request, timeout in seen} == {2.5}
+
+
+def test_cloudflare_access_smoke_blocks_unexpected_status():
+    def fake_urlopen(request, timeout=None):
+        path = request.full_url.removeprefix("http://127.0.0.1:8421")
+        if path == "/client/bootstrap" and not request.get_header(
+            "Cf-access-jwt-assertion"
+        ):
+            return FakeResponse(200, b'{"auth":{}}')
+        if path == "/client/bootstrap" and not request.get_header(
+            "X-sm-edge-signature"
+        ):
+            raise _http_error(
+                request.full_url,
+                403,
+                {"detail": "Public edge assertion is required"},
+            )
+        if path == "/client/bootstrap":
+            return FakeResponse(200, b'{"auth":{}}')
+        if path == "/client/sessions" and not request.get_header("Authorization"):
+            raise _http_error(
+                request.full_url,
+                401,
+                {"detail": "Authentication required"},
+            )
+        if path == "/client/sessions":
+            return FakeResponse(200, b'{"sessions":[]}')
+        if path == "/apps/session-manager-android/meta.json":
+            return FakeResponse(200, b'{"artifact_hash":"deadbeef"}')
+        raise AssertionError(f"unexpected request path {path}")
+
+    report = build_smoke_report(
+        mobile_host="sm-app.example.com",
+        mobile_access_jwt="mobile.jwt",
+        public_edge_secret="edge-secret",
+        bearer_token="smat_token",
+        timeout_seconds=1.0,
+        urlopen=fake_urlopen,
+    )
+
+    assert report["status"] == "blocked"
+    assert report["blockers"] == [
+        {
+            "check_id": "mobile.bootstrap_requires_access",
+            "kind": "unexpected_status",
+            "detail": "expected HTTP 403, got HTTP 200",
+        }
+    ]
+
+
+def test_cloudflare_access_smoke_blocks_redirects():
+    def fake_urlopen(request, timeout=None):
+        path = request.full_url.removeprefix("http://127.0.0.1:8421")
+        if path == "/client/bootstrap" and not request.get_header(
+            "Cf-access-jwt-assertion"
+        ):
+            raise urllib.error.HTTPError(
+                request.full_url,
+                302,
+                "redirect",
+                {"content-type": "text/html", "location": "https://login.example.com"},
+                _BytesHandle(b"<html>login</html>"),
+            )
+        if path == "/client/bootstrap" and not request.get_header(
+            "X-sm-edge-signature"
+        ):
+            raise _http_error(
+                request.full_url,
+                403,
+                {"detail": "Public edge assertion is required"},
+            )
+        if path == "/client/bootstrap":
+            return FakeResponse(200, b'{"auth":{}}')
+        if path == "/client/sessions" and not request.get_header("Authorization"):
+            raise _http_error(
+                request.full_url,
+                401,
+                {"detail": "Authentication required"},
+            )
+        if path == "/client/sessions":
+            return FakeResponse(200, b'{"sessions":[]}')
+        if path == "/apps/session-manager-android/meta.json":
+            return FakeResponse(200, b'{"artifact_hash":"deadbeef"}')
+        raise AssertionError(f"unexpected request path {path}")
+
+    report = build_smoke_report(
+        mobile_host="sm-app.example.com",
+        mobile_access_jwt="mobile.jwt",
+        public_edge_secret="edge-secret",
+        bearer_token="smat_token",
+        timeout_seconds=1.0,
+        urlopen=fake_urlopen,
+    )
+
+    assert report["status"] == "blocked"
+    assert report["blockers"] == [
+        {
+            "check_id": "mobile.bootstrap_requires_access",
+            "kind": "unexpected_status",
+            "detail": "expected HTTP 403, got HTTP 302",
+        }
+    ]
+
+
+def test_cloudflare_access_smoke_blocks_bootstrap_without_contract_keys():
+    def fake_urlopen(request, timeout=None):
+        path = request.full_url.removeprefix("http://127.0.0.1:8421")
+        if path == "/client/bootstrap" and not request.get_header(
+            "Cf-access-jwt-assertion"
+        ):
+            raise _http_error(
+                request.full_url,
+                403,
+                {"detail": "Cloudflare Access mobile app assertion is required"},
+            )
+        if path == "/client/bootstrap" and not request.get_header(
+            "X-sm-edge-signature"
+        ):
+            raise _http_error(
+                request.full_url,
+                403,
+                {"detail": "Public edge assertion is required"},
+            )
+        if path == "/client/bootstrap":
+            return FakeResponse(200, b'{"detail":"wrong service"}')
+        if path == "/client/sessions" and not request.get_header("Authorization"):
+            raise _http_error(
+                request.full_url,
+                401,
+                {"detail": "Authentication required"},
+            )
+        if path == "/client/sessions":
+            return FakeResponse(200, b'{"sessions":[]}')
+        if path == "/apps/session-manager-android/meta.json":
+            return FakeResponse(200, b'{"artifact_hash":"deadbeef"}')
+        raise AssertionError(f"unexpected request path {path}")
+
+    report = build_smoke_report(
+        mobile_host="sm-app.example.com",
+        mobile_access_jwt="mobile.jwt",
+        public_edge_secret="edge-secret",
+        bearer_token="smat_token",
+        timeout_seconds=1.0,
+        urlopen=fake_urlopen,
+    )
+
+    assert report["status"] == "blocked"
+    assert report["blockers"] == [
+        {
+            "check_id": "mobile.bootstrap_with_access",
+            "kind": "unexpected_json",
+            "detail": "missing expected JSON keys: auth",
+        }
+    ]
+
+
+def test_cloudflare_access_smoke_blocks_login_html_success_responses():
+    def fake_urlopen(request, timeout=None):
+        if request.full_url.endswith("/client/bootstrap") and not request.get_header(
+            "Cf-access-jwt-assertion"
+        ):
+            raise _http_error(
+                request.full_url,
+                403,
+                {"detail": "Cloudflare Access mobile app assertion is required"},
+            )
+        if request.full_url.endswith("/client/bootstrap") and not request.get_header(
+            "X-sm-edge-signature"
+        ):
+            raise _http_error(
+                request.full_url,
+                403,
+                {"detail": "Public edge assertion is required"},
+            )
+        if request.full_url.endswith("/client/bootstrap"):
+            return FakeResponse(
+                200,
+                b"<html>login</html>",
+                headers={"content-type": "text/html"},
+            )
+        if request.full_url.endswith("/client/sessions") and not request.get_header(
+            "Authorization"
+        ):
+            raise _http_error(
+                request.full_url,
+                401,
+                {"detail": "Authentication required"},
+            )
+        if request.full_url.endswith("/client/sessions"):
+            return FakeResponse(200, b'{"sessions":[]}')
+        if request.full_url.endswith("/apps/session-manager-android/meta.json"):
+            return FakeResponse(200, b'{"artifact_hash":"deadbeef"}')
+        raise AssertionError("unexpected request")
+
+    report = build_smoke_report(
+        mobile_host="sm-app.example.com",
+        mobile_access_jwt="mobile.jwt",
+        public_edge_secret="edge-secret",
+        bearer_token="smat_token",
+        timeout_seconds=1.0,
+        urlopen=fake_urlopen,
+    )
+
+    by_id = {check["id"]: check for check in report["checks"]}
+    assert by_id["mobile.bootstrap_requires_access"]["status"] == "passed"
+    assert by_id["mobile.bootstrap_with_access"]["status"] == "blocked"
+    assert by_id["mobile.bootstrap_with_access"]["blocker_kind"] == "unexpected_json"
+    assert report["blockers"] == [
+        {
+            "check_id": "mobile.bootstrap_with_access",
+            "kind": "unexpected_json",
+            "detail": "expected JSON dict, got non-matching response",
+        }
+    ]
+
+
+def test_cloudflare_access_smoke_skips_browser_origin_access_checks():
+    def fake_urlopen(request, timeout=None):
+        raise AssertionError(f"unexpected request to {request.full_url}")
+
+    report = build_smoke_report(
+        browser_host="sm.example.com",
+        browser_access_jwt="browser.jwt",
+        urlopen=fake_urlopen,
+    )
+
+    by_id = {check["id"]: check for check in report["checks"]}
+    assert by_id["browser.auth_session_requires_access"] == {
+        "id": "browser.auth_session_requires_access",
+        "description": "browser host denies auth-session without browser Access assertion",
+        "status": "skipped",
+        "detail": "browser Cloudflare Access is enforced at the edge, not by the Rust origin",
+        "required": False,
+    }
+    assert by_id["browser.auth_session_with_access"] == {
+        "id": "browser.auth_session_with_access",
+        "description": "browser host reaches SM auth-session after browser Access proof",
+        "status": "skipped",
+        "detail": "browser Cloudflare Access is enforced at the edge, not by the Rust origin",
+        "required": False,
+    }
+    assert report["status"] == "blocked"
+    assert all(
+        blocker["check_id"].startswith("mobile.") for blocker in report["blockers"]
+    )
+
+
+def test_cloudflare_access_smoke_cli_writes_json_and_fails_on_blockers(
+    tmp_path, monkeypatch, capsys
+):
+    def fake_report(**_kwargs):
+        return {
+            "status": "blocked",
+            "summary": {"passed": 0, "blocked": 1, "skipped": 0},
+            "checks": [],
+            "blockers": [
+                {
+                    "check_id": "mobile.bootstrap_requires_access",
+                    "kind": "unexpected_status",
+                    "detail": "expected HTTP 403, got HTTP 200",
+                }
+            ],
+        }
+
+    monkeypatch.setattr(
+        "scripts.rust_migration.cloudflare_access_smoke.build_smoke_report",
+        fake_report,
+    )
+    output = tmp_path / "cloudflare-smoke.json"
+
+    exit_code = main(["--output", str(output), "--json", "--fail-on-blockers"])
+
+    assert exit_code == 1
+    assert json.loads(output.read_text(encoding="utf-8"))["status"] == "blocked"
+    assert json.loads(capsys.readouterr().out)["status"] == "blocked"
+
+
+def test_cloudflare_access_smoke_cli_resolves_secret_env_vars(monkeypatch):
+    captured = {}
+
+    def fake_report(**kwargs):
+        captured.update(kwargs)
+        return {
+            "status": "passed",
+            "summary": {"passed": 0, "blocked": 0, "skipped": 0},
+            "checks": [],
+            "blockers": [],
+        }
+
+    monkeypatch.setenv("CF_MOBILE_ACCESS_JWT", "mobile.jwt")
+    monkeypatch.setenv("CF_BROWSER_ACCESS_JWT", "browser.jwt")
+    monkeypatch.setenv("SM_PUBLIC_EDGE_SECRET", "edge-secret")
+    monkeypatch.setenv("SM_DEVICE_BEARER_TOKEN", "smat_token")
+    monkeypatch.setattr(
+        "scripts.rust_migration.cloudflare_access_smoke.build_smoke_report",
+        fake_report,
+    )
+
+    exit_code = main(
+        [
+            "--mobile-access-jwt-env",
+            "CF_MOBILE_ACCESS_JWT",
+            "--browser-access-jwt-env",
+            "CF_BROWSER_ACCESS_JWT",
+            "--public-edge-secret-env",
+            "SM_PUBLIC_EDGE_SECRET",
+            "--bearer-token-env",
+            "SM_DEVICE_BEARER_TOKEN",
+        ]
+    )
+
+    assert exit_code == 0
+    assert captured["mobile_access_jwt"] == "mobile.jwt"
+    assert captured["browser_access_jwt"] == "browser.jwt"
+    assert captured["public_edge_secret"] == "edge-secret"
+    assert captured["bearer_token"] == "smat_token"
+
+
+def test_cloudflare_access_smoke_cli_resolves_secret_files(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_report(**kwargs):
+        captured.update(kwargs)
+        return {
+            "status": "passed",
+            "summary": {"passed": 0, "blocked": 0, "skipped": 0},
+            "checks": [],
+            "blockers": [],
+        }
+
+    cookie_file = tmp_path / "cookie.txt"
+    cookie_file.write_text("session=abc\n", encoding="utf-8")
+    monkeypatch.setattr(
+        "scripts.rust_migration.cloudflare_access_smoke.build_smoke_report",
+        fake_report,
+    )
+
+    exit_code = main(["--cookie-file", str(cookie_file)])
+
+    assert exit_code == 0
+    assert captured["cookie"] == "session=abc"


### PR DESCRIPTION
## Summary

- add a read-only Cloudflare Access/mobile smoke evidence script
- record mobile/browser Access boundary checks, public-edge signing headers, and optional SM-auth native reads
- document the operator command for collecting Cloudflare/mobile cutover evidence

## Validation

- `./venv/bin/python -m pytest tests/unit/test_rust_cloudflare_access_smoke.py -q`
- `./venv/bin/python -m pytest tests/unit/test_rust_cloudflare_access_smoke.py tests/unit/test_rust_migration_contracts.py -q`
- `./venv/bin/python -m py_compile scripts/rust_migration/cloudflare_access_smoke.py`
- `git diff --check`

Fixes #995