### PR TITLE
Add Rust public tunnel preflight

### DIFF
--- a/scripts/rust_migration/README.md
+++ b/scripts/rust_migration/README.md
@@ -82,6 +82,27 @@ For `--target rust`, CLI checks default to `target/debug/sm` so retired or
 Rust-only CLI contracts do not accidentally exercise the Python `sm` on PATH.
 Pass `--sm-binary <path>` when testing another Rust CLI build.
 
+## Public Tunnel Preflight
+
+After Rust owns the production service port, validate the local cloudflared
+ingress config before relying on the public app path:
+
+```bash
+python -m scripts.rust_migration.public_tunnel_preflight \
+  --config .local/android-parity/cloudflared/config-http-only.yml \
+  --fail-on-blockers
+```
+
+The default gate expects:
+
+- `sm-app.rajeshgo.li` routes to `http://127.0.0.1:8420`;
+- legacy `sm.rajeshgo.li` is absent;
+- wildcard SM hostnames are absent;
+- the final catch-all ingress row is `http_status:404`.
+
+This command only parses local YAML and prints evidence. It does not mutate
+Cloudflare account state or tunnel credentials.
+
 Audit the retained/retired CLI cutover scope without running commands:
 
 ```bash

--- a/scripts/rust_migration/public_tunnel_preflight.py
+++ b/scripts/rust_migration/public_tunnel_preflight.py
@@ -1,0 +1,333 @@
+"""Validate the public tunnel shape for Rust service cutover.
+
+This is intentionally local and non-mutating. It reads a cloudflared ingress
+config and verifies that the protected SM app hostname reaches the
+launchd-managed Rust service origin while legacy public operational hostnames
+do not route to origin.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+DEFAULT_CONFIG = Path(".local/android-parity/cloudflared/config-http-only.yml")
+DEFAULT_APP_HOST = "sm-app.rajeshgo.li"
+DEFAULT_EXPECTED_ORIGIN = "http://127.0.0.1:8420"
+DEFAULT_FORBIDDEN_HOSTS = ("sm.rajeshgo.li",)
+
+
+@dataclass(frozen=True)
+class IngressRow:
+    index: int
+    hostname: str | None
+    path: str | None
+    service: str | None
+
+
+def build_public_tunnel_preflight_report(
+    *,
+    config_path: Path = DEFAULT_CONFIG,
+    app_host: str = DEFAULT_APP_HOST,
+    expected_origin: str = DEFAULT_EXPECTED_ORIGIN,
+    forbidden_hosts: tuple[str, ...] = DEFAULT_FORBIDDEN_HOSTS,
+) -> dict[str, Any]:
+    config_path = config_path.expanduser().resolve()
+    blockers: list[dict[str, Any]] = []
+    warnings: list[dict[str, Any]] = []
+    rows: list[IngressRow] = []
+
+    if not config_path.exists():
+        blockers.append(_issue("config_missing", f"path does not exist: {config_path}"))
+    elif not config_path.is_file():
+        blockers.append(_issue("config_not_file", f"path is not a file: {config_path}"))
+    else:
+        try:
+            config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        except Exception as exc:  # pragma: no cover - exact parser errors vary by PyYAML
+            blockers.append(_issue("config_parse_error", str(exc)))
+            config = {}
+        ingress = config.get("ingress")
+        if not isinstance(ingress, list):
+            blockers.append(_issue("ingress_missing", "cloudflared config must contain an ingress list"))
+        else:
+            rows = [_row_from_raw(index, raw) for index, raw in enumerate(ingress)]
+            blockers.extend(_validate_rows(rows, app_host, expected_origin, forbidden_hosts))
+            warnings.extend(_warning_rows(rows))
+
+    return {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "status": "blocked" if blockers else "passed",
+        "inputs": {
+            "config": str(config_path),
+            "app_host": _normalize_host(app_host),
+            "expected_origin": expected_origin,
+            "forbidden_hosts": [_normalize_host(host) for host in forbidden_hosts],
+        },
+        "summary": {
+            "ingress_rows": len(rows),
+            "blockers": len(blockers),
+            "warnings": len(warnings),
+        },
+        "ingress": [
+            {
+                "index": row.index,
+                "hostname": row.hostname,
+                "path": row.path,
+                "service": row.service,
+            }
+            for row in rows
+        ],
+        "blockers": blockers,
+        "warnings": warnings,
+    }
+
+
+def render_text_report(report: dict[str, Any]) -> str:
+    summary = report["summary"]
+    inputs = report["inputs"]
+    lines = [
+        "Rust public tunnel preflight",
+        f"status: {report['status']}",
+        f"config: {inputs['config']}",
+        f"app_host: {inputs['app_host']}",
+        f"expected_origin: {inputs['expected_origin']}",
+        f"forbidden_hosts: {', '.join(inputs['forbidden_hosts']) or '<none>'}",
+        f"ingress_rows: {summary['ingress_rows']}",
+        f"blockers: {summary['blockers']}",
+        f"warnings: {summary['warnings']}",
+        "",
+        "Ingress:",
+    ]
+    for row in report["ingress"]:
+        hostname = row["hostname"] if row["hostname"] is not None else "<catch-all>"
+        path = f" {row['path']}" if row["path"] is not None else ""
+        service = row["service"] if row["service"] is not None else "<missing>"
+        lines.append(f"  {row['index']}: {hostname}{path} -> {service}")
+    if report["blockers"]:
+        lines.extend(["", "Blockers:"])
+        for issue in report["blockers"]:
+            lines.append(f"  {issue['kind']}: {issue['detail']}")
+    if report["warnings"]:
+        lines.extend(["", "Warnings:"])
+        for issue in report["warnings"]:
+            lines.append(f"  {issue['kind']}: {issue['detail']}")
+    return "\n".join(lines)
+
+
+def _validate_rows(
+    rows: list[IngressRow],
+    app_host: str,
+    expected_origin: str,
+    forbidden_hosts: tuple[str, ...],
+) -> list[dict[str, Any]]:
+    blockers: list[dict[str, Any]] = []
+    normalized_app_host = _normalize_host(app_host)
+    normalized_forbidden = {_normalize_host(host) for host in forbidden_hosts if host.strip()}
+
+    unscoped_app_rows = [
+        row
+        for row in rows
+        if _normalize_host(row.hostname) == normalized_app_host and row.path is None
+    ]
+    all_app_rows = [row for row in rows if _normalize_host(row.hostname) == normalized_app_host]
+    if not unscoped_app_rows:
+        blockers.append(
+            _issue(
+                "app_host_missing",
+                f"{normalized_app_host} is not present as an unscoped ingress host",
+            )
+        )
+    elif len(unscoped_app_rows) > 1:
+        blockers.append(
+            _issue(
+                "app_host_duplicate",
+                f"{normalized_app_host} appears {len(unscoped_app_rows)} times",
+            )
+        )
+    elif unscoped_app_rows[0].service != expected_origin:
+        blockers.append(
+            _issue(
+                "app_host_wrong_origin",
+                (
+                    f"{normalized_app_host} routes to {unscoped_app_rows[0].service!r}; "
+                    f"expected {expected_origin!r}"
+                ),
+                index=unscoped_app_rows[0].index,
+            )
+        )
+    for row in all_app_rows:
+        if row.path is not None:
+            blockers.append(
+                _issue(
+                    "app_host_path_scoped",
+                    f"{normalized_app_host} row is path-scoped to {row.path!r}; expected all paths",
+                    index=row.index,
+                )
+            )
+
+    first_match = _first_host_match(rows, normalized_app_host)
+    if first_match is None:
+        blockers.append(
+            _issue("app_host_no_matching_rule", f"no ingress rule matches {normalized_app_host}")
+        )
+    elif _normalize_host(first_match.hostname) != normalized_app_host or first_match.path is not None:
+        blockers.append(
+            _issue(
+                "app_host_shadowed",
+                (
+                    f"row {first_match.index} matches {normalized_app_host} before the "
+                    "unscoped app-host rule"
+                ),
+                index=first_match.index,
+            )
+        )
+    elif first_match.service != expected_origin:
+        blockers.append(
+            _issue(
+                "app_host_first_match_wrong_origin",
+                (
+                    f"first {normalized_app_host} match routes to {first_match.service!r}; "
+                    f"expected {expected_origin!r}"
+                ),
+                index=first_match.index,
+            )
+        )
+
+    for row in rows:
+        host = _normalize_host(row.hostname)
+        if host in normalized_forbidden:
+            blockers.append(
+                _issue(
+                    "forbidden_host_present",
+                    f"{host} must not be present in the public ingress config",
+                    index=row.index,
+                )
+            )
+        if host.startswith("*.") or host == "*":
+            blockers.append(
+                _issue(
+                    "wildcard_hostname_present",
+                    f"wildcard hostname {host!r} is not allowed for SM public ingress",
+                    index=row.index,
+                )
+            )
+
+    if not rows:
+        blockers.append(_issue("ingress_empty", "ingress list is empty"))
+    elif rows[-1].hostname is not None or rows[-1].service != "http_status:404":
+        blockers.append(
+            _issue(
+                "catch_all_not_404",
+                "final ingress row must be catch-all service http_status:404",
+                index=rows[-1].index,
+            )
+        )
+    return blockers
+
+
+def _warning_rows(rows: list[IngressRow]) -> list[dict[str, Any]]:
+    warnings: list[dict[str, Any]] = []
+    for row in rows:
+        if row.service is None:
+            warnings.append(
+                _issue(
+                    "service_missing",
+                    f"ingress row {row.index} has no service",
+                    severity="warning",
+                    index=row.index,
+                )
+            )
+    return warnings
+
+
+def _row_from_raw(index: int, raw: Any) -> IngressRow:
+    if not isinstance(raw, dict):
+        return IngressRow(index=index, hostname=None, path=None, service=None)
+    hostname = raw.get("hostname")
+    path = raw.get("path")
+    service = raw.get("service")
+    return IngressRow(
+        index=index,
+        hostname=str(hostname).strip() if hostname is not None else None,
+        path=str(path).strip() if path is not None else None,
+        service=str(service).strip() if service is not None else None,
+    )
+
+
+def _first_host_match(rows: list[IngressRow], hostname: str) -> IngressRow | None:
+    for row in rows:
+        row_host = _normalize_host(row.hostname)
+        if row.hostname is None or row_host == hostname or _wildcard_matches(row_host, hostname):
+            return row
+    return None
+
+
+def _wildcard_matches(pattern: str, hostname: str) -> bool:
+    if pattern == "*":
+        return True
+    if pattern.startswith("*."):
+        suffix = pattern[1:]
+        return hostname.endswith(suffix) and hostname != pattern[2:]
+    return False
+
+
+def _normalize_host(hostname: str | None) -> str:
+    if hostname is None:
+        return ""
+    return hostname.strip().rstrip(".").lower()
+
+
+def _issue(
+    kind: str,
+    detail: str,
+    *,
+    severity: str = "blocker",
+    index: int | None = None,
+) -> dict[str, Any]:
+    issue: dict[str, Any] = {"kind": kind, "severity": severity, "detail": detail}
+    if index is not None:
+        issue["index"] = index
+    return issue
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--app-host", default=DEFAULT_APP_HOST)
+    parser.add_argument("--expected-origin", default=DEFAULT_EXPECTED_ORIGIN)
+    parser.add_argument(
+        "--forbid-host",
+        action="append",
+        default=list(DEFAULT_FORBIDDEN_HOSTS),
+        help="Hostnames that must not appear in ingress. Repeatable.",
+    )
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--fail-on-blockers", action="store_true")
+    args = parser.parse_args(argv)
+
+    report = build_public_tunnel_preflight_report(
+        config_path=args.config,
+        app_host=args.app_host,
+        expected_origin=args.expected_origin,
+        forbidden_hosts=tuple(args.forbid_host),
+    )
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_text_report(report))
+    if args.fail_on_blockers and report["blockers"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/specs/762_stage5_artifacts/mvp_progress.md
+++ b/specs/762_stage5_artifacts/mvp_progress.md
@@ -1,20 +1,24 @@
 # Rust MVP Progress Snapshot
 
-Status: implementation snapshot after PR #1039 accelerated Rust canary evidence
-mode, with issue #1040 adding Rust service cutover tooling/runbook.
+Status: implementation snapshot after PR #1041 Rust service cutover tooling was
+merged and used for the first Rust canary flip on 2026-06-17. Issue #1042 adds
+the public tunnel preflight that verifies `sm-app.rajeshgo.li` routes directly
+to the launchd-managed Rust service and legacy `sm.rajeshgo.li` does not route
+to origin.
+
 The last clean full real-state MVP rehearsal remains the post-#938 run; the
 post-#1035 rehearsal proves state gates, live core contracts, read-only
 fixtures, mutating fixtures, and Rust baseline on isolated sidecars, but blocks
-on Python-origin availability during Python baseline and shadow. PRs #986-#1039
+on Python-origin availability during Python baseline and shadow. PRs #986-#1041
 added node restore fixtures, stopped-origin final backup gates, rehearsal
 final-backup integration, Cloudflare Access smoke evidence tooling, Rust
 mobile-device enrollment, Cloudflare mTLS CA automation, the Android Camera-app
-enrollment handoff, and Rust native Google device-auth bearer issuance, plus
-Android mTLS, artifact read fixes, and a larger live HTTP read budget. Public
-cutover still needs full Cloudflare policy/proof inputs and real mobile/browser
-smoke evidence. A stable Python-authoritative shadow window is preferred, but
-the explicit accelerated canary path may replace it when Python availability is
-the unstable component.
+enrollment handoff, Rust native Google device-auth bearer issuance, Android
+mTLS, artifact read fixes, a larger live HTTP read budget, accelerated Rust
+canary evidence mode, and reviewed launchd/service cutover tooling. The first
+live cutover stopped the Python launchd label, copied a stopped-origin final
+backup, started Rust on `127.0.0.1:8420`, enabled Rust core writes, verified the
+Android app path, and removed the legacy public tunnel route.
 
 This file is a handoff aid for the Rust cutover implementation track. It does
 not change retained or removed scope. Binding scope remains
@@ -117,7 +121,8 @@ not change retained or removed scope. Binding scope remains
 | #1035 | Android app artifacts can be read with cert-gated app auth while preserving edge/session fallbacks |
 | #1037 | Contract harness HTTP reads default to a larger budget for live `/client/sessions` payloads |
 | #1039 | Accelerated Rust canary evidence mode for Python-origin instability |
-| issue #1040 | Rust service launchd cutover tooling and first-canary runbook |
+| #1041 | Rust service launchd cutover tooling and first-canary runbook |
+| issue #1042 | Public tunnel preflight for the protected app hostname and legacy-host absence |
 
 ## Implemented Capability Groups
 
@@ -135,15 +140,31 @@ The Rust sidecar now has executable coverage for:
 | External fallback | Email/human fallback delivery and inbound email validation path are retained in the Rust track. |
 | Queue and nodes | Queue list/detail, CLI list/status, pending submit, simple execute/cancel, queue recovery, queue fixtures, node reads, and node HTTP routes are implemented; remaining work is final live/recovery cutover evidence and any retained node-agent remote-control gaps. |
 
-## Current Live Shadow And Contract State
+## Current Live Cutover And Contract State
 
-Live Python-authoritative Rust shadow mode is active in the local config:
+Rust is now the live local service owner:
 
-- Python origin: `:8420`;
-- Rust sidecar: `127.0.0.1:8421`;
-- shadow ledger: `~/.local/share/claude-sessions/rust_shadow.jsonl`;
-- config backup created by the activation helper:
-  `config.yaml.shadow-backup-20260612T023248Z`.
+- Rust launchd label: `com.rajeshgoli.session-manager-rust`;
+- Rust origin: `127.0.0.1:8420`;
+- final stopped-origin backup:
+  `.local/rust-final-backup-20260617T033653Z`;
+- protected app hostname: `sm-app.rajeshgo.li`;
+- legacy public hostname: `sm.rajeshgo.li` returns 404 from the tunnel and does
+  not route to origin;
+- local cloudflared ingress should route `sm-app.rajeshgo.li` directly to
+  `http://127.0.0.1:8420`, with a final `http_status:404` catch-all.
+
+The old Python-authoritative shadow mode remains historical evidence only. The
+manual `127.0.0.1:8421` sidecar is not part of the live target after the public
+tunnel is repointed to the launchd-managed Rust service.
+
+Validate the live tunnel shape with:
+
+```bash
+./venv/bin/python -m scripts.rust_migration.public_tunnel_preflight \
+  --config .local/android-parity/cloudflared/config-http-only.yml \
+  --fail-on-blockers
+```
 
 The latest clean passive shadow report after #996 used
 `--last-minutes 30 --fail-on-blockers --json` and returned:

