### PR TITLE
Record post-1025 mobile auth smoke boundary

### DIFF
--- a/scripts/rust_migration/cloudflare_access_smoke.py
+++ b/scripts/rust_migration/cloudflare_access_smoke.py
@@ -57,7 +57,6 @@ def build_smoke_report(
             expected_detail="Cloudflare Access mobile app assertion is required",
             timeout_seconds=timeout_seconds,
             urlopen=urlopen,
-            require_public_edge_secret=True,
         ),
         _request_check(
             check_id="mobile.bootstrap_with_access",
@@ -89,7 +88,6 @@ def build_smoke_report(
             timeout_seconds=timeout_seconds,
             urlopen=urlopen,
             skip_without_access=True,
-            require_public_edge_secret=True,
             send_public_edge_proof=False,
         ),
         _request_check(

--- a/specs/762_stage5_artifacts/cloudflare_access_cutover_evidence.md
+++ b/specs/762_stage5_artifacts/cloudflare_access_cutover_evidence.md
@@ -1,6 +1,7 @@
 # Cloudflare Access Cutover Evidence
 
-Status: implementation evidence after PR #1012 merged.
+Status: implementation evidence after PR #1025 merged and the first post-#1025
+smoke-boundary run was recorded.
 
 This artifact records the current Rust-side Cloudflare Access boundary for the
 Rust cutover track. It complements the design in
@@ -11,7 +12,8 @@ and does not replace the rollout gates in [gate_matrix.md](gate_matrix.md).
 
 Rust `main` now includes the Cloudflare Access origin gate, read-only smoke
 evidence runner, Rust mobile-device enrollment, Cloudflare mTLS CA automation,
-and Android Camera-app enrollment flow through PR #1012:
+Android Camera-app enrollment flow, and native Google device-auth bearer
+issuance:
 
 | PR | Evidence added |
 | --- | --- |
@@ -25,6 +27,8 @@ and Android Camera-app enrollment flow through PR #1012:
 | #1007 | Cloudflare mTLS CA upload/association automation for the mobile app hostname, keeping the CA private key local. |
 | #1010 | Android artifact version-code/version-name override support so published APK metadata matches the installed build. |
 | #1012 | Android Camera-app QR handoff via `sm-enroll://enroll`, direct in-app certificate save, no camera permission, no in-app scanner, and no certificate material exposed in Settings. |
+| #1025 | Rust native Google device-auth success path for `/auth/device/google`, including Google JWKS verification, mobile Access actor binding, public-edge gate, and zero-skew temporal checks. |
+| #1026 | Post-#1025 smoke evidence slice; runner now records denial-path boundary evidence even when success-path proof inputs are missing. |
 
 Current origin behavior:
 
@@ -99,12 +103,21 @@ needs operator-side Cloudflare and native-app evidence:
 | Node fallback smoke | Once node fallback is ported, prove LAN-first behavior and Cloudflare node certificate fallback for a registered node. |
 | Shadow/rehearsal | Record a clean shadow/rehearsal window that includes native app traffic or an explicit operator-driven mobile route exercise. |
 
-The smoke runner requires real deployment inputs. The local shell used for the
-post-#1012 handoff refresh did not have `CF_MOBILE_ACCESS_JWT`,
-`CF_BROWSER_ACCESS_JWT`, `SM_PUBLIC_EDGE_SECRET`, `SM_DEVICE_BEARER_TOKEN`,
-or `SM_COOKIE` set, and `--mobile-host` / `--browser-host` were not supplied,
-so no passing Cloudflare/mobile smoke evidence was produced there. Missing
-required mobile inputs are blockers by design.
+The smoke runner requires real deployment inputs. The post-#1025 run used
+`--mobile-host sm-app.rajeshgo.li` and `--browser-host sm.rajeshgo.li` against a
+freshly rebuilt Rust sidecar on `127.0.0.1:8421`. It wrote:
+
+```text
+.local/rust-mvp-rehearsals/post-1025-mobile-auth-smoke-blocked.json
+```
+
+The run passed `mobile.bootstrap_requires_access`, proving the Rust origin
+denies mobile bootstrap requests on the app host when no Cloudflare Access
+assertion is present. It remained blocked because the local shell did not have
+`CF_MOBILE_ACCESS_JWT`, `CF_BROWSER_ACCESS_JWT`, `SM_PUBLIC_EDGE_SECRET`,
+`SM_DEVICE_BEARER_TOKEN`, or `SM_COOKIE` set. Summary: `1` passed, `5`
+blocked, `7` skipped. Missing required mobile success-path inputs are blockers
+by design; this partial pass is not full mobile cutover evidence.
 
 The Android artifact published during PR #1012 is versionCode `1013`,
 versionName `0.1.0-enroll-ui-cleanup`, artifact hash `cbb61798`. It supports

--- a/specs/762_stage5_artifacts/mvp_progress.md
+++ b/specs/762_stage5_artifacts/mvp_progress.md
@@ -1,16 +1,17 @@
 # Rust MVP Progress Snapshot
 
-Status: implementation snapshot after PR #1012 Android Camera-app enrollment
-flow.
+Status: implementation snapshot after PR #1025 Rust native Google device auth
+success.
 The last clean full real-state MVP rehearsal remains the post-#938 run; the
 post-#984 focused rehearsal proves state gates, live core contracts, read-only
 fixtures, and mutating fixtures on isolated sidecars, but intentionally skips
-Python baseline and shadow. PRs #986-#1012 added node restore fixtures,
+Python baseline and shadow. PRs #986-#1025 added node restore fixtures,
 stopped-origin final backup gates, rehearsal final-backup integration,
 Cloudflare Access smoke evidence tooling, Rust mobile-device enrollment,
-Cloudflare mTLS CA automation, and the Android Camera-app enrollment handoff.
-Public cutover still needs Cloudflare policy setup, real mobile/browser smoke
-evidence, and a stable Python-authoritative shadow window.
+Cloudflare mTLS CA automation, the Android Camera-app enrollment handoff, and
+Rust native Google device-auth bearer issuance. Public cutover still needs full
+Cloudflare policy/proof inputs, real mobile/browser smoke evidence, and a
+stable Python-authoritative shadow window.
 
 This file is a handoff aid for the Rust cutover implementation track. It does
 not change retained or removed scope. Binding scope remains
@@ -104,6 +105,9 @@ not change retained or removed scope. Binding scope remains
 | #1007 | Cloudflare mTLS CA upload and mobile app hostname association automation |
 | #1010 | Android artifact version-code/version-name override support |
 | #1012 | Android Camera-app QR handoff, `sm-enroll://enroll` deep link, direct in-app credential save, and no camera permission/manual cert UI |
+| #1023 | Block unported `/auth/device/google` shadow successes until Rust can issue native device bearers |
+| #1025 | Rust native Google device-auth success with Google JWKS verification, mobile Access actor binding, public-edge gate, and zero-skew token temporal checks |
+| #1026 | Post-#1025 smoke evidence slice; first blocked run records the mobile Access-denial boundary and missing proof inputs |
 
 ## Implemented Capability Groups
 
@@ -116,8 +120,8 @@ The Rust sidecar now has executable coverage for:
 | Core reads | Health, auth session, bootstrap, session list/detail, client session list/detail, output, events state, SSE hello, nodes list, queue jobs list/detail, Codex review requests list/detail, and tool/audit read projections are implemented. |
 | Core runtime | Session/tmux/spawn/session-graph/message-queue/task-complete/input-batch/subagent and retained review-route slices are merged, with shadow and contract fixtures covering the early cutover path. |
 | Codex retained reads | Codex event stream, pending request ledger reads, activity actions, review detail/list, and Claude/Codex tool-call projections are implemented and covered by manifest checks. |
-| Mobile | Native bootstrap/session support, attach-ticket proofing, terminal WebSocket auth/bridge, runtime disable, device revoke/list CLI support, public-edge assertion validation, Android client-certificate storage, Rust `sm enroll-device`, and Camera-app deep-link enrollment are merged. |
-| Cloudflare Access origin gate | Config parsing, JWT/audience classification, host/app separation, public-host fail-closed behavior, mobile/app route gating, app artifact gating, device-token exchange gating, JWKS cache refresh/TTL behavior, mobile Access CN actor binding, Cloudflare mTLS CA upload/hostname association, per-device Common Name policy sync, and read-only smoke evidence collection are merged. |
+| Mobile | Native bootstrap/session support, attach-ticket proofing, terminal WebSocket auth/bridge, runtime disable, device revoke/list CLI support, public-edge assertion validation, Android client-certificate storage, Rust `sm enroll-device`, Camera-app deep-link enrollment, and Rust Google device-auth bearer issuance are merged. |
+| Cloudflare Access origin gate | Config parsing, JWT/audience classification, host/app separation, public-host fail-closed behavior, mobile/app route gating, app artifact gating, device-token exchange, Google JWKS cache refresh/TTL behavior, mobile Access CN actor binding, Cloudflare mTLS CA upload/hostname association, per-device Common Name policy sync, and read-only smoke evidence collection are merged. |
 | External fallback | Email/human fallback delivery and inbound email validation path are retained in the Rust track. |
 | Queue and nodes | Queue list/detail, CLI list/status, pending submit, simple execute/cancel, queue recovery, queue fixtures, node reads, and node HTTP routes are implemented; remaining work is final live/recovery cutover evidence and any retained node-agent remote-control gaps. |
 
@@ -147,6 +151,22 @@ This passive window did not satisfy the new mobile route/pattern coverage gates
 from PR #942; those gates need real native app traffic or explicit operator
 exercise. It also does not include Cloudflare Access proof inputs, so it is not
 public-edge cutover evidence.
+
+After PR #1025, the Rust sidecar was rebuilt and restarted from current `main`
+on `127.0.0.1:8421`, then the Cloudflare/mobile smoke runner was executed with
+`--mobile-host sm-app.rajeshgo.li` and `--browser-host sm.rajeshgo.li`. The
+blocked evidence file is:
+
+```text
+.local/rust-mvp-rehearsals/post-1025-mobile-auth-smoke-blocked.json
+```
+
+That run passed `mobile.bootstrap_requires_access`, proving the Rust origin
+denies mobile bootstrap requests on the app host when no Cloudflare Access
+assertion is present. It remains blocked because the shell did not provide the
+Access JWTs, public-edge HMAC secret, or SM bearer/cookie needed for success
+checks. Summary: `1` passed, `5` blocked, `7` skipped. This is partial boundary
+evidence only, not full mobile auth smoke evidence.
 
 The local shell used for this refresh did not have the Cloudflare/mobile smoke
 secret inputs set, and the hostnames still need to be supplied with the runner

--- a/specs/762_stage5_artifacts/resume_handoff.md
+++ b/specs/762_stage5_artifacts/resume_handoff.md
@@ -161,6 +161,14 @@ Merged Rust slices cover:
 - PR #1012 added Android Camera-app QR handoff, `sm-enroll://enroll`, direct
   in-app credential save, local/private HTTP pairing fallback, and removed
   camera permission plus manual certificate UI.
+- PR #1023 blocked `/auth/device/google` shadow successes while Rust still
+  lacked native bearer issuance.
+- PR #1025 implemented Rust native Google device auth success, including Google
+  JWKS verification, mobile Access actor binding, public-edge gating, and
+  zero-skew token temporal checks.
+- PR #1026 is the post-#1025 smoke evidence slice; the first run records one
+  mobile Access-denial boundary pass and the missing proof inputs blocking full
+  smoke.
 - Current contract manifest size:
   - `134` checks total
   - `73` `python_and_rust`
@@ -298,8 +306,24 @@ Observed after #996 at `2026-06-14T23:36Z`:
   `SM_PUBLIC_EDGE_SECRET`, `SM_DEVICE_BEARER_TOKEN`, or `SM_COOKIE` set, and
   `--mobile-host` / `--browser-host` were not supplied for a real smoke run.
 
-No newer clean full passive shadow or Cloudflare/mobile smoke artifact has been
-recorded in this handoff. PR #1012 published Android artifact `cbb61798`
+Post-#1025, the Rust sidecar was rebuilt and restarted from current `main` on
+`127.0.0.1:8421`. The Cloudflare/mobile smoke runner was executed with
+`--mobile-host sm-app.rajeshgo.li` and `--browser-host sm.rajeshgo.li`; output
+was recorded at:
+
+```text
+.local/rust-mvp-rehearsals/post-1025-mobile-auth-smoke-blocked.json
+```
+
+That run passed `mobile.bootstrap_requires_access`, proving the Rust origin
+denies mobile bootstrap requests on the app host when no Cloudflare Access
+assertion is present. It remains blocked because the shell did not have
+`CF_MOBILE_ACCESS_JWT`, `CF_BROWSER_ACCESS_JWT`, `SM_PUBLIC_EDGE_SECRET`,
+`SM_DEVICE_BEARER_TOKEN`, or `SM_COOKIE` set. Summary: `1` passed, `5`
+blocked, `7` skipped. This is partial boundary evidence only.
+
+No newer clean full passive shadow or full Cloudflare/mobile smoke artifact has
+been recorded in this handoff. PR #1012 published Android artifact `cbb61798`
 (`versionCode=1013`, `versionName=0.1.0-enroll-ui-cleanup`) and operator
 testing confirmed the app reached "Client certificate saved" after Camera-app
 deep-link enrollment, but the full Access smoke runner and sustained shadow
@@ -411,16 +435,19 @@ Do not start Rust writer ownership or MVP cutover until:
 Continue with Cloudflare Access deployment evidence, then return to the shadow
 observation gate:
 
-1. Configure or verify the Cloudflare Access apps/policies described in
+1. Provide the smoke runner proof inputs for the already configured Cloudflare
+   Access apps: mobile/browser Access JWTs, public-edge HMAC secret, and SM
+   bearer/cookie.
+2. Configure or verify any remaining Cloudflare Access apps/policies described in
    [cloudflare_access_cutover_evidence.md](cloudflare_access_cutover_evidence.md).
-2. Exercise the native app route class through the app hostname so mobile gates
+3. Exercise the native app route class through the app hostname so mobile gates
    collect real traffic and smoke evidence.
-3. Keep Python-authoritative Rust shadow mode running for retained reads against
+4. Keep Python-authoritative Rust shadow mode running for retained reads against
    the local Rust sidecar.
-4. Let it observe real traffic for the agreed window.
-5. Summarize the shadow ledger by route, comparison class, and unexplained
+5. Let it observe real traffic for the agreed window.
+6. Summarize the shadow ledger by route, comparison class, and unexplained
    mismatch.
-6. Convert any unexplained retained-surface mismatch into a bounded Rust slice.
+7. Convert any unexplained retained-surface mismatch into a bounded Rust slice.
 
 This is the highest-signal next step because the Rust origin gate is now merged,
 but the public edge still needs actual Cloudflare policy and mobile/browser

--- a/tests/unit/test_rust_cloudflare_access_smoke.py
+++ b/tests/unit/test_rust_cloudflare_access_smoke.py
@@ -106,6 +106,23 @@ def test_cloudflare_access_smoke_blocks_when_access_assertion_is_missing():
 
 def test_cloudflare_access_smoke_blocks_when_public_edge_secret_is_missing():
     def fake_urlopen(request, timeout):
+        path = request.full_url.removeprefix("http://127.0.0.1:8421")
+        if path == "/client/bootstrap" and not request.get_header(
+            "Cf-access-jwt-assertion"
+        ):
+            raise _http_error(
+                request.full_url,
+                403,
+                {"detail": "Cloudflare Access mobile app assertion is required"},
+            )
+        if path == "/client/bootstrap" and not request.get_header(
+            "X-sm-edge-signature"
+        ):
+            raise _http_error(
+                request.full_url,
+                403,
+                {"detail": "Public edge assertion is required"},
+            )
         raise AssertionError(f"unexpected request to {request.full_url}")
 
     report = build_smoke_report(
@@ -118,9 +135,7 @@ def test_cloudflare_access_smoke_blocks_when_public_edge_secret_is_missing():
 
     assert report["status"] == "blocked"
     assert [blocker["check_id"] for blocker in report["blockers"]] == [
-        "mobile.bootstrap_requires_access",
         "mobile.bootstrap_with_access",
-        "mobile.bootstrap_requires_public_edge",
         "mobile.sessions_require_sm_auth",
         "mobile.sessions_with_sm_auth",
         "mobile.app_artifact_metadata",
@@ -131,8 +146,11 @@ def test_cloudflare_access_smoke_blocks_when_public_edge_secret_is_missing():
     assert {
         check["detail"]
         for check in report["checks"]
-        if check["id"].startswith("mobile.")
+        if check["id"].startswith("mobile.") and check["status"] == "skipped"
     } == {"public edge secret was not supplied"}
+    by_id = {check["id"]: check for check in report["checks"]}
+    assert by_id["mobile.bootstrap_requires_access"]["status"] == "passed"
+    assert by_id["mobile.bootstrap_requires_public_edge"]["status"] == "passed"
 
 
 def test_cloudflare_access_smoke_records_mobile_boundary_and_headers():


### PR DESCRIPTION
Fixes #1026

## Summary
- let the Cloudflare/mobile smoke runner record denial-path boundary checks even when success-path public-edge proof inputs are missing
- record the post-#1025 blocked smoke run: mobile bootstrap without Access now reaches the Rust origin and is denied as expected
- refresh Stage 5 progress, handoff, and Cloudflare evidence docs with #1025/#1026 status

## Validation
- `./venv/bin/python -m pytest tests/unit/test_rust_cloudflare_access_smoke.py -q`
- `./venv/bin/python -m py_compile scripts/rust_migration/cloudflare_access_smoke.py`
- `git diff --check`
- blocked smoke run: `./venv/bin/python -m scripts.rust_migration.cloudflare_access_smoke --base-url http://127.0.0.1:8421 --mobile-host sm-app.rajeshgo.li --browser-host sm.rajeshgo.li --output .local/rust-mvp-rehearsals/post-1025-mobile-auth-smoke-blocked.json --json --fail-on-blockers`
