### PR TITLE
Add live Rust canary report

### DIFF
--- a/scripts/rust_migration/README.md
+++ b/scripts/rust_migration/README.md
@@ -103,6 +103,22 @@ The default gate expects:
 This command only parses local YAML and prints evidence. It does not mutate
 Cloudflare account state or tunnel credentials.
 
+After Rust owns the live service port, collect the non-mutating live canary
+evidence bundle:
+
+```bash
+python -m scripts.rust_migration.live_canary_report \
+  --output .local/rust-mvp-rehearsals/live-canary-$(date -u +%Y%m%dT%H%M%SZ).json \
+  --fail-on-blockers
+```
+
+The report records launchd ownership, local Rust health/bootstrap/session and
+analytics reads, `sm status` against the live Rust origin, local cloudflared
+ingress shape, unauthenticated public `sm-app` Cloudflare Access denial, legacy
+public-host absence, and an optional supplied Cloudflare/mobile smoke report.
+It performs no writes and is intended as post-cutover evidence, not as a
+replacement for the state backup/freeze/rollback gates.
+
 Audit the retained/retired CLI cutover scope without running commands:
 
 ```bash

--- a/scripts/rust_migration/live_canary_report.py
+++ b/scripts/rust_migration/live_canary_report.py
@@ -1,0 +1,618 @@
+"""Collect post-cutover Rust canary evidence.
+
+This command observes the live Rust service after ownership has moved to Rust.
+It is intentionally non-mutating: it records local Rust health/read checks,
+launchd ownership, public tunnel preflight, unauthenticated public edge probes,
+and optional Cloudflare/mobile smoke evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+from urllib.parse import urlparse
+
+from .public_tunnel_preflight import (
+    DEFAULT_APP_HOST,
+    DEFAULT_CONFIG as DEFAULT_TUNNEL_CONFIG,
+    DEFAULT_EXPECTED_ORIGIN,
+    DEFAULT_FORBIDDEN_HOSTS,
+    build_public_tunnel_preflight_report,
+)
+
+
+DEFAULT_BASE_URL = "http://127.0.0.1:8420"
+DEFAULT_SM_BINARY = "target/release/sm"
+DEFAULT_RUST_LABEL = "com.rajeshgoli.session-manager-rust"
+DEFAULT_LEGACY_HOST = "sm.rajeshgo.li"
+
+CommandRunner = Callable[..., subprocess.CompletedProcess[str]]
+JsonValidator = Callable[[dict[str, Any]], tuple[str, str] | None]
+
+
+def build_live_canary_report(
+    *,
+    base_url: str = DEFAULT_BASE_URL,
+    sm_binary: str = DEFAULT_SM_BINARY,
+    rust_label: str = DEFAULT_RUST_LABEL,
+    app_host: str = DEFAULT_APP_HOST,
+    legacy_host: str = DEFAULT_LEGACY_HOST,
+    tunnel_config: Path = DEFAULT_TUNNEL_CONFIG,
+    expected_tunnel_origin: str = DEFAULT_EXPECTED_ORIGIN,
+    cloudflare_smoke_report: Path | None = None,
+    timeout_seconds: float = 5.0,
+    command_runner: CommandRunner = subprocess.run,
+    urlopen=urllib.request.urlopen,
+) -> dict[str, Any]:
+    if timeout_seconds <= 0:
+        raise ValueError("--timeout must be positive")
+    base_url = base_url.rstrip("/")
+    checks: list[dict[str, Any]] = []
+
+    checks.append(
+        _command_check(
+            "launchd.rust_service_running",
+            f"Rust launchd label {rust_label} is running",
+            ["launchctl", "print", f"gui/{_uid()}/{rust_label}"],
+            command_runner=command_runner,
+            timeout_seconds=timeout_seconds,
+            expected_stdout_fragment="state = running",
+        )
+    )
+    checks.extend(
+        [
+            _http_check(
+                "local.health",
+                "local Rust health is healthy",
+                f"{base_url}/health",
+                expected_status=200,
+                expected_json_keys=("status",),
+                expected_json_values={"status": "healthy"},
+                timeout_seconds=timeout_seconds,
+                urlopen=urlopen,
+            ),
+            _http_check(
+                "local.health_detailed",
+                "local Rust detailed health responds",
+                f"{base_url}/health/detailed",
+                expected_status=200,
+                expected_json_keys=("status", "checks"),
+                timeout_seconds=timeout_seconds,
+                urlopen=urlopen,
+            ),
+            _http_check(
+                "local.client_bootstrap",
+                "local Rust bootstrap advertises app host",
+                f"{base_url}/client/bootstrap",
+                expected_status=200,
+                expected_json_keys=("auth", "external_access"),
+                expected_json_values={
+                    "external_access.public_http_host": app_host,
+                },
+                expected_json_validators=(
+                    _mobile_terminal_ws_url_validator(app_host),
+                ),
+                timeout_seconds=timeout_seconds,
+                urlopen=urlopen,
+            ),
+            _http_check(
+                "local.client_sessions",
+                "local Rust native session list responds",
+                f"{base_url}/client/sessions",
+                expected_status=200,
+                expected_json_keys=("sessions",),
+                timeout_seconds=timeout_seconds,
+                urlopen=urlopen,
+            ),
+            _http_check(
+                "local.client_analytics_summary",
+                "local Rust native analytics responds",
+                f"{base_url}/client/analytics/summary",
+                expected_status=200,
+                expected_json_keys=("generated_at", "kpis"),
+                timeout_seconds=timeout_seconds,
+                urlopen=urlopen,
+            ),
+        ]
+    )
+    checks.append(
+        _command_check(
+            "cli.status",
+            "Rust CLI status works against live service",
+            [sm_binary, "--api-url", base_url, "status"],
+            command_runner=command_runner,
+            timeout_seconds=timeout_seconds,
+        )
+    )
+    checks.append(
+        _public_tunnel_check(
+            config_path=tunnel_config,
+            app_host=app_host,
+            expected_origin=expected_tunnel_origin,
+            forbidden_hosts=_forbidden_hosts(legacy_host),
+        )
+    )
+    checks.extend(
+        [
+            _http_check(
+                "public.sm_app_requires_access",
+                "public app host denies unauthenticated health before origin",
+                f"https://{app_host}/health",
+                expected_status=403,
+                expected_body_contains_any=(
+                    "Cloudflare Access",
+                    "error code: 1010",
+                ),
+                timeout_seconds=timeout_seconds,
+                urlopen=urlopen,
+            ),
+            _http_check(
+                "public.legacy_host_absent",
+                "legacy public host does not route to origin",
+                f"https://{legacy_host}/health",
+                expected_status=404,
+                expected_statuses=(403, 404),
+                timeout_seconds=timeout_seconds,
+                urlopen=urlopen,
+            ),
+        ]
+    )
+    checks.append(_cloudflare_smoke_check(cloudflare_smoke_report))
+
+    blockers = [
+        {
+            "check_id": check["id"],
+            "kind": check.get("blocker_kind", "check_failed"),
+            "detail": check["detail"],
+        }
+        for check in checks
+        if check["status"] == "blocked"
+    ]
+    return {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "status": "blocked" if blockers else "passed",
+        "inputs": {
+            "base_url": base_url,
+            "sm_binary": sm_binary,
+            "rust_label": rust_label,
+            "app_host": app_host,
+            "legacy_host": legacy_host,
+            "tunnel_config": str(tunnel_config),
+            "expected_tunnel_origin": expected_tunnel_origin,
+            "cloudflare_smoke_report": (
+                str(cloudflare_smoke_report) if cloudflare_smoke_report else None
+            ),
+        },
+        "summary": {
+            "checks": len(checks),
+            "passed": sum(1 for check in checks if check["status"] == "passed"),
+            "blocked": len(blockers),
+            "skipped": sum(1 for check in checks if check["status"] == "skipped"),
+        },
+        "checks": checks,
+        "blockers": blockers,
+    }
+
+
+def render_text_report(report: dict[str, Any]) -> str:
+    lines = [
+        "Rust live canary report",
+        f"status: {report['status']}",
+        f"base_url: {report['inputs']['base_url']}",
+        f"app_host: {report['inputs']['app_host']}",
+        f"legacy_host: {report['inputs']['legacy_host']}",
+        f"checks: {report['summary']['checks']}",
+        f"passed: {report['summary']['passed']}",
+        f"blocked: {report['summary']['blocked']}",
+        f"skipped: {report['summary']['skipped']}",
+        "",
+        "Checks:",
+    ]
+    for check in report["checks"]:
+        lines.append(f"  {check['status']:7} {check['id']}: {check['detail']}")
+    if report["blockers"]:
+        lines.extend(["", "Blockers:"])
+        for blocker in report["blockers"]:
+            lines.append(
+                f"  {blocker['check_id']}: {blocker['kind']} - {blocker['detail']}"
+            )
+    return "\n".join(lines)
+
+
+def _command_check(
+    check_id: str,
+    description: str,
+    command: list[str],
+    *,
+    command_runner: CommandRunner,
+    timeout_seconds: float,
+    expected_stdout_fragment: str | None = None,
+) -> dict[str, Any]:
+    try:
+        result = command_runner(
+            command,
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired:
+        return _blocked(
+            check_id,
+            description,
+            "command_timeout",
+            f"command timed out after {timeout_seconds} seconds",
+        )
+    except FileNotFoundError as exc:
+        return _blocked(check_id, description, "command_not_found", str(exc))
+    except Exception as exc:  # pragma: no cover - defensive for platform errors
+        return _blocked(check_id, description, "command_error", str(exc))
+    stdout = result.stdout or ""
+    stderr = result.stderr or ""
+    response = {
+        "returncode": result.returncode,
+        "stdout_preview": stdout[:500],
+        "stderr_preview": stderr[:500],
+    }
+    if result.returncode != 0:
+        return _blocked(
+            check_id,
+            description,
+            "command_failed",
+            f"command exited {result.returncode}",
+            response=response,
+        )
+    if expected_stdout_fragment and expected_stdout_fragment not in stdout:
+        return _blocked(
+            check_id,
+            description,
+            "stdout_mismatch",
+            f"stdout did not contain {expected_stdout_fragment!r}",
+            response=response,
+        )
+    return _passed(check_id, description, response=response)
+
+
+def _http_check(
+    check_id: str,
+    description: str,
+    url: str,
+    *,
+    expected_status: int,
+    timeout_seconds: float,
+    urlopen,
+    expected_statuses: tuple[int, ...] = (),
+    expected_body_contains: str | None = None,
+    expected_body_contains_any: tuple[str, ...] = (),
+    expected_json_keys: tuple[str, ...] = (),
+    expected_json_values: dict[str, Any] | None = None,
+    expected_json_validators: tuple[JsonValidator, ...] = (),
+) -> dict[str, Any]:
+    try:
+        request = urllib.request.Request(url, method="GET")
+        with urlopen(request, timeout=timeout_seconds) as response:
+            status = response.getcode()
+            body = response.read()
+            headers = dict(response.headers)
+    except urllib.error.HTTPError as exc:
+        status = exc.code
+        body = exc.read()
+        headers = dict(exc.headers)
+    except Exception as exc:
+        return _blocked(check_id, description, "request_failed", str(exc))
+
+    response_summary = _response_summary(status, body, headers)
+    allowed_statuses = expected_statuses or (expected_status,)
+    if status not in allowed_statuses:
+        expected_detail = (
+            f"HTTP {allowed_statuses[0]}"
+            if len(allowed_statuses) == 1
+            else "one of " + ", ".join(f"HTTP {value}" for value in allowed_statuses)
+        )
+        return _blocked(
+            check_id,
+            description,
+            "status_mismatch",
+            f"expected {expected_detail}, got HTTP {status}",
+            response=response_summary,
+        )
+    text = _decode_body(body)
+    if expected_body_contains and expected_body_contains not in text:
+        return _blocked(
+            check_id,
+            description,
+            "body_mismatch",
+            f"response body did not contain {expected_body_contains!r}",
+            response=response_summary,
+        )
+    if expected_body_contains_any and not any(
+        value in text for value in expected_body_contains_any
+    ):
+        return _blocked(
+            check_id,
+            description,
+            "body_mismatch",
+            "response body did not contain any of "
+            + ", ".join(repr(value) for value in expected_body_contains_any),
+            response=response_summary,
+        )
+    if expected_json_keys or expected_json_values:
+        try:
+            payload = json.loads(text or "{}")
+        except json.JSONDecodeError:
+            return _blocked(
+                check_id,
+                description,
+                "invalid_json",
+                "response was not valid JSON",
+                response=response_summary,
+            )
+        if not isinstance(payload, dict):
+            return _blocked(
+                check_id,
+                description,
+                "json_shape_mismatch",
+                "response JSON was not an object",
+                response=response_summary,
+            )
+        for key in expected_json_keys:
+            if key not in payload:
+                return _blocked(
+                    check_id,
+                    description,
+                    "json_key_missing",
+                    f"response JSON omitted {key!r}",
+                    response=response_summary,
+                )
+        for dotted_key, expected_value in (expected_json_values or {}).items():
+            actual_value = _json_path(payload, dotted_key)
+            if actual_value != expected_value:
+                return _blocked(
+                    check_id,
+                    description,
+                    "json_value_mismatch",
+                    f"{dotted_key} expected {expected_value!r}, got {actual_value!r}",
+                    response=response_summary,
+                )
+        for validator in expected_json_validators:
+            validation_error = validator(payload)
+            if validation_error is not None:
+                kind, detail = validation_error
+                return _blocked(
+                    check_id,
+                    description,
+                    kind,
+                    detail,
+                    response=response_summary,
+                )
+    return _passed(check_id, description, response=response_summary)
+
+
+def _public_tunnel_check(
+    *,
+    config_path: Path,
+    app_host: str,
+    expected_origin: str,
+    forbidden_hosts: tuple[str, ...],
+) -> dict[str, Any]:
+    report = build_public_tunnel_preflight_report(
+        config_path=config_path,
+        app_host=app_host,
+        expected_origin=expected_origin,
+        forbidden_hosts=forbidden_hosts,
+    )
+    response = {
+        "status": report["status"],
+        "summary": report["summary"],
+        "blockers": report["blockers"],
+        "ingress": report["ingress"],
+    }
+    if report["status"] != "passed":
+        return _blocked(
+            "tunnel.public_preflight",
+            "public tunnel routes app host to Rust and blocks legacy host",
+            "tunnel_preflight_blocked",
+            f"{report['summary']['blockers']} tunnel blocker(s)",
+            response=response,
+        )
+    return _passed(
+        "tunnel.public_preflight",
+        "public tunnel routes app host to Rust and blocks legacy host",
+        response=response,
+    )
+
+
+def _cloudflare_smoke_check(path: Path | None) -> dict[str, Any]:
+    description = "optional Cloudflare/mobile smoke report is passing when supplied"
+    if path is None:
+        return {
+            "id": "cloudflare.smoke_report",
+            "description": description,
+            "status": "skipped",
+            "detail": "cloudflare smoke report was not supplied",
+            "required": False,
+        }
+    try:
+        report = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return _blocked(
+            "cloudflare.smoke_report",
+            description,
+            "smoke_report_unreadable",
+            str(exc),
+        )
+    response = {
+        "status": report.get("status"),
+        "summary": report.get("summary"),
+        "blockers": report.get("blockers", []),
+    }
+    if report.get("status") != "passed":
+        return _blocked(
+            "cloudflare.smoke_report",
+            description,
+            "smoke_report_blocked",
+            f"smoke report status is {report.get('status')!r}",
+            response=response,
+        )
+    return _passed("cloudflare.smoke_report", description, response=response)
+
+
+def _response_summary(status: int, body: bytes, headers: dict[str, Any]) -> dict[str, Any]:
+    summary = {
+        "status": status,
+        "content_type": headers.get("content-type") or headers.get("Content-Type"),
+        "body_bytes": len(body),
+        "body_preview": _decode_body(body)[:300],
+    }
+    try:
+        payload = json.loads(_decode_body(body) or "{}")
+    except json.JSONDecodeError:
+        return summary
+    if isinstance(payload, dict):
+        summary["json_keys"] = sorted(payload.keys())
+    return summary
+
+
+def _json_path(payload: dict[str, Any], dotted_key: str) -> Any:
+    current: Any = payload
+    for part in dotted_key.split("."):
+        if not isinstance(current, dict):
+            return None
+        current = current.get(part)
+    return current
+
+
+def _mobile_terminal_ws_url_validator(app_host: str) -> JsonValidator:
+    def validate(payload: dict[str, Any]) -> tuple[str, str] | None:
+        value = _json_path(payload, "external_access.mobile_terminal_ws_url")
+        if not isinstance(value, str) or not value:
+            return (
+                "json_value_mismatch",
+                "external_access.mobile_terminal_ws_url was not a non-empty string",
+            )
+        parsed = urlparse(value)
+        if parsed.scheme != "wss":
+            return (
+                "json_value_mismatch",
+                f"mobile terminal URL scheme expected 'wss', got {parsed.scheme!r}",
+            )
+        if parsed.hostname != app_host:
+            return (
+                "json_value_mismatch",
+                f"mobile terminal URL host expected {app_host!r}, got {parsed.hostname!r}",
+            )
+        if not parsed.path.endswith("/client/terminal"):
+            return (
+                "json_value_mismatch",
+                "mobile terminal URL path did not end with '/client/terminal'",
+            )
+        return None
+
+    return validate
+
+
+def _decode_body(body: bytes) -> str:
+    return body.decode("utf-8", errors="replace")
+
+
+def _passed(check_id: str, description: str, *, response: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": check_id,
+        "description": description,
+        "status": "passed",
+        "detail": "ok",
+        "response": response,
+    }
+
+
+def _blocked(
+    check_id: str,
+    description: str,
+    kind: str,
+    detail: str,
+    *,
+    response: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    check = {
+        "id": check_id,
+        "description": description,
+        "status": "blocked",
+        "blocker_kind": kind,
+        "detail": detail,
+    }
+    if response is not None:
+        check["response"] = response
+    return check
+
+
+def _uid() -> str:
+    try:
+        import os
+
+        return str(os.getuid())
+    except Exception:  # pragma: no cover
+        return "$(id -u)"
+
+
+def _forbidden_hosts(legacy_host: str) -> tuple[str, ...]:
+    return tuple(dict.fromkeys((*DEFAULT_FORBIDDEN_HOSTS, legacy_host)))
+
+
+def main(
+    argv: list[str] | None = None,
+    *,
+    command_runner: CommandRunner = subprocess.run,
+    urlopen=urllib.request.urlopen,
+) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    parser.add_argument("--sm-binary", default=DEFAULT_SM_BINARY)
+    parser.add_argument("--rust-label", default=DEFAULT_RUST_LABEL)
+    parser.add_argument("--app-host", default=DEFAULT_APP_HOST)
+    parser.add_argument("--legacy-host", default=DEFAULT_LEGACY_HOST)
+    parser.add_argument("--tunnel-config", type=Path, default=DEFAULT_TUNNEL_CONFIG)
+    parser.add_argument("--expected-tunnel-origin", default=DEFAULT_EXPECTED_ORIGIN)
+    parser.add_argument("--cloudflare-smoke-report", type=Path)
+    parser.add_argument("--timeout", type=float, default=5.0)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--fail-on-blockers", action="store_true")
+    args = parser.parse_args(argv)
+
+    report = build_live_canary_report(
+        base_url=args.base_url,
+        sm_binary=args.sm_binary,
+        rust_label=args.rust_label,
+        app_host=args.app_host,
+        legacy_host=args.legacy_host,
+        tunnel_config=args.tunnel_config,
+        expected_tunnel_origin=args.expected_tunnel_origin,
+        cloudflare_smoke_report=args.cloudflare_smoke_report,
+        timeout_seconds=args.timeout,
+        command_runner=command_runner,
+        urlopen=urlopen,
+    )
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_text_report(report))
+    if args.fail_on_blockers and report["blockers"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/specs/762_stage5_artifacts/mvp_progress.md
+++ b/specs/762_stage5_artifacts/mvp_progress.md
@@ -4,7 +4,8 @@ Status: implementation snapshot after PR #1041 Rust service cutover tooling was
 merged and used for the first Rust canary flip on 2026-06-17. Issue #1042 adds
 the public tunnel preflight that verifies `sm-app.rajeshgo.li` routes directly
 to the launchd-managed Rust service and legacy `sm.rajeshgo.li` does not route
-to origin.
+to origin. Issue #1044 adds a non-mutating live canary report for the
+post-cutover Rust service.
 
 The last clean full real-state MVP rehearsal remains the post-#938 run; the
 post-#1035 rehearsal proves state gates, live core contracts, read-only
@@ -123,6 +124,7 @@ not change retained or removed scope. Binding scope remains
 | #1039 | Accelerated Rust canary evidence mode for Python-origin instability |
 | #1041 | Rust service launchd cutover tooling and first-canary runbook |
 | issue #1042 | Public tunnel preflight for the protected app hostname and legacy-host absence |
+| issue #1044 | Live Rust canary evidence collector for launchd/local/public-tunnel post-cutover checks |
 
 ## Implemented Capability Groups
 
@@ -130,7 +132,7 @@ The Rust sidecar now has executable coverage for:
 
 | Group | Current state |
 | --- | --- |
-| Harness and baselines | Contract manifest, fixture assertions, minimal value baseline runner, shadow comparison, MVP rehearsal, synthetic read-only fixture sidecar, disposable mutating fixtures, Rust CLI build gating, state preflight/backup/restore, stopped-origin final backup, freeze/drain evidence gates, Cloudflare Access smoke evidence runner, mobile-aware shadow observation gates, and accelerated Rust canary evidence mode exist. |
+| Harness and baselines | Contract manifest, fixture assertions, minimal value baseline runner, shadow comparison, MVP rehearsal, synthetic read-only fixture sidecar, disposable mutating fixtures, Rust CLI build gating, state preflight/backup/restore, stopped-origin final backup, freeze/drain evidence gates, Cloudflare Access smoke evidence runner, mobile-aware shadow observation gates, accelerated Rust canary evidence mode, public tunnel preflight, and live Rust canary report exist. |
 | Retired-surface checks | Retired public/watch/summary/remind/job-watch/queue-policy checks are represented as Rust-target absence or denial fixtures. |
 | Core reads | Health, auth session, bootstrap, session list/detail, client session list/detail, output, events state, SSE hello, nodes list, queue jobs list/detail, Codex review requests list/detail, and tool/audit read projections are implemented. |
 | Core runtime | Session/tmux/spawn/session-graph/message-queue/task-complete/input-batch/subagent and retained review-route slices are merged, with shadow and contract fixtures covering the early cutover path. |
@@ -149,8 +151,8 @@ Rust is now the live local service owner:
 - final stopped-origin backup:
   `.local/rust-final-backup-20260617T033653Z`;
 - protected app hostname: `sm-app.rajeshgo.li`;
-- legacy public hostname: `sm.rajeshgo.li` returns 404 from the tunnel and does
-  not route to origin;
+- legacy public hostname: `sm.rajeshgo.li` returns a Cloudflare denial or tunnel
+  404 and does not route to origin;
 - local cloudflared ingress should route `sm-app.rajeshgo.li` directly to
   `http://127.0.0.1:8420`, with a final `http_status:404` catch-all.
 
