### PR TITLE
Add Android emulator smoke for native app

### DIFF
--- a/android-app/app/src/debug/AndroidManifest.xml
+++ b/android-app/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <activity
+            android:name=".debug.AndroidSmokeActivity"
+            android:exported="true"
+            android:theme="@style/Theme.SessionManager" />
+    </application>
+
+</manifest>

--- a/android-app/app/src/debug/java/li/rajeshgo/sm/debug/AndroidSmokeActivity.kt
+++ b/android-app/app/src/debug/java/li/rajeshgo/sm/debug/AndroidSmokeActivity.kt
@@ -6,10 +6,14 @@ import androidx.activity.ComponentActivity
 import androidx.lifecycle.lifecycleScope
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.Json
 import li.rajeshgo.sm.data.model.ClientSession
+import li.rajeshgo.sm.data.model.MobileAttachTicketResponse
 import li.rajeshgo.sm.data.remote.ApiService
 import li.rajeshgo.sm.data.remote.HttpClientFactory
 import li.rajeshgo.sm.data.repository.DeviceEnrollmentRepository
@@ -17,11 +21,16 @@ import li.rajeshgo.sm.data.repository.SettingsRepository
 import li.rajeshgo.sm.data.repository.SessionManagerRepository
 import li.rajeshgo.sm.data.security.DeviceKeyManager
 import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
 import org.json.JSONArray
 import org.json.JSONObject
 import retrofit2.Retrofit
 import java.io.File
 import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
 
 class AndroidSmokeActivity : ComponentActivity() {
     private val steps = JSONArray()
@@ -51,6 +60,8 @@ class AndroidSmokeActivity : ComponentActivity() {
         val deviceKeyManager = DeviceKeyManager()
         val sessionRepository = SessionManagerRepository(settingsRepository)
         var sessions: List<ClientSession> = emptyList()
+        var attachSession: ClientSession? = null
+        var attachTicket: MobileAttachTicketResponse? = null
 
         step("configure_settings") {
             settingsRepository.saveServerUrl(serverUrl)
@@ -76,7 +87,7 @@ class AndroidSmokeActivity : ComponentActivity() {
         }
 
         step("client_bootstrap") {
-            val payload = sessionRepository.fetchBootstrap(serverUrl)
+            val payload = retrySmokeRead { sessionRepository.fetchBootstrap(serverUrl) }
             JSONObject()
                 .put("auth_mode", payload.auth.mode)
                 .put("device_auth_endpoint", payload.auth.deviceAuthEndpoint)
@@ -120,6 +131,7 @@ class AndroidSmokeActivity : ComponentActivity() {
                     ?: return@step JSONObject()
                         .put("status_override", "skipped")
                         .put("reason", "no session advertises mobile_terminal.supported")
+                attachSession = supported
                 val path = sessionRepository.mobileAttachTicketPath(
                     baseUrl = serverUrl,
                     sessionId = supported.id,
@@ -134,12 +146,32 @@ class AndroidSmokeActivity : ComponentActivity() {
                 val ticket = sessionRepository
                     .createMobileAttachTicket(serverUrl, accessToken, supported.id, proof)
                     .getOrThrow()
+                attachTicket = ticket
                 JSONObject()
                     .put("session_id", supported.id)
                     .put("ticket_id_present", ticket.ticketId.isNotBlank())
                     .put("device_key_id", ticket.deviceKeyId)
                     .put("ws_url_host", hostFromUrl(ticket.wsUrl))
                     .put("expires_at", ticket.expiresAt)
+            }
+
+            step("mobile_terminal_socket") {
+                val supported = attachSession
+                    ?: return@step JSONObject()
+                        .put("status_override", "skipped")
+                        .put("reason", "mobile attach ticket was skipped")
+                val ticket = attachTicket
+                    ?: return@step JSONObject()
+                        .put("status_override", "skipped")
+                        .put("reason", "mobile attach ticket was not minted")
+                runMobileTerminalSocketSmoke(
+                    sessionRepository = sessionRepository,
+                    ticket = ticket,
+                    accessToken = accessToken,
+                    deviceKeyManager = deviceKeyManager,
+                    session = supported,
+                    actorEmail = userEmail,
+                )
             }
         }
 
@@ -206,6 +238,132 @@ class AndroidSmokeActivity : ComponentActivity() {
             .create(ApiService::class.java)
     }
 
+    private suspend fun <T> retrySmokeRead(block: suspend () -> T): T {
+        var lastError: Throwable? = null
+        repeat(SMOKE_READ_ATTEMPTS) { attempt ->
+            try {
+                return block()
+            } catch (error: Throwable) {
+                lastError = error
+                if (attempt < SMOKE_READ_ATTEMPTS - 1) {
+                    delay(SMOKE_READ_RETRY_DELAY_MS)
+                }
+            }
+        }
+        throw lastError ?: IllegalStateException("smoke read failed")
+    }
+
+    private suspend fun runMobileTerminalSocketSmoke(
+        sessionRepository: SessionManagerRepository,
+        ticket: MobileAttachTicketResponse,
+        accessToken: String,
+        deviceKeyManager: DeviceKeyManager,
+        session: ClientSession,
+        actorEmail: String,
+    ): JSONObject = withTimeout(SOCKET_SMOKE_TIMEOUT_MS) {
+        val completed = AtomicBoolean(false)
+        val result = CompletableDeferred<JSONObject>()
+        var socket: WebSocket? = null
+
+        fun finish(payload: JSONObject) {
+            if (completed.compareAndSet(false, true)) {
+                socket?.close(1000, "android smoke complete")
+                result.complete(payload)
+            }
+        }
+
+        fun fail(error: Throwable) {
+            if (completed.compareAndSet(false, true)) {
+                socket?.close(1000, "android smoke failed")
+                result.completeExceptionally(error)
+            }
+        }
+
+        val wsNonce = UUID.randomUUID().toString()
+        val wsSignature = deviceKeyManager.signWebSocketAuth(
+            ticketId = ticket.ticketId,
+            sessionId = session.id,
+            actorEmail = actorEmail,
+            deviceKeyId = ticket.deviceKeyId,
+            nonce = wsNonce,
+        )
+
+        socket = sessionRepository.openMobileTerminalSocket(
+            ticket = ticket,
+            accessToken = accessToken,
+            listener = object : WebSocketListener() {
+                override fun onOpen(webSocket: WebSocket, response: Response) {
+                    val authFrame = JSONObject()
+                        .put("type", "auth")
+                        .put("ticket_id", ticket.ticketId)
+                        .put("ticket_secret", ticket.ticketSecret)
+                        .put("device_key_id", ticket.deviceKeyId)
+                        .put("nonce", wsNonce)
+                        .put("signature", wsSignature)
+                    webSocket.send(authFrame.toString())
+                    webSocket.send(
+                        JSONObject()
+                            .put("type", "resize")
+                            .put("cols", 80)
+                            .put("rows", 24)
+                            .toString(),
+                    )
+                }
+
+                override fun onMessage(webSocket: WebSocket, text: String) {
+                    val payload = runCatching { JSONObject(text) }.getOrNull() ?: return
+                    when (payload.optString("type")) {
+                        "status" -> finish(
+                            JSONObject()
+                                .put("session_id", session.id)
+                                .put("ws_url_host", hostFromUrl(ticket.wsUrl))
+                                .put("first_frame_type", "status")
+                                .put("state", payload.optString("state")),
+                        )
+                        "output" -> finish(
+                            JSONObject()
+                                .put("session_id", session.id)
+                                .put("ws_url_host", hostFromUrl(ticket.wsUrl))
+                                .put("first_frame_type", "output")
+                                .put("encoding", payload.optString("encoding"))
+                                .put("mode", payload.optString("mode"))
+                                .put("data_present", payload.optString("data").isNotBlank()),
+                        )
+                        "error" -> fail(
+                            IllegalStateException(
+                                payload.optString("message", "terminal socket returned error"),
+                            ),
+                        )
+                    }
+                }
+
+                override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+                    val detail = buildString {
+                        response?.let {
+                            append(it.message.ifBlank { "HTTP error" })
+                            append(" (")
+                            append(it.code)
+                            append("): ")
+                        }
+                        append(t.message ?: "Terminal socket failed")
+                    }
+                    fail(IllegalStateException(detail, t))
+                }
+
+                override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+                    fail(IllegalStateException("Terminal socket closed before output ($code): $reason"))
+                }
+            },
+        )
+        try {
+            result.await()
+        } finally {
+            if (!completed.get()) {
+                socket?.close(1000, "android smoke cancelled")
+            }
+        }
+    }
+
     private fun requiredExtra(name: String, defaultValue: String? = null): String {
         val value = intent.getStringExtra(name)?.trim().orEmpty()
         if (value.isNotEmpty()) {
@@ -221,5 +379,8 @@ class AndroidSmokeActivity : ComponentActivity() {
         const val TAG = "SM_ADB_SMOKE"
         const val DEFAULT_REPORT_FILE = "android-smoke-report.json"
         const val MAX_DETAIL_CHARS = 500
+        const val SOCKET_SMOKE_TIMEOUT_MS = 10_000L
+        const val SMOKE_READ_ATTEMPTS = 6
+        const val SMOKE_READ_RETRY_DELAY_MS = 1_000L
     }
 }

--- a/android-app/app/src/debug/java/li/rajeshgo/sm/debug/AndroidSmokeActivity.kt
+++ b/android-app/app/src/debug/java/li/rajeshgo/sm/debug/AndroidSmokeActivity.kt
@@ -1,0 +1,225 @@
+package li.rajeshgo.sm.debug
+
+import android.os.Bundle
+import android.util.Log
+import androidx.activity.ComponentActivity
+import androidx.lifecycle.lifecycleScope
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import li.rajeshgo.sm.data.model.ClientSession
+import li.rajeshgo.sm.data.remote.ApiService
+import li.rajeshgo.sm.data.remote.HttpClientFactory
+import li.rajeshgo.sm.data.repository.DeviceEnrollmentRepository
+import li.rajeshgo.sm.data.repository.SettingsRepository
+import li.rajeshgo.sm.data.repository.SessionManagerRepository
+import li.rajeshgo.sm.data.security.DeviceKeyManager
+import okhttp3.MediaType.Companion.toMediaType
+import org.json.JSONArray
+import org.json.JSONObject
+import retrofit2.Retrofit
+import java.io.File
+import java.time.Instant
+
+class AndroidSmokeActivity : ComponentActivity() {
+    private val steps = JSONArray()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        lifecycleScope.launch {
+            runSmoke()
+            finish()
+        }
+    }
+
+    private suspend fun runSmoke() {
+        val reportFileName = requiredExtra("report_file", DEFAULT_REPORT_FILE)
+        val reportFile = File(filesDir, reportFileName)
+        reportFile.delete()
+
+        val serverUrl = requiredExtra("server_url").trim().trimEnd('/')
+        val enrollmentUrl = requiredExtra("enrollment_url")
+        val accessToken = requiredExtra("access_token")
+        val userEmail = requiredExtra("user_email").trim().lowercase()
+        val userName = requiredExtra("user_name", userEmail).trim().ifBlank { userEmail }
+        val expiresAt = requiredExtra("expires_at")
+        val includeAttachTicket = intent.getBooleanExtra("include_attach_ticket", true)
+
+        val settingsRepository = SettingsRepository(applicationContext)
+        val deviceKeyManager = DeviceKeyManager()
+        val sessionRepository = SessionManagerRepository(settingsRepository)
+        var sessions: List<ClientSession> = emptyList()
+
+        step("configure_settings") {
+            settingsRepository.saveServerUrl(serverUrl)
+            JSONObject()
+                .put("server_url_host", hostFromUrl(serverUrl))
+                .put("user_email", userEmail)
+        }
+
+        step("enroll_device_certificate") {
+            val result = DeviceEnrollmentRepository(settingsRepository, deviceKeyManager)
+                .enrollFromQr(enrollmentUrl)
+            JSONObject()
+                .put("device_id", result.deviceId)
+                .put("expires_at", result.expiresAt)
+                .put("device_name_present", !result.deviceName.isNullOrBlank())
+        }
+
+        step("seed_device_auth") {
+            settingsRepository.saveAuth(accessToken, userEmail, userName, expiresAt)
+            JSONObject()
+                .put("user_email", userEmail)
+                .put("expires_at", expiresAt)
+        }
+
+        step("client_bootstrap") {
+            val payload = sessionRepository.fetchBootstrap(serverUrl)
+            JSONObject()
+                .put("auth_mode", payload.auth.mode)
+                .put("device_auth_endpoint", payload.auth.deviceAuthEndpoint)
+                .put("mobile_terminal_supported", payload.externalAccess.mobileTerminalSupported)
+        }
+
+        step("auth_session") {
+            val payload = sessionRepository.fetchAuthSession(serverUrl, accessToken)
+            JSONObject()
+                .put("authenticated", payload.authenticated)
+                .put("auth_type", payload.authType)
+                .put("email", payload.email)
+        }
+
+        step("client_sessions") {
+            sessions = sessionRepository.fetchSessions(serverUrl, accessToken)
+            JSONObject()
+                .put("count", sessions.size)
+                .put("mobile_terminal_supported_count", sessions.count { it.mobileTerminal?.supported == true })
+        }
+
+        step("analytics_summary") {
+            val payload = sessionRepository.fetchAnalytics(serverUrl, accessToken)
+            JSONObject()
+                .put("generated_at_present", payload.generatedAt.isNotBlank())
+                .put("active_sessions", payload.kpis.activeSessions.value)
+                .put("attach_available", payload.attachAvailable)
+        }
+
+        step("app_artifact_metadata") {
+            val metadata = apiService(serverUrl, settingsRepository).getAppArtifactMetadata("session-manager-android")
+            JSONObject()
+                .put("artifact_hash_present", !metadata.artifactHash.isNullOrBlank())
+                .put("version_name", metadata.versionName)
+                .put("size_bytes", metadata.sizeBytes)
+        }
+
+        if (includeAttachTicket) {
+            step("mobile_attach_ticket") {
+                val supported = sessions.firstOrNull { it.mobileTerminal?.supported == true }
+                    ?: return@step JSONObject()
+                        .put("status_override", "skipped")
+                        .put("reason", "no session advertises mobile_terminal.supported")
+                val path = sessionRepository.mobileAttachTicketPath(
+                    baseUrl = serverUrl,
+                    sessionId = supported.id,
+                    advertisedEndpoint = supported.mobileTerminal?.ticketEndpoint,
+                )
+                val proof = deviceKeyManager.signTicketRequest(
+                    method = "POST",
+                    path = path,
+                    sessionId = supported.id,
+                    actorEmail = userEmail,
+                )
+                val ticket = sessionRepository
+                    .createMobileAttachTicket(serverUrl, accessToken, supported.id, proof)
+                    .getOrThrow()
+                JSONObject()
+                    .put("session_id", supported.id)
+                    .put("ticket_id_present", ticket.ticketId.isNotBlank())
+                    .put("device_key_id", ticket.deviceKeyId)
+                    .put("ws_url_host", hostFromUrl(ticket.wsUrl))
+                    .put("expires_at", ticket.expiresAt)
+            }
+        }
+
+        val blockers = countSteps("blocked")
+        val report = JSONObject()
+            .put("schema_version", 1)
+            .put("generated_at", Instant.now().toString())
+            .put("server_url_host", hostFromUrl(serverUrl))
+            .put("steps", steps)
+            .put(
+                "summary",
+                JSONObject()
+                    .put("passed", countSteps("passed"))
+                    .put("skipped", countSteps("skipped"))
+                    .put("blocked", blockers)
+                    .put("status", if (blockers == 0) "passed" else "blocked"),
+            )
+        withContext(Dispatchers.IO) {
+            reportFile.writeText(report.toString(2))
+        }
+        Log.i(TAG, "android_smoke_report_written path=${reportFile.name} blocked=$blockers")
+    }
+
+    private suspend fun step(id: String, block: suspend () -> JSONObject) {
+        val startedAt = Instant.now()
+        val payload = try {
+            block()
+        } catch (error: Throwable) {
+            val result = JSONObject()
+                .put("id", id)
+                .put("status", "blocked")
+                .put("started_at", startedAt.toString())
+                .put("finished_at", Instant.now().toString())
+                .put("error_class", error.javaClass.name)
+                .put("detail", error.message.orEmpty().take(MAX_DETAIL_CHARS))
+            steps.put(result)
+            Log.w(TAG, "android_smoke_step_blocked id=$id", error)
+            return
+        }
+        val status = payload.optString("status_override", "passed")
+        payload.remove("status_override")
+        steps.put(
+            JSONObject()
+                .put("id", id)
+                .put("status", status)
+                .put("started_at", startedAt.toString())
+                .put("finished_at", Instant.now().toString())
+                .put("detail", payload),
+        )
+    }
+
+    private fun countSteps(status: String): Int =
+        (0 until steps.length()).count { index ->
+            steps.optJSONObject(index)?.optString("status") == status
+        }
+
+    private suspend fun apiService(serverUrl: String, settingsRepository: SettingsRepository): ApiService {
+        val json = Json { ignoreUnknownKeys = true; coerceInputValues = true }
+        return Retrofit.Builder()
+            .baseUrl(serverUrl.trim().trimEnd('/') + "/")
+            .client(HttpClientFactory(settingsRepository).create(includeLogging = false))
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+            .create(ApiService::class.java)
+    }
+
+    private fun requiredExtra(name: String, defaultValue: String? = null): String {
+        val value = intent.getStringExtra(name)?.trim().orEmpty()
+        if (value.isNotEmpty()) {
+            return value
+        }
+        return defaultValue ?: error("Missing required extra: $name")
+    }
+
+    private fun hostFromUrl(url: String): String =
+        runCatching { java.net.URI(url).host.orEmpty() }.getOrDefault("")
+
+    private companion object {
+        const val TAG = "SM_ADB_SMOKE"
+        const val DEFAULT_REPORT_FILE = "android-smoke-report.json"
+        const val MAX_DETAIL_CHARS = 500
+    }
+}

--- a/scripts/rust_migration/README.md
+++ b/scripts/rust_migration/README.md
@@ -518,6 +518,28 @@ the loopback smoke report records those checks as skipped edge-only evidence.
 Use the JSON output as operator evidence alongside
 `specs/762_stage5_artifacts/cloudflare_access_cutover_evidence.md`.
 
+## Android Emulator Native App Smoke
+
+After the public mobile Access policy and Rust origin are configured, run the
+native app smoke in a managed Android emulator instead of a plugged-in phone:
+
+```bash
+python -m scripts.rust_migration.android_emulator_smoke \
+  --server-url https://sm-app.rajeshgo.li \
+  --avd sm_mtls_api35 \
+  --config config.yaml \
+  --fail-on-blockers
+```
+
+The runner builds and installs the debug APK, starts an `sm enroll-device`
+pairing listener on `127.0.0.1`, exposes it to the emulator with
+`adb reverse tcp:<port> tcp:<port>`, advertises it to the app as
+`http://127.0.0.1:<port>`, and launches a debug-only app activity. The app uses
+its normal enrollment repository to save the Cloudflare client certificate, then
+performs HTTPS reads through the normal OkHttp/Retrofit stack with that saved
+client cert plus a short-lived SM device bearer. The report redacts bearer,
+pairing token, certificate, and key material.
+
 ## Accelerated Rust Canary Evidence
 
 Normal cutover evidence still prefers Python-authoritative shadow for the

--- a/scripts/rust_migration/android_emulator_smoke.py
+++ b/scripts/rust_migration/android_emulator_smoke.py
@@ -166,6 +166,8 @@ def run_android_emulator_smoke(args: argparse.Namespace) -> dict[str, Any]:
 
         _run_checked([args.adb, "-s", serial, "install", "-r", str(apk_path)])
         _host_step(report, "install_debug_apk", "passed")
+        _run_checked([args.adb, "-s", serial, "shell", "pm", "clear", args.app_id])
+        _host_step(report, "clear_app_data", "passed")
 
         token = build_device_access_token(
             session_cookie_secret=identity["session_cookie_secret"],

--- a/scripts/rust_migration/android_emulator_smoke.py
+++ b/scripts/rust_migration/android_emulator_smoke.py
@@ -1,0 +1,558 @@
+"""Run a managed Android emulator smoke for the native SM app.
+
+The smoke uses a debug-only app activity. It does not drive production UI, and
+it does not require a plugged-in phone. The host starts an enrollment listener,
+the emulator enrolls through the same repository path used by the deep link, and
+then the app performs real HTTPS reads with its saved Cloudflare client cert.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import hmac
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+DEFAULT_AVD = "sm_mtls_api35"
+DEFAULT_SERVER_URL = "https://sm-app.rajeshgo.li"
+DEFAULT_REPORT_FILE = "android-smoke-report.json"
+DEFAULT_CONFIG = Path("config.yaml")
+DEFAULT_APK = Path("android-app/app/build/outputs/apk/debug/app-debug.apk")
+DEFAULT_APP_ID = "li.rajeshgo.sm"
+DEFAULT_ACTIVITY = "li.rajeshgo.sm/.debug.AndroidSmokeActivity"
+DEFAULT_OUTPUT_DIR = Path(".local/rust-mvp-rehearsals")
+DEFAULT_SMOKE_TIMEOUT_SECONDS = 240
+DEFAULT_BOOT_TIMEOUT_SECONDS = 180
+DEVICE_TOKEN_MAX_AGE_SECONDS = 60 * 60 * 24 * 14
+
+
+def build_device_access_token(
+    *,
+    session_cookie_secret: str,
+    email: str,
+    name: str,
+    now: int | None = None,
+    expires_in_seconds: int = 60 * 60,
+) -> dict[str, Any]:
+    secret = session_cookie_secret.strip()
+    if not secret:
+        raise ValueError("session_cookie_secret is required")
+    if expires_in_seconds <= 0 or expires_in_seconds > DEVICE_TOKEN_MAX_AGE_SECONDS:
+        raise ValueError("expires_in_seconds must be between 1 and 1209600")
+    issued_at = int(time.time() if now is None else now)
+    expires_at_unix = issued_at + expires_in_seconds
+    payload = {
+        "v": 1,
+        "type": "device_access",
+        "email": email.strip().lower(),
+        "name": name.strip() or email.strip().lower(),
+        "iat": issued_at,
+        "exp": expires_at_unix,
+    }
+    payload_b64 = _urlsafe_no_pad(
+        json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    )
+    signature = _urlsafe_no_pad(
+        hmac.new(secret.encode("utf-8"), payload_b64.encode("ascii"), hashlib.sha256).digest()
+    )
+    expires_at = datetime.fromtimestamp(expires_at_unix, timezone.utc).isoformat()
+    return {
+        "access_token": f"smat_{payload_b64}.{signature}",
+        "expires_at": expires_at,
+        "email": payload["email"],
+        "name": payload["name"],
+    }
+
+
+def load_mobile_smoke_identity(
+    config_path: Path,
+    *,
+    user_id: str | None = None,
+    email: str | None = None,
+    name: str | None = None,
+) -> dict[str, str]:
+    config = _load_runtime_config(config_path)
+    mobile_terminal = _mapping(config.get("mobile_terminal"))
+    allowed_users = _mapping(mobile_terminal.get("allowed_users"))
+    resolved_user_id = (user_id or "").strip()
+    if not resolved_user_id:
+        interactive_users = sorted(
+            key
+            for key, raw in allowed_users.items()
+            if _mapping(raw).get("interactive_shell_access") is True
+        )
+        if len(interactive_users) != 1:
+            raise ValueError("pass --user-id when config has zero or multiple interactive mobile users")
+        resolved_user_id = interactive_users[0]
+    user_config = _mapping(allowed_users.get(resolved_user_id))
+    resolved_email = (email or str(user_config.get("email") or resolved_user_id)).strip().lower()
+    if not resolved_email:
+        raise ValueError("mobile smoke email could not be resolved")
+    google_auth = _mapping(_mapping(config.get("auth")).get("google"))
+    secret = str(google_auth.get("session_cookie_secret") or "").strip()
+    if not secret:
+        raise ValueError("auth.google.session_cookie_secret is required to mint a device token")
+    return {
+        "user_id": resolved_user_id,
+        "email": resolved_email,
+        "name": (name or resolved_email).strip() or resolved_email,
+        "session_cookie_secret": secret,
+    }
+
+
+def run_android_emulator_smoke(args: argparse.Namespace) -> dict[str, Any]:
+    output = Path(args.output) if args.output else _default_output_path()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    report: dict[str, Any] = {
+        "schema_version": 1,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "inputs": {
+            "server_url_host": _host_from_url(args.server_url),
+            "config": str(args.config),
+            "avd": args.avd,
+            "serial": args.serial,
+            "app_id": args.app_id,
+            "include_attach_ticket": args.include_attach_ticket,
+        },
+        "host_steps": [],
+        "android_report": None,
+        "summary": {"status": "blocked", "passed": 0, "skipped": 0, "blocked": 0},
+        "artifacts": {"output": str(output)},
+    }
+    emulator_process: subprocess.Popen[str] | None = None
+    enrollment_process: subprocess.Popen[str] | None = None
+    reversed_port: int | None = None
+    try:
+        identity = load_mobile_smoke_identity(
+            Path(args.config),
+            user_id=args.user_id,
+            email=args.email,
+            name=args.name,
+        )
+        report["inputs"]["user_id"] = identity["user_id"]
+        report["inputs"]["email"] = identity["email"]
+        _host_step(report, "resolve_mobile_identity", "passed")
+
+        if args.build_apk:
+            _run_checked(["./gradlew", "assembleDebug"], cwd=Path("android-app"))
+            _host_step(report, "build_debug_apk", "passed")
+        else:
+            _host_step(report, "build_debug_apk", "skipped", "disabled by --no-build-apk")
+
+        apk_path = Path(args.apk)
+        if not apk_path.is_file():
+            raise RuntimeError(f"debug APK not found: {apk_path}")
+
+        serial = args.serial or _first_booted_device(args.adb)
+        if not serial:
+            emulator_process = _start_emulator(args)
+            serial = _wait_for_booted_device(args.adb, args.boot_timeout_seconds)
+            _host_step(report, "start_emulator", "passed", f"serial={serial}")
+        else:
+            _host_step(report, "start_emulator", "skipped", f"using existing serial={serial}")
+        report["inputs"]["serial"] = serial
+
+        _run_checked([args.adb, "-s", serial, "install", "-r", str(apk_path)])
+        _host_step(report, "install_debug_apk", "passed")
+
+        token = build_device_access_token(
+            session_cookie_secret=identity["session_cookie_secret"],
+            email=identity["email"],
+            name=identity["name"],
+            expires_in_seconds=args.token_expires_minutes * 60,
+        )
+        _host_step(report, "mint_short_lived_device_bearer", "passed")
+
+        enrollment_port = _free_tcp_port()
+        _run_checked([args.adb, "-s", serial, "reverse", f"tcp:{enrollment_port}", f"tcp:{enrollment_port}"])
+        reversed_port = enrollment_port
+        _host_step(report, "configure_adb_reverse_pairing_port", "passed")
+        enrollment_process = _start_enrollment_listener(args, identity["user_id"], enrollment_port)
+        enrollment_url = _read_enrollment_url(enrollment_process, args.smoke_timeout_seconds)
+        _host_step(report, "start_enrollment_listener", "passed")
+
+        _remove_android_report(args.adb, serial, args.app_id, args.report_file)
+        _start_android_smoke_activity(
+            args,
+            serial,
+            enrollment_url=enrollment_url,
+            token=token,
+        )
+        _host_step(report, "start_debug_smoke_activity", "passed")
+
+        android_report = _poll_android_report(
+            args.adb,
+            serial,
+            args.app_id,
+            args.report_file,
+            args.smoke_timeout_seconds,
+        )
+        report["android_report"] = android_report
+        _host_step(report, "collect_android_report", "passed")
+
+        if enrollment_process.poll() is None:
+            try:
+                enrollment_process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+
+        report["summary"] = _summarize(report)
+    except Exception as error:
+        _host_step(report, "android_emulator_smoke", "blocked", str(error))
+        report["summary"] = _summarize(report)
+        report["error"] = {"class": error.__class__.__name__, "detail": str(error)}
+    finally:
+        if reversed_port is not None:
+            subprocess.run(
+                [args.adb, "-s", report["inputs"].get("serial") or "", "reverse", "--remove", f"tcp:{reversed_port}"],
+                check=False,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        if enrollment_process and enrollment_process.poll() is None:
+            enrollment_process.terminate()
+            try:
+                enrollment_process.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                enrollment_process.kill()
+        if emulator_process and args.stop_started_emulator:
+            subprocess.run([args.adb, "emu", "kill"], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return report
+
+
+def _start_emulator(args: argparse.Namespace) -> subprocess.Popen[str]:
+    return subprocess.Popen(
+        [
+            args.emulator,
+            "-avd",
+            args.avd,
+            "-no-window",
+            "-no-audio",
+            "-no-boot-anim",
+            "-gpu",
+            "swiftshader_indirect",
+            "-no-snapshot-save",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+
+
+def _first_booted_device(adb: str) -> str | None:
+    result = subprocess.run([adb, "devices"], check=True, capture_output=True, text=True)
+    for line in result.stdout.splitlines()[1:]:
+        parts = line.split()
+        if len(parts) >= 2 and parts[1] == "device":
+            serial = parts[0]
+            booted = subprocess.run(
+                [adb, "-s", serial, "shell", "getprop", "sys.boot_completed"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            if booted.stdout.strip() == "1":
+                return serial
+    return None
+
+
+def _wait_for_booted_device(adb: str, timeout_seconds: int) -> str:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        serial = _first_booted_device(adb)
+        if serial:
+            return serial
+        time.sleep(2)
+    raise TimeoutError("Android emulator did not boot in time")
+
+
+def _start_enrollment_listener(
+    args: argparse.Namespace,
+    user_id: str,
+    port: int,
+) -> subprocess.Popen[str]:
+    sm_binary = _resolve_sm_binary(Path(args.sm_binary))
+    command = [
+        str(sm_binary),
+        "enroll-device",
+        "--config",
+        str(args.config),
+        "--user-id",
+        user_id,
+        "--expires-in-minutes",
+        str(args.enrollment_expires_minutes),
+        "--listen",
+        f"127.0.0.1:{port}",
+        "--url-base",
+        f"http://127.0.0.1:{port}",
+        "--no-qr",
+    ]
+    return subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+
+
+def _read_enrollment_url(process: subprocess.Popen[str], timeout_seconds: int) -> str:
+    assert process.stdout is not None
+    deadline = time.monotonic() + timeout_seconds
+    lines: list[str] = []
+    while time.monotonic() < deadline:
+        line = process.stdout.readline()
+        if not line:
+            if process.poll() is not None:
+                raise RuntimeError("enroll-device exited before printing an enrollment URL: " + "".join(lines)[-500:])
+            time.sleep(0.1)
+            continue
+        lines.append(line)
+        marker = "Enrollment URL:"
+        if marker in line:
+            url = line.split(marker, 1)[1].strip()
+            if url:
+                return url
+    raise TimeoutError("timed out waiting for enroll-device enrollment URL")
+
+
+def _start_android_smoke_activity(
+    args: argparse.Namespace,
+    serial: str,
+    *,
+    enrollment_url: str,
+    token: dict[str, Any],
+) -> None:
+    command = [
+        args.adb,
+        "-s",
+        serial,
+        "shell",
+        "am",
+        "start",
+        "-W",
+        "-n",
+        args.activity,
+        "--es",
+        "server_url",
+        args.server_url,
+        "--es",
+        "enrollment_url",
+        enrollment_url,
+        "--es",
+        "access_token",
+        token["access_token"],
+        "--es",
+        "user_email",
+        token["email"],
+        "--es",
+        "user_name",
+        token["name"],
+        "--es",
+        "expires_at",
+        token["expires_at"],
+        "--es",
+        "report_file",
+        args.report_file,
+        "--ez",
+        "include_attach_ticket",
+        "true" if args.include_attach_ticket else "false",
+    ]
+    _run_checked(command)
+
+
+def _poll_android_report(
+    adb: str,
+    serial: str,
+    app_id: str,
+    report_file: str,
+    timeout_seconds: int,
+) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout_seconds
+    last_error = ""
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            [adb, "-s", serial, "exec-out", "run-as", app_id, "cat", f"files/{report_file}"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            try:
+                return json.loads(result.stdout)
+            except json.JSONDecodeError as error:
+                last_error = f"invalid JSON report while polling: {error}"
+                time.sleep(1)
+                continue
+        last_error = (result.stderr or result.stdout).strip()
+        time.sleep(1)
+    raise TimeoutError(f"timed out waiting for Android smoke report: {last_error}")
+
+
+def _remove_android_report(adb: str, serial: str, app_id: str, report_file: str) -> None:
+    subprocess.run(
+        [adb, "-s", serial, "shell", "run-as", app_id, "rm", "-f", f"files/{report_file}"],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+
+
+def _run_checked(command: list[str], *, cwd: Path | None = None) -> None:
+    subprocess.run(command, cwd=cwd, check=True)
+
+
+def _resolve_sm_binary(path: Path) -> Path:
+    if path.is_file():
+        return path
+    fallback = Path("target/debug/sm")
+    if fallback.is_file():
+        return fallback
+    subprocess.run(["cargo", "build", "-p", "sm-server", "--bin", "sm"], check=True)
+    if fallback.is_file():
+        return fallback
+    raise FileNotFoundError("Rust sm binary was not built")
+
+
+def _free_tcp_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _load_runtime_config(config_path: Path) -> dict[str, Any]:
+    # src.main.load_config applies the same default local-env overlay as the
+    # live Python/Rust migration config path. Keep the import lazy so unit tests
+    # can exercise helper functions without importing the server stack.
+    try:
+        from src.main import load_config
+    except Exception:
+        with config_path.open("r", encoding="utf-8") as handle:
+            return yaml.safe_load(handle) or {}
+    return load_config(str(config_path))
+
+
+def _host_step(report: dict[str, Any], step_id: str, status: str, detail: str | None = None) -> None:
+    row = {
+        "id": step_id,
+        "status": status,
+        "at": datetime.now(timezone.utc).isoformat(),
+    }
+    if detail:
+        row["detail"] = detail[:500]
+    report["host_steps"].append(row)
+
+
+def _summarize(report: dict[str, Any]) -> dict[str, Any]:
+    passed = skipped = blocked = 0
+    for row in report.get("host_steps", []):
+        status = row.get("status")
+        if status == "passed":
+            passed += 1
+        elif status == "skipped":
+            skipped += 1
+        elif status == "blocked":
+            blocked += 1
+    android_report = report.get("android_report")
+    if isinstance(android_report, dict):
+        summary = android_report.get("summary") or {}
+        passed += int(summary.get("passed") or 0)
+        skipped += int(summary.get("skipped") or 0)
+        blocked += int(summary.get("blocked") or 0)
+    return {
+        "status": "passed" if blocked == 0 else "blocked",
+        "passed": passed,
+        "skipped": skipped,
+        "blocked": blocked,
+    }
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _urlsafe_no_pad(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _default_output_path() -> Path:
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return DEFAULT_OUTPUT_DIR / f"android-emulator-smoke-{stamp}.json"
+
+
+def _host_from_url(url: str) -> str:
+    from urllib.parse import urlparse
+
+    return urlparse(url).hostname or ""
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--server-url", default=DEFAULT_SERVER_URL)
+    parser.add_argument("--user-id")
+    parser.add_argument("--email")
+    parser.add_argument("--name")
+    parser.add_argument("--adb", default=os.environ.get("ADB", "adb"))
+    parser.add_argument(
+        "--emulator",
+        default=os.environ.get("ANDROID_EMULATOR", "/opt/homebrew/share/android-commandlinetools/emulator/emulator"),
+    )
+    parser.add_argument("--avd", default=DEFAULT_AVD)
+    parser.add_argument("--serial")
+    parser.add_argument("--apk", type=Path, default=DEFAULT_APK)
+    parser.add_argument("--sm-binary", default="target/release/sm")
+    parser.add_argument("--app-id", default=DEFAULT_APP_ID)
+    parser.add_argument("--activity", default=DEFAULT_ACTIVITY)
+    parser.add_argument("--report-file", default=DEFAULT_REPORT_FILE)
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--boot-timeout-seconds", type=int, default=DEFAULT_BOOT_TIMEOUT_SECONDS)
+    parser.add_argument("--smoke-timeout-seconds", type=int, default=DEFAULT_SMOKE_TIMEOUT_SECONDS)
+    parser.add_argument("--enrollment-expires-minutes", type=int, default=15)
+    parser.add_argument("--token-expires-minutes", type=int, default=60)
+    parser.add_argument("--no-build-apk", dest="build_apk", action="store_false")
+    parser.set_defaults(build_apk=True)
+    parser.add_argument("--no-attach-ticket", dest="include_attach_ticket", action="store_false")
+    parser.set_defaults(include_attach_ticket=True)
+    parser.add_argument("--keep-started-emulator", dest="stop_started_emulator", action="store_false")
+    parser.set_defaults(stop_started_emulator=True)
+    parser.add_argument("--json", action="store_true")
+    parser.add_argument("--fail-on-blockers", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    report = run_android_emulator_smoke(args)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(
+            "Android emulator smoke: "
+            f"{report['summary']['status']} "
+            f"(passed={report['summary']['passed']} "
+            f"skipped={report['summary']['skipped']} "
+            f"blocked={report['summary']['blocked']})"
+        )
+        print(f"Report: {report['artifacts']['output']}")
+    if args.fail_on_blockers and report["summary"]["blocked"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/specs/762_stage5_artifacts/mvp_progress.md
+++ b/specs/762_stage5_artifacts/mvp_progress.md
@@ -5,7 +5,8 @@ merged and used for the first Rust canary flip on 2026-06-17. Issue #1042 adds
 the public tunnel preflight that verifies `sm-app.rajeshgo.li` routes directly
 to the launchd-managed Rust service and legacy `sm.rajeshgo.li` does not route
 to origin. Issue #1044 adds a non-mutating live canary report for the
-post-cutover Rust service.
+post-cutover Rust service. Issue #1048 adds an adb-managed Android emulator
+smoke for the native app enrollment/cert-auth path without a plugged-in phone.
 
 The last clean full real-state MVP rehearsal remains the post-#938 run; the
 post-#1035 rehearsal proves state gates, live core contracts, read-only
@@ -125,6 +126,7 @@ not change retained or removed scope. Binding scope remains
 | #1041 | Rust service launchd cutover tooling and first-canary runbook |
 | issue #1042 | Public tunnel preflight for the protected app hostname and legacy-host absence |
 | issue #1044 | Live Rust canary evidence collector for launchd/local/public-tunnel post-cutover checks |
+| issue #1048 | Android emulator native app smoke for enrollment, cert-auth reads, and attach-ticket proof |
 
 ## Implemented Capability Groups
 
@@ -137,7 +139,7 @@ The Rust sidecar now has executable coverage for:
 | Core reads | Health, auth session, bootstrap, session list/detail, client session list/detail, output, events state, SSE hello, nodes list, queue jobs list/detail, Codex review requests list/detail, and tool/audit read projections are implemented. |
 | Core runtime | Session/tmux/spawn/session-graph/message-queue/task-complete/input-batch/subagent and retained review-route slices are merged, with shadow and contract fixtures covering the early cutover path. |
 | Codex retained reads | Codex event stream, pending request ledger reads, activity actions, review detail/list, and Claude/Codex tool-call projections are implemented and covered by manifest checks. |
-| Mobile | Native bootstrap/session support, attach-ticket proofing, terminal WebSocket auth/bridge, runtime disable, device revoke/list CLI support, public-edge assertion validation, Android client-certificate storage, Rust `sm enroll-device`, Camera-app deep-link enrollment, and Rust Google device-auth bearer issuance are merged. |
+| Mobile | Native bootstrap/session support, attach-ticket proofing, terminal WebSocket auth/bridge, runtime disable, device revoke/list CLI support, public-edge assertion validation, Android client-certificate storage, Rust `sm enroll-device`, Camera-app deep-link enrollment, Rust Google device-auth bearer issuance, and adb-managed emulator smoke tooling are merged. |
 | Cloudflare Access origin gate | Config parsing, JWT/audience classification, host/app separation, public-host fail-closed behavior, mobile/app route gating, app artifact gating, device-token exchange, Google JWKS cache refresh/TTL behavior, mobile Access CN actor binding, Cloudflare mTLS CA upload/hostname association, per-device Common Name policy sync, and read-only smoke evidence collection are merged. |
 | External fallback | Email/human fallback delivery and inbound email validation path are retained in the Rust track. |
 | Queue and nodes | Queue list/detail, CLI list/status, pending submit, simple execute/cancel, queue recovery, queue fixtures, node reads, and node HTTP routes are implemented; remaining work is final live/recovery cutover evidence and any retained node-agent remote-control gaps. |
@@ -190,6 +192,18 @@ Current live canary artifact:
 Summary: `10` passed, `0` blocked, `1` skipped. The skipped check is the
 optional supplied Cloudflare/mobile smoke report; all launchd, local Rust,
 tunnel, and public unauthenticated denial checks passed.
+
+Current adb-managed Android emulator smoke artifact:
+
+```text
+.local/rust-mvp-rehearsals/android-emulator-smoke-20260617T205819Z.json
+```
+
+Summary: `16` passed, `0` blocked, `2` skipped. The host runner reused the
+booted `sm_mtls_api35` emulator, installed the debug APK, exposed the pairing
+listener over `adb reverse`, and the debug-only app activity passed enrollment,
+auth-session, client sessions, analytics, app artifact metadata, and
+attach-ticket proof through `https://sm-app.rajeshgo.li`.
 
 The latest clean passive shadow report after #996 used
 `--last-minutes 30 --fail-on-blockers --json` and returned:

--- a/specs/762_stage5_artifacts/resume_handoff.md
+++ b/specs/762_stage5_artifacts/resume_handoff.md
@@ -5,7 +5,8 @@ Rust service launchd cutover tooling and the first Rust canary flip moved local
 production traffic to Rust. Issue #1042 adds the public tunnel preflight that
 keeps `sm-app.rajeshgo.li` pointed at the launchd-managed Rust service and
 keeps legacy `sm.rajeshgo.li` off origin. Issue #1044 adds the post-cutover
-live Rust canary report.
+live Rust canary report. Issue #1048 adds an adb-managed Android emulator
+smoke for native app enrollment/cert-auth evidence without a plugged-in phone.
 
 Use this file to resume the Rust cutover track without reconstructing state from
 chat history. Binding scope still lives in [cutover_scope.md](cutover_scope.md),
@@ -204,6 +205,10 @@ Merged Rust slices cover:
 - Issue #1044 adds the live canary report that records launchd ownership, local
   Rust health/native reads, `sm status`, public tunnel shape, public Access
   denial, and legacy-host absence without mutating live state.
+- Issue #1048 adds `scripts.rust_migration.android_emulator_smoke`, a
+  debug-APK/emulator smoke that enrolls the app over an `adb reverse` pairing
+  listener and verifies native HTTPS cert-auth reads through
+  `https://sm-app.rajeshgo.li`.
 - Current contract manifest size:
   - `134` checks total
   - `73` `python_and_rust`
@@ -420,8 +425,23 @@ unauthenticated `sm-app` public denial before origin, and legacy public-host
 absence. The skipped check is the optional supplied Cloudflare/mobile smoke
 report.
 
-No newer clean full passive shadow or full Cloudflare/mobile smoke artifact has
-been recorded in this handoff. PR #1012 published Android artifact `cbb61798`
+Post-#1048 adb-managed Android emulator smoke evidence:
+
+```text
+.local/rust-mvp-rehearsals/android-emulator-smoke-20260617T205819Z.json
+```
+
+Summary: `16` passed, `0` blocked, `2` skipped. The smoke reused booted AVD
+`sm_mtls_api35`, installed the debug APK, paired through a loopback
+`sm enroll-device` listener exposed with `adb reverse`, and the debug-only app
+activity passed certificate enrollment, device-bearer auth-session, client
+sessions, analytics, app artifact metadata, and attach-ticket proof through the
+public app hostname. The report excludes bearer, pairing token, certificate,
+and private-key material.
+
+No newer clean full passive shadow artifact or loopback-origin
+Cloudflare/mobile smoke artifact has been recorded in this handoff. PR #1012
+published Android artifact `cbb61798`
 (`versionCode=1013`, `versionName=0.1.0-enroll-ui-cleanup`) and operator
 testing confirmed the app reached "Client certificate saved" after Camera-app
 deep-link enrollment. After PR #1035, operator testing also confirmed Android

--- a/tests/unit/test_rust_android_emulator_smoke.py
+++ b/tests/unit/test_rust_android_emulator_smoke.py
@@ -1,0 +1,146 @@
+import base64
+import hashlib
+import hmac
+import json
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from scripts.rust_migration import android_emulator_smoke as smoke
+
+
+def test_device_access_token_matches_server_signature_shape():
+    issued = smoke.build_device_access_token(
+        session_cookie_secret="secret",
+        email="RAJESH@example.com",
+        name="Rajesh",
+        now=1000,
+        expires_in_seconds=60,
+    )
+
+    assert issued["access_token"].startswith("smat_")
+    payload_b64, signature = issued["access_token"].removeprefix("smat_").split(".", 1)
+    expected_signature = base64.urlsafe_b64encode(
+        hmac.new(b"secret", payload_b64.encode("ascii"), hashlib.sha256).digest()
+    ).decode("ascii").rstrip("=")
+    assert signature == expected_signature
+
+    padded_payload = payload_b64 + "=" * ((4 - len(payload_b64) % 4) % 4)
+    payload = json.loads(base64.urlsafe_b64decode(padded_payload.encode("ascii")))
+    assert payload == {
+        "email": "rajesh@example.com",
+        "exp": 1060,
+        "iat": 1000,
+        "name": "Rajesh",
+        "type": "device_access",
+        "v": 1,
+    }
+    assert issued["expires_at"].startswith("1970-01-01T00:17:40")
+
+
+def test_mobile_smoke_identity_resolves_single_interactive_user(monkeypatch):
+    monkeypatch.setattr(
+        smoke,
+        "_load_runtime_config",
+        lambda _path: {
+            "auth": {"google": {"session_cookie_secret": "secret"}},
+            "mobile_terminal": {
+                "allowed_users": {
+                    "rajesh": {
+                        "email": "rajesh@example.com",
+                        "interactive_shell_access": True,
+                    }
+                }
+            },
+        },
+    )
+
+    identity = smoke.load_mobile_smoke_identity(Path("config.yaml"))
+
+    assert identity == {
+        "user_id": "rajesh",
+        "email": "rajesh@example.com",
+        "name": "rajesh@example.com",
+        "session_cookie_secret": "secret",
+    }
+
+
+def test_mobile_smoke_identity_requires_explicit_user_when_ambiguous(monkeypatch):
+    monkeypatch.setattr(
+        smoke,
+        "_load_runtime_config",
+        lambda _path: {
+            "auth": {"google": {"session_cookie_secret": "secret"}},
+            "mobile_terminal": {
+                "allowed_users": {
+                    "one": {"interactive_shell_access": True},
+                    "two": {"interactive_shell_access": True},
+                }
+            },
+        },
+    )
+
+    with pytest.raises(ValueError, match="pass --user-id"):
+        smoke.load_mobile_smoke_identity(Path("config.yaml"))
+
+
+def test_smoke_summary_includes_android_report_counts():
+    report = {
+        "host_steps": [
+            {"id": "host", "status": "passed"},
+            {"id": "optional", "status": "skipped"},
+        ],
+        "android_report": {
+            "summary": {
+                "passed": 3,
+                "skipped": 1,
+                "blocked": 0,
+            }
+        },
+    }
+
+    assert smoke._summarize(report) == {
+        "status": "passed",
+        "passed": 4,
+        "skipped": 2,
+        "blocked": 0,
+    }
+
+
+def test_start_enrollment_listener_uses_adb_reverse_local_url(monkeypatch):
+    captured = {}
+
+    class FakePopen:
+        stdout = None
+
+        def __init__(self, command, **kwargs):
+            captured["command"] = command
+            captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(smoke, "_resolve_sm_binary", lambda path: Path("target/debug/sm"))
+    monkeypatch.setattr(smoke.subprocess, "Popen", FakePopen)
+
+    args = Namespace(
+        sm_binary="target/debug/sm",
+        config=Path("config.yaml"),
+        enrollment_expires_minutes=15,
+    )
+
+    smoke._start_enrollment_listener(args, "rajesh", 19192)
+
+    assert captured["command"] == [
+        "target/debug/sm",
+        "enroll-device",
+        "--config",
+        "config.yaml",
+        "--user-id",
+        "rajesh",
+        "--expires-in-minutes",
+        "15",
+        "--listen",
+        "127.0.0.1:19192",
+        "--url-base",
+        "http://127.0.0.1:19192",
+        "--no-qr",
+    ]


### PR DESCRIPTION
## Summary
- add a debug-only Android emulator smoke step that opens the native mobile terminal WebSocket after attach-ticket minting
- clear debug app data after install so each emulator smoke starts from a clean enrollment state
- record terminal socket status/output/error details in the smoke artifact

## Validation
- `./gradlew assembleDebug`
- `./venv/bin/python -m pytest tests/unit/test_rust_android_emulator_smoke.py tests/unit/test_rust_migration_contracts.py -q`
- `python -m py_compile scripts/rust_migration/android_emulator_smoke.py`
- `git diff --check`
- Public-host smoke evidence: `.local/rust-mvp-rehearsals/android-emulator-smoke-20260617T213604Z.json` showed `mobile_terminal_socket` passed with first frame `output` for session `007c6275`; the run had an unrelated immediate post-enrollment bootstrap propagation blocker.

Fixes #1048
Fixes #1050
