### PR TITLE
Refresh post-1035 Rust MVP evidence

### DIFF
--- a/scripts/rust_migration/contracts.py
+++ b/scripts/rust_migration/contracts.py
@@ -23,6 +23,7 @@ from typing import Any, Iterable
 
 MANIFEST_PATH = Path(__file__).with_name("contracts_manifest.json")
 DEFAULT_TIMEOUT_SECONDS = 5.0
+DEFAULT_HTTP_READ_BYTES = 4 * 1024 * 1024
 DEFAULT_PYTHON_SM_BINARY = "sm"
 DEFAULT_RUST_SM_BINARY = "target/debug/sm"
 
@@ -70,7 +71,7 @@ class ContractCheck:
     env: tuple[tuple[str, str], ...] = ()
     body: Any = None
     read_mode: str = "bytes"
-    read_bytes: int = 65536
+    read_bytes: int = DEFAULT_HTTP_READ_BYTES
     expected_body_contains_any: tuple[str, ...] = ()
     expected_body_contains_all: tuple[str, ...] = ()
     expected_json: tuple[JsonExpectation, ...] = ()
@@ -103,7 +104,7 @@ class ContractCheck:
             env=tuple((str(key), str(value)) for key, value in raw.get("env", {}).items()),
             body=raw.get("body"),
             read_mode=str(raw.get("read_mode", "bytes")),
-            read_bytes=int(raw.get("read_bytes", 65536)),
+            read_bytes=int(raw.get("read_bytes", DEFAULT_HTTP_READ_BYTES)),
             expected_body_contains_any=tuple(
                 str(v) for v in raw.get("expected_body_contains_any", [])
             ),

--- a/specs/762_stage5_artifacts/mvp_progress.md
+++ b/specs/762_stage5_artifacts/mvp_progress.md
@@ -1,15 +1,15 @@
 # Rust MVP Progress Snapshot
 
-Status: implementation snapshot after PR #1025 Rust native Google device auth
-success.
+Status: implementation snapshot after PR #1035 Android artifact auth fix.
 The last clean full real-state MVP rehearsal remains the post-#938 run; the
-post-#984 focused rehearsal proves state gates, live core contracts, read-only
-fixtures, and mutating fixtures on isolated sidecars, but intentionally skips
-Python baseline and shadow. PRs #986-#1025 added node restore fixtures,
-stopped-origin final backup gates, rehearsal final-backup integration,
-Cloudflare Access smoke evidence tooling, Rust mobile-device enrollment,
-Cloudflare mTLS CA automation, the Android Camera-app enrollment handoff, and
-Rust native Google device-auth bearer issuance. Public cutover still needs full
+post-#1035 rehearsal proves state gates, live core contracts, read-only
+fixtures, mutating fixtures, and Rust baseline on isolated sidecars, but blocks
+on Python-origin availability during Python baseline and shadow. PRs #986-#1035
+added node restore fixtures, stopped-origin final backup gates, rehearsal
+final-backup integration, Cloudflare Access smoke evidence tooling, Rust
+mobile-device enrollment, Cloudflare mTLS CA automation, the Android Camera-app
+enrollment handoff, and Rust native Google device-auth bearer issuance, plus
+Android mTLS and artifact read fixes. Public cutover still needs full
 Cloudflare policy/proof inputs, real mobile/browser smoke evidence, and a
 stable Python-authoritative shadow window.
 
@@ -107,7 +107,11 @@ not change retained or removed scope. Binding scope remains
 | #1012 | Android Camera-app QR handoff, `sm-enroll://enroll` deep link, direct in-app credential save, and no camera permission/manual cert UI |
 | #1023 | Block unported `/auth/device/google` shadow successes until Rust can issue native device bearers |
 | #1025 | Rust native Google device-auth success with Google JWKS verification, mobile Access actor binding, public-edge gate, and zero-skew token temporal checks |
