### PR TITLE
Add Android QR device enrollment

### DIFF
--- a/android-app/README.md
+++ b/android-app/README.md
@@ -60,11 +60,18 @@ The server stores:
 ## Attach security model
 
 The intended Android attach path is:
-- copy the app's mobile device key/CSR from Settings
-- issue an SM mobile Cloudflare Access client certificate whose Common Name matches that device key id
-- paste the signed certificate chain into Settings
+- run `sm enroll-device` on the trusted Session Manager host and scan its QR
+  code from Settings within the short enrollment window
+- the app submits its Android Keystore CSR and public key to the pairing URL
+- Session Manager issues an SM mobile Cloudflare Access client certificate
+  whose Common Name matches that device key id
+- the app stores the signed certificate chain returned by enrollment
 - authenticate the native HTTPS origin with Cloudflare Access client-certificate proof
 - sign in with Google and exchange the ID token for the SM device bearer token
 - request an in-app terminal attach ticket using the Android Keystore device key
 
 Cloudflare client-certificate proof is only the public-edge gate. The app still needs the SM bearer token and route-local attach-ticket proof before shell access is available.
+
+Manual CSR copy and certificate-chain paste in Settings remain available for
+debugging, but QR enrollment is the normal path. The server pairing token should
+be single-use and expire after about 15 minutes.

