### PR TITLE
Add Android Cloudflare client certificate support

### DIFF
--- a/android-app/README.md
+++ b/android-app/README.md
@@ -26,9 +26,8 @@ The app expects:
 - external Session Manager origin protected by Google auth
 - `/auth/device/google` enabled on the server
 - `/apps/session-manager-android/meta.json` and `/apps/session-manager-android/latest.apk` available on the server
-- Termux installed for direct tmux attach
-- SSH attach exposed through a tunnel such as Cloudflare Access SSH
-- SSH origin configured for public-key auth only; password auth should remain disabled
+- `/client/*`, `/auth/device/google`, and app update routes available through the native app endpoint
+- when the native endpoint is behind Cloudflare Access, a signed SM mobile client certificate chain pasted into Settings
 
 ## Publish a new APK
 
@@ -61,8 +60,11 @@ The server stores:
 ## Attach security model
 
 The intended Android attach path is:
-- sign in to the HTTPS origin with Google
-- authenticate the SSH tunnel with Cloudflare Access
-- connect from Termux using a previously authorized SSH key
+- copy the app's mobile device key/CSR from Settings
+- issue an SM mobile Cloudflare Access client certificate whose Common Name matches that device key id
+- paste the signed certificate chain into Settings
+- authenticate the native HTTPS origin with Cloudflare Access client-certificate proof
+- sign in with Google and exchange the ID token for the SM device bearer token
+- request an in-app terminal attach ticket using the Android Keystore device key
 
-The app does not assume password-based SSH access.
+Cloudflare client-certificate proof is only the public-edge gate. The app still needs the SM bearer token and route-local attach-ticket proof before shell access is available.