-| #1026 | Post-#1025 smoke evidence slice; first blocked run records the mobile Access-denial boundary and missing proof inputs |
+| #1027 | Post-#1025 mobile auth smoke boundary evidence; records mobile Access denial and missing proof inputs |
+| #1029 | Clarify post-#1025 smoke input status |
+| #1031 | Android enrollment uses separate RSA mTLS credentials |
+| #1033 | Android Cloudflare mTLS uses a software RSA key with protected local storage |
+| #1035 | Android app artifacts can be read with cert-gated app auth while preserving edge/session fallbacks |
 
 ## Implemented Capability Groups
 
@@ -197,7 +201,7 @@ fixture false failures:
 The skipped checks are mutating checks without `--include-mutating`, which is
 the expected safety behavior for a live-state read run.
 
-Current executable manifest size after PR #1012:
+Current executable manifest size after PR #1035:
 
 | Metric | Count |
 | --- | ---: |
@@ -207,7 +211,7 @@ Current executable manifest size after PR #1012:
 | Read-only checks | 93 |
 | Mutating checks | 41 |
 
-The latest focused isolated-sidecar rehearsal for the current fixture set is:
+The latest focused isolated-sidecar rehearsal before the post-#1035 run is:
 
 ```bash
 /tmp/session-manager-pr981-rehearsal-ports/mvp-rehearsal-report.json
@@ -226,10 +230,8 @@ on port `8421`. Results:
 | Rust mutating fixture contracts | 35 passed, 0 failed, 0 skipped |
 
 This is not a full cutover rehearsal because it skips Python baseline and
-shadow. It remains the current best fixture/state-gate evidence for the
-post-#984 contract set; PRs #986-#996 added additional tooling/evidence gates
-that still need a fresh full rehearsal once Cloudflare/mobile inputs are
-available and Python-origin availability is stable.
+shadow. It remains useful historical fixture/state-gate evidence for the
+post-#984 contract set; newer post-#1035 evidence is below.
 
 ## Latest Real-State Rehearsal
 
@@ -276,37 +278,42 @@ Measured baseline snapshot from the same run:
 | `GET /sessions` median | 25.746 ms | 7.972 ms |
 | `GET /client/sessions` median | 58.486 ms | 7.946 ms |
 
-## Latest Post-942 Rehearsal Attempt
+## Latest Post-1035 Rehearsal Attempt
 
 Reports:
 
-- `.local/rust-mvp-rehearsals/20260613T020040Z-after-942-mobile-shadow/mvp-rehearsal-report.json`
-- `.local/rust-mvp-rehearsals/20260613T020731Z-after-942-mobile-shadow-rerun/mvp-rehearsal-report.json`
+- `.local/rust-mvp-rehearsals/20260616T215701Z-post-1035/mvp-rehearsal-report.json`
+- `.local/rust-mvp-rehearsals/20260616T220122Z-post-1035/mvp-rehearsal-report.json`
+- `.local/rust-mvp-rehearsals/20260616T221117Z-post-1035/mvp-rehearsal-report.json`
 
-The rerun is the current snapshot:
+The latest run is the current snapshot. It includes the contract harness fix
+that raised the default HTTP read budget above the old 64 KiB limit; before that
+fix, live `/client/sessions` responses were valid JSON but the harness truncated
+them before JSON assertion checks.
 
 | Area | Result |
 | --- | --- |
 | Overall status | Blocked with 2 blockers |
 | Python health | Passed at start |
-| State ownership gate | Passed: 17 stores checked, 13 existing, 13 copied, 13 verified, 13 restored, freeze/drain ledger written |
-| Rust sidecar health | Passed using existing sidecar |
+| State ownership gate | Passed: 17 stores checked, 14 existing, 14 copied, 14 verified, 14 restored, freeze/drain ledger written |
+| Rust sidecar health | Passed using fresh sidecar |
 | Isolated runtime smoke | Passed |
 | Rust live core sidecar contracts | 17 passed, 0 failed, 0 skipped |
-| Rust synthetic read-only fixture contracts | 10 passed, 0 failed, 0 skipped |
-| Rust mutating fixture contracts | 30 passed, 0 failed, 0 skipped |
+| Rust synthetic read-only fixture contracts | 14 passed, 0 failed, 0 skipped |
+| Rust mutating fixture contracts | 37 passed, 0 failed, 0 skipped |
 | Gap probes | 0 failed |
 | Python baseline | Failed: Python origin refused connections after the first health probe |
-| Rust baseline | Passed: 20.172 MiB RSS, 6.891 MiB physical footprint |
+| Rust baseline | Passed: 19.359 MiB RSS, 8.125 MiB physical footprint |
 | Mobile shadow path resolution | Skipped: Python `/sessions` was unavailable |
 | Shadow read summary | Failed: 9 requested read probes failed with connection refused |
 
 This is not a Rust contract regression: the Rust/state/fixture portions passed.
 The blocker is Python-authoritative origin availability during the baseline and
-shadow steps. Launchd logs around both runs show the Python watchdog reporting
-an event-loop freeze and killing the process for restart. The next clean
-cutover-evidence run needs Python to remain up through baseline and shadow,
-including the new mobile read probes from PR #942.
+shadow steps. Logs around the latest run show the Python watchdog reporting an
+event-loop freeze and killing the process for restart; after the kill, port
+`8420` stopped accepting connections. The next clean cutover-evidence run needs
+Python to remain up through baseline and shadow, including the mobile read
+probes from PR #942.
 
 ## Near-Term Remaining Work
 

--- a/specs/762_stage5_artifacts/resume_handoff.md
+++ b/specs/762_stage5_artifacts/resume_handoff.md
@@ -1,7 +1,7 @@
 # Rust Port Resume Handoff
 
-Status: handoff snapshot from 2026-06-14 after PR #1012 Android Camera-app
-enrollment flow.
+Status: handoff snapshot from 2026-06-16 after PR #1035 Android artifact auth
+fix and the post-#1035 evidence refresh.
 
 Use this file to resume the Rust cutover track without reconstructing state from
 chat history. Binding scope still lives in [cutover_scope.md](cutover_scope.md),
@@ -11,9 +11,9 @@ coverage in
 
 ## Current Repository State
 
-- Branch: `main` after PR #1012.
-- Latest merged commit before this docs refresh: `5fbbfa4` (`Merge pull
-  request #1012`)
+- Branch: `main` after PR #1035.
+- Latest merged commit before this docs refresh: `1f85ce9` (`Merge pull
+  request #1035`)
 - Open PRs at handoff: none before this docs refresh PR.
 - Dirty worktree at handoff: only pre-existing untracked
   `.claude/settings.local.json`, `certs/`, `data/`, and the local
