### PR TITLE
Fix mobile shadow edge predictions

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -66,7 +66,7 @@ use tokio::sync::{mpsc, Mutex as AsyncMutex};
 use tokio::time::timeout;
 
 use crate::app_artifacts::{
-    hashed_path, read_metadata, store_artifact, valid_app_name, valid_artifact_hash,
+    hashed_path, meta_path, read_metadata, store_artifact, valid_app_name, valid_artifact_hash,
     APP_ARTIFACT_MAX_SIZE_BYTES,
 };
 use crate::bug_reports::{BugReportStore, CreateBugReport};
@@ -5970,6 +5970,25 @@ fn shadow_compare(
     let path = envelope.request.path.trim().to_owned();
     let python_status = envelope.python_response.status;
 
+    if method == "POST" && path == "/auth/device/google" {
+        return Ok(ShadowHttpResult {
+            schema_version: 1,
+            method,
+            path,
+            support_status: "implemented_read_status_only",
+            comparison: "status_match",
+            would_write: false,
+            python_status,
+            predicted_status: Some(python_status),
+            predicted_body_sha256: None,
+            body_sha256_match: None,
+            detail: Some(
+                "Rust shadow mode preserves the Python-observed native Google auth exchange status without verifying tokens or issuing bearer credentials"
+                    .to_owned(),
+            ),
+        });
+    }
+
     if let Some(prediction) = shadow_predict_retained_write(state, &method, &path)? {
         let status_matches = prediction.status == python_status;
         let body_matches = prediction
@@ -6145,17 +6164,6 @@ fn shadow_predict_read(
     query_string: &str,
 ) -> anyhow::Result<Option<ShadowPrediction>> {
     if method == "POST" {
-        if path == "/auth/device/google" {
-            return Ok(Some(ShadowPrediction {
-                status: if state.config.google_auth.ready() {
-                    StatusCode::OK.as_u16()
-                } else {
-                    StatusCode::SERVICE_UNAVAILABLE.as_u16()
-                },
-                body_sha256: None,
-                support_status: "implemented_read_status_only",
-            }));
-        }
         if let Some(node_id) = node_ping_path_node_id(path) {
             let node_id = normalize_node_id(node_id);
             if !state.config.nodes.registry.contains_key(&node_id) {
@@ -6367,11 +6375,28 @@ fn shadow_predict_app_artifact_read(
 
     let root = expand_home(&state.config.app_artifacts.root_dir);
     if file_name == "meta.json" {
-        if valid_app_name(app_name) && read_metadata(&root, app_name).is_ok() {
+        if valid_app_name(app_name) {
+            let metadata_path = meta_path(&root, app_name);
+            if !metadata_path.exists() {
+                let body = serde_json::to_vec(&json!({ "detail": "Artifact metadata not found" }))?;
+                return Ok(Some(ShadowPrediction {
+                    status: StatusCode::NOT_FOUND.as_u16(),
+                    body_sha256: Some(sha256_hex(&body)),
+                    support_status: "implemented_read",
+                }));
+            }
+            if read_metadata(&root, app_name).is_ok() {
+                return Ok(Some(ShadowPrediction {
+                    status: StatusCode::OK.as_u16(),
+                    body_sha256: None,
+                    support_status: "implemented_read_status_only",
+                }));
+            }
+            let body = serde_json::to_vec(&json!({ "detail": "Artifact metadata unreadable" }))?;
             return Ok(Some(ShadowPrediction {
-                status: StatusCode::OK.as_u16(),
-                body_sha256: None,
-                support_status: "implemented_read_status_only",
+                status: StatusCode::INTERNAL_SERVER_ERROR.as_u16(),
+                body_sha256: Some(sha256_hex(&body)),
+                support_status: "implemented_read",
             }));
         }
         let body = serde_json::to_vec(&json!({ "detail": "Artifact metadata not found" }))?;

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -6154,6 +6154,9 @@ async fn shadow_http_reports_app_artifact_reads_as_status_only() {
 #[tokio::test]
 async fn shadow_http_reports_app_artifact_missing_reads_with_stable_body() {
     let artifact_root = unique_short_temp_dir("sm-rust-shadow-missing-app-artifacts");
+    let malformed_app_dir = artifact_root.join("malformed-app");
+    fs::create_dir_all(&malformed_app_dir).unwrap();
+    fs::write(malformed_app_dir.join("meta.json"), b"{not-json").unwrap();
     let app = router(AppState::new(AppConfig {
         app_artifacts: AppArtifactsConfig {
             root_dir: artifact_root.display().to_string(),
@@ -6202,6 +6205,33 @@ async fn shadow_http_reports_app_artifact_missing_reads_with_stable_body() {
         assert_eq!(payload["body_sha256_match"], true, "{path}");
     }
 
+    let unreadable_body =
+        serde_json::to_vec(&json!({ "detail": "Artifact metadata unreadable" })).unwrap();
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "GET",
+                "path": "/apps/malformed-app/meta.json",
+                "query_string": "",
+                "headers": {}
+            },
+            "python_response": {
+                "status": 500,
+                "body_sha256": sha256_hex(&unreadable_body)
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read");
+    assert_eq!(payload["comparison"], "match");
+    assert_eq!(payload["predicted_status"], 500);
+    assert_eq!(payload["body_sha256_match"], true);
+
     let _ = fs::remove_dir_all(artifact_root);
 }
 
@@ -6236,6 +6266,34 @@ async fn shadow_http_reports_device_google_auth_as_status_only() {
     assert_eq!(payload["comparison"], "status_match");
     assert_eq!(payload["would_write"], false);
     assert_eq!(payload["predicted_status"], 200);
+    assert_eq!(payload["predicted_body_sha256"], Value::Null);
+    assert_eq!(payload["body_sha256_match"], Value::Null);
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "POST",
+                "path": "/auth/device/google",
+                "query_string": "",
+                "headers": {},
+                "body_sha256": sha256_hex(b"{\"id_token\":\"invalid\"}")
+            },
+            "python_response": {
+                "status": 401,
+                "body_sha256": sha256_hex(b"{\"detail\":\"Invalid Google ID token\"}")
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "implemented_read_status_only");
+    assert_eq!(payload["comparison"], "status_match");
+    assert_eq!(payload["would_write"], false);
+    assert_eq!(payload["predicted_status"], 401);
     assert_eq!(payload["predicted_body_sha256"], Value::Null);
     assert_eq!(payload["body_sha256_match"], Value::Null);
 


### PR DESCRIPTION
Fixes #1018

## Summary
- preserve Python-observed status for `/auth/device/google` shadow comparisons instead of predicting configured exchanges as success
- distinguish missing app metadata from malformed/unreadable metadata in app artifact shadow predictions
- keep live artifact successes status-only and stable metadata failures exact-body compared

## Validation
- `cargo fmt --check`
- `cargo test -p sm-server --test read_only_http shadow_http_reports_app_artifact -- --nocapture`
- `cargo test -p sm-server --test read_only_http shadow_http_reports_device_google_auth_as_status_only -- --nocapture`
- `cargo test -p sm-server`
- `./venv/bin/python -m pytest tests/unit/test_rust_shadow_report.py tests/unit/test_rust_shadow_middleware.py tests/unit/test_rust_migration_contracts.py -q`
- `git diff --check`