@@ -165,6 +167,29 @@ Validate the live tunnel shape with:
   --config .local/android-parity/cloudflared/config-http-only.yml \
   --fail-on-blockers
 ```
+
+Collect the live Rust canary evidence bundle with:
+
+```bash
+./venv/bin/python -m scripts.rust_migration.live_canary_report \
+  --output .local/rust-mvp-rehearsals/live-canary-$(date -u +%Y%m%dT%H%M%SZ).json \
+  --fail-on-blockers
+```
+
+The report is intentionally non-mutating. It records the Rust launchd label,
+local Rust health/bootstrap/session/analytics reads, `sm status`, the public
+tunnel preflight, unauthenticated `sm-app` Cloudflare Access denial, legacy
+public-host absence, and optional Cloudflare/mobile smoke evidence.
+
+Current live canary artifact:
+
+```text
+.local/rust-mvp-rehearsals/live-canary-20260617T192700Z.json
+```
+
+Summary: `10` passed, `0` blocked, `1` skipped. The skipped check is the
+optional supplied Cloudflare/mobile smoke report; all launchd, local Rust,
+tunnel, and public unauthenticated denial checks passed.
 
 The latest clean passive shadow report after #996 used
 `--last-minutes 30 --fail-on-blockers --json` and returned:
@@ -390,13 +415,13 @@ These are the next practical buckets before an MVP cutover trial:
 
 | Bucket | Why it remains |
 | --- | --- |
-| Shadow/canary observation window | Python-authoritative shadow mode is enabled and a short clean window has been recorded, but mobile gates from PR #942 still need real app/operator traffic. Prefer a longer agreed shadow window when Python stays healthy; otherwise use `--rust-canary-cutover` with Python spot checks plus Rust/state/Cloudflare gates and triage any blockers before Rust becomes the writer. |
+| Shadow/canary observation window | Python-authoritative shadow mode is now historical because Rust owns the live port. The live Rust canary report passes for launchd/local/tunnel/public-denial checks; remaining work is bounded app/operator smoke and any targeted comparison needed for specific bugs. If Python is restarted for comparison, use it only for targeted checks rather than broad hardening. |
 | Full fixture manifest execution | The MVP rehearsal now runs the current synthetic read-only and mutating fixture sets, including review-route fixtures. Remaining work is final live mobile/device fixture evidence and any additional retained fixture rows added by later slices. |
 | CLI cutover audit | Verify every retained CLI command in [cutover_scope.md](cutover_scope.md) is native Rust or intentionally routed, and every removed command is absent or explicitly retired. |
 | State ownership and migration tooling | Initial preflight, backup, restore, and freeze/drain evidence tools are merged and exercised by the rehearsal. Remaining work is live write-admission freeze/journal ownership and rollback accounting from [state_ownership_and_migration.md](state_ownership_and_migration.md). |
 | Cloudflare Access deployment integration | Pair the merged Rust origin gate with the actual Cloudflare Access apps, mTLS/service-auth policies, device Common Name enrollment/revocation, app-host native auth smoke, browser OAuth smoke, and later node fallback tests. Current evidence lives in [cloudflare_access_cutover_evidence.md](cloudflare_access_cutover_evidence.md). |
 | Node and queue writer completion | Basic node HTTP routes and narrow queue writer/recovery are implemented. Remaining work is final live/recovery cutover evidence, audit/rollback accounting, and any retained node-agent remote-control gaps. |
-| Service packaging and rollback | Exercise launchd/service cutover, non-destructive port ownership, health checks, rollback, and operator diagnostics. |
+| Service packaging and rollback | Launchd/service cutover has been exercised for the first Rust canary. Remaining work is continued live canary evidence, rollback rehearsal if needed, and operator diagnostics. |
 | Final native mobile smoke | Run bootstrap/session/attach/request-status/analytics/bug-report/app-artifact smoke checks against Rust using real mobile assumptions. |
 | Python-origin availability during evidence runs | Post-#1035 full rehearsal is blocked because Python watchdog-restarted during baseline/shadow. This does not call for broad Python hardening. Either collect the normal stable Python-authoritative window, or use the accelerated Rust canary evidence path with spot checks and Cloudflare/mobile smoke. |
 

--- a/specs/762_stage5_artifacts/resume_handoff.md
+++ b/specs/762_stage5_artifacts/resume_handoff.md
@@ -4,7 +4,8 @@ Status: handoff snapshot from 2026-06-17 after PR #1041 merged the reviewed
 Rust service launchd cutover tooling and the first Rust canary flip moved local
 production traffic to Rust. Issue #1042 adds the public tunnel preflight that
 keeps `sm-app.rajeshgo.li` pointed at the launchd-managed Rust service and
-keeps legacy `sm.rajeshgo.li` off origin.
+keeps legacy `sm.rajeshgo.li` off origin. Issue #1044 adds the post-cutover
+live Rust canary report.
 
 Use this file to resume the Rust cutover track without reconstructing state from
 chat history. Binding scope still lives in [cutover_scope.md](cutover_scope.md),
@@ -32,12 +33,14 @@ Service cutover commands live in
   `.local/rust-final-backup-20260617T033653Z`.
 - `sm-app.rajeshgo.li` is the protected public app hostname. It should route
   through Cloudflare Access to `http://127.0.0.1:8420`.