@@ -64,7 +64,7 @@ Merged Rust slices cover:
 
 ### Documentation And Manifest
 
-- [mvp_progress.md](mvp_progress.md) records the PR lineage through #1012.
+- [mvp_progress.md](mvp_progress.md) records the PR lineage through #1035.
 - [cloudflare_access_cutover_evidence.md](cloudflare_access_cutover_evidence.md)
   records the current Cloudflare Access origin-gate behavior and remaining
   operator setup/smoke evidence.
@@ -166,9 +166,15 @@ Merged Rust slices cover:
 - PR #1025 implemented Rust native Google device auth success, including Google
   JWKS verification, mobile Access actor binding, public-edge gating, and
   zero-skew token temporal checks.
-- PR #1026 is the post-#1025 smoke evidence slice; the first run records one
+- PR #1027 is the post-#1025 smoke evidence slice; the first run records one
   mobile Access-denial boundary pass and the missing proof inputs blocking full
   smoke.
+- PR #1029 clarified the post-#1025 smoke input status.
+- PR #1031 made Android enrollment use a separate RSA mTLS credential.
+- PR #1033 made Android Cloudflare mTLS use a software RSA key with protected
+  local storage.
+- PR #1035 allowed Android app artifacts to be read with cert-gated app auth
+  while preserving Cloudflare edge and session-auth fallbacks.
 - Current contract manifest size:
   - `134` checks total
   - `73` `python_and_rust`