--- a/specs/762_stage5_artifacts/resume_handoff.md
+++ b/specs/762_stage5_artifacts/resume_handoff.md
@@ -1,8 +1,10 @@
 # Rust Port Resume Handoff
 
-Status: handoff snapshot from 2026-06-16 after PR #1039 accelerated Rust
-canary evidence mode. Issue #1040 adds the reviewed Rust service launchd
-cutover runbook/tooling for the first canary flip.
+Status: handoff snapshot from 2026-06-17 after PR #1041 merged the reviewed
+Rust service launchd cutover tooling and the first Rust canary flip moved local
+production traffic to Rust. Issue #1042 adds the public tunnel preflight that
+keeps `sm-app.rajeshgo.li` pointed at the launchd-managed Rust service and
+keeps legacy `sm.rajeshgo.li` off origin.
 
 Use this file to resume the Rust cutover track without reconstructing state from
 chat history. Binding scope still lives in [cutover_scope.md](cutover_scope.md),
@@ -14,19 +16,28 @@ Service cutover commands live in
 
 ## Current Repository State
 
-- Branch: `main` after PR #1039.
-- Latest merged commit before this docs refresh: `c638d10` (`Merge pull
-  request #1039`)
+- Branch: `main` after PR #1041.
+- Latest merged commit before this docs refresh: `f7e74af` (`Merge pull
+  request #1041`)
 - Open PRs at handoff: none before this docs refresh PR.
 - Dirty worktree at handoff: only pre-existing untracked
   `.claude/settings.local.json`, `certs/`, `data/`, and the local
   `config.yaml.shadow-backup-20260612T023248Z` created when enabling shadow
   mode.
