### PR TITLE
Add public mTLS Cloudflare smoke evidence

### DIFF
--- a/scripts/rust_migration/README.md
+++ b/scripts/rust_migration/README.md
@@ -488,7 +488,39 @@ rehearsal gates, not by executing Rust against live state from shadow mode.
 ## Cloudflare Access Smoke Evidence
 
 After the Cloudflare Access apps and tunnel policies are configured, collect
-read-only origin-gate evidence with:
+read-only public mTLS evidence with:
+
+```bash
+cn=$(sqlite3 "$HOME/.local/share/claude-sessions/mobile_devices.db" \
+  "SELECT common_name FROM mobile_device_enrollments WHERE revoked_at IS NULL ORDER BY paired_at DESC LIMIT 1;")
+
+python -m scripts.rust_migration.cloudflare_access_smoke \
+  --mode public-mtls \
+  --public-base-url https://sm-app.rajeshgo.li \
+  --client-cert-common-name "$cn" \
+  --device-ca-cert-file certs/sm-mobile-device-ca.pem \
+  --device-ca-key-file certs/sm-mobile-device-ca.key \
+  --output /tmp/sm-cloudflare-access-smoke.json \
+  --json \
+  --fail-on-blockers
+```
+
+This public mode generates an ephemeral client certificate in a temporary
+directory from the local mobile CA and enrolled device Common Name. The report
+does not record certificate material, private keys, Cloudflare cookies, Access
+tokens, bearer tokens, or raw auth-sensitive response bodies. It proves:
+
+- the public app host denies `/client/bootstrap` without a client certificate;
+- a valid client certificate reaches `/client/bootstrap`;
+- `/client/sessions` still stops at the SM auth boundary without an SM bearer or
+  session cookie;
+- app artifact metadata is reachable through the certificate-gated app host.
+
+The optional authenticated `/client/sessions` check runs only when an SM bearer
+token or cookie is supplied.
+
+The older origin-gate mode remains available for synthetic header checks against
+a local origin:
 
 ```bash
 python -m scripts.rust_migration.cloudflare_access_smoke \
@@ -508,11 +540,8 @@ provided through `--*-env` or `--*-file` options so they do not appear in proces
 arguments or shell history. File inputs strip one trailing newline.
 
 The smoke runner does not configure Cloudflare and does not perform mutating
-native app flows by default. It records missing/provided Access proof behavior,
-mobile bootstrap, app artifact metadata, the mobile Access-to-SM-auth boundary,
-and optional authenticated native session reads when an SM bearer token or
-cookie is supplied. Mobile success probes reject redirects/login HTML by
-requiring the expected JSON response shape. Browser `/auth/session` Access
+native app flows by default. Mobile success probes reject redirects/login HTML
+by requiring the expected JSON response shape. Browser `/auth/session` Access
 denial is enforced by Cloudflare at the edge rather than by the Rust origin, so
 the loopback smoke report records those checks as skipped edge-only evidence.
 Use the JSON output as operator evidence alongside
@@ -526,14 +555,15 @@ the system, use the explicit Rust canary path instead of spending time on
 throwaway Python hardening:
 
 ```bash
+cn=$(sqlite3 "$HOME/.local/share/claude-sessions/mobile_devices.db" \
+  "SELECT common_name FROM mobile_device_enrollments WHERE revoked_at IS NULL ORDER BY paired_at DESC LIMIT 1;")
+
 python -m scripts.rust_migration.cloudflare_access_smoke \
-  --base-url http://127.0.0.1:8421 \
-  --mobile-host sm-app.rajeshgo.li \
-  --browser-host sm.rajeshgo.li \
-  --mobile-access-jwt-env CF_MOBILE_ACCESS_JWT \
-  --browser-access-jwt-env CF_BROWSER_ACCESS_JWT \
-  --public-edge-secret-env SM_PUBLIC_EDGE_SECRET \
-  --bearer-token-env SM_DEVICE_BEARER_TOKEN \
+  --mode public-mtls \
+  --public-base-url https://sm-app.rajeshgo.li \
+  --client-cert-common-name "$cn" \
+  --device-ca-cert-file certs/sm-mobile-device-ca.pem \
+  --device-ca-key-file certs/sm-mobile-device-ca.key \
   --output /tmp/sm-cloudflare-access-smoke.json \
   --json \
   --fail-on-blockers
@@ -549,7 +579,7 @@ baseline. It replaces sustained Python baseline/shadow with
 `python_canary_spot_checks` for a small authority sanity set, then requires a
 passed Cloudflare/mobile smoke report as `cloudflare_access_smoke_report`.
 Reports produced this way are cutover-candidate evidence only when blockers are
-zero and the smoke report used real Access/public-edge/SM auth inputs.
+zero and the smoke report used the real public mTLS app host.
 
 ## MVP Sidecar Rehearsal
 

--- a/scripts/rust_migration/cloudflare_access_smoke.py
+++ b/scripts/rust_migration/cloudflare_access_smoke.py
@@ -13,6 +13,8 @@ import hashlib
 import hmac
 import json
 import os
+import subprocess
+import tempfile
 import time
 import urllib.error
 import urllib.request
@@ -24,11 +26,15 @@ from typing import Any
 
 DEFAULT_BASE_URL = "http://127.0.0.1:8421"
 DEFAULT_APP_NAME = "session-manager-android"