@@ -245,39 +251,47 @@ post-#984 manifest:
   skipped;
 - Rust mutating fixture contracts: `35` passed, `0` failed, `0` skipped.
 
-PRs #986-#1012 added more cutover tooling and evidence gates after this focused
+PRs #986-#1035 added more cutover tooling and evidence gates after this focused
 run, including node restore fixtures, stopped-origin final backup, rehearsal
 final-backup integration, the Cloudflare Access mobile smoke runner, Rust
-mobile-device enrollment, Cloudflare mTLS CA automation, and Android Camera-app
-enrollment. Run a fresh full rehearsal once Cloudflare/mobile smoke inputs are
-available and Python-origin availability is stable.
+mobile-device enrollment, Cloudflare mTLS CA automation, Android Camera-app
+enrollment, Android mTLS fixes, native device auth, and app artifact auth
+fixes. The latest post-#1035 rehearsal below is the current evidence snapshot.
 
-The latest post-#942 full rehearsal attempts are blocked, not cutover evidence:
+The latest post-#1035 full rehearsal attempts are blocked, not cutover evidence:
 
 ```bash
-.local/rust-mvp-rehearsals/20260613T020040Z-after-942-mobile-shadow/mvp-rehearsal-report.json
-.local/rust-mvp-rehearsals/20260613T020731Z-after-942-mobile-shadow-rerun/mvp-rehearsal-report.json
+.local/rust-mvp-rehearsals/20260616T215701Z-post-1035/mvp-rehearsal-report.json
+.local/rust-mvp-rehearsals/20260616T220122Z-post-1035/mvp-rehearsal-report.json
+.local/rust-mvp-rehearsals/20260616T221117Z-post-1035/mvp-rehearsal-report.json
 ```
 
-The second run is the clearer current snapshot. It started with Python `/health`
-passing, and the state/Rust-side gates passed:
+The first run exposed a contract-harness limit: live `/client/sessions`
+responses were valid JSON but exceeded the old 64 KiB default read budget, so
+the harness truncated the body before JSON assertions. This refresh raises the
+default contract HTTP read budget and adds a regression test for large JSON
+responses.
 
-- state ownership gate: `17` stores checked, `13` copied, `13` verified, `13`
+The latest run is the clearer current snapshot. It started with Python
+`/health` passing, and the state/Rust-side gates passed:
+
+- state ownership gate: `17` stores checked, `14` copied, `14` verified, `14`
   restored, freeze/drain ledger written;
 - Rust live core sidecar contracts: `17` passed, `0` failed, `0` skipped;
-- Rust synthetic read-only fixture contracts: `10` passed, `0` failed, `0`
+- Rust synthetic read-only fixture contracts: `14` passed, `0` failed, `0`
   skipped;
-- Rust mutating fixture contracts: `30` passed, `0` failed, `0` skipped;
-- Rust baseline: passed, `20.172 MiB` RSS and `6.891 MiB` physical footprint.
+- Rust mutating fixture contracts: `37` passed, `0` failed, `0` skipped;
+- Rust baseline: passed, `19.359 MiB` RSS and `8.125 MiB` physical footprint.
 
 The same run blocked because the Python authoritative service stopped accepting
 connections during `python_baseline`, after the first health probe. The
 `shadow_mobile_path_resolution` step therefore skipped with connection refused,
 and `shadow_read_summary` failed all `9` requested read probes. Launchd logs
 around the run show the Python watchdog reporting an event-loop freeze and
-killing the process for restart. Do not treat the post-#942 rehearsal as a clean
-MVP cutover artifact until Python-origin availability is stable for the
-baseline/shadow steps.
+killing the process for restart; after that, port `8420` stopped accepting
+connections. Do not treat the post-#1035 rehearsal as a clean MVP cutover
+artifact until Python-origin availability is stable for the baseline/shadow
+steps.
 
 ## Live Observation
 
