### PR TITLE
Restore Codex-fork tmux fallback

### DIFF
--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -658,6 +658,7 @@ pub struct CodexForkLaunchConfig {
     pub args: Vec<String>,
     pub default_model: Option<String>,
     pub event_schema_version: u32,
+    pub control_tmux_fallback_enabled: bool,
 }
 
 impl Default for CodexForkLaunchConfig {
@@ -667,6 +668,7 @@ impl Default for CodexForkLaunchConfig {
             args: codex_fork_managed_args(Vec::new()),
             default_model: None,
             event_schema_version: 2,
+            control_tmux_fallback_enabled: true,
         }
     }
 }
@@ -1171,6 +1173,8 @@ struct RawCodexForkLaunchConfig {
     provider: RawProviderLaunchConfig,
     #[serde(default)]
     event_schema_version: Option<u32>,
+    #[serde(default)]
+    control_tmux_fallback_enabled: Option<YamlValue>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -1256,6 +1260,10 @@ fn codex_fork_launch_config(
         args: codex_fork_managed_args(args),
         default_model,
         event_schema_version: raw.event_schema_version.unwrap_or(2),
+        control_tmux_fallback_enabled: coerce_rollout_flag(
+            raw.control_tmux_fallback_enabled.as_ref(),
+            true,
+        ),
     }
 }
 
@@ -2112,6 +2120,7 @@ codex:
   default_model: "gpt-5"
 codex_fork:
   event_schema_version: 7
+  control_tmux_fallback_enabled: "off"
 "#,
         )
         .unwrap();
@@ -2128,6 +2137,15 @@ codex_fork:
         );
         assert_eq!(config.codex_fork.default_model.as_deref(), Some("gpt-5"));
         assert_eq!(config.codex_fork.event_schema_version, 7);
