### PR TITLE
Use status-only shadow for live attach descriptors

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -6373,7 +6373,7 @@ fn shadow_predict_session_read(
         .strip_prefix("/sessions/")
         .and_then(|value| value.strip_suffix("/attach-descriptor"))
     {
-        let Some(session) = state.session_store.get_session(session_id)? else {
+        let Some(_session) = state.session_store.get_session(session_id)? else {
             let body = serde_json::to_vec(&json!({ "detail": "Session not found" }))?;
             return Ok(Some(ShadowPrediction {
                 status: StatusCode::NOT_FOUND.as_u16(),
@@ -6381,11 +6381,10 @@ fn shadow_predict_session_read(
                 support_status: "implemented_read",
             }));
         };
-        let body = serde_json::to_vec(&attach_descriptor_response(session))?;
         return Ok(Some(ShadowPrediction {
             status: StatusCode::OK.as_u16(),
-            body_sha256: Some(sha256_hex(&body)),
-            support_status: "implemented_read",
+            body_sha256: None,
+            support_status: "implemented_read_status_only",
         }));
     }
 

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -8880,19 +8880,15 @@ async fn fixture_registry_clear_removes_recovered_maintainer_history() {
 }
 
 #[tokio::test]
-async fn shadow_attach_descriptor_reuses_real_attach_support_rules() {
+async fn shadow_attach_descriptor_uses_status_only_for_live_sessions() {
     let state_file = write_session_fixture();
     let app = router(AppState::new(config_with_state_file(&state_file)));
-    let expected_body = serde_json::to_vec(&json!({
+    let python_body = serde_json::to_vec(&json!({
         "attach": {
             "session_id": "stop1234",
             "provider": "claude",
             "attach_supported": false,
-            "tmux_session": "claude-stop1234",
-            "tmux_socket_name": null,
-            "runtime_id": null,
-            "lifecycle_state": "stopped",
-            "message": "Session is stopped"
+            "python_only_runtime_field": "live descriptor values can drift"
         }
     }))
     .unwrap();
@@ -8910,6 +8906,37 @@ async fn shadow_attach_descriptor_reuses_real_attach_support_rules() {
             },
             "python_response": {
                 "status": 200,
+                "body_sha256": sha256_hex(&python_body)
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read_status_only");
+    assert_eq!(payload["comparison"], "status_match");
+    assert_eq!(payload["body_sha256_match"], Value::Null);
+}
+
+#[tokio::test]
+async fn shadow_attach_descriptor_compares_missing_session_body() {
+    let state_file = write_session_fixture();
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+    let expected_body = serde_json::to_vec(&json!({ "detail": "Session not found" })).unwrap();
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/sessions/missing/attach-descriptor",
+                "query_string": "",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 404,
                 "body_sha256": sha256_hex(&expected_body)
             }
         }),


### PR DESCRIPTION
Fixes #1014

## Summary
- classify live `/sessions/{session_id}/attach-descriptor` 200 shadow predictions as status-only
- keep missing-session attach-descriptor 404 exact-body shadow comparison
- keep fixture-backed attach descriptor contract coverage body/assertion based

## Validation
- `cargo fmt --check`
- `cargo test -p sm-server --test read_only_http shadow_attach_descriptor -- --nocapture`
- `cargo test -p sm-server`
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py tests/unit/test_rust_cloudflare_access_smoke.py tests/unit/test_rust_shadow_report.py tests/unit/test_rust_shadow_middleware.py -q`
- `./venv/bin/python -m scripts.rust_migration.mvp_rehearsal --output-dir .local/rust-mvp-rehearsals/20260615T053445Z-attach-descriptor-shadow-fix --rust-base-url http://127.0.0.1:18421 --mutating-rust-base-url http://127.0.0.1:18422 --read-only-fixture-rust-base-url http://127.0.0.1:18423` -> passed, 0 blockers
- `git diff --check`