### PR TITLE
Avoid shadow-matching unported device auth success

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -5970,7 +5970,10 @@ fn shadow_compare(
     let path = envelope.request.path.trim().to_owned();
     let python_status = envelope.python_response.status;
 
-    if method == "POST" && path == "/auth/device/google" {
+    if method == "POST"
+        && path == "/auth/device/google"
+        && is_device_google_auth_shadow_status(python_status)
+    {
         return Ok(ShadowHttpResult {
             schema_version: 1,
             method,
@@ -8657,6 +8660,10 @@ fn validate_requested_friendly_name(name: &str) -> Result<(), ApiError> {
 
 fn is_auth_denial_status(status: u16) -> bool {
     matches!(status, 401 | 403 | 503)
+}
+
+fn is_device_google_auth_shadow_status(status: u16) -> bool {
+    matches!(status, 401 | 422 | 503)
 }
 
 fn is_protected_read_surface(method: &str, path: &str) -> bool {

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -6262,15 +6262,18 @@ async fn shadow_http_reports_device_google_auth_as_status_only() {
     .await;
 
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(payload["support_status"], "implemented_read_status_only");
-    assert_eq!(payload["comparison"], "status_match");
+    assert_eq!(payload["support_status"], "unsupported");
+    assert_eq!(payload["comparison"], "not_compared");
     assert_eq!(payload["would_write"], false);
-    assert_eq!(payload["predicted_status"], 200);
+    assert_eq!(payload["predicted_status"], Value::Null);
     assert_eq!(payload["predicted_body_sha256"], Value::Null);
     assert_eq!(payload["body_sha256_match"], Value::Null);
 
+    let app = router(AppState::new(config_with_state_file_and_auth(
+        &write_session_fixture(),
+    )));
     let (status, payload) = post_json(
-        app,
+        app.clone(),
         "/__shadow/http",
         json!({
             "schema_version": 1,
@@ -6294,6 +6297,34 @@ async fn shadow_http_reports_device_google_auth_as_status_only() {
     assert_eq!(payload["comparison"], "status_match");
     assert_eq!(payload["would_write"], false);
     assert_eq!(payload["predicted_status"], 401);
+    assert_eq!(payload["predicted_body_sha256"], Value::Null);
+    assert_eq!(payload["body_sha256_match"], Value::Null);
+
+    let (status, payload) = post_json(
+        app,
+        "/__shadow/http",
+        json!({
+            "schema_version": 1,
+            "request": {
+                "method": "POST",
+                "path": "/auth/device/google",
+                "query_string": "",
+                "headers": {},
+                "body_sha256": sha256_hex(b"{\"id_token\":\"unallowlisted\"}")
+            },
+            "python_response": {
+                "status": 403,
+                "body_sha256": sha256_hex(b"{\"detail\":\"Google account is not allowlisted\"}")
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["support_status"], "unsupported");
+    assert_eq!(payload["comparison"], "not_compared");
+    assert_eq!(payload["would_write"], false);
+    assert_eq!(payload["predicted_status"], Value::Null);
     assert_eq!(payload["predicted_body_sha256"], Value::Null);
     assert_eq!(payload["body_sha256_match"], Value::Null);
 


### PR DESCRIPTION
Fixes #1020

## Summary
- keep `/auth/device/google` shadow status-only only for stable pre-success failures (`401`, `422`, `503`)
- leave Python `200` successful exchanges and `403` account-policy denials unsupported until Rust implements real Google token verification and allowlist handling
- add regression coverage so native-auth cutover evidence cannot pass on copied Python success statuses

## Validation
- `cargo fmt --check`
- `cargo test -p sm-server --test read_only_http shadow_http_reports_device_google_auth_as_status_only -- --nocapture`
- `cargo test -p sm-server`
- `./venv/bin/python -m pytest tests/unit/test_rust_shadow_report.py tests/unit/test_rust_shadow_middleware.py tests/unit/test_rust_migration_contracts.py -q`
- `git diff --check`