-- Legacy `sm.rajeshgo.li` should not route to origin and should return 404 from
-  the tunnel.
+- Legacy `sm.rajeshgo.li` should not route to origin. It may return Cloudflare
+  denial or tunnel 404, but must not return the Rust origin health response.
 - The prior `127.0.0.1:8421` Rust sidecar was useful for shadow/rehearsal but
   is not part of the live target after the tunnel is repointed to `8420`.
 - Validate the local public tunnel shape with
   `./venv/bin/python -m scripts.rust_migration.public_tunnel_preflight --config .local/android-parity/cloudflared/config-http-only.yml --fail-on-blockers`.
+- Collect live canary evidence with
+  `./venv/bin/python -m scripts.rust_migration.live_canary_report --output .local/rust-mvp-rehearsals/live-canary-$(date -u +%Y%m%dT%H%M%SZ).json --fail-on-blockers`.
 
 ## Completed Work
 
@@ -198,6 +201,9 @@ Merged Rust slices cover:
 - Issue #1042 adds the public tunnel preflight so the protected app hostname is
   validated against `127.0.0.1:8420` and legacy public host routes are blocked
   before relying on the app path.
+- Issue #1044 adds the live canary report that records launchd ownership, local
+  Rust health/native reads, `sm status`, public tunnel shape, public Access
+  denial, and legacy-host absence without mutating live state.
 - Current contract manifest size:
   - `134` checks total
   - `73` `python_and_rust`
