### PR TITLE
Port Rust session metadata PATCH endpoint

### DIFF
--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -12,6 +12,7 @@ use sha2::{Digest, Sha256};
 #[derive(Debug, Clone)]
 pub struct AppConfig {
     pub paths: PathsConfig,
+    pub human_recipient_reserved_names: Vec<String>,
     pub email: EmailConfig,
     pub mobile_analytics: MobileAnalyticsConfig,
     pub app_artifacts: AppArtifactsConfig,
@@ -42,6 +43,7 @@ impl Default for AppConfig {
     fn default() -> Self {
         Self {
             paths: PathsConfig::default(),
+            human_recipient_reserved_names: Vec::new(),
             email: EmailConfig::default(),
             mobile_analytics: MobileAnalyticsConfig::default(),
             app_artifacts: AppArtifactsConfig::default(),
@@ -969,6 +971,8 @@ struct RawConfig {
     #[serde(default)]
     paths: RawPathsConfig,
     #[serde(default)]
+    humans: YamlValue,
+    #[serde(default)]
     email: EmailConfig,
     #[serde(default)]
     auth: RawAuthConfig,
@@ -1060,6 +1064,7 @@ impl From<RawConfig> for AppConfig {
             paths: PathsConfig {
                 state_file: paths.state_file,
             },
+            human_recipient_reserved_names: human_reserved_names_from_yaml(&raw.humans),
             email: raw.email,
             mobile_analytics: MobileAnalyticsConfig {
                 message_queue_db: paths.message_queue_db,
@@ -1357,6 +1362,44 @@ fn nodes_config_from_yaml(value: YamlValue) -> NodesConfig {
     config
 }
 
+fn human_reserved_names_from_yaml(value: &YamlValue) -> Vec<String> {
+    let Some(root) = value.as_mapping() else {
+        return Vec::new();
+    };
+    let mut names = Vec::new();
+    for (raw_name, raw_spec) in root {
+        if let Some(name) = yaml_clean_optional(raw_name) {
+            names.push(name);
+        }
+        let Some(spec) = raw_spec.as_mapping() else {
+            continue;
+        };
+        if let Some(aliases) = yaml_mapping_get(spec, "aliases") {
+            names.extend(yaml_string_values(aliases));
+        }
+    }
+    dedupe_strings(names)
+}
+
+fn yaml_string_values(value: &YamlValue) -> Vec<String> {
+    match value {
+        YamlValue::Sequence(values) => values.iter().filter_map(yaml_clean_optional).collect(),
+        _ => yaml_clean_optional(value).into_iter().collect(),
+    }
+}
+
+fn dedupe_strings(values: Vec<String>) -> Vec<String> {
+    let mut seen = std::collections::BTreeSet::new();
+    let mut result = Vec::new();
+    for value in values {
+        let value = value.trim();
+        if !value.is_empty() && seen.insert(value.to_ascii_lowercase()) {
+            result.push(value.to_owned());
+        }
+    }
+    result
+}
+
 fn yaml_mapping_get<'a>(mapping: &'a YamlMapping, key: &str) -> Option<&'a YamlValue> {
     mapping.get(YamlValue::String(key.to_owned()))
 }
@@ -1619,6 +1662,37 @@ sm_send:
         let config = AppConfig::from(raw);
 
         assert_eq!(config.sm_send.db_path, "/tmp/custom-message-queue.db");
+    }
+
+    #[test]
+    fn raw_config_reads_top_level_human_names_and_aliases() {
+        let raw: RawConfig = serde_yaml::from_str(
+            r#"
+humans:
+  rajesh:
+    aliases:
+      - rg
+      - "Rajesh Goli"
+  owner:
+    aliases: rg
+"#,
+        )
+        .unwrap();
+        let config = AppConfig::from(raw);
+        let names = config
+            .human_recipient_reserved_names
+            .into_iter()
+            .collect::<std::collections::BTreeSet<_>>();
+
+        assert_eq!(
+            names,
+            std::collections::BTreeSet::from([
+                "owner".to_owned(),
+                "Rajesh Goli".to_owned(),
+                "rajesh".to_owned(),
+                "rg".to_owned()
+            ])
+        );
     }
 
     #[test]

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -106,10 +106,11 @@ use crate::sessions::{
     CoreClearOutcome, CoreInputBatchResponse, CoreInputBatchResult, CoreRestoreOutcome,
     CoreRetireOutcome, CoreReviewOutcome, CreateCoreSessionRequest, HandoffOutcome, HandoffRequest,
     MaintainerMutationOutcome, RegistryMutationOutcome, RoleRegistrationRequest,
-    SendCoreInputBatchRequest, SendCoreInputRequest, SessionRecord, SessionResponse, SessionStore,
-    SessionsEnvelope, SetMaintainerRequest, SpawnReviewRequest, StartReviewRequest,
-    SubagentStartOutcome, SubagentStartRequest, SubagentStopOutcome, SubagentStopRequest,
-    TaskCompleteOutcome, TaskCompleteRequest, TurnCompleteOutcome,
+    SendCoreInputBatchRequest, SendCoreInputRequest, SessionMetadataOutcome, SessionRecord,
+    SessionResponse, SessionStore, SessionsEnvelope, SetMaintainerRequest, SpawnReviewRequest,
+    StartReviewRequest, SubagentStartOutcome, SubagentStartRequest, SubagentStopOutcome,
+    SubagentStopRequest, TaskCompleteOutcome, TaskCompleteRequest, TurnCompleteOutcome,
+    UpdateSessionMetadataRequest,
 };
 use crate::tool_usage::{
     list_recent_codex_fork_tool_calls_from_path, list_recent_tool_calls_from_path, ToolCallRow,
@@ -898,7 +899,10 @@ pub fn router(state: AppState) -> Router {
         .route("/sessions/spawn", post(spawn_session))
         .route("/sessions/review", post(spawn_review_session))
         .route("/sessions/context-monitor", get(get_context_monitor_status))
-        .route("/sessions/{session_id}", get(get_session))
+        .route(
+            "/sessions/{session_id}",
+            get(get_session).patch(update_session_metadata),
+        )
         .route("/sessions/{session_id}/review", post(start_session_review))
         .route(
             "/sessions/{parent_session_id}/children",
@@ -3766,6 +3770,24 @@ fn queue_admission_policy(config: &AppConfig) -> QueueAdmissionPolicy {
     }
 }
 
+fn reserved_human_names(config: &AppConfig) -> anyhow::Result<BTreeSet<String>> {
+    let mut names = config
+        .human_recipient_reserved_names
+        .iter()
+        .map(|alias| normalize_role_like_python(alias))
+        .filter(|alias| !alias.is_empty())
+        .collect::<BTreeSet<_>>();
+    names.extend(
+        EmailBridge::load(config)?
+            .list_humans()
+            .into_iter()
+            .flat_map(|human| human.aliases.into_iter())
+            .map(|alias| normalize_role_like_python(&alias))
+            .filter(|alias| !alias.is_empty()),
+    );
+    Ok(names)
+}
+
 async fn get_session(
     State(state): State<Arc<AppState>>,
     Path(session_id): Path<String>,
@@ -3776,6 +3798,55 @@ async fn get_session(
         return Err(ApiError::NotFound("Session not found"));
     };
     Ok(Json(SessionResponse::from(session)))
+}
+
+async fn update_session_metadata(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(payload): Json<UpdateSessionMetadataRequest>,
+) -> Result<Json<SessionResponse>, ApiError> {
+    ensure_session_allowed_from_parts(
+        &state.config,
+        &headers,
+        Some(peer_addr),
+        &format!("/sessions/{session_id}"),
+    )?;
+    ensure_core_writes_enabled(&state)?;
+    if let Some(friendly_name) = payload.friendly_name.as_deref() {
+        validate_requested_friendly_name(friendly_name)?;
+    }
+    let requested_friendly_name = payload.friendly_name.clone();
+    let reserved_human_names = if requested_friendly_name.is_some() {
+        reserved_human_names(&state.config)?
+    } else {
+        BTreeSet::new()
+    };
+    match state.session_store.update_session_metadata(
+        &session_id,
+        payload,
+        &reserved_human_names,
+    )? {
+        SessionMetadataOutcome::Updated(session) => {
+            if let Some(friendly_name) = requested_friendly_name.as_deref() {
+                let _ = state
+                    .session_store
+                    .queue_provider_native_rename(&session, friendly_name);
+                if state.config.rust_core.runtime_enabled && !session.tmux_session.trim().is_empty()
+                {
+                    let runtime = TmuxRuntime::from_app_config(&state.config);
+                    let _ = runtime.set_status_bar(&session.tmux_session, friendly_name);
+                }
+            }
+            Ok(Json(SessionResponse::from(session)))
+        }
+        SessionMetadataOutcome::NotFound => Err(ApiError::NotFound("Session not found")),
+        SessionMetadataOutcome::BadRequest(detail) => Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail,
+        }),
+    }
 }
 
 async fn get_client_session(
@@ -6144,6 +6215,28 @@ fn shadow_predict_retained_write(
     method: &str,
     path: &str,
 ) -> anyhow::Result<Option<ShadowPrediction>> {
+    if method == "PATCH" {
+        if let Some(session_id) = path
+            .strip_prefix("/sessions/")
+            .filter(|value| !value.is_empty() && !value.contains('/'))
+        {
+            return match state.session_store.get_session(session_id)? {
+                Some(_) => Ok(Some(ShadowPrediction {
+                    status: StatusCode::OK.as_u16(),
+                    body_sha256: None,
+                    support_status: "implemented_retained_write_status_only",
+                })),
+                None => {
+                    let body = serde_json::to_vec(&json!({ "detail": "Session not found" }))?;
+                    Ok(Some(ShadowPrediction {
+                        status: StatusCode::NOT_FOUND.as_u16(),
+                        body_sha256: Some(sha256_hex(&body)),
+                        support_status: "implemented_retained_write",
+                    }))
+                }
+            };
+        }
+    }
     if method == "POST"
         && (path == "/sessions/review" || session_review_path_session_id(path).is_some())
     {
@@ -8729,6 +8822,24 @@ fn validate_requested_friendly_name(name: &str) -> Result<(), ApiError> {
         }),
         None => Ok(()),
     }
+}
+
+fn normalize_role_like_python(role: &str) -> String {
+    let mut normalized = String::new();
+    let mut last_was_dash = false;
+    for ch in role.trim().chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() {
+            normalized.push(ch);
+            last_was_dash = false;
+        } else if !last_was_dash && !normalized.is_empty() {
+            normalized.push('-');
+            last_was_dash = true;
+        }
+    }
+    while normalized.ends_with('-') {
+        normalized.pop();
+    }
+    normalized
 }
 
 fn is_auth_denial_status(status: u16) -> bool {

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -1181,6 +1181,25 @@ impl RetainedQueueStore {
         })
     }
 
+    pub fn cancel_pending_messages_for_target_category(
+        &self,
+        target_session_id: &str,
+        message_category: &str,
+    ) -> Result<usize> {
+        self.with_connection(|conn| {
+            let changed = conn.execute(
+                r#"
+                DELETE FROM message_queue
+                WHERE target_session_id = ?1
+                  AND message_category = ?2
+                  AND delivered_at IS NULL
+                "#,
+                params![target_session_id, message_category],
+            )?;
+            Ok(changed)
+        })
+    }
+
     pub fn upsert_stop_notify(
         &self,
         session_id: &str,

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -379,6 +379,21 @@ impl TmuxRuntime {
         Ok(true)
     }
 
+    pub fn set_status_bar(&self, tmux_session: &str, friendly_name: &str) -> Result<bool> {
+        if !self.session_exists(tmux_session)? {
+            return Ok(false);
+        }
+        let status_left = format!("[{friendly_name}] ");
+        self.run_tmux([
+            "set-option",
+            "-t",
+            tmux_session,
+            "status-left",
+            status_left.as_str(),
+        ])?;
+        Ok(true)
+    }
+
     pub fn session_exists(&self, tmux_session: &str) -> Result<bool> {
         let output = self
             .tmux_command(["has-session", "-t", tmux_session])
@@ -873,6 +888,19 @@ mod tests {
         assert!(command.contains("unset CLAUDECODE"));
         assert!(command.contains("export ENABLE_TOOL_SEARCH=false"));
         assert!(command.ends_with("; claude"));
+    }
+
+    #[test]
+    fn set_status_bar_updates_tmux_status_left() {
+        let (tmux_binary, log_path, _temp_dir) = fake_tmux_binary();
+        let mut runtime = TmuxRuntime::from_config(&RustCoreConfig::default());
+        runtime.tmux_binary = tmux_binary.display().to_string();
+
+        assert!(runtime.set_status_bar("sm-test", "deskbar-name").unwrap());
+
+        let log = fs::read_to_string(log_path).unwrap();
+        assert!(log.contains("has-session -t sm-test"));
+        assert!(log.contains("set-option -t sm-test status-left [deskbar-name]"));
     }
 
     #[test]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -977,6 +977,117 @@ impl SessionStore {
         Ok(registration)
     }
 
+    pub fn update_session_metadata(
+        &self,
+        session_id: &str,
+        request: UpdateSessionMetadataRequest,
+        reserved_human_names: &BTreeSet<String>,
+    ) -> Result<SessionMetadataOutcome> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        recover_missing_maintainer_registration_raw(&mut state)?;
+        prune_agent_registrations_raw(&mut state)?;
+
+        let snapshot = snapshot_from_raw_value(&state)?;
+        if !snapshot
+            .sessions
+            .iter()
+            .any(|session| session.id == session_id)
+        {
+            return Ok(SessionMetadataOutcome::NotFound);
+        }
+        let primary_alias = snapshot
+            .alias_map()
+            .get(session_id)
+            .and_then(|aliases| aliases.iter().next().cloned());
+        if let Some(friendly_name) = request.friendly_name.as_deref() {
+            if let Some(error) = validate_friendly_name_update_raw(
+                &state,
+                session_id,
+                friendly_name,
+                &primary_alias,
+                reserved_human_names,
+            )? {
+                return Ok(SessionMetadataOutcome::BadRequest(error));
+            }
+        }
+
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        for candidate in sessions.iter_mut() {
+            let Some(candidate) = candidate.as_object_mut() else {
+                continue;
+            };
+            let is_target = candidate.get("id").and_then(Value::as_str) == Some(session_id);
+            if is_target {
+                if let Some(friendly_name) = request.friendly_name.as_deref() {
+                    candidate.insert(
+                        "friendly_name".to_owned(),
+                        Value::String(friendly_name.to_owned()),
+                    );
+                    candidate.insert("friendly_name_is_explicit".to_owned(), Value::Bool(true));
+                    candidate.insert(
+                        "friendly_name_updated_at_ns".to_owned(),
+                        Value::Number(serde_json::Number::from(now_unix_timestamp_nanos())),
+                    );
+                }
+                if let Some(is_em) = request.is_em {
+                    candidate.insert("is_em".to_owned(), Value::Bool(is_em));
+                    if is_em {
+                        candidate.insert("role".to_owned(), Value::String("em".to_owned()));
+                    } else if json_text(candidate.get("role")).as_deref() == Some("em") {
+                        candidate.insert("role".to_owned(), Value::Null);
+                    }
+                }
+            } else if request.is_em == Some(true)
+                && candidate.get("is_em").and_then(Value::as_bool) == Some(true)
+            {
+                candidate.insert("is_em".to_owned(), Value::Bool(false));
+                if json_text(candidate.get("role")).as_deref() == Some("em") {
+                    candidate.insert("role".to_owned(), Value::Null);
+                }
+            }
+        }
+
+        self.write_raw_json_value(&state)?;
+        let session = snapshot_from_raw_value(&state)?
+            .into_sessions()
+            .into_iter()
+            .find(|session| session.id == session_id)
+            .ok_or_else(|| anyhow::anyhow!("updated session {session_id} was not readable"))?;
+        Ok(SessionMetadataOutcome::Updated(session))
+    }
+
+    pub fn queue_provider_native_rename(
+        &self,
+        session: &SessionRecord,
+        friendly_name: &str,
+    ) -> Result<bool> {
+        if !is_safe_provider_native_rename_name(friendly_name)
+            || session.is_stopped()
+            || !matches!(session.provider.as_str(), "claude" | "codex-fork")
+            || session.tmux_session.trim().is_empty()
+        {
+            return Ok(false);
+        }
+        let Some(queue) = &self.queue_store else {
+            if session.native_title.as_deref().map(str::trim) == Some(friendly_name) {
+                return Ok(true);
+            }
+            return Ok(false);
+        };
+        queue.cancel_pending_messages_for_target_category(&session.id, "native_rename")?;
+        if session.native_title.as_deref().map(str::trim) == Some(friendly_name) {
+            return Ok(true);
+        }
+        queue.enqueue_message(
+            &session.id,
+            &format!("/rename {friendly_name}"),
+            "sequential",
+            Some("native_rename"),
+        )?;
+        Ok(true)
+    }
+
     pub fn register_agent_role(
         &self,
         session_id: &str,
@@ -2242,6 +2353,14 @@ pub struct RoleRegistrationRequest {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct UpdateSessionMetadataRequest {
+    #[serde(default)]
+    pub friendly_name: Option<String>,
+    #[serde(default)]
+    pub is_em: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
 pub struct TaskCompleteRequest {
     pub requester_session_id: String,
 }
@@ -2454,6 +2573,13 @@ pub enum RegistryMutationOutcome {
 
 #[derive(Debug, Clone)]
 pub enum MaintainerMutationOutcome {
+    Updated(SessionRecord),
+    NotFound,
+    BadRequest(String),
+}
+
+#[derive(Debug, Clone)]
+pub enum SessionMetadataOutcome {
     Updated(SessionRecord),
     NotFound,
     BadRequest(String),
@@ -3095,6 +3221,54 @@ fn deliver_urgent_runtime_text_to_session_raw(
     Ok((status, delivered))
 }
 
+fn deliver_runtime_native_rename_to_session_raw(
+    state: &mut Value,
+    session_id: &str,
+    text: &str,
+    runtime: &TmuxRuntime,
+) -> Result<(String, bool)> {
+    let sessions = ensure_sessions_array_mut(state)?;
+    let session = session_object_mut(sessions, session_id)
+        .ok_or_else(|| anyhow::anyhow!("session {session_id} disappeared during delivery"))?;
+    let node = json_text(session.get("node")).unwrap_or_else(default_node);
+    ensure_runtime_local_node(&node)?;
+    let status = json_text(session.get("status")).unwrap_or_else(|| "running".to_owned());
+    if normalized_status(&status) == "stopped" {
+        return Ok((status, false));
+    }
+    let Some(friendly_name) = extract_provider_native_rename_name(text) else {
+        return Ok((status, false));
+    };
+    let provider = json_text(session.get("provider")).unwrap_or_else(default_provider);
+    let delivered = if provider.eq_ignore_ascii_case("codex-fork") {
+        match codex_fork_control_socket_path_for_session_raw(session_id, session, runtime).and_then(
+            |control_socket_path| codex_fork_set_thread_name(&control_socket_path, &friendly_name),
+        ) {
+            Ok(()) => {
+                clear_codex_fork_control_degraded_raw(session);
+                true
+            }
+            Err(error) => {
+                mark_codex_fork_control_degraded_raw(session, &error.to_string());
+                false
+            }
+        }
+    } else if provider.eq_ignore_ascii_case("claude") {
+        let tmux_session = json_text(session.get("tmux_session"))
+            .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?;
+        let session_socket_name = json_text(session.get("tmux_socket_name"));
+        runtime
+            .for_socket_name(session_socket_name.as_deref())
+            .send_input(&tmux_session, &format!("/rename {friendly_name}"))?
+    } else {
+        false
+    };
+    if delivered {
+        session.insert("last_activity".to_owned(), Value::String(now_rfc3339()));
+    }
+    Ok((status, delivered))
+}
+
 fn deliver_codex_fork_control_text_to_session_raw(
     session_id: &str,
     session: &mut Map<String, Value>,
@@ -3167,6 +3341,35 @@ fn codex_fork_submit_message(control_socket_path: &Path, text: &str) -> Result<(
     ensure_codex_fork_response_ok(&response, "control command failed")
 }
 
+fn codex_fork_set_thread_name(control_socket_path: &Path, friendly_name: &str) -> Result<()> {
+    if !control_socket_path.exists() {
+        return Err(anyhow::anyhow!(
+            "control socket not found: {}",
+            control_socket_path.display()
+        ));
+    }
+
+    let mut epoch = codex_fork_refresh_control_epoch(control_socket_path)?;
+    let mut response = codex_fork_send_control_command_payload(
+        control_socket_path,
+        "set_thread_name",
+        &epoch,
+        json!({ "name": friendly_name }),
+    )?;
+    if !codex_fork_response_ok(&response)
+        && codex_fork_error_code(&response).as_deref() == Some("stale_epoch")
+    {
+        epoch = codex_fork_refresh_control_epoch(control_socket_path)?;
+        response = codex_fork_send_control_command_payload(
+            control_socket_path,
+            "set_thread_name",
+            &epoch,
+            json!({ "name": friendly_name }),
+        )?;
+    }
+    ensure_codex_fork_response_ok(&response, "control command failed")
+}
+
 fn codex_fork_refresh_control_epoch(control_socket_path: &Path) -> Result<String> {
     let request = json!({
         "request_id": codex_fork_control_request_id(),
@@ -3185,13 +3388,36 @@ fn codex_fork_send_control_command(
     expected_epoch: &str,
     message: &str,
 ) -> Result<Value> {
-    let request = json!({
-        "request_id": codex_fork_control_request_id(),
-        "expected_epoch": expected_epoch,
-        "command": command,
-        "message": message,
-    });
-    codex_fork_control_roundtrip(control_socket_path, &request)
+    codex_fork_send_control_command_payload(
+        control_socket_path,
+        command,
+        expected_epoch,
+        json!({ "message": message }),
+    )
+}
+
+fn codex_fork_send_control_command_payload(
+    control_socket_path: &Path,
+    command: &str,
+    expected_epoch: &str,
+    payload: Value,
+) -> Result<Value> {
+    let mut request = Map::new();
+    request.insert(
+        "request_id".to_owned(),
+        Value::String(codex_fork_control_request_id()),
+    );
+    request.insert(
+        "expected_epoch".to_owned(),
+        Value::String(expected_epoch.to_owned()),
+    );
+    request.insert("command".to_owned(), Value::String(command.to_owned()));
+    if let Some(payload) = payload.as_object() {
+        for (key, value) in payload {
+            request.insert(key.clone(), value.clone());
+        }
+    }
+    codex_fork_control_roundtrip(control_socket_path, &Value::Object(request))
         .with_context(|| "control command failed")
 }
 
@@ -3324,7 +3550,14 @@ fn drain_pending_runtime_messages_raw(
         let mut should_continue = true;
         for message in messages {
             let (next_status, delivered) =
-                if normalized_delivery_mode(&message.delivery_mode) == "urgent" {
+                if message.message_category.as_deref() == Some("native_rename") {
+                    deliver_runtime_native_rename_to_session_raw(
+                        state,
+                        session_id,
+                        &message.text,
+                        runtime,
+                    )?
+                } else if normalized_delivery_mode(&message.delivery_mode) == "urgent" {
                     deliver_urgent_runtime_text_to_session_raw(
                         state,
                         session_id,
@@ -3777,6 +4010,51 @@ fn sync_maintainer_alias_raw(state: &mut Value) -> Result<()> {
     Ok(())
 }
 
+fn validate_friendly_name_update_raw(
+    state: &Value,
+    session_id: &str,
+    friendly_name: &str,
+    primary_alias: &Option<String>,
+    reserved_human_names: &BTreeSet<String>,
+) -> Result<Option<String>> {
+    if let Some(primary_alias) = primary_alias {
+        if friendly_name != primary_alias {
+            return Ok(Some(format!(
+                "Session identity is controlled by registry role \"{primary_alias}\""
+            )));
+        }
+    }
+
+    let normalized_name = normalize_role(friendly_name);
+    let mut reserved_aliases = BTreeSet::from(["maintainer".to_owned()]);
+    for registration in state
+        .get("agent_registrations")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default()
+        .iter()
+        .filter_map(raw_registration_record)
+    {
+        reserved_aliases.insert(registration.role);
+    }
+    if reserved_aliases.contains(&normalized_name)
+        && primary_alias.as_deref() != Some(normalized_name.as_str())
+    {
+        return Ok(Some(format!(
+            "Name \"{friendly_name}\" is reserved for registry identity \"{normalized_name}\""
+        )));
+    }
+    if reserved_human_names.contains(&normalized_name) {
+        return Ok(Some(format!(
+            "Name \"{friendly_name}\" is reserved for configured human recipient \"{normalized_name}\""
+        )));
+    }
+    if session_id.trim().is_empty() {
+        return Ok(Some("Session not found".to_owned()));
+    }
+    Ok(None)
+}
+
 fn recover_missing_maintainer_registration_raw(state: &mut Value) -> Result<bool> {
     if find_raw_registration(state, "maintainer")?.is_some() {
         return Ok(false);
@@ -4091,6 +4369,10 @@ fn now_rfc3339() -> String {
     OffsetDateTime::now_utc()
         .format(&Rfc3339)
         .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned())
+}
+
+fn now_unix_timestamp_nanos() -> i64 {
+    i64::try_from(OffsetDateTime::now_utc().unix_timestamp_nanos()).unwrap_or(i64::MAX)
 }
 
 fn now_python_naive_iso() -> String {
@@ -4812,6 +5094,34 @@ fn normalize_role(role: &str) -> String {
         normalized.pop();
     }
     normalized
+}
+
+fn is_safe_provider_native_rename_name(friendly_name: &str) -> bool {
+    !friendly_name.is_empty()
+        && friendly_name.chars().count() <= 32
+        && friendly_name
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+}
+
+fn extract_provider_native_rename_name(text: &str) -> Option<String> {
+    let text = text.trim();
+    let rest = text.strip_prefix("/rename")?;
+    if !rest
+        .chars()
+        .next()
+        .is_some_and(|character| character.is_whitespace())
+    {
+        return None;
+    }
+    let friendly_name = rest.trim();
+    if friendly_name.split_whitespace().count() == 1
+        && is_safe_provider_native_rename_name(friendly_name)
+    {
+        Some(friendly_name.to_owned())
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -24,6 +24,8 @@ use sm_server::{
         QueueRunnerConfig, RustCoreConfig, SmSendConfig, ToolLoggingConfig,
     },
     http::{router, AppState, GitHubReviewComment, GitHubReviewMatch, GitHubReviewPoster},
+    runtime::TmuxRuntime,
+    sessions::SessionStore,
 };
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -89,6 +91,18 @@ async fn put_json(app: axum::Router, uri: &str, payload: Value) -> (StatusCode, 
     json_request_with_headers_and_peer(
         app,
         "PUT",
+        uri,
+        payload,
+        &[],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await
+}
+
+async fn patch_json(app: axum::Router, uri: &str, payload: Value) -> (StatusCode, Value) {
+    json_request_with_headers_and_peer(
+        app,
+        "PATCH",
         uri,
         payload,
         &[],
@@ -8963,6 +8977,344 @@ async fn fixture_registry_and_maintainer_endpoints_round_trip_state() {
 }
 
 #[tokio::test]
+async fn patch_session_metadata_updates_friendly_name_and_em_state() {
+    let state_file = unique_temp_path();
+    let queue_db = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        sm_send: SmSendConfig {
+            db_path: queue_db.display().to_string(),
+            ..SmSendConfig::default()
+        },
+        rust_core: RustCoreConfig {
+            fixture_writes_enabled: true,
+            log_dir: Some(log_dir.display().to_string()),
+            ..RustCoreConfig::default()
+        },
+        ..AppConfig::default()
+    }));
+
+    for (session_id, name) in [("rename1", "rename-one"), ("rename2", "rename-two")] {
+        let (status, _payload) = post_json(
+            app.clone(),
+            "/sessions",
+            json!({
+                "id": session_id,
+                "name": name,
+                "working_dir": "/repo",
+                "provider": "claude"
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+    }
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "rename-codex",
+            "name": "rename-codex",
+            "working_dir": "/repo",
+            "provider": "codex"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, payload) = patch_json(
+        app.clone(),
+        "/sessions/rename1",
+        json!({
+            "friendly_name": "deskbar-name",
+            "is_em": true
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["id"], "rename1");
+    assert_eq!(payload["friendly_name"], "deskbar-name");
+    assert_eq!(payload["is_em"], true);
+    assert_eq!(payload["role"], "em");
+
+    let queue_conn = Connection::open(&queue_db).unwrap();
+    let queued_message: (String, String, String, String) = queue_conn
+        .query_row(
+            "SELECT target_session_id, text, delivery_mode, message_category FROM message_queue WHERE target_session_id = 'rename1'",
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        queued_message,
+        (
+            "rename1".to_owned(),
+            "/rename deskbar-name".to_owned(),
+            "sequential".to_owned(),
+            "native_rename".to_owned()
+        )
+    );
+
+    let (status, payload) = patch_json(
+        app.clone(),
+        "/sessions/rename-codex",
+        json!({ "friendly_name": "codex-display" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["friendly_name"], "codex-display");
+    let pending_codex_native_renames: i64 = queue_conn
+        .query_row(
+            "SELECT COUNT(*) FROM message_queue WHERE target_session_id = 'rename-codex' AND message_category = 'native_rename' AND delivered_at IS NULL",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(pending_codex_native_renames, 0);
+
+    let state = fs::read_to_string(&state_file).unwrap();
+    let mut raw: Value = serde_json::from_str(&state).unwrap();
+    let sessions = raw["sessions"].as_array().unwrap();
+    let renamed = sessions
+        .iter()
+        .find(|session| session["id"] == "rename1")
+        .unwrap();
+    assert_eq!(renamed["friendly_name"], "deskbar-name");
+    assert_eq!(renamed["friendly_name_is_explicit"], true);
+    assert!(renamed["friendly_name_updated_at_ns"].as_i64().unwrap() > 0);
+
+    let rename1 = raw["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "rename1")
+        .unwrap();
+    rename1["native_title"] = json!("deskbar-current");
+    fs::write(&state_file, serde_json::to_string(&raw).unwrap()).unwrap();
+
+    let (status, payload) = patch_json(
+        app.clone(),
+        "/sessions/rename1",
+        json!({ "friendly_name": "deskbar-current" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["friendly_name"], "deskbar-current");
+    let pending_native_renames: i64 = queue_conn
+        .query_row(
+            "SELECT COUNT(*) FROM message_queue WHERE target_session_id = 'rename1' AND message_category = 'native_rename' AND delivered_at IS NULL",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(pending_native_renames, 0);
+
+    let (status, payload) =
+        patch_json(app.clone(), "/sessions/rename2", json!({ "is_em": true })).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["is_em"], true);
+
+    let (status, payload) = get_json(app.clone(), "/sessions/rename1").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["is_em"], false);
+    assert_eq!(payload["role"], Value::Null);
+}
+
+#[tokio::test]
+async fn patch_session_metadata_rejects_invalid_and_reserved_friendly_names() {
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        rust_core: RustCoreConfig {
+            fixture_writes_enabled: true,
+            log_dir: Some(log_dir.display().to_string()),
+            ..RustCoreConfig::default()
+        },
+        human_recipient_reserved_names: vec!["human-owner".to_owned()],
+        ..AppConfig::default()
+    }));
+
+    for (session_id, name) in [
+        ("registryowner", "registry-owner"),
+        ("otherowner", "other-owner"),
+    ] {
+        let (status, _payload) = post_json(
+            app.clone(),
+            "/sessions",
+            json!({
+                "id": session_id,
+                "name": name,
+                "working_dir": "/repo",
+                "provider": "claude"
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+    }
+
+    let (status, payload) = patch_json(
+        app.clone(),
+        "/sessions/registryowner",
+        json!({ "friendly_name": "bad name" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        payload["detail"],
+        "Invalid name: Name must be alphanumeric with - or _ only (no spaces)"
+    );
+
+    let (status, payload) = put_json(
+        app.clone(),
+        "/sessions/registryowner/maintainer",
+        json!({ "requester_session_id": "registryowner" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["aliases"], json!(["maintainer"]));
+
+    let (status, payload) = patch_json(
+        app.clone(),
+        "/sessions/otherowner",
+        json!({ "friendly_name": "maintainer" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        payload["detail"],
+        "Name \"maintainer\" is reserved for registry identity \"maintainer\""
+    );
+
+    let (status, payload) = patch_json(
+        app.clone(),
+        "/sessions/registryowner",
+        json!({ "friendly_name": "not-maintainer" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        payload["detail"],
+        "Session identity is controlled by registry role \"maintainer\""
+    );
+
+    let (status, payload) = patch_json(
+        app.clone(),
+        "/sessions/otherowner",
+        json!({ "friendly_name": "human-owner" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        payload["detail"],
+        "Name \"human-owner\" is reserved for configured human recipient \"human-owner\""
+    );
+}
+
+#[tokio::test]
+async fn patch_session_metadata_is_em_does_not_load_human_config() {
+    let state_file = unique_temp_path();
+    let bridge_config = unique_temp_path();
+    let log_dir = unique_temp_path();
+    fs::write(&bridge_config, "humans: [").unwrap();
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        email: EmailConfig {
+            bridge_config: bridge_config.display().to_string(),
+            ..EmailConfig::default()
+        },
+        rust_core: RustCoreConfig {
+            fixture_writes_enabled: true,
+            log_dir: Some(log_dir.display().to_string()),
+            ..RustCoreConfig::default()
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "emonly",
+            "name": "em-only",
+            "working_dir": "/repo",
+            "provider": "claude"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, payload) =
+        patch_json(app.clone(), "/sessions/emonly", json!({ "is_em": true })).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["is_em"], true);
+    assert_eq!(payload["role"], "em");
+}
+
+#[tokio::test]
+async fn shadow_http_predicts_patch_session_metadata_without_writing() {
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        rust_core: RustCoreConfig {
+            fixture_writes_enabled: true,
+            log_dir: Some(log_dir.display().to_string()),
+            ..RustCoreConfig::default()
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "shadowpatch",
+            "name": "shadow-patch",
+            "working_dir": "/repo",
+            "provider": "claude"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/__shadow/http",
+        json!({
+            "request": {
+                "method": "PATCH",
+                "path": "/sessions/shadowpatch"
+            },
+            "python_response": {
+                "status": 200,
+                "body_sha256": "ignored"
+            }
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        payload["support_status"],
+        "implemented_retained_write_status_only"
+    );
+    assert_eq!(payload["comparison"], "status_match");
+    assert_eq!(payload["would_write"], false);
+
+    let (status, payload) = get_json(app.clone(), "/sessions/shadowpatch").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["friendly_name"], "shadow-patch");
+}
+
+#[tokio::test]
 async fn fixture_registry_prunes_stale_roles_and_updates_maintainer_alias() {
     let state_file = unique_temp_path();
     fs::write(
@@ -12212,6 +12564,49 @@ while true; do sleep 1; done
             retry_submit_request["message"],
             "control socket retry message"
         );
+
+        let rename_requests =
+            spawn_codex_fork_control_socket(control_path.clone(), "epoch-runtimefork-rename");
+        let (status, payload) = patch_json(
+            app.clone(),
+            "/sessions/runtimefork",
+            json!({ "friendly_name": "deskbar-rename" }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(payload["friendly_name"], "deskbar-rename");
+        let runtime = TmuxRuntime::from_app_config(&AppConfig {
+            rust_core: RustCoreConfig {
+                runtime_enabled: true,
+                log_dir: Some(log_dir.display().to_string()),
+                tmux_socket_name: Some(tmux_socket.clone()),
+                ..RustCoreConfig::default()
+            },
+            ..AppConfig::default()
+        });
+        SessionStore::new_with_queue(state_file.clone(), queue_db_path.clone())
+            .drain_runtime_pending_messages_for_session("runtimefork", &runtime)
+            .unwrap();
+        let rename_epoch_request = rename_requests
+            .recv_timeout(Duration::from_secs(2))
+            .expect("codex-fork rename get_epoch request");
+        assert_eq!(rename_epoch_request["command"], "get_epoch");
+        let rename_request = rename_requests
+            .recv_timeout(Duration::from_secs(2))
+            .expect("codex-fork set_thread_name request");
+        assert_eq!(rename_request["command"], "set_thread_name");
+        assert_eq!(rename_request["expected_epoch"], "epoch-runtimefork-rename");
+        assert_eq!(rename_request["name"], "deskbar-rename");
+        assert!(rename_request.get("message").is_none());
+        let delivered_native_renames: i64 = Connection::open(&queue_db_path)
+            .unwrap()
+            .query_row(
+                "SELECT COUNT(*) FROM message_queue WHERE target_session_id = 'runtimefork' AND message_category = 'native_rename' AND delivered_at IS NOT NULL",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(delivered_native_renames, 1);
     }
 
     let tmux_session = payload["tmux_session"].as_str().unwrap().to_owned();
@@ -13833,6 +14228,11 @@ fn spawn_codex_fork_control_socket(path: PathBuf, epoch: &'static str) -> mpsc::
                     "result": { "epoch": epoch }
                 }),
                 Some("submit_message") => json!({
+                    "ok": true,
+                    "epoch": epoch,
+                    "result": {}
+                }),
+                Some("set_thread_name") => json!({
                     "ok": true,
                     "epoch": epoch,
                     "result": {}


### PR DESCRIPTION
## Summary
- add Rust PATCH /sessions/{session_id} support for friendly_name and is_em metadata updates
- preserve Python-style friendly-name validation plus registry and human-recipient reserved-name checks
- classify implemented PATCH session metadata writes in shadow mode without replaying side effects

## Validation
- cargo fmt --check
- cargo test -p sm-server
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py
- git diff --check

Fixes #1053