-- Stale session-manager review agents from the overnight run and PR #932 were retired.
-- Unrelated non-session-manager agents were left alone.
-- Live Python-authoritative Rust shadow mode is enabled in `config.yaml`, with
-  Python serving on `:8420`, the Rust sidecar on `127.0.0.1:8421`, and the
-  ledger at `~/.local/share/claude-sessions/rust_shadow.jsonl`.
+- Rust is live on `127.0.0.1:8420` under launchd label
+  `com.rajeshgoli.session-manager-rust`.
+- Python launchd label `com.rajeshgoli.session-manager` was stopped before the
+  final backup.
+- Final stopped-origin backup:
+  `.local/rust-final-backup-20260617T033653Z`.
+- `sm-app.rajeshgo.li` is the protected public app hostname. It should route
+  through Cloudflare Access to `http://127.0.0.1:8420`.
+- Legacy `sm.rajeshgo.li` should not route to origin and should return 404 from
+  the tunnel.
+- The prior `127.0.0.1:8421` Rust sidecar was useful for shadow/rehearsal but
+  is not part of the live target after the tunnel is repointed to `8420`.
+- Validate the local public tunnel shape with
+  `./venv/bin/python -m scripts.rust_migration.public_tunnel_preflight --config .local/android-parity/cloudflared/config-http-only.yml --fail-on-blockers`.
 
 ## Completed Work
 