@@ -401,6 +407,19 @@ assertion is present. It remains blocked because the shell did not have
 `SM_DEVICE_BEARER_TOKEN`, or `SM_COOKIE` set. Summary: `1` passed, `5`
 blocked, `7` skipped. This is partial boundary evidence only.
 
+Post-cutover live Rust canary evidence:
+
+```text
+.local/rust-mvp-rehearsals/live-canary-20260617T192700Z.json
+```
+
+Summary: `10` passed, `0` blocked, `1` skipped. The passing checks cover the
+Rust launchd label, local Rust health/detailed health/bootstrap/session
+list/native analytics reads, `sm status`, local public tunnel preflight,
+unauthenticated `sm-app` public denial before origin, and legacy public-host
+absence. The skipped check is the optional supplied Cloudflare/mobile smoke
+report.
+
 No newer clean full passive shadow or full Cloudflare/mobile smoke artifact has
 been recorded in this handoff. PR #1012 published Android artifact `cbb61798`
 (`versionCode=1013`, `versionName=0.1.0-enroll-ui-cleanup`) and operator
@@ -519,26 +538,24 @@ Do not start Rust writer ownership or MVP cutover until:
 
 ## Recommended Resume Point
 
-Continue with Cloudflare Access deployment evidence, then produce either normal
-shadow evidence or the accelerated Rust canary report:
+Continue with the live Rust canary report, then fill in any remaining bounded
+Cloudflare/mobile smoke gaps:
 
