### PR TITLE
Project recent agent activity in Rust sessions

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -101,10 +101,11 @@ use crate::queue::{
 };
 use crate::runtime::TmuxRuntime;
 use crate::sessions::{
-    expand_home, is_primary_node, AgentStatusRequest, ArmStopNotifyOutcome, ArmStopNotifyRequest,
-    ClearSessionRequest, ClientSessionResponse, ContextMonitorOutcome, ContextMonitorRequest,
-    CoreClearOutcome, CoreInputBatchResponse, CoreInputBatchResult, CoreRestoreOutcome,
-    CoreRetireOutcome, CoreReviewOutcome, CreateCoreSessionRequest, HandoffOutcome, HandoffRequest,
+    expand_home, is_primary_node, AgentRegistrationResponse, AgentStatusRequest,
+    ArmStopNotifyOutcome, ArmStopNotifyRequest, ChildSessionResponse, ClearSessionRequest,
+    ClientSessionResponse, ContextMonitorOutcome, ContextMonitorRequest, CoreClearOutcome,
+    CoreInputBatchResponse, CoreInputBatchResult, CoreRestoreOutcome, CoreRetireOutcome,
+    CoreReviewOutcome, CreateCoreSessionRequest, HandoffOutcome, HandoffRequest,
     MaintainerMutationOutcome, RegistryMutationOutcome, RoleRegistrationRequest,
     SendCoreInputBatchRequest, SendCoreInputRequest, SessionMetadataOutcome, SessionRecord,
     SessionResponse, SessionStore, SessionsEnvelope, SetMaintainerRequest, SpawnReviewRequest,
@@ -2127,7 +2128,7 @@ async fn list_sessions(
         .session_store
         .list_sessions(query.include_stopped)?
         .into_iter()
-        .map(SessionResponse::from)
+        .map(|session| session_response_with_live_activity(&state, session))
         .collect::<Vec<_>>();
     Ok(Json(SessionsEnvelope::from(sessions)))
 }
@@ -2139,12 +2140,17 @@ async fn list_children_sessions(
     request: Request,
 ) -> Result<Json<Value>, ApiError> {
     ensure_session_read_allowed(&state, &request)?;
-    let children = state.session_store.list_children(
-        &parent_session_id,
-        query.recursive,
-        query.status.as_deref(),
-        query.include_terminated,
-    )?;
+    let children = state
+        .session_store
+        .list_child_records(
+            &parent_session_id,
+            query.recursive,
+            query.status.as_deref(),
+            query.include_terminated,
+        )?
+        .into_iter()
+        .map(|session| child_session_response_with_live_activity(&state, session))
+        .collect::<Vec<_>>();
     Ok(Json(json!({
         "parent_session_id": parent_session_id,
         "children": children,
@@ -2170,7 +2176,7 @@ async fn create_session(
     } else {
         state.session_store.create_core_session(payload, log_dir)?
     };
-    Ok(Json(SessionResponse::from(session)))
+    Ok(Json(session_response_with_live_activity(&state, session)))
 }
 
 async fn spawn_session(
@@ -2827,7 +2833,9 @@ async fn restore_node_restore_candidate(
         state.session_store.restore_core_session(&session_id)?
     };
     match outcome {
-        Some(CoreRestoreOutcome::Restored(session)) => Ok(Json(SessionResponse::from(session))),
+        Some(CoreRestoreOutcome::Restored(session)) => {
+            Ok(Json(session_response_with_live_activity(&state, session)))
+        }
         Some(CoreRestoreOutcome::NotStopped) => Err(ApiError::Status {
             status: StatusCode::CONFLICT,
             detail: "Session is not stopped".to_owned(),
@@ -3827,7 +3835,7 @@ async fn get_session(
     let Some(session) = state.session_store.get_session(&session_id)? else {
         return Err(ApiError::NotFound("Session not found"));
     };
-    Ok(Json(SessionResponse::from(session)))
+    Ok(Json(session_response_with_live_activity(&state, session)))
 }
 
 async fn update_session_metadata(
@@ -3869,7 +3877,7 @@ async fn update_session_metadata(
                     let _ = runtime.set_status_bar(&session.tmux_session, friendly_name);
                 }
             }
-            Ok(Json(SessionResponse::from(session)))
+            Ok(Json(session_response_with_live_activity(&state, session)))
         }
         SessionMetadataOutcome::NotFound => Err(ApiError::NotFound("Session not found")),
         SessionMetadataOutcome::BadRequest(detail) => Err(ApiError::Status {
@@ -5579,7 +5587,9 @@ async fn restore_session(
         return Err(ApiError::NotFound("Session not found"));
     };
     match outcome {
-        CoreRestoreOutcome::Restored(session) => Ok(Json(SessionResponse::from(session))),
+        CoreRestoreOutcome::Restored(session) => {
+            Ok(Json(session_response_with_live_activity(&state, session)))
+        }
         CoreRestoreOutcome::NotStopped => Err(ApiError::Status {
             status: StatusCode::CONFLICT,
             detail: "Session is not stopped".to_owned(),
@@ -5774,7 +5784,9 @@ async fn set_maintainer(
         .session_store
         .set_maintainer_session(&session_id, payload)?
     {
-        MaintainerMutationOutcome::Updated(session) => Ok(Json(SessionResponse::from(session))),
+        MaintainerMutationOutcome::Updated(session) => {
+            Ok(Json(session_response_with_live_activity(&state, session)))
+        }
         MaintainerMutationOutcome::NotFound => Err(ApiError::NotFound("Session not found")),
         MaintainerMutationOutcome::BadRequest(detail) => Err(ApiError::Status {
             status: StatusCode::BAD_REQUEST,
@@ -5801,7 +5813,9 @@ async fn clear_maintainer(
         .session_store
         .clear_maintainer_session(&session_id, payload)?
     {
-        MaintainerMutationOutcome::Updated(session) => Ok(Json(SessionResponse::from(session))),
+        MaintainerMutationOutcome::Updated(session) => {
+            Ok(Json(session_response_with_live_activity(&state, session)))
+        }
         MaintainerMutationOutcome::NotFound => Err(ApiError::NotFound("Session not found")),
         MaintainerMutationOutcome::BadRequest(detail) => Err(ApiError::Status {
             status: StatusCode::BAD_REQUEST,
@@ -5815,7 +5829,12 @@ async fn list_agent_registry(
     request: Request,
 ) -> Result<Json<Value>, ApiError> {
     ensure_session_read_allowed(&state, &request)?;
-    let registrations = state.session_store.list_agent_registrations()?;
+    let registrations = state
+        .session_store
+        .list_agent_registrations()?
+        .into_iter()
+        .map(|registration| agent_registration_response_with_live_activity(&state, registration))
+        .collect::<Result<Vec<_>, _>>()?;
     Ok(Json(json!({ "registrations": registrations })))
 }
 
@@ -5831,6 +5850,7 @@ async fn lookup_agent_registry(
             detail: "Role not registered".to_owned(),
         });
     };
+    let registration = agent_registration_response_with_live_activity(&state, registration)?;
     Ok(Json(serde_json::to_value(registration)?))
 }
 
@@ -5849,6 +5869,7 @@ async fn register_agent_role(
     )?;
     ensure_core_writes_enabled(&state)?;
     registry_mutation_response(
+        &state,
         state
             .session_store
             .register_agent_role(&session_id, payload)?,
@@ -5870,17 +5891,21 @@ async fn unregister_agent_role(
     )?;
     ensure_core_writes_enabled(&state)?;
     registry_mutation_response(
+        &state,
         state
             .session_store
             .unregister_agent_role(&session_id, payload)?,
     )
 }
 
-fn registry_mutation_response(outcome: RegistryMutationOutcome) -> Result<Json<Value>, ApiError> {
+fn registry_mutation_response(
+    state: &AppState,
+    outcome: RegistryMutationOutcome,
+) -> Result<Json<Value>, ApiError> {
     match outcome {
-        RegistryMutationOutcome::Registered(registration) => {
-            Ok(Json(serde_json::to_value(registration)?))
-        }
+        RegistryMutationOutcome::Registered(registration) => Ok(Json(serde_json::to_value(
+            agent_registration_response_with_live_activity(state, registration)?,
+        )?)),
         RegistryMutationOutcome::NotFound => Err(ApiError::NotFound("Session not found")),
         RegistryMutationOutcome::RoleNotRegistered => Err(ApiError::Status {
             status: StatusCode::NOT_FOUND,
@@ -5899,6 +5924,18 @@ fn registry_mutation_response(outcome: RegistryMutationOutcome) -> Result<Json<V
             detail,
         }),
     }
+}
+
+fn agent_registration_response_with_live_activity(
+    state: &AppState,
+    mut registration: AgentRegistrationResponse,
+) -> Result<AgentRegistrationResponse, ApiError> {
+    if let Some(session) = state.session_store.get_session(&registration.session_id)? {
+        if let Some(activity_state) = live_activity_state(state, &session) {
+            registration.activity_state = activity_state.to_owned();
+        }
+    }
+    Ok(registration)
 }
 
 async fn session_output(
@@ -6642,12 +6679,17 @@ fn shadow_predict_session_read(
         .strip_prefix("/sessions/")
         .and_then(|value| value.strip_suffix("/children"))
     {
-        let children = state.session_store.list_children(
-            parent_session_id,
-            query_bool(query_string, "recursive"),
-            query_value(query_string, "status"),
-            query_bool(query_string, "include_terminated"),
-        )?;
+        let children = state
+            .session_store
+            .list_child_records(
+                parent_session_id,
+                query_bool(query_string, "recursive"),
+                query_value(query_string, "status"),
+                query_bool(query_string, "include_terminated"),
+            )?
+            .into_iter()
+            .map(|session| child_session_response_with_live_activity(state, session))
+            .collect::<Vec<_>>();
         let body = serde_json::to_vec(&json!({
             "parent_session_id": parent_session_id,
             "children": children,
@@ -7012,8 +7054,11 @@ fn client_session_value(
     actor_email: Option<&str>,
     route_prefix: Option<&str>,
 ) -> Value {
-    let mut value = serde_json::to_value(ClientSessionResponse::from(session.clone()))
-        .unwrap_or_else(|_| json!({}));
+    let mut value = serde_json::to_value(client_session_response_with_live_activity(
+        state,
+        session.clone(),
+    ))
+    .unwrap_or_else(|_| json!({}));
     let attach_descriptor = attach_descriptor_payload(session.clone());
     value["attach_descriptor"] = attach_descriptor.clone();
     value["termux_attach"] = Value::Null;
@@ -7060,6 +7105,70 @@ fn mobile_primary_action(mobile_terminal: &Value, attach_descriptor: &Value) -> 
             "label": "View details",
         })
     }
+}
+
+fn session_response_with_live_activity(
+    state: &AppState,
+    session: SessionRecord,
+) -> SessionResponse {
+    let mut response = SessionResponse::from(session.clone());
+    if let Some(activity_state) = live_activity_state(state, &session) {
+        response.set_activity_state(activity_state);
+    }
+    response
+}
+
+fn client_session_response_with_live_activity(
+    state: &AppState,
+    session: SessionRecord,
+) -> ClientSessionResponse {
+    let mut response = ClientSessionResponse::from(session.clone());
+    if let Some(activity_state) = live_activity_state(state, &session) {
+        response.set_activity_state(activity_state);
+    }
+    response
+}
+
+fn child_session_response_with_live_activity(
+    state: &AppState,
+    session: SessionRecord,
+) -> ChildSessionResponse {
+    let mut response = ChildSessionResponse::from(session.clone());
+    if let Some(activity_state) = live_activity_state(state, &session) {
+        response.set_activity_state(activity_state);
+    }
+    response
+}
+
+fn live_activity_state(state: &AppState, session: &SessionRecord) -> Option<&'static str> {
+    if session.status.trim() == "stopped" || session.completion_status.is_some() {
+        return None;
+    }
+    if session.agent_task_completed_at.is_some() {
+        return None;
+    }
+    if session.provider.trim() != "codex-fork" || session.tmux_session.trim().is_empty() {
+        return None;
+    }
+    let runtime = TmuxRuntime::from_app_config(&state.config)
+        .for_socket_name(session.tmux_socket_name.as_deref());
+    let pane_title = runtime.pane_title(&session.tmux_session)?;
+    codex_fork_pane_title_indicates_working(&pane_title).then_some("working")
+}
+
+fn codex_fork_pane_title_indicates_working(pane_title: &str) -> bool {
+    let title = pane_title.trim();
+    let Some((first_token, _)) = title.split_once(' ') else {
+        return false;
+    };
+    let mut chars = first_token.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if chars.next().is_some() {
+        return false;
+    }
+    (0x2801..=0x28ff).contains(&(first as u32))
 }
 
 fn mobile_terminal_metadata(
@@ -9369,14 +9478,14 @@ fn bug_report_server_state(
         .session_store
         .list_sessions(false)?
         .into_iter()
-        .map(SessionResponse::from)
+        .map(|session| session_response_with_live_activity(state, session))
         .map(serde_json::to_value)
         .collect::<Result<Vec<_>, _>>()?;
     let selected_session = if let Some(session_id) = selected_session_id {
         match state.session_store.get_session(session_id)? {
             Some(session) => json!({
                 "found": true,
-                "session": ClientSessionResponse::from(session),
+                "session": client_session_response_with_live_activity(state, session),
             }),
             None => json!({
                 "id": session_id,
@@ -10375,6 +10484,23 @@ mod tests {
     use serde::Serialize;
     use std::{env, process};
     use tower::ServiceExt;
+
+    #[test]
+    fn codex_fork_pane_title_spinner_indicates_working() {
+        assert!(codex_fork_pane_title_indicates_working("⠏ session-manager"));
+        assert!(codex_fork_pane_title_indicates_working(
+            "  ⠇ fractal-algo-rust  "
+        ));
+        assert!(!codex_fork_pane_title_indicates_working(
+            "fractal-algo-rust"
+        ));
+        assert!(!codex_fork_pane_title_indicates_working(
+            "⠏\tfractal-algo-rust"
+        ));
+        assert!(!codex_fork_pane_title_indicates_working(
+            "⠏⠇ fractal-algo-rust"
+        ));
+    }
 
     fn write_session_state(session_id: &str, status: &str) -> String {
         let dir = env::temp_dir().join(format!(

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -427,6 +427,19 @@ impl TmuxRuntime {
         }
     }
 
+    pub fn pane_title(&self, tmux_session: &str) -> Option<String> {
+        let output = self
+            .tmux_command(["display-message", "-p", "-t", tmux_session, "#{pane_title}"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        Some(String::from_utf8_lossy(&output.stdout).trim().to_owned())
+    }
+
     fn exit_copy_mode_if_needed(&self, tmux_session: &str) {
         if self.pane_in_mode(tmux_session) == Some(1) {
             let _ = self.run_tmux(["send-keys", "-t", tmux_session, "-X", "cancel"]);

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -92,6 +92,25 @@ impl SessionStore {
         status_filter: Option<&str>,
         include_terminated: bool,
     ) -> Result<Vec<ChildSessionResponse>> {
+        Ok(self
+            .list_child_records(
+                parent_session_id,
+                recursive,
+                status_filter,
+                include_terminated,
+            )?
+            .into_iter()
+            .map(ChildSessionResponse::from)
+            .collect())
+    }
+
+    pub fn list_child_records(
+        &self,
+        parent_session_id: &str,
+        recursive: bool,
+        status_filter: Option<&str>,
+        include_terminated: bool,
+    ) -> Result<Vec<SessionRecord>> {
         let all_sessions = self.load_snapshot()?.into_sessions();
         let mut children = if recursive {
             let mut descendants = Vec::new();
@@ -122,10 +141,7 @@ impl SessionStore {
             children.retain(|session| session.completion_status.as_deref() != Some("killed"));
         }
 
-        Ok(children
-            .into_iter()
-            .map(ChildSessionResponse::from)
-            .collect())
+        Ok(children)
     }
 
     pub fn get_session(&self, session_id: &str) -> Result<Option<SessionRecord>> {
@@ -296,7 +312,7 @@ impl SessionStore {
         let delivered = normalized_status(&status) != "stopped";
         if delivered {
             let now = now_rfc3339();
-            session.insert("last_activity".to_owned(), Value::String(now));
+            mark_session_followup_activity(session, &now);
             if let Some(log_file) = json_text(session.get("log_file")) {
                 append_log_line(&expand_home(&log_file), &request.text)?;
                 if let Some(seconds) = request.notify_after_seconds {
@@ -1509,6 +1525,8 @@ impl SessionStore {
             "agent_task_completed_at".to_owned(),
             Value::String(completed_at.clone()),
         );
+        session_object.insert("agent_status_text".to_owned(), Value::Null);
+        session_object.insert("agent_status_at".to_owned(), Value::Null);
 
         let mut em_notified = false;
         if let Some(em_session_id) = em_session_id {
@@ -3283,7 +3301,7 @@ fn deliver_runtime_text_to_session_raw(
         }
         let now = now_rfc3339();
         if delivered {
-            session.insert("last_activity".to_owned(), Value::String(now));
+            mark_session_followup_activity(session, &now);
         } else {
             status = "stopped".to_owned();
             session.insert("status".to_owned(), Value::String(status.clone()));
@@ -3327,7 +3345,7 @@ fn deliver_urgent_runtime_text_to_session_raw(
         }
         let now = now_rfc3339();
         if delivered {
-            session.insert("last_activity".to_owned(), Value::String(now));
+            mark_session_followup_activity(session, &now);
         } else {
             status = "stopped".to_owned();
             session.insert("status".to_owned(), Value::String(status.clone()));
@@ -4299,13 +4317,14 @@ fn agent_registration_response(
     created_at: Option<&str>,
 ) -> AgentRegistrationResponse {
     let status = normalized_status(&session.status);
+    let activity_state = projected_activity_state(session, status);
     AgentRegistrationResponse {
         role: normalize_role(role),
         session_id: session.id.clone(),
         friendly_name: session.cached_display_name(),
         provider: Some(non_empty_or(session.provider.clone(), "claude")),
         status: status.to_owned(),
-        activity_state: fallback_activity_state(status),
+        activity_state,
         created_at: created_at
             .map(ToOwned::to_owned)
             .unwrap_or_else(now_rfc3339),
@@ -4368,6 +4387,11 @@ fn reset_session_after_clear(session: &mut Map<String, Value>, now: &str) {
     session.insert("completed_at".to_owned(), Value::Null);
     session.insert("last_activity".to_owned(), Value::String(now.to_owned()));
     mark_review_dispatch_completed(session, now);
+}
+
+fn mark_session_followup_activity(session: &mut Map<String, Value>, now: &str) {
+    session.insert("agent_task_completed_at".to_owned(), Value::Null);
+    session.insert("last_activity".to_owned(), Value::String(now.to_owned()));
 }
 
 fn mark_session_killed(session: &mut Map<String, Value>, now: &str) {
@@ -4954,6 +4978,7 @@ impl From<SessionRecord> for SessionResponse {
         let friendly_name = session.cached_display_name();
         let is_maintainer = session.aliases.iter().any(|alias| alias == "maintainer");
         let telegram_thread_id = session.resolved_telegram_thread_id();
+        let activity_state = projected_activity_state(&session, status);
         Self {
             id: session.id,
             name: session.name,
@@ -4985,7 +5010,7 @@ impl From<SessionRecord> for SessionResponse {
             agent_task_completed_at: session.agent_task_completed_at,
             is_em: session.is_em,
             role: session.role,
-            activity_state: fallback_activity_state(status),
+            activity_state,
             last_tool_call: session.last_tool_call,
             last_tool_name: session.last_tool_name,
             last_action_summary: None,
@@ -4996,6 +5021,12 @@ impl From<SessionRecord> for SessionResponse {
             aliases: session.aliases,
             is_maintainer,
         }
+    }
+}
+
+impl SessionResponse {
+    pub fn set_activity_state(&mut self, activity_state: impl Into<String>) {
+        self.activity_state = activity_state.into();
     }
 }
 
@@ -5027,12 +5058,13 @@ impl From<SessionRecord> for ChildSessionResponse {
             .spawned_at
             .clone()
             .or(Some(session.created_at.clone()));
+        let activity_state = projected_activity_state(&session, &status);
         Self {
             id: session.id,
             name: session.name,
             friendly_name,
             status: status.clone(),
-            activity_state: fallback_activity_state(&status),
+            activity_state,
             completion_status: session.completion_status,
             completion_message: session.completion_message,
             last_activity: session.last_activity,
@@ -5045,6 +5077,12 @@ impl From<SessionRecord> for ChildSessionResponse {
             provider: non_empty_or(session.provider, "claude"),
             activity_projection: None,
         }
+    }
+}
+
+impl ChildSessionResponse {
+    pub fn set_activity_state(&mut self, activity_state: impl Into<String>) {
+        self.activity_state = activity_state.into();
     }
 }
 
@@ -5086,6 +5124,12 @@ impl From<SessionRecord> for ClientSessionResponse {
     }
 }
 
+impl ClientSessionResponse {
+    pub fn set_activity_state(&mut self, activity_state: impl Into<String>) {
+        self.session.set_activity_state(activity_state);
+    }
+}
+
 #[derive(Debug, Serialize)]
 pub struct AttachDescriptor {
     attach_supported: bool,
@@ -5117,6 +5161,29 @@ fn fallback_activity_state(status: &str) -> String {
         "running" => "working".to_owned(),
         _ => "idle".to_owned(),
     }
+}
+
+fn projected_activity_state(session: &SessionRecord, status: &str) -> String {
+    let status = normalized_status(status);
+    if status == "stopped" {
+        return "stopped".to_owned();
+    }
+    if session.completion_status.as_deref() == Some("killed") {
+        return "stopped".to_owned();
+    }
+    if session.completion_status.is_some() {
+        return "waiting_input".to_owned();
+    }
+    if session.agent_task_completed_at.is_some() {
+        return "idle".to_owned();
+    }
+    if matches!(status, "running" | "working") {
+        return "working".to_owned();
+    }
+    if status == "idle" {
+        return "idle".to_owned();
+    }
+    fallback_activity_state(status)
 }
 
 fn non_empty_or(value: String, fallback: &str) -> String {
@@ -5326,6 +5393,60 @@ mod tests {
 
         assert_eq!(response.status, "idle");
         assert_eq!(response.activity_state, "idle");
+    }
+
+    #[test]
+    fn session_projection_keeps_stored_idle_until_live_projection() {
+        let mut status_session = session_record("idle");
+        status_session.agent_status_text = Some("Working on a review".to_owned());
+        status_session.agent_status_at = Some(now_rfc3339());
+        let response = SessionResponse::from(status_session.clone());
+        assert_eq!(response.activity_state, "idle");
+        let client_response = ClientSessionResponse::from(status_session);
+        assert_eq!(client_response.session.activity_state, "idle");
+
+        let mut stale_status_session = session_record("idle");
+        stale_status_session.agent_status_text = Some("old work".to_owned());
+        stale_status_session.agent_status_at = Some("2026-06-01T00:00:00Z".to_owned());
+        let response = SessionResponse::from(stale_status_session);
+        assert_eq!(response.activity_state, "idle");
+
+        let mut completed_task_session = session_record("idle");
+        completed_task_session.agent_status_text = Some("recent but complete".to_owned());
+        completed_task_session.agent_status_at = Some(now_rfc3339());
+        completed_task_session.agent_task_completed_at = Some(now_rfc3339());
+        let response = SessionResponse::from(completed_task_session);
+        assert_eq!(response.activity_state, "idle");
+
+        let mut local_status_session = session_record("idle");
+        local_status_session.agent_status_text = Some("local timestamp".to_owned());
+        local_status_session.agent_status_at = Some(now_python_naive_iso());
+        let response = SessionResponse::from(local_status_session);
+        assert_eq!(response.activity_state, "idle");
+
+        let mut stale_task_session = session_record("idle");
+        stale_task_session.current_task = Some("reviewing".to_owned());
+        stale_task_session.last_activity = now_rfc3339();
+        let response = SessionResponse::from(stale_task_session);
+        assert_eq!(response.activity_state, "idle");
+
+        let mut explicit_idle_session = session_record("idle");
+        explicit_idle_session.last_activity = now_rfc3339();
+        let response = SessionResponse::from(explicit_idle_session);
+        assert_eq!(response.activity_state, "idle");
+
+        let mut recent_activity_session = session_record("paused");
+        recent_activity_session.last_activity = now_rfc3339();
+        let response = SessionResponse::from(recent_activity_session);
+        assert_eq!(response.activity_state, "idle");
+    }
+
+    #[test]
+    fn session_projection_uses_canonical_waiting_input_activity() {
+        let mut session = session_record("idle");
+        session.completion_status = Some("completed".to_owned());
+        let response = SessionResponse::from(session);
+        assert_eq!(response.activity_state, "waiting_input");
     }
 
     #[test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -8732,6 +8732,8 @@ async fn fixture_completion_endpoints_preserve_python_compatible_state() {
         .find(|session| session["id"] == "child001")
         .unwrap();
     assert!(child["agent_task_completed_at"].is_string());
+    assert_eq!(child["agent_status_text"], Value::Null);
+    assert_eq!(child["agent_status_at"], Value::Null);
     assert_eq!(
         state["retained_remind_registrations"][0]["is_active"],
         false
@@ -8768,6 +8770,26 @@ async fn fixture_completion_endpoints_preserve_python_compatible_state() {
             "important".to_owned()
         )
     );
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/child001/input",
+        json!({
+            "text": "follow-up work after completion",
+            "delivery_mode": "sequential"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["delivered"], true);
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let child = state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "child001")
+        .unwrap();
+    assert_eq!(child["agent_task_completed_at"], Value::Null);
 
     let state_file = write_completion_fixture();
     let mut config = config_with_state_file_and_queue(&state_file);


### PR DESCRIPTION
## Summary
- compute Rust session activity from recent agent status/current task/activity timestamps instead of serializing stored idle for live agents
- apply the projection to session, client-session, child-session, and agent-registration responses
- add regression coverage for recent status/activity projection and stale status staying idle

## Validation
- cargo fmt --check
- git diff --check
- cargo test -p sm-server
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py

Fixes #1055