### PR TITLE
Use software RSA key for Android Cloudflare mTLS

### DIFF
--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/remote/HttpClientFactory.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/remote/HttpClientFactory.kt
@@ -7,12 +7,15 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import java.io.ByteArrayInputStream
 import java.net.Socket
+import java.security.KeyFactory
 import java.security.KeyStore
 import java.security.Principal
 import java.security.PrivateKey
 import java.security.SecureRandom
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
+import java.security.spec.PKCS8EncodedKeySpec
+import java.util.Base64
 import java.util.concurrent.TimeUnit
 import javax.net.ssl.SSLContext
 import javax.net.ssl.SSLEngine
@@ -55,11 +58,16 @@ class HttpClientFactory(
             ?.first()
             ?.trim()
             .orEmpty()
-        if (certificateAlias.isNotBlank() && certificateChainPem.isNotBlank()) {
+        val privateKeyPkcs8 = settingsRepository
+            ?.cloudflareDevicePrivateKeyPkcs8()
+            ?.trim()
+            .orEmpty()
+        if (certificateAlias.isNotBlank() && certificateChainPem.isNotBlank() && privateKeyPkcs8.isNotBlank()) {
             runCatching {
                 loadClientCertificate(
                     alias = certificateAlias,
                     certificateChainPem = certificateChainPem,
+                    privateKeyPkcs8 = privateKeyPkcs8,
                 )
             }
                 .onSuccess { sslConfig ->
@@ -78,14 +86,13 @@ class HttpClientFactory(
     private fun loadClientCertificate(
         alias: String,
         certificateChainPem: String,
+        privateKeyPkcs8: String,
     ): Pair<SSLSocketFactory, X509TrustManager>? {
         val certificateChain = decodeCertificates(certificateChainPem)
         if (certificateChain.isEmpty()) {
             return null
         }
-        val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
-        val privateKey = runCatching { keyStore.getKey(alias, null) as? PrivateKey }.getOrNull()
-            ?: return null
+        val privateKey = decodePrivateKey(privateKeyPkcs8) ?: return null
 
         val keyManager = SingleAliasKeyManager(
             alias = alias,
@@ -118,9 +125,14 @@ class HttpClientFactory(
             .filterIsInstance<X509Certificate>()
     }
 
+    private fun decodePrivateKey(privateKeyPkcs8: String): PrivateKey? =
+        runCatching {
+            val keyBytes = Base64.getDecoder().decode(privateKeyPkcs8.trim())
+            KeyFactory.getInstance("RSA").generatePrivate(PKCS8EncodedKeySpec(keyBytes))
+        }.getOrNull()
+
     private companion object {
         const val TAG = "HttpClientFactory"
-        const val ANDROID_KEYSTORE = "AndroidKeyStore"
     }
 
     private class SingleAliasKeyManager(

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/DeviceEnrollmentRepository.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/DeviceEnrollmentRepository.kt
@@ -44,10 +44,14 @@ class DeviceEnrollmentRepository(
         val enrollmentUrl = enrollmentUrlFromQrContents(qrContents)
         val previousAlias = settingsRepository.cloudflareDeviceCertificateAlias.first().trim()
         val alias = cloudflareCredentialManager.newCredentialAlias()
+        val cloudflareCredential = cloudflareCredentialManager.certificateSigningRequest(
+            alias,
+            deviceKeyManager.deviceKeyId(),
+        )
         val requestBody = DeviceEnrollmentRequest(
             deviceId = deviceKeyManager.deviceKeyId(),
             deviceName = deviceName(),
-            csrPem = cloudflareCredentialManager.certificateSigningRequestPem(alias, deviceKeyManager.deviceKeyId()),
+            csrPem = cloudflareCredential.csrPem,
             publicKeyPem = deviceKeyManager.publicKeyPem(),
         )
         try {
@@ -61,10 +65,19 @@ class DeviceEnrollmentRepository(
             check(payload.deviceId.trim() == requestBody.deviceId) {
                 "Enrollment response device id did not match this device"
             }
-            check(cloudflareCredentialManager.certificateChainMatchesAlias(payload.certificateChainPem, alias)) {
+            check(
+                cloudflareCredentialManager.certificateChainMatchesPrivateKey(
+                    payload.certificateChainPem,
+                    cloudflareCredential.privateKeyPkcs8,
+                ),
+            ) {
                 "Enrollment certificate does not match this device credential"
             }
-            settingsRepository.saveCloudflareDeviceCredential(alias, payload.certificateChainPem)
+            settingsRepository.saveCloudflareDeviceCredential(
+                alias,
+                payload.certificateChainPem,
+                cloudflareCredential.privateKeyPkcs8,
+            )
             if (previousAlias.isNotBlank() && previousAlias != alias) {
                 cloudflareCredentialManager.deleteCredential(previousAlias)
             }

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SettingsRepository.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SettingsRepository.kt
@@ -8,6 +8,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import kotlinx.coroutines.flow.first
 import li.rajeshgo.sm.data.security.CloudflareDeviceCredentialManager
+import li.rajeshgo.sm.data.security.CloudflareDevicePrivateKeyProtector
 import li.rajeshgo.sm.util.LocalDefaults
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -17,7 +18,10 @@ import java.security.cert.X509Certificate
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "session_manager_android")
 
-class SettingsRepository(private val context: Context) {
+class SettingsRepository(
+    private val context: Context,
+    private val cloudflarePrivateKeyProtector: CloudflareDevicePrivateKeyProtector = CloudflareDevicePrivateKeyProtector(),
+) {
     private object Keys {
         val SERVER_URL = stringPreferencesKey("server_url")
         val ACCESS_TOKEN = stringPreferencesKey("access_token")
@@ -26,7 +30,9 @@ class SettingsRepository(private val context: Context) {
         val EXPIRES_AT = stringPreferencesKey("expires_at")
         val CLOUDFLARE_DEVICE_CERTIFICATE_ALIAS = stringPreferencesKey("cloudflare_device_certificate_alias")
         val CLOUDFLARE_DEVICE_CERTIFICATE_CHAIN_PEM = stringPreferencesKey("cloudflare_device_certificate_chain_pem")
-        val CLOUDFLARE_DEVICE_PRIVATE_KEY_PKCS8 = stringPreferencesKey("cloudflare_device_private_key_pkcs8")
+        val LEGACY_CLOUDFLARE_DEVICE_PRIVATE_KEY_PKCS8 = stringPreferencesKey("cloudflare_device_private_key_pkcs8")
+        val CLOUDFLARE_DEVICE_PRIVATE_KEY_PKCS8_WRAPPED =
+            stringPreferencesKey("cloudflare_device_private_key_pkcs8_wrapped")
         val DISMISSED_UPDATE_ARTIFACT_HASH = stringPreferencesKey("dismissed_update_artifact_hash")
     }
 
@@ -63,7 +69,7 @@ class SettingsRepository(private val context: Context) {
     val hasCloudflareDeviceCertificate: Flow<Boolean> = context.dataStore.data.map { prefs ->
         val alias = prefs[Keys.CLOUDFLARE_DEVICE_CERTIFICATE_ALIAS]?.trim().orEmpty()
         val certificateChainPem = prefs[Keys.CLOUDFLARE_DEVICE_CERTIFICATE_CHAIN_PEM]?.trim().orEmpty()
-        val privateKeyPkcs8 = prefs[Keys.CLOUDFLARE_DEVICE_PRIVATE_KEY_PKCS8]?.trim().orEmpty()
+        val privateKeyPkcs8 = cloudflareDevicePrivateKeyPkcs8FromPrefs(prefs)
         hasUsableCloudflareDeviceCredential(alias, certificateChainPem, privateKeyPkcs8)
     }
 
@@ -86,14 +92,27 @@ class SettingsRepository(private val context: Context) {
         }
     }
 
-    suspend fun cloudflareDevicePrivateKeyPkcs8(): String =
-        context.dataStore.data.first()[Keys.CLOUDFLARE_DEVICE_PRIVATE_KEY_PKCS8]?.trim().orEmpty()
+    suspend fun cloudflareDevicePrivateKeyPkcs8(): String {
+        val prefs = context.dataStore.data.first()
+        val privateKeyPkcs8 = cloudflareDevicePrivateKeyPkcs8FromPrefs(prefs)
+        val legacyPrivateKeyPkcs8 = prefs[Keys.LEGACY_CLOUDFLARE_DEVICE_PRIVATE_KEY_PKCS8]?.trim().orEmpty()
+        if (privateKeyPkcs8.isNotBlank() && legacyPrivateKeyPkcs8.isNotBlank()) {
+            context.dataStore.edit { updatedPrefs ->
+                updatedPrefs[Keys.CLOUDFLARE_DEVICE_PRIVATE_KEY_PKCS8_WRAPPED] =
+                    cloudflarePrivateKeyProtector.protect(privateKeyPkcs8)
+                updatedPrefs.remove(Keys.LEGACY_CLOUDFLARE_DEVICE_PRIVATE_KEY_PKCS8)
+            }
+        }
+        return privateKeyPkcs8
+    }
 
     suspend fun saveCloudflareDeviceCredential(alias: String, certificateChainPem: String, privateKeyPkcs8: String) {
         context.dataStore.edit { prefs ->
             prefs[Keys.CLOUDFLARE_DEVICE_CERTIFICATE_ALIAS] = alias.trim()
             prefs[Keys.CLOUDFLARE_DEVICE_CERTIFICATE_CHAIN_PEM] = certificateChainPem.trim()
-            prefs[Keys.CLOUDFLARE_DEVICE_PRIVATE_KEY_PKCS8] = privateKeyPkcs8.trim()
+            prefs[Keys.CLOUDFLARE_DEVICE_PRIVATE_KEY_PKCS8_WRAPPED] =
+                cloudflarePrivateKeyProtector.protect(privateKeyPkcs8)
+            prefs.remove(Keys.LEGACY_CLOUDFLARE_DEVICE_PRIVATE_KEY_PKCS8)
         }
     }
 
@@ -101,8 +120,24 @@ class SettingsRepository(private val context: Context) {
         context.dataStore.edit { prefs ->
             prefs.remove(Keys.CLOUDFLARE_DEVICE_CERTIFICATE_ALIAS)
             prefs.remove(Keys.CLOUDFLARE_DEVICE_CERTIFICATE_CHAIN_PEM)
-            prefs.remove(Keys.CLOUDFLARE_DEVICE_PRIVATE_KEY_PKCS8)
+            prefs.remove(Keys.CLOUDFLARE_DEVICE_PRIVATE_KEY_PKCS8_WRAPPED)
+            prefs.remove(Keys.LEGACY_CLOUDFLARE_DEVICE_PRIVATE_KEY_PKCS8)
         }
+    }
+
+    suspend fun clearIncompleteCloudflareDeviceCredential(): String? {
+        var removedAlias: String? = null
+        context.dataStore.edit { prefs ->
+            val alias = prefs[Keys.CLOUDFLARE_DEVICE_CERTIFICATE_ALIAS]?.trim().orEmpty()
+            val certificateChainPem = prefs[Keys.CLOUDFLARE_DEVICE_CERTIFICATE_CHAIN_PEM]?.trim().orEmpty()
+            val privateKey = storedCloudflarePrivateKey(prefs)
+            if ((alias.isNotBlank() || certificateChainPem.isNotBlank()) && privateKey.isBlank()) {
+                removedAlias = alias.takeIf { it.isNotBlank() }
+                prefs.remove(Keys.CLOUDFLARE_DEVICE_CERTIFICATE_ALIAS)
+                prefs.remove(Keys.CLOUDFLARE_DEVICE_CERTIFICATE_CHAIN_PEM)
+            }
+        }
+        return removedAlias
     }
 
     suspend fun saveDismissedUpdateArtifactHash(artifactHash: String) {
@@ -143,4 +178,15 @@ class SettingsRepository(private val context: Context) {
                 leaf.publicKey.algorithm.equals("RSA", ignoreCase = true) &&
                 CloudflareDeviceCredentialManager().certificateChainMatchesPrivateKey(certificateChainPem, privateKeyPkcs8)
         }.getOrDefault(false)
+
+    private fun cloudflareDevicePrivateKeyPkcs8FromPrefs(prefs: Preferences): String {
+        val storedPrivateKey = storedCloudflarePrivateKey(prefs)
+        return cloudflarePrivateKeyProtector.unprotect(storedPrivateKey).orEmpty()
+    }
+
+    private fun storedCloudflarePrivateKey(prefs: Preferences): String =
+        prefs[Keys.CLOUDFLARE_DEVICE_PRIVATE_KEY_PKCS8_WRAPPED]?.trim().orEmpty()
+            .ifBlank {
+                prefs[Keys.LEGACY_CLOUDFLARE_DEVICE_PRIVATE_KEY_PKCS8]?.trim().orEmpty()
+            }
 }

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SettingsRepository.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SettingsRepository.kt
@@ -6,11 +6,12 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.first
+import li.rajeshgo.sm.data.security.CloudflareDeviceCredentialManager
 import li.rajeshgo.sm.util.LocalDefaults
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import java.io.ByteArrayInputStream
-import java.security.KeyStore
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
 
@@ -25,6 +26,7 @@ class SettingsRepository(private val context: Context) {
         val EXPIRES_AT = stringPreferencesKey("expires_at")
         val CLOUDFLARE_DEVICE_CERTIFICATE_ALIAS = stringPreferencesKey("cloudflare_device_certificate_alias")
         val CLOUDFLARE_DEVICE_CERTIFICATE_CHAIN_PEM = stringPreferencesKey("cloudflare_device_certificate_chain_pem")
+        val CLOUDFLARE_DEVICE_PRIVATE_KEY_PKCS8 = stringPreferencesKey("cloudflare_device_private_key_pkcs8")
         val DISMISSED_UPDATE_ARTIFACT_HASH = stringPreferencesKey("dismissed_update_artifact_hash")
     }
 
@@ -61,7 +63,8 @@ class SettingsRepository(private val context: Context) {
     val hasCloudflareDeviceCertificate: Flow<Boolean> = context.dataStore.data.map { prefs ->
         val alias = prefs[Keys.CLOUDFLARE_DEVICE_CERTIFICATE_ALIAS]?.trim().orEmpty()
         val certificateChainPem = prefs[Keys.CLOUDFLARE_DEVICE_CERTIFICATE_CHAIN_PEM]?.trim().orEmpty()
-        hasUsableCloudflareDeviceCredential(alias, certificateChainPem)
+        val privateKeyPkcs8 = prefs[Keys.CLOUDFLARE_DEVICE_PRIVATE_KEY_PKCS8]?.trim().orEmpty()
+        hasUsableCloudflareDeviceCredential(alias, certificateChainPem, privateKeyPkcs8)
     }
 
     val dismissedUpdateArtifactHash: Flow<String> = context.dataStore.data.map { prefs ->
@@ -83,10 +86,14 @@ class SettingsRepository(private val context: Context) {
         }
     }
 
-    suspend fun saveCloudflareDeviceCredential(alias: String, certificateChainPem: String) {
+    suspend fun cloudflareDevicePrivateKeyPkcs8(): String =
+        context.dataStore.data.first()[Keys.CLOUDFLARE_DEVICE_PRIVATE_KEY_PKCS8]?.trim().orEmpty()
+
+    suspend fun saveCloudflareDeviceCredential(alias: String, certificateChainPem: String, privateKeyPkcs8: String) {
         context.dataStore.edit { prefs ->
             prefs[Keys.CLOUDFLARE_DEVICE_CERTIFICATE_ALIAS] = alias.trim()
             prefs[Keys.CLOUDFLARE_DEVICE_CERTIFICATE_CHAIN_PEM] = certificateChainPem.trim()
+            prefs[Keys.CLOUDFLARE_DEVICE_PRIVATE_KEY_PKCS8] = privateKeyPkcs8.trim()
         }
     }
 
@@ -94,6 +101,7 @@ class SettingsRepository(private val context: Context) {
         context.dataStore.edit { prefs ->
             prefs.remove(Keys.CLOUDFLARE_DEVICE_CERTIFICATE_ALIAS)
             prefs.remove(Keys.CLOUDFLARE_DEVICE_CERTIFICATE_CHAIN_PEM)
+            prefs.remove(Keys.CLOUDFLARE_DEVICE_PRIVATE_KEY_PKCS8)
         }
     }
 
@@ -112,28 +120,27 @@ class SettingsRepository(private val context: Context) {
         }
     }
 
-    private fun hasUsableCloudflareDeviceCredential(alias: String, certificateChainPem: String): Boolean =
+    private fun hasUsableCloudflareDeviceCredential(
+        alias: String,
+        certificateChainPem: String,
+        privateKeyPkcs8: String,
+    ): Boolean =
         alias.isNotBlank() &&
             certificateChainPem.isNotBlank() &&
-            cloudflareDeviceCertificateMatchesAlias(alias, certificateChainPem)
+            privateKeyPkcs8.isNotBlank() &&
+            cloudflareDeviceCertificateMatchesPrivateKey(certificateChainPem, privateKeyPkcs8)
 
-    private fun cloudflareDeviceCertificateMatchesAlias(alias: String, certificateChainPem: String): Boolean =
+    private fun cloudflareDeviceCertificateMatchesPrivateKey(
+        certificateChainPem: String,
+        privateKeyPkcs8: String,
+    ): Boolean =
         runCatching {
             val certificates = CertificateFactory.getInstance("X.509")
                 .generateCertificates(ByteArrayInputStream(certificateChainPem.toByteArray()))
                 .filterIsInstance<X509Certificate>()
             val leaf = certificates.firstOrNull()
-            val storedPublicKey = KeyStore.getInstance(ANDROID_KEYSTORE)
-                .apply { load(null) }
-                .getCertificate(alias)
-                ?.publicKey
             leaf != null &&
                 leaf.publicKey.algorithm.equals("RSA", ignoreCase = true) &&
-                storedPublicKey != null &&
-                leaf.publicKey.encoded.contentEquals(storedPublicKey.encoded)
+                CloudflareDeviceCredentialManager().certificateChainMatchesPrivateKey(certificateChainPem, privateKeyPkcs8)
         }.getOrDefault(false)
-
-    private companion object {
-        const val ANDROID_KEYSTORE = "AndroidKeyStore"
-    }
 }

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/security/CloudflareDeviceCredentialManager.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/security/CloudflareDeviceCredentialManager.kt
@@ -1,7 +1,5 @@
 package li.rajeshgo.sm.data.security
 
-import android.security.keystore.KeyGenParameterSpec
-import android.security.keystore.KeyProperties
 import org.bouncycastle.asn1.x500.X500Name
 import org.bouncycastle.openssl.jcajce.JcaPEMWriter
 import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
@@ -12,14 +10,24 @@ import java.io.StringWriter
 import java.security.KeyPair
 import java.security.KeyPairGenerator
 import java.security.KeyStore
+import java.security.KeyFactory
 import java.security.cert.CertificateFactory
 import java.security.cert.X509Certificate
+import java.security.interfaces.RSAPrivateCrtKey
+import java.security.interfaces.RSAPublicKey
+import java.security.spec.PKCS8EncodedKeySpec
+import java.util.Base64
 import java.util.UUID
+
+data class CloudflareDeviceCredentialRequest(
+    val csrPem: String,
+    val privateKeyPkcs8: String,
+)
 
 class CloudflareDeviceCredentialManager {
     fun newCredentialAlias(): String = "$KEY_ALIAS_PREFIX${UUID.randomUUID()}"
 
-    fun certificateSigningRequestPem(alias: String, commonName: String): String {
+    fun certificateSigningRequest(alias: String, commonName: String): CloudflareDeviceCredentialRequest {
         val keyPair = generateKeyPair(alias)
         val subject = X500Name("CN=${commonName.ifBlank { "Session Manager Android Device" }}")
         val builder = JcaPKCS10CertificationRequestBuilder(subject, keyPair.public)
@@ -29,14 +37,18 @@ class CloudflareDeviceCredentialManager {
         JcaPEMWriter(writer).use { pemWriter ->
             pemWriter.writeObject(request)
         }
-        return writer.toString()
+        return CloudflareDeviceCredentialRequest(
+            csrPem = writer.toString(),
+            privateKeyPkcs8 = Base64.getEncoder().encodeToString(keyPair.private.encoded),
+        )
     }
 
-    fun certificateChainMatchesAlias(certificateChainPem: String, alias: String): Boolean {
+    fun certificateChainMatchesPrivateKey(certificateChainPem: String, privateKeyPkcs8: String): Boolean {
         val leaf = decodeCertificates(certificateChainPem).firstOrNull() ?: return false
-        val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
-        val storedPublicKey = keyStore.getCertificate(alias)?.publicKey ?: return false
-        return leaf.publicKey.encoded.contentEquals(storedPublicKey.encoded)
+        val leafPublicKey = leaf.publicKey as? RSAPublicKey ?: return false
+        val privateKey = decodePrivateKey(privateKeyPkcs8) as? RSAPrivateCrtKey ?: return false
+        return leafPublicKey.modulus == privateKey.modulus &&
+            leafPublicKey.publicExponent == privateKey.publicExponent
     }
 
     fun deleteCredential(alias: String) {
@@ -48,30 +60,19 @@ class CloudflareDeviceCredentialManager {
         }
     }
 
+    fun decodePrivateKey(privateKeyPkcs8: String) =
+        runCatching {
+            val keyBytes = Base64.getDecoder().decode(privateKeyPkcs8.trim())
+            KeyFactory.getInstance("RSA").generatePrivate(PKCS8EncodedKeySpec(keyBytes))
+        }.getOrNull()
+
     private fun generateKeyPair(alias: String): KeyPair {
+        // Remove any stale AndroidKeyStore entry from earlier builds. The Cloudflare
+        // mTLS key itself is software-backed because Conscrypt can fail client auth
+        // signing with AndroidKeyStore RSA keys on affected devices.
         deleteCredential(alias)
-        val keyPairGenerator = KeyPairGenerator.getInstance(
-            KeyProperties.KEY_ALGORITHM_RSA,
-            ANDROID_KEYSTORE,
-        )
-        keyPairGenerator.initialize(
-            KeyGenParameterSpec.Builder(
-                alias,
-                KeyProperties.PURPOSE_SIGN or KeyProperties.PURPOSE_VERIFY,
-            )
-                .setKeySize(2048)
-                .setDigests(
-                    KeyProperties.DIGEST_SHA256,
-                    KeyProperties.DIGEST_SHA384,
-                    KeyProperties.DIGEST_SHA512,
-                )
-                .setSignaturePaddings(
-                    KeyProperties.SIGNATURE_PADDING_RSA_PKCS1,
-                    KeyProperties.SIGNATURE_PADDING_RSA_PSS,
-                )
-                .setUserAuthenticationRequired(false)
-                .build(),
-        )
+        val keyPairGenerator = KeyPairGenerator.getInstance("RSA")
+        keyPairGenerator.initialize(2048)
         return keyPairGenerator.generateKeyPair()
     }
 

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/security/CloudflareDevicePrivateKeyProtector.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/security/CloudflareDevicePrivateKeyProtector.kt
@@ -1,0 +1,78 @@
+package li.rajeshgo.sm.data.security
+
+import android.security.keystore.KeyGenParameterSpec
+import android.security.keystore.KeyProperties
+import java.security.KeyStore
+import java.util.Base64
+import javax.crypto.Cipher
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
+import javax.crypto.spec.GCMParameterSpec
+
+class CloudflareDevicePrivateKeyProtector {
+    fun protect(privateKeyPkcs8: String): String {
+        val trimmed = privateKeyPkcs8.trim()
+        if (trimmed.isBlank() || isProtectedPayload(trimmed)) {
+            return trimmed
+        }
+        val cipher = Cipher.getInstance(TRANSFORMATION).apply {
+            init(Cipher.ENCRYPT_MODE, getOrCreateSecretKey())
+        }
+        val ciphertext = cipher.doFinal(trimmed.toByteArray(Charsets.UTF_8))
+        return "$PAYLOAD_PREFIX:${encode(cipher.iv)}:${encode(ciphertext)}"
+    }
+
+    fun unprotect(storedPrivateKey: String): String? {
+        val trimmed = storedPrivateKey.trim()
+        if (trimmed.isBlank()) {
+            return ""
+        }
+        if (!isProtectedPayload(trimmed)) {
+            return trimmed
+        }
+        return runCatching {
+            val parts = trimmed.split(':', limit = 3)
+            require(parts.size == 3 && parts[0] == PAYLOAD_PREFIX)
+            val iv = decode(parts[1])
+            val ciphertext = decode(parts[2])
+            val cipher = Cipher.getInstance(TRANSFORMATION).apply {
+                init(Cipher.DECRYPT_MODE, getOrCreateSecretKey(), GCMParameterSpec(GCM_TAG_BITS, iv))
+            }
+            String(cipher.doFinal(ciphertext), Charsets.UTF_8).trim()
+        }.getOrNull()
+    }
+
+    fun isProtectedPayload(value: String): Boolean =
+        value.trim().startsWith("$PAYLOAD_PREFIX:")
+
+    private fun getOrCreateSecretKey(): SecretKey {
+        val keyStore = KeyStore.getInstance(ANDROID_KEYSTORE).apply { load(null) }
+        (keyStore.getKey(KEY_ALIAS, null) as? SecretKey)?.let { return it }
+
+        val keyGenerator = KeyGenerator.getInstance(KeyProperties.KEY_ALGORITHM_AES, ANDROID_KEYSTORE)
+        val spec = KeyGenParameterSpec.Builder(
+            KEY_ALIAS,
+            KeyProperties.PURPOSE_ENCRYPT or KeyProperties.PURPOSE_DECRYPT,
+        )
+            .setBlockModes(KeyProperties.BLOCK_MODE_GCM)
+            .setEncryptionPaddings(KeyProperties.ENCRYPTION_PADDING_NONE)
+            .setKeySize(256)
+            .build()
+        keyGenerator.init(spec)
+        return keyGenerator.generateKey()
+    }
+
+    private fun encode(bytes: ByteArray): String =
+        Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+
+    private fun decode(value: String): ByteArray =
+        Base64.getUrlDecoder().decode(value)
+
+    private companion object {
+        private const val ANDROID_KEYSTORE = "AndroidKeyStore"
+        private const val KEY_ALIAS = "li.rajeshgo.sm.cloudflare_device_private_key.wrap"
+        private const val PAYLOAD_PREFIX = "smcfpk1"
+        private const val TRANSFORMATION = "AES/GCM/NoPadding"
+        private const val GCM_TAG_BITS = 128
+    }
+}

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsViewModel.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/settings/SettingsViewModel.kt
@@ -50,6 +50,9 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
 
     init {
         viewModelScope.launch {
+            settingsRepository.clearIncompleteCloudflareDeviceCredential()?.let { staleAlias ->
+                cloudflareCredentialManager.deleteCredential(staleAlias)
+            }
             _uiState.value = _uiState.value.copy(
                 serverUrl = settingsRepository.serverUrl.first(),
                 userEmail = settingsRepository.userEmail.first(),

--- a/android-app/app/src/test/java/li/rajeshgo/sm/data/security/CloudflareDeviceCredentialManagerTest.kt
+++ b/android-app/app/src/test/java/li/rajeshgo/sm/data/security/CloudflareDeviceCredentialManagerTest.kt
@@ -1,0 +1,83 @@
+package li.rajeshgo.sm.data.security
+
+import org.bouncycastle.asn1.x500.X500Name
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
+import org.bouncycastle.openssl.PEMParser
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
+import org.bouncycastle.pkcs.PKCS10CertificationRequest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.StringReader
+import java.io.StringWriter
+import java.math.BigInteger
+import java.security.KeyFactory
+import java.security.PrivateKey
+import java.security.interfaces.RSAPrivateCrtKey
+import java.security.interfaces.RSAPublicKey
+import java.security.spec.PKCS8EncodedKeySpec
+import java.time.Instant
+import java.util.Base64
+import java.util.Date
+
+class CloudflareDeviceCredentialManagerTest {
+    private val manager = CloudflareDeviceCredentialManager()
+
+    @Test
+    fun credentialRequestPersistsSoftwareRsaKeyMatchingCsr() {
+        val credential = manager.certificateSigningRequest("test-alias", "fixture-device")
+        val csrPublicKey = csrPublicKey(credential.csrPem)
+        val privateKey = privateKey(credential.privateKeyPkcs8)
+
+        assertEquals("RSA", csrPublicKey.algorithm)
+        assertEquals((csrPublicKey as RSAPublicKey).modulus, privateKey.modulus)
+        assertEquals(csrPublicKey.publicExponent, privateKey.publicExponent)
+    }
+
+    @Test
+    fun certificateChainMatchUsesSavedPrivateKeyMaterial() {
+        val credential = manager.certificateSigningRequest("test-alias", "fixture-device")
+        val certificatePem = selfSignedCertificatePem(credential)
+        val otherCredential = manager.certificateSigningRequest("other-alias", "other-device")
+
+        assertTrue(manager.certificateChainMatchesPrivateKey(certificatePem, credential.privateKeyPkcs8))
+        assertFalse(manager.certificateChainMatchesPrivateKey(certificatePem, otherCredential.privateKeyPkcs8))
+    }
+
+    private fun csrPublicKey(csrPem: String) =
+        PEMParser(StringReader(csrPem)).use { parser ->
+            val csr = parser.readObject() as PKCS10CertificationRequest
+            JcaPEMKeyConverter().getPublicKey(csr.subjectPublicKeyInfo)
+        }
+
+    private fun privateKey(privateKeyPkcs8: String): RSAPrivateCrtKey {
+        val keyBytes = Base64.getDecoder().decode(privateKeyPkcs8)
+        return KeyFactory.getInstance("RSA")
+            .generatePrivate(PKCS8EncodedKeySpec(keyBytes)) as RSAPrivateCrtKey
+    }
+
+    private fun selfSignedCertificatePem(credential: CloudflareDeviceCredentialRequest): String {
+        val publicKey = csrPublicKey(credential.csrPem)
+        val privateKey: PrivateKey = privateKey(credential.privateKeyPkcs8)
+        val now = Instant.parse("2026-06-16T00:00:00Z")
+        val subject = X500Name("CN=fixture-device")
+        val certificateHolder = JcaX509v3CertificateBuilder(
+            subject,
+            BigInteger.ONE,
+            Date.from(now),
+            Date.from(now.plusSeconds(3600)),
+            subject,
+            publicKey,
+        ).build(JcaContentSignerBuilder("SHA256withRSA").build(privateKey))
+        val certificate = JcaX509CertificateConverter().getCertificate(certificateHolder)
+        val writer = StringWriter()
+        JcaPEMWriter(writer).use { pemWriter ->
+            pemWriter.writeObject(certificate)
+        }
+        return writer.toString()
+    }
+}


### PR DESCRIPTION
Fixes #1032

## Summary
- generate the Cloudflare mTLS CSR from a software RSA key instead of AndroidKeyStore RSA
- encrypt the software RSA PKCS#8 material at rest with an AndroidKeyStore AES-GCM wrapping key before saving it in DataStore
- migrate the short-lived plaintext PKCS#8 preference to the wrapped format on first use, and clear stale alias/cert-only credentials from older builds so the user re-enrolls instead of silently losing mTLS
- keep the existing AndroidKeyStore EC device key path for attach-ticket proof unchanged
- add a JVM regression test that the CSR/certificate matching logic uses the saved RSA key material

## Validation
- `./gradlew testDebugUnitTest --no-daemon`
- `SM_VERSION_CODE=1033 SM_VERSION_NAME=0.1.1-rsa-mtls-wrapped-key ./gradlew assembleDebug --no-daemon`
- `VERSION_CODE=1033 VERSION_NAME=0.1.1-rsa-mtls-wrapped-key ./scripts/deploy_android_app.sh`
- manual phone verification: installed the published 1032 app, re-enrolled Cloudflare client auth, and completed Google sign-in after adding the local Rust `cloudflare_access.team_domain` deployment config

Published Android artifact: versionCode 1033, versionName `0.1.1-rsa-mtls-wrapped-key`, artifact hash `be8c6269`.