-1. Provide the smoke runner proof inputs for the already configured Cloudflare
+1. Keep `scripts.rust_migration.live_canary_report` passing against the live
+   Rust service and treat any new blocker as a bounded Rust/service/tunnel bug.
+2. Provide the smoke runner proof inputs for the already configured Cloudflare
    Access apps: mobile/browser Access JWTs, public-edge HMAC secret, and SM
    bearer/cookie.
-2. Configure or verify any remaining Cloudflare Access apps/policies described in
+3. Configure or verify any remaining Cloudflare Access apps/policies described in
    [cloudflare_access_cutover_evidence.md](cloudflare_access_cutover_evidence.md).
-3. Exercise the native app route class through the app hostname so mobile gates
+4. Exercise the native app route class through the app hostname so mobile gates
    collect real traffic and smoke evidence.
-4. If Python remains stable, keep Python-authoritative Rust shadow running for
-   retained reads, let it observe real traffic for the agreed window, and
-   summarize the ledger by route/comparison/mismatch.
-5. If Python remains the unstable component, run `mvp_rehearsal
-   --rust-canary-cutover --cloudflare-smoke-report <passed-smoke-json>` and use
-   that report as the cutover-candidate evidence artifact.
+5. If Python is restarted for comparison, keep it to targeted checks or the
+   explicit `--rust-canary-cutover` path; do not do broad Python hardening.
 6. Convert any unexplained retained-surface mismatch or canary blocker into a
    bounded Rust slice.
 
 This is the highest-signal next step because the Rust origin gate is merged and
