### PR TITLE
Keep Codex-fork retry errors non-terminal

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -1137,10 +1137,40 @@ async fn tmux_client_hook(
             detail: "unsupported tmux client event".to_owned(),
         });
     }
-    Ok(Json(json!({
+    let revived_session_id = if state.config.rust_core.runtime_enabled
+        && matches!(event_name, "client-attached" | "client-session-changed")
+    {
+        query
+            .session
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .or_else(|| {
+                query
+                    .client_session
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+            })
+            .map(|tmux_session| {
+                let runtime = TmuxRuntime::from_app_config(&state.config);
+                state
+                    .session_store
+                    .revive_stopped_tmux_client_session(tmux_session, &runtime)
+            })
+            .transpose()?
+            .flatten()
+    } else {
+        None
+    };
+    let mut response = json!({
         "status": "ok",
         "tmux_client_event_version": 0,
-    })))
+    });
+    if let Some(session_id) = revived_session_id {
+        response["revived_session_id"] = Value::String(session_id);
+    }
+    Ok(Json(response))
 }
 
 async fn client_bootstrap(
@@ -9771,6 +9801,10 @@ struct IssuedDeviceAccessToken {
 #[derive(Debug, Deserialize)]
 struct TmuxClientHookQuery {
     event: String,
+    #[serde(default)]
+    session: Option<String>,
+    #[serde(default, rename = "client_session")]
+    client_session: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -853,6 +853,78 @@ impl SessionStore {
         Ok(Some(CoreRestoreOutcome::Restored(restored)))
     }
 
+    pub fn revive_stopped_tmux_client_session(
+        &self,
+        tmux_session: &str,
+        runtime: &TmuxRuntime,
+    ) -> Result<Option<String>> {
+        let tmux_session = tmux_session.trim();
+        if tmux_session.is_empty() {
+            return Ok(None);
+        }
+
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let Some(session_index) = sessions.iter().position(|value| {
+            let Some(session) = value.as_object() else {
+                return false;
+            };
+            json_text(session.get("tmux_session")).as_deref() == Some(tmux_session)
+                && json_text(session.get("provider")).as_deref() == Some("codex-fork")
+                && json_text(session.get("node"))
+                    .as_deref()
+                    .is_none_or(is_primary_node)
+                && json_text(session.get("status"))
+                    .as_deref()
+                    .is_some_and(|status| normalized_status(status) == "stopped")
+        }) else {
+            return Ok(None);
+        };
+
+        let Some(session) = sessions[session_index].as_object() else {
+            return Ok(None);
+        };
+        let Some(session_id) = json_text(session.get("id")) else {
+            return Ok(None);
+        };
+        let session_runtime =
+            runtime.for_socket_name(json_text(session.get("tmux_socket_name")).as_deref());
+        if !session_runtime.session_exists(tmux_session)? {
+            return Ok(None);
+        }
+
+        let now = now_rfc3339();
+        let Some(session) = sessions[session_index].as_object_mut() else {
+            return Ok(None);
+        };
+        session.insert("status".to_owned(), Value::String("idle".to_owned()));
+        session.insert("stopped_at".to_owned(), Value::Null);
+        session.insert("completion_status".to_owned(), Value::Null);
+        session.insert("completion_message".to_owned(), Value::Null);
+        session.insert("completed_at".to_owned(), Value::Null);
+        session.insert("agent_task_completed_at".to_owned(), Value::Null);
+        session.insert("error_message".to_owned(), Value::Null);
+        session.insert("last_activity".to_owned(), Value::String(now));
+        if let Some(socket_name) = session_runtime.socket_name() {
+            session.insert(
+                "tmux_socket_name".to_owned(),
+                Value::String(socket_name.to_owned()),
+            );
+        }
+
+        let spec = codex_fork_spec_for_session_raw(&session_id, session)?;
+        let codex_fork_artifacts = session_runtime.codex_fork_runtime_artifacts(&spec)?;
+        self.write_raw_json_value(&state)?;
+        if let Some(artifacts) = codex_fork_artifacts {
+            self.start_codex_fork_event_monitor_from_current_end(
+                session_id.clone(),
+                artifacts.event_stream_path,
+            )?;
+        }
+        Ok(Some(session_id))
+    }
+
     pub fn set_context_monitor(
         &self,
         session_id: &str,
@@ -1662,6 +1734,26 @@ impl SessionStore {
         session_id: String,
         event_stream_path: PathBuf,
     ) -> Result<()> {
+        self.start_codex_fork_event_monitor_at_offset(session_id, event_stream_path, 0)
+    }
+
+    fn start_codex_fork_event_monitor_from_current_end(
+        &self,
+        session_id: String,
+        event_stream_path: PathBuf,
+    ) -> Result<()> {
+        let initial_offset = fs::metadata(&event_stream_path)
+            .map(|metadata| metadata.len())
+            .unwrap_or(0);
+        self.start_codex_fork_event_monitor_at_offset(session_id, event_stream_path, initial_offset)
+    }
+
+    fn start_codex_fork_event_monitor_at_offset(
+        &self,
+        session_id: String,
+        event_stream_path: PathBuf,
+        initial_offset: u64,
+    ) -> Result<()> {
         let store = self.clone();
         let thread_session_id = format!(
             "{}-{}",
@@ -1670,13 +1762,20 @@ impl SessionStore {
         );
         thread::Builder::new()
             .name(format!("sm-codex-fork-events-{thread_session_id}"))
-            .spawn(move || store.monitor_codex_fork_event_stream(session_id, event_stream_path))
+            .spawn(move || {
+                store.monitor_codex_fork_event_stream(session_id, event_stream_path, initial_offset)
+            })
             .with_context(|| "failed to start codex-fork event monitor")?;
         Ok(())
     }
 
-    fn monitor_codex_fork_event_stream(&self, session_id: String, event_stream_path: PathBuf) {
-        let mut offset = 0;
+    fn monitor_codex_fork_event_stream(
+        &self,
+        session_id: String,
+        event_stream_path: PathBuf,
+        initial_offset: u64,
+    ) {
+        let mut offset = initial_offset;
         let mut buffer = String::new();
         loop {
             match self.codex_fork_monitor_should_continue(&session_id) {
@@ -2029,11 +2128,29 @@ fn codex_fork_status_for_event(event: &Map<String, Value>) -> Option<&'static st
         | "item_completed"
         | "agent_message"
         | "exec_command_end" => Some("running"),
+        "error" if codex_fork_error_will_retry(event) => Some("running"),
         "error" | "shutdown" => Some("stopped"),
         "shutdown_complete" | "stream_error" | "thread_started" | "thread_name_updated" => None,
         other if other.ends_with("_begin") || other.ends_with("_delta") => Some("running"),
         _ => None,
     }
+}
+
+fn codex_fork_error_will_retry(event: &Map<String, Value>) -> bool {
+    event
+        .get("willRetry")
+        .or_else(|| event.get("will_retry"))
+        .and_then(Value::as_bool)
+        .or_else(|| {
+            codex_fork_payload(event)
+                .and_then(|payload| {
+                    payload
+                        .get("willRetry")
+                        .or_else(|| payload.get("will_retry"))
+                })
+                .and_then(Value::as_bool)
+        })
+        .unwrap_or(false)
 }
 
 fn codex_fork_event_type(event: &Map<String, Value>) -> Option<String> {
@@ -3125,13 +3242,24 @@ fn codex_fork_control_socket_path_for_session_raw(
     session: &Map<String, Value>,
     runtime: &TmuxRuntime,
 ) -> Result<PathBuf> {
+    let spec = codex_fork_spec_for_session_raw(session_id, session)?;
+    let artifacts = runtime
+        .codex_fork_runtime_artifacts(&spec)?
+        .ok_or_else(|| anyhow::anyhow!("session {session_id} is not a codex-fork session"))?;
+    Ok(artifacts.control_socket_path)
+}
+
+fn codex_fork_spec_for_session_raw(
+    session_id: &str,
+    session: &Map<String, Value>,
+) -> Result<TmuxSessionSpec> {
     let tmux_session = json_text(session.get("tmux_session"))
         .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?;
     let working_dir = json_text(session.get("working_dir"))
         .ok_or_else(|| anyhow::anyhow!("session {session_id} missing working_dir"))?;
     let log_file = json_text(session.get("log_file"))
         .ok_or_else(|| anyhow::anyhow!("session {session_id} missing log_file"))?;
-    let spec = TmuxSessionSpec {
+    Ok(TmuxSessionSpec {
         session_id: session_id.to_owned(),
         tmux_session,
         working_dir: expand_home(&working_dir).display().to_string(),
@@ -3139,11 +3267,7 @@ fn codex_fork_control_socket_path_for_session_raw(
         provider: "codex-fork".to_owned(),
         initial_message: None,
         model: json_text(session.get("model")),
-    };
-    let artifacts = runtime
-        .codex_fork_runtime_artifacts(&spec)?
-        .ok_or_else(|| anyhow::anyhow!("session {session_id} is not a codex-fork session"))?;
-    Ok(artifacts.control_socket_path)
+    })
 }
 
 fn codex_fork_submit_message(control_socket_path: &Path, text: &str) -> Result<()> {
@@ -5041,6 +5165,33 @@ mod tests {
 
         assert_eq!(sessions.len(), 1);
         assert_eq!(sessions[0].id, "tmux1");
+    }
+
+    #[test]
+    fn codex_fork_retry_error_events_are_not_terminal() {
+        let retry = json!({
+            "event_type": "error",
+            "payload": {
+                "willRetry": true,
+                "error": {
+                    "message": "Reconnecting... 1/5"
+                }
+            }
+        });
+        let retry_event = retry.as_object().unwrap();
+        assert_eq!(codex_fork_status_for_event(retry_event), Some("running"));
+
+        let terminal = json!({
+            "event_type": "error",
+            "payload": {
+                "willRetry": false,
+                "error": {
+                    "message": "Selected model is at capacity."
+                }
+            }
+        });
+        let terminal_event = terminal.as_object().unwrap();
+        assert_eq!(codex_fork_status_for_event(terminal_event), Some("stopped"));
     }
 
     #[test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -4974,6 +4974,158 @@ async fn tmux_client_hook_preserves_local_only_and_event_validation() {
 }
 
 #[tokio::test]
+async fn tmux_client_hook_revives_stopped_codex_fork_with_live_tmux_session() {
+    if !tmux_available() {
+        return;
+    }
+
+    let state_file = unique_temp_path();
+    let log_dir = unique_short_temp_dir("sm-rust-hook-revive");
+    let working_dir = unique_short_temp_dir("sm-rust-hook-revive-work");
+    fs::create_dir_all(&log_dir).unwrap();
+    fs::create_dir_all(&working_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-hook-revive-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let tmux_session = "codex-fork-revive";
+    let status = Command::new("tmux")
+        .args([
+            "-L",
+            &tmux_socket,
+            "new-session",
+            "-d",
+            "-s",
+            tmux_session,
+            "sleep 60",
+        ])
+        .status()
+        .unwrap();
+    assert!(status.success());
+    assert!(tmux_session_exists(&tmux_socket, tmux_session));
+
+    fs::write(
+        &state_file,
+        json!({
+            "sessions": [
+                {
+                    "id": "remote-revive",
+                    "name": "remote-codex-fork-revive",
+                    "working_dir": working_dir.display().to_string(),
+                    "tmux_session": tmux_session,
+                    "tmux_socket_name": tmux_socket,
+                    "provider": "codex-fork",
+                    "node": "macbook",
+                    "log_file": log_dir.join("remote-revive.log").display().to_string(),
+                    "provider_resume_id": "remote-thread-123",
+                    "friendly_name": "remote-hidden-agent",
+                    "status": "stopped",
+                    "stopped_at": "2026-06-17T20:16:56Z",
+                    "completion_status": "killed",
+                    "completion_message": "retry error",
+                    "completed_at": "2026-06-17T20:16:56Z",
+                    "error_message": "codex_fork_control_degraded: stale control socket",
+                    "created_at": "2026-06-17T19:00:00Z",
+                    "last_activity": "2026-06-17T20:16:56Z"
+                },
+                {
+                    "id": "revive1",
+                    "name": "codex-fork-revive",
+                    "working_dir": working_dir.display().to_string(),
+                    "tmux_session": tmux_session,
+                    "tmux_socket_name": tmux_socket,
+                    "provider": "codex-fork",
+                    "log_file": log_dir.join("revive1.log").display().to_string(),
+                    "provider_resume_id": "provider-thread-123",
+                    "friendly_name": "hidden-live-agent",
+                    "status": "stopped",
+                    "stopped_at": "2026-06-17T20:16:56Z",
+                    "completion_status": "killed",
+                    "completion_message": "retry error",
+                    "completed_at": "2026-06-17T20:16:56Z",
+                    "error_message": "codex_fork_control_degraded: stale control socket",
+                    "created_at": "2026-06-17T19:00:00Z",
+                    "last_activity": "2026-06-17T20:16:56Z"
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let mut config = config_with_state_file(&state_file);
+    config.rust_core.runtime_enabled = true;
+    config.rust_core.tmux_socket_name = Some(tmux_socket.clone());
+    config.rust_core.log_dir = Some(log_dir.display().to_string());
+    let app = router(AppState::new(config));
+
+    let (status, payload) = get_json(app.clone(), "/sessions").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(payload["sessions"].as_array().unwrap().is_empty());
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/hooks/tmux-client?event=client-detached&session=codex-fork-revive",
+        json!({}),
+        &[("host", "127.0.0.1:8421")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "ok");
+    assert!(payload.get("revived_session_id").is_none());
+
+    let (status, payload) = get_json(app.clone(), "/sessions").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(payload["sessions"].as_array().unwrap().is_empty());
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/hooks/tmux-client?event=client-session-changed&session=&client_session=codex-fork-revive",
+        json!({}),
+        &[("host", "127.0.0.1:8421")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "ok");
+    assert_eq!(payload["revived_session_id"], "revive1");
+
+    let (status, payload) = get_json(app, "/sessions").await;
+    assert_eq!(status, StatusCode::OK);
+    let sessions = payload["sessions"].as_array().unwrap();
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0]["id"], "revive1");
+    assert_eq!(sessions[0]["status"], "idle");
+    assert_eq!(sessions[0]["stopped_at"], Value::Null);
+
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let remote = state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "remote-revive")
+        .unwrap();
+    assert_eq!(remote["status"], "stopped");
+    assert_eq!(remote["node"], "macbook");
+    let restored = state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "revive1")
+        .unwrap();
+    assert_eq!(restored["status"], "idle");
+    assert_eq!(restored["stopped_at"], Value::Null);
+    assert_eq!(restored["completion_status"], Value::Null);
+    assert_eq!(restored["error_message"], Value::Null);
+}
+
+#[tokio::test]
 async fn shadow_http_reports_match_for_stable_read_only_route() {
     let app = router(AppState::new(AppConfig::default()));
     let python_body = serde_json::to_vec(&json!({ "status": "healthy" })).unwrap();


### PR DESCRIPTION
## Summary

- keep Codex-fork `error` events with `willRetry: true` from marking sessions stopped
- add Rust tmux-client hook revival for stopped Codex-fork rows whose tmux session is still alive
- restart revived event monitors from the current event-stream end to avoid replaying stale retry/error events

## Validation

- `cargo fmt`
- `cargo test -p sm-server codex_fork_retry_error_events_are_not_terminal -- --nocapture`
- `cargo test -p sm-server --test read_only_http tmux_client_hook_revives_stopped_codex_fork_with_live_tmux_session -- --nocapture`
- `cargo test -p sm-server`
- `git diff --check`

Fixes #1051