--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -86,6 +86,7 @@ dependencies {
     implementation("com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0")
     implementation("org.bouncycastle:bcprov-jdk15to18:1.78.1")
     implementation("org.bouncycastle:bcpkix-jdk15to18:1.78.1")
+    implementation("com.journeyapps:zxing-android-embedded:4.3.0")
 
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0")

--- a/android-app/app/src/main/AndroidManifest.xml
+++ b/android-app/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="com.termux.permission.RUN_COMMAND" />
 

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/model/ApiModels.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/model/ApiModels.kt
@@ -84,6 +84,30 @@ data class DeviceGoogleAuthResponse(
 )
 
 @Serializable
+data class DeviceEnrollmentRequest(
+    @SerialName("device_id")
+    val deviceId: String,
+    @SerialName("device_name")
+    val deviceName: String,
+    @SerialName("csr_pem")
+    val csrPem: String,
+    @SerialName("public_key_pem")
+    val publicKeyPem: String,
+)
+
+@Serializable
+data class DeviceEnrollmentResponse(
+    @SerialName("device_id")
+    val deviceId: String,
+    @SerialName("device_name")
+    val deviceName: String? = null,
+    @SerialName("certificate_chain_pem")
+    val certificateChainPem: String,
+    @SerialName("expires_at")
+    val expiresAt: String? = null,
+)
+
+@Serializable
 data class AppArtifactMetadata(
     @SerialName("artifact_hash")
     val artifactHash: String? = null,

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/DeviceEnrollmentRepository.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/DeviceEnrollmentRepository.kt
@@ -1,0 +1,125 @@
+package li.rajeshgo.sm.data.repository
+
+import android.os.Build
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import li.rajeshgo.sm.data.model.DeviceEnrollmentRequest
+import li.rajeshgo.sm.data.model.DeviceEnrollmentResponse
+import li.rajeshgo.sm.data.remote.HttpClientFactory
+import li.rajeshgo.sm.data.security.DeviceKeyManager
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.net.URI
+
+data class DeviceEnrollmentResult(
+    val deviceId: String,
+    val deviceName: String?,
+    val expiresAt: String?,
+)
+
+class DeviceEnrollmentRepository(
+    private val settingsRepository: SettingsRepository,
+    private val deviceKeyManager: DeviceKeyManager,
+) {
+    private val json = Json { ignoreUnknownKeys = true; coerceInputValues = true }
+    private val httpClientFactory = HttpClientFactory(settingsRepository, deviceKeyManager)
+
+    suspend fun enrollFromQr(qrContents: String): DeviceEnrollmentResult = withContext(Dispatchers.IO) {
+        val enrollmentUrl = enrollmentUrlFromQrContents(qrContents)
+        val requestBody = DeviceEnrollmentRequest(
+            deviceId = deviceKeyManager.deviceKeyId(),
+            deviceName = deviceName(),
+            csrPem = deviceKeyManager.certificateSigningRequestPem(),
+            publicKeyPem = deviceKeyManager.publicKeyPem(),
+        )
+        val request = Request.Builder()
+            .url(enrollmentUrl)
+            .post(
+                json.encodeToString(DeviceEnrollmentRequest.serializer(), requestBody)
+                    .toRequestBody("application/json".toMediaType()),
+            )
+            .build()
+        val response = httpClientFactory.create(
+            includeLogging = false,
+            connectTimeoutSeconds = 10,
+            readTimeoutSeconds = 30,
+        )
+            .newCall(request)
+            .execute()
+        response.use { result ->
+            val body = result.body?.string().orEmpty()
+            if (!result.isSuccessful) {
+                throw IllegalStateException(enrollmentErrorMessage(body, result.code))
+            }
+            val payload = json.decodeFromString(DeviceEnrollmentResponse.serializer(), body)
+            check(payload.deviceId.trim() == requestBody.deviceId) {
+                "Enrollment response device id did not match this device"
+            }
+            check(deviceKeyManager.certificateChainMatchesDeviceKey(payload.certificateChainPem)) {
+                "Enrollment certificate does not match this device key"
+            }
+            settingsRepository.saveCloudflareDeviceCertificateChainPem(payload.certificateChainPem)
+            DeviceEnrollmentResult(
+                deviceId = payload.deviceId,
+                deviceName = payload.deviceName,
+                expiresAt = payload.expiresAt,
+            )
+        }
+    }
+
+    private fun deviceName(): String {
+        val manufacturer = Build.MANUFACTURER.trim()
+        val model = Build.MODEL.trim()
+        return listOf(manufacturer, model)
+            .filter { it.isNotBlank() }
+            .joinToString(" ")
+            .ifBlank { "Android device" }
+    }
+
+    private fun enrollmentErrorMessage(body: String, statusCode: Int): String {
+        val trimmed = body.trim()
+        if (trimmed.isBlank()) {
+            return "Enrollment failed (HTTP $statusCode)"
+        }
+        return runCatching {
+            val obj = json.parseToJsonElement(trimmed).jsonObject
+            listOf("detail", "message", "error")
+                .firstNotNullOfOrNull { key ->
+                    obj[key]?.jsonPrimitive?.content?.trim()?.takeIf { it.isNotBlank() }
+                }
+        }.getOrNull()
+            ?: trimmed.takeUnless { it.startsWith("<!DOCTYPE") || it.startsWith("<html", ignoreCase = true) }
+            ?: "Enrollment failed (HTTP $statusCode)"
+    }
+
+    companion object {
+        fun enrollmentUrlFromQrContents(qrContents: String): String {
+            val raw = qrContents.trim()
+            require(raw.isNotBlank()) { "Enrollment QR code was empty" }
+            val candidate = if (raw.startsWith("{")) {
+                val payload = Json.parseToJsonElement(raw).jsonObject
+                listOf("enrollment_url", "pairing_url", "url")
+                    .firstNotNullOfOrNull { key ->
+                        payload[key]?.jsonPrimitive?.content?.trim()?.takeIf { it.isNotBlank() }
+                    }
+                    ?: throw IllegalArgumentException("Enrollment QR code is missing enrollment_url")
+            } else {
+                raw
+            }
+            val uri = runCatching { URI(candidate) }.getOrNull()
+                ?: throw IllegalArgumentException("Enrollment URL is not valid")
+            val scheme = uri.scheme?.lowercase()
+            require(scheme == "https" || scheme == "http") {
+                "Enrollment URL must be http(s)"
+            }
+            require(!uri.host.isNullOrBlank()) {
+                "Enrollment URL must include a host"
+            }
+            return candidate
+        }
+    }
+}

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsScreen.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsScreen.kt
@@ -1,5 +1,6 @@
 package li.rajeshgo.sm.ui.settings
 
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -27,6 +28,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.journeyapps.barcodescanner.ScanContract
+import com.journeyapps.barcodescanner.ScanOptions
 import li.rajeshgo.sm.BuildConfig
 import li.rajeshgo.sm.auth.GoogleSignInManager
 import li.rajeshgo.sm.ui.theme.BorderStrong
@@ -46,6 +49,9 @@ fun SettingsScreen(
     val context = LocalContext.current
     val googleSignInManager = GoogleSignInManager(context)
     val coroutineScope = rememberCoroutineScope()
+    val enrollmentScanner = rememberLauncherForActivityResult(ScanContract()) { result ->
+        result.contents?.trim()?.takeIf { it.isNotBlank() }?.let(viewModel::enrollCloudflareDeviceFromQr)
+    }
     val effectiveGoogleClientId = state.bootstrap?.auth?.googleServerClientId?.takeIf { it.isNotBlank() }
         ?: LocalDefaults.googleServerClientId.takeIf { it.isNotBlank() }
 
@@ -201,6 +207,26 @@ fun SettingsScreen(
                     fontFamily = FontFamily.Monospace,
                 )
                 Spacer(Modifier.height(10.dp))
+                Button(
+                    onClick = {
+                        val options = ScanOptions().apply {
+                            setDesiredBarcodeFormats(ScanOptions.QR_CODE)
+                            setPrompt("Scan sm enroll-device QR")
+                            setBeepEnabled(false)
+                            setOrientationLocked(false)
+                        }
+                        enrollmentScanner.launch(options)
+                    },
+                    enabled = !state.cloudflareEnrollmentInProgress,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    if (state.cloudflareEnrollmentInProgress) {
+                        CircularProgressIndicator(strokeWidth = 2.dp, modifier = Modifier.height(18.dp))
+                    } else {
+                        Text("Scan enrollment QR")
+                    }
+                }
+                Spacer(Modifier.height(10.dp))
                 OutlinedButton(
                     onClick = {
                         val clipboard = context.getSystemService(android.content.ClipboardManager::class.java)
@@ -230,16 +256,33 @@ fun SettingsScreen(
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     Button(
                         onClick = viewModel::saveCloudflareDeviceCertificateChain,
-                        enabled = state.cloudflareDeviceCertificateChainPem.isNotBlank(),
+                        enabled = state.cloudflareDeviceCertificateChainPem.isNotBlank() && !state.cloudflareEnrollmentInProgress,
                     ) {
                         Text("Save cert")
                     }
                     OutlinedButton(
                         onClick = viewModel::clearCloudflareDeviceCertificateChain,
-                        enabled = state.cloudflareDeviceCertificateConfigured || state.cloudflareDeviceCertificateChainPem.isNotBlank(),
+                        enabled = (state.cloudflareDeviceCertificateConfigured || state.cloudflareDeviceCertificateChainPem.isNotBlank()) &&
+                            !state.cloudflareEnrollmentInProgress,
                     ) {
                         Text("Clear cert")
                     }
+                }
+                state.cloudflareEnrollmentStatus?.let { status ->
+                    Spacer(Modifier.height(10.dp))
+                    Text(
+                        text = status,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Emerald,
+                    )
+                }
+                state.cloudflareEnrollmentError?.let { error ->
+                    Spacer(Modifier.height(10.dp))
+                    Text(
+                        text = error,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Rose,
+                    )
                 }
             }
         }

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsViewModel.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsViewModel.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.withContext
 import li.rajeshgo.sm.data.model.ClientBootstrapResponse
 import li.rajeshgo.sm.data.repository.AppUpdateRepository
 import li.rajeshgo.sm.data.repository.AvailableAppUpdate
+import li.rajeshgo.sm.data.repository.DeviceEnrollmentRepository
 import li.rajeshgo.sm.data.repository.SessionManagerRepository
 import li.rajeshgo.sm.data.repository.SettingsRepository
 import li.rajeshgo.sm.data.security.DeviceKeyManager
@@ -30,6 +31,9 @@ data class SettingsUiState(
     val mobileDeviceCertificateSigningRequest: String = "",
     val cloudflareDeviceCertificateChainPem: String = "",
     val cloudflareDeviceCertificateConfigured: Boolean = false,
+    val cloudflareEnrollmentInProgress: Boolean = false,
+    val cloudflareEnrollmentStatus: String? = null,
+    val cloudflareEnrollmentError: String? = null,
     val mobileDeviceKeyError: String? = null,
     val updateInstalling: Boolean = false,
     val updateError: String? = null,
@@ -41,6 +45,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     private val sessionRepository = SessionManagerRepository(settingsRepository)
     private val appUpdateRepository = AppUpdateRepository(application, settingsRepository)
     private val deviceKeyManager = DeviceKeyManager()
+    private val deviceEnrollmentRepository = DeviceEnrollmentRepository(settingsRepository, deviceKeyManager)
 
     private val _uiState = MutableStateFlow(SettingsUiState())
     val uiState: StateFlow<SettingsUiState> = _uiState
@@ -108,7 +113,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     fun updateCloudflareDeviceCertificateChain(value: String) {
         _uiState.value = _uiState.value.copy(
             cloudflareDeviceCertificateChainPem = value,
-            mobileDeviceKeyError = null,
+            cloudflareEnrollmentError = null,
         )
     }
 
@@ -130,11 +135,50 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                 _uiState.value = _uiState.value.copy(
                     cloudflareDeviceCertificateChainPem = certificateChainPem,
                     cloudflareDeviceCertificateConfigured = true,
-                    mobileDeviceKeyError = null,
+                    cloudflareEnrollmentStatus = "Client certificate saved",
+                    cloudflareEnrollmentError = null,
                 )
             }.onFailure { error ->
                 _uiState.value = _uiState.value.copy(
-                    mobileDeviceKeyError = error.message ?: "Failed to save Cloudflare certificate",
+                    cloudflareEnrollmentError = error.message ?: "Failed to save Cloudflare certificate",
+                )
+            }
+        }
+    }
+
+    fun enrollCloudflareDeviceFromQr(qrContents: String) {
+        if (_uiState.value.cloudflareEnrollmentInProgress) {
+            return
+        }
+        _uiState.value = _uiState.value.copy(
+            cloudflareEnrollmentInProgress = true,
+            cloudflareEnrollmentStatus = "Enrolling device",
+            cloudflareEnrollmentError = null,
+        )
+        viewModelScope.launch {
+            runCatching {
+                deviceEnrollmentRepository.enrollFromQr(qrContents)
+            }.onSuccess { result ->
+                val certificateChainPem = settingsRepository.cloudflareDeviceCertificateChainPem.first()
+                _uiState.value = _uiState.value.copy(
+                    cloudflareDeviceCertificateChainPem = certificateChainPem,
+                    cloudflareDeviceCertificateConfigured = certificateChainPem.isNotBlank(),
+                    cloudflareEnrollmentInProgress = false,
+                    cloudflareEnrollmentStatus = buildString {
+                        append("Enrolled ")
+                        append(result.deviceName?.takeIf { it.isNotBlank() } ?: result.deviceId)
+                        result.expiresAt?.takeIf { it.isNotBlank() }?.let { expiresAt ->
+                            append(" until ")
+                            append(expiresAt)
+                        }
+                    },
+                    cloudflareEnrollmentError = null,
+                )
+            }.onFailure { error ->
+                _uiState.value = _uiState.value.copy(
+                    cloudflareEnrollmentInProgress = false,
+                    cloudflareEnrollmentStatus = null,
+                    cloudflareEnrollmentError = error.message ?: "Device enrollment failed",
                 )
             }
         }
@@ -146,7 +190,8 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             _uiState.value = _uiState.value.copy(
                 cloudflareDeviceCertificateChainPem = "",
                 cloudflareDeviceCertificateConfigured = false,
-                mobileDeviceKeyError = null,
+                cloudflareEnrollmentStatus = "Client certificate cleared",
+                cloudflareEnrollmentError = null,
             )
         }
     }

