### PR TITLE
Use RSA mTLS credentials for Android enrollment

### DIFF
--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/remote/HttpClientFactory.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/remote/HttpClientFactory.kt
@@ -3,7 +3,6 @@ package li.rajeshgo.sm.data.remote
 import android.util.Log
 import kotlinx.coroutines.flow.first
 import li.rajeshgo.sm.data.repository.SettingsRepository
-import li.rajeshgo.sm.data.security.DeviceKeyManager
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import java.io.ByteArrayInputStream
@@ -24,7 +23,6 @@ import javax.net.ssl.X509TrustManager
 
 class HttpClientFactory(
     private val settingsRepository: SettingsRepository? = null,
-    private val deviceKeyManager: DeviceKeyManager? = null,
 ) {
     suspend fun create(
         token: String = "",
@@ -47,16 +45,20 @@ class HttpClientFactory(
             )
         }
 
+        val certificateAlias = settingsRepository
+            ?.cloudflareDeviceCertificateAlias
+            ?.first()
+            ?.trim()
+            .orEmpty()
         val certificateChainPem = settingsRepository
             ?.cloudflareDeviceCertificateChainPem
             ?.first()
             ?.trim()
             .orEmpty()
-        if (certificateChainPem.isNotBlank()) {
+        if (certificateAlias.isNotBlank() && certificateChainPem.isNotBlank()) {
             runCatching {
-                val manager = deviceKeyManager ?: DeviceKeyManager()
                 loadClientCertificate(
-                    alias = manager.deviceKeyAlias(),
+                    alias = certificateAlias,
                     certificateChainPem = certificateChainPem,
                 )
             }

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/DeviceEnrollmentRepository.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/DeviceEnrollmentRepository.kt
@@ -2,6 +2,7 @@ package li.rajeshgo.sm.data.repository
 
 import android.os.Build
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
@@ -9,6 +10,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import li.rajeshgo.sm.data.model.DeviceEnrollmentRequest
 import li.rajeshgo.sm.data.model.DeviceEnrollmentResponse
 import li.rajeshgo.sm.data.remote.HttpClientFactory
+import li.rajeshgo.sm.data.security.CloudflareDeviceCredentialManager
 import li.rajeshgo.sm.data.security.DeviceKeyManager
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Request
@@ -33,37 +35,48 @@ private data class EnrollmentHttpResponse(
 class DeviceEnrollmentRepository(
     private val settingsRepository: SettingsRepository,
     private val deviceKeyManager: DeviceKeyManager,
+    private val cloudflareCredentialManager: CloudflareDeviceCredentialManager = CloudflareDeviceCredentialManager(),
 ) {
     private val json = Json { ignoreUnknownKeys = true; coerceInputValues = true }
-    private val httpClientFactory = HttpClientFactory(settingsRepository, deviceKeyManager)
+    private val httpClientFactory = HttpClientFactory(settingsRepository)
 
     suspend fun enrollFromQr(qrContents: String): DeviceEnrollmentResult = withContext(Dispatchers.IO) {
         val enrollmentUrl = enrollmentUrlFromQrContents(qrContents)
+        val previousAlias = settingsRepository.cloudflareDeviceCertificateAlias.first().trim()
+        val alias = cloudflareCredentialManager.newCredentialAlias()
         val requestBody = DeviceEnrollmentRequest(
             deviceId = deviceKeyManager.deviceKeyId(),
             deviceName = deviceName(),
-            csrPem = deviceKeyManager.certificateSigningRequestPem(),
+            csrPem = cloudflareCredentialManager.certificateSigningRequestPem(alias, deviceKeyManager.deviceKeyId()),
             publicKeyPem = deviceKeyManager.publicKeyPem(),
         )
-        val requestJson = json.encodeToString(DeviceEnrollmentRequest.serializer(), requestBody)
-        val response = postEnrollmentRequest(enrollmentUrl, requestJson)
-        val body = response.body
-        if (response.statusCode !in 200..299) {
-            throw IllegalStateException(enrollmentErrorMessage(body, response.statusCode))
+        try {
+            val requestJson = json.encodeToString(DeviceEnrollmentRequest.serializer(), requestBody)
+            val response = postEnrollmentRequest(enrollmentUrl, requestJson)
+            val body = response.body
+            if (response.statusCode !in 200..299) {
+                throw IllegalStateException(enrollmentErrorMessage(body, response.statusCode))
+            }
+            val payload = json.decodeFromString(DeviceEnrollmentResponse.serializer(), body)
+            check(payload.deviceId.trim() == requestBody.deviceId) {
+                "Enrollment response device id did not match this device"
+            }
+            check(cloudflareCredentialManager.certificateChainMatchesAlias(payload.certificateChainPem, alias)) {
+                "Enrollment certificate does not match this device credential"
+            }
+            settingsRepository.saveCloudflareDeviceCredential(alias, payload.certificateChainPem)
+            if (previousAlias.isNotBlank() && previousAlias != alias) {
+                cloudflareCredentialManager.deleteCredential(previousAlias)
+            }
+            DeviceEnrollmentResult(
+                deviceId = payload.deviceId,
+                deviceName = payload.deviceName,
+                expiresAt = payload.expiresAt,
+            )
+        } catch (error: Exception) {
+            cloudflareCredentialManager.deleteCredential(alias)
+            throw error
         }
-        val payload = json.decodeFromString(DeviceEnrollmentResponse.serializer(), body)
-        check(payload.deviceId.trim() == requestBody.deviceId) {
-            "Enrollment response device id did not match this device"
-        }
-        check(deviceKeyManager.certificateChainMatchesDeviceKey(payload.certificateChainPem)) {
-            "Enrollment certificate does not match this device key"
-        }
-        settingsRepository.saveCloudflareDeviceCertificateChainPem(payload.certificateChainPem)
-        DeviceEnrollmentResult(
-            deviceId = payload.deviceId,
-            deviceName = payload.deviceName,
-            expiresAt = payload.expiresAt,
-        )
     }
 
     private suspend fun postEnrollmentRequest(enrollmentUrl: String, requestJson: String): EnrollmentHttpResponse {

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SettingsRepository.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SettingsRepository.kt
@@ -9,6 +9,10 @@ import androidx.datastore.preferences.preferencesDataStore
 import li.rajeshgo.sm.util.LocalDefaults
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import java.io.ByteArrayInputStream
+import java.security.KeyStore
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "session_manager_android")
 
@@ -19,6 +23,7 @@ class SettingsRepository(private val context: Context) {
         val USER_EMAIL = stringPreferencesKey("user_email")
         val USER_NAME = stringPreferencesKey("user_name")
         val EXPIRES_AT = stringPreferencesKey("expires_at")
+        val CLOUDFLARE_DEVICE_CERTIFICATE_ALIAS = stringPreferencesKey("cloudflare_device_certificate_alias")
         val CLOUDFLARE_DEVICE_CERTIFICATE_CHAIN_PEM = stringPreferencesKey("cloudflare_device_certificate_chain_pem")
         val DISMISSED_UPDATE_ARTIFACT_HASH = stringPreferencesKey("dismissed_update_artifact_hash")
     }
@@ -45,11 +50,19 @@ class SettingsRepository(private val context: Context) {
 
     val isLoggedIn: Flow<Boolean> = accessToken.map { it.isNotBlank() }
 
+    val cloudflareDeviceCertificateAlias: Flow<String> = context.dataStore.data.map { prefs ->
+        prefs[Keys.CLOUDFLARE_DEVICE_CERTIFICATE_ALIAS] ?: ""
+    }
+
     val cloudflareDeviceCertificateChainPem: Flow<String> = context.dataStore.data.map { prefs ->
         prefs[Keys.CLOUDFLARE_DEVICE_CERTIFICATE_CHAIN_PEM] ?: ""
     }
 
-    val hasCloudflareDeviceCertificate: Flow<Boolean> = cloudflareDeviceCertificateChainPem.map { it.isNotBlank() }
+    val hasCloudflareDeviceCertificate: Flow<Boolean> = context.dataStore.data.map { prefs ->
+        val alias = prefs[Keys.CLOUDFLARE_DEVICE_CERTIFICATE_ALIAS]?.trim().orEmpty()
+        val certificateChainPem = prefs[Keys.CLOUDFLARE_DEVICE_CERTIFICATE_CHAIN_PEM]?.trim().orEmpty()
+        hasUsableCloudflareDeviceCredential(alias, certificateChainPem)
+    }
 
     val dismissedUpdateArtifactHash: Flow<String> = context.dataStore.data.map { prefs ->
         prefs[Keys.DISMISSED_UPDATE_ARTIFACT_HASH] ?: ""
@@ -70,14 +83,16 @@ class SettingsRepository(private val context: Context) {
         }
     }
 
-    suspend fun saveCloudflareDeviceCertificateChainPem(certificateChainPem: String) {
+    suspend fun saveCloudflareDeviceCredential(alias: String, certificateChainPem: String) {
         context.dataStore.edit { prefs ->
+            prefs[Keys.CLOUDFLARE_DEVICE_CERTIFICATE_ALIAS] = alias.trim()
             prefs[Keys.CLOUDFLARE_DEVICE_CERTIFICATE_CHAIN_PEM] = certificateChainPem.trim()
         }
     }
 
-    suspend fun clearCloudflareDeviceCertificateChainPem() {
+    suspend fun clearCloudflareDeviceCredential() {
         context.dataStore.edit { prefs ->
+            prefs.remove(Keys.CLOUDFLARE_DEVICE_CERTIFICATE_ALIAS)
             prefs.remove(Keys.CLOUDFLARE_DEVICE_CERTIFICATE_CHAIN_PEM)
         }
     }
@@ -95,5 +110,30 @@ class SettingsRepository(private val context: Context) {
             prefs.remove(Keys.USER_NAME)
             prefs.remove(Keys.EXPIRES_AT)
         }
+    }
+
+    private fun hasUsableCloudflareDeviceCredential(alias: String, certificateChainPem: String): Boolean =
+        alias.isNotBlank() &&
+            certificateChainPem.isNotBlank() &&
+            cloudflareDeviceCertificateMatchesAlias(alias, certificateChainPem)
+
+    private fun cloudflareDeviceCertificateMatchesAlias(alias: String, certificateChainPem: String): Boolean =
+        runCatching {
+            val certificates = CertificateFactory.getInstance("X.509")
+                .generateCertificates(ByteArrayInputStream(certificateChainPem.toByteArray()))
+                .filterIsInstance<X509Certificate>()
+            val leaf = certificates.firstOrNull()
+            val storedPublicKey = KeyStore.getInstance(ANDROID_KEYSTORE)
+                .apply { load(null) }
+                .getCertificate(alias)
+                ?.publicKey
+            leaf != null &&
+                leaf.publicKey.algorithm.equals("RSA", ignoreCase = true) &&
+                storedPublicKey != null &&
+                leaf.publicKey.encoded.contentEquals(storedPublicKey.encoded)
+        }.getOrDefault(false)
+
+    private companion object {
+        const val ANDROID_KEYSTORE = "AndroidKeyStore"
     }
 }

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/security/CloudflareDeviceCredentialManager.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/security/CloudflareDeviceCredentialManager.kt
@@ -1,0 +1,91 @@
+package li.rajeshgo.sm.data.security
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import org.bouncycastle.pkcs.PKCS10CertificationRequest
+import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder
+import java.io.ByteArrayInputStream
+import java.io.StringWriter
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.security.KeyStore
+import java.security.cert.CertificateFactory
+import java.security.cert.X509Certificate
+import java.util.UUID
+
+class CloudflareDeviceCredentialManager {
+    fun newCredentialAlias(): String = "$KEY_ALIAS_PREFIX${UUID.randomUUID()}"
+
+    fun certificateSigningRequestPem(alias: String, commonName: String): String {
+        val keyPair = generateKeyPair(alias)
+        val subject = X500Name("CN=${commonName.ifBlank { "Session Manager Android Device" }}")
+        val builder = JcaPKCS10CertificationRequestBuilder(subject, keyPair.public)
+        val signer = JcaContentSignerBuilder("SHA256withRSA").build(keyPair.private)
+        val request: PKCS10CertificationRequest = builder.build(signer)
+        val writer = StringWriter()
+        JcaPEMWriter(writer).use { pemWriter ->
+            pemWriter.writeObject(request)
+        }
+        return writer.toString()
+    }
+
+    fun certificateChainMatchesAlias(certificateChainPem: String, alias: String): Boolean {
+        val leaf = decodeCertificates(certificateChainPem).firstOrNull() ?: return false
+        val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+        val storedPublicKey = keyStore.getCertificate(alias)?.publicKey ?: return false
+        return leaf.publicKey.encoded.contentEquals(storedPublicKey.encoded)
+    }
+
+    fun deleteCredential(alias: String) {
+        if (alias.isBlank()) {
+            return
+        }
+        runCatching {
+            KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }.deleteEntry(alias)
+        }
+    }
+
+    private fun generateKeyPair(alias: String): KeyPair {
+        deleteCredential(alias)
+        val keyPairGenerator = KeyPairGenerator.getInstance(
+            KeyProperties.KEY_ALGORITHM_RSA,
+            ANDROID_KEYSTORE,
+        )
+        keyPairGenerator.initialize(
+            KeyGenParameterSpec.Builder(
+                alias,
+                KeyProperties.PURPOSE_SIGN or KeyProperties.PURPOSE_VERIFY,
+            )
+                .setKeySize(2048)
+                .setDigests(
+                    KeyProperties.DIGEST_SHA256,
+                    KeyProperties.DIGEST_SHA384,
+                    KeyProperties.DIGEST_SHA512,
+                )
+                .setSignaturePaddings(
+                    KeyProperties.SIGNATURE_PADDING_RSA_PKCS1,
+                    KeyProperties.SIGNATURE_PADDING_RSA_PSS,
+                )
+                .setUserAuthenticationRequired(false)
+                .build(),
+        )
+        return keyPairGenerator.generateKeyPair()
+    }
+
+    private fun decodeCertificates(certificateChainPem: String): List<X509Certificate> {
+        if (certificateChainPem.isBlank()) {
+            return emptyList()
+        }
+        val certificateFactory = CertificateFactory.getInstance("X.509")
+        return certificateFactory.generateCertificates(ByteArrayInputStream(certificateChainPem.toByteArray()))
+            .filterIsInstance<X509Certificate>()
+    }
+
+    private companion object {
+        private const val ANDROID_KEYSTORE = "AndroidKeyStore"
+        private const val KEY_ALIAS_PREFIX = "li.rajeshgo.sm.cloudflare_device."
+    }
+}

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/security/DeviceKeyManager.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/security/DeviceKeyManager.kt
@@ -3,20 +3,11 @@ package li.rajeshgo.sm.data.security
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import android.util.Base64
-import org.bouncycastle.asn1.x500.X500Name
-import org.bouncycastle.openssl.jcajce.JcaPEMWriter
-import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
-import org.bouncycastle.pkcs.PKCS10CertificationRequest
-import org.bouncycastle.pkcs.jcajce.JcaPKCS10CertificationRequestBuilder
-import java.io.ByteArrayInputStream
-import java.io.StringWriter
 import java.security.KeyPairGenerator
 import java.security.KeyStore
 import java.security.MessageDigest
 import java.security.PrivateKey
 import java.security.Signature
-import java.security.cert.CertificateFactory
-import java.security.cert.X509Certificate
 import java.security.spec.ECGenParameterSpec
 
 data class DeviceProof(
@@ -28,8 +19,6 @@ data class DeviceProof(
 
 class DeviceKeyManager {
     private val keyStore: KeyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
-
-    fun deviceKeyAlias(): String = KEY_ALIAS
 
     fun deviceKeyId(): String {
         val publicKey = ensureKeyPair().certificate.publicKey.encoded
@@ -43,24 +32,6 @@ class DeviceKeyManager {
             .chunked(64)
             .joinToString("\n")
         return "-----BEGIN PUBLIC KEY-----\n$body\n-----END PUBLIC KEY-----"
-    }
-
-    fun certificateSigningRequestPem(): String {
-        val entry = ensureKeyPair()
-        val subject = X500Name("CN=${deviceKeyId()}")
-        val builder = JcaPKCS10CertificationRequestBuilder(subject, entry.certificate.publicKey)
-        val signer = JcaContentSignerBuilder("SHA256withECDSA").build(entry.privateKey)
-        val request: PKCS10CertificationRequest = builder.build(signer)
-        val writer = StringWriter()
-        JcaPEMWriter(writer).use { pemWriter ->
-            pemWriter.writeObject(request)
-        }
-        return writer.toString()
-    }
-
-    fun certificateChainMatchesDeviceKey(certificateChainPem: String): Boolean {
-        val leaf = decodeCertificates(certificateChainPem).firstOrNull() ?: return false
-        return leaf.publicKey.encoded.contentEquals(ensureKeyPair().certificate.publicKey.encoded)
     }
 
     fun signTicketRequest(
@@ -145,15 +116,6 @@ class DeviceKeyManager {
         val bytes = ByteArray(18)
         java.security.SecureRandom().nextBytes(bytes)
         return Base64.encodeToString(bytes, Base64.URL_SAFE or Base64.NO_WRAP or Base64.NO_PADDING)
-    }
-
-    private fun decodeCertificates(certificateChainPem: String): List<X509Certificate> {
-        if (certificateChainPem.isBlank()) {
-            return emptyList()
-        }
-        val certificateFactory = CertificateFactory.getInstance("X.509")
-        return certificateFactory.generateCertificates(ByteArrayInputStream(certificateChainPem.toByteArray()))
-            .filterIsInstance<X509Certificate>()
     }
 
     private companion object {

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsViewModel.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsViewModel.kt
@@ -14,6 +14,7 @@ import li.rajeshgo.sm.data.repository.AvailableAppUpdate
 import li.rajeshgo.sm.data.repository.DeviceEnrollmentRepository
 import li.rajeshgo.sm.data.repository.SessionManagerRepository
 import li.rajeshgo.sm.data.repository.SettingsRepository
+import li.rajeshgo.sm.data.security.CloudflareDeviceCredentialManager
 import li.rajeshgo.sm.data.security.DeviceKeyManager
 
 data class SettingsUiState(
@@ -26,7 +27,6 @@ data class SettingsUiState(
     val availableUpdate: AvailableAppUpdate? = null,
     val mobileDeviceKeyId: String = "",
     val mobileDevicePublicKey: String = "",
-    val mobileDeviceCertificateSigningRequest: String = "",
     val cloudflareDeviceCertificateConfigured: Boolean = false,
     val cloudflareEnrollmentInProgress: Boolean = false,
     val cloudflareEnrollmentStatus: String? = null,
@@ -42,6 +42,7 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     private val sessionRepository = SessionManagerRepository(settingsRepository)
     private val appUpdateRepository = AppUpdateRepository(application, settingsRepository)
     private val deviceKeyManager = DeviceKeyManager()
+    private val cloudflareCredentialManager = CloudflareDeviceCredentialManager()
     private val deviceEnrollmentRepository = DeviceEnrollmentRepository(settingsRepository, deviceKeyManager)
 
     private val _uiState = MutableStateFlow(SettingsUiState())
@@ -87,16 +88,11 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     fun loadMobileDeviceKey() {
         runCatching {
-            Triple(
-                deviceKeyManager.deviceKeyId(),
-                deviceKeyManager.publicKeyPem(),
-                deviceKeyManager.certificateSigningRequestPem(),
-            )
-        }.onSuccess { (keyId, publicKey, certificateSigningRequest) ->
+            deviceKeyManager.deviceKeyId() to deviceKeyManager.publicKeyPem()
+        }.onSuccess { (keyId, publicKey) ->
             _uiState.value = _uiState.value.copy(
                 mobileDeviceKeyId = keyId,
                 mobileDevicePublicKey = publicKey,
-                mobileDeviceCertificateSigningRequest = certificateSigningRequest,
                 mobileDeviceKeyError = null,
             )
         }.onFailure { error ->
@@ -144,7 +140,9 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     fun clearCloudflareDeviceCertificateChain() {
         viewModelScope.launch {
-            settingsRepository.clearCloudflareDeviceCertificateChainPem()
+            val alias = settingsRepository.cloudflareDeviceCertificateAlias.first()
+            cloudflareCredentialManager.deleteCredential(alias)
+            settingsRepository.clearCloudflareDeviceCredential()
             _uiState.value = _uiState.value.copy(
                 cloudflareDeviceCertificateConfigured = false,
                 cloudflareEnrollmentStatus = "Client certificate cleared",

--- a/crates/sm-server/src/mobile_devices.rs
+++ b/crates/sm-server/src/mobile_devices.rs
@@ -18,6 +18,7 @@ use axum::{
     Json, Router,
 };
 use base64::Engine as _;
+use p256::{ecdsa::VerifyingKey, pkcs8::DecodePublicKey};
 use qrcode::{render::unicode, QrCode};
 use rand_core::{OsRng, RngCore};
 use rusqlite::{params, Connection, OptionalExtension};
@@ -512,9 +513,11 @@ async fn complete_device_enrollment(
             return invalid_csr_response(&state, &token, Some(&remote_addr.to_string()), &error)
         }
     };
-    if normalize_pem(&csr_public_key_pem) != normalize_pem(&payload.public_key_pem) {
-        let error = anyhow::anyhow!("CSR public key does not match public_key_pem");
+    if let Err(error) = validate_cloudflare_client_csr_public_key(&csr_public_key_pem) {
         return invalid_csr_response(&state, &token, Some(&remote_addr.to_string()), &error);
+    }
+    if let Err(error) = validate_mobile_terminal_proof_public_key(&payload.public_key_pem) {
+        return invalid_public_key_response(&state, &token, Some(&remote_addr.to_string()), &error);
     }
     let certificate_pem = match sign_csr_with_openssl(
         &state.ca_cert_path,
@@ -535,7 +538,7 @@ async fn complete_device_enrollment(
         &token,
         &device_id,
         &device_name,
-        &csr_public_key_pem,
+        &payload.public_key_pem,
         Some(&remote_addr.to_string()),
     ) {
         Ok(Some(registration)) => registration,
@@ -590,6 +593,30 @@ fn invalid_csr_response(
         )
     } else {
         json_error(StatusCode::BAD_REQUEST, "Invalid device CSR")
+    }
+}
+
+fn invalid_public_key_response(
+    state: &PairingState,
+    token: &str,
+    remote_addr: Option<&str>,
+    error: &anyhow::Error,
+) -> Response {
+    let exhausted = record_pairing_failure(
+        &state.db_path,
+        token,
+        "pairing_public_key_rejected",
+        remote_addr,
+        &error.to_string(),
+    )
+    .unwrap_or(false);
+    if exhausted {
+        json_error(
+            StatusCode::TOO_MANY_REQUESTS,
+            "Too many invalid enrollment attempts",
+        )
+    } else {
+        json_error(StatusCode::BAD_REQUEST, "Invalid device public key")
     }
 }
 
@@ -1319,6 +1346,35 @@ fn extract_public_key_from_csr_with_openssl(csr_pem: &str) -> Result<String> {
         .context("openssl returned non-UTF-8 CSR public key")
 }
 
+fn validate_cloudflare_client_csr_public_key(public_key_pem: &str) -> Result<()> {
+    let temp_dir = temporary_dir("sm-mobile-csr-public-key")?;
+    let public_key_path = temp_dir.join("device.pub.pem");
+    fs::write(&public_key_path, public_key_pem).context("failed to write device CSR public key")?;
+    let output = Command::new("openssl")
+        .arg("pkey")
+        .arg("-pubin")
+        .arg("-in")
+        .arg(&public_key_path)
+        .arg("-noout")
+        .arg("-text")
+        .output()
+        .context("failed to invoke openssl for CSR public key type check")?;
+    let _ = fs::remove_dir_all(&temp_dir);
+    if !output.status.success() {
+        bail!("openssl failed to inspect CSR public key");
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    let has_rsa_modulus = text.lines().any(|line| line.trim_start() == "Modulus:");
+    let has_rsa_exponent = text
+        .lines()
+        .any(|line| line.trim_start().starts_with("Exponent:"));
+    if has_rsa_modulus && has_rsa_exponent {
+        Ok(())
+    } else {
+        bail!("Cloudflare client certificate CSR public key must be RSA")
+    }
+}
+
 fn verify_csr_self_signature_with_openssl(csr_path: &Path) -> Result<()> {
     let output = Command::new("openssl")
         .arg("req")
@@ -1594,18 +1650,15 @@ fn valid_device_id(value: &str) -> bool {
             .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'))
 }
 
-fn normalize_pem(value: &str) -> String {
-    value
-        .lines()
-        .map(str::trim)
-        .filter(|line| !line.is_empty())
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
 fn public_key_fingerprint(value: &str) -> String {
     let digest = Sha256::digest(value.trim().as_bytes());
     hex_bytes(&digest)
+}
+
+fn validate_mobile_terminal_proof_public_key(public_key_pem: &str) -> Result<()> {
+    VerifyingKey::from_public_key_pem(public_key_pem.trim())
+        .map(|_| ())
+        .context("mobile terminal proof public key must be a P-256 public key")
 }
 
 fn hex_bytes(bytes: &[u8]) -> String {
@@ -1633,6 +1686,10 @@ fn local_timestamp() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use p256::{
+        ecdsa::SigningKey,
+        pkcs8::{EncodePublicKey, LineEnding},
+    };
 
     #[test]
     fn enrollment_db_round_trip_and_revoke() {
@@ -1661,6 +1718,30 @@ mod tests {
     }
 
     #[test]
+    fn enrollment_proof_public_key_requires_p256_key() {
+        let signing_key = SigningKey::random(&mut OsRng);
+        let public_key = signing_key
+            .verifying_key()
+            .to_public_key_pem(LineEnding::LF)
+            .expect("public key pem");
+
+        validate_mobile_terminal_proof_public_key(&public_key).expect("p256 key accepted");
+        validate_mobile_terminal_proof_public_key(
+            "-----BEGIN PUBLIC KEY-----\ninvalid\n-----END PUBLIC KEY-----",
+        )
+        .expect_err("invalid key rejected");
+    }
+
+    #[test]
+    fn enrollment_csr_public_key_requires_rsa_for_cloudflare_mtls() {
+        let rsa_public_key = openssl_public_key_pem("rsa").expect("rsa public key");
+        let ec_public_key = openssl_public_key_pem("ec").expect("ec public key");
+
+        validate_cloudflare_client_csr_public_key(&rsa_public_key).expect("rsa key accepted");
+        validate_cloudflare_client_csr_public_key(&ec_public_key).expect_err("ec key rejected");
+    }
+
+    #[test]
     fn ensure_device_ca_generates_missing_pair() {
         let temp_dir = temporary_dir("sm-mobile-ca-test").expect("temp dir");
         let cert_path = temp_dir.join("device-ca.pem");
@@ -1682,6 +1763,51 @@ mod tests {
             assert_eq!(mode, 0o600);
         }
         let _ = fs::remove_dir_all(temp_dir);
+    }
+
+    fn openssl_public_key_pem(kind: &str) -> Result<String> {
+        let temp_dir = temporary_dir("sm-mobile-key-test")?;
+        let key_path = temp_dir.join(format!("{kind}.key"));
+        let public_key_path = temp_dir.join(format!("{kind}.pub.pem"));
+        let key_status = if kind == "rsa" {
+            Command::new("openssl")
+                .arg("genrsa")
+                .arg("-out")
+                .arg(&key_path)
+                .arg("2048")
+                .status()
+                .context("failed to invoke openssl genrsa")?
+        } else {
+            Command::new("openssl")
+                .arg("ecparam")
+                .arg("-name")
+                .arg("prime256v1")
+                .arg("-genkey")
+                .arg("-noout")
+                .arg("-out")
+                .arg(&key_path)
+                .status()
+                .context("failed to invoke openssl ecparam")?
+        };
+        if !key_status.success() {
+            bail!("openssl failed to generate {kind} key");
+        }
+        let output_status = Command::new("openssl")
+            .arg("pkey")
+            .arg("-in")
+            .arg(&key_path)
+            .arg("-pubout")
+            .arg("-out")
+            .arg(&public_key_path)
+            .status()
+            .context("failed to invoke openssl public key export")?;
+        if !output_status.success() {
+            bail!("openssl failed to export {kind} public key");
+        }
+        let public_key =
+            fs::read_to_string(&public_key_path).context("failed to read generated public key")?;
+        let _ = fs::remove_dir_all(temp_dir);
+        Ok(public_key)
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- split Android credentials so Cloudflare Access mTLS uses a generated RSA AndroidKeyStore alias while the existing EC/P-256 device key remains the mobile terminal proof key
- store and validate the Cloudflare client-cert alias with the certificate chain before showing the device credential as configured
- update Rust pairing to accept distinct CSR and proof public keys, while validating the stored proof key is P-256

Fixes #1030

## Validation

- `cargo fmt --check`
- `git diff --check`
- `cargo test -p sm-server mobile_devices -- --nocapture`
- `cargo test -p sm-server`

Android Gradle validation could not run in this checkout because no Android SDK path is configured: `./gradlew testDebugUnitTest --no-daemon` failed with `SDK location not found` and no `ANDROID_HOME` / `android-app/local.properties` SDK path is present.

## Operational note

Existing EC client-cert enrollments should be considered stale after this app update. Re-run `sm enroll-device` from the updated app so the phone receives a new RSA client certificate for Cloudflare Access mTLS.