### PR TITLE
Block unported native auth success in shadow reports

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -5970,6 +5970,26 @@ fn shadow_compare(
     let path = envelope.request.path.trim().to_owned();
     let python_status = envelope.python_response.status;
 
+    if method == "POST" && path == "/auth/device/google" && python_status == StatusCode::OK.as_u16()
+    {
+        return Ok(ShadowHttpResult {
+            schema_version: 1,
+            method,
+            path,
+            support_status: "unimplemented_device_auth_success",
+            comparison: "status_mismatch",
+            would_write: false,
+            python_status,
+            predicted_status: Some(StatusCode::UNAUTHORIZED.as_u16()),
+            predicted_body_sha256: None,
+            body_sha256_match: None,
+            detail: Some(
+                "Rust cannot yet verify Google ID tokens or issue native bearer credentials; successful Python exchanges block cutover evidence"
+                    .to_owned(),
+            ),
+        });
+    }
+
     if method == "POST"
         && path == "/auth/device/google"
         && is_device_google_auth_shadow_status(python_status)

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -6262,12 +6262,19 @@ async fn shadow_http_reports_device_google_auth_as_status_only() {
     .await;
 
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(payload["support_status"], "unsupported");
-    assert_eq!(payload["comparison"], "not_compared");
+    assert_eq!(
+        payload["support_status"],
+        "unimplemented_device_auth_success"
+    );
+    assert_eq!(payload["comparison"], "status_mismatch");
     assert_eq!(payload["would_write"], false);
-    assert_eq!(payload["predicted_status"], Value::Null);
+    assert_eq!(payload["predicted_status"], 401);
     assert_eq!(payload["predicted_body_sha256"], Value::Null);
     assert_eq!(payload["body_sha256_match"], Value::Null);
+    assert!(payload["detail"]
+        .as_str()
+        .unwrap()
+        .contains("block cutover evidence"));
 
     let app = router(AppState::new(config_with_state_file_and_auth(
         &write_session_fixture(),

--- a/tests/unit/test_rust_shadow_report.py
+++ b/tests/unit/test_rust_shadow_report.py
@@ -121,6 +121,46 @@ def test_shadow_report_marks_mismatches_and_shadow_errors_as_blockers(tmp_path):
     assert report["blockers"][1]["detail"] == "connection refused"
 
 
+def test_shadow_report_blocks_unimplemented_device_auth_success(tmp_path):
+    ledger = tmp_path / "rust_shadow.jsonl"
+    _write_jsonl(
+        ledger,
+        [
+            {
+                "schema_version": 1,
+                "observed_at": "2026-06-12T01:00:00Z",
+                "method": "POST",
+                "path": "/auth/device/google",
+                "query_string": "",
+                "python_status": 200,
+                "python_body_sha256": "python-device-auth",
+                "rust_http_status": 200,
+                "rust_result": {
+                    "comparison": "status_mismatch",
+                    "support_status": "unimplemented_device_auth_success",
+                    "predicted_status": 401,
+                    "body_sha256_match": None,
+                },
+            }
+        ],
+    )
+
+    report = summarize_ledger(ledger)
+
+    assert report["status"] == "blocked"
+    assert report["comparison_counts"] == {"status_mismatch": 1}
+    assert report["blockers"] == [
+        {
+            "kind": "status_mismatch",
+            "line": 1,
+            "route": "POST /auth/device/google",
+            "support_status": "unimplemented_device_auth_success",
+            "predicted_status": 401,
+            "python_status": 200,
+        }
+    ]
+
+
 def test_shadow_report_tracks_invalid_json_as_blocker(tmp_path):
     ledger = tmp_path / "rust_shadow.jsonl"
     ledger.write_text(


### PR DESCRIPTION
Fixes #1022

## Summary
- make successful Python `/auth/device/google` shadow rows block as `status_mismatch` with `support_status=unimplemented_device_auth_success`
- keep stable pre-success failures (`401`, `422`, `503`) status-only
- keep account-policy `403` outcomes not compared until Rust can verify tokens and allowlists
- add report-level regression so unimplemented native-auth success is blocking evidence

## Validation
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p sm-server --test read_only_http shadow_http_reports_device_google_auth_as_status_only -- --nocapture`
- `cargo test -p sm-server`
- `./venv/bin/python -m pytest tests/unit/test_rust_shadow_report.py tests/unit/test_rust_shadow_middleware.py tests/unit/test_rust_migration_contracts.py -q`