--- a/android-app/app/src/test/java/li/rajeshgo/sm/data/repository/SessionManagerRepositoryTest.kt
+++ b/android-app/app/src/test/java/li/rajeshgo/sm/data/repository/SessionManagerRepositoryTest.kt
@@ -99,6 +99,31 @@ class SessionManagerRepositoryTest {
         assertFalse(repository.isRetryableMobileTerminalSocketFailure(null, "timeout"))
     }
 
+    @Test
+    fun deviceEnrollmentQrAcceptsPlainPairingUrl() {
+        assertEquals(
+            "http://studio.local:8420/client/mobile-terminal/enroll/abc",
+            DeviceEnrollmentRepository.enrollmentUrlFromQrContents(
+                " http://studio.local:8420/client/mobile-terminal/enroll/abc ",
+            ),
+        )
+    }
+
+    @Test
+    fun deviceEnrollmentQrAcceptsJsonEnrollmentUrl() {
+        assertEquals(
+            "https://sm-app.example.com/client/mobile-terminal/enroll/abc",
+            DeviceEnrollmentRepository.enrollmentUrlFromQrContents(
+                """{"enrollment_url":"https://sm-app.example.com/client/mobile-terminal/enroll/abc"}""",
+            ),
+        )
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun deviceEnrollmentQrRejectsNonHttpUrl() {
+        DeviceEnrollmentRepository.enrollmentUrlFromQrContents("sm-enroll://abc")
+    }
+
     private fun ticket(): MobileAttachTicketResponse {
         return MobileAttachTicketResponse(
             ticketId = "ticket-1",


### PR DESCRIPTION
## Summary

- add QR scanning from Android Settings for the upcoming `sm enroll-device` pairing flow
- POST the Android Keystore device id, device name, CSR, and public key to the scanned enrollment URL
- validate the returned cert chain against the current device key before saving it as the Cloudflare Access client cert
- keep manual CSR copy / certificate-chain paste as a fallback

## Validation

- `git diff --check`
- verified `zxing-android-embedded:4.3.0` exposes `ScanOptions.QR_CODE` and vararg `setDesiredBarcodeFormats`
- `cd android-app && ./gradlew testDebugUnitTest` is blocked locally because no Android SDK is configured (`ANDROID_HOME` / `android-app/local.properties` missing)

Fixes #1001
