### PR TITLE
Add accelerated Rust canary evidence mode

### DIFF
--- a/scripts/rust_migration/README.md
+++ b/scripts/rust_migration/README.md
@@ -481,6 +481,39 @@ the loopback smoke report records those checks as skipped edge-only evidence.
 Use the JSON output as operator evidence alongside
 `specs/762_stage5_artifacts/cloudflare_access_cutover_evidence.md`.
 
+## Accelerated Rust Canary Evidence
+
+Normal cutover evidence still prefers Python-authoritative shadow for the
+agreed observation window. When the Python origin itself is the unstable part of
+the system, use the explicit Rust canary path instead of spending time on
+throwaway Python hardening:
+
+```bash
+python -m scripts.rust_migration.cloudflare_access_smoke \
+  --base-url http://127.0.0.1:8421 \
+  --mobile-host sm-app.rajeshgo.li \
+  --browser-host sm.rajeshgo.li \
+  --mobile-access-jwt-env CF_MOBILE_ACCESS_JWT \
+  --browser-access-jwt-env CF_BROWSER_ACCESS_JWT \
+  --public-edge-secret-env SM_PUBLIC_EDGE_SECRET \
+  --bearer-token-env SM_DEVICE_BEARER_TOKEN \
+  --output /tmp/sm-cloudflare-access-smoke.json \
+  --json \
+  --fail-on-blockers
+
+python -m scripts.rust_migration.mvp_rehearsal \
+  --rust-canary-cutover \
+  --cloudflare-smoke-report /tmp/sm-cloudflare-access-smoke.json
+```
+
+This mode still runs the state preflight/backup/restore/freeze-drain gate, Rust
+core contracts, synthetic read-only and mutating fixture contracts, and the Rust
+baseline. It replaces sustained Python baseline/shadow with
+`python_canary_spot_checks` for a small authority sanity set, then requires a
+passed Cloudflare/mobile smoke report as `cloudflare_access_smoke_report`.
+Reports produced this way are cutover-candidate evidence only when blockers are
+zero and the smoke report used real Access/public-edge/SM auth inputs.
+
 ## MVP Sidecar Rehearsal
 
 The MVP rehearsal gate starts Rust as a sidecar, keeps Python authoritative, and

--- a/scripts/rust_migration/mvp_rehearsal.py
+++ b/scripts/rust_migration/mvp_rehearsal.py
@@ -136,6 +136,16 @@ BASELINE_CHECK_IDS = (
     "http.api_sessions_absent",
 )
 
+PYTHON_CANARY_SPOT_CHECK_IDS = (
+    "http.health",
+    "http.auth_session",
+    "http.client_bootstrap",
+    "http.events_state",
+    "http.sessions",
+    "http.client_sessions",
+    "http.api_sessions_absent",
+)
+
 SHADOW_COMPARE_PATHS = (
     "/health",
     "/health/detailed",
@@ -162,6 +172,12 @@ def run_rehearsal(args: argparse.Namespace) -> dict[str, Any]:
             "rust_base_url": args.rust_base_url,
             "config": str(args.config),
             "local_env": str(args.local_env) if args.local_env else None,
+            "rust_canary_cutover": args.rust_canary_cutover,
+            "cloudflare_smoke_report": (
+                str(args.cloudflare_smoke_report)
+                if args.cloudflare_smoke_report
+                else None
+            ),
             "reuse_rust_sidecar": args.reuse_rust_sidecar,
             "include_gap_probes": not args.core_only,
             "skip_python_health": args.skip_python_health,
@@ -203,6 +219,23 @@ def run_rehearsal(args: argparse.Namespace) -> dict[str, Any]:
                     "status": "skipped",
                     "detail": "Python liveness probe is superseded by stopped-origin final backup gate",
                 }
+            )
+
+        if args.rust_canary_cutover:
+            python_spot = _run_contract_group(
+                manifest,
+                name="python_canary_spot_checks",
+                target="python",
+                base_url=args.python_base_url,
+                sm_binary=args.sm_binary,
+                check_ids=set(PYTHON_CANARY_SPOT_CHECK_IDS),
+                timeout_seconds=args.timeout,
+            )
+            report["steps"].append(python_spot)
+            _add_contract_blockers(
+                report,
+                python_spot,
+                blocker_kind="python_canary_spot_check",
             )
 
         if args.skip_state_gate:
@@ -455,7 +488,37 @@ def run_rehearsal(args: argparse.Namespace) -> dict[str, Any]:
             report["steps"].append(gap_contracts)
             _add_contract_blockers(report, gap_contracts, blocker_kind="mvp_gap")
 
