### PR TITLE
Refresh Rust handoff contract assertions

### DIFF
--- a/specs/762_stage5_artifacts/cloudflare_access_cutover_evidence.md
+++ b/specs/762_stage5_artifacts/cloudflare_access_cutover_evidence.md
@@ -1,6 +1,6 @@
 # Cloudflare Access Cutover Evidence
 
-Status: implementation evidence after PR #996 merged.
+Status: implementation evidence after PR #1012 merged.
 
 This artifact records the current Rust-side Cloudflare Access boundary for the
 Rust cutover track. It complements the design in
@@ -9,8 +9,9 @@ and does not replace the rollout gates in [gate_matrix.md](gate_matrix.md).
 
 ## Merged Runtime Boundary
 
-Rust `main` now includes the Cloudflare Access origin gate and read-only smoke
-evidence runner through PR #996:
+Rust `main` now includes the Cloudflare Access origin gate, read-only smoke
+evidence runner, Rust mobile-device enrollment, Cloudflare mTLS CA automation,
+and Android Camera-app enrollment flow through PR #1012:
 
 | PR | Evidence added |
 | --- | --- |
@@ -18,6 +19,12 @@ evidence runner through PR #996:
 | #948 | Rust config parsing and Cloudflare Access JWT/audience/context classification. |
 | #950 | Origin route gates, JWKS caching/refresh, public-host fail-closed behavior, app artifact gating, device-token exchange gating, and mobile device identity binding. |
 | #996 | Read-only Cloudflare Access smoke runner for mobile app origin-gate, public-edge proof, SM-auth boundary, app artifact metadata, and browser edge-only notes. |
+| #1000 | Android Cloudflare Access client-certificate storage and OkHttp/WebSocket client-certificate presentation. |
+| #1002 | Initial Android QR enrollment support; superseded by the Camera-app deep-link flow in #1012 for scanning. |
+| #1005 | Rust `sm enroll-device`, 15-minute mobile-device pairing listener, mobile device DB enrollment, CSR signing, and per-device Common Name policy sync. |
+| #1007 | Cloudflare mTLS CA upload/association automation for the mobile app hostname, keeping the CA private key local. |
+| #1010 | Android artifact version-code/version-name override support so published APK metadata matches the installed build. |
+| #1012 | Android Camera-app QR handoff via `sm-enroll://enroll`, direct in-app certificate save, no camera permission, no in-app scanner, and no certificate material exposed in Settings. |
 
 Current origin behavior:
 
@@ -38,6 +45,14 @@ Current origin behavior:
   device identity before returning native bootstrap metadata.
 - Local loopback plus trusted local host still preserves local operator bypass.
 - Non-mobile Access contexts are not accepted for native app routes.
+- `sm enroll-device` is the intended pairing path for native app
+  client-certificate setup. The pairing token is short-lived, the app submits
+  its Android Keystore-backed CSR, Rust signs it with the local mobile-device
+  CA, and the app stores the returned credential internally.
+- When Cloudflare API configuration is present, enrollment ensures the mobile
+  device CA is uploaded/associated with the app hostname and syncs the enrolled
+  device key id as a Common Name include entry. Broad "any valid certificate"
+  policy remains out of scope for cutover approval.
 
 The merged Rust tests currently cover:
 
@@ -85,11 +100,16 @@ needs operator-side Cloudflare and native-app evidence:
 | Shadow/rehearsal | Record a clean shadow/rehearsal window that includes native app traffic or an explicit operator-driven mobile route exercise. |
 
 The smoke runner requires real deployment inputs. The local shell used for the
-post-#996 handoff refresh did not have `CF_MOBILE_ACCESS_JWT`,
+post-#1012 handoff refresh did not have `CF_MOBILE_ACCESS_JWT`,
 `CF_BROWSER_ACCESS_JWT`, `SM_PUBLIC_EDGE_SECRET`, `SM_DEVICE_BEARER_TOKEN`,
 or `SM_COOKIE` set, and `--mobile-host` / `--browser-host` were not supplied,
 so no passing Cloudflare/mobile smoke evidence was produced there. Missing
 required mobile inputs are blockers by design.
