### PR TITLE
Open mobile enrollment links in the Android app

### DIFF
--- a/android-app/README.md
+++ b/android-app/README.md
@@ -63,9 +63,9 @@ The intended Android attach path is:
 - run `sm enroll-device` on the trusted Session Manager host and scan its QR
   code from Settings within the short enrollment window
 - the app submits its Android Keystore CSR and public key to the pairing URL
-- Session Manager issues an SM mobile Cloudflare Access client certificate
-  whose Common Name matches that device key id
-- the app stores the signed certificate chain returned by enrollment
+- Session Manager issues an SM mobile Cloudflare Access client-certificate
+  credential whose Common Name matches that device key id
+- the app stores the credential internally for HTTPS client-certificate auth
 - authenticate the native HTTPS origin with Cloudflare Access client-certificate proof
 - sign in with Google and exchange the ID token for the SM device bearer token
 - request an in-app terminal attach ticket using the Android Keystore device key
@@ -74,5 +74,5 @@ Cloudflare client-certificate proof is only the public-edge gate. The app still 
 
 QR enrollment through the phone Camera app is the supported path. The app does
 not request camera permission, does not include an in-app scanner, and does not
-expose the signed certificate chain in Settings. The server pairing token should
+expose the certificate material in Settings. The server pairing token should
 be single-use and expire after about 15 minutes.

--- a/android-app/README.md
+++ b/android-app/README.md
@@ -27,7 +27,7 @@ The app expects:
 - `/auth/device/google` enabled on the server
 - `/apps/session-manager-android/meta.json` and `/apps/session-manager-android/latest.apk` available on the server
 - `/client/*`, `/auth/device/google`, and app update routes available through the native app endpoint
-- when the native endpoint is behind Cloudflare Access, a signed SM mobile client certificate chain pasted into Settings
+- when the native endpoint is behind Cloudflare Access, a device certificate enrolled through `sm enroll-device`
 
 ## Publish a new APK
 
@@ -72,6 +72,7 @@ The intended Android attach path is:
 
 Cloudflare client-certificate proof is only the public-edge gate. The app still needs the SM bearer token and route-local attach-ticket proof before shell access is available.
 
-Manual CSR copy and certificate-chain paste in Settings remain available for
-debugging, but QR enrollment is the normal path. The server pairing token should
+QR enrollment through the phone Camera app is the supported path. The app does
+not request camera permission, does not include an in-app scanner, and does not
+expose the signed certificate chain in Settings. The server pairing token should
 be single-use and expire after about 15 minutes.

--- a/android-app/app/build.gradle.kts
+++ b/android-app/app/build.gradle.kts
@@ -99,7 +99,6 @@ dependencies {
     implementation("com.jakewharton.retrofit:retrofit2-kotlinx-serialization-converter:1.0.0")
     implementation("org.bouncycastle:bcprov-jdk15to18:1.78.1")
     implementation("org.bouncycastle:bcpkix-jdk15to18:1.78.1")
-    implementation("com.journeyapps:zxing-android-embedded:4.3.0")
 
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.3")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0")

--- a/android-app/app/src/main/AndroidManifest.xml
+++ b/android-app/app/src/main/AndroidManifest.xml
@@ -21,10 +21,21 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
+            android:launchMode="singleTop"
             android:theme="@style/Theme.SessionManager">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:scheme="sm-enroll"
+                    android:host="enroll" />
             </intent-filter>
         </activity>
         <provider

--- a/android-app/app/src/main/AndroidManifest.xml
+++ b/android-app/app/src/main/AndroidManifest.xml
@@ -2,7 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="com.termux.permission.RUN_COMMAND" />
 

--- a/android-app/app/src/main/java/li/rajeshgo/sm/MainActivity.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/MainActivity.kt
@@ -20,9 +20,7 @@ class MainActivity : ComponentActivity() {
             SessionManagerTheme {
                 AppNavigation(
                     pendingEnrollmentUrl = pendingEnrollmentUrl.value,
-                    onEnrollmentDeepLinkConsumed = {
-                        pendingEnrollmentUrl.value = null
-                    },
+                    onEnrollmentDeepLinkConsumed = ::clearEnrollmentDeepLink,
                 )
             }
         }
@@ -40,5 +38,10 @@ class MainActivity : ComponentActivity() {
             return null
         }
         return uri.getQueryParameter("url")?.trim()?.takeIf { it.isNotBlank() }
+    }
+
+    private fun clearEnrollmentDeepLink() {
+        pendingEnrollmentUrl.value = null
+        setIntent(Intent(this, MainActivity::class.java))
     }
 }

--- a/android-app/app/src/main/java/li/rajeshgo/sm/MainActivity.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/MainActivity.kt
@@ -1,20 +1,44 @@
 package li.rajeshgo.sm
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.runtime.mutableStateOf
 import li.rajeshgo.sm.ui.navigation.AppNavigation
 import li.rajeshgo.sm.ui.theme.SessionManagerTheme
 
 class MainActivity : ComponentActivity() {
+    private val pendingEnrollmentUrl = mutableStateOf<String?>(null)
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        pendingEnrollmentUrl.value = enrollmentUrlFromIntent(intent)
         enableEdgeToEdge()
         setContent {
             SessionManagerTheme {
-                AppNavigation()
+                AppNavigation(
+                    pendingEnrollmentUrl = pendingEnrollmentUrl.value,
+                    onEnrollmentDeepLinkConsumed = {
+                        pendingEnrollmentUrl.value = null
+                    },
+                )
             }
         }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        pendingEnrollmentUrl.value = enrollmentUrlFromIntent(intent)
+    }
+
+    private fun enrollmentUrlFromIntent(intent: Intent?): String? {
+        val uri = intent?.data ?: return null
+        if (uri.scheme != "sm-enroll" || uri.host != "enroll") {
+            return null
+        }
+        return uri.getQueryParameter("url")?.trim()?.takeIf { it.isNotBlank() }
     }
 }

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/DeviceEnrollmentRepository.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/DeviceEnrollmentRepository.kt
@@ -13,12 +13,21 @@ import li.rajeshgo.sm.data.security.DeviceKeyManager
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.net.InetSocketAddress
 import java.net.URI