@@ -67,7 +78,7 @@ Merged Rust slices cover:
 
 ### Documentation And Manifest
 
-- [mvp_progress.md](mvp_progress.md) records the PR lineage through #1039.
+- [mvp_progress.md](mvp_progress.md) records the PR lineage through #1041.
 - [cloudflare_access_cutover_evidence.md](cloudflare_access_cutover_evidence.md)
   records the current Cloudflare Access origin-gate behavior and remaining
   operator setup/smoke evidence.
@@ -182,8 +193,11 @@ Merged Rust slices cover:
   `/client/sessions` JSON responses are not truncated before assertion checks.
 - PR #1039 adds the accelerated Rust canary evidence mode for the case where
   Python-origin availability prevents sustained baseline/shadow evidence.
-- Issue #1040 adds the Rust service cutover helper and runbook for reviewed
+- PR #1041 adds the Rust service cutover helper and runbook for reviewed
   launchd ownership transfer.
+- Issue #1042 adds the public tunnel preflight so the protected app hostname is
+  validated against `127.0.0.1:8420` and legacy public host routes are blocked
+  before relying on the app path.
 - Current contract manifest size:
   - `134` checks total
   - `73` `python_and_rust`

--- a/specs/762_stage5_artifacts/rust_service_cutover_runbook.md
+++ b/specs/762_stage5_artifacts/rust_service_cutover_runbook.md
@@ -99,6 +99,47 @@ The helper writes:
 - stdout: `logs/rust-launchd.out.log`
 - stderr: `logs/rust-launchd.err.log`
 