--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -84,6 +84,8 @@ dependencies {
     implementation("com.squareup.okhttp3:okhttp:4.12.0")
     implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
     implementation("com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0")
+    implementation("org.bouncycastle:bcprov-jdk15to18:1.78.1")
+    implementation("org.bouncycastle:bcpkix-jdk15to18:1.78.1")
 
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0")

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/remote/HttpClientFactory.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/remote/HttpClientFactory.kt
@@ -1,0 +1,180 @@
+package li.rajeshgo.sm.data.remote
+
+import android.util.Log
+import kotlinx.coroutines.flow.first
+import li.rajeshgo.sm.data.repository.SettingsRepository
+import li.rajeshgo.sm.data.security.DeviceKeyManager
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import java.io.ByteArrayInputStream
+import java.net.Socket
+import java.security.KeyStore
+import java.security.Principal
+import java.security.PrivateKey
+import java.security.SecureRandom
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.util.concurrent.TimeUnit
+import javax.net.ssl.SSLContext
+import javax.net.ssl.SSLEngine
+import javax.net.ssl.SSLSocketFactory
+import javax.net.ssl.TrustManagerFactory
+import javax.net.ssl.X509ExtendedKeyManager
+import javax.net.ssl.X509TrustManager
+
+class HttpClientFactory(
+    private val settingsRepository: SettingsRepository? = null,
+    private val deviceKeyManager: DeviceKeyManager? = null,
+) {
+    suspend fun create(
+        token: String = "",
+        includeLogging: Boolean = true,
+        connectTimeoutSeconds: Long = 10,
+        readTimeoutSeconds: Long = 30,
+    ): OkHttpClient {
+        val builder = OkHttpClient.Builder()
+            .followRedirects(false)
+            .followSslRedirects(false)
+            .connectTimeout(connectTimeoutSeconds, TimeUnit.SECONDS)
+            .readTimeout(readTimeoutSeconds, TimeUnit.SECONDS)
+            .addInterceptor(AuthInterceptor { token })
+
+        if (includeLogging) {
+            builder.addInterceptor(
+                HttpLoggingInterceptor().apply {
+                    level = HttpLoggingInterceptor.Level.BASIC
+                },
+            )
+        }
+
+        val certificateChainPem = settingsRepository
+            ?.cloudflareDeviceCertificateChainPem
+            ?.first()
+            ?.trim()
+            .orEmpty()
+        if (certificateChainPem.isNotBlank()) {
+            runCatching {
+                val manager = deviceKeyManager ?: DeviceKeyManager()
+                loadClientCertificate(
+                    alias = manager.deviceKeyAlias(),
+                    certificateChainPem = certificateChainPem,
+                )
+            }
+                .onSuccess { sslConfig ->
+                    sslConfig?.let { (sslSocketFactory, trustManager) ->
+                        builder.sslSocketFactory(sslSocketFactory, trustManager)
+                    }
+                }
+                .onFailure { error ->
+                    Log.w(TAG, "Unable to load SM Cloudflare client certificate", error)
+                }
+        }
+
+        return builder.build()
+    }
+
+    private fun loadClientCertificate(
+        alias: String,
+        certificateChainPem: String,
+    ): Pair<SSLSocketFactory, X509TrustManager>? {
+        val certificateChain = decodeCertificates(certificateChainPem)
+        if (certificateChain.isEmpty()) {
+            return null
+        }
+        val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+        val privateKey = runCatching { keyStore.getKey(alias, null) as? PrivateKey }.getOrNull()
+            ?: return null
+
+        val keyManager = SingleAliasKeyManager(
+            alias = alias,
+            privateKey = privateKey,
+            certificateChain = certificateChain.toTypedArray(),
+        )
+
+        val trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm()).apply {
+            init(null as KeyStore?)
+        }
+        val trustManager = trustManagerFactory.trustManagers
+            .filterIsInstance<X509TrustManager>()
+            .singleOrNull()
+            ?: return null
+
+        val sslContext = SSLContext.getInstance("TLS").apply {
+            init(
+                arrayOf(keyManager),
+                arrayOf(trustManager),
+                SecureRandom(),
+            )
+        }
+
+        return sslContext.socketFactory to trustManager
+    }
+
+    private fun decodeCertificates(certificateChainPem: String): List<X509Certificate> {
+        val certificateFactory = CertificateFactory.getInstance("X.509")
+        return certificateFactory.generateCertificates(ByteArrayInputStream(certificateChainPem.toByteArray()))
+            .filterIsInstance<X509Certificate>()
+    }
+
+    private companion object {
+        const val TAG = "HttpClientFactory"
+        const val ANDROID_KEYSTORE = "AndroidKeyStore"
+    }
+
+    private class SingleAliasKeyManager(
+        private val alias: String,
+        private val privateKey: PrivateKey,
+        private val certificateChain: Array<X509Certificate>,
+    ) : X509ExtendedKeyManager() {
+        private val certificateKeyType = certificateChain
+            .firstOrNull()
+            ?.publicKey
+            ?.algorithm
+            ?.uppercase()
+            .orEmpty()
+
+        override fun getClientAliases(keyType: String?, issuers: Array<out Principal>?): Array<String> =
+            if (supportsKeyType(keyType)) arrayOf(alias) else emptyArray()
+
+        override fun chooseClientAlias(
+            keyType: Array<out String>?,
+            issuers: Array<out Principal>?,
+            socket: Socket?,
+        ): String? = alias.takeIf { keyType.orEmpty().any(::supportsKeyType) }
+
+        override fun getServerAliases(keyType: String?, issuers: Array<out Principal>?): Array<String>? = null
+
+        override fun chooseServerAlias(
+            keyType: String?,
+            issuers: Array<out Principal>?,
+            socket: Socket?,
+        ): String? = null
+
+        override fun getCertificateChain(requestedAlias: String?): Array<X509Certificate>? =
+            certificateChain.takeIf { requestedAlias == alias }
+
+        override fun getPrivateKey(requestedAlias: String?): PrivateKey? =
+            privateKey.takeIf { requestedAlias == alias }
+
+        override fun chooseEngineClientAlias(
+            keyType: Array<out String>?,
+            issuers: Array<out Principal>?,
+            engine: SSLEngine?,
+        ): String? = alias.takeIf { keyType.orEmpty().any(::supportsKeyType) }
+
+        override fun chooseEngineServerAlias(
+            keyType: String?,
+            issuers: Array<out Principal>?,
+            engine: SSLEngine?,
+        ): String? = null
+
+        private fun supportsKeyType(keyType: String?): Boolean {
+            val requested = keyType?.uppercase().orEmpty()
+            return when (certificateKeyType) {
+                "EC", "ECDSA" -> requested == "EC" || requested == "ECDSA" || requested.startsWith("EC_")
+                "RSA" -> requested == "RSA" || requested == "RSASSA-PSS" || requested.startsWith("RSA_")
+                else -> requested == certificateKeyType
+            }
+        }
+    }
+}

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/AppUpdateRepository.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/AppUpdateRepository.kt
@@ -8,7 +8,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
-import okhttp3.OkHttpClient
 import okhttp3.Request
 import retrofit2.HttpException
 import retrofit2.Retrofit