@@ -326,8 +340,10 @@ No newer clean full passive shadow or full Cloudflare/mobile smoke artifact has
 been recorded in this handoff. PR #1012 published Android artifact `cbb61798`
 (`versionCode=1013`, `versionName=0.1.0-enroll-ui-cleanup`) and operator
 testing confirmed the app reached "Client certificate saved" after Camera-app
-deep-link enrollment, but the full Access smoke runner and sustained shadow
-window still need recorded artifacts.
+deep-link enrollment. After PR #1035, operator testing also confirmed Android
+app update artifact access works through the certificate-gated app path. The
+full Access smoke runner and sustained shadow window still need recorded
+artifacts.
 
 The broad live Rust contract run now uses the fixture filter:
 

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -265,7 +265,7 @@ def test_cloudflare_access_cutover_evidence_pins_policy_and_origin_gates():
         assert required in evidence
 
 
-def test_handoff_and_progress_are_current_through_android_enrollment_pr1012():
+def test_handoff_and_progress_are_current_through_android_artifact_auth_pr1035():
     progress = (STAGE5_DIR / "mvp_progress.md").read_text(encoding="utf-8")
     handoff = (STAGE5_DIR / "resume_handoff.md").read_text(encoding="utf-8")
 
@@ -276,14 +276,16 @@ def test_handoff_and_progress_are_current_through_android_enrollment_pr1012():
         assert "#1005" in text
         assert "#1007" in text
         assert "#1012" in text
+        assert "#1025" in text
+        assert "#1035" in text
         assert "Cloudflare Access" in text
         assert "cloudflare_access_cutover_evidence.md" in text
 
-    assert "Latest merged commit before this docs refresh: `5fbbfa4`" in handoff
-    assert "records the PR lineage through #1012" in handoff
+    assert "Latest merged commit before this docs refresh: `1f85ce9`" in handoff
+    assert "records the PR lineage through #1035" in handoff
     assert "Camera-app" in handoff
     assert "deep-link enrollment" in handoff
-    assert "versionName=0.1.0-enroll-ui-cleanup" in handoff
+    assert "app update artifact access works through the certificate-gated app path" in handoff
 
 
 def test_manifest_covers_rust_only_retired_http_surfaces():
@@ -1554,6 +1556,48 @@ def test_http_check_renders_json_expectation_fixture_values():
         )
 
     assert result.status == "passed"
+
+
+def test_http_check_reads_large_json_response_by_default():
+    large_value = "x" * 80_000
+    body = json.dumps({"sessions": [{"id": "fixture001", "output": large_value}]}).encode()
+    assert len(body) > 65_536
+    seen = {}
+    check = ContractCheck(
+        id="http.large_json",
+        surface="http",
+        classification="retained",
+        target="python_and_rust",
+        safety="read_only",
+        method="GET",
+        path="/client/sessions",
+        expected_status=(200,),
+        expected_json=(JsonExpectation(path="/sessions", value_type="array"),),
+        preconditions=("live_server",),
+        source="test",
+    )
+
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self, size):
+            seen["size"] = size
+            return body[:size]
+
+    with patch(
+        "scripts.rust_migration.contracts.urllib.request.urlopen",
+        return_value=FakeResponse(),
+    ):
+        result = _run_http_check(check, "http://127.0.0.1:8420", {}, 1.0)
+
+    assert result.status == "passed"
+    assert seen["size"] > 65_536
 
 
 def test_http_check_reports_json_shape_mismatch():


### PR DESCRIPTION
## Summary
- raise the Rust migration contract harness default HTTP read budget so large live JSON responses are not truncated before assertions
- refresh Stage 5 MVP progress and resume handoff through PR #1035
- record the latest post-#1035 evidence: Rust/state/fixture gates pass, while full cutover evidence remains blocked by Python-origin availability during baseline/shadow

## Validation
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py -q`
- `git diff --check`
- stale handoff search for old #1012/#1026/#942 status text
- post-#1035 rehearsal: `.local/rust-mvp-rehearsals/20260616T221117Z-post-1035/mvp-rehearsal-report.json`

Fixes #1036
