### PR TITLE
Use activity state for Android watch grouping

### DIFF
--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchModels.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchModels.kt
@@ -61,15 +61,23 @@ private fun sessionPriority(session: ClientSession): Int {
 fun isActiveSession(session: ClientSession): Boolean = sessionPriority(session) == 0
 
 fun isOperationallyActive(session: ClientSession): Boolean {
-    val activity = activityLabel(session.activityState)
-    return session.status == "running" || activity == "working" || activity == "thinking" || activity == "waiting"
+    val rawActivity = session.activityState?.trim()
+    val activity = activityLabel(rawActivity)
+    return when {
+        activity == "working" || activity == "thinking" || activity == "waiting" -> true
+        !rawActivity.isNullOrEmpty() -> false
+        else -> session.status == "running"
+    }
 }
 
 fun projectedStatusLabel(session: ClientSession): String {
+    val rawActivity = session.activityState?.trim()
+    val activity = activityLabel(rawActivity)
     return when {
-        session.status == "running" -> "running"
         session.status == "stopped" -> "stopped"
-        isOperationallyActive(session) -> "active"
+        isOperationallyActive(session) -> activity
+        !rawActivity.isNullOrEmpty() -> activity
+        session.status == "running" -> "running"
         session.status.isNotBlank() -> session.status
         else -> "idle"
     }

--- a/android-app/app/src/test/java/li/rajeshgo/sm/ui/watch/WatchModelsTest.kt
+++ b/android-app/app/src/test/java/li/rajeshgo/sm/ui/watch/WatchModelsTest.kt
@@ -21,7 +21,7 @@ class WatchModelsTest {
 
         assertTrue(isOperationallyActive(session))
         assertTrue(isActiveSession(session))
-        assertEquals("active", projectedStatusLabel(session))
+        assertEquals("working", projectedStatusLabel(session))
     }
 
     @Test
@@ -43,6 +43,22 @@ class WatchModelsTest {
         assertFalse(isOperationallyActive(session))
         assertFalse(isActiveSession(session))
         assertEquals("idle", projectedStatusLabel(session))
+    }
+
+    @Test
+    fun runningSessionWithIdleActivityProjectsAsIdle() {
+        val session = session(status = "running", activityState = "idle")
+        val sections = buildSections(listOf(session))
+
+        assertFalse(isOperationallyActive(session))
+        assertFalse(isActiveSession(session))
+        assertEquals("idle", projectedStatusLabel(session))
+
+        val runningSections = filterSections(sections, statusFilter = "running", query = "")
+        val idleSections = filterSections(sections, statusFilter = "idle", query = "")
+
+        assertTrue(runningSections.isEmpty())
+        assertEquals(listOf(session.id), idleSections.flatMap { it.roots }.map { it.session.id })
     }
 
     private fun session(


### PR DESCRIPTION
Fixes #1071

## Summary
- make Android watch grouping treat `activity_state` as authoritative when present
- show `status=running, activity_state=idle` sessions as idle instead of active
- keep `status=running` as a compatibility fallback only when no activity state is supplied

## Validation
- `(cd android-app && ./gradlew testDebugUnitTest --tests 'li.rajeshgo.sm.ui.watch.WatchModelsTest' assembleDebug)`
- `git diff --check`
