### PR TITLE
Add Rust service cutover runbook

### DIFF
--- a/scripts/rust-service-cutover.sh
+++ b/scripts/rust-service-cutover.sh
@@ -1,0 +1,407 @@
+#!/usr/bin/env bash
+# Rust Session Manager launchd cutover helper.
+#
+# This script intentionally avoids arbitrary process killing. It only unloads
+# known Session Manager launchd labels and refuses to start Rust when the target
+# port is already owned by any process.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+COMMAND="${1:-}"
+if [[ -z "$COMMAND" ]]; then
+  COMMAND="help"
+else
+  shift
+fi
+
+HOST="127.0.0.1"
+PORT="8420"
+CONFIG="$REPO_ROOT/config.yaml"
+LOCAL_ENV=""
+BINARY="$REPO_ROOT/target/release/sm-server"
+RUST_LABEL="com.rajeshgoli.session-manager-rust"
+PYTHON_LABELS=("com.rajeshgoli.session-manager" "com.claude.session-manager")
+PLIST_DST="$HOME/Library/LaunchAgents/$RUST_LABEL.plist"
+LOG_DIR="$REPO_ROOT/logs"
+DOMAIN="gui/$(id -u)"
+
+_resolve_path() {
+  case "$1" in
+    /*) printf '%s\n' "$1" ;;
+    *) printf '%s\n' "$REPO_ROOT/$1" ;;
+  esac
+}
+
+xml_text() {
+  local value="$1"
+  value="${value//&/&amp;}"
+  value="${value//</&lt;}"
+  value="${value//>/&gt;}"
+  printf '%s' "$value"
+}
+
+usage() {
+  cat <<EOF
+Usage: scripts/rust-service-cutover.sh <command> [options]
+
+Commands:
+  plan             Show Rust service command, launchd paths, port owners, and blockers.
+  render-plist     Print the Rust launchd plist to stdout.
+  write-plist      Write the Rust launchd plist, but do not load it.
+  stop-python      Unload known Python Session Manager launchd labels, then verify the port is free.
+  start-rust       Write/load the Rust launchd plist. Refuses if the port is occupied.
+  stop-rust        Unload the Rust launchd label.
+  restart-rust     stop-rust then start-rust.
+  rollback-python  Stop Rust and bootstrap the existing Python launchd plist if present.
+  status           Show launchd, port, and Rust health status.
+
+Options:
+  --host HOST          Listen host for Rust (default: $HOST)
+  --port PORT          Listen port for Rust (default: $PORT)
+  --config PATH        Rust config path (default: config.yaml)
+  --local-env PATH     Optional local env overlay path
+  --binary PATH        Rust sm-server binary (default: target/release/sm-server)
+  --label LABEL        Rust launchd label (default: $RUST_LABEL)
+  --plist PATH         Rust plist destination (default: ~/Library/LaunchAgents/<label>.plist)
+  --log-dir PATH       Rust launchd stdout/stderr directory (default: logs/)
+
+First canary shape:
+  cargo build -p sm-server --release
+  ./scripts/rust-service-cutover.sh plan
+  ./scripts/rust-service-cutover.sh stop-python
+  ./venv/bin/python -m scripts.rust_migration.final_backup --config config.yaml --output-dir .local/rust-final-backup-\$(date -u +%Y%m%dT%H%M%SZ) --ledger .local/rust-cutover-ledger.jsonl --record-ledger --execute --fail-on-blockers
+  ./scripts/rust-service-cutover.sh start-rust
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host)
+      HOST="${2:?missing --host value}"
+      shift 2
+      ;;
+    --port)
+      PORT="${2:?missing --port value}"
+      shift 2
+      ;;
+    --config)
+      CONFIG="$(_resolve_path "${2:?missing --config value}")"
+      shift 2
+      ;;
+    --local-env)
+      LOCAL_ENV="$(_resolve_path "${2:?missing --local-env value}")"
+      shift 2
+      ;;
+    --binary)
+      BINARY="$(_resolve_path "${2:?missing --binary value}")"
+      shift 2
+      ;;
+    --label)
+      RUST_LABEL="${2:?missing --label value}"
+      PLIST_DST="$HOME/Library/LaunchAgents/$RUST_LABEL.plist"
+      shift 2
+      ;;
+    --plist)
+      PLIST_DST="$(_resolve_path "${2:?missing --plist value}")"
+      shift 2
+      ;;
+    --log-dir)
+      LOG_DIR="$(_resolve_path "${2:?missing --log-dir value}")"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+rust_command_args() {
+  printf '%s\n' "$BINARY"
+  printf '%s\n' "--host"
+  printf '%s\n' "$HOST"
+  printf '%s\n' "--port"
+  printf '%s\n' "$PORT"
+  printf '%s\n' "--config"
+  printf '%s\n' "$CONFIG"
+  if [[ -n "$LOCAL_ENV" ]]; then
+    printf '%s\n' "--local-env"
+    printf '%s\n' "$LOCAL_ENV"
+  fi
+}
+
+rust_command_text() {
+  local parts=()
+  while IFS= read -r part; do
+    parts+=("$part")
+  done < <(rust_command_args)
+  printf '%q ' "${parts[@]}"
+  printf '\n'
+}
+
+port_owner_pids() {
+  lsof -nP -iTCP:"$PORT" -sTCP:LISTEN -t 2>/dev/null | sort -u || true
+}
+
+launchctl_print_label() {
+  local label="$1"
+  launchctl print "$DOMAIN/$label" >/dev/null 2>&1
+}
+
+print_port_owners() {
+  local pids
+  pids="$(port_owner_pids)"
+  if [[ -z "$pids" ]]; then
+    echo "port_$PORT: free"
+    return
+  fi
+  echo "port_$PORT: occupied"
+  while IFS= read -r pid; do
+    [[ -z "$pid" ]] && continue
+    ps -p "$pid" -o pid=,ppid=,command= || true
+  done <<< "$pids"
+}
+
+collect_blockers() {
+  local blockers=()
+  if [[ ! -x "$BINARY" ]]; then
+    blockers+=("rust_binary_not_executable: $BINARY")
+  fi
+  if [[ ! -r "$CONFIG" ]]; then
+    blockers+=("config_not_readable: $CONFIG")
+  fi
+  if [[ -n "$LOCAL_ENV" && ! -r "$LOCAL_ENV" ]]; then
+    blockers+=("local_env_not_readable: $LOCAL_ENV")
+  fi
+  local pids
+  pids="$(port_owner_pids)"
+  if [[ -n "$pids" ]]; then
+    blockers+=("port_in_use: $PORT is already listening")
+  fi
+  if [[ "${#blockers[@]}" -eq 0 ]]; then
+    return 0
+  fi
+  printf '%s\n' "${blockers[@]}"
+}
+
+print_plan() {
+  echo "Rust Session Manager service cutover plan"
+  echo "repo_root: $REPO_ROOT"
+  echo "launch_domain: $DOMAIN"
+  echo "rust_label: $RUST_LABEL"
+  echo "rust_plist: $PLIST_DST"
+  echo "rust_binary: $BINARY"
+  echo "config: $CONFIG"
+  echo "local_env: ${LOCAL_ENV:-<none>}"
+  echo "listen: $HOST:$PORT"
+  echo "stdout_log: $LOG_DIR/rust-launchd.out.log"
+  echo "stderr_log: $LOG_DIR/rust-launchd.err.log"
+  echo "rust_command: $(rust_command_text)"
+  echo
+  echo "Known Python labels:"
+  for label in "${PYTHON_LABELS[@]}"; do
+    if launchctl_print_label "$label"; then
+      echo "  loaded: $label"
+    else
+      echo "  not loaded: $label"
+    fi
+  done
+  echo
+  print_port_owners
+  echo
+  local blockers
+  blockers="$(collect_blockers)"
+  if [[ -z "$blockers" ]]; then
+    echo "blockers: 0"
+  else
+    echo "blockers:"
+    while IFS= read -r blocker; do
+      [[ -z "$blocker" ]] && continue
+      echo "  - $blocker"
+    done <<< "$blockers"
+  fi
+}
+
+render_plist() {
+  cat <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>$(xml_text "$RUST_LABEL")</string>
+
+    <key>ProgramArguments</key>
+    <array>
+$(while IFS= read -r arg; do printf '        <string>%s</string>\n' "$(xml_text "$arg")"; done < <(rust_command_args))
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>WorkingDirectory</key>
+    <string>$(xml_text "$REPO_ROOT")</string>
+
+    <key>StandardOutPath</key>
+    <string>$(xml_text "$LOG_DIR/rust-launchd.out.log")</string>
+
+    <key>StandardErrorPath</key>
+    <string>$(xml_text "$LOG_DIR/rust-launchd.err.log")</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>$(xml_text "$REPO_ROOT/target/release:$REPO_ROOT/target/debug:$REPO_ROOT/venv/bin:/Users/rajesh/.cargo/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin")</string>
+    </dict>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+</dict>
+</plist>
+EOF
+}
+
+write_plist() {
+  mkdir -p "$(dirname "$PLIST_DST")" "$LOG_DIR"
+  render_plist > "$PLIST_DST"
+  chmod 644 "$PLIST_DST"
+  echo "wrote $PLIST_DST"
+}
+
+require_no_blockers() {
+  local blockers
+  blockers="$(collect_blockers)"
+  if [[ -n "$blockers" ]]; then
+    print_plan >&2
+    exit 1
+  fi
+}
+
+stop_rust() {
+  if launchctl_print_label "$RUST_LABEL"; then
+    launchctl bootout "$DOMAIN/$RUST_LABEL" || true
+    echo "stopped $RUST_LABEL"
+  else
+    echo "$RUST_LABEL is not loaded"
+  fi
+}
+
+start_rust() {
+  require_no_blockers
+  write_plist
+  if launchctl_print_label "$RUST_LABEL"; then
+    launchctl bootout "$DOMAIN/$RUST_LABEL" || true
+  fi
+  launchctl bootstrap "$DOMAIN" "$PLIST_DST"
+  launchctl kickstart -k "$DOMAIN/$RUST_LABEL"
+  echo "started $RUST_LABEL"
+}
+
+stop_python() {
+  for label in "${PYTHON_LABELS[@]}"; do
+    if launchctl_print_label "$label"; then
+      launchctl bootout "$DOMAIN/$label" || true
+      echo "stopped $label"
+    fi
+  done
+  sleep 1
+  local pids
+  pids="$(port_owner_pids)"
+  if [[ -n "$pids" ]]; then
+    echo "port $PORT is still occupied after unloading known Python labels" >&2
+    print_port_owners >&2
+    exit 1
+  fi
+  echo "port $PORT is free"
+}
+
+rollback_python() {
+  stop_rust
+  local python_plist=""
+  for candidate in \
+    "$HOME/Library/LaunchAgents/com.rajeshgoli.session-manager.plist" \
+    "$HOME/Library/LaunchAgents/com.claude.session-manager.plist"; do
+    if [[ -f "$candidate" ]]; then
+      python_plist="$candidate"
+      break
+    fi
+  done
+  if [[ -z "$python_plist" ]]; then
+    echo "no Python Session Manager plist found in ~/Library/LaunchAgents" >&2
+    exit 1
+  fi
+  launchctl bootstrap "$DOMAIN" "$python_plist" 2>/dev/null || true
+  local label
+  label="$(/usr/libexec/PlistBuddy -c 'Print :Label' "$python_plist")"
+  launchctl kickstart -k "$DOMAIN/$label" || true
+  echo "bootstrapped Python service from $python_plist"
+}
+
+status() {
+  echo "Rust label: $RUST_LABEL"
+  if launchctl_print_label "$RUST_LABEL"; then
+    launchctl print "$DOMAIN/$RUST_LABEL" | sed -n '1,60p'
+  else
+    echo "not loaded"
+  fi
+  echo
+  print_port_owners
+  echo
+  echo "Rust health:"
+  if curl -sf --connect-timeout 2 --max-time 2 "http://$HOST:$PORT/health"; then
+    echo
+    echo "health: ok"
+  else
+    echo "health: failed"
+  fi
+}
+
+case "$COMMAND" in
+  help|-h|--help)
+    usage
+    ;;
+  plan)
+    print_plan
+    ;;
+  render-plist)
+    render_plist
+    ;;
+  write-plist)
+    write_plist
+    ;;
+  stop-python)
+    stop_python
+    ;;
+  start-rust)
+    start_rust
+    ;;
+  stop-rust)
+    stop_rust
+    ;;
+  restart-rust)
+    stop_rust
+    start_rust
+    ;;
+  rollback-python)
+    rollback_python
+    ;;
+  status)
+    status
+    ;;
+  *)
+    echo "Unknown command: $COMMAND" >&2
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/specs/762_stage5_artifacts/index.md
+++ b/specs/762_stage5_artifacts/index.md
@@ -14,6 +14,7 @@ This bundle supports Stage 5 of [762_rust_migration_and_ruggedization.md](../762
 | [mvp_progress.md](mvp_progress.md) | Dated implementation snapshot for the Rust MVP track after merged PR #1012 and the latest clean real-state rehearsal. |
 | [resume_handoff.md](resume_handoff.md) | Current resume point, validation state, known fixtures, and next slices for the Rust port. |
 | [cloudflare_access_cutover_evidence.md](cloudflare_access_cutover_evidence.md) | Current Cloudflare Access origin-gate evidence, required policies, and remaining public/mobile setup checks. |
+| [rust_service_cutover_runbook.md](rust_service_cutover_runbook.md) | Reviewed launchd/service cutover command sequence for rotating production ownership from Python to Rust. |
 
 The owner has approved the cutover scope reductions in [cutover_scope.md](cutover_scope.md). Future breaking changes outside that artifact still require explicit owner approval.
 

--- a/specs/762_stage5_artifacts/mvp_progress.md
+++ b/specs/762_stage5_artifacts/mvp_progress.md
@@ -1,11 +1,11 @@
 # Rust MVP Progress Snapshot
 
-Status: implementation snapshot after PR #1037 contract harness read-budget fix,
-with issue #1038 adding an accelerated Rust canary evidence path.
+Status: implementation snapshot after PR #1039 accelerated Rust canary evidence
+mode, with issue #1040 adding Rust service cutover tooling/runbook.
 The last clean full real-state MVP rehearsal remains the post-#938 run; the
 post-#1035 rehearsal proves state gates, live core contracts, read-only
 fixtures, mutating fixtures, and Rust baseline on isolated sidecars, but blocks
-on Python-origin availability during Python baseline and shadow. PRs #986-#1037
+on Python-origin availability during Python baseline and shadow. PRs #986-#1039
 added node restore fixtures, stopped-origin final backup gates, rehearsal
 final-backup integration, Cloudflare Access smoke evidence tooling, Rust
 mobile-device enrollment, Cloudflare mTLS CA automation, the Android Camera-app
@@ -116,7 +116,8 @@ not change retained or removed scope. Binding scope remains
 | #1033 | Android Cloudflare mTLS uses a software RSA key with protected local storage |
 | #1035 | Android app artifacts can be read with cert-gated app auth while preserving edge/session fallbacks |
 | #1037 | Contract harness HTTP reads default to a larger budget for live `/client/sessions` payloads |
-| issue #1038 | Accelerated Rust canary evidence mode for Python-origin instability |
+| #1039 | Accelerated Rust canary evidence mode for Python-origin instability |
+| issue #1040 | Rust service launchd cutover tooling and first-canary runbook |
 
 ## Implemented Capability Groups
 

--- a/specs/762_stage5_artifacts/resume_handoff.md
+++ b/specs/762_stage5_artifacts/resume_handoff.md
@@ -1,20 +1,22 @@
 # Rust Port Resume Handoff
 
-Status: handoff snapshot from 2026-06-16 after PR #1037 contract harness
-read-budget fix, with issue #1038 adding an accelerated Rust canary evidence
-path for Python-origin instability.
+Status: handoff snapshot from 2026-06-16 after PR #1039 accelerated Rust
+canary evidence mode. Issue #1040 adds the reviewed Rust service launchd
+cutover runbook/tooling for the first canary flip.
 
 Use this file to resume the Rust cutover track without reconstructing state from
 chat history. Binding scope still lives in [cutover_scope.md](cutover_scope.md),
 release gates in [gate_matrix.md](gate_matrix.md), and executable contract
 coverage in
 [`scripts/rust_migration/contracts_manifest.json`](../../scripts/rust_migration/contracts_manifest.json).
+Service cutover commands live in
+[rust_service_cutover_runbook.md](rust_service_cutover_runbook.md).
 
 ## Current Repository State
 
-- Branch: `main` after PR #1037.
-- Latest merged commit before this docs refresh: `68adc3b` (`Merge pull
-  request #1037`)
+- Branch: `main` after PR #1039.
+- Latest merged commit before this docs refresh: `c638d10` (`Merge pull
+  request #1039`)
 - Open PRs at handoff: none before this docs refresh PR.
 - Dirty worktree at handoff: only pre-existing untracked
   `.claude/settings.local.json`, `certs/`, `data/`, and the local
@@ -65,7 +67,7 @@ Merged Rust slices cover:
 
 ### Documentation And Manifest
 
-- [mvp_progress.md](mvp_progress.md) records the PR lineage through #1035.
+- [mvp_progress.md](mvp_progress.md) records the PR lineage through #1039.
 - [cloudflare_access_cutover_evidence.md](cloudflare_access_cutover_evidence.md)
   records the current Cloudflare Access origin-gate behavior and remaining
   operator setup/smoke evidence.
@@ -178,8 +180,10 @@ Merged Rust slices cover:
   while preserving Cloudflare edge and session-auth fallbacks.
 - PR #1037 raised the contract harness default HTTP read budget so large live
   `/client/sessions` JSON responses are not truncated before assertion checks.
-- Issue #1038 adds the accelerated Rust canary evidence mode for the case where
+- PR #1039 adds the accelerated Rust canary evidence mode for the case where
   Python-origin availability prevents sustained baseline/shadow evidence.
+- Issue #1040 adds the Rust service cutover helper and runbook for reviewed
+  launchd ownership transfer.
 - Current contract manifest size:
   - `134` checks total
   - `73` `python_and_rust`
@@ -256,7 +260,7 @@ post-#984 manifest:
   skipped;
 - Rust mutating fixture contracts: `35` passed, `0` failed, `0` skipped.
 
-PRs #986-#1037 added more cutover tooling and evidence gates after this focused
+PRs #986-#1039 added more cutover tooling and evidence gates after this focused
 run, including node restore fixtures, stopped-origin final backup, rehearsal
 final-backup integration, the Cloudflare Access mobile smoke runner, Rust
 mobile-device enrollment, Cloudflare mTLS CA automation, Android Camera-app
@@ -302,7 +306,7 @@ checks plus Rust/state/Cloudflare gates.
 
 ## Accelerated Rust Canary Evidence Path
 
-Issue #1038 adds an explicit path for rotating faster when Python-origin
+PR #1039 adds an explicit path for rotating faster when Python-origin
 availability is the blocker. This is not a silent shadow skip. The report must
 show:
 

--- a/specs/762_stage5_artifacts/rust_service_cutover_runbook.md
+++ b/specs/762_stage5_artifacts/rust_service_cutover_runbook.md
@@ -1,0 +1,176 @@
+# Rust Service Cutover Runbook
+
+Status: issue #1040 implementation handoff.
+
+This runbook is the first reviewed path for rotating production service
+ownership from Python to Rust when Python-origin availability is the blocker.
+It does not silently skip state safety. The cutover keeps the final backup,
+freeze/drain ledger, Rust launchd ownership, and rollback commands explicit.
+
+## Scope
+
+- Rust owns the service port (`127.0.0.1:8420`) through launchd label
+  `com.rajeshgoli.session-manager-rust`.
+- Python launchd labels are stopped only by label, not by arbitrary port kill.
+- Rust refuses to start when the target port is already occupied.
+- Final backup is copied only after Python is stopped and the health probe is
+  connection-refused for the configured hold window.
+- The first canary may use the accelerated Rust evidence path from issue #1038
+  instead of sustained Python-authoritative shadow, because Python is the
+  unstable component.
+
+## Build
+
+Build the Rust server and CLI from the exact commit being deployed:
+
+```bash
+cargo build -p sm-server --release
+```
+
+The service helper defaults to `target/release/sm-server`. Use
+`--binary target/debug/sm-server` only for a local dry run, not production.
+
+## Pre-Cutover Review
+
+Run the non-mutating service plan:
+
+```bash
+./scripts/rust-service-cutover.sh plan
+```
+
+Expected before stopping Python:
+
+- Rust binary is executable.
+- `config.yaml` is readable.
+- known Python label `com.rajeshgoli.session-manager` may be loaded.
+- port `8420` may be occupied by the current Python service.
+
+Any unknown process on port `8420` is a blocker. Do not use `kill -9` as a
+cutover primitive.
+
+Optional pre-freeze safety backup while Python may still be running:
+
+```bash
+./venv/bin/python -m scripts.rust_migration.state_backup \
+  --config config.yaml \
+  --output-dir .local/rust-precutover-backup-$(date -u +%Y%m%dT%H%M%SZ) \
+  --execute \
+  --fail-on-blockers
+```
+
+This is not the rollback restore point. It is only a safety snapshot before the
+stopped-origin final backup.
+
+## Stop Python And Create Final Backup
+
+Stop only known Python Session Manager launchd labels:
+
+```bash
+./scripts/rust-service-cutover.sh stop-python
+```
+
+Create the final stopped-origin backup and ledger:
+
+```bash
+./venv/bin/python -m scripts.rust_migration.final_backup \
+  --config config.yaml \
+  --output-dir .local/rust-final-backup-$(date -u +%Y%m%dT%H%M%SZ) \
+  --ledger .local/rust-cutover-ledger.jsonl \
+  --record-ledger \
+  --execute \
+  --fail-on-blockers
+```
+
+Do not start Rust if this command blocks. Fix the blocker or restart Python
+with `./scripts/rust-service-cutover.sh rollback-python`.
+
+## Start Rust
+
+Write/load the Rust launchd plist and start Rust on the service port:
+
+```bash
+./scripts/rust-service-cutover.sh start-rust
+./scripts/rust-service-cutover.sh status
+```
+
+The helper writes:
+
+- plist: `~/Library/LaunchAgents/com.rajeshgoli.session-manager-rust.plist`
+- stdout: `logs/rust-launchd.out.log`
+- stderr: `logs/rust-launchd.err.log`
+
+## First 15-Minute Smoke Checklist
+
+Run these immediately after Rust is listening:
+
+```bash
+curl -sf http://127.0.0.1:8420/health
+curl -sf http://127.0.0.1:8420/health/detailed
+target/release/sm --api-url http://127.0.0.1:8420 status
+target/release/sm --api-url http://127.0.0.1:8420 queue list
+curl -sf http://127.0.0.1:8420/nodes
+curl -sf http://127.0.0.1:8420/client/bootstrap
+```
+
+Then exercise one controlled session:
+
+```bash
+target/release/sm --api-url http://127.0.0.1:8420 spawn --name rust-cutover-smoke "echo rust cutover smoke && exit"
+target/release/sm --api-url http://127.0.0.1:8420 status
+```
+
+App/operator checks:
+
+- Android app opens against `sm-app.rajeshgo.li`.
+- client certificate shows configured.
+- Google sign-in/device auth succeeds.
+- session list loads.
+- app artifact update metadata/download works.
+- request-status and analytics routes do not return login HTML.
+
+Record any failure as a Rust canary bug. Do not restart Python unless the bug
+blocks core command/session/mobile recovery.
+
+## Rollback
+
+For service rollback before incompatible Rust state changes:
+
+```bash
+./scripts/rust-service-cutover.sh rollback-python
+./scripts/rust-service-cutover.sh status
+```
+
+If Rust has written bad state, stop Rust first:
+
+```bash
+./scripts/rust-service-cutover.sh stop-rust
+```
+
+Then use the final backup manifest as the audited restore source. The current
+restore tool rehearses into a disposable root; live destructive restore remains
+operator-reviewed and should not be automated silently:
+
+```bash
+./venv/bin/python -m scripts.rust_migration.state_restore \
+  --manifest .local/rust-final-backup-<STAMP>/state-backup-manifest.json \
+  --restore-dir /tmp/session-manager-restore-review-$(date -u +%Y%m%dT%H%M%SZ) \
+  --execute-restore \
+  --fail-on-blockers
+```
+
+After reviewing the restore contents, copy live state back only with explicit
+operator approval.
+
+## Stop Conditions
+
+Stop the canary and rollback service ownership if:
+
+- Rust cannot answer `/health` on port `8420`.
+- `target/release/sm status` or `sm send` fails for retained core paths.
+- mobile app auth/session list cannot recover quickly.
+- app artifacts cannot be downloaded by the enrolled app.
+- queue jobs or node status show ownership/corruption errors.
+- any state backup/ledger blocker appears during final backup.
+
+Non-critical retained-path bugs should be fixed forward in Rust while keeping
+Python stopped, because Python is the current unstable component.

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -267,7 +267,7 @@ def test_cloudflare_access_cutover_evidence_pins_policy_and_origin_gates():
         assert required in evidence
 
 
-def test_handoff_and_progress_are_current_through_canary_evidence_issue1038():
+def test_handoff_and_progress_are_current_through_rust_cutover_issue1040():
     progress = (STAGE5_DIR / "mvp_progress.md").read_text(encoding="utf-8")
     handoff = (STAGE5_DIR / "resume_handoff.md").read_text(encoding="utf-8")
     gate_matrix = (STAGE5_DIR / "gate_matrix.md").read_text(encoding="utf-8")
@@ -291,14 +291,16 @@ def test_handoff_and_progress_are_current_through_canary_evidence_issue1038():
         assert "#1025" in text
         assert "#1035" in text
         assert "#1037" in text
-        assert "issue #1038" in text
+        assert "#1039" in text
+        assert "issue #1040" in text.lower()
         assert "Cloudflare Access" in text
         assert "cloudflare_access_cutover_evidence.md" in text
         assert "python_canary_spot_checks" in text
         assert "cloudflare_access_smoke_report" in text
 
-    assert "Latest merged commit before this docs refresh: `68adc3b`" in handoff
-    assert "PR #1037" in handoff
+    assert "Latest merged commit before this docs refresh: `c638d10`" in handoff
+    assert "PR #1039" in handoff
+    assert "rust_service_cutover_runbook.md" in handoff
     assert "Camera-app" in handoff
     assert "deep-link enrollment" in handoff
     assert "app update artifact access works through the certificate-gated app path" in handoff

--- a/tests/unit/test_rust_service_cutover_script.py
+++ b/tests/unit/test_rust_service_cutover_script.py
@@ -1,0 +1,89 @@
+import plistlib
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "rust-service-cutover.sh"
+
+
+def run_script(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_rust_service_cutover_script_has_valid_bash_syntax():
+    result = subprocess.run(
+        ["bash", "-n", str(SCRIPT)],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_rust_service_cutover_plan_is_non_mutating_and_reports_blockers(tmp_path):
+    config = tmp_path / "config.yaml"
+    config.write_text("server:\n  host: 127.0.0.1\n  port: 8420\n", encoding="utf-8")
+    missing_binary = tmp_path / "missing-sm-server"
+    plist_path = tmp_path / "rust.plist"
+
+    result = run_script(
+        "plan",
+        "--config",
+        str(config),
+        "--binary",
+        str(missing_binary),
+        "--port",
+        "18420",
+        "--plist",
+        str(plist_path),
+    )
+
+    assert result.returncode == 0
+    assert "Rust Session Manager service cutover plan" in result.stdout
+    assert "rust_binary_not_executable" in result.stdout
+    assert str(missing_binary) in result.stdout
+    assert str(plist_path) in result.stdout
+    assert not plist_path.exists()
+
+
+def test_rust_service_cutover_render_plist_uses_rust_binary_and_config(tmp_path):
+    config = tmp_path / "config.yaml"
+    config.write_text("server:\n  host: 127.0.0.1\n  port: 18420\n", encoding="utf-8")
+    binary = tmp_path / "sm-server"
+    binary.write_text("#!/bin/sh\n", encoding="utf-8")
+    binary.chmod(0o755)
+
+    result = run_script(
+        "render-plist",
+        "--config",
+        str(config),
+        "--binary",
+        str(binary),
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "18420",
+    )
+
+    assert result.returncode == 0, result.stderr
+    plist = plistlib.loads(result.stdout.encode("utf-8"))
+    assert plist["Label"] == "com.rajeshgoli.session-manager-rust"
+    assert plist["ProgramArguments"] == [
+        str(binary),
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "18420",
+        "--config",
+        str(config),
+    ]
+    assert plist["WorkingDirectory"] == str(REPO_ROOT)


### PR DESCRIPTION
Fixes #1040

## Summary
- add non-destructive Rust launchd cutover helper for plan/write/start/stop/status/rollback
- add Stage 5 first-canary runbook with backup, stop-Python, start-Rust, smoke, and rollback steps
- pin service helper behavior with unit tests and refresh handoff/progress docs

## Validation
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py tests/unit/test_rust_service_cutover_script.py -q`
- `cargo build -p sm-server --release`
- `bash -n scripts/rust-service-cutover.sh`
- `./scripts/rust-service-cutover.sh plan --port 18420`
- `git diff --check`