+## Protected Public Tunnel
+
+After Rust owns `127.0.0.1:8420`, the Cloudflare tunnel should forward the
+protected app hostname directly to that launchd-managed Rust service. Do not
+leave `sm-app.rajeshgo.li` pointed at a manually started `8421` sidecar, and do
+not leave legacy `sm.rajeshgo.li` routed to origin.
+
+Validate the local cloudflared ingress shape:
+
+```bash
+./venv/bin/python -m scripts.rust_migration.public_tunnel_preflight \
+  --config .local/android-parity/cloudflared/config-http-only.yml \
+  --fail-on-blockers
+```
+
+Expected post-cutover shape:
+
+```yaml
+ingress:
+  - hostname: sm-app.rajeshgo.li
+    service: http://127.0.0.1:8420
+  - service: http_status:404
+```
+
+Then validate cloudflared syntax and restart the tunnel:
+
+```bash
+cloudflared tunnel --config .local/android-parity/cloudflared/config-http-only.yml ingress validate
+launchctl kickstart -k gui/$(id -u)/com.rajesh.sm-android-tunnel
+```
+
+Public unauthenticated probes should show Cloudflare Access on the app host and
+no origin route on the legacy host:
+
+```bash
+curl -sS -o /tmp/sm-app-health-public.txt -w 'sm-app %{http_code}\n' https://sm-app.rajeshgo.li/health
+curl -sS -o /tmp/sm-legacy-health-public.txt -w 'legacy %{http_code}\n' https://sm.rajeshgo.li/health
+```
+
+Expected: `sm-app 403` from Cloudflare Access and `legacy 404`.
+
 ## First 15-Minute Smoke Checklist
 
 Run these immediately after Rust is listening:

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -267,7 +267,7 @@ def test_cloudflare_access_cutover_evidence_pins_policy_and_origin_gates():
         assert required in evidence
 
 