+        assert!(!config.codex_fork.control_tmux_fallback_enabled);
+    }
+
+    #[test]
+    fn raw_config_defaults_codex_fork_control_tmux_fallback_enabled() {
+        let raw: RawConfig = serde_yaml::from_str("codex_fork: {}\n").unwrap();
+        let config = AppConfig::from(raw);
+
+        assert!(config.codex_fork.control_tmux_fallback_enabled);
     }
 
     #[test]

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -32,6 +32,7 @@ pub struct TmuxRuntime {
     codex_fork_args: Vec<String>,
     codex_fork_default_model: Option<String>,
     codex_fork_event_schema_version: u32,
+    codex_fork_control_tmux_fallback_enabled: bool,
     prompt_mode: String,
     start_settle_ms: u64,
     send_keys_settle_ms: f64,
@@ -86,6 +87,7 @@ impl TmuxRuntime {
             ],
             codex_fork_default_model: None,
             codex_fork_event_schema_version: 2,
+            codex_fork_control_tmux_fallback_enabled: true,
             prompt_mode: config
                 .runtime_prompt_mode
                 .as_deref()
@@ -137,11 +139,17 @@ impl TmuxRuntime {
         runtime.codex_fork_args = config.codex_fork.args.clone();
         runtime.codex_fork_default_model = config.codex_fork.default_model.clone();
         runtime.codex_fork_event_schema_version = config.codex_fork.event_schema_version;
+        runtime.codex_fork_control_tmux_fallback_enabled =
+            config.codex_fork.control_tmux_fallback_enabled;
         runtime
     }
 
     pub fn socket_name(&self) -> Option<&str> {
         self.socket_name.as_deref()
+    }
+
+    pub fn codex_fork_control_tmux_fallback_enabled(&self) -> bool {
+        self.codex_fork_control_tmux_fallback_enabled
     }
 
     pub fn startup_settle_duration(&self) -> Duration {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -3321,19 +3321,27 @@ fn deliver_runtime_text_to_session_raw(
     let session_socket_name = json_text(session.get("tmux_socket_name"));
     let session_runtime = runtime.for_socket_name(session_socket_name.as_deref());
     let mut delivered = false;
+    let mut mark_stopped_on_failure = true;
     if normalized_status(&status) != "stopped" {
         match deliver_codex_fork_control_text_to_session_raw(session_id, session, text, runtime)? {
             Some(true) => {
                 delivered = true;
             }
-            _ => {
+            Some(false) if runtime.codex_fork_control_tmux_fallback_enabled() => {
+                delivered = session_runtime.send_input(&tmux_session, text)?;
+            }
+            Some(false) => {
+                delivered = false;
+                mark_stopped_on_failure = false;
+            }
+            None => {
                 delivered = session_runtime.send_input(&tmux_session, text)?;
             }
         }
         let now = now_rfc3339();
         if delivered {
             mark_session_followup_activity(session, &now);
-        } else {
+        } else if mark_stopped_on_failure {
             status = "stopped".to_owned();
             session.insert("status".to_owned(), Value::String(status.clone()));
             session.insert("stopped_at".to_owned(), Value::String(now.clone()));
@@ -3361,12 +3369,24 @@ fn deliver_urgent_runtime_text_to_session_raw(
     let session_socket_name = json_text(session.get("tmux_socket_name"));
     let session_runtime = runtime.for_socket_name(session_socket_name.as_deref());
     let mut delivered = false;
+    let mut mark_stopped_on_failure = true;
     if normalized_status(&status) != "stopped" {
         match deliver_codex_fork_control_text_to_session_raw(session_id, session, text, runtime)? {
             Some(true) => {
                 delivered = true;
             }
-            _ => {
+            Some(false) if runtime.codex_fork_control_tmux_fallback_enabled() => {
+                delivered = session_runtime.send_urgent_input(
+                    &tmux_session,
+                    text,
+                    provider.eq_ignore_ascii_case("claude"),
+                )?;
+            }
+            Some(false) => {
+                delivered = false;
+                mark_stopped_on_failure = false;
+            }
+            None => {
                 delivered = session_runtime.send_urgent_input(
                     &tmux_session,
                     text,
@@ -3377,7 +3397,7 @@ fn deliver_urgent_runtime_text_to_session_raw(
         let now = now_rfc3339();
         if delivered {
             mark_session_followup_activity(session, &now);
-        } else {
+        } else if mark_stopped_on_failure {
             status = "stopped".to_owned();
             session.insert("status".to_owned(), Value::String(status.clone()));
             session.insert("stopped_at".to_owned(), Value::String(now.clone()));
@@ -3416,7 +3436,17 @@ fn deliver_runtime_native_rename_to_session_raw(
             }
             Err(error) => {
                 mark_codex_fork_control_degraded_raw(session, &error.to_string());
-                false
+                if runtime.codex_fork_control_tmux_fallback_enabled() {
+                    let tmux_session = json_text(session.get("tmux_session")).ok_or_else(|| {
+                        anyhow::anyhow!("session {session_id} missing tmux_session")
+                    })?;
+                    let session_socket_name = json_text(session.get("tmux_socket_name"));
+                    runtime
+                        .for_socket_name(session_socket_name.as_deref())
+                        .send_input(&tmux_session, &format!("/rename {friendly_name}"))?
+                } else {
+                    false
+                }
             }
         }
     } else if provider.eq_ignore_ascii_case("claude") {

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -25,7 +25,7 @@ use sm_server::{
     },
     http::{router, AppState, GitHubReviewComment, GitHubReviewMatch, GitHubReviewPoster},
     runtime::TmuxRuntime,
-    sessions::SessionStore,
+    sessions::{SendCoreInputRequest, SessionStore},
 };
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -12604,6 +12604,7 @@ while true; do sleep 1; done
             ],
             default_model: Some("gpt-default".to_owned()),
             event_schema_version: 7,
+            control_tmux_fallback_enabled: true,
         },
         rust_core: RustCoreConfig {
             runtime_enabled: true,
@@ -12781,6 +12782,67 @@ while true; do sleep 1; done
             )
             .unwrap();
         assert_eq!(delivered_native_renames, 1);
+
+        let _ = fs::remove_file(&control_path);
+        assert!(!control_path.exists());
+        let (status, payload) = post_json(
+            app.clone(),
+            "/sessions/runtimefork/input",
+            json!({
+                "text": "tmux fallback message",
+                "delivery_mode": "direct"
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(payload["delivered"], true);
+        let fallback_output =
+            wait_for_output_contains(app.clone(), "runtimefork", "tmux fallback message").await;
+        assert!(fallback_output["output"]
+            .as_str()
+            .unwrap()
+            .contains("tmux fallback message"));
+
+        let disabled_fallback_runtime = TmuxRuntime::from_app_config(&AppConfig {
+            codex_fork: CodexForkLaunchConfig {
+                control_tmux_fallback_enabled: false,
+                ..CodexForkLaunchConfig::default()
+            },
+            rust_core: RustCoreConfig {
+                runtime_enabled: true,
+                log_dir: Some(log_dir.display().to_string()),
+                tmux_socket_name: Some(tmux_socket.clone()),
+                ..RustCoreConfig::default()
+            },
+            ..AppConfig::default()
+        });
+        let (status, delivered) =
+            SessionStore::new_with_queue(state_file.clone(), queue_db_path.clone())
+                .send_core_input_with_runtime(
+                    "runtimefork",
+                    SendCoreInputRequest {
+                        text: "disabled fallback message".to_owned(),
+                        delivery_mode: "direct".to_owned(),
+                        sender_session_id: None,
+                        from_sm_send: false,
+                        timeout_seconds: None,
+                        notify_on_delivery: false,
+                        notify_after_seconds: None,
+                        notify_on_stop: false,
+                        remind_soft_threshold: None,
+                        remind_hard_threshold: None,
+                        remind_cancel_on_reply_session_id: None,
+                        parent_session_id: None,
+                    },
+                    &disabled_fallback_runtime,
+                )
+                .unwrap()
+                .map(|result| (result.status, result.delivered))
+                .unwrap();
+        assert_eq!(status, "idle");
+        assert!(!delivered);
+        let (_, still_running_session) = get_json(app.clone(), "/sessions/runtimefork").await;
+        assert_eq!(still_running_session["status"], "idle");
     }
 
     let tmux_session = payload["tmux_session"].as_str().unwrap().to_owned();
@@ -12908,6 +12970,7 @@ while true; do sleep 1; done
             ],
             default_model: None,
             event_schema_version: 2,
+            control_tmux_fallback_enabled: true,
         },
         rust_core: RustCoreConfig {
             runtime_enabled: true,


### PR DESCRIPTION
Fixes #1067

## Summary
- add Python-compatible codex_fork.control_tmux_fallback_enabled config defaulting true
- make Codex-fork control failure fallback explicit for normal, urgent, and native rename delivery
- avoid marking a live session stopped when fallback is explicitly disabled and only the control socket failed
- add config and runtime regression coverage for missing control sockets

## Validation
- cargo fmt --check
- cargo test -p sm-server
- ./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py
- git diff --check