+
+The Android artifact published during PR #1012 is versionCode `1013`,
+versionName `0.1.0-enroll-ui-cleanup`, artifact hash `cbb61798`. It supports
+Camera-app enrollment handoff and direct internal credential storage, but that
+published artifact is not by itself full Cloudflare Access cutover evidence.
 
 Do not treat the Cloudflare Access design as complete cutover evidence until
 these setup and smoke checks are recorded. The revoked-device denial and native

--- a/specs/762_stage5_artifacts/index.md
+++ b/specs/762_stage5_artifacts/index.md
@@ -11,7 +11,7 @@ This bundle supports Stage 5 of [762_rust_migration_and_ruggedization.md](../762
 | [state_ownership_and_migration.md](state_ownership_and_migration.md) | Store-by-store ownership, backup, migration, rollback, and downgrade rules. |
 | [gate_matrix.md](gate_matrix.md) | Falsifiable value gate, compatibility/security/ops gates, and observability requirements. |
 | [implementation_workstreams.md](implementation_workstreams.md) | Epic split and sequencing for implementation tickets after this spec converges. |
-| [mvp_progress.md](mvp_progress.md) | Dated implementation snapshot for the Rust MVP track after merged PR #950 and the clean real-state rehearsal. |
+| [mvp_progress.md](mvp_progress.md) | Dated implementation snapshot for the Rust MVP track after merged PR #1012 and the latest clean real-state rehearsal. |
 | [resume_handoff.md](resume_handoff.md) | Current resume point, validation state, known fixtures, and next slices for the Rust port. |
 | [cloudflare_access_cutover_evidence.md](cloudflare_access_cutover_evidence.md) | Current Cloudflare Access origin-gate evidence, required policies, and remaining public/mobile setup checks. |
 

--- a/specs/762_stage5_artifacts/mvp_progress.md
+++ b/specs/762_stage5_artifacts/mvp_progress.md
@@ -1,15 +1,16 @@
 # Rust MVP Progress Snapshot
 
-Status: implementation snapshot after PR #996 Cloudflare Access mobile smoke
-runner.
+Status: implementation snapshot after PR #1012 Android Camera-app enrollment
+flow.
 The last clean full real-state MVP rehearsal remains the post-#938 run; the
 post-#984 focused rehearsal proves state gates, live core contracts, read-only
 fixtures, and mutating fixtures on isolated sidecars, but intentionally skips
-Python baseline and shadow. PRs #986-#996 added node restore fixtures,
-stopped-origin final backup gates, rehearsal final-backup integration, and the
-Cloudflare Access mobile smoke evidence runner. Public cutover still needs
-Cloudflare policy setup, real mobile/browser smoke evidence, and a stable
-Python-authoritative shadow window.
+Python baseline and shadow. PRs #986-#1012 added node restore fixtures,
+stopped-origin final backup gates, rehearsal final-backup integration,
+Cloudflare Access smoke evidence tooling, Rust mobile-device enrollment,
+Cloudflare mTLS CA automation, and the Android Camera-app enrollment handoff.
+Public cutover still needs Cloudflare policy setup, real mobile/browser smoke
+evidence, and a stable Python-authoritative shadow window.
 
 This file is a handoff aid for the Rust cutover implementation track. It does
 not change retained or removed scope. Binding scope remains
@@ -96,6 +97,13 @@ not change retained or removed scope. Binding scope remains
 | #992 | Stopped-service final backup gate |
 | #994 | Final backup gate integrated into MVP rehearsal |
 | #996 | Cloudflare Access mobile smoke evidence runner |
+| #998 | Handoff refresh after Cloudflare smoke runner |
+| #1000 | Android Cloudflare client-certificate storage and native HTTP/WebSocket client-certificate presentation |
+| #1002 | Initial Android QR enrollment support; later replaced by the Camera-app deep-link flow |
+| #1005 | Rust `sm enroll-device`, mobile device DB enrollment, CSR signing, and per-device Common Name sync |
+| #1007 | Cloudflare mTLS CA upload and mobile app hostname association automation |
+| #1010 | Android artifact version-code/version-name override support |
+| #1012 | Android Camera-app QR handoff, `sm-enroll://enroll` deep link, direct in-app credential save, and no camera permission/manual cert UI |
 
 ## Implemented Capability Groups
 
@@ -108,8 +116,8 @@ The Rust sidecar now has executable coverage for:
 | Core reads | Health, auth session, bootstrap, session list/detail, client session list/detail, output, events state, SSE hello, nodes list, queue jobs list/detail, Codex review requests list/detail, and tool/audit read projections are implemented. |
 | Core runtime | Session/tmux/spawn/session-graph/message-queue/task-complete/input-batch/subagent and retained review-route slices are merged, with shadow and contract fixtures covering the early cutover path. |
 | Codex retained reads | Codex event stream, pending request ledger reads, activity actions, review detail/list, and Claude/Codex tool-call projections are implemented and covered by manifest checks. |
-| Mobile | Native bootstrap/session support, attach-ticket proofing, terminal WebSocket auth/bridge, runtime disable, device revoke/list CLI support, and public-edge assertion validation are merged. |
-| Cloudflare Access origin gate | Config parsing, JWT/audience classification, host/app separation, public-host fail-closed behavior, mobile/app route gating, app artifact gating, device-token exchange gating, JWKS cache refresh/TTL behavior, mobile Access CN actor binding, and read-only smoke evidence collection are merged. |
+| Mobile | Native bootstrap/session support, attach-ticket proofing, terminal WebSocket auth/bridge, runtime disable, device revoke/list CLI support, public-edge assertion validation, Android client-certificate storage, Rust `sm enroll-device`, and Camera-app deep-link enrollment are merged. |
+| Cloudflare Access origin gate | Config parsing, JWT/audience classification, host/app separation, public-host fail-closed behavior, mobile/app route gating, app artifact gating, device-token exchange gating, JWKS cache refresh/TTL behavior, mobile Access CN actor binding, Cloudflare mTLS CA upload/hostname association, per-device Common Name policy sync, and read-only smoke evidence collection are merged. |
 | External fallback | Email/human fallback delivery and inbound email validation path are retained in the Rust track. |
 | Queue and nodes | Queue list/detail, CLI list/status, pending submit, simple execute/cancel, queue recovery, queue fixtures, node reads, and node HTTP routes are implemented; remaining work is final live/recovery cutover evidence and any retained node-agent remote-control gaps. |
 
@@ -171,14 +179,14 @@ fixture false failures:
 The skipped checks are mutating checks without `--include-mutating`, which is
 the expected safety behavior for a live-state read run.
 
-Current executable manifest size after PR #996:
+Current executable manifest size after PR #1012:
 
 | Metric | Count |
 | --- | ---: |
-| Total checks | 133 |
+| Total checks | 134 |
 | `python_and_rust` checks | 73 |
-| `rust_only` checks | 60 |
-| Read-only checks | 92 |
+| `rust_only` checks | 61 |
+| Read-only checks | 93 |
 | Mutating checks | 41 |
 
 The latest focused isolated-sidecar rehearsal for the current fixture set is:

--- a/specs/762_stage5_artifacts/resume_handoff.md
+++ b/specs/762_stage5_artifacts/resume_handoff.md
@@ -1,7 +1,7 @@
 # Rust Port Resume Handoff
 
-Status: handoff snapshot from 2026-06-14 after PR #996 Cloudflare Access
-mobile smoke evidence runner.
+Status: handoff snapshot from 2026-06-14 after PR #1012 Android Camera-app
+enrollment flow.
 
 Use this file to resume the Rust cutover track without reconstructing state from
 chat history. Binding scope still lives in [cutover_scope.md](cutover_scope.md),
@@ -11,13 +11,14 @@ coverage in
 
 ## Current Repository State
 
-- Branch: `main` after PR #996.
-- Latest merged commit before this docs refresh: `af7ac2d` (`Merge pull
-  request #996`)
+- Branch: `main` after PR #1012.
+- Latest merged commit before this docs refresh: `5fbbfa4` (`Merge pull
+  request #1012`)
 - Open PRs at handoff: none before this docs refresh PR.
-- Dirty worktree at handoff: only pre-existing untracked `.claude/settings.local.json`
-  and the local `config.yaml.shadow-backup-20260612T023248Z` created when
-  enabling shadow mode.
+- Dirty worktree at handoff: only pre-existing untracked
+  `.claude/settings.local.json`, `certs/`, `data/`, and the local
+  `config.yaml.shadow-backup-20260612T023248Z` created when enabling shadow
+  mode.
 - Stale session-manager review agents from the overnight run and PR #932 were retired.
 - Unrelated non-session-manager agents were left alone.
 - Live Python-authoritative Rust shadow mode is enabled in `config.yaml`, with
@@ -63,7 +64,7 @@ Merged Rust slices cover:
 
 ### Documentation And Manifest
 
-- [mvp_progress.md](mvp_progress.md) records the PR lineage through #996.
+- [mvp_progress.md](mvp_progress.md) records the PR lineage through #1012.
 - [cloudflare_access_cutover_evidence.md](cloudflare_access_cutover_evidence.md)
   records the current Cloudflare Access origin-gate behavior and remaining
   operator setup/smoke evidence.
@@ -146,10 +147,25 @@ Merged Rust slices cover:
 - PR #992 added the stopped-service final backup gate.
 - PR #994 integrated the final backup gate into MVP rehearsal.
 - PR #996 added the Cloudflare Access mobile smoke evidence runner.
+- PR #998 refreshed the handoff after the Cloudflare smoke runner.
+- PR #1000 added Android Cloudflare client-certificate storage and native
+  HTTP/WebSocket client-certificate presentation.
+- PR #1002 added the first Android QR enrollment flow; PR #1012 later replaced
+  the in-app scanner/manual certificate UI with Camera-app deep-link
+  enrollment.
+- PR #1005 added Rust `sm enroll-device`, mobile device DB enrollment, CSR
+  signing, and per-device Common Name policy sync.
+- PR #1007 automated Cloudflare mTLS CA upload and mobile app hostname
+  association while keeping the CA private key local.
+- PR #1010 added Android artifact version-code/version-name override support.
+- PR #1012 added Android Camera-app QR handoff, `sm-enroll://enroll`, direct
+  in-app credential save, local/private HTTP pairing fallback, and removed
+  camera permission plus manual certificate UI.
 - Current contract manifest size:
-  - `133` checks total
+  - `134` checks total
   - `73` `python_and_rust`
-  - `60` `rust_only`
+  - `61` `rust_only`
+  - `93` read-only checks
   - `41` mutating checks
 
 ## Validation At Handoff
@@ -221,11 +237,12 @@ post-#984 manifest:
   skipped;
 - Rust mutating fixture contracts: `35` passed, `0` failed, `0` skipped.
 
-PRs #986-#996 added more cutover tooling and evidence gates after this focused
+PRs #986-#1012 added more cutover tooling and evidence gates after this focused
 run, including node restore fixtures, stopped-origin final backup, rehearsal
-final-backup integration, and the Cloudflare Access mobile smoke runner. Run a
-fresh full rehearsal once Cloudflare/mobile smoke inputs are available and
-Python-origin availability is stable.
+final-backup integration, the Cloudflare Access mobile smoke runner, Rust
+mobile-device enrollment, Cloudflare mTLS CA automation, and Android Camera-app
+enrollment. Run a fresh full rehearsal once Cloudflare/mobile smoke inputs are
+available and Python-origin availability is stable.
 
 The latest post-#942 full rehearsal attempts are blocked, not cutover evidence:
 
@@ -280,6 +297,13 @@ Observed after #996 at `2026-06-14T23:36Z`:
   `CF_MOBILE_ACCESS_JWT`, `CF_BROWSER_ACCESS_JWT`,
   `SM_PUBLIC_EDGE_SECRET`, `SM_DEVICE_BEARER_TOKEN`, or `SM_COOKIE` set, and
   `--mobile-host` / `--browser-host` were not supplied for a real smoke run.
+
+No newer clean full passive shadow or Cloudflare/mobile smoke artifact has been
+recorded in this handoff. PR #1012 published Android artifact `cbb61798`
+(`versionCode=1013`, `versionName=0.1.0-enroll-ui-cleanup`) and operator
+testing confirmed the app reached "Client certificate saved" after Camera-app
+deep-link enrollment, but the full Access smoke runner and sustained shadow
+window still need recorded artifacts.
 
 The broad live Rust contract run now uses the fixture filter:
 
@@ -359,9 +383,11 @@ needed for final cutover evidence.
 8. Run final native mobile smoke checks.
    - bootstrap, session list/detail, attach, request-status, analytics, bug
      reports, app artifacts.
-   - PR #996 added the read-only Cloudflare Access smoke runner; passing
-     evidence still requires the real Cloudflare Access JWTs, public-edge
-     secret, and SM auth token or cookie.
+   - PR #996 added the read-only Cloudflare Access smoke runner.
+   - PRs #1005, #1007, and #1012 added the mobile enrollment path needed to
+     generate app credentials for that smoke.
+   - Passing evidence still requires the real Cloudflare Access JWTs,
+     public-edge secret, SM auth token or cookie, and mobile app traffic.
 
 ### Cutover Stop Conditions
 

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -247,31 +247,43 @@ def test_cloudflare_access_cutover_evidence_pins_policy_and_origin_gates():
 
     assert "cloudflare_access_cutover_evidence.md" in index
     for required in [
-        "PR #950",
+        "PR #1012",
         "sm-browser",
         "sm-mobile-app",
         "sm-node-fallback",
         "sm-email-worker",
         "No broad Valid Certificate policy",
         "same mobile user resolved from the SM session or bearer actor",
+        "sm enroll-device",
+        "Camera-app QR handoff",
+        "no camera permission",
+        "no certificate material exposed in Settings",
         "revoked-device denial",
         "Native app smoke",
+        "versionCode `1013`",
     ]:
         assert required in evidence
 
 
-def test_handoff_and_progress_are_current_through_review_route_pr984():
+def test_handoff_and_progress_are_current_through_android_enrollment_pr1012():
     progress = (STAGE5_DIR / "mvp_progress.md").read_text(encoding="utf-8")
     handoff = (STAGE5_DIR / "resume_handoff.md").read_text(encoding="utf-8")
 
     for text in [progress, handoff]:
         assert "#950" in text
         assert "#984" in text
+        assert "#996" in text
+        assert "#1005" in text
+        assert "#1007" in text
+        assert "#1012" in text
         assert "Cloudflare Access" in text
         assert "cloudflare_access_cutover_evidence.md" in text
 
-    assert "Latest merged commit before this docs refresh: `8c261ee`" in handoff
-    assert "records the PR lineage through #984" in handoff
+    assert "Latest merged commit before this docs refresh: `5fbbfa4`" in handoff
+    assert "records the PR lineage through #1012" in handoff
+    assert "Camera-app" in handoff
+    assert "deep-link enrollment" in handoff
+    assert "versionName=0.1.0-enroll-ui-cleanup" in handoff
 
 
 def test_manifest_covers_rust_only_retired_http_surfaces():


### PR DESCRIPTION
Fixes #1009
Fixes #1003
Fixes #997

## Summary
- refresh Stage 5 progress, resume handoff, and Cloudflare Access evidence through PR #1012
- record the Android Camera-app enrollment flow, Rust enroll-device path, Cloudflare mTLS CA automation, and current Android artifact metadata
- update migration-contract assertions from the stale #950/#984 anchors to the current #1012 handoff anchors

## Validation
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py -q`
- `git diff --check`