+import java.net.Socket
 
 data class DeviceEnrollmentResult(
     val deviceId: String,
     val deviceName: String?,
     val expiresAt: String?,
+)
+
+private data class EnrollmentHttpResponse(
+    val statusCode: Int,
+    val body: String,
 )
 
 class DeviceEnrollmentRepository(
@@ -36,11 +45,41 @@ class DeviceEnrollmentRepository(
             csrPem = deviceKeyManager.certificateSigningRequestPem(),
             publicKeyPem = deviceKeyManager.publicKeyPem(),
         )
+        val requestJson = json.encodeToString(DeviceEnrollmentRequest.serializer(), requestBody)
+        val response = postEnrollmentRequest(enrollmentUrl, requestJson)
+        val body = response.body
+        if (response.statusCode !in 200..299) {
+            throw IllegalStateException(enrollmentErrorMessage(body, response.statusCode))
+        }
+        val payload = json.decodeFromString(DeviceEnrollmentResponse.serializer(), body)
+        check(payload.deviceId.trim() == requestBody.deviceId) {
+            "Enrollment response device id did not match this device"
+        }
+        check(deviceKeyManager.certificateChainMatchesDeviceKey(payload.certificateChainPem)) {
+            "Enrollment certificate does not match this device key"
+        }
+        settingsRepository.saveCloudflareDeviceCertificateChainPem(payload.certificateChainPem)
+        DeviceEnrollmentResult(
+            deviceId = payload.deviceId,
+            deviceName = payload.deviceName,
+            expiresAt = payload.expiresAt,
+        )
+    }
+
+    private suspend fun postEnrollmentRequest(enrollmentUrl: String, requestJson: String): EnrollmentHttpResponse {
+        val uri = URI(enrollmentUrl)
+        return if (uri.scheme.equals("http", ignoreCase = true)) {
+            postLocalHttpEnrollmentRequest(uri, requestJson)
+        } else {
+            postHttpsEnrollmentRequest(enrollmentUrl, requestJson)
+        }
+    }
+
+    private suspend fun postHttpsEnrollmentRequest(enrollmentUrl: String, requestJson: String): EnrollmentHttpResponse {
         val request = Request.Builder()
             .url(enrollmentUrl)
             .post(
-                json.encodeToString(DeviceEnrollmentRequest.serializer(), requestBody)
-                    .toRequestBody("application/json".toMediaType()),
+                requestJson.toRequestBody("application/json".toMediaType()),
             )
             .build()
         val response = httpClientFactory.create(
@@ -51,24 +90,114 @@ class DeviceEnrollmentRepository(
             .newCall(request)
             .execute()
         response.use { result ->
-            val body = result.body?.string().orEmpty()
-            if (!result.isSuccessful) {
-                throw IllegalStateException(enrollmentErrorMessage(body, result.code))
-            }
-            val payload = json.decodeFromString(DeviceEnrollmentResponse.serializer(), body)
-            check(payload.deviceId.trim() == requestBody.deviceId) {
-                "Enrollment response device id did not match this device"
-            }
-            check(deviceKeyManager.certificateChainMatchesDeviceKey(payload.certificateChainPem)) {
-                "Enrollment certificate does not match this device key"
-            }
-            settingsRepository.saveCloudflareDeviceCertificateChainPem(payload.certificateChainPem)
-            DeviceEnrollmentResult(
-                deviceId = payload.deviceId,
-                deviceName = payload.deviceName,
-                expiresAt = payload.expiresAt,
-            )
+            return EnrollmentHttpResponse(result.code, result.body?.string().orEmpty())
         }
+    }
+
+    private fun postLocalHttpEnrollmentRequest(uri: URI, requestJson: String): EnrollmentHttpResponse {
+        val host = uri.host?.trim().orEmpty()
+        require(isLocalPairingHttpHost(host)) {
+            "HTTP enrollment URLs must use a local or private host"
+        }
+        val port = if (uri.port == -1) 80 else uri.port
+        require(port in 1..65535) { "Enrollment URL port is invalid" }
+        val target = buildString {
+            append(uri.rawPath?.takeIf { it.isNotBlank() } ?: "/")
+            uri.rawQuery?.takeIf { it.isNotBlank() }?.let { query ->
+                append('?')
+                append(query)
+            }
+        }
+        val bodyBytes = requestJson.toByteArray(Charsets.UTF_8)
+        Socket().use { socket ->
+            socket.connect(InetSocketAddress(host, port), 10_000)
+            socket.soTimeout = 30_000
+            val requestHeaders = buildString {
+                append("POST ")
+                append(target)
+                append(" HTTP/1.1\r\n")
+                append("Host: ")
+                append(host)
+                if (uri.port != -1) {
+                    append(':')
+                    append(port)
+                }
+                append("\r\n")
+                append("Accept: application/json\r\n")
+                append("Content-Type: application/json\r\n")
+                append("Content-Length: ")
+                append(bodyBytes.size)
+                append("\r\n")
+                append("Connection: close\r\n")
+                append("\r\n")
+            }.toByteArray(Charsets.US_ASCII)
+            val output = socket.getOutputStream()
+            output.write(requestHeaders)
+            output.write(bodyBytes)
+            output.flush()
+            socket.shutdownOutput()
+            return readEnrollmentHttpResponse(socket.getInputStream())
+        }
+    }
+
+    private fun readEnrollmentHttpResponse(input: InputStream): EnrollmentHttpResponse {
+        val headerBytes = readHeaderBytes(input)
+        val headerText = headerBytes.toString(Charsets.ISO_8859_1)
+        val lines = headerText.split("\r\n")
+        val statusCode = lines.firstOrNull()
+            ?.split(' ', limit = 3)
+            ?.getOrNull(1)
+            ?.toIntOrNull()
+            ?: throw IllegalStateException("Enrollment response did not include an HTTP status")
+        val headers = lines.drop(1)
+            .mapNotNull { line ->
+                val separator = line.indexOf(':')
+                if (separator <= 0) {
+                    null
+                } else {
+                    line.substring(0, separator).trim().lowercase() to line.substring(separator + 1).trim()
+                }
+            }
+            .toMap()
+        val contentLength = headers["content-length"]?.toIntOrNull()
+        val bodyBytes = if (contentLength != null && contentLength >= 0) {
+            readExactly(input, contentLength)
+        } else {
+            input.readBytes()
+        }
+        return EnrollmentHttpResponse(statusCode, bodyBytes.toString(Charsets.UTF_8))
+    }
+
+    private fun readHeaderBytes(input: InputStream): ByteArray {
+        val out = ByteArrayOutputStream()
+        var matched = 0
+        val delimiter = byteArrayOf('\r'.code.toByte(), '\n'.code.toByte(), '\r'.code.toByte(), '\n'.code.toByte())
+        while (true) {
+            val next = input.read()
+            if (next == -1) {
+                throw IllegalStateException("Enrollment response ended before HTTP headers")
+            }
+            out.write(next)
+            matched = if (next.toByte() == delimiter[matched]) matched + 1 else if (next == '\r'.code) 1 else 0
+            if (matched == delimiter.size) {
+                val bytes = out.toByteArray()
+                return bytes.copyOf(bytes.size - delimiter.size)
+            }
+            check(out.size() <= 64 * 1024) { "Enrollment response headers were too large" }
+        }
+    }
+
+    private fun readExactly(input: InputStream, length: Int): ByteArray {
+        val result = ByteArray(length)
+        var offset = 0
+        while (offset < length) {
+            val read = input.read(result, offset, length - offset)
+            if (read == -1) {
+                throw IllegalStateException("Enrollment response body ended early")
+            }
+            offset += read
+        }
+        return result
     }
 
     private fun deviceName(): String {
@@ -119,7 +248,48 @@ class DeviceEnrollmentRepository(
             require(!uri.host.isNullOrBlank()) {
                 "Enrollment URL must include a host"
             }
+            if (scheme == "http") {
+                require(isLocalPairingHttpHost(uri.host)) {
+                    "HTTP enrollment URLs must use a local or private host"
+                }
+            }
             return candidate
+        }
+
+        fun isLocalPairingHttpHost(host: String?): Boolean {
+            val normalized = host
+                ?.trim()
+                ?.removePrefix("[")
+                ?.removeSuffix("]")
+                ?.lowercase()
+                .orEmpty()
+            if (normalized.isBlank()) {
+                return false
+            }
+            if (normalized == "localhost" || normalized.endsWith(".local")) {
+                return true
+            }
+            if (normalized == "::1" || normalized.startsWith("fe80:")) {
+                return true
+            }
+            if (normalized.length >= 2 && normalized[0] == 'f' && normalized[1] in setOf('c', 'd')) {
+                return true
+            }
+            val octets = normalized.split('.')
+            if (octets.size != 4) {
+                return false
+            }
+            val values = octets.map { part ->
+                if (part.length > 1 && part.startsWith('0')) {
+                    return false
+                }
+                part.toIntOrNull()?.takeIf { it in 0..255 } ?: return false
+            }
+            return values[0] == 10 ||
+                values[0] == 127 ||
+                (values[0] == 169 && values[1] == 254) ||
+                (values[0] == 172 && values[1] in 16..31) ||
+                (values[0] == 192 && values[1] == 168)
         }
     }
 }

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/DeviceEnrollmentRepository.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/DeviceEnrollmentRepository.kt
@@ -135,7 +135,6 @@ class DeviceEnrollmentRepository(
             output.write(requestHeaders)
             output.write(bodyBytes)
             output.flush()
-            socket.shutdownOutput()
             return readEnrollmentHttpResponse(socket.getInputStream())
         }
     }

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/DeviceEnrollmentRepository.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/DeviceEnrollmentRepository.kt
@@ -272,8 +272,11 @@ class DeviceEnrollmentRepository(
             if (normalized == "::1" || normalized.startsWith("fe80:")) {
                 return true
             }
-            if (normalized.length >= 2 && normalized[0] == 'f' && normalized[1] in setOf('c', 'd')) {
-                return true
+            if (normalized.contains(':')) {
+                val firstWord = normalized.substringBefore(':').toIntOrNull(16)
+                if (firstWord != null && (firstWord and 0xfe00) == 0xfc00) {
+                    return true
+                }
             }
             val octets = normalized.split('.')
             if (octets.size != 4) {

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/navigation/AppNavigation.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/navigation/AppNavigation.kt
@@ -1,6 +1,7 @@
 package li.rajeshgo.sm.ui.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.LocalContext
@@ -21,7 +22,10 @@ object Routes {
 }
 
 @Composable
-fun AppNavigation() {
+fun AppNavigation(
+    pendingEnrollmentUrl: String? = null,
+    onEnrollmentDeepLinkConsumed: () -> Unit = {},
+) {
     val navController = rememberNavController()
     val context = LocalContext.current
     val settingsRepository = SettingsRepository(context)
@@ -33,6 +37,14 @@ fun AppNavigation() {
         null -> return
     }
 
+    LaunchedEffect(pendingEnrollmentUrl) {
+        if (!pendingEnrollmentUrl.isNullOrBlank()) {
+            navController.navigate(Routes.SETTINGS) {
+                launchSingleTop = true
+            }
+        }
+    }
+
     NavHost(navController = navController, startDestination = startDestination) {
         composable(Routes.SETTINGS) {
             SettingsScreen(
@@ -41,6 +53,8 @@ fun AppNavigation() {
                         popUpTo(Routes.SETTINGS) { inclusive = true }
                     }
                 },
+                pendingEnrollmentUrl = pendingEnrollmentUrl,
+                onEnrollmentDeepLinkConsumed = onEnrollmentDeepLinkConsumed,
             )
         }
         composable(Routes.WATCH) {

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsScreen.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsScreen.kt
@@ -1,6 +1,5 @@
 package li.rajeshgo.sm.ui.settings
 
-import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -28,8 +27,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.journeyapps.barcodescanner.ScanContract
-import com.journeyapps.barcodescanner.ScanOptions
 import li.rajeshgo.sm.BuildConfig
 import li.rajeshgo.sm.auth.GoogleSignInManager
 import li.rajeshgo.sm.ui.theme.BorderStrong
@@ -52,9 +49,6 @@ fun SettingsScreen(
     val googleSignInManager = GoogleSignInManager(context)
     val coroutineScope = rememberCoroutineScope()
     val deepLinkEnrollmentUrl = pendingEnrollmentUrl?.trim()?.takeIf { it.isNotBlank() }
-    val enrollmentScanner = rememberLauncherForActivityResult(ScanContract()) { result ->
-        result.contents?.trim()?.takeIf { it.isNotBlank() }?.let(viewModel::enrollCloudflareDeviceFromQr)
-    }
     val effectiveGoogleClientId = state.bootstrap?.auth?.googleServerClientId?.takeIf { it.isNotBlank() }
         ?: LocalDefaults.googleServerClientId.takeIf { it.isNotBlank() }
 
@@ -193,7 +187,7 @@ fun SettingsScreen(
                 )
                 Spacer(Modifier.height(8.dp))
                 Text(
-                    text = "Use this CSR when issuing the SM mobile Access certificate. The certificate Common Name should stay equal to the device key id.",
+                    text = "Run sm enroll-device on the Session Manager host, scan the QR with the phone Camera app, then open the link in Session Manager.",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
@@ -209,26 +203,6 @@ fun SettingsScreen(
                     color = if (state.cloudflareDeviceCertificateConfigured) Emerald else Rose,
                     fontFamily = FontFamily.Monospace,
                 )
-                Spacer(Modifier.height(10.dp))
-                Button(
-                    onClick = {
-                        val options = ScanOptions().apply {
-                            setDesiredBarcodeFormats(ScanOptions.QR_CODE)
-                            setPrompt("Scan sm enroll-device QR")
-                            setBeepEnabled(false)
-                            setOrientationLocked(false)
-                        }
-                        enrollmentScanner.launch(options)
-                    },
-                    enabled = !state.cloudflareEnrollmentInProgress,
-                    modifier = Modifier.fillMaxWidth(),
-                ) {
-                    if (state.cloudflareEnrollmentInProgress) {
-                        CircularProgressIndicator(strokeWidth = 2.dp, modifier = Modifier.height(18.dp))
-                    } else {
-                        Text("Scan enrollment QR")
-                    }
-                }
                 deepLinkEnrollmentUrl?.let { enrollmentUrl ->
                     Spacer(Modifier.height(10.dp))
                     Text(
@@ -265,46 +239,15 @@ fun SettingsScreen(
                     }
                 }
                 Spacer(Modifier.height(10.dp))
-                OutlinedButton(
-                    onClick = {
-                        val clipboard = context.getSystemService(android.content.ClipboardManager::class.java)
-                        clipboard?.setPrimaryClip(
-                            android.content.ClipData.newPlainText(
-                                "sm mobile cloudflare csr",
-                                state.mobileDeviceCertificateSigningRequest,
-                            ),
-                        )
-                    },
-                    enabled = state.mobileDeviceCertificateSigningRequest.isNotBlank(),
-                ) {
-                    Text("Copy CSR")
+                if (state.cloudflareEnrollmentInProgress) {
+                    CircularProgressIndicator(strokeWidth = 2.dp, modifier = Modifier.height(18.dp))
+                    Spacer(Modifier.height(10.dp))
                 }
-                Spacer(Modifier.height(10.dp))
-                OutlinedTextField(
-                    value = state.cloudflareDeviceCertificateChainPem,
-                    onValueChange = viewModel::updateCloudflareDeviceCertificateChain,
-                    label = { Text("Signed certificate chain PEM") },
-                    placeholder = { Text("-----BEGIN CERTIFICATE-----") },
-                    maxLines = 8,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(170.dp),
-                )
-                Spacer(Modifier.height(10.dp))
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    Button(
-                        onClick = viewModel::saveCloudflareDeviceCertificateChain,
-                        enabled = state.cloudflareDeviceCertificateChainPem.isNotBlank() && !state.cloudflareEnrollmentInProgress,
-                    ) {
-                        Text("Save cert")
-                    }
-                    OutlinedButton(
-                        onClick = viewModel::clearCloudflareDeviceCertificateChain,
-                        enabled = (state.cloudflareDeviceCertificateConfigured || state.cloudflareDeviceCertificateChainPem.isNotBlank()) &&
-                            !state.cloudflareEnrollmentInProgress,
-                    ) {
-                        Text("Clear cert")
-                    }
+                OutlinedButton(
+                    onClick = viewModel::clearCloudflareDeviceCertificateChain,
+                    enabled = state.cloudflareDeviceCertificateConfigured && !state.cloudflareEnrollmentInProgress,
+                ) {
+                    Text("Clear cert")
                 }
                 state.cloudflareEnrollmentStatus?.let { status ->
                     Spacer(Modifier.height(10.dp))

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsScreen.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
@@ -43,6 +44,8 @@ import kotlinx.coroutines.launch
 @Composable
 fun SettingsScreen(
     onNavigateToWatch: () -> Unit,
+    pendingEnrollmentUrl: String? = null,
+    onEnrollmentDeepLinkConsumed: () -> Unit = {},
     viewModel: SettingsViewModel = viewModel(),
 ) {
     val state by viewModel.uiState.collectAsState()
@@ -54,6 +57,14 @@ fun SettingsScreen(
     }
     val effectiveGoogleClientId = state.bootstrap?.auth?.googleServerClientId?.takeIf { it.isNotBlank() }
         ?: LocalDefaults.googleServerClientId.takeIf { it.isNotBlank() }
+
+    LaunchedEffect(pendingEnrollmentUrl) {
+        val enrollmentUrl = pendingEnrollmentUrl?.trim()
+        if (!enrollmentUrl.isNullOrBlank()) {
+            viewModel.enrollCloudflareDeviceFromQr(enrollmentUrl)
+            onEnrollmentDeepLinkConsumed()
+        }
+    }
 
     Column(
         modifier = Modifier

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsScreen.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsScreen.kt
@@ -20,13 +20,9 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
@@ -55,20 +51,12 @@ fun SettingsScreen(
     val context = LocalContext.current
     val googleSignInManager = GoogleSignInManager(context)
     val coroutineScope = rememberCoroutineScope()
-    var pendingDeepLinkEnrollmentUrl by remember { mutableStateOf<String?>(null) }
+    val deepLinkEnrollmentUrl = pendingEnrollmentUrl?.trim()?.takeIf { it.isNotBlank() }
     val enrollmentScanner = rememberLauncherForActivityResult(ScanContract()) { result ->
         result.contents?.trim()?.takeIf { it.isNotBlank() }?.let(viewModel::enrollCloudflareDeviceFromQr)
     }
     val effectiveGoogleClientId = state.bootstrap?.auth?.googleServerClientId?.takeIf { it.isNotBlank() }
         ?: LocalDefaults.googleServerClientId.takeIf { it.isNotBlank() }
-
-    LaunchedEffect(pendingEnrollmentUrl) {
-        val enrollmentUrl = pendingEnrollmentUrl?.trim()
-        if (!enrollmentUrl.isNullOrBlank()) {
-            pendingDeepLinkEnrollmentUrl = enrollmentUrl
-            onEnrollmentDeepLinkConsumed()
-        }
-    }
 
     Column(
         modifier = Modifier
@@ -241,7 +229,7 @@ fun SettingsScreen(
                         Text("Scan enrollment QR")
                     }
                 }
-                pendingDeepLinkEnrollmentUrl?.let { enrollmentUrl ->
+                deepLinkEnrollmentUrl?.let { enrollmentUrl ->
                     Spacer(Modifier.height(10.dp))
                     Text(
                         text = "Enrollment link opened from camera",
@@ -260,7 +248,7 @@ fun SettingsScreen(
                         Button(
                             onClick = {
                                 viewModel.enrollCloudflareDeviceFromQr(enrollmentUrl)
-                                pendingDeepLinkEnrollmentUrl = null
+                                onEnrollmentDeepLinkConsumed()
                             },
                             enabled = !state.cloudflareEnrollmentInProgress,
                         ) {
@@ -268,7 +256,7 @@ fun SettingsScreen(
                         }
                         OutlinedButton(
                             onClick = {
-                                pendingDeepLinkEnrollmentUrl = null
+                                onEnrollmentDeepLinkConsumed()
                             },
                             enabled = !state.cloudflareEnrollmentInProgress,
                         ) {

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsScreen.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsScreen.kt
@@ -23,7 +23,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
@@ -52,6 +55,7 @@ fun SettingsScreen(
     val context = LocalContext.current
     val googleSignInManager = GoogleSignInManager(context)
     val coroutineScope = rememberCoroutineScope()
+    var pendingDeepLinkEnrollmentUrl by remember { mutableStateOf<String?>(null) }
     val enrollmentScanner = rememberLauncherForActivityResult(ScanContract()) { result ->
         result.contents?.trim()?.takeIf { it.isNotBlank() }?.let(viewModel::enrollCloudflareDeviceFromQr)
     }
@@ -61,7 +65,7 @@ fun SettingsScreen(
     LaunchedEffect(pendingEnrollmentUrl) {
         val enrollmentUrl = pendingEnrollmentUrl?.trim()
         if (!enrollmentUrl.isNullOrBlank()) {
-            viewModel.enrollCloudflareDeviceFromQr(enrollmentUrl)
+            pendingDeepLinkEnrollmentUrl = enrollmentUrl
             onEnrollmentDeepLinkConsumed()
         }
     }
@@ -235,6 +239,41 @@ fun SettingsScreen(
                         CircularProgressIndicator(strokeWidth = 2.dp, modifier = Modifier.height(18.dp))
                     } else {
                         Text("Scan enrollment QR")
+                    }
+                }
+                pendingDeepLinkEnrollmentUrl?.let { enrollmentUrl ->
+                    Spacer(Modifier.height(10.dp))
+                    Text(
+                        text = "Enrollment link opened from camera",
+                        style = MaterialTheme.typography.titleSmall,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    Spacer(Modifier.height(6.dp))
+                    Text(
+                        text = enrollmentUrl,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Cyan,
+                        fontFamily = FontFamily.Monospace,
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Button(
+                            onClick = {
+                                viewModel.enrollCloudflareDeviceFromQr(enrollmentUrl)
+                                pendingDeepLinkEnrollmentUrl = null
+                            },
+                            enabled = !state.cloudflareEnrollmentInProgress,
+                        ) {
+                            Text("Enroll device")
+                        }
+                        OutlinedButton(
+                            onClick = {
+                                pendingDeepLinkEnrollmentUrl = null
+                            },
+                            enabled = !state.cloudflareEnrollmentInProgress,
+                        ) {
+                            Text("Dismiss")
+                        }
                     }
                 }
                 Spacer(Modifier.height(10.dp))

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsViewModel.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsViewModel.kt
@@ -4,12 +4,10 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import kotlin.Result
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import li.rajeshgo.sm.data.model.ClientBootstrapResponse
 import li.rajeshgo.sm.data.repository.AppUpdateRepository
 import li.rajeshgo.sm.data.repository.AvailableAppUpdate
@@ -29,7 +27,6 @@ data class SettingsUiState(
     val mobileDeviceKeyId: String = "",
     val mobileDevicePublicKey: String = "",
     val mobileDeviceCertificateSigningRequest: String = "",
-    val cloudflareDeviceCertificateChainPem: String = "",
     val cloudflareDeviceCertificateConfigured: Boolean = false,
     val cloudflareEnrollmentInProgress: Boolean = false,
     val cloudflareEnrollmentStatus: String? = null,
@@ -57,7 +54,6 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                 userEmail = settingsRepository.userEmail.first(),
                 userName = settingsRepository.userName.first(),
                 isLoggedIn = settingsRepository.isLoggedIn.first(),
-                cloudflareDeviceCertificateChainPem = settingsRepository.cloudflareDeviceCertificateChainPem.first(),
                 cloudflareDeviceCertificateConfigured = settingsRepository.hasCloudflareDeviceCertificate.first(),
             )
             loadMobileDeviceKey()
@@ -110,42 +106,6 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         }
     }
 
-    fun updateCloudflareDeviceCertificateChain(value: String) {
-        _uiState.value = _uiState.value.copy(
-            cloudflareDeviceCertificateChainPem = value,
-            cloudflareEnrollmentError = null,
-        )
-    }
-
-    fun saveCloudflareDeviceCertificateChain() {
-        val certificateChainPem = _uiState.value.cloudflareDeviceCertificateChainPem.trim()
-        if (certificateChainPem.isBlank()) {
-            clearCloudflareDeviceCertificateChain()
-            return
-        }
-        viewModelScope.launch {
-            runCatching {
-                withContext(Dispatchers.IO) {
-                    check(deviceKeyManager.certificateChainMatchesDeviceKey(certificateChainPem)) {
-                        "Certificate chain does not match this mobile device key"
-                    }
-                }
-                settingsRepository.saveCloudflareDeviceCertificateChainPem(certificateChainPem)
-            }.onSuccess {
-                _uiState.value = _uiState.value.copy(
-                    cloudflareDeviceCertificateChainPem = certificateChainPem,
-                    cloudflareDeviceCertificateConfigured = true,
-                    cloudflareEnrollmentStatus = "Client certificate saved",
-                    cloudflareEnrollmentError = null,
-                )
-            }.onFailure { error ->
-                _uiState.value = _uiState.value.copy(
-                    cloudflareEnrollmentError = error.message ?: "Failed to save Cloudflare certificate",
-                )
-            }
-        }
-    }
-
     fun enrollCloudflareDeviceFromQr(qrContents: String) {
         if (_uiState.value.cloudflareEnrollmentInProgress) {
             return
@@ -159,10 +119,8 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
             runCatching {
                 deviceEnrollmentRepository.enrollFromQr(qrContents)
             }.onSuccess { result ->
-                val certificateChainPem = settingsRepository.cloudflareDeviceCertificateChainPem.first()
                 _uiState.value = _uiState.value.copy(
-                    cloudflareDeviceCertificateChainPem = certificateChainPem,
-                    cloudflareDeviceCertificateConfigured = certificateChainPem.isNotBlank(),
+                    cloudflareDeviceCertificateConfigured = true,
                     cloudflareEnrollmentInProgress = false,
                     cloudflareEnrollmentStatus = buildString {
                         append("Enrolled ")
@@ -188,7 +146,6 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         viewModelScope.launch {
             settingsRepository.clearCloudflareDeviceCertificateChainPem()
             _uiState.value = _uiState.value.copy(
-                cloudflareDeviceCertificateChainPem = "",
                 cloudflareDeviceCertificateConfigured = false,
                 cloudflareEnrollmentStatus = "Client certificate cleared",
                 cloudflareEnrollmentError = null,

--- a/android-app/app/src/test/java/li/rajeshgo/sm/data/repository/SessionManagerRepositoryTest.kt
+++ b/android-app/app/src/test/java/li/rajeshgo/sm/data/repository/SessionManagerRepositoryTest.kt
@@ -149,8 +149,13 @@ class SessionManagerRepositoryTest {
         assertTrue(DeviceEnrollmentRepository.isLocalPairingHttpHost("10.0.0.9"))
         assertTrue(DeviceEnrollmentRepository.isLocalPairingHttpHost("172.16.1.2"))
         assertTrue(DeviceEnrollmentRepository.isLocalPairingHttpHost("192.168.4.31"))
+        assertTrue(DeviceEnrollmentRepository.isLocalPairingHttpHost("fd00::1"))
+        assertTrue(DeviceEnrollmentRepository.isLocalPairingHttpHost("[fc00::1]"))
+        assertTrue(DeviceEnrollmentRepository.isLocalPairingHttpHost("fe80::1"))
         assertFalse(DeviceEnrollmentRepository.isLocalPairingHttpHost("8.8.8.8"))
         assertFalse(DeviceEnrollmentRepository.isLocalPairingHttpHost("example.com"))
+        assertFalse(DeviceEnrollmentRepository.isLocalPairingHttpHost("fdattacker.example.com"))
+        assertFalse(DeviceEnrollmentRepository.isLocalPairingHttpHost("2001:4860:4860::8888"))
     }
 
     private fun ticket(): MobileAttachTicketResponse {

--- a/android-app/app/src/test/java/li/rajeshgo/sm/data/repository/SessionManagerRepositoryTest.kt
+++ b/android-app/app/src/test/java/li/rajeshgo/sm/data/repository/SessionManagerRepositoryTest.kt
@@ -110,6 +110,16 @@ class SessionManagerRepositoryTest {
     }
 
     @Test
+    fun deviceEnrollmentQrAcceptsPrivateHttpPairingUrl() {
+        assertEquals(
+            "http://192.168.4.31:19192/client/mobile-terminal/enroll/abc",
+            DeviceEnrollmentRepository.enrollmentUrlFromQrContents(
+                "http://192.168.4.31:19192/client/mobile-terminal/enroll/abc",
+            ),
+        )
+    }
+
+    @Test
     fun deviceEnrollmentQrAcceptsJsonEnrollmentUrl() {
         assertEquals(
             "https://sm-app.example.com/client/mobile-terminal/enroll/abc",
@@ -122,6 +132,25 @@ class SessionManagerRepositoryTest {
     @Test(expected = IllegalArgumentException::class)
     fun deviceEnrollmentQrRejectsNonHttpUrl() {
         DeviceEnrollmentRepository.enrollmentUrlFromQrContents("sm-enroll://abc")
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun deviceEnrollmentQrRejectsPublicHttpUrl() {
+        DeviceEnrollmentRepository.enrollmentUrlFromQrContents(
+            "http://attacker.example.com/client/mobile-terminal/enroll/abc",
+        )
+    }
+
+    @Test
+    fun deviceEnrollmentLocalHttpHostClassifierMatchesPairingHosts() {
+        assertTrue(DeviceEnrollmentRepository.isLocalPairingHttpHost("localhost"))
+        assertTrue(DeviceEnrollmentRepository.isLocalPairingHttpHost("studio.local"))
+        assertTrue(DeviceEnrollmentRepository.isLocalPairingHttpHost("127.0.0.1"))
+        assertTrue(DeviceEnrollmentRepository.isLocalPairingHttpHost("10.0.0.9"))
+        assertTrue(DeviceEnrollmentRepository.isLocalPairingHttpHost("172.16.1.2"))
+        assertTrue(DeviceEnrollmentRepository.isLocalPairingHttpHost("192.168.4.31"))
+        assertFalse(DeviceEnrollmentRepository.isLocalPairingHttpHost("8.8.8.8"))
+        assertFalse(DeviceEnrollmentRepository.isLocalPairingHttpHost("example.com"))
     }
 
     private fun ticket(): MobileAttachTicketResponse {

--- a/crates/sm-server/src/mobile_devices.rs
+++ b/crates/sm-server/src/mobile_devices.rs
@@ -1553,7 +1553,7 @@ fn enrollment_redirect_html(enrollment_url: &str) -> String {
   <p>This enrollment link must be opened in the Session Manager Android app.</p>
   <p><a href="{intent_link}">Open Session Manager</a></p>
   <p><a href="{app_link}">Open with app link</a></p>
-  <p>If the button does not work, open the app Settings screen and use Scan enrollment QR.</p>
+  <p>If the button does not work, scan the QR again with the phone Camera app and open it in Session Manager.</p>
   <p>Enrollment URL: <code>{enrollment_url}</code></p>
 </body>
 </html>"#,

--- a/crates/sm-server/src/mobile_devices.rs
+++ b/crates/sm-server/src/mobile_devices.rs
@@ -12,9 +12,9 @@ use std::{
 use anyhow::{bail, Context, Result};
 use axum::{
     extract::{ConnectInfo, Path as AxumPath, State},
-    http::StatusCode,
-    response::{IntoResponse, Response},
-    routing::{get, post},
+    http::{header::HOST, HeaderMap, StatusCode},
+    response::{Html, IntoResponse, Response},
+    routing::get,
     Json, Router,
 };
 use base64::Engine as _;
@@ -374,7 +374,7 @@ pub async fn serve_pairing_listener(
         .route("/health", get(pairing_health))
         .route(
             &format!("{PAIRING_PATH_PREFIX}/{{token}}"),
-            post(complete_device_enrollment),
+            get(open_device_enrollment).post(complete_device_enrollment),
         )
         .with_state(state);
     let listener = TcpListener::bind(bind_addr)
@@ -397,6 +397,40 @@ pub fn enrollment_path(token: &str) -> String {
 
 async fn pairing_health() -> impl IntoResponse {
     (StatusCode::OK, Json(json!({"ok": true})))
+}
+
+async fn open_device_enrollment(
+    State(state): State<PairingState>,
+    AxumPath(token): AxumPath<String>,
+    headers: HeaderMap,
+) -> Response {
+    let token = token.trim().to_owned();
+    if token.is_empty() {
+        return json_error(StatusCode::BAD_REQUEST, "Enrollment token is required");
+    }
+    match pending_pairing_registration(&state.db_path, &token) {
+        Ok(Some(_registration)) => {}
+        Ok(None) => {
+            return json_error(
+                StatusCode::NOT_FOUND,
+                "Unknown, expired, or already used enrollment token",
+            )
+        }
+        Err(error) => {
+            return json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                &format!("Enrollment lookup failed: {error}"),
+            )
+        }
+    }
+    let host = headers
+        .get(HOST)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("127.0.0.1:19192");
+    let enrollment_url = format!("http://{host}{}", enrollment_path(&token));
+    Html(enrollment_redirect_html(&enrollment_url)).into_response()
 }
 
 async fn complete_device_enrollment(
@@ -1479,6 +1513,62 @@ fn qr_ascii(value: &str) -> Result<String> {
         .build())
 }
 
+fn enrollment_redirect_html(enrollment_url: &str) -> String {
+    let encoded_url = percent_encode_query_value(enrollment_url);
+    let app_link = format!("sm-enroll://enroll?url={encoded_url}");
+    let intent_link = format!(
+        "intent://enroll?url={encoded_url}#Intent;scheme=sm-enroll;package=li.rajeshgo.sm;S.browser_fallback_url={encoded_url};end"
+    );
+    let intent_js = serde_json::to_string(&intent_link).unwrap_or_else(|_| "\"\"".to_owned());
+    format!(
+        r#"<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Open Session Manager</title>
+  <script>
+    window.location.href = {intent_js};
+  </script>
+</head>
+<body>
+  <h1>Open Session Manager</h1>
+  <p>This enrollment link must be opened in the Session Manager Android app.</p>
+  <p><a href="{intent_link}">Open Session Manager</a></p>
+  <p><a href="{app_link}">Open with app link</a></p>
+  <p>If the button does not work, open the app Settings screen and use Scan enrollment QR.</p>
+  <p>Enrollment URL: <code>{enrollment_url}</code></p>
+</body>
+</html>"#,
+        intent_link = escape_html_attr(&intent_link),
+        app_link = escape_html_attr(&app_link),
+        enrollment_url = escape_html(enrollment_url),
+    )
+}
+
+fn percent_encode_query_value(value: &str) -> String {
+    let mut output = String::new();
+    for byte in value.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~') {
+            output.push(byte as char);
+        } else {
+            output.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    output
+}
+
+fn escape_html(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+fn escape_html_attr(value: &str) -> String {
+    escape_html(value).replace('"', "&quot;")
+}
+
 fn valid_device_id(value: &str) -> bool {
     let len = value.len();
     (3..=128).contains(&len)
@@ -1681,6 +1771,24 @@ mod tests {
         assert_eq!(
             enrollment_path("abc123"),
             "/client/mobile-terminal/enroll/abc123"
+        );
+    }
+
+    #[test]
+    fn enrollment_redirect_html_contains_android_intent_deep_link() {
+        let url = "http://192.168.4.31:19192/client/mobile-terminal/enroll/abc123";
+        let html = enrollment_redirect_html(url);
+
+        assert!(html.contains("intent://enroll?url=http%3A%2F%2F192.168.4.31%3A19192%2Fclient%2Fmobile-terminal%2Fenroll%2Fabc123#Intent;scheme=sm-enroll;package=li.rajeshgo.sm;"));
+        assert!(html.contains("sm-enroll://enroll?url=http%3A%2F%2F192.168.4.31%3A19192%2Fclient%2Fmobile-terminal%2Fenroll%2Fabc123"));
+        assert!(html.contains("Enrollment URL:"));
+    }
+
+    #[test]
+    fn percent_encode_query_value_matches_deep_link_needs() {
+        assert_eq!(
+            percent_encode_query_value("http://host/path?x=1&y=a b"),
+            "http%3A%2F%2Fhost%2Fpath%3Fx%3D1%26y%3Da%20b"
         );
     }
 }

--- a/crates/sm-server/src/mobile_devices.rs
+++ b/crates/sm-server/src/mobile_devices.rs
@@ -18,7 +18,7 @@ use axum::{
     Json, Router,
 };
 use base64::Engine as _;
-use qrcode::QrCode;
+use qrcode::{render::unicode, QrCode};
 use rand_core::{OsRng, RngCore};
 use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
@@ -71,6 +71,7 @@ struct PairingState {
     db_path: PathBuf,
     ca_cert_path: PathBuf,
     ca_key_path: PathBuf,
+    advertised_base_url: String,
     unknown_attempts: Arc<Mutex<u32>>,
     shutdown: Arc<Notify>,
 }
@@ -351,6 +352,7 @@ pub fn run_enroll_device(options: EnrollDeviceOptions) -> Result<()> {
         options.listen,
         ca_cert_path,
         ca_key_path,
+        base_url,
     ))
 }
 
@@ -360,6 +362,7 @@ pub async fn serve_pairing_listener(
     bind_addr: SocketAddr,
     ca_cert_path: PathBuf,
     ca_key_path: PathBuf,
+    advertised_base_url: String,
 ) -> Result<()> {
     let shutdown = Arc::new(Notify::new());
     let state = PairingState {
@@ -367,6 +370,7 @@ pub async fn serve_pairing_listener(
         db_path,
         ca_cert_path,
         ca_key_path,
+        advertised_base_url,
         unknown_attempts: Arc::new(Mutex::new(0)),
         shutdown: shutdown.clone(),
     };
@@ -423,13 +427,11 @@ async fn open_device_enrollment(
             )
         }
     }
-    let host = headers
-        .get(HOST)
-        .and_then(|value| value.to_str().ok())
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or("127.0.0.1:19192");
-    let enrollment_url = format!("http://{host}{}", enrollment_path(&token));
+    let enrollment_url = format!(
+        "{}/{}",
+        request_base_url(&state, &headers).trim_end_matches('/'),
+        enrollment_path(&token).trim_start_matches('/')
+    );
     Html(enrollment_redirect_html(&enrollment_url)).into_response()
 }
 
@@ -1496,6 +1498,27 @@ fn pairing_base_url(listen: SocketAddr) -> String {
     format!("http://{host}:{port}")
 }
 
+fn request_base_url(state: &PairingState, headers: &HeaderMap) -> String {
+    let advertised = state.advertised_base_url.trim();
+    if !advertised.is_empty() {
+        return advertised.to_owned();
+    }
+    let host = headers
+        .get(HOST)
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("127.0.0.1:19192");
+    let scheme = headers
+        .get("x-forwarded-proto")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(',').next())
+        .map(str::trim)
+        .filter(|value| matches!(*value, "http" | "https"))
+        .unwrap_or("http");
+    format!("{scheme}://{host}")
+}
+
 fn local_lan_ip() -> Option<String> {
     let socket = UdpSocket::bind("0.0.0.0:0").ok()?;
     socket.connect("1.1.1.1:80").ok()?;
@@ -1504,13 +1527,7 @@ fn local_lan_ip() -> Option<String> {
 
 fn qr_ascii(value: &str) -> Result<String> {
     let code = QrCode::new(value.as_bytes()).context("failed to render enrollment QR")?;
-    Ok(code
-        .render::<char>()
-        .quiet_zone(true)
-        .module_dimensions(2, 1)
-        .dark_color('#')
-        .light_color(' ')
-        .build())
+    Ok(code.render::<unicode::Dense1x2>().quiet_zone(true).build())
 }
 
 fn enrollment_redirect_html(enrollment_url: &str) -> String {
@@ -1771,6 +1788,56 @@ mod tests {
         assert_eq!(
             enrollment_path("abc123"),
             "/client/mobile-terminal/enroll/abc123"
+        );
+    }
+
+    #[test]
+    fn qr_ascii_uses_dense_unicode_blocks() {
+        let qr = qr_ascii("http://192.168.4.31:19192/client/mobile-terminal/enroll/abc123")
+            .expect("render QR");
+
+        assert!(!qr.contains('#'));
+        assert!(qr.contains('█') || qr.contains('▀') || qr.contains('▄'));
+    }
+
+    #[test]
+    fn request_base_url_prefers_advertised_url() {
+        let state = PairingState {
+            config: AppConfig::default(),
+            db_path: PathBuf::new(),
+            ca_cert_path: PathBuf::new(),
+            ca_key_path: PathBuf::new(),
+            advertised_base_url: "https://sm-app.rajeshgo.li/pair".to_owned(),
+            unknown_attempts: Arc::new(Mutex::new(0)),
+            shutdown: Arc::new(Notify::new()),
+        };
+        let mut headers = HeaderMap::new();
+        headers.insert(HOST, "127.0.0.1:19192".parse().expect("host header"));
+
+        assert_eq!(
+            request_base_url(&state, &headers),
+            "https://sm-app.rajeshgo.li/pair"
+        );
+    }
+
+    #[test]
+    fn request_base_url_falls_back_to_forwarded_proto_and_host() {
+        let state = PairingState {
+            config: AppConfig::default(),
+            db_path: PathBuf::new(),
+            ca_cert_path: PathBuf::new(),
+            ca_key_path: PathBuf::new(),
+            advertised_base_url: String::new(),
+            unknown_attempts: Arc::new(Mutex::new(0)),
+            shutdown: Arc::new(Notify::new()),
+        };
+        let mut headers = HeaderMap::new();
+        headers.insert(HOST, "pairing.internal:19192".parse().expect("host header"));
+        headers.insert("x-forwarded-proto", "https".parse().expect("proto header"));
+
+        assert_eq!(
+            request_base_url(&state, &headers),
+            "https://pairing.internal:19192"
         );
     }
 


### PR DESCRIPTION
Fixes #1011

## Summary
- add an Android `sm-enroll://enroll` deep link for Camera-app QR handoff into Settings
- make `sm enroll-device` serve a browser landing page for `/client/mobile-terminal/enroll/{token}` with Android app links
- enroll the Cloudflare Access client certificate directly in-app without exposing certificate material or requiring camera permission
- preserve local/private HTTP pairing support through the app socket fallback while keeping public HTTP rejected

## Validation
- `ANDROID_HOME=/opt/homebrew/share/android-commandlinetools ANDROID_SDK_ROOT=/opt/homebrew/share/android-commandlinetools ./gradlew :app:testDebugUnitTest :app:assembleDebug`
- `cargo fmt --check`
- `cargo test -p sm-server mobile_devices --lib`
- `cargo build -p sm-server --bin sm`
- `git diff --check`
- published Android artifact `cbb61798` as versionCode `1013`, versionName `0.1.0-enroll-ui-cleanup`