-def test_handoff_and_progress_are_current_through_rust_cutover_issue1040():
+def test_handoff_and_progress_are_current_through_public_tunnel_issue1042():
     progress = (STAGE5_DIR / "mvp_progress.md").read_text(encoding="utf-8")
     handoff = (STAGE5_DIR / "resume_handoff.md").read_text(encoding="utf-8")
     gate_matrix = (STAGE5_DIR / "gate_matrix.md").read_text(encoding="utf-8")
@@ -292,19 +292,25 @@ def test_handoff_and_progress_are_current_through_rust_cutover_issue1040():
         assert "#1035" in text
         assert "#1037" in text
         assert "#1039" in text
-        assert "issue #1040" in text.lower()
+        assert "#1041" in text
+        assert "issue #1042" in text.lower()
         assert "Cloudflare Access" in text
         assert "cloudflare_access_cutover_evidence.md" in text
+        assert "public_tunnel_preflight" in text
+        assert "sm-app.rajeshgo.li" in text
         assert "python_canary_spot_checks" in text
         assert "cloudflare_access_smoke_report" in text
 
-    assert "Latest merged commit before this docs refresh: `c638d10`" in handoff
-    assert "PR #1039" in handoff
+    assert "Latest merged commit before this docs refresh: `f7e74af`" in handoff
+    assert "PR #1041" in handoff
     assert "rust_service_cutover_runbook.md" in handoff
