### PR TITLE
Keep Codex review watches active on missing notify session

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -3207,14 +3207,16 @@ fn recover_codex_review_request_watchers(state: Arc<AppState>) {
                     .is_none()
                 {
                     if let Err(error) =
-                        RetainedQueueStore::cancel_codex_review_request_with_error_in_path(
+                        RetainedQueueStore::mark_codex_review_request_poll_error_in_path(
                             &queue_db_path,
                             &registration.id,
+                            &now_rfc3339(),
                             "Notify session no longer exists",
+                            None,
                         )
                     {
                         eprintln!(
-                            "Codex review request recovery failed to cancel {}: {error:#}",
+                            "Codex review request recovery failed to mark {} missing notify session: {error:#}",
                             registration.id
                         );
                     }
@@ -3280,9 +3282,12 @@ async fn run_codex_review_request_watcher(
             .map_err(|error| error.to_string())?
             .is_none()
         {
-            let _ = RetainedQueueStore::cancel_codex_review_request_in_path(
+            let _ = RetainedQueueStore::mark_codex_review_request_poll_error_in_path(
                 &queue_db_path,
                 &request_id,
+                &now_rfc3339(),
+                "Notify session no longer exists",
+                None,
             )
             .map_err(|error| error.to_string())?;
             return Ok(());

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -2666,7 +2666,7 @@ async fn codex_review_request_recovery_spawns_active_watchers() {
 }
 
 #[tokio::test]
-async fn codex_review_request_recovery_cancels_missing_notify_session() {
+async fn codex_review_request_recovery_keeps_missing_notify_session_active() {
     let state_file = unique_temp_path();
     let queue_db = state_file.with_extension("codex-review-recover-missing-notify.db");
     fs::write(&state_file, json!({ "sessions": [] }).to_string()).unwrap();
@@ -2695,8 +2695,8 @@ async fn codex_review_request_recovery_cancels_missing_notify_session() {
             |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
         )
         .unwrap();
-    assert_eq!(row.0, "cancelled");
-    assert_eq!(row.1, 0);
+    assert_eq!(row.0, "active");
+    assert_eq!(row.1, 1);
     assert_eq!(row.2.as_deref(), Some("Notify session no longer exists"));
 }
 


### PR DESCRIPTION
Fixes #1061

## Summary
- treat missing notify-session lookups during Codex review watch recovery/polling as retryable errors
- keep the retained review request active instead of permanently cancelling it
- update recovery regression coverage for the new non-destructive behavior

## Validation
- cargo test -p sm-server
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py
- git diff --check