### PR TITLE
Fix Codex-fork activity after assistant messages

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -10621,6 +10621,33 @@ mod tests {
         );
     }
 
+    #[test]
+    fn codex_fork_event_stream_activity_treats_completed_agent_message_as_idle() {
+        let dir = env::temp_dir().join(format!(
+            "sm-rust-codex-agent-message-idle-{}-{}",
+            process::id(),
+            random_urlsafe_token(8)
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let event_stream = dir.join("events.jsonl");
+        fs::write(
+            &event_stream,
+            concat!(
+                "{\"type\":\"thread/status/changed\",\"payload\":{\"status\":{\"type\":\"active\"}}}\n",
+                "{\"event_type\":\"item/agentMessage/delta\",\"payload\":{}}\n",
+                "{\"event_type\":\"item_completed\",\"payload\":{\"item\":{\"type\":\"agentMessage\"}}}\n",
+                "{\"event_type\":\"thread/tokenUsage/updated\",\"payload\":{}}\n",
+                "{\"event_type\":\"account/rateLimits/updated\",\"payload\":{}}\n"
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(
+            codex_fork_event_stream_activity_from_path(event_stream),
+            Some("idle")
+        );
+    }
+
     fn write_session_state(session_id: &str, status: &str) -> String {
         let dir = env::temp_dir().join(format!(
             "sm-rust-mobile-ticket-{}-{}",

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -2266,14 +2266,34 @@ fn codex_fork_status_for_event(event: &Map<String, Value>) -> Option<&'static st
         | "turn_delta"
         | "turn_diff"
         | "item_started"
-        | "item_completed"
         | "agent_message"
         | "exec_command_end" => Some("running"),
+        "item_completed" => codex_fork_item_completed_status(event),
         "error" if codex_fork_error_will_retry(event) => Some("running"),
         "error" | "shutdown" => Some("stopped"),
         "shutdown_complete" | "stream_error" | "thread_started" | "thread_name_updated" => None,
         other if other.ends_with("_begin") || other.ends_with("_delta") => Some("running"),
         _ => None,
+    }
+}
+
+fn codex_fork_item_completed_status(event: &Map<String, Value>) -> Option<&'static str> {
+    let payload = codex_fork_payload(event)?;
+    let item = payload
+        .get("item")
+        .and_then(Value::as_object)
+        .unwrap_or(payload);
+    let item_type = item
+        .get("type")
+        .and_then(Value::as_str)
+        .or_else(|| item.get("kind").and_then(Value::as_str))
+        .map(str::trim)
+        .map(str::to_ascii_lowercase);
+
+    match item_type.as_deref() {
+        Some("agentmessage" | "agent_message" | "message") => Some("idle"),
+        Some(_) => Some("running"),
+        None => Some("running"),
     }
 }
 
@@ -5726,6 +5746,22 @@ mod tests {
         assert_eq!(codex_fork_status_for_event_line(active), Some("running"));
         assert_eq!(codex_fork_status_for_event_line(idle), Some("idle"));
         assert_eq!(codex_fork_status_for_event_line(unknown), None);
+    }
+
+    #[test]
+    fn codex_fork_completed_agent_message_is_idle() {
+        let completed_agent_message =
+            r#"{"event_type":"item_completed","payload":{"item":{"type":"agentMessage"}}}"#;
+        let completed_command = r#"{"event_type":"item_completed","payload":{"item":{"type":"commandExecution","status":"completed"}}}"#;
+
+        assert_eq!(
+            codex_fork_status_for_event_line(completed_agent_message),
+            Some("idle")
+        );
+        assert_eq!(
+            codex_fork_status_for_event_line(completed_command),
+            Some("running")
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1069

## Summary
- classify completed Codex-fork `agentMessage` items as idle instead of working
- keep command/tool item completions active until a later idle/status event arrives
- add event-stream tail coverage matching the live stale-active pattern: assistant message completed followed by token/rate-limit updates

## Validation
- `cargo test -p sm-server codex_fork -- --nocapture`
- `cargo test -p sm-server`
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py -q`
- `git diff --check`