+SMOKE_MODE_ORIGIN = "origin"
+SMOKE_MODE_PUBLIC_MTLS = "public-mtls"
 
 
 def build_smoke_report(
     *,
+    mode: str = SMOKE_MODE_ORIGIN,
     base_url: str = DEFAULT_BASE_URL,
+    public_base_url: str | None = None,
     mobile_host: str | None = None,
     browser_host: str | None = None,
     mobile_access_jwt: str | None = None,
@@ -38,11 +44,32 @@ def build_smoke_report(
     cookie: str | None = None,
     session_id: str | None = None,
     app_name: str = DEFAULT_APP_NAME,
+    client_cert_file: Path | None = None,
+    client_key_file: Path | None = None,
+    client_cert_common_name: str | None = None,
+    device_ca_cert_file: Path | None = None,
+    device_ca_key_file: Path | None = None,
     timeout_seconds: float = 5.0,
     urlopen=None,
 ) -> dict[str, Any]:
     if timeout_seconds <= 0:
         raise ValueError("--timeout must be positive")
+    if mode == SMOKE_MODE_PUBLIC_MTLS:
+        return _build_public_mtls_smoke_report(
+            public_base_url=public_base_url,
+            bearer_token=bearer_token,
+            cookie=cookie,
+            app_name=app_name,
+            client_cert_file=client_cert_file,
+            client_key_file=client_key_file,
+            client_cert_common_name=client_cert_common_name,
+            device_ca_cert_file=device_ca_cert_file,
+            device_ca_key_file=device_ca_key_file,
+            timeout_seconds=timeout_seconds,
+            urlopen=urlopen,
+        )
+    if mode != SMOKE_MODE_ORIGIN:
+        raise ValueError(f"unknown smoke mode: {mode}")
     base_url = base_url.rstrip("/")
     checks = [
         _request_check(
@@ -222,6 +249,386 @@ def build_smoke_report(
         },
         "checks": checks,
         "blockers": blockers,
+    }
+
+
+def _build_public_mtls_smoke_report(
+    *,
+    public_base_url: str | None,
+    bearer_token: str | None,
+    cookie: str | None,
+    app_name: str,
+    client_cert_file: Path | None,
+    client_key_file: Path | None,
+    client_cert_common_name: str | None,
+    device_ca_cert_file: Path | None,
+    device_ca_key_file: Path | None,
+    timeout_seconds: float,
+    urlopen,
+) -> dict[str, Any]:
+    public_base_url = (public_base_url or "").rstrip("/")
+    cert_source = _resolve_public_mtls_cert_source(
+        client_cert_file=client_cert_file,
+        client_key_file=client_key_file,
+        client_cert_common_name=client_cert_common_name,
+        device_ca_cert_file=device_ca_cert_file,
+        device_ca_key_file=device_ca_key_file,
+    )
+    checks: list[dict[str, Any]]
+    if not public_base_url:
+        checks = [
+            _skipped(
+                "public_mtls.bootstrap_requires_client_cert",
+                "public host denies bootstrap without a client certificate",
+                "public base URL was not supplied",
+                required=True,
+            )
+        ]
+    elif cert_source["status"] == "blocked":
+        checks = [
+            _blocked(
+                "public_mtls.client_certificate_available",
+                "public mTLS client certificate is available for the smoke run",
+                cert_source["blocker_kind"],
+                cert_source["detail"],
+                method="GET",
+                path="/client/bootstrap",
+                expected_status=200,
+                actual_status=None,
+                response=None,
+            )
+        ]
+    else:
+        cert_file = cert_source["cert_file"]
+        key_file = cert_source["key_file"]
+        checks = _run_public_mtls_checks(
+            public_base_url=public_base_url,
+            bearer_token=bearer_token,
+            cookie=cookie,
+            app_name=app_name,
+            client_cert_file=cert_file,
+            client_key_file=key_file,
+            timeout_seconds=timeout_seconds,
+            urlopen=urlopen,
+        )
+
+    blockers = []
+    for check in checks:
+        if check["status"] == "blocked":
+            blockers.append(
+                {
+                    "check_id": check["id"],
+                    "kind": check["blocker_kind"],
+                    "detail": check["detail"],
+                }
+            )
+        elif check["status"] == "skipped" and check.get("required"):
+            blockers.append(
+                {
+                    "check_id": check["id"],
+                    "kind": "required_check_skipped",
+                    "detail": check["detail"],
+                }
+            )
+    return {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "inputs": {
+            "mode": SMOKE_MODE_PUBLIC_MTLS,
+            "public_base_url": public_base_url or None,
+            "client_cert_file_supplied": bool(client_cert_file),
+            "client_key_file_supplied": bool(client_key_file),
+            "client_cert_common_name_supplied": bool(client_cert_common_name),
+            "device_ca_cert_file_supplied": bool(device_ca_cert_file),
+            "device_ca_key_file_supplied": bool(device_ca_key_file),
+            "ephemeral_client_cert_generated": cert_source.get("ephemeral", False),
+            "client_cert_common_name": client_cert_common_name,
+            "sm_auth_supplied": bool(bearer_token or cookie),
+            "app_name": app_name,
+        },
+        "status": "blocked" if blockers else "passed",
+        "summary": {
+            "passed": sum(1 for check in checks if check["status"] == "passed"),
+            "blocked": len(blockers),
+            "skipped": sum(1 for check in checks if check["status"] == "skipped"),
+        },
+        "checks": checks,
+        "blockers": blockers,
+    }
+
+
+def _resolve_public_mtls_cert_source(
+    *,
+    client_cert_file: Path | None,
+    client_key_file: Path | None,
+    client_cert_common_name: str | None,
+    device_ca_cert_file: Path | None,
+    device_ca_key_file: Path | None,
+) -> dict[str, Any]:
+    if (client_cert_file is None) ^ (client_key_file is None):
+        return {
+            "status": "blocked",
+            "blocker_kind": "client_cert_incomplete",
+            "detail": "both client cert and key files must be supplied",
+        }
+    if client_cert_file and client_key_file:
+        if not client_cert_file.is_file():
+            return {
+                "status": "blocked",
+                "blocker_kind": "client_cert_missing",
+                "detail": f"client cert file does not exist: {client_cert_file}",
+            }
+        if not client_key_file.is_file():
+            return {
+                "status": "blocked",
+                "blocker_kind": "client_key_missing",
+                "detail": f"client key file does not exist: {client_key_file}",
+            }
+        return {
+            "status": "ok",
+            "cert_file": client_cert_file,
+            "key_file": client_key_file,
+            "ephemeral": False,
+        }
+    if not (client_cert_common_name and device_ca_cert_file and device_ca_key_file):
+        return {
+            "status": "blocked",
+            "blocker_kind": "client_cert_missing",
+            "detail": (
+                "supply client cert/key files or client cert common name plus device CA "
+                "cert/key files"
+            ),
+        }
+    try:
+        _validate_client_cert_common_name(client_cert_common_name)
+        generated = _generate_ephemeral_client_cert(
+            common_name=client_cert_common_name,
+            device_ca_cert_file=device_ca_cert_file,
+            device_ca_key_file=device_ca_key_file,
+        )
+    except Exception as exc:  # noqa: BLE001 - evidence report should capture failures.
+        return {
+            "status": "blocked",
+            "blocker_kind": "client_cert_generation_failed",
+            "detail": f"{type(exc).__name__}: {exc}",
+        }
+    return {
+        "status": "ok",
+        "cert_file": generated["cert_file"],
+        "key_file": generated["key_file"],
+        "ephemeral": True,
+        "_tempdir": generated["_tempdir"],
+    }
+
+
+def _run_public_mtls_checks(
+    *,
+    public_base_url: str,
+    bearer_token: str | None,
+    cookie: str | None,
+    app_name: str,
+    client_cert_file: Path,
+    client_key_file: Path,
+    timeout_seconds: float,
+    urlopen,
+) -> list[dict[str, Any]]:
+    cert_urlopen = urlopen or _build_client_cert_urlopen(client_cert_file, client_key_file)
+    no_cert_urlopen = urlopen or _urlopen_no_redirect
+    checks = [
+        _public_request_check(
+            check_id="public_mtls.bootstrap_requires_client_cert",
+            description="public host denies bootstrap without a client certificate",
+            base_url=public_base_url,
+            method="GET",
+            path="/client/bootstrap",
+            expected_status=403,
+            timeout_seconds=timeout_seconds,
+            urlopen=no_cert_urlopen,
+            include_response_body=False,
+        ),
+        _public_request_check(
+            check_id="public_mtls.bootstrap_with_client_cert",
+            description="public host accepts a valid client certificate for bootstrap",
+            base_url=public_base_url,
+            method="GET",
+            path="/client/bootstrap",
+            expected_status=200,
+            expected_json_type=dict,
+            expected_json_keys=("auth",),
+            timeout_seconds=timeout_seconds,
+            urlopen=cert_urlopen,
+            include_response_body=False,
+        ),
+        _public_request_check(
+            check_id="public_mtls.sessions_require_sm_auth",
+            description="public mobile API reaches SM auth boundary after mTLS",
+            base_url=public_base_url,
+            method="GET",
+            path="/client/sessions",
+            expected_status=401,
+            expected_detail="Authentication required",
+            timeout_seconds=timeout_seconds,
+            urlopen=cert_urlopen,
+            include_response_body=False,
+        ),
+        _public_request_check(
+            check_id="public_mtls.app_artifact_metadata",
+            description="public host serves app artifact metadata after mTLS",
+            base_url=public_base_url,
+            method="GET",
+            path=f"/apps/{app_name}/meta.json",
+            expected_status=200,
+            expected_json_type=dict,
+            expected_json_keys=("artifact_hash",),
+            timeout_seconds=timeout_seconds,
+            urlopen=cert_urlopen,
+            include_response_body=False,
+        ),
+    ]
+    if bearer_token or cookie:
+        checks.append(
+            _public_request_check(
+                check_id="public_mtls.sessions_with_sm_auth",
+                description="public mobile API returns sessions after mTLS and SM auth",
+                base_url=public_base_url,
+                method="GET",
+                path="/client/sessions",
+                expected_status=200,
+                expected_json_type=dict,
+                expected_json_keys=("sessions",),
+                timeout_seconds=timeout_seconds,
+                urlopen=cert_urlopen,
+                bearer_token=bearer_token,
+                cookie=cookie,
+                include_response_body=False,
+            )
+        )
+    else:
+        checks.append(
+            _skipped(
+                "public_mtls.sessions_with_sm_auth",
+                "public mobile API returns sessions after mTLS and SM auth",
+                "SM bearer token or cookie was not supplied",
+                required=False,
+            )
+        )
+    return checks
+
+
+def _public_request_check(
+    *,
+    check_id: str,
+    description: str,
+    base_url: str,
+    method: str,
+    path: str,
+    expected_status: int,
+    timeout_seconds: float,
+    urlopen,
+    bearer_token: str | None = None,
+    cookie: str | None = None,
+    expected_detail: str | None = None,
+    expected_json_type: type | None = None,
+    expected_json_keys: tuple[str, ...] = (),
+    include_response_body: bool = False,
+) -> dict[str, Any]:
+    headers: dict[str, str] = {}
+    if bearer_token:
+        headers["Authorization"] = f"Bearer {bearer_token}"
+    if cookie:
+        headers["Cookie"] = cookie
+    request = urllib.request.Request(base_url + path, method=method, headers=headers)
+    try:
+        with urlopen(request, timeout=timeout_seconds) as response:
+            status = response.getcode()
+            body = response.read()
+            content_type = response.headers.get("content-type")
+    except urllib.error.HTTPError as exc:
+        status = exc.code
+        body = exc.read()
+        content_type = exc.headers.get("content-type")
+    except Exception as exc:  # noqa: BLE001 - evidence report should capture probe failures.
+        return {
+            "id": check_id,
+            "description": description,
+            "status": "blocked",
+            "blocker_kind": "request_failed",
+            "detail": f"{type(exc).__name__}: {exc}",
+            "method": method,
+            "path": path,
+            "expected_status": expected_status,
+            "actual_status": None,
+            "response": None,
+        }
+    actual_json = _parse_json_body(body)
+    response = _response_summary(
+        body,
+        content_type,
+        parsed_json=actual_json,
+        include_json_body=include_response_body,
+    )
+    if status != expected_status:
+        return _blocked(
+            check_id,
+            description,
+            "unexpected_status",
+            f"expected HTTP {expected_status}, got HTTP {status}",
+            method=method,
+            path=path,
+            expected_status=expected_status,
+            actual_status=status,
+            response=response,
+        )
+    if expected_detail is not None:
+        actual_detail = actual_json.get("detail") if isinstance(actual_json, dict) else None
+        if actual_detail != expected_detail:
+            return _blocked(
+                check_id,
+                description,
+                "unexpected_detail",
+                f"expected detail {expected_detail!r}, got {actual_detail!r}",
+                method=method,
+                path=path,
+                expected_status=expected_status,
+                actual_status=status,
+                response=response,
+            )
+    if expected_json_type is not None:
+        if not isinstance(actual_json, expected_json_type):
+            return _blocked(
+                check_id,
+                description,
+                "unexpected_json",
+                f"expected JSON {expected_json_type.__name__}, got non-matching response",
+                method=method,
+                path=path,
+                expected_status=expected_status,
+                actual_status=status,
+                response=response,
+            )
+        if isinstance(actual_json, dict):
+            missing_keys = [key for key in expected_json_keys if key not in actual_json]
+            if missing_keys:
+                return _blocked(
+                    check_id,
+                    description,
+                    "unexpected_json",
+                    f"missing expected JSON keys: {', '.join(missing_keys)}",
+                    method=method,
+                    path=path,
+                    expected_status=expected_status,
+                    actual_status=status,
+                    response=response,
+                )
+    return {
+        "id": check_id,
+        "description": description,
+        "status": "passed",
+        "method": method,
+        "path": path,
+        "expected_status": expected_status,
+        "actual_status": status,
+        "response": response,
     }
 
 
@@ -422,6 +829,201 @@ def _urlopen_no_redirect(request: urllib.request.Request, *, timeout: float):
     return _NO_REDIRECT_OPENER.open(request, timeout=timeout)
 
 
+def _build_client_cert_urlopen(client_cert_file: Path, client_key_file: Path):
+    # Cloudflare Access mTLS did not reliably accept Python urllib's client
+    # certificate presentation in local validation, while curl exercises the
+    # same platform TLS stack the operator uses for manual public smoke checks.
+    def _open(request: urllib.request.Request, *, timeout: float):
+        return _curl_client_cert_request(
+            request,
+            timeout=timeout,
+            client_cert_file=client_cert_file,
+            client_key_file=client_key_file,
+        )
+
+    return _open
+
+
+class _SimpleResponse:
+    def __init__(self, *, status: int, body: bytes, headers: dict[str, str]):
+        self.status = status
+        self._body = body
+        self.headers = headers
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+    def getcode(self) -> int:
+        return self.status
+
+    def read(self) -> bytes:
+        return self._body
+
+
+def _curl_client_cert_request(
+    request: urllib.request.Request,
+    *,
+    timeout: float,
+    client_cert_file: Path,
+    client_key_file: Path,
+) -> _SimpleResponse:
+    with tempfile.TemporaryDirectory(prefix="sm-public-mtls-curl-") as tempdir:
+        root = Path(tempdir)
+        body_file = root / "body"
+        headers_file = root / "headers"
+        command = [
+            "/usr/bin/curl",
+            "--silent",
+            "--show-error",
+            "--max-time",
+            str(timeout),
+            "--request",
+            request.get_method(),
+            "--cert",
+            str(client_cert_file),
+            "--key",
+            str(client_key_file),
+            "--dump-header",
+            str(headers_file),
+            "--output",
+            str(body_file),
+            "--write-out",
+            "%{http_code}",
+        ]
+        for key, value in request.header_items():
+            command.extend(["--header", f"{key}: {value}"])
+        command.append(request.full_url)
+        completed = subprocess.run(
+            command,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        if completed.returncode != 0:
+            stderr = completed.stderr.strip()
+            raise RuntimeError(stderr or f"curl exited {completed.returncode}")
+        status_text = completed.stdout.strip()
+        try:
+            status = int(status_text)
+        except ValueError as exc:
+            raise RuntimeError(f"curl returned non-numeric status {status_text!r}") from exc
+        return _SimpleResponse(
+            status=status,
+            body=body_file.read_bytes() if body_file.exists() else b"",
+            headers=_parse_curl_headers(headers_file.read_text(encoding="utf-8"))
+            if headers_file.exists()
+            else {},
+        )
+
+
+def _parse_curl_headers(raw_headers: str) -> dict[str, str]:
+    blocks = [block for block in raw_headers.replace("\r\n", "\n").split("\n\n") if block]
+    if not blocks:
+        return {}
+    headers: dict[str, str] = {}
+    for line in blocks[-1].splitlines()[1:]:
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        headers[key.strip().lower()] = value.strip()
+    return headers
+
+
+def _validate_client_cert_common_name(common_name: str) -> None:
+    if not common_name:
+        raise ValueError("client cert common name must not be empty")
+    if len(common_name) > 128:
+        raise ValueError("client cert common name is too long")
+    if any(char in common_name for char in ("/", "\n", "\r", "\0")):
+        raise ValueError("client cert common name contains an unsafe character")
+
+
+def _generate_ephemeral_client_cert(
+    *,
+    common_name: str,
+    device_ca_cert_file: Path,
+    device_ca_key_file: Path,
+) -> dict[str, Any]:
+    if not device_ca_cert_file.is_file():
+        raise FileNotFoundError(f"device CA cert file does not exist: {device_ca_cert_file}")
+    if not device_ca_key_file.is_file():
+        raise FileNotFoundError(f"device CA key file does not exist: {device_ca_key_file}")
+    tempdir = tempfile.TemporaryDirectory(prefix="sm-public-mtls-smoke-")
+    root = Path(tempdir.name)
+    key_file = root / "client.key.pem"
+    csr_file = root / "client.csr.pem"
+    cert_file = root / "client.cert.pem"
+    serial_file = root / "device-ca.srl"
+    _run_openssl(
+        [
+            "openssl",
+            "ecparam",
+            "-name",
+            "prime256v1",
+            "-genkey",
+            "-noout",
+            "-out",
+            str(key_file),
+        ]
+    )
+    _run_openssl(
+        [
+            "openssl",
+            "req",
+            "-new",
+            "-key",
+            str(key_file),
+            "-subj",
+            f"/CN={common_name}",
+            "-out",
+            str(csr_file),
+        ]
+    )
+    _run_openssl(
+        [
+            "openssl",
+            "x509",
+            "-req",
+            "-in",
+            str(csr_file),
+            "-CA",
+            str(device_ca_cert_file),
+            "-CAkey",
+            str(device_ca_key_file),
+            "-CAcreateserial",
+            "-CAserial",
+            str(serial_file),
+            "-out",
+            str(cert_file),
+            "-days",
+            "1",
+            "-sha256",
+        ]
+    )
+    return {
+        "cert_file": cert_file,
+        "key_file": key_file,
+        "_tempdir": tempdir,
+    }
+
+
+def _run_openssl(args: list[str]) -> None:
+    completed = subprocess.run(
+        args,
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    if completed.returncode != 0:
+        stderr = completed.stderr.strip()
+        raise RuntimeError(stderr or f"openssl exited {completed.returncode}")
+
+
 def _public_edge_headers(secret: str, method: str, path: str) -> dict[str, str]:
     timestamp = str(time.time())
     nonce = uuid.uuid4().hex
@@ -538,7 +1140,17 @@ def render_text_report(report: dict[str, Any]) -> str:
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--mode",
+        choices=(SMOKE_MODE_ORIGIN, SMOKE_MODE_PUBLIC_MTLS),
+        default=SMOKE_MODE_ORIGIN,
+        help=(
+            "origin checks synthetic Access/public-edge headers against --base-url; "
+            "public-mtls checks the deployed public host with a client certificate"
+        ),
+    )
     parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    parser.add_argument("--public-base-url", default=None)
     parser.add_argument("--mobile-host", default=None)
     parser.add_argument("--browser-host", default=None)
     _add_secret_source_args(
@@ -560,6 +1172,11 @@ def _build_parser() -> argparse.ArgumentParser:
     _add_secret_source_args(parser, "cookie", "SM browser cookie header")
     parser.add_argument("--session-id", default=None)
     parser.add_argument("--app-name", default=DEFAULT_APP_NAME)
+    parser.add_argument("--client-cert-file", type=Path, default=None)
+    parser.add_argument("--client-key-file", type=Path, default=None)
+    parser.add_argument("--client-cert-common-name", default=None)
+    parser.add_argument("--device-ca-cert-file", type=Path, default=None)
+    parser.add_argument("--device-ca-key-file", type=Path, default=None)
     parser.add_argument("--timeout", type=float, default=5.0)
     parser.add_argument("--output", type=Path, default=None)
     parser.add_argument("--json", action="store_true")
@@ -605,7 +1222,9 @@ def main(argv: list[str] | None = None) -> int:
     parser = _build_parser()
     args = parser.parse_args(argv)
     report = build_smoke_report(
+        mode=args.mode,
         base_url=args.base_url,
+        public_base_url=args.public_base_url,
         mobile_host=args.mobile_host,
         browser_host=args.browser_host,
         mobile_access_jwt=_resolve_secret(
@@ -640,6 +1259,11 @@ def main(argv: list[str] | None = None) -> int:
         ),
         session_id=args.session_id,
         app_name=args.app_name,
+        client_cert_file=args.client_cert_file,
+        client_key_file=args.client_key_file,
+        client_cert_common_name=args.client_cert_common_name,
+        device_ca_cert_file=args.device_ca_cert_file,
+        device_ca_key_file=args.device_ca_key_file,
         timeout_seconds=args.timeout,
     )
     if args.output:

--- a/specs/762_stage5_artifacts/cloudflare_access_cutover_evidence.md
+++ b/specs/762_stage5_artifacts/cloudflare_access_cutover_evidence.md
@@ -1,7 +1,7 @@
 # Cloudflare Access Cutover Evidence
 
-Status: implementation evidence after PR #1025 merged and the first post-#1025
-smoke-boundary run was recorded.
+Status: implementation evidence after public mTLS smoke was recorded for
+`sm-app.rajeshgo.li` on 2026-06-17.
 
 This artifact records the current Rust-side Cloudflare Access boundary for the
 Rust cutover track. It complements the design in
@@ -29,6 +29,7 @@ issuance:
 | #1012 | Android Camera-app QR handoff via `sm-enroll://enroll`, direct in-app certificate save, no camera permission, no in-app scanner, and no certificate material exposed in Settings. |
 | #1025 | Rust native Google device-auth success path for `/auth/device/google`, including Google JWKS verification, mobile Access actor binding, public-edge gate, and zero-skew temporal checks. |
 | #1026 | Post-#1025 smoke evidence slice; runner now records denial-path boundary evidence even when success-path proof inputs are missing. |
+| issue #1046 | Public mTLS smoke mode for the deployed app host, using an ephemeral client cert signed by the local mobile CA for an enrolled Common Name. |
 
 Current origin behavior:
 
@@ -88,20 +89,50 @@ Cloudflare tunnel requirements:
 - deny or 404 unmatched ingress;
 - record each Access application audience in SM config.
 
+## Current Public App-Host Evidence
+
+The public mTLS smoke runner recorded:
+
+```text
+.local/rust-mvp-rehearsals/public-mtls-smoke-20260617T202635Z.json
+```
+
+Summary: `4` passed, `0` blocked, `1` skipped. The passing checks prove:
+
+- `sm-app.rajeshgo.li` denies `/client/bootstrap` without a client certificate;
+- an ephemeral client certificate signed by the local mobile CA for the enrolled
+  Android Common Name reaches `/client/bootstrap`;
+- `/client/sessions` still returns SM-auth `401` without an SM bearer or
+  session cookie after mTLS succeeds;
+- app artifact metadata is reachable through the certificate-gated app host.
+
+The skipped check is optional authenticated `/client/sessions` because no SM
+bearer token or cookie was supplied to the smoke runner. The report redacts raw
+response JSON bodies and records no certificate material, private keys,
+Cloudflare cookies, Access tokens, bearer tokens, or SM cookies.
+
+The live canary report consumed that smoke report:
+
+```text
+.local/rust-mvp-rehearsals/live-canary-with-public-mtls-20260617T202645Z.json
+```
+
+Summary: `11` passed, `0` blocked, `0` skipped.
+
 ## Remaining Cutover Evidence
 
-The Rust origin gate and smoke runner are merged, but public cutover still
-needs operator-side Cloudflare and native-app evidence:
+The Rust origin gate and public app-host mTLS smoke are recorded, but public
+cutover still needs the remaining operator-side and native-app evidence:
 
 | Evidence | Required before public mobile cutover |
 | --- | --- |
-| Cloudflare policy setup | Prove each Access app exists with the expected hostname, audience, and no bypass/broad-certificate policy. |
-| Mobile device enrollment | Prove an enrolled phone certificate Common Name appears in the `sm-mobile-app` policy and in SM mobile device config. |
-| Revoked-device denial | Prove a removed/revoked device Common Name is denied by Cloudflare or origin and cannot use `/client/*`, `/apps/*`, `/apk`, or `/auth/device/google`. |
-| Native app smoke | Exercise `/client/bootstrap`, `/auth/device/google`, `/client/sessions`, `/client/sessions/{id}`, attach ticket, WebSocket auth, request-status, analytics, bug report, and app artifact metadata/download through the app hostname. |
+| Cloudflare policy setup | Prove each Access app exists with the expected hostname, audience, and no bypass/broad-certificate policy. The app-host policy has working mTLS behavior for the enrolled Common Name from the smoke above. |
+| Mobile device enrollment | Prove an enrolled phone certificate Common Name appears in the `sm-mobile-app` policy and in SM mobile device config. The public mTLS smoke used the current enrolled Common Name. |
+| revoked-device denial | Prove a removed/revoked device Common Name is denied by Cloudflare or origin and cannot use `/client/*`, `/apps/*`, `/apk`, or `/auth/device/google`. |
+| Native app smoke | Exercise `/auth/device/google`, authenticated `/client/sessions`, `/client/sessions/{id}`, attach ticket, WebSocket auth, request-status, analytics, bug report, and app artifact download through the app hostname. Bootstrap and app artifact metadata are already covered by the public mTLS smoke. |
 | Browser smoke | Exercise browser Access owner email login, SM Google OAuth callback, `/auth/session`, and authenticated/proofed watch diagnostics through the browser hostname. |
 | Node fallback smoke | Once node fallback is ported, prove LAN-first behavior and Cloudflare node certificate fallback for a registered node. |
-| Shadow/rehearsal | Record a clean shadow/rehearsal window that includes native app traffic or an explicit operator-driven mobile route exercise. |
+| Shadow/rehearsal | Record any targeted comparison needed for specific bugs. Broad Python-authoritative shadow is historical because Rust now owns the live port. |
 
 The smoke runner requires real deployment inputs. The post-#1025 run used
 `--mobile-host sm-app.rajeshgo.li` and `--browser-host sm.rajeshgo.li` against a
@@ -125,5 +156,6 @@ Camera-app enrollment handoff and direct internal credential storage, but that
 published artifact is not by itself full Cloudflare Access cutover evidence.
 
 Do not treat the Cloudflare Access design as complete cutover evidence until
-these setup and smoke checks are recorded. The revoked-device denial and native
-app smoke checks are release gates, not optional diagnostics.
+the remaining setup and smoke checks above are recorded. Revoked-device denial
+and fuller native app authenticated smoke remain release gates, not optional
+diagnostics.

--- a/specs/762_stage5_artifacts/mvp_progress.md
+++ b/specs/762_stage5_artifacts/mvp_progress.md
@@ -1,25 +1,27 @@
 # Rust MVP Progress Snapshot
 
-Status: implementation snapshot after PR #1041 Rust service cutover tooling was
-merged and used for the first Rust canary flip on 2026-06-17. Issue #1042 adds
-the public tunnel preflight that verifies `sm-app.rajeshgo.li` routes directly
-to the launchd-managed Rust service and legacy `sm.rajeshgo.li` does not route
-to origin. Issue #1044 adds a non-mutating live canary report for the
-post-cutover Rust service.
+Status: implementation snapshot after PR #1045 live canary tooling was merged
+following the first Rust canary flip on 2026-06-17. Issue #1042 adds the public
+tunnel preflight that verifies `sm-app.rajeshgo.li` routes directly to the
+launchd-managed Rust service and legacy `sm.rajeshgo.li` does not route to
+origin. Issue #1044 adds a non-mutating live canary report for the post-cutover
+Rust service. Issue #1046 adds a public mTLS smoke mode and a live canary
+artifact with Cloudflare/mobile smoke supplied.
 
 The last clean full real-state MVP rehearsal remains the post-#938 run; the
 post-#1035 rehearsal proves state gates, live core contracts, read-only
 fixtures, mutating fixtures, and Rust baseline on isolated sidecars, but blocks
-on Python-origin availability during Python baseline and shadow. PRs #986-#1041
+on Python-origin availability during Python baseline and shadow. PRs #986-#1045
 added node restore fixtures, stopped-origin final backup gates, rehearsal
 final-backup integration, Cloudflare Access smoke evidence tooling, Rust
 mobile-device enrollment, Cloudflare mTLS CA automation, the Android Camera-app
 enrollment handoff, Rust native Google device-auth bearer issuance, Android
 mTLS, artifact read fixes, a larger live HTTP read budget, accelerated Rust
-canary evidence mode, and reviewed launchd/service cutover tooling. The first
-live cutover stopped the Python launchd label, copied a stopped-origin final
-backup, started Rust on `127.0.0.1:8420`, enabled Rust core writes, verified the
-Android app path, and removed the legacy public tunnel route.
+canary evidence mode, reviewed launchd/service cutover tooling, and public mTLS
+Cloudflare smoke evidence. The first live cutover stopped the Python launchd
+label, copied a stopped-origin final backup, started Rust on `127.0.0.1:8420`,
+enabled Rust core writes, verified the Android app path, and removed the legacy
+public tunnel route.
 
 This file is a handoff aid for the Rust cutover implementation track. It does
 not change retained or removed scope. Binding scope remains
@@ -125,6 +127,8 @@ not change retained or removed scope. Binding scope remains
 | #1041 | Rust service launchd cutover tooling and first-canary runbook |
 | issue #1042 | Public tunnel preflight for the protected app hostname and legacy-host absence |
 | issue #1044 | Live Rust canary evidence collector for launchd/local/public-tunnel post-cutover checks |
+| #1045 | Merge of the live Rust canary evidence collector |
+| issue #1046 | Public mTLS Cloudflare/mobile smoke mode and live canary evidence with smoke supplied |
 
 ## Implemented Capability Groups
 
@@ -132,7 +136,7 @@ The Rust sidecar now has executable coverage for:
 
 | Group | Current state |
 | --- | --- |
-| Harness and baselines | Contract manifest, fixture assertions, minimal value baseline runner, shadow comparison, MVP rehearsal, synthetic read-only fixture sidecar, disposable mutating fixtures, Rust CLI build gating, state preflight/backup/restore, stopped-origin final backup, freeze/drain evidence gates, Cloudflare Access smoke evidence runner, mobile-aware shadow observation gates, accelerated Rust canary evidence mode, public tunnel preflight, and live Rust canary report exist. |
+| Harness and baselines | Contract manifest, fixture assertions, minimal value baseline runner, shadow comparison, MVP rehearsal, synthetic read-only fixture sidecar, disposable mutating fixtures, Rust CLI build gating, state preflight/backup/restore, stopped-origin final backup, freeze/drain evidence gates, Cloudflare Access smoke evidence runner, public mTLS smoke mode, mobile-aware shadow observation gates, accelerated Rust canary evidence mode, public tunnel preflight, and live Rust canary report exist. |
 | Retired-surface checks | Retired public/watch/summary/remind/job-watch/queue-policy checks are represented as Rust-target absence or denial fixtures. |
 | Core reads | Health, auth session, bootstrap, session list/detail, client session list/detail, output, events state, SSE hello, nodes list, queue jobs list/detail, Codex review requests list/detail, and tool/audit read projections are implemented. |
 | Core runtime | Session/tmux/spawn/session-graph/message-queue/task-complete/input-batch/subagent and retained review-route slices are merged, with shadow and contract fixtures covering the early cutover path. |
@@ -172,6 +176,7 @@ Collect the live Rust canary evidence bundle with:
 
 ```bash
 ./venv/bin/python -m scripts.rust_migration.live_canary_report \
+  --cloudflare-smoke-report .local/rust-mvp-rehearsals/public-mtls-smoke-20260617T202635Z.json \
   --output .local/rust-mvp-rehearsals/live-canary-$(date -u +%Y%m%dT%H%M%SZ).json \
   --fail-on-blockers
 ```
@@ -179,17 +184,37 @@ Collect the live Rust canary evidence bundle with:
 The report is intentionally non-mutating. It records the Rust launchd label,
 local Rust health/bootstrap/session/analytics reads, `sm status`, the public
 tunnel preflight, unauthenticated `sm-app` Cloudflare Access denial, legacy
-public-host absence, and optional Cloudflare/mobile smoke evidence.
+public-host absence, and supplied Cloudflare/mobile smoke evidence.
+
+Current public mTLS smoke artifact:
+
+```text
+.local/rust-mvp-rehearsals/public-mtls-smoke-20260617T202635Z.json
+```
+
+Summary: `4` passed, `0` blocked, `1` skipped. The passed checks prove:
+
+- `sm-app.rajeshgo.li` denies `/client/bootstrap` without a client certificate;
+- an ephemeral client certificate signed by the local mobile CA for the enrolled
+  Android Common Name reaches `/client/bootstrap`;
+- `/client/sessions` still returns SM-auth `401` without an SM bearer or
+  session cookie after mTLS succeeds;
+- app artifact metadata is served through the certificate-gated app host.
+
+The skipped check is optional authenticated `/client/sessions` because no SM
+bearer token or cookie was supplied to the smoke runner.
 
 Current live canary artifact:
 
 ```text
-.local/rust-mvp-rehearsals/live-canary-20260617T192700Z.json
+.local/rust-mvp-rehearsals/live-canary-with-public-mtls-20260617T202645Z.json
 ```
 
-Summary: `10` passed, `0` blocked, `1` skipped. The skipped check is the
-optional supplied Cloudflare/mobile smoke report; all launchd, local Rust,
-tunnel, and public unauthenticated denial checks passed.
+Summary: `11` passed, `0` blocked, `0` skipped. The passing checks cover the
+Rust launchd label, local Rust health/detailed health/bootstrap/session
+list/native analytics reads, `sm status`, local public tunnel preflight,
+unauthenticated `sm-app` public denial before origin, legacy public-host
+absence, and the supplied public mTLS Cloudflare/mobile smoke report.
 
 The latest clean passive shadow report after #996 used
 `--last-minutes 30 --fail-on-blockers --json` and returned:
@@ -378,14 +403,15 @@ normal full rehearsal and should be identified as such in reports.
 Required command shape:
 
 ```bash
+cn=$(sqlite3 "$HOME/.local/share/claude-sessions/mobile_devices.db" \
+  "SELECT common_name FROM mobile_device_enrollments WHERE revoked_at IS NULL ORDER BY paired_at DESC LIMIT 1;")
+
 ./venv/bin/python -m scripts.rust_migration.cloudflare_access_smoke \
-  --base-url http://127.0.0.1:8421 \
-  --mobile-host sm-app.rajeshgo.li \
-  --browser-host sm.rajeshgo.li \
-  --mobile-access-jwt-env CF_MOBILE_ACCESS_JWT \
-  --browser-access-jwt-env CF_BROWSER_ACCESS_JWT \
-  --public-edge-secret-env SM_PUBLIC_EDGE_SECRET \
-  --bearer-token-env SM_DEVICE_BEARER_TOKEN \
+  --mode public-mtls \
+  --public-base-url https://sm-app.rajeshgo.li \
+  --client-cert-common-name "$cn" \
+  --device-ca-cert-file certs/sm-mobile-device-ca.pem \
+  --device-ca-key-file certs/sm-mobile-device-ca.key \
   --output .local/rust-mvp-rehearsals/cloudflare-smoke.json \
   --json \
   --fail-on-blockers
@@ -401,8 +427,8 @@ Blocking evidence in this path:
 - state preflight, backup, restore rehearsal, and freeze/drain ledger;
 - Rust live core contracts and synthetic read-only/mutating fixture contracts;
 - Rust baseline;
-- `cloudflare_access_smoke_report` from a passed smoke report using real
-  Access/public-edge/SM auth inputs.
+- `cloudflare_access_smoke_report` from a passed smoke report using the real
+  public mTLS app host.
 
 The mode intentionally skips sustained `python_baseline` and
 `shadow_read_summary`; those steps must be recorded as skipped, not silently
@@ -415,14 +441,14 @@ These are the next practical buckets before an MVP cutover trial:
 
 | Bucket | Why it remains |
 | --- | --- |
-| Shadow/canary observation window | Python-authoritative shadow mode is now historical because Rust owns the live port. The live Rust canary report passes for launchd/local/tunnel/public-denial checks; remaining work is bounded app/operator smoke and any targeted comparison needed for specific bugs. If Python is restarted for comparison, use it only for targeted checks rather than broad hardening. |
+| Shadow/canary observation window | Python-authoritative shadow mode is now historical because Rust owns the live port. The live Rust canary report now passes with public mTLS Cloudflare/mobile smoke supplied; remaining work is targeted comparison only for specific bugs. If Python is restarted for comparison, use it only for targeted checks rather than broad hardening. |
 | Full fixture manifest execution | The MVP rehearsal now runs the current synthetic read-only and mutating fixture sets, including review-route fixtures. Remaining work is final live mobile/device fixture evidence and any additional retained fixture rows added by later slices. |
 | CLI cutover audit | Verify every retained CLI command in [cutover_scope.md](cutover_scope.md) is native Rust or intentionally routed, and every removed command is absent or explicitly retired. |
 | State ownership and migration tooling | Initial preflight, backup, restore, and freeze/drain evidence tools are merged and exercised by the rehearsal. Remaining work is live write-admission freeze/journal ownership and rollback accounting from [state_ownership_and_migration.md](state_ownership_and_migration.md). |
-| Cloudflare Access deployment integration | Pair the merged Rust origin gate with the actual Cloudflare Access apps, mTLS/service-auth policies, device Common Name enrollment/revocation, app-host native auth smoke, browser OAuth smoke, and later node fallback tests. Current evidence lives in [cloudflare_access_cutover_evidence.md](cloudflare_access_cutover_evidence.md). |
+| Cloudflare Access deployment integration | Public app-host mTLS smoke now passes. Remaining work is browser OAuth smoke, any fuller native authenticated session/action smoke that needs a real SM bearer/cookie, and later node fallback tests. Current evidence lives in [cloudflare_access_cutover_evidence.md](cloudflare_access_cutover_evidence.md). |
 | Node and queue writer completion | Basic node HTTP routes and narrow queue writer/recovery are implemented. Remaining work is final live/recovery cutover evidence, audit/rollback accounting, and any retained node-agent remote-control gaps. |
 | Service packaging and rollback | Launchd/service cutover has been exercised for the first Rust canary. Remaining work is continued live canary evidence, rollback rehearsal if needed, and operator diagnostics. |
-| Final native mobile smoke | Run bootstrap/session/attach/request-status/analytics/bug-report/app-artifact smoke checks against Rust using real mobile assumptions. |
+| Final native mobile smoke | Public mTLS bootstrap/session-auth-boundary/app-artifact smoke is recorded. Remaining checks are authenticated mobile actions such as attach/request-status/analytics/bug-report when they need a real app bearer/session. |
 | Python-origin availability during evidence runs | Post-#1035 full rehearsal is blocked because Python watchdog-restarted during baseline/shadow. This does not call for broad Python hardening. Either collect the normal stable Python-authoritative window, or use the accelerated Rust canary evidence path with spot checks and Cloudflare/mobile smoke. |
 
 ## Stop Conditions For MVP Cutover

--- a/specs/762_stage5_artifacts/resume_handoff.md
+++ b/specs/762_stage5_artifacts/resume_handoff.md
@@ -1,11 +1,12 @@
 # Rust Port Resume Handoff
 
-Status: handoff snapshot from 2026-06-17 after PR #1041 merged the reviewed
-Rust service launchd cutover tooling and the first Rust canary flip moved local
+Status: handoff snapshot from 2026-06-17 after PR #1045 merged the
+post-cutover live Rust canary report. The first Rust canary flip moved local
 production traffic to Rust. Issue #1042 adds the public tunnel preflight that
 keeps `sm-app.rajeshgo.li` pointed at the launchd-managed Rust service and
-keeps legacy `sm.rajeshgo.li` off origin. Issue #1044 adds the post-cutover
-live Rust canary report.
+keeps legacy `sm.rajeshgo.li` off origin. Issue #1046 adds public mTLS
+Cloudflare/mobile smoke evidence and a live canary artifact with that smoke
+supplied.
 
 Use this file to resume the Rust cutover track without reconstructing state from
 chat history. Binding scope still lives in [cutover_scope.md](cutover_scope.md),
@@ -17,9 +18,9 @@ Service cutover commands live in
 
 ## Current Repository State
 
-- Branch: `main` after PR #1041.
-- Latest merged commit before this docs refresh: `f7e74af` (`Merge pull
-  request #1041`)
+- Branch: `main` after PR #1045.
+- Latest merged commit before this docs refresh: `948e6ec` (`Merge pull
+  request #1045`)
 - Open PRs at handoff: none before this docs refresh PR.
 - Dirty worktree at handoff: only pre-existing untracked
   `.claude/settings.local.json`, `certs/`, `data/`, and the local
@@ -40,7 +41,7 @@ Service cutover commands live in
 - Validate the local public tunnel shape with
   `./venv/bin/python -m scripts.rust_migration.public_tunnel_preflight --config .local/android-parity/cloudflared/config-http-only.yml --fail-on-blockers`.
 - Collect live canary evidence with
-  `./venv/bin/python -m scripts.rust_migration.live_canary_report --output .local/rust-mvp-rehearsals/live-canary-$(date -u +%Y%m%dT%H%M%SZ).json --fail-on-blockers`.
+  `./venv/bin/python -m scripts.rust_migration.live_canary_report --cloudflare-smoke-report .local/rust-mvp-rehearsals/public-mtls-smoke-20260617T202635Z.json --output .local/rust-mvp-rehearsals/live-canary-$(date -u +%Y%m%dT%H%M%SZ).json --fail-on-blockers`.
 
 ## Completed Work
 
@@ -81,7 +82,8 @@ Merged Rust slices cover:
 
 ### Documentation And Manifest
 
-- [mvp_progress.md](mvp_progress.md) records the PR lineage through #1041.
+- [mvp_progress.md](mvp_progress.md) records the PR lineage through #1045 and
+  issue #1046.
 - [cloudflare_access_cutover_evidence.md](cloudflare_access_cutover_evidence.md)
   records the current Cloudflare Access origin-gate behavior and remaining
   operator setup/smoke evidence.
@@ -204,6 +206,11 @@ Merged Rust slices cover:
 - Issue #1044 adds the live canary report that records launchd ownership, local
   Rust health/native reads, `sm status`, public tunnel shape, public Access
   denial, and legacy-host absence without mutating live state.
+- PR #1045 merged the live canary report.
+- Issue #1046 adds a public mTLS mode to the Cloudflare smoke runner. It can
+  generate an ephemeral client certificate from the local mobile CA for the
+  enrolled Android Common Name, records no cert/key/token material, and produces
+  a smoke report accepted by the live canary gate.
 - Current contract manifest size:
   - `134` checks total
   - `73` `python_and_rust`
@@ -335,22 +342,23 @@ show:
 - Rust live core, synthetic read-only fixture, and mutating fixture contracts
   passed;
 - Rust baseline passed;
-- `cloudflare_access_smoke_report` passed from a smoke report that used real
-  Cloudflare Access, public-edge, and SM auth proof inputs;
+- `cloudflare_access_smoke_report` passed from a smoke report that used the
+  real public mTLS app host;
 - `python_baseline` and `shadow_read_summary` recorded as skipped because
   `--rust-canary-cutover` was intentionally selected.
 
 Command shape:
 
 ```bash
+cn=$(sqlite3 "$HOME/.local/share/claude-sessions/mobile_devices.db" \
+  "SELECT common_name FROM mobile_device_enrollments WHERE revoked_at IS NULL ORDER BY paired_at DESC LIMIT 1;")
+
 ./venv/bin/python -m scripts.rust_migration.cloudflare_access_smoke \
-  --base-url http://127.0.0.1:8421 \
-  --mobile-host sm-app.rajeshgo.li \
-  --browser-host sm.rajeshgo.li \
-  --mobile-access-jwt-env CF_MOBILE_ACCESS_JWT \
-  --browser-access-jwt-env CF_BROWSER_ACCESS_JWT \
-  --public-edge-secret-env SM_PUBLIC_EDGE_SECRET \
-  --bearer-token-env SM_DEVICE_BEARER_TOKEN \
+  --mode public-mtls \
+  --public-base-url https://sm-app.rajeshgo.li \
+  --client-cert-common-name "$cn" \
+  --device-ca-cert-file certs/sm-mobile-device-ca.pem \
+  --device-ca-key-file certs/sm-mobile-device-ca.key \
   --output .local/rust-mvp-rehearsals/cloudflare-smoke.json \
   --json \
   --fail-on-blockers
@@ -410,24 +418,36 @@ blocked, `7` skipped. This is partial boundary evidence only.
 Post-cutover live Rust canary evidence:
 
 ```text
-.local/rust-mvp-rehearsals/live-canary-20260617T192700Z.json
+.local/rust-mvp-rehearsals/live-canary-with-public-mtls-20260617T202645Z.json
 ```
 
-Summary: `10` passed, `0` blocked, `1` skipped. The passing checks cover the
+Summary: `11` passed, `0` blocked, `0` skipped. The passing checks cover the
 Rust launchd label, local Rust health/detailed health/bootstrap/session
 list/native analytics reads, `sm status`, local public tunnel preflight,
 unauthenticated `sm-app` public denial before origin, and legacy public-host
-absence. The skipped check is the optional supplied Cloudflare/mobile smoke
-report.
+absence. The final passing check is the supplied public mTLS Cloudflare/mobile
+smoke report.
 
-No newer clean full passive shadow or full Cloudflare/mobile smoke artifact has
-been recorded in this handoff. PR #1012 published Android artifact `cbb61798`
-(`versionCode=1013`, `versionName=0.1.0-enroll-ui-cleanup`) and operator
-testing confirmed the app reached "Client certificate saved" after Camera-app
-deep-link enrollment. After PR #1035, operator testing also confirmed Android
-app update artifact access works through the certificate-gated app path. The
-full Access smoke runner and sustained shadow window still need recorded
-artifacts.
+Public mTLS Cloudflare/mobile smoke evidence:
+
+```text
+.local/rust-mvp-rehearsals/public-mtls-smoke-20260617T202635Z.json
+```
+
+Summary: `4` passed, `0` blocked, `1` skipped. The passing checks prove
+Cloudflare denies `sm-app.rajeshgo.li/client/bootstrap` without a client cert,
+an ephemeral client cert signed by the local mobile CA for the enrolled Android
+Common Name reaches bootstrap, `/client/sessions` still stops at SM auth with
+`401` without an SM bearer/cookie, and app artifact metadata is reachable
+through the certificate-gated app host. The skipped check is optional
+authenticated `/client/sessions` because no SM bearer token or cookie was
+supplied to the smoke runner.
+
+No newer clean full passive shadow artifact has been recorded in this handoff.
+PR #1012 published Android artifact `cbb61798` (`versionCode=1013`,
+`versionName=0.1.0-enroll-ui-cleanup`) and operator testing confirmed the app
+reached "Client certificate saved" after Camera-app deep-link enrollment. After
+PR #1035, operator testing also confirmed Android app update artifact access works through the certificate-gated app path.
 
 The broad live Rust contract run now uses the fixture filter:
 

--- a/specs/762_stage5_artifacts/rollout_plan.md
+++ b/specs/762_stage5_artifacts/rollout_plan.md
@@ -42,7 +42,7 @@ Python-authoritative baseline/shadow, the owner-approved path is not broad
 Python hardening. Use the accelerated Rust canary evidence mode instead:
 `mvp_rehearsal --rust-canary-cutover` runs short Python canary spot checks, keeps
 the Rust/state/fixture gates and Rust baseline blocking, and requires a passed
-Cloudflare/mobile smoke report with real Access/public-edge/SM auth proof inputs
+Cloudflare/mobile smoke report with real public app-host proof inputs
 before the run can count as cutover-candidate evidence.
 
 ## Cutover Sequence

--- a/tests/unit/test_rust_cloudflare_access_smoke.py
+++ b/tests/unit/test_rust_cloudflare_access_smoke.py
@@ -580,3 +580,211 @@ def test_cloudflare_access_smoke_cli_resolves_secret_files(tmp_path, monkeypatch
 
     assert exit_code == 0
     assert captured["cookie"] == "session=abc"
+
+
+def test_cloudflare_access_smoke_public_mtls_records_public_boundary(tmp_path):
+    cert_file = tmp_path / "client.cert.pem"
+    key_file = tmp_path / "client.key.pem"
+    cert_file.write_text("cert", encoding="utf-8")
+    key_file.write_text("key", encoding="utf-8")
+    seen = []
+
+    def fake_urlopen(request, timeout):
+        seen.append((request.full_url, request.get_header("Authorization"), timeout))
+        path = request.full_url.removeprefix("https://sm-app.example.com")
+        if len(seen) == 1 and path == "/client/bootstrap":
+            raise urllib.error.HTTPError(
+                request.full_url,
+                403,
+                "forbidden",
+                {"content-type": "text/html"},
+                _BytesHandle(b"<html>Cloudflare Access</html>"),
+            )
+        if path == "/client/bootstrap":
+            return FakeResponse(200, b'{"auth":{},"external_access":{}}')
+        if path == "/client/sessions":
+            raise _http_error(
+                request.full_url,
+                401,
+                {"detail": "Authentication required"},
+            )
+        if path == "/apps/session-manager-android/meta.json":
+            return FakeResponse(
+                200,
+                b'{"artifact_hash":"deadbeef","version_code":1033}',
+            )
+        raise AssertionError(f"unexpected request path {path}")
+
+    report = build_smoke_report(
+        mode="public-mtls",
+        public_base_url="https://sm-app.example.com",
+        client_cert_file=cert_file,
+        client_key_file=key_file,
+        timeout_seconds=2.5,
+        urlopen=fake_urlopen,
+    )
+
+    assert report["status"] == "passed"
+    assert report["summary"] == {"passed": 4, "blocked": 0, "skipped": 1}
+    assert report["blockers"] == []
+    assert report["inputs"]["mode"] == "public-mtls"
+    assert report["inputs"]["client_cert_file_supplied"] is True
+    assert report["inputs"]["client_key_file_supplied"] is True
+    assert report["inputs"]["ephemeral_client_cert_generated"] is False
+    by_id = {check["id"]: check for check in report["checks"]}
+    assert by_id["public_mtls.bootstrap_requires_client_cert"]["status"] == "passed"
+    assert by_id["public_mtls.bootstrap_with_client_cert"]["status"] == "passed"
+    assert by_id["public_mtls.sessions_require_sm_auth"]["status"] == "passed"
+    assert by_id["public_mtls.app_artifact_metadata"]["status"] == "passed"
+    assert by_id["public_mtls.sessions_with_sm_auth"] == {
+        "id": "public_mtls.sessions_with_sm_auth",
+        "description": "public mobile API returns sessions after mTLS and SM auth",
+        "status": "skipped",
+        "detail": "SM bearer token or cookie was not supplied",
+        "required": False,
+    }
+    assert by_id["public_mtls.bootstrap_with_client_cert"]["response"][
+        "json_redacted"
+    ] is True
+    assert by_id["public_mtls.bootstrap_with_client_cert"]["response"]["json_keys"] == [
+        "auth",
+        "external_access",
+    ]
+    assert "json" not in by_id["public_mtls.bootstrap_with_client_cert"]["response"]
+    assert seen == [
+        ("https://sm-app.example.com/client/bootstrap", None, 2.5),
+        ("https://sm-app.example.com/client/bootstrap", None, 2.5),
+        ("https://sm-app.example.com/client/sessions", None, 2.5),
+        (
+            "https://sm-app.example.com/apps/session-manager-android/meta.json",
+            None,
+            2.5,
+        ),
+    ]
+
+
+def test_cloudflare_access_smoke_public_mtls_blocks_missing_cert_source():
+    report = build_smoke_report(
+        mode="public-mtls",
+        public_base_url="https://sm-app.example.com",
+    )
+
+    assert report["status"] == "blocked"
+    assert report["blockers"] == [
+        {
+            "check_id": "public_mtls.client_certificate_available",
+            "kind": "client_cert_missing",
+            "detail": (
+                "supply client cert/key files or client cert common name plus device CA "
+                "cert/key files"
+            ),
+        }
+    ]
+
+
+def test_cloudflare_access_smoke_public_mtls_uses_generated_ephemeral_cert(
+    tmp_path, monkeypatch
+):
+    ca_cert = tmp_path / "ca.cert.pem"
+    ca_key = tmp_path / "ca.key.pem"
+    client_cert = tmp_path / "generated.cert.pem"
+    client_key = tmp_path / "generated.key.pem"
+    ca_cert.write_text("ca cert", encoding="utf-8")
+    ca_key.write_text("ca key", encoding="utf-8")
+    client_cert.write_text("client cert", encoding="utf-8")
+    client_key.write_text("client key", encoding="utf-8")
+    captured = {}
+
+    def fake_generate(**kwargs):
+        captured.update(kwargs)
+        return {
+            "cert_file": client_cert,
+            "key_file": client_key,
+            "_tempdir": object(),
+        }
+
+    def fake_urlopen(request, timeout):
+        path = request.full_url.removeprefix("https://sm-app.example.com")
+        if path == "/client/bootstrap" and not hasattr(fake_urlopen, "denied"):
+            fake_urlopen.denied = True
+            raise urllib.error.HTTPError(
+                request.full_url,
+                403,
+                "forbidden",
+                {"content-type": "text/html"},
+                _BytesHandle(b"<html>Cloudflare Access</html>"),
+            )
+        if path == "/client/bootstrap":
+            return FakeResponse(200, b'{"auth":{}}')
+        if path == "/client/sessions":
+            raise _http_error(
+                request.full_url,
+                401,
+                {"detail": "Authentication required"},
+            )
+        if path == "/apps/session-manager-android/meta.json":
+            return FakeResponse(200, b'{"artifact_hash":"deadbeef"}')
+        raise AssertionError(f"unexpected request path {path}")
+
+    monkeypatch.setattr(
+        "scripts.rust_migration.cloudflare_access_smoke._generate_ephemeral_client_cert",
+        fake_generate,
+    )
+
+    report = build_smoke_report(
+        mode="public-mtls",
+        public_base_url="https://sm-app.example.com",
+        client_cert_common_name="android-c6c90c26d0d90faf",
+        device_ca_cert_file=ca_cert,
+        device_ca_key_file=ca_key,
+        urlopen=fake_urlopen,
+    )
+
+    assert report["status"] == "passed"
+    assert report["inputs"]["ephemeral_client_cert_generated"] is True
+    assert report["inputs"]["client_cert_common_name"] == "android-c6c90c26d0d90faf"
+    assert captured == {
+        "common_name": "android-c6c90c26d0d90faf",
+        "device_ca_cert_file": ca_cert,
+        "device_ca_key_file": ca_key,
+    }
+
+
+def test_cloudflare_access_smoke_cli_passes_public_mtls_args(tmp_path, monkeypatch):
+    captured = {}
+
+    def fake_report(**kwargs):
+        captured.update(kwargs)
+        return {
+            "status": "passed",
+            "summary": {"passed": 4, "blocked": 0, "skipped": 1},
+            "checks": [],
+            "blockers": [],
+        }
+
+    monkeypatch.setattr(
+        "scripts.rust_migration.cloudflare_access_smoke.build_smoke_report",
+        fake_report,
+    )
+
+    exit_code = main(
+        [
+            "--mode",
+            "public-mtls",
+            "--public-base-url",
+            "https://sm-app.example.com",
+            "--client-cert-common-name",
+            "android-c6c90c26d0d90faf",
+            "--device-ca-cert-file",
+            str(tmp_path / "ca.cert.pem"),
+            "--device-ca-key-file",
+            str(tmp_path / "ca.key.pem"),
+        ]
+    )
+
+    assert exit_code == 0
+    assert captured["mode"] == "public-mtls"
+    assert captured["public_base_url"] == "https://sm-app.example.com"
+    assert captured["client_cert_common_name"] == "android-c6c90c26d0d90faf"
+    assert captured["device_ca_cert_file"] == tmp_path / "ca.cert.pem"
+    assert captured["device_ca_key_file"] == tmp_path / "ca.key.pem"

--- a/tests/unit/test_rust_migration_contracts.py
+++ b/tests/unit/test_rust_migration_contracts.py
@@ -267,7 +267,7 @@ def test_cloudflare_access_cutover_evidence_pins_policy_and_origin_gates():
         assert required in evidence
 
 
-def test_handoff_and_progress_are_current_through_live_canary_issue1044():
+def test_handoff_and_progress_are_current_through_public_mtls_issue1046():
     progress = (STAGE5_DIR / "mvp_progress.md").read_text(encoding="utf-8")
     handoff = (STAGE5_DIR / "resume_handoff.md").read_text(encoding="utf-8")
     gate_matrix = (STAGE5_DIR / "gate_matrix.md").read_text(encoding="utf-8")
@@ -293,8 +293,10 @@ def test_handoff_and_progress_are_current_through_live_canary_issue1044():
         assert "#1037" in text
         assert "#1039" in text
         assert "#1041" in text
+        assert "#1045" in text
         assert "issue #1042" in text.lower()
         assert "issue #1044" in text.lower()
+        assert "issue #1046" in text.lower()
         assert "Cloudflare Access" in text
         assert "cloudflare_access_cutover_evidence.md" in text
         assert "public_tunnel_preflight" in text
@@ -302,16 +304,22 @@ def test_handoff_and_progress_are_current_through_live_canary_issue1044():
         assert "sm-app.rajeshgo.li" in text
         assert "python_canary_spot_checks" in text
         assert "cloudflare_access_smoke_report" in text
+        assert "public mTLS" in text
 
-    assert "Latest merged commit before this docs refresh: `f7e74af`" in handoff
-    assert "PR #1041" in handoff
+    assert "Latest merged commit before this docs refresh: `948e6ec`" in handoff
+    assert "PR #1045" in handoff
     assert "rust_service_cutover_runbook.md" in handoff
     assert "127.0.0.1:8420" in handoff
     assert "Legacy `sm.rajeshgo.li` should not route to origin" in handoff
     assert "Camera-app" in handoff
     assert "deep-link enrollment" in handoff
     assert "app update artifact access works through the certificate-gated app path" in handoff
+    assert "public-mtls-smoke-20260617T202635Z.json" in handoff
+    assert "live-canary-with-public-mtls-20260617T202645Z.json" in handoff
+    assert "Summary: `11` passed, `0` blocked, `0` skipped" in handoff
     assert "--cloudflare-smoke-report" in readme
+    assert "--mode public-mtls" in readme
+    assert "--client-cert-common-name" in readme
     assert "public_tunnel_preflight" in readme
     assert "live_canary_report" in readme
 


### PR DESCRIPTION
Fixes #1046

## Summary
- add `--mode public-mtls` to the Cloudflare Access smoke runner
- support an existing client cert/key or an ephemeral client cert generated from the local mobile CA and enrolled Common Name
- prove the real `sm-app.rajeshgo.li` boundary: no-cert denial, certed bootstrap, SM-auth boundary for `/client/sessions`, and certed app metadata
- update Stage 5 handoff/evidence docs with the passing public mTLS smoke and live canary artifacts

## Evidence
- public mTLS smoke: `.local/rust-mvp-rehearsals/public-mtls-smoke-20260617T202635Z.json` (`4` passed, `0` blocked, `1` optional skipped)
- live canary with supplied smoke: `.local/rust-mvp-rehearsals/live-canary-with-public-mtls-20260617T202645Z.json` (`11` passed, `0` blocked, `0` skipped)

## Validation
- `./venv/bin/python -m py_compile scripts/rust_migration/cloudflare_access_smoke.py`
- `./venv/bin/python -m pytest tests/unit/test_rust_cloudflare_access_smoke.py tests/unit/test_rust_migration_contracts.py -q`
- `git diff --check`