### PR TITLE
Allow Android artifact version overrides

### DIFF
--- a/android-app/README.md
+++ b/android-app/README.md
@@ -35,14 +35,14 @@ Build the app:
 
 ```
 cd android-app
-./gradlew assembleDebug
+SM_VERSION_CODE=2 SM_VERSION_NAME=0.1.1 ./gradlew assembleDebug
 ```
 
 Then publish it to the local Session Manager artifact server:
 
 ```
 cd ..
-VERSION_NAME=0.1.0 ./scripts/deploy_android_app.sh
+VERSION_CODE=2 VERSION_NAME=0.1.1 ./scripts/deploy_android_app.sh
 ```
 
 By default the deploy script uploads:

--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -18,10 +18,23 @@ fun Project.stringProp(name: String, default: String = ""): String {
     if (fromLocalDefaults.isNotBlank()) {
         return fromLocalDefaults
     }
+    val fromEnv = (System.getenv(name) ?: "").trim()
+    if (fromEnv.isNotBlank()) {
+        return fromEnv
+    }
     return (findProperty(name) as String?)?.trim() ?: default
 }
 
 fun String.toBuildConfigString(): String = '"' + replace("\\", "\\\\").replace("\"", "\\\"") + '"'
+
+fun Project.intProp(name: String, default: Int): Int {
+    val value = stringProp(name)
+    if (value.isBlank()) {
+        return default
+    }
+    return value.toIntOrNull()
+        ?: throw GradleException("$name must be an integer")
+}
 
 android {
     namespace = "li.rajeshgo.sm"
@@ -31,8 +44,8 @@ android {
         applicationId = "li.rajeshgo.sm"
         minSdk = 26
         targetSdk = 35
-        versionCode = 1
-        versionName = "0.1.0"
+        versionCode = project.intProp("SM_VERSION_CODE", 1)
+        versionName = project.stringProp("SM_VERSION_NAME", "0.1.0")
 
         buildConfigField("String", "SM_DEFAULT_SERVER_URL", project.stringProp("SM_DEFAULT_SERVER_URL").toBuildConfigString())
         buildConfigField("String", "SM_GOOGLE_SERVER_CLIENT_ID", project.stringProp("SM_GOOGLE_SERVER_CLIENT_ID").toBuildConfigString())


### PR DESCRIPTION
Fixes #1008\n\n## Summary\n- let the Android Gradle build read SM_VERSION_CODE and SM_VERSION_NAME from local defaults, environment, or Gradle properties\n- use those values for the actual APK manifest versionCode/versionName\n- update Android publish docs so build and deploy metadata stay aligned\n\n## Validation\n- ANDROID_HOME=/opt/homebrew/share/android-commandlinetools ANDROID_SDK_ROOT=/opt/homebrew/share/android-commandlinetools SM_VERSION_CODE=1007 SM_VERSION_NAME=0.1.0-qr-enroll-b8fd090 ./gradlew :app:assembleDebug\n- aapt dump badging android-app/app/build/outputs/apk/debug/app-debug.apk confirmed versionCode=1007 and versionName=0.1.0-qr-enroll-b8fd090\n- /opt/homebrew/share/android-commandlinetools/build-tools/35.0.0/apksigner verify --print-certs android-app/app/build/outputs/apk/debug/app-debug.apk\n- git diff --check\n\n## Notes\n- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py -q currently fails on unrelated stale Stage 5 doc assertions; tracked in #1009.\n- Published corrected APK artifact hash 044edfdc to the local/public app artifact server for immediate mobile update retry.