### PR TITLE
Classify mobile app shadow surfaces

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -6145,6 +6145,17 @@ fn shadow_predict_read(
     query_string: &str,
 ) -> anyhow::Result<Option<ShadowPrediction>> {
     if method == "POST" {
+        if path == "/auth/device/google" {
+            return Ok(Some(ShadowPrediction {
+                status: if state.config.google_auth.ready() {
+                    StatusCode::OK.as_u16()
+                } else {
+                    StatusCode::SERVICE_UNAVAILABLE.as_u16()
+                },
+                body_sha256: None,
+                support_status: "implemented_read_status_only",
+            }));
+        }
         if let Some(node_id) = node_ping_path_node_id(path) {
             let node_id = normalize_node_id(node_id);
             if !state.config.nodes.registry.contains_key(&node_id) {
@@ -6169,6 +6180,10 @@ fn shadow_predict_read(
     }
     if method != "GET" {
         return Ok(None);
+    }
+
+    if let Some(prediction) = shadow_predict_app_artifact_read(state, path)? {
+        return Ok(Some(prediction));
     }
 
     if let Some(request_id) = path
@@ -6323,6 +6338,93 @@ fn shadow_predict_read(
 
     Ok(body.map(|body| ShadowPrediction {
         status: StatusCode::OK.as_u16(),
+        body_sha256: Some(sha256_hex(&body)),
+        support_status: "implemented_read",
+    }))
+}
+
+fn shadow_predict_app_artifact_read(
+    state: &AppState,
+    path: &str,
+) -> anyhow::Result<Option<ShadowPrediction>> {
+    if path == "/apk" {
+        return Ok(Some(ShadowPrediction {
+            status: StatusCode::FOUND.as_u16(),
+            body_sha256: None,
+            support_status: "implemented_read_status_only",
+        }));
+    }
+
+    let Some(rest) = path.strip_prefix("/apps/") else {
+        return Ok(None);
+    };
+    let Some((app_name, file_name)) = rest.split_once('/') else {
+        return Ok(None);
+    };
+    if app_name.is_empty() || file_name.is_empty() || file_name.contains('/') {
+        return Ok(None);
+    }
+
+    let root = expand_home(&state.config.app_artifacts.root_dir);
+    if file_name == "meta.json" {
+        if valid_app_name(app_name) && read_metadata(&root, app_name).is_ok() {
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::OK.as_u16(),
+                body_sha256: None,
+                support_status: "implemented_read_status_only",
+            }));
+        }
+        let body = serde_json::to_vec(&json!({ "detail": "Artifact metadata not found" }))?;
+        return Ok(Some(ShadowPrediction {
+            status: StatusCode::NOT_FOUND.as_u16(),
+            body_sha256: Some(sha256_hex(&body)),
+            support_status: "implemented_read",
+        }));
+    }
+
+    if file_name == "latest.apk" {
+        let metadata = valid_app_name(app_name)
+            .then(|| read_metadata(&root, app_name).ok())
+            .flatten();
+        if metadata
+            .as_ref()
+            .is_some_and(|metadata| valid_artifact_hash(&metadata.artifact_hash))
+        {
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::FOUND.as_u16(),
+                body_sha256: None,
+                support_status: "implemented_read_status_only",
+            }));
+        }
+        let body = serde_json::to_vec(&json!({ "detail": "Artifact not found" }))?;
+        return Ok(Some(ShadowPrediction {
+            status: StatusCode::NOT_FOUND.as_u16(),
+            body_sha256: Some(sha256_hex(&body)),
+            support_status: "implemented_read",
+        }));
+    }
+
+    let Some(artifact_hash) = file_name.strip_suffix(".apk") else {
+        let body = serde_json::to_vec(&json!({ "detail": "Artifact not found" }))?;
+        return Ok(Some(ShadowPrediction {
+            status: StatusCode::NOT_FOUND.as_u16(),
+            body_sha256: Some(sha256_hex(&body)),
+            support_status: "implemented_read",
+        }));
+    };
+    if valid_app_name(app_name)
+        && valid_artifact_hash(artifact_hash)
+        && hashed_path(&root, app_name, artifact_hash).is_file()
+    {
+        return Ok(Some(ShadowPrediction {
+            status: StatusCode::OK.as_u16(),
+            body_sha256: None,
+            support_status: "implemented_read_status_only",
+        }));
+    }
+    let body = serde_json::to_vec(&json!({ "detail": "Artifact not found" }))?;
+    Ok(Some(ShadowPrediction {
+        status: StatusCode::NOT_FOUND.as_u16(),
         body_sha256: Some(sha256_hex(&body)),
         support_status: "implemented_read",
     }))

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -6085,6 +6085,189 @@ async fn shadow_http_classifies_native_mobile_writes_without_side_effects() {
 }
 
 #[tokio::test]