-        if not args.skip_baseline:
+        if args.rust_canary_cutover and not args.skip_baseline:
+            baseline_dir = output_dir / "baseline"
+            baseline_dir.mkdir(parents=True, exist_ok=True)
+            report["steps"].append(
+                {
+                    "name": "python_baseline",
+                    "status": "skipped",
+                    "detail": (
+                        "accelerated Rust canary mode uses short Python spot "
+                        "checks instead of sustained Python baseline"
+                    ),
+                }
+            )
+            rust_pid = rust_process.pid if rust_process else None
+            rust_baseline = run_baseline(
+                target="rust",
+                base_url=args.rust_base_url,
+                sm_binary=args.sm_binary,
+                repetitions=args.baseline_repetitions,
+                output=baseline_dir / "rust-baseline.json",
+                server_pid=rust_pid,
+                check_ids=set(BASELINE_CHECK_IDS),
+            )
+            report["artifacts"]["rust_baseline"] = str(
+                baseline_dir / "rust-baseline.json"
+            )
+            rust_baseline_step = _baseline_step("rust_baseline", rust_baseline)
+            report["steps"].append(rust_baseline_step)
+            if rust_baseline_step["status"] != "passed":
+                _add_blocker(report, "rust_baseline", rust_baseline_step["detail"])
+        elif not args.skip_baseline:
             baseline_dir = output_dir / "baseline"
             baseline_dir.mkdir(parents=True, exist_ok=True)
             python_baseline = run_baseline(
@@ -488,7 +551,28 @@ def run_rehearsal(args: argparse.Namespace) -> dict[str, Any]:
                 if step["status"] != "passed":
                     _add_blocker(report, step["name"], step["detail"])
 
-        if not args.skip_shadow:
+        if args.rust_canary_cutover:
+            shadow_step = {
+                "name": "shadow_read_summary",
+                "status": "skipped",
+                "detail": (
+                    "accelerated Rust canary mode intentionally replaces "
+                    "sustained Python-authoritative shadow with Python spot "
+                    "checks plus Rust/state/Cloudflare gates"
+                ),
+            }
+            report["steps"].append(shadow_step)
+            cloudflare_step = _cloudflare_smoke_report_step(args.cloudflare_smoke_report)
+            report["steps"].append(cloudflare_step)
+            if cloudflare_step.get("artifact"):
+                report["artifacts"]["cloudflare_smoke_report"] = cloudflare_step["artifact"]
+            if cloudflare_step["status"] != "passed":
+                _add_blocker(
+                    report,
+                    "cloudflare_access_smoke",
+                    cloudflare_step.get("detail", "Cloudflare/mobile smoke failed"),
+                )
+        elif not args.skip_shadow:
             shadow_paths = _resolve_shadow_compare_paths(
                 python_base_url=args.python_base_url,
                 base_paths=SHADOW_COMPARE_PATHS,
@@ -529,6 +613,57 @@ def _finalize_report(
     report["artifacts"]["report"] = str(report_path)
     report_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
     return report
+
+
+def _cloudflare_smoke_report_step(report_path: Path | None) -> dict[str, Any]:
+    step: dict[str, Any] = {
+        "name": "cloudflare_access_smoke_report",
+    }
+    if report_path is None:
+        step.update(
+            {
+                "status": "failed",
+                "detail": (
+                    "accelerated Rust canary mode requires "
+                    "--cloudflare-smoke-report from cloudflare_access_smoke"
+                ),
+            }
+        )
+        return step
+    step["artifact"] = str(report_path)
+    try:
+        payload = json.loads(report_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        step.update({"status": "failed", "detail": f"failed to read report: {exc}"})
+        return step
+    except json.JSONDecodeError as exc:
+        step.update({"status": "failed", "detail": f"invalid JSON report: {exc}"})
+        return step
+    status = payload.get("status")
+    summary = payload.get("summary")
+    blockers = payload.get("blockers")
+    step["summary"] = summary if isinstance(summary, dict) else {}
+    if isinstance(blockers, list):
+        step["blockers"] = blockers
+    if status == "passed" and isinstance(blockers, list) and not blockers:
+        step.update(
+            {
+                "status": "passed",
+                "detail": "Cloudflare/mobile smoke report passed",
+            }
+        )
+    else:
+        blocker_count = len(blockers) if isinstance(blockers, list) else "unknown"
+        step.update(
+            {
+                "status": "failed",
+                "detail": (
+                    f"Cloudflare/mobile smoke report status is {status!r} "
+                    f"with {blocker_count} blocker(s)"
+                ),
+            }
+        )
+    return step
 
 
 def _resolve_output_dir(raw: Path | None) -> Path:
@@ -1548,6 +1683,25 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--config", type=Path, default=Path("config.yaml"))
     parser.add_argument("--local-env", type=Path, default=None)
     parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument(
+        "--rust-canary-cutover",
+        action="store_true",
+        help=(
+            "Use accelerated Rust canary evidence: short Python spot checks, "
+            "Rust/state/fixture gates, Rust baseline, and a required "
+            "Cloudflare/mobile smoke report instead of sustained Python "
+            "baseline/shadow"
+        ),
+    )
+    parser.add_argument(
+        "--cloudflare-smoke-report",
+        type=Path,
+        default=None,
+        help=(
+            "JSON output from scripts.rust_migration.cloudflare_access_smoke; "
+            "required when --rust-canary-cutover is used"
+        ),
+    )
     parser.add_argument("--reuse-rust-sidecar", action="store_true")
     parser.add_argument("--skip-python-health", action="store_true")
     parser.add_argument("--skip-state-gate", action="store_true")

--- a/specs/762_stage5_artifacts/gate_matrix.md
+++ b/specs/762_stage5_artifacts/gate_matrix.md
@@ -16,6 +16,7 @@ Status: converged after three sequential independent reviewer convergence signal
 | backup/restore | Pre-freeze safety backup and post-freeze final backup are created, verified, and restored in rehearsal. | Live cutover. |
 | rollback | Python service can be restored and smoke checks pass after Rust rehearsal writes copied state. | Live cutover. |
 | observability | Operator-visible health/status exists for auth, queue, mobile, nodes, Codex, summary, sensitive reads, migration, and slow requests. | Live cutover. |
+| accelerated Rust canary evidence | If Python-origin instability prevents sustained Python-authoritative shadow, `mvp_rehearsal --rust-canary-cutover` may replace the sustained Python baseline/shadow with short Python canary spot checks, Rust/state/fixture gates, Rust baseline, and a passed Cloudflare/mobile smoke report using real proof inputs. | Live cutover when the normal shadow gate is intentionally bypassed. |
 | user review | Every accepted breaking change, destructive migration, or operational risk is explicitly approved. | Implementing that change. |
 
 ## Baseline Workloads
@@ -87,6 +88,9 @@ Reviewers should verify:
 - Python/Rust coexistence has a single-writer model for must-preserve stores.
 - backups and rollback are concrete enough to execute against copied real state.
 - contract and baseline gates are measurable, not aspirational.
+- either the normal Python-authoritative shadow gate passes, or the accelerated
+  Rust canary gate explicitly records `python_canary_spot_checks`,
+  Rust/state/fixture gates, Rust baseline, and passed Cloudflare/mobile smoke.
 - launchd/service cutover avoids arbitrary process killing without ownership checks.
 - active sessions, queues, node agents, provider requests, and external notifiers are drained or explicitly risk-accepted before cutover.
 - observability covers failures an operator would need to diagnose rollback.

--- a/specs/762_stage5_artifacts/mvp_progress.md
+++ b/specs/762_stage5_artifacts/mvp_progress.md
@@ -1,17 +1,20 @@
 # Rust MVP Progress Snapshot
 
-Status: implementation snapshot after PR #1035 Android artifact auth fix.
+Status: implementation snapshot after PR #1037 contract harness read-budget fix,
+with issue #1038 adding an accelerated Rust canary evidence path.
 The last clean full real-state MVP rehearsal remains the post-#938 run; the
 post-#1035 rehearsal proves state gates, live core contracts, read-only
 fixtures, mutating fixtures, and Rust baseline on isolated sidecars, but blocks
-on Python-origin availability during Python baseline and shadow. PRs #986-#1035
+on Python-origin availability during Python baseline and shadow. PRs #986-#1037
 added node restore fixtures, stopped-origin final backup gates, rehearsal
 final-backup integration, Cloudflare Access smoke evidence tooling, Rust
 mobile-device enrollment, Cloudflare mTLS CA automation, the Android Camera-app
 enrollment handoff, and Rust native Google device-auth bearer issuance, plus
-Android mTLS and artifact read fixes. Public cutover still needs full
-Cloudflare policy/proof inputs, real mobile/browser smoke evidence, and a
-stable Python-authoritative shadow window.
+Android mTLS, artifact read fixes, and a larger live HTTP read budget. Public
+cutover still needs full Cloudflare policy/proof inputs and real mobile/browser
+smoke evidence. A stable Python-authoritative shadow window is preferred, but
+the explicit accelerated canary path may replace it when Python availability is
+the unstable component.
 
 This file is a handoff aid for the Rust cutover implementation track. It does
 not change retained or removed scope. Binding scope remains
@@ -112,6 +115,8 @@ not change retained or removed scope. Binding scope remains
 | #1031 | Android enrollment uses separate RSA mTLS credentials |
 | #1033 | Android Cloudflare mTLS uses a software RSA key with protected local storage |
 | #1035 | Android app artifacts can be read with cert-gated app auth while preserving edge/session fallbacks |
+| #1037 | Contract harness HTTP reads default to a larger budget for live `/client/sessions` payloads |
+| issue #1038 | Accelerated Rust canary evidence mode for Python-origin instability |
 
 ## Implemented Capability Groups
 
@@ -119,7 +124,7 @@ The Rust sidecar now has executable coverage for:
 
 | Group | Current state |
 | --- | --- |
-| Harness and baselines | Contract manifest, fixture assertions, minimal value baseline runner, shadow comparison, MVP rehearsal, synthetic read-only fixture sidecar, disposable mutating fixtures, Rust CLI build gating, state preflight/backup/restore, stopped-origin final backup, freeze/drain evidence gates, Cloudflare Access smoke evidence runner, and mobile-aware shadow observation gates exist. |
+| Harness and baselines | Contract manifest, fixture assertions, minimal value baseline runner, shadow comparison, MVP rehearsal, synthetic read-only fixture sidecar, disposable mutating fixtures, Rust CLI build gating, state preflight/backup/restore, stopped-origin final backup, freeze/drain evidence gates, Cloudflare Access smoke evidence runner, mobile-aware shadow observation gates, and accelerated Rust canary evidence mode exist. |
 | Retired-surface checks | Retired public/watch/summary/remind/job-watch/queue-policy checks are represented as Rust-target absence or denial fixtures. |
 | Core reads | Health, auth session, bootstrap, session list/detail, client session list/detail, output, events state, SSE hello, nodes list, queue jobs list/detail, Codex review requests list/detail, and tool/audit read projections are implemented. |
 | Core runtime | Session/tmux/spawn/session-graph/message-queue/task-complete/input-batch/subagent and retained review-route slices are merged, with shadow and contract fixtures covering the early cutover path. |
@@ -311,9 +316,51 @@ This is not a Rust contract regression: the Rust/state/fixture portions passed.
 The blocker is Python-authoritative origin availability during the baseline and
 shadow steps. Logs around the latest run show the Python watchdog reporting an
 event-loop freeze and killing the process for restart; after the kill, port
-`8420` stopped accepting connections. The next clean cutover-evidence run needs
-Python to remain up through baseline and shadow, including the mobile read
-probes from PR #942.
+`8420` stopped accepting connections. The normal cutover-evidence path still
+needs Python to remain up through baseline and shadow, including the mobile read
+probes from PR #942. If Python-origin availability remains the blocker, use the
+accelerated Rust canary path instead of broad Python hardening.
+
+## Accelerated Rust Canary Evidence Path
+
+Issue #1038 adds an explicit owner-approved canary mode for the case where Rust
+passes state/fixture/core gates but Python cannot stay healthy long enough to be
+the sustained shadow authority. The mode is intentionally narrower than the
+normal full rehearsal and should be identified as such in reports.
+
+Required command shape:
+
+```bash
+./venv/bin/python -m scripts.rust_migration.cloudflare_access_smoke \
+  --base-url http://127.0.0.1:8421 \
+  --mobile-host sm-app.rajeshgo.li \
+  --browser-host sm.rajeshgo.li \
+  --mobile-access-jwt-env CF_MOBILE_ACCESS_JWT \
+  --browser-access-jwt-env CF_BROWSER_ACCESS_JWT \
+  --public-edge-secret-env SM_PUBLIC_EDGE_SECRET \
+  --bearer-token-env SM_DEVICE_BEARER_TOKEN \
+  --output .local/rust-mvp-rehearsals/cloudflare-smoke.json \
+  --json \
+  --fail-on-blockers
+
+./venv/bin/python -m scripts.rust_migration.mvp_rehearsal \
+  --rust-canary-cutover \
+  --cloudflare-smoke-report .local/rust-mvp-rehearsals/cloudflare-smoke.json
+```
+
+Blocking evidence in this path:
+
+- `python_canary_spot_checks` for a short authority sanity set;
+- state preflight, backup, restore rehearsal, and freeze/drain ledger;
+- Rust live core contracts and synthetic read-only/mutating fixture contracts;
+- Rust baseline;
+- `cloudflare_access_smoke_report` from a passed smoke report using real
+  Access/public-edge/SM auth inputs.
+
+The mode intentionally skips sustained `python_baseline` and
+`shadow_read_summary`; those steps must be recorded as skipped, not silently
+omitted. A canary report with missing or blocked Cloudflare smoke is not
+cutover-candidate evidence.
 
 ## Near-Term Remaining Work
 
@@ -321,7 +368,7 @@ These are the next practical buckets before an MVP cutover trial:
 
 | Bucket | Why it remains |
 | --- | --- |
-| Shadow observation window | Python-authoritative shadow mode is enabled and a short clean window has been recorded, but mobile gates from PR #942 still need real app/operator traffic. Continue it for a longer agreed window and triage any unexplained retained-core mismatches before Rust becomes the writer. |
+| Shadow/canary observation window | Python-authoritative shadow mode is enabled and a short clean window has been recorded, but mobile gates from PR #942 still need real app/operator traffic. Prefer a longer agreed shadow window when Python stays healthy; otherwise use `--rust-canary-cutover` with Python spot checks plus Rust/state/Cloudflare gates and triage any blockers before Rust becomes the writer. |
 | Full fixture manifest execution | The MVP rehearsal now runs the current synthetic read-only and mutating fixture sets, including review-route fixtures. Remaining work is final live mobile/device fixture evidence and any additional retained fixture rows added by later slices. |
 | CLI cutover audit | Verify every retained CLI command in [cutover_scope.md](cutover_scope.md) is native Rust or intentionally routed, and every removed command is absent or explicitly retired. |
 | State ownership and migration tooling | Initial preflight, backup, restore, and freeze/drain evidence tools are merged and exercised by the rehearsal. Remaining work is live write-admission freeze/journal ownership and rollback accounting from [state_ownership_and_migration.md](state_ownership_and_migration.md). |
@@ -329,14 +376,17 @@ These are the next practical buckets before an MVP cutover trial:
 | Node and queue writer completion | Basic node HTTP routes and narrow queue writer/recovery are implemented. Remaining work is final live/recovery cutover evidence, audit/rollback accounting, and any retained node-agent remote-control gaps. |
 | Service packaging and rollback | Exercise launchd/service cutover, non-destructive port ownership, health checks, rollback, and operator diagnostics. |
 | Final native mobile smoke | Run bootstrap/session/attach/request-status/analytics/bug-report/app-artifact smoke checks against Rust using real mobile assumptions. |
-| Python-origin availability during evidence runs | Post-#942 full rehearsal is blocked because Python watchdog-restarted during baseline/shadow. This does not call for broad Python hardening, but the cutover evidence path needs a stable Python authority for the observation window. |
+| Python-origin availability during evidence runs | Post-#1035 full rehearsal is blocked because Python watchdog-restarted during baseline/shadow. This does not call for broad Python hardening. Either collect the normal stable Python-authoritative window, or use the accelerated Rust canary evidence path with spot checks and Cloudflare/mobile smoke. |
 
 ## Stop Conditions For MVP Cutover
 
 Do not start an MVP cutover until:
 
 - retained manifest checks pass for Python and Rust on the selected fixture set;
-- shadow mode shows no unexplained mismatches on retained core reads for the agreed observation window;
+- either shadow mode shows no unexplained mismatches on retained core reads for
+  the agreed observation window, or an accelerated Rust canary report records
+  passing `python_canary_spot_checks`, Rust/state/fixture gates, Rust baseline,
+  and Cloudflare/mobile smoke;
 - final backup happens after write admission is frozen or journaled;
 - public traffic has proof-of-possession before origin plus origin auth/capability checks;
 - Cloudflare Access browser/mobile/node/email route classes are configured with no bypass/broad-certificate policy and verified against Rust origin gates;

--- a/specs/762_stage5_artifacts/resume_handoff.md
+++ b/specs/762_stage5_artifacts/resume_handoff.md
@@ -1,7 +1,8 @@
 # Rust Port Resume Handoff
 
-Status: handoff snapshot from 2026-06-16 after PR #1035 Android artifact auth
-fix and the post-#1035 evidence refresh.
+Status: handoff snapshot from 2026-06-16 after PR #1037 contract harness
+read-budget fix, with issue #1038 adding an accelerated Rust canary evidence
+path for Python-origin instability.
 
 Use this file to resume the Rust cutover track without reconstructing state from
 chat history. Binding scope still lives in [cutover_scope.md](cutover_scope.md),
@@ -11,9 +12,9 @@ coverage in
 
 ## Current Repository State
 
-- Branch: `main` after PR #1035.
-- Latest merged commit before this docs refresh: `1f85ce9` (`Merge pull
-  request #1035`)
+- Branch: `main` after PR #1037.
+- Latest merged commit before this docs refresh: `68adc3b` (`Merge pull
+  request #1037`)
 - Open PRs at handoff: none before this docs refresh PR.
 - Dirty worktree at handoff: only pre-existing untracked
   `.claude/settings.local.json`, `certs/`, `data/`, and the local
@@ -175,6 +176,10 @@ Merged Rust slices cover:
   local storage.
 - PR #1035 allowed Android app artifacts to be read with cert-gated app auth
   while preserving Cloudflare edge and session-auth fallbacks.
+- PR #1037 raised the contract harness default HTTP read budget so large live
+  `/client/sessions` JSON responses are not truncated before assertion checks.
+- Issue #1038 adds the accelerated Rust canary evidence mode for the case where
+  Python-origin availability prevents sustained baseline/shadow evidence.
 - Current contract manifest size:
   - `134` checks total
   - `73` `python_and_rust`
@@ -251,12 +256,13 @@ post-#984 manifest:
   skipped;
 - Rust mutating fixture contracts: `35` passed, `0` failed, `0` skipped.
 
-PRs #986-#1035 added more cutover tooling and evidence gates after this focused
+PRs #986-#1037 added more cutover tooling and evidence gates after this focused
 run, including node restore fixtures, stopped-origin final backup, rehearsal
 final-backup integration, the Cloudflare Access mobile smoke runner, Rust
 mobile-device enrollment, Cloudflare mTLS CA automation, Android Camera-app
 enrollment, Android mTLS fixes, native device auth, and app artifact auth
-fixes. The latest post-#1035 rehearsal below is the current evidence snapshot.
+fixes, plus the larger live HTTP read budget. The latest post-#1035 rehearsal
+below is the current evidence snapshot.
 
 The latest post-#1035 full rehearsal attempts are blocked, not cutover evidence:
 
@@ -291,7 +297,48 @@ around the run show the Python watchdog reporting an event-loop freeze and
 killing the process for restart; after that, port `8420` stopped accepting
 connections. Do not treat the post-#1035 rehearsal as a clean MVP cutover
 artifact until Python-origin availability is stable for the baseline/shadow
-steps.
+steps, or until the accelerated Rust canary evidence path records passing spot
+checks plus Rust/state/Cloudflare gates.
+
+## Accelerated Rust Canary Evidence Path
+
+Issue #1038 adds an explicit path for rotating faster when Python-origin
+availability is the blocker. This is not a silent shadow skip. The report must
+show:
+
+- `python_canary_spot_checks` passed;
+- state preflight/backup/restore/freeze-drain gate passed;
+- Rust live core, synthetic read-only fixture, and mutating fixture contracts
+  passed;
+- Rust baseline passed;
+- `cloudflare_access_smoke_report` passed from a smoke report that used real
+  Cloudflare Access, public-edge, and SM auth proof inputs;
+- `python_baseline` and `shadow_read_summary` recorded as skipped because
+  `--rust-canary-cutover` was intentionally selected.
+
+Command shape:
+
+```bash
+./venv/bin/python -m scripts.rust_migration.cloudflare_access_smoke \
+  --base-url http://127.0.0.1:8421 \
+  --mobile-host sm-app.rajeshgo.li \
+  --browser-host sm.rajeshgo.li \
+  --mobile-access-jwt-env CF_MOBILE_ACCESS_JWT \
+  --browser-access-jwt-env CF_BROWSER_ACCESS_JWT \
+  --public-edge-secret-env SM_PUBLIC_EDGE_SECRET \
+  --bearer-token-env SM_DEVICE_BEARER_TOKEN \
+  --output .local/rust-mvp-rehearsals/cloudflare-smoke.json \
+  --json \
+  --fail-on-blockers
+
+./venv/bin/python -m scripts.rust_migration.mvp_rehearsal \
+  --rust-canary-cutover \
+  --cloudflare-smoke-report .local/rust-mvp-rehearsals/cloudflare-smoke.json
+```
+
+A missing, blocked, or synthetic Cloudflare smoke report keeps the canary run
+blocked. Use this path only after the operator accepts that sustained Python
+shadow is being replaced because Python is the unstable component.
 
 ## Live Observation
 
@@ -390,8 +437,12 @@ needed for final cutover evidence.
 
 ### Near-Term Work
 
-1. Continue Python-authoritative shadow mode for a longer real observation
-   window and triage unexplained mismatches.
+1. Collect either the normal Python-authoritative shadow window or the
+   accelerated Rust canary evidence report.
+   - Normal path: keep shadow mode running for retained reads and triage
+     unexplained mismatches.
+   - Canary path: run `--rust-canary-cutover` with a passed
+     `--cloudflare-smoke-report` and treat any blocker as cutover-blocking.
 2. Continue expanding fixture/live evidence as new retained rows land.
    - The MVP rehearsal already runs the current synthetic read-only and
      mutating fixture sets, including review-route fixtures.
@@ -434,8 +485,10 @@ needed for final cutover evidence.
 Do not start Rust writer ownership or MVP cutover until:
 
 - retained manifest checks pass for Python and Rust on the selected fixture set;
-- shadow mode shows no unexplained retained-core mismatches for the agreed
-  observation window;
+- either shadow mode shows no unexplained retained-core mismatches for the
+  agreed observation window, or the accelerated Rust canary report records
+  passing `python_canary_spot_checks`, Rust/state/fixture gates, Rust baseline,
+  and Cloudflare/mobile smoke;
 - final backup happens after write admission is frozen or journaled;
 - public traffic has proof-of-possession before origin plus origin
   auth/capability checks;
@@ -448,8 +501,8 @@ Do not start Rust writer ownership or MVP cutover until:
 
 ## Recommended Resume Point
 
-Continue with Cloudflare Access deployment evidence, then return to the shadow
-observation gate:
+Continue with Cloudflare Access deployment evidence, then produce either normal
+shadow evidence or the accelerated Rust canary report:
 
 1. Provide the smoke runner proof inputs for the already configured Cloudflare
    Access apps: mobile/browser Access JWTs, public-edge HMAC secret, and SM
@@ -458,13 +511,16 @@ observation gate:
    [cloudflare_access_cutover_evidence.md](cloudflare_access_cutover_evidence.md).
 3. Exercise the native app route class through the app hostname so mobile gates
    collect real traffic and smoke evidence.
-4. Keep Python-authoritative Rust shadow mode running for retained reads against
-   the local Rust sidecar.
-5. Let it observe real traffic for the agreed window.
-6. Summarize the shadow ledger by route, comparison class, and unexplained
-   mismatch.
-7. Convert any unexplained retained-surface mismatch into a bounded Rust slice.
+4. If Python remains stable, keep Python-authoritative Rust shadow running for
+   retained reads, let it observe real traffic for the agreed window, and
+   summarize the ledger by route/comparison/mismatch.
+5. If Python remains the unstable component, run `mvp_rehearsal
+   --rust-canary-cutover --cloudflare-smoke-report <passed-smoke-json>` and use
+   that report as the cutover-candidate evidence artifact.
+6. Convert any unexplained retained-surface mismatch or canary blocker into a
+   bounded Rust slice.
 
-This is the highest-signal next step because the Rust origin gate is now merged,
-but the public edge still needs actual Cloudflare policy and mobile/browser
-smoke evidence before it can count as cutover-ready.
+This is the highest-signal next step because the Rust origin gate is merged and
+the broad Python service is now the limiting factor. Do not do broad Python
+hardening; prove the Rust canary path or fix bounded Rust/Cloudflare/mobile
+blockers.

--- a/specs/762_stage5_artifacts/rollout_plan.md
+++ b/specs/762_stage5_artifacts/rollout_plan.md
@@ -37,6 +37,14 @@ The Rust migration should pause or narrow if:
 
 The comparison is against current Python as operated for retained workflows. Do not file Python hardening work as part of the Rust value gate unless the owner later reopens that decision.
 
+If the current Python origin cannot remain healthy through sustained
+Python-authoritative baseline/shadow, the owner-approved path is not broad
+Python hardening. Use the accelerated Rust canary evidence mode instead:
+`mvp_rehearsal --rust-canary-cutover` runs short Python canary spot checks, keeps
+the Rust/state/fixture gates and Rust baseline blocking, and requires a passed
+Cloudflare/mobile smoke report with real Access/public-edge/SM auth proof inputs
+before the run can count as cutover-candidate evidence.
+
 ## Cutover Sequence
 
 1. Build the contract harness from Stage 2/3/4 artifacts and run it against Python.

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -38,9 +38,11 @@ from scripts.rust_migration.mutating_fixture import (
 from scripts.rust_migration.mvp_rehearsal import (
     CORE_MUTATING_CHECK_IDS,
     DEFAULT_RUST_SM_BINARY,
+    PYTHON_CANARY_SPOT_CHECK_IDS,
     READ_ONLY_FIXTURE_CHECK_IDS,
     READ_ONLY_FIXTURE_VALUES,
     _build_parser,
+    _cloudflare_smoke_report_step,
     _default_read_only_fixture_rust_base_url,
     _default_mutating_rust_base_url,
     _ensure_rust_cli_available,
@@ -265,9 +267,19 @@ def test_cloudflare_access_cutover_evidence_pins_policy_and_origin_gates():
         assert required in evidence
 
 
-def test_handoff_and_progress_are_current_through_android_artifact_auth_pr1035():
+def test_handoff_and_progress_are_current_through_canary_evidence_issue1038():
     progress = (STAGE5_DIR / "mvp_progress.md").read_text(encoding="utf-8")
     handoff = (STAGE5_DIR / "resume_handoff.md").read_text(encoding="utf-8")
+    gate_matrix = (STAGE5_DIR / "gate_matrix.md").read_text(encoding="utf-8")
+    rollout_plan = (STAGE5_DIR / "rollout_plan.md").read_text(encoding="utf-8")
+    readme = (REPO_ROOT / "scripts/rust_migration/README.md").read_text(
+        encoding="utf-8"
+    )
+
+    for text in [progress, handoff, gate_matrix, rollout_plan, readme]:
+        assert "accelerated rust canary" in text.lower()
+        assert "--rust-canary-cutover" in text
+        assert "cloudflare" in text.lower()
 
     for text in [progress, handoff]:
         assert "#950" in text
@@ -278,14 +290,19 @@ def test_handoff_and_progress_are_current_through_android_artifact_auth_pr1035()
         assert "#1012" in text
         assert "#1025" in text
         assert "#1035" in text
+        assert "#1037" in text
+        assert "issue #1038" in text
         assert "Cloudflare Access" in text
         assert "cloudflare_access_cutover_evidence.md" in text
+        assert "python_canary_spot_checks" in text
+        assert "cloudflare_access_smoke_report" in text
 
-    assert "Latest merged commit before this docs refresh: `1f85ce9`" in handoff
-    assert "records the PR lineage through #1035" in handoff
+    assert "Latest merged commit before this docs refresh: `68adc3b`" in handoff
+    assert "PR #1037" in handoff
     assert "Camera-app" in handoff
     assert "deep-link enrollment" in handoff
     assert "app update artifact access works through the certificate-gated app path" in handoff
+    assert "--cloudflare-smoke-report" in readme
 
 
 def test_manifest_covers_rust_only_retired_http_surfaces():
@@ -662,6 +679,117 @@ def test_mvp_rehearsal_records_read_only_fixture_skip_step(tmp_path, monkeypatch
     )
     assert step["status"] == "skipped"
     assert report["summary"]["status"] == "passed"
+
+
+def test_mvp_rehearsal_canary_mode_uses_spot_checks_and_smoke_report(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("SM_CLIENT_CONFIG", str(tmp_path / "missing-client.yaml"))
+    smoke_report = tmp_path / "cloudflare-smoke.json"
+    smoke_report.write_text(
+        json.dumps(
+            {
+                "status": "passed",
+                "summary": {"passed": 3, "blocked": 0, "skipped": 0},
+                "blockers": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+    args = _build_parser().parse_args(
+        [
+            "--rust-canary-cutover",
+            "--cloudflare-smoke-report",
+            str(smoke_report),
+            "--skip-state-gate",
+            "--skip-smoke",
+            "--skip-read-only-fixture-contracts",
+            "--skip-mutating-contracts",
+            "--core-only",
+            "--reuse-rust-sidecar",
+            "--output-dir",
+            str(tmp_path / "rehearsal"),
+        ]
+    )
+
+    def fake_run_contract_group(
+        _manifest,
+        *,
+        name,
+        target,
+        base_url,
+        sm_binary,
+        check_ids,
+        timeout_seconds,
+        **_kwargs,
+    ):
+        if name == "python_canary_spot_checks":
+            assert target == "python"
+            assert base_url == args.python_base_url
+            assert check_ids == set(PYTHON_CANARY_SPOT_CHECK_IDS)
+        if name == "rust_core_sidecar_contracts":
+            assert target == "rust"
+            assert base_url == args.rust_base_url
+        return {
+            "name": name,
+            "status": "passed",
+            "elapsed_ms": 1.0,
+            "summary": {"passed": len(check_ids), "failed": 0, "skipped": 0},
+            "results": [],
+        }
+
+    def fake_baseline(**kwargs):
+        assert kwargs["target"] == "rust"
+        return {
+            "elapsed_seconds": 0.01,
+            "memory": {"status": "measured"},
+            "latency": {"failed": {}, "skipped": {}, "summaries": {}},
+        }
+
+    with patch("scripts.rust_migration.mvp_rehearsal._probe_health") as probe:
+        probe.return_value = {
+            "status": "passed",
+            "elapsed_ms": 1.0,
+            "detail": "mock healthy",
+        }
+        with patch(
+            "scripts.rust_migration.mvp_rehearsal._run_contract_group",
+            side_effect=fake_run_contract_group,
+        ):
+            with patch(
+                "scripts.rust_migration.mvp_rehearsal.run_baseline",
+                side_effect=fake_baseline,
+            ):
+                report = run_rehearsal(args)
+
+    steps = {step["name"]: step for step in report["steps"]}
+    assert steps["python_canary_spot_checks"]["status"] == "passed"
+    assert steps["python_baseline"]["status"] == "skipped"
+    assert steps["rust_baseline"]["status"] == "passed"
+    assert steps["shadow_read_summary"]["status"] == "skipped"
+    assert steps["cloudflare_access_smoke_report"]["status"] == "passed"
+    assert report["artifacts"]["cloudflare_smoke_report"] == str(smoke_report)
+    assert report["summary"]["status"] == "passed"
+
+
+def test_mvp_rehearsal_canary_mode_requires_cloudflare_smoke_report():
+    step = _cloudflare_smoke_report_step(None)
+
+    assert step["status"] == "failed"
+    assert "--cloudflare-smoke-report" in step["detail"]
+
+
+def test_mvp_rehearsal_canary_mode_rejects_incomplete_smoke_report(tmp_path):
+    smoke_report = tmp_path / "cloudflare-smoke.json"
+    smoke_report.write_text(
+        json.dumps({"status": "passed", "summary": {"passed": 1}}),
+        encoding="utf-8",
+    )
+
+    step = _cloudflare_smoke_report_step(smoke_report)
+
+    assert step["status"] == "failed"
+    assert "unknown blocker" in step["detail"]
 
 
 def test_mvp_rehearsal_resolves_mobile_shadow_paths(monkeypatch):


### PR DESCRIPTION
Fixes #1038

## Summary
- add `mvp_rehearsal --rust-canary-cutover` to record explicit faster Rust canary evidence when Python-origin availability blocks sustained baseline/shadow
- require short Python spot checks, Rust/state/fixture gates, Rust baseline, and a passed Cloudflare/mobile smoke report in that mode
- update Stage 5 handoff/gate docs and README so this is an intentional evidence path, not a silent shadow skip

## Validation
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py -q`
- `./venv/bin/python -m py_compile scripts/rust_migration/mvp_rehearsal.py`
- `git diff --check`