+    assert "127.0.0.1:8420" in handoff
+    assert "Legacy `sm.rajeshgo.li` should not route to origin" in handoff
     assert "Camera-app" in handoff
     assert "deep-link enrollment" in handoff
     assert "app update artifact access works through the certificate-gated app path" in handoff
     assert "--cloudflare-smoke-report" in readme
+    assert "public_tunnel_preflight" in readme
 
 
 def test_manifest_covers_rust_only_retired_http_surfaces():

--- a/tests/unit/test_rust_public_tunnel_preflight.py
+++ b/tests/unit/test_rust_public_tunnel_preflight.py
@@ -1,0 +1,172 @@
+from pathlib import Path
+
+from scripts.rust_migration.public_tunnel_preflight import (
+    build_public_tunnel_preflight_report,
+    main as public_tunnel_preflight_main,
+    render_text_report,
+)
+
+
+def _write_tunnel_config(path: Path, ingress: str) -> None:
+    path.write_text(
+        f"""
+tunnel: test-tunnel
+credentials-file: /tmp/test-tunnel.json
+ingress:
+{ingress}
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+
+def test_public_tunnel_preflight_accepts_protected_app_to_rust_service(tmp_path):
+    config = tmp_path / "cloudflared.yml"
+    _write_tunnel_config(
+        config,
+        """
+  - hostname: sm-app.rajeshgo.li
+    service: http://127.0.0.1:8420
+  - service: http_status:404
+""".rstrip(),
+    )
+
+    report = build_public_tunnel_preflight_report(config_path=config)
+
+    assert report["status"] == "passed"
+    assert report["summary"]["blockers"] == 0
+    assert report["ingress"][0]["hostname"] == "sm-app.rajeshgo.li"
+    assert report["ingress"][0]["service"] == "http://127.0.0.1:8420"
+
+
+def test_public_tunnel_preflight_blocks_manual_8421_sidecar_target(tmp_path):
+    config = tmp_path / "cloudflared.yml"
+    _write_tunnel_config(
+        config,
+        """
+  - hostname: sm-app.rajeshgo.li
+    service: http://127.0.0.1:8421
+  - service: http_status:404
+""".rstrip(),
+    )
+
+    report = build_public_tunnel_preflight_report(config_path=config)
+
+    assert report["status"] == "blocked"
+    assert {
+        "kind": "app_host_wrong_origin",
+        "severity": "blocker",
+        "detail": (
+            "sm-app.rajeshgo.li routes to 'http://127.0.0.1:8421'; "
+            "expected 'http://127.0.0.1:8420'"
+        ),
+        "index": 0,
+    } in report["blockers"]
+
+
+def test_public_tunnel_preflight_blocks_earlier_hostless_rule(tmp_path):
+    config = tmp_path / "cloudflared.yml"
+    _write_tunnel_config(
+        config,
+        """
+  - service: http://127.0.0.1:8421
+  - hostname: sm-app.rajeshgo.li
+    service: http://127.0.0.1:8420
+  - service: http_status:404
+""".rstrip(),
+    )
+
+    report = build_public_tunnel_preflight_report(config_path=config)
+
+    assert report["status"] == "blocked"
+    assert any(
+        issue["kind"] == "app_host_shadowed" and issue["index"] == 0
+        for issue in report["blockers"]
+    )
+
+
+def test_public_tunnel_preflight_blocks_path_scoped_app_rule(tmp_path):
+    config = tmp_path / "cloudflared.yml"
+    _write_tunnel_config(
+        config,
+        """
+  - hostname: sm-app.rajeshgo.li
+    path: /client/*
+    service: http://127.0.0.1:8420
+  - hostname: sm-app.rajeshgo.li
+    service: http://127.0.0.1:8420
+  - service: http_status:404
+""".rstrip(),
+    )
+
+    report = build_public_tunnel_preflight_report(config_path=config)
+
+    assert report["status"] == "blocked"
+    kinds = {issue["kind"] for issue in report["blockers"]}
+    assert "app_host_path_scoped" in kinds
+    assert "app_host_shadowed" in kinds
+
+
+def test_public_tunnel_preflight_blocks_legacy_public_host(tmp_path):
+    config = tmp_path / "cloudflared.yml"
+    _write_tunnel_config(
+        config,
+        """
+  - hostname: sm-app.rajeshgo.li
+    service: http://127.0.0.1:8420
+  - hostname: sm.rajeshgo.li
+    service: http://127.0.0.1:8420
+  - service: http_status:404
+""".rstrip(),
+    )
+
+    report = build_public_tunnel_preflight_report(config_path=config)
+
+    assert report["status"] == "blocked"
+    assert any(
+        issue["kind"] == "forbidden_host_present" and issue["index"] == 1
+        for issue in report["blockers"]
+    )
+
+
+def test_public_tunnel_preflight_blocks_wildcard_and_missing_404(tmp_path):
+    config = tmp_path / "cloudflared.yml"
+    _write_tunnel_config(
+        config,
+        """
+  - hostname: sm-app.rajeshgo.li
+    service: http://127.0.0.1:8420
+  - hostname: '*.rajeshgo.li'
+    service: http://127.0.0.1:8420
+""".rstrip(),
+    )
+
+    report = build_public_tunnel_preflight_report(config_path=config)
+
+    assert report["status"] == "blocked"
+    kinds = {issue["kind"] for issue in report["blockers"]}
+    assert "wildcard_hostname_present" in kinds
+    assert "catch_all_not_404" in kinds
+
+
+def test_public_tunnel_preflight_text_and_cli_fail_on_blockers(tmp_path, capsys):
+    config = tmp_path / "cloudflared.yml"
+    _write_tunnel_config(
+        config,
+        """
+  - hostname: sm-app.rajeshgo.li
+    service: http://127.0.0.1:8421
+  - service: http_status:404
+""".rstrip(),
+    )
+
+    report = build_public_tunnel_preflight_report(config_path=config)
+    text = render_text_report(report)
+    assert "Rust public tunnel preflight" in text
+    assert "app_host_wrong_origin" in text
+
+    rc = public_tunnel_preflight_main(
+        ["--config", str(config), "--fail-on-blockers"]
+    )
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "status: blocked" in captured.out


### PR DESCRIPTION
Fixes #1042

## Summary
- add a non-mutating cloudflared ingress validator for the protected SM app tunnel
- fail when sm-app does not route to the launchd-managed Rust service or legacy sm.rajeshgo.li is still present
- update the Rust cutover runbook and handoff/progress docs for the live post-cutover tunnel shape

## Validation
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py tests/unit/test_rust_public_tunnel_preflight.py -q`
- `./venv/bin/python -m scripts.rust_migration.public_tunnel_preflight --config .local/android-parity/cloudflared/config-http-only.yml --fail-on-blockers`
- `./venv/bin/python -m py_compile scripts/rust_migration/public_tunnel_preflight.py`
- `git diff --check`
- live checks: no listener on 8421, local Rust /health healthy, sm-app unauthenticated probe returns Cloudflare Access 403, legacy sm.rajeshgo.li returns 404