@@ -16,10 +15,10 @@ import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFact
 import li.rajeshgo.sm.BuildConfig
 import li.rajeshgo.sm.data.model.AppArtifactMetadata
 import li.rajeshgo.sm.data.remote.ApiService
+import li.rajeshgo.sm.data.remote.HttpClientFactory
 import java.io.File
 import java.io.IOException
 import java.security.MessageDigest
-import java.util.concurrent.TimeUnit
 
 data class AvailableAppUpdate(
     val artifactHash: String,
@@ -32,6 +31,7 @@ class AppUpdateRepository(
     private val settingsRepository: SettingsRepository,
 ) {
     private val json = Json { ignoreUnknownKeys = true; coerceInputValues = true }
+    private val httpClientFactory = HttpClientFactory(settingsRepository)
 
     @Volatile
     private var cachedCurrentArtifactHash: String? = null
@@ -70,7 +70,7 @@ class AppUpdateRepository(
         val updatesDir = File(context.cacheDir, "updates").apply { mkdirs() }
         val apkFile = File(updatesDir, "session-manager-${update.artifactHash}.apk")
 
-        okHttpClient().newCall(request).execute().use { response ->
+        httpClientFactory.create(includeLogging = false).newCall(request).execute().use { response ->
             if (!response.isSuccessful) {
                 throw IOException("Update download failed: HTTP ${response.code}")
             }
@@ -144,17 +144,12 @@ class AppUpdateRepository(
             .take(8)
     }
 
-    private fun apiService(serverUrl: String): ApiService {
+    private suspend fun apiService(serverUrl: String): ApiService {
         val retrofit = Retrofit.Builder()
             .baseUrl("$serverUrl/")
-            .client(okHttpClient())
+            .client(httpClientFactory.create(includeLogging = false))
             .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
             .build()
         return retrofit.create(ApiService::class.java)
     }
-
-    private fun okHttpClient(): OkHttpClient = OkHttpClient.Builder()
-        .connectTimeout(10, TimeUnit.SECONDS)
-        .readTimeout(30, TimeUnit.SECONDS)
-        .build()
 }

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SessionManagerRepository.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SessionManagerRepository.kt
@@ -20,14 +20,13 @@ import li.rajeshgo.sm.data.model.RequestStatusResponse
 import li.rajeshgo.sm.data.model.SessionDetail
 import li.rajeshgo.sm.data.model.ToolCallRow
 import li.rajeshgo.sm.data.remote.ApiService
-import li.rajeshgo.sm.data.remote.AuthInterceptor
+import li.rajeshgo.sm.data.remote.HttpClientFactory
 import li.rajeshgo.sm.data.security.DeviceProof
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
-import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.HttpException
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
@@ -40,8 +39,11 @@ class SessionManagerBackendUnavailableException(message: String, cause: Throwabl
 
 const val RETIRE_REQUEST_FAILED_MESSAGE = "Retire request failed"
 
-class SessionManagerRepository {
+class SessionManagerRepository(
+    private val settingsRepository: SettingsRepository? = null,
+) {
     private val json = Json { ignoreUnknownKeys = true }
+    private val httpClientFactory = HttpClientFactory(settingsRepository)
 
     private companion object {
         private const val READ_RETRY_ATTEMPTS = 3
@@ -56,15 +58,9 @@ class SessionManagerRepository {
         val message: String? = null,
     )
 
-    private fun httpClient(token: String = ""): OkHttpClient {
-        val logger = HttpLoggingInterceptor().apply { level = HttpLoggingInterceptor.Level.BASIC }
-        return OkHttpClient.Builder()
-            .addInterceptor(AuthInterceptor { token })
-            .addInterceptor(logger)
-            .build()
-    }
+    private suspend fun httpClient(token: String = ""): OkHttpClient = httpClientFactory.create(token = token)
 
-    private fun api(baseUrl: String, token: String = ""): ApiService {
+    private suspend fun api(baseUrl: String, token: String = ""): ApiService {
         require(baseUrl.isNotBlank()) { "Server URL is required" }
         val normalizedBaseUrl = baseUrl.trim().trimEnd('/') + "/"
         return Retrofit.Builder()
@@ -246,7 +242,7 @@ class SessionManagerRepository {
         return if (trimmed.startsWith("/")) trimmed else "/$trimmed"
     }
 
-    fun openMobileTerminalSocket(
+    suspend fun openMobileTerminalSocket(
         ticket: MobileAttachTicketResponse,
         accessToken: String,
         listener: WebSocketListener,

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SettingsRepository.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SettingsRepository.kt
@@ -19,6 +19,7 @@ class SettingsRepository(private val context: Context) {
         val USER_EMAIL = stringPreferencesKey("user_email")
         val USER_NAME = stringPreferencesKey("user_name")
         val EXPIRES_AT = stringPreferencesKey("expires_at")
+        val CLOUDFLARE_DEVICE_CERTIFICATE_CHAIN_PEM = stringPreferencesKey("cloudflare_device_certificate_chain_pem")
         val DISMISSED_UPDATE_ARTIFACT_HASH = stringPreferencesKey("dismissed_update_artifact_hash")
     }
 
@@ -44,6 +45,12 @@ class SettingsRepository(private val context: Context) {
 
     val isLoggedIn: Flow<Boolean> = accessToken.map { it.isNotBlank() }
 
+    val cloudflareDeviceCertificateChainPem: Flow<String> = context.dataStore.data.map { prefs ->
+        prefs[Keys.CLOUDFLARE_DEVICE_CERTIFICATE_CHAIN_PEM] ?: ""
+    }
+
+    val hasCloudflareDeviceCertificate: Flow<Boolean> = cloudflareDeviceCertificateChainPem.map { it.isNotBlank() }
+
     val dismissedUpdateArtifactHash: Flow<String> = context.dataStore.data.map { prefs ->
         prefs[Keys.DISMISSED_UPDATE_ARTIFACT_HASH] ?: ""
     }
@@ -60,6 +67,18 @@ class SettingsRepository(private val context: Context) {
             prefs[Keys.USER_EMAIL] = email
             prefs[Keys.USER_NAME] = name.orEmpty()
             prefs[Keys.EXPIRES_AT] = expiresAt
+        }
+    }
+
+    suspend fun saveCloudflareDeviceCertificateChainPem(certificateChainPem: String) {
+        context.dataStore.edit { prefs ->
+            prefs[Keys.CLOUDFLARE_DEVICE_CERTIFICATE_CHAIN_PEM] = certificateChainPem.trim()
+        }
+    }
+
+    suspend fun clearCloudflareDeviceCertificateChainPem() {
+        context.dataStore.edit { prefs ->
+            prefs.remove(Keys.CLOUDFLARE_DEVICE_CERTIFICATE_CHAIN_PEM)
         }
     }
 

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/security/DeviceKeyManager.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/security/DeviceKeyManager.kt
@@ -3,11 +3,20 @@ package li.rajeshgo.sm.data.security
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import android.util.Base64
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import org.bouncycastle.pkcs.PKCS10CertificationRequest
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder
+import java.io.ByteArrayInputStream
+import java.io.StringWriter
 import java.security.KeyPairGenerator
 import java.security.KeyStore
 import java.security.MessageDigest
 import java.security.PrivateKey
 import java.security.Signature
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
 import java.security.spec.ECGenParameterSpec
 
 data class DeviceProof(
@@ -19,6 +28,8 @@ data class DeviceProof(
 
 class DeviceKeyManager {
     private val keyStore: KeyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+
+    fun deviceKeyAlias(): String = KEY_ALIAS
 
     fun deviceKeyId(): String {
         val publicKey = ensureKeyPair().certificate.publicKey.encoded
@@ -32,6 +43,24 @@ class DeviceKeyManager {
             .chunked(64)
             .joinToString("\n")
         return "-----BEGIN PUBLIC KEY-----\n$body\n-----END PUBLIC KEY-----"
+    }
+
+    fun certificateSigningRequestPem(): String {
+        val entry = ensureKeyPair()
+        val subject = X500Name("CN=${deviceKeyId()}")
+        val builder = JcaPKCS10CertificationRequestBuilder(subject, entry.certificate.publicKey)
+        val signer = JcaContentSignerBuilder("SHA256withECDSA").build(entry.privateKey)
+        val request: PKCS10CertificationRequest = builder.build(signer)
+        val writer = StringWriter()
+        JcaPEMWriter(writer).use { pemWriter ->
+            pemWriter.writeObject(request)
+        }
+        return writer.toString()
+    }
+
+    fun certificateChainMatchesDeviceKey(certificateChainPem: String): Boolean {
+        val leaf = decodeCertificates(certificateChainPem).firstOrNull() ?: return false
+        return leaf.publicKey.encoded.contentEquals(ensureKeyPair().certificate.publicKey.encoded)
     }
 
     fun signTicketRequest(
@@ -116,6 +145,15 @@ class DeviceKeyManager {
         val bytes = ByteArray(18)
         java.security.SecureRandom().nextBytes(bytes)
         return Base64.encodeToString(bytes, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
+    }
+
+    private fun decodeCertificates(certificateChainPem: String): List<X509Certificate> {
+        if (certificateChainPem.isBlank()) {
+            return emptyList()
+        }
+        val certificateFactory = CertificateFactory.getInstance("X.509")
+        return certificateFactory.generateCertificates(ByteArrayInputStream(certificateChainPem.toByteArray()))
+            .filterIsInstance<X509Certificate>()
     }
 
     private companion object {

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/analytics/AnalyticsViewModel.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/analytics/AnalyticsViewModel.kt
@@ -26,7 +26,7 @@ data class AnalyticsUiState(
 
 class AnalyticsViewModel(application: Application) : AndroidViewModel(application) {
     private val settingsRepository = SettingsRepository(application)
-    private val sessionRepository = SessionManagerRepository()
+    private val sessionRepository = SessionManagerRepository(settingsRepository)
     private var refreshJob: Job? = null
 
     private val _uiState = MutableStateFlow(AnalyticsUiState())

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsScreen.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsScreen.kt
@@ -176,6 +176,71 @@ fun SettingsScreen(
                         Text("Copy config")
                     }
                 }
+                Spacer(Modifier.height(18.dp))
+                Text(
+                    text = "Cloudflare Access client certificate",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = "Use this CSR when issuing the SM mobile Access certificate. The certificate Common Name should stay equal to the device key id.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(Modifier.height(8.dp))
+                Text(
+                    text = "Client auth",
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Text(
+                    text = if (state.cloudflareDeviceCertificateConfigured) "Configured" else "Not configured",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = if (state.cloudflareDeviceCertificateConfigured) Emerald else Rose,
+                    fontFamily = FontFamily.Monospace,
+                )
+                Spacer(Modifier.height(10.dp))
+                OutlinedButton(
+                    onClick = {
+                        val clipboard = context.getSystemService(android.content.ClipboardManager::class.java)
+                        clipboard?.setPrimaryClip(
+                            android.content.ClipData.newPlainText(
+                                "sm mobile cloudflare csr",
+                                state.mobileDeviceCertificateSigningRequest,
+                            ),
+                        )
+                    },
+                    enabled = state.mobileDeviceCertificateSigningRequest.isNotBlank(),
+                ) {
+                    Text("Copy CSR")
+                }
+                Spacer(Modifier.height(10.dp))
+                OutlinedTextField(
+                    value = state.cloudflareDeviceCertificateChainPem,
+                    onValueChange = viewModel::updateCloudflareDeviceCertificateChain,
+                    label = { Text("Signed certificate chain PEM") },
+                    placeholder = { Text("-----BEGIN CERTIFICATE-----") },
+                    maxLines = 8,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(170.dp),
+                )
+                Spacer(Modifier.height(10.dp))
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Button(
+                        onClick = viewModel::saveCloudflareDeviceCertificateChain,
+                        enabled = state.cloudflareDeviceCertificateChainPem.isNotBlank(),
+                    ) {
+                        Text("Save cert")
+                    }
+                    OutlinedButton(
+                        onClick = viewModel::clearCloudflareDeviceCertificateChain,
+                        enabled = state.cloudflareDeviceCertificateConfigured || state.cloudflareDeviceCertificateChainPem.isNotBlank(),
+                    ) {
+                        Text("Clear cert")
+                    }
+                }
             }
         }
 
@@ -310,7 +375,7 @@ fun SettingsScreen(
 
         Spacer(Modifier.height(24.dp))
         Text(
-            text = "Attach note: HTTPS in-app attach is primary when mobile_terminal is enabled server-side. Termux remains a temporary fallback for sessions without mobile terminal support.",
+            text = "Attach note: HTTPS in-app attach is available when mobile_terminal is enabled server-side and this device key is registered.",
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsViewModel.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsViewModel.kt
@@ -4,10 +4,12 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import kotlin.Result
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import li.rajeshgo.sm.data.model.ClientBootstrapResponse
 import li.rajeshgo.sm.data.repository.AppUpdateRepository
 import li.rajeshgo.sm.data.repository.AvailableAppUpdate
@@ -25,6 +27,9 @@ data class SettingsUiState(
     val availableUpdate: AvailableAppUpdate? = null,
     val mobileDeviceKeyId: String = "",
     val mobileDevicePublicKey: String = "",
+    val mobileDeviceCertificateSigningRequest: String = "",
+    val cloudflareDeviceCertificateChainPem: String = "",
+    val cloudflareDeviceCertificateConfigured: Boolean = false,
     val mobileDeviceKeyError: String? = null,
     val updateInstalling: Boolean = false,
     val updateError: String? = null,
@@ -33,7 +38,7 @@ data class SettingsUiState(
 
 class SettingsViewModel(application: Application) : AndroidViewModel(application) {
     private val settingsRepository = SettingsRepository(application)
-    private val sessionRepository = SessionManagerRepository()
+    private val sessionRepository = SessionManagerRepository(settingsRepository)
     private val appUpdateRepository = AppUpdateRepository(application, settingsRepository)
     private val deviceKeyManager = DeviceKeyManager()
 
@@ -47,6 +52,8 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                 userEmail = settingsRepository.userEmail.first(),
                 userName = settingsRepository.userName.first(),
                 isLoggedIn = settingsRepository.isLoggedIn.first(),
+                cloudflareDeviceCertificateChainPem = settingsRepository.cloudflareDeviceCertificateChainPem.first(),
+                cloudflareDeviceCertificateConfigured = settingsRepository.hasCloudflareDeviceCertificate.first(),
             )
             loadMobileDeviceKey()
             refreshBootstrap()
@@ -79,16 +86,67 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     fun loadMobileDeviceKey() {
         runCatching {
-            deviceKeyManager.deviceKeyId() to deviceKeyManager.publicKeyPem()
-        }.onSuccess { (keyId, publicKey) ->
+            Triple(
+                deviceKeyManager.deviceKeyId(),
+                deviceKeyManager.publicKeyPem(),
+                deviceKeyManager.certificateSigningRequestPem(),
+            )
+        }.onSuccess { (keyId, publicKey, certificateSigningRequest) ->
             _uiState.value = _uiState.value.copy(
                 mobileDeviceKeyId = keyId,
                 mobileDevicePublicKey = publicKey,
+                mobileDeviceCertificateSigningRequest = certificateSigningRequest,
                 mobileDeviceKeyError = null,
             )
         }.onFailure { error ->
             _uiState.value = _uiState.value.copy(
                 mobileDeviceKeyError = error.message ?: "Failed to load mobile attach device key",
+            )
+        }
+    }
+
+    fun updateCloudflareDeviceCertificateChain(value: String) {
+        _uiState.value = _uiState.value.copy(
+            cloudflareDeviceCertificateChainPem = value,
+            mobileDeviceKeyError = null,
+        )
+    }
+
+    fun saveCloudflareDeviceCertificateChain() {
+        val certificateChainPem = _uiState.value.cloudflareDeviceCertificateChainPem.trim()
+        if (certificateChainPem.isBlank()) {
+            clearCloudflareDeviceCertificateChain()
+            return
+        }
+        viewModelScope.launch {
+            runCatching {
+                withContext(Dispatchers.IO) {
+                    check(deviceKeyManager.certificateChainMatchesDeviceKey(certificateChainPem)) {
+                        "Certificate chain does not match this mobile device key"
+                    }
+                }
+                settingsRepository.saveCloudflareDeviceCertificateChainPem(certificateChainPem)
+            }.onSuccess {
+                _uiState.value = _uiState.value.copy(
+                    cloudflareDeviceCertificateChainPem = certificateChainPem,
+                    cloudflareDeviceCertificateConfigured = true,
+                    mobileDeviceKeyError = null,
+                )
+            }.onFailure { error ->
+                _uiState.value = _uiState.value.copy(
+                    mobileDeviceKeyError = error.message ?: "Failed to save Cloudflare certificate",
+                )
+            }
+        }
+    }
+
+    fun clearCloudflareDeviceCertificateChain() {
+        viewModelScope.launch {
+            settingsRepository.clearCloudflareDeviceCertificateChainPem()
+            _uiState.value = _uiState.value.copy(
+                cloudflareDeviceCertificateChainPem = "",
+                cloudflareDeviceCertificateConfigured = false,
+                mobileDeviceKeyError = null,
             )
         }
     }

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchViewModel.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchViewModel.kt
@@ -70,7 +70,7 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     private val settingsRepository = SettingsRepository(application)
-    private val sessionRepository = SessionManagerRepository()
+    private val sessionRepository = SessionManagerRepository(settingsRepository)
     private val deviceKeyManager = DeviceKeyManager()
     private var refreshJob: Job? = null
     private var terminalSocket: WebSocket? = null

--- a/android-app/local.defaults.properties.example
+++ b/android-app/local.defaults.properties.example
@@ -1,5 +1,6 @@
 # Copy to local.defaults.properties and fill local-only values.
 # Keep the real file untracked.
-# The SSH attach path is expected to use Cloudflare Access + public-key auth.
+# Remote app access should use the SM native endpoint; Settings stores the
+# Cloudflare Access client certificate chain when that endpoint is enabled.
 SM_DEFAULT_SERVER_URL=https://sm.example.com
 SM_GOOGLE_SERVER_CLIENT_ID=your-web-client-id.apps.googleusercontent.com


### PR DESCRIPTION
Fixes #999

## Summary
- add Android CSR generation from the existing mobile attach device key so the Cloudflare certificate CN can match the SM device key id
- store/clear the signed Cloudflare client certificate chain in Settings and validate it matches the app device key before saving
- route REST calls, app update downloads, and mobile terminal WebSocket connections through a shared OkHttp client that presents the configured certificate and refuses native API redirects
- update Android app docs/default comments from the old SSH/Termux remote model to the native Cloudflare client-certificate + SM auth model

## Validation
- `git diff --check`
- `./gradlew testDebugUnitTest` could not run locally because this machine has no Android SDK configured (`ANDROID_HOME`/`android-app/local.properties` missing)