-the broad Python service is now the limiting factor. Do not do broad Python
-hardening; prove the Rust canary path or fix bounded Rust/Cloudflare/mobile
+the broad Python service is no longer the live owner. Do not do broad Python
+hardening; prove the Rust live canary path or fix bounded Rust/Cloudflare/mobile
 blockers.

--- a/specs/762_stage5_artifacts/rust_service_cutover_runbook.md
+++ b/specs/762_stage5_artifacts/rust_service_cutover_runbook.md
@@ -138,7 +138,22 @@ curl -sS -o /tmp/sm-app-health-public.txt -w 'sm-app %{http_code}\n' https://sm-
 curl -sS -o /tmp/sm-legacy-health-public.txt -w 'legacy %{http_code}\n' https://sm.rajeshgo.li/health
 ```
 
-Expected: `sm-app 403` from Cloudflare Access and `legacy 404`.
+Expected: `sm-app 403` from Cloudflare Access or another Cloudflare
+before-origin denial, and `legacy 403` or `legacy 404`. A `200` health response
+from either public hostname is a blocker because it means unauthenticated
+traffic reached origin.
+
+Collect the same checks as a single JSON evidence artifact:
+
+```bash
+./venv/bin/python -m scripts.rust_migration.live_canary_report \
+  --output .local/rust-mvp-rehearsals/live-canary-$(date -u +%Y%m%dT%H%M%SZ).json \
+  --fail-on-blockers
+```
+
+This command is non-mutating. It records Rust launchd ownership, local Rust
+health/native-read checks, `sm status`, tunnel config shape, public Access
+denial, legacy-host absence, and optional Cloudflare/mobile smoke evidence.
 
 ## First 15-Minute Smoke Checklist
 

--- a/tests/unit/test_rust_live_canary_report.py
+++ b/tests/unit/test_rust_live_canary_report.py
@@ -1,0 +1,405 @@
+import json
+import subprocess
+import urllib.error
+from pathlib import Path
+
+from scripts.rust_migration.live_canary_report import (
+    build_live_canary_report,
+    main as live_canary_main,
+    render_text_report,
+)
+
+
+class FakeResponse:
+    def __init__(self, status, body, headers=None):
+        self.status = status
+        self._body = body
+        self.headers = headers or {"content-type": "application/json"}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def getcode(self):
+        return self.status
+
+    def read(self):
+        return self._body
+
+
+class _BytesHandle:
+    def __init__(self, body):
+        self._body = body
+
+    def read(self):
+        return self._body
+
+    def close(self):
+        pass
+
+
+def _http_error(url, status, body, content_type="application/json"):
+    if isinstance(body, dict):
+        payload = json.dumps(body).encode("utf-8")
+    elif isinstance(body, str):
+        payload = body.encode("utf-8")
+    else:
+        payload = body
+    return urllib.error.HTTPError(
+        url,
+        status,
+        "error",
+        {"content-type": content_type},
+        _BytesHandle(payload),
+    )
+
+
+def _write_tunnel_config(path: Path, service="http://127.0.0.1:8420") -> None:
+    path.write_text(
+        f"""
+tunnel: test-tunnel
+credentials-file: /tmp/test-tunnel.json
+ingress:
+  - hostname: sm-app.rajeshgo.li
+    service: {service}
+  - service: http_status:404
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+
+def _command_runner(command, text, capture_output, check, timeout):
+    assert text is True
+    assert capture_output is True
+    assert check is False
+    assert timeout == 2.5
+    if command[0] == "launchctl":
+        return subprocess.CompletedProcess(command, 0, "state = running\n", "")
+    if command[-1] == "status":
+        return subprocess.CompletedProcess(command, 0, "007c6275 idle sm-maintainer\n", "")
+    raise AssertionError(f"unexpected command {command}")
+
+
+def _urlopen(request, timeout):
+    assert timeout == 2.5
+    url = request.full_url
+    if url.endswith("/health") and url.startswith("http://127.0.0.1:8420"):
+        return FakeResponse(200, b'{"status":"healthy"}')
+    if url.endswith("/health/detailed"):
+        return FakeResponse(200, b'{"status":"healthy","checks":{}}')
+    if url.endswith("/client/bootstrap"):
+        return FakeResponse(
+            200,
+            json.dumps(
+                {
+                    "auth": {},
+                    "external_access": {
+                        "public_http_host": "sm-app.rajeshgo.li",
+                        "mobile_terminal_ws_url": "wss://sm-app.rajeshgo.li/client/terminal",
+                    },
+                }
+            ).encode("utf-8"),
+        )
+    if url.endswith("/client/sessions"):
+        return FakeResponse(200, b'{"sessions":[]}')
+    if url.endswith("/client/analytics/summary"):
+        return FakeResponse(200, b'{"generated_at":"now","kpis":{}}')
+    if url == "https://sm-app.rajeshgo.li/health":
+        raise _http_error(
+            url,
+            403,
+            "<title>Error - Cloudflare Access</title>",
+            content_type="text/html",
+        )
+    if url == "https://sm.rajeshgo.li/health":
+        raise _http_error(url, 404, b"", content_type="text/plain")
+    raise AssertionError(f"unexpected URL {url}")
+
+
+def test_live_canary_report_passes_with_expected_cutover_shape(tmp_path):
+    tunnel_config = tmp_path / "cloudflared.yml"
+    _write_tunnel_config(tunnel_config)
+
+    report = build_live_canary_report(
+        tunnel_config=tunnel_config,
+        timeout_seconds=2.5,
+        command_runner=_command_runner,
+        urlopen=_urlopen,
+    )
+
+    assert report["status"] == "passed"
+    assert report["blockers"] == []
+    assert report["summary"]["blocked"] == 0
+    by_id = {check["id"]: check for check in report["checks"]}
+    assert by_id["launchd.rust_service_running"]["status"] == "passed"
+    assert by_id["tunnel.public_preflight"]["status"] == "passed"
+    assert by_id["public.sm_app_requires_access"]["status"] == "passed"
+    assert by_id["public.legacy_host_absent"]["status"] == "passed"
+    assert by_id["cloudflare.smoke_report"]["status"] == "skipped"
+
+
+def test_live_canary_report_blocks_when_app_public_probe_reaches_origin(tmp_path):
+    tunnel_config = tmp_path / "cloudflared.yml"
+    _write_tunnel_config(tunnel_config)
+
+    def urlopen_origin_leak(request, timeout):
+        if request.full_url == "https://sm-app.rajeshgo.li/health":
+            return FakeResponse(200, b'{"status":"healthy"}')
+        return _urlopen(request, timeout)
+
+    report = build_live_canary_report(
+        tunnel_config=tunnel_config,
+        timeout_seconds=2.5,
+        command_runner=_command_runner,
+        urlopen=urlopen_origin_leak,
+    )
+
+    assert report["status"] == "blocked"
+    assert {
+        "check_id": "public.sm_app_requires_access",
+        "kind": "status_mismatch",
+        "detail": "expected HTTP 403, got HTTP 200",
+    } in report["blockers"]
+
+
+def test_live_canary_report_accepts_prefixed_mobile_terminal_url(tmp_path):
+    tunnel_config = tmp_path / "cloudflared.yml"
+    _write_tunnel_config(tunnel_config)
+
+    def urlopen_prefixed_terminal(request, timeout):
+        if request.full_url.endswith("/client/bootstrap"):
+            return FakeResponse(
+                200,
+                json.dumps(
+                    {
+                        "auth": {},
+                        "external_access": {
+                            "public_http_host": "sm-app.rajeshgo.li",
+                            "mobile_terminal_ws_url": (
+                                "wss://sm-app.rajeshgo.li/app/client/terminal"
+                            ),
+                        },
+                    }
+                ).encode("utf-8"),
+            )
+        return _urlopen(request, timeout)
+
+    report = build_live_canary_report(
+        tunnel_config=tunnel_config,
+        timeout_seconds=2.5,
+        command_runner=_command_runner,
+        urlopen=urlopen_prefixed_terminal,
+    )
+
+    assert report["status"] == "passed"
+
+
+def test_live_canary_report_blocks_invalid_mobile_terminal_url(tmp_path):
+    tunnel_config = tmp_path / "cloudflared.yml"
+    _write_tunnel_config(tunnel_config)
+
+    def urlopen_bad_terminal(request, timeout):
+        if request.full_url.endswith("/client/bootstrap"):
+            return FakeResponse(
+                200,
+                json.dumps(
+                    {
+                        "auth": {},
+                        "external_access": {
+                            "public_http_host": "sm-app.rajeshgo.li",
+                            "mobile_terminal_ws_url": (
+                                "wss://sm-app.rajeshgo.li/app/not-terminal"
+                            ),
+                        },
+                    }
+                ).encode("utf-8"),
+            )
+        return _urlopen(request, timeout)
+
+    report = build_live_canary_report(
+        tunnel_config=tunnel_config,
+        timeout_seconds=2.5,
+        command_runner=_command_runner,
+        urlopen=urlopen_bad_terminal,
+    )
+
+    assert report["status"] == "blocked"
+    assert any(
+        blocker["check_id"] == "local.client_bootstrap"
+        and blocker["kind"] == "json_value_mismatch"
+        for blocker in report["blockers"]
+    )
+
+
+def test_live_canary_report_accepts_cloudflare_1010_denials(tmp_path):
+    tunnel_config = tmp_path / "cloudflared.yml"
+    _write_tunnel_config(tunnel_config)
+
+    def urlopen_cloudflare_1010(request, timeout):
+        if request.full_url in {
+            "https://sm-app.rajeshgo.li/health",
+            "https://sm.rajeshgo.li/health",
+        }:
+            raise _http_error(
+                request.full_url,
+                403,
+                "error code: 1010",
+                content_type="text/plain",
+            )
+        return _urlopen(request, timeout)
+
+    report = build_live_canary_report(
+        tunnel_config=tunnel_config,
+        timeout_seconds=2.5,
+        command_runner=_command_runner,
+        urlopen=urlopen_cloudflare_1010,
+    )
+
+    assert report["status"] == "passed"
+    by_id = {check["id"]: check for check in report["checks"]}
+    assert by_id["public.sm_app_requires_access"]["status"] == "passed"
+    assert by_id["public.legacy_host_absent"]["status"] == "passed"
+
+
+def test_live_canary_report_blocks_when_tunnel_targets_sidecar(tmp_path):
+    tunnel_config = tmp_path / "cloudflared.yml"
+    _write_tunnel_config(tunnel_config, service="http://127.0.0.1:8421")
+
+    report = build_live_canary_report(
+        tunnel_config=tunnel_config,
+        timeout_seconds=2.5,
+        command_runner=_command_runner,
+        urlopen=_urlopen,
+    )
+
+    assert report["status"] == "blocked"
+    assert any(
+        blocker["check_id"] == "tunnel.public_preflight"
+        and blocker["kind"] == "tunnel_preflight_blocked"
+        for blocker in report["blockers"]
+    )
+
+
+def test_live_canary_report_uses_configured_legacy_host_in_tunnel_preflight(tmp_path):
+    tunnel_config = tmp_path / "cloudflared.yml"
+    tunnel_config.write_text(
+        """
+tunnel: test-tunnel
+credentials-file: /tmp/test-tunnel.json
+ingress:
+  - hostname: sm-app.rajeshgo.li
+    service: http://127.0.0.1:8420
+  - hostname: old.example.com
+    service: http://127.0.0.1:8420
+  - service: http_status:404
+""".lstrip(),
+        encoding="utf-8",
+    )
+
+    def urlopen_custom_legacy(request, timeout):
+        if request.full_url == "https://old.example.com/health":
+            raise _http_error(
+                request.full_url,
+                403,
+                "error code: 1010",
+                content_type="text/plain",
+            )
+        return _urlopen(request, timeout)
+
+    report = build_live_canary_report(
+        tunnel_config=tunnel_config,
+        legacy_host="old.example.com",
+        timeout_seconds=2.5,
+        command_runner=_command_runner,
+        urlopen=urlopen_custom_legacy,
+    )
+
+    assert report["status"] == "blocked"
+    assert any(
+        blocker["check_id"] == "tunnel.public_preflight"
+        and blocker["kind"] == "tunnel_preflight_blocked"
+        for blocker in report["blockers"]
+    )
+
+
+def test_live_canary_report_blocks_command_timeouts(tmp_path):
+    tunnel_config = tmp_path / "cloudflared.yml"
+    _write_tunnel_config(tunnel_config)
+
+    def command_timeout(command, text, capture_output, check, timeout):
+        if command[-1] == "status":
+            raise subprocess.TimeoutExpired(command, timeout)
+        return _command_runner(command, text, capture_output, check, timeout)
+
+    report = build_live_canary_report(
+        tunnel_config=tunnel_config,
+        timeout_seconds=2.5,
+        command_runner=command_timeout,
+        urlopen=_urlopen,
+    )
+
+    assert report["status"] == "blocked"
+    assert {
+        "check_id": "cli.status",
+        "kind": "command_timeout",
+        "detail": "command timed out after 2.5 seconds",
+    } in report["blockers"]
+
+
+def test_live_canary_report_blocks_supplied_failed_smoke_report(tmp_path):
+    tunnel_config = tmp_path / "cloudflared.yml"
+    _write_tunnel_config(tunnel_config)
+    smoke_report = tmp_path / "smoke.json"
+    smoke_report.write_text(
+        json.dumps({"status": "blocked", "summary": {"blocked": 1}, "blockers": [{"x": 1}]}),
+        encoding="utf-8",
+    )
+
+    report = build_live_canary_report(
+        tunnel_config=tunnel_config,
+        cloudflare_smoke_report=smoke_report,
+        timeout_seconds=2.5,
+        command_runner=_command_runner,
+        urlopen=_urlopen,
+    )
+
+    assert report["status"] == "blocked"
+    assert any(
+        blocker["check_id"] == "cloudflare.smoke_report"
+        and blocker["kind"] == "smoke_report_blocked"
+        for blocker in report["blockers"]
+    )
+
+
+def test_live_canary_report_text_cli_and_output_file(tmp_path, capsys):
+    tunnel_config = tmp_path / "cloudflared.yml"
+    _write_tunnel_config(tunnel_config, service="http://127.0.0.1:8421")
+    output = tmp_path / "report.json"
+
+    report = build_live_canary_report(
+        tunnel_config=tunnel_config,
+        timeout_seconds=2.5,
+        command_runner=_command_runner,
+        urlopen=_urlopen,
+    )
+    text = render_text_report(report)
+    assert "Rust live canary report" in text
+    assert "tunnel.public_preflight" in text
+
+    rc = live_canary_main(
+        [
+            "--tunnel-config",
+            str(tunnel_config),
+            "--output",
+            str(output),
+            "--fail-on-blockers",
+        ],
+        command_runner=_command_runner,
+        urlopen=_urlopen,
+    )
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "status: blocked" in captured.out
+    assert json.loads(output.read_text(encoding="utf-8"))["status"] == "blocked"

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -267,7 +267,7 @@ def test_cloudflare_access_cutover_evidence_pins_policy_and_origin_gates():
         assert required in evidence
 
 
-def test_handoff_and_progress_are_current_through_public_tunnel_issue1042():
+def test_handoff_and_progress_are_current_through_live_canary_issue1044():
     progress = (STAGE5_DIR / "mvp_progress.md").read_text(encoding="utf-8")
     handoff = (STAGE5_DIR / "resume_handoff.md").read_text(encoding="utf-8")
     gate_matrix = (STAGE5_DIR / "gate_matrix.md").read_text(encoding="utf-8")
@@ -294,9 +294,11 @@ def test_handoff_and_progress_are_current_through_public_tunnel_issue1042():
         assert "#1039" in text
         assert "#1041" in text
         assert "issue #1042" in text.lower()
+        assert "issue #1044" in text.lower()
         assert "Cloudflare Access" in text
         assert "cloudflare_access_cutover_evidence.md" in text
         assert "public_tunnel_preflight" in text
+        assert "live_canary_report" in text
         assert "sm-app.rajeshgo.li" in text
         assert "python_canary_spot_checks" in text
         assert "cloudflare_access_smoke_report" in text
@@ -311,6 +313,7 @@ def test_handoff_and_progress_are_current_through_public_tunnel_issue1042():
     assert "app update artifact access works through the certificate-gated app path" in handoff
     assert "--cloudflare-smoke-report" in readme
     assert "public_tunnel_preflight" in readme
+    assert "live_canary_report" in readme
 
 
 def test_manifest_covers_rust_only_retired_http_surfaces():


### PR DESCRIPTION
## Summary
- add a non-mutating live Rust canary collector for launchd, local Rust reads, CLI status, tunnel shape, public app denial, and legacy host absence
- document the post-cutover canary command in the Rust migration README and Stage 5 runbook/handoff
- record the current passing live canary artifact `.local/rust-mvp-rehearsals/live-canary-20260617T192700Z.json`

## Validation
- `./venv/bin/python -m pytest tests/unit/test_rust_live_canary_report.py tests/unit/test_rust_public_tunnel_preflight.py tests/unit/test_rust_migration_contracts.py -q`
- `./venv/bin/python -m py_compile scripts/rust_migration/live_canary_report.py`
- `git diff --check`
- `./venv/bin/python -m scripts.rust_migration.live_canary_report --output .local/rust-mvp-rehearsals/live-canary-20260617T192700Z.json --fail-on-blockers`

Fixes #1044