+async fn shadow_http_reports_app_artifact_reads_as_status_only() {
+    let artifact_root = unique_short_temp_dir("sm-rust-shadow-app-artifacts");
+    let app_dir = artifact_root.join("session-manager-android");
+    fs::create_dir_all(&app_dir).unwrap();
+    fs::write(app_dir.join("deadbeef.apk"), b"apk-bytes").unwrap();
+    fs::write(app_dir.join("latest.apk"), b"apk-bytes").unwrap();
+    fs::write(
+        app_dir.join("meta.json"),
+        json!({
+            "artifact_hash": "deadbeef",
+            "size_bytes": 9,
+            "uploaded_at": "2026-06-15T00:00:00Z",
+            "uploaded_by": "local_bypass",
+            "version_code": 1016,
+            "version_name": "0.1.0-shadow"
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let app = router(AppState::new(AppConfig {
+        app_artifacts: AppArtifactsConfig {
+            root_dir: artifact_root.display().to_string(),
+        },
+        ..AppConfig::default()
+    }));
+
+    for (path, python_status) in [
+        ("/apk", 302),
+        ("/apps/session-manager-android/latest.apk", 302),
+        ("/apps/session-manager-android/deadbeef.apk", 200),
+        ("/apps/session-manager-android/meta.json", 200),
+    ] {
+        let (status, payload) = post_json(
+            app.clone(),
+            "/__shadow/http",
+            json!({
+                "schema_version": 1,
+                "request": {
+                    "method": "GET",
+                    "path": path,
+                    "query_string": "",
+                    "headers": {}
+                },
+                "python_response": {
+                    "status": python_status,
+                    "body_sha256": sha256_hex(b"live-artifact-body-or-redirect")
+                }
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK, "{path}");
+        assert_eq!(
+            payload["support_status"], "implemented_read_status_only",
+            "{path}"
+        );
+        assert_eq!(payload["comparison"], "status_match", "{path}");
+        assert_eq!(payload["would_write"], false, "{path}");
+        assert_eq!(payload["predicted_status"], python_status, "{path}");
+        assert_eq!(payload["predicted_body_sha256"], Value::Null, "{path}");
+        assert_eq!(payload["body_sha256_match"], Value::Null, "{path}");
+    }
+
+    let _ = fs::remove_dir_all(artifact_root);
+}
+
+#[tokio::test]
+async fn shadow_http_reports_app_artifact_missing_reads_with_stable_body() {
+    let artifact_root = unique_short_temp_dir("sm-rust-shadow-missing-app-artifacts");
+    let app = router(AppState::new(AppConfig {
+        app_artifacts: AppArtifactsConfig {
+            root_dir: artifact_root.display().to_string(),
+        },
+        ..AppConfig::default()
+    }));
+
+    for (path, detail) in [
+        (
+            "/apps/session-manager-android/meta.json",
+            "Artifact metadata not found",
+        ),
+        (
+            "/apps/session-manager-android/latest.apk",
+            "Artifact not found",
+        ),
+        (
+            "/apps/session-manager-android/deadbeef.apk",
+            "Artifact not found",
+        ),
+    ] {
+        let body = serde_json::to_vec(&json!({ "detail": detail })).unwrap();
+        let (status, payload) = post_json(
+            app.clone(),
+            "/__shadow/http",
+            json!({
+                "schema_version": 1,
+                "request": {
+                    "method": "GET",
+                    "path": path,
+                    "query_string": "",
+                    "headers": {}
+                },
+                "python_response": {
+                    "status": 404,
+                    "body_sha256": sha256_hex(&body)
+                }
+            }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK, "{path}");
+        assert_eq!(payload["support_status"], "implemented_read", "{path}");
+        assert_eq!(payload["comparison"], "match", "{path}");
+        assert_eq!(payload["predicted_status"], 404, "{path}");
+        assert_eq!(payload["body_sha256_match"], true, "{path}");
+    }
+
+    let _ = fs::remove_dir_all(artifact_root);
+}
+
+#[tokio::test]
+async fn shadow_http_reports_device_google_auth_as_status_only() {
+    let app = router(AppState::new(config_with_state_file_and_auth(
+        &write_session_fixture(),
+    )));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "POST",
+                "path": "/auth/device/google",
+                "query_string": "",
+                "headers": {},
+                "body_sha256": sha256_hex(b"{\"id_token\":\"valid\"}")
+            },
+            "python_response": {
+                "status": 200,
+                "body_sha256": sha256_hex(b"{\"access_token\":\"python-owned\"}")
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read_status_only");
+    assert_eq!(payload["comparison"], "status_match");
+    assert_eq!(payload["would_write"], false);
+    assert_eq!(payload["predicted_status"], 200);
+    assert_eq!(payload["predicted_body_sha256"], Value::Null);
+    assert_eq!(payload["body_sha256_match"], Value::Null);
+
+    let app = router(AppState::new(AppConfig::default()));
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "POST",
+                "path": "/auth/device/google",
+                "query_string": "",
+                "headers": {},
+                "body_sha256": sha256_hex(b"{\"id_token\":\"valid\"}")
+            },
+            "python_response": {
+                "status": 503,
+                "body_sha256": sha256_hex(b"{\"detail\":\"Google auth is not configured\"}")
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read_status_only");
+    assert_eq!(payload["comparison"], "status_match");
+    assert_eq!(payload["predicted_status"], 503);
+    assert_eq!(payload["predicted_body_sha256"], Value::Null);
+}
+
+#[tokio::test]
 async fn shadow_http_preserves_python_auth_denial_for_app_artifact_reads() {
     let app = router(AppState::new(AppConfig::default()));
 


### PR DESCRIPTION
Fixes #1016

## Summary
- classify app artifact reads (`/apk`, `/apps/{app}/latest.apk`, `/apps/{app}/meta.json`, hashed APKs) in Rust shadow instead of leaving them unsupported
- use status-only prediction for live artifact successes and exact 404 bodies for missing artifacts
- classify `POST /auth/device/google` as status-only in shadow, with 503 prediction when Google auth is not configured

## Validation
- `cargo fmt --check`
- `cargo test -p sm-server --test read_only_http shadow_http_reports_app_artifact -- --nocapture`
- `cargo test -p sm-server --test read_only_http shadow_http_reports_device_google_auth_as_status_only -- --nocapture`
- `cargo test -p sm-server`
- `./venv/bin/python -m pytest tests/unit/test_rust_shadow_report.py tests/unit/test_rust_shadow_middleware.py tests/unit/test_rust_migration_contracts.py -q`
- `git diff --check`