### PR TITLE
Restore Rust Claude hook activity updates

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -4,7 +4,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     convert::Infallible,
     fs,
-    io::{Read, Seek, SeekFrom},
+    io::{BufRead, BufReader, Read, Seek, SeekFrom},
     net::SocketAddr,
     path::PathBuf,
     process::{Child, Command, Output, Stdio},
@@ -13,7 +13,7 @@ use std::{
         Arc, Mutex,
     },
     thread,
-    time::{Duration, Instant},
+    time::{Duration, Instant, UNIX_EPOCH},
 };
 
 use axum::{
@@ -65,7 +65,7 @@ use sha1::{Digest, Sha1};
 use sha2::Sha256;
 use time::{format_description::well_known::Rfc3339, Duration as TimeDuration, OffsetDateTime};
 use tokio::sync::{mpsc, Mutex as AsyncMutex};
-use tokio::time::timeout;
+use tokio::time::{sleep, timeout};
 
 use crate::app_artifacts::{
     hashed_path, meta_path, read_metadata, store_artifact, valid_app_name, valid_artifact_hash,
@@ -116,7 +116,8 @@ use crate::sessions::{
     UpdateSessionMetadataRequest,
 };
 use crate::tool_usage::{
-    list_recent_codex_fork_tool_calls_from_path, list_recent_tool_calls_from_path, ToolCallRow,
+    list_recent_codex_fork_tool_calls_from_path, list_recent_tool_calls_from_path,
+    log_tool_usage_to_path, ToolCallRow, ToolUsageEvent,
 };
 
 const SESSION_COOKIE_NAME: &str = "sm_auth";
@@ -840,6 +841,8 @@ pub fn router(state: AppState) -> Router {
         .route("/health/detailed", get(health_detailed))
         .route("/auth/session", get(auth_session))
         .route("/auth/device/google", post(auth_device_google))
+        .route("/hooks/claude", post(claude_hook))
+        .route("/hooks/tool-use", post(tool_use_hook))
         .route("/hooks/tmux-client", post(tmux_client_hook))
         .route("/client/bootstrap", get(client_bootstrap))
         .route("/client/analytics/summary", get(client_analytics_summary))
@@ -1179,6 +1182,329 @@ async fn tmux_client_hook(
         response["revived_session_id"] = Value::String(session_id);
     }
     Ok(Json(response))
+}
+
+async fn claude_hook(
+    State(state): State<Arc<AppState>>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(payload): Json<Value>,
+) -> Result<Response, ApiError> {
+    let Some(session_id) = hook_session_id(&payload) else {
+        return Ok(Json(json!({ "status": "unknown_session" })).into_response());
+    };
+    let is_local_hook = is_local_bypass_request(&headers, Some(peer_addr), &state.config);
+    verify_hook_auth_or_secret(
+        &state,
+        &headers,
+        Some(peer_addr),
+        &session_id,
+        "/hooks/claude",
+    )?;
+
+    let hook_event = payload
+        .get("hook_event_name")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    if hook_event == "Stop" {
+        let mut last_message = payload
+            .get("sm_last_message")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        let mut native_title = payload
+            .get("sm_native_title")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        let mut native_title_mtime_ns = payload_i64(payload.get("sm_transcript_mtime_ns"));
+        let transcript_path = payload
+            .get("transcript_path")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        let transcript_metadata = if is_local_hook
+            && transcript_path.is_some()
+            && (last_message.is_none() || native_title.is_none() || native_title_mtime_ns.is_none())
+        {
+            let first_read = transcript_path.and_then(read_claude_transcript_metadata);
+            if should_retry_local_stop_transcript_read(first_read.as_ref()) {
+                sleep(Duration::from_millis(500)).await;
+                let second_read = transcript_path.and_then(read_claude_transcript_metadata);
+                choose_newer_transcript_metadata(first_read, second_read)
+            } else {
+                first_read
+            }
+        } else {
+            None
+        };
+        if let Some(metadata) = transcript_metadata.as_ref() {
+            if last_message.is_none() {
+                last_message = metadata.last_message.as_deref();
+            }
+            if native_title.is_none() {
+                native_title = metadata.native_title.as_deref();
+            }
+            if native_title_mtime_ns.is_none() {
+                native_title_mtime_ns = metadata.mtime_ns;
+            }
+        }
+        state.session_store.apply_claude_stop_hook(
+            &session_id,
+            last_message,
+            native_title,
+            native_title_mtime_ns,
+            transcript_path,
+        )?;
+    }
+
+    Ok(Json(json!({ "status": "ok" })).into_response())
+}
+
+async fn tool_use_hook(
+    State(state): State<Arc<AppState>>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(payload): Json<Value>,
+) -> Result<Response, ApiError> {
+    let Some(session_id) = hook_session_id(&payload) else {
+        return Ok(Json(json!({ "status": "unknown_session" })).into_response());
+    };
+    verify_hook_auth_or_secret(
+        &state,
+        &headers,
+        Some(peer_addr),
+        &session_id,
+        "/hooks/tool-use",
+    )?;
+
+    let hook_type = payload
+        .get("hook_event_name")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("unknown");
+    let tool_name = payload
+        .get("tool_name")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(hook_type);
+    let session = state.session_store.get_session(&session_id)?;
+    if hook_type == "PreToolUse" {
+        state
+            .session_store
+            .apply_claude_pre_tool_use_hook(&session_id, Some(tool_name))?;
+    }
+
+    let db_path = expand_home(&state.config.tool_logging.db_path);
+    log_tool_usage_to_path(
+        &db_path,
+        ToolUsageEvent {
+            session_id: Some(&session_id),
+            claude_session_id: payload
+                .get("session_id")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty()),
+            session_name: session.as_ref().map(|session| session.name.as_str()),
+            parent_session_id: session
+                .as_ref()
+                .and_then(|session| session.parent_session_id.as_deref()),
+            hook_type,
+            tool_name,
+            tool_input: payload.get("tool_input"),
+            tool_response: payload.get("tool_response"),
+            tool_use_id: payload
+                .get("tool_use_id")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty()),
+            cwd: payload
+                .get("cwd")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty()),
+            agent_id: payload
+                .get("agent_id")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty()),
+        },
+    )
+    .map_err(ApiError::Internal)?;
+
+    Ok(Json(json!({ "status": "logged" })).into_response())
+}
+
+fn hook_session_id(payload: &Value) -> Option<String> {
+    payload
+        .get("session_manager_id")
+        .or_else(|| payload.get("CLAUDE_SESSION_MANAGER_ID"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+#[derive(Debug, Default)]
+struct ClaudeTranscriptMetadata {
+    last_message: Option<String>,
+    native_title: Option<String>,
+    mtime_ns: Option<i64>,
+}
+
+fn read_claude_transcript_metadata(transcript_path: &str) -> Option<ClaudeTranscriptMetadata> {
+    let path = expand_home(transcript_path);
+    let metadata = fs::metadata(&path).ok()?;
+    if !metadata.is_file() {
+        return None;
+    }
+    let mtime_ns = metadata
+        .modified()
+        .ok()
+        .and_then(|mtime| mtime.duration_since(UNIX_EPOCH).ok())
+        .and_then(|duration| i64::try_from(duration.as_nanos()).ok());
+    let file = fs::File::open(&path).ok()?;
+    let lines = BufReader::new(file)
+        .lines()
+        .map_while(Result::ok)
+        .collect::<Vec<_>>();
+
+    let mut native_title = None;
+    let mut last_message = None;
+    let mut assistant_seen = false;
+    for line in lines.into_iter().rev() {
+        let Ok(entry) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        if native_title.is_none() {
+            match entry.get("type").and_then(Value::as_str) {
+                Some("custom-title") => {
+                    native_title = non_empty_json_str(entry.get("customTitle"));
+                }
+                Some("agent-name") => {
+                    native_title = non_empty_json_str(entry.get("agentName"));
+                }
+                _ => {}
+            }
+        }
+        if !assistant_seen && entry.get("type").and_then(Value::as_str) == Some("assistant") {
+            assistant_seen = true;
+            last_message = assistant_message_text(&entry);
+        }
+        if native_title.is_some() && (last_message.is_some() || assistant_seen) {
+            break;
+        }
+    }
+
+    Some(ClaudeTranscriptMetadata {
+        last_message,
+        native_title,
+        mtime_ns,
+    })
+}
+
+fn should_retry_local_stop_transcript_read(metadata: Option<&ClaudeTranscriptMetadata>) -> bool {
+    metadata.is_none_or(|metadata| metadata.last_message.is_none())
+}
+
+fn choose_newer_transcript_metadata(
+    first: Option<ClaudeTranscriptMetadata>,
+    second: Option<ClaudeTranscriptMetadata>,
+) -> Option<ClaudeTranscriptMetadata> {
+    match (first, second) {
+        (None, second) => second,
+        (first, None) => first,
+        (Some(first), Some(second)) => {
+            if second.mtime_ns.unwrap_or_default() >= first.mtime_ns.unwrap_or_default()
+                && (second.last_message.is_some()
+                    || second.native_title.is_some()
+                    || second.mtime_ns.is_some())
+            {
+                Some(second)
+            } else {
+                Some(first)
+            }
+        }
+    }
+}
+
+fn assistant_message_text(entry: &Value) -> Option<String> {
+    let content = entry
+        .get("message")
+        .and_then(|message| message.get("content"))
+        .and_then(Value::as_array)?;
+    let text = content
+        .iter()
+        .filter(|item| item.get("type").and_then(Value::as_str) == Some("text"))
+        .filter_map(|item| item.get("text").and_then(Value::as_str))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let text = text.trim();
+    (!text.is_empty()).then(|| text.to_owned())
+}
+
+fn non_empty_json_str(value: Option<&Value>) -> Option<String> {
+    value
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn payload_i64(value: Option<&Value>) -> Option<i64> {
+    match value? {
+        Value::Number(number) => number
+            .as_i64()
+            .or_else(|| number.as_u64().and_then(|value| i64::try_from(value).ok())),
+        Value::String(value) => value.trim().parse::<i64>().ok(),
+        _ => None,
+    }
+    .filter(|value| *value >= 0)
+}
+
+fn verify_hook_auth_or_secret(
+    state: &AppState,
+    headers: &HeaderMap,
+    peer_addr: Option<SocketAddr>,
+    session_id: &str,
+    path: &str,
+) -> Result<(), ApiError> {
+    if is_local_bypass_request(headers, peer_addr, &state.config) {
+        return Ok(());
+    }
+
+    let Some(session) = state.session_store.get_session(session_id)? else {
+        return ensure_session_allowed_from_parts(&state.config, headers, peer_addr, path);
+    };
+    let node_id = session.node.trim();
+    if node_id.is_empty() || node_id == "primary" {
+        return ensure_session_allowed_from_parts(&state.config, headers, peer_addr, path);
+    }
+    let expected_secret = state
+        .config
+        .nodes
+        .registry
+        .get(node_id)
+        .and_then(|node| node.hook_secret.as_deref())
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let Some(expected_secret) = expected_secret else {
+        return ensure_session_allowed_from_parts(&state.config, headers, peer_addr, path);
+    };
+    let actual_secret = headers
+        .get("x-sm-hook-secret")
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .unwrap_or("");
+    if constant_time_eq(expected_secret.as_bytes(), actual_secret.as_bytes()) {
+        return Ok(());
+    }
+    Err(ApiError::Status {
+        status: StatusCode::FORBIDDEN,
+        detail: "Invalid hook secret".to_owned(),
+    })
 }
 
 async fn client_bootstrap(

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -159,6 +159,115 @@ impl SessionStore {
             }))
     }
 
+    pub fn apply_claude_stop_hook(
+        &self,
+        session_id: &str,
+        last_message: Option<&str>,
+        native_title: Option<&str>,
+        native_title_mtime_ns: Option<i64>,
+        transcript_path: Option<&str>,
+    ) -> Result<bool> {
+        let session_id = session_id.trim();
+        if session_id.is_empty() {
+            return Ok(false);
+        }
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let Some(session) = session_object_mut(sessions, session_id) else {
+            return Ok(false);
+        };
+        if normalized_status(&json_text(session.get("status")).unwrap_or_default()) == "stopped" {
+            return Ok(false);
+        }
+
+        let now = now_rfc3339();
+        session.insert("status".to_owned(), Value::String("idle".to_owned()));
+        session.insert("last_activity".to_owned(), Value::String(now.clone()));
+        session.insert("agent_status_text".to_owned(), Value::Null);
+        session.insert("agent_status_at".to_owned(), Value::Null);
+        if let Some(last_message) = last_message {
+            session.insert(
+                "last_action_summary".to_owned(),
+                Value::String(last_message.to_owned()),
+            );
+        }
+        if let Some(transcript_path) = transcript_path {
+            session.insert(
+                "transcript_path".to_owned(),
+                Value::String(transcript_path.to_owned()),
+            );
+            let provider =
+                json_text(session.get("provider")).unwrap_or_else(|| "claude".to_owned());
+            if provider == "claude" {
+                if let Some(resume_id) = provider_resume_id_from_transcript_path(transcript_path) {
+                    session.insert("provider_resume_id".to_owned(), Value::String(resume_id));
+                }
+            }
+        }
+        if let Some(native_title) = native_title {
+            let title_changed =
+                json_text(session.get("native_title")).as_deref() != Some(native_title);
+            session.insert(
+                "native_title".to_owned(),
+                Value::String(native_title.to_owned()),
+            );
+            if let Some(native_title_mtime_ns) = native_title_mtime_ns {
+                session.insert(
+                    "native_title_source_mtime_ns".to_owned(),
+                    json!(native_title_mtime_ns),
+                );
+                if title_changed {
+                    session.insert(
+                        "native_title_updated_at_ns".to_owned(),
+                        json!(native_title_mtime_ns),
+                    );
+                }
+            } else if title_changed {
+                session.insert(
+                    "native_title_updated_at_ns".to_owned(),
+                    json!(now_unix_timestamp_nanos()),
+                );
+            }
+        }
+        self.write_raw_json_value(&state)?;
+        Ok(true)
+    }
+
+    pub fn apply_claude_pre_tool_use_hook(
+        &self,
+        session_id: &str,
+        tool_name: Option<&str>,
+    ) -> Result<bool> {
+        let session_id = session_id.trim();
+        if session_id.is_empty() {
+            return Ok(false);
+        }
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let Some(session) = session_object_mut(sessions, session_id) else {
+            return Ok(false);
+        };
+        if normalized_status(&json_text(session.get("status")).unwrap_or_default()) == "stopped" {
+            return Ok(false);
+        }
+
+        let now = now_rfc3339();
+        session.insert("status".to_owned(), Value::String("running".to_owned()));
+        session.insert("last_activity".to_owned(), Value::String(now.clone()));
+        session.insert("agent_task_completed_at".to_owned(), Value::Null);
+        if let Some(tool_name) = tool_name {
+            session.insert(
+                "last_tool_name".to_owned(),
+                Value::String(tool_name.to_owned()),
+            );
+            session.insert("last_tool_call".to_owned(), Value::String(now));
+        }
+        self.write_raw_json_value(&state)?;
+        Ok(true)
+    }
+
     pub fn capture_output(&self, session_id: &str, lines: usize) -> Result<Option<String>> {
         let Some(session) = self.get_session(session_id)? else {
             return Ok(None);
@@ -4526,6 +4635,15 @@ fn subagent_response_from_value(value: &Value) -> Result<SubagentResponse> {
         status: json_text(value.get("status")).unwrap_or_else(|| "running".to_owned()),
         summary: json_text(value.get("summary")),
     })
+}
+
+fn provider_resume_id_from_transcript_path(transcript_path: &str) -> Option<String> {
+    Path::new(transcript_path)
+        .file_stem()
+        .and_then(|value| value.to_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
 }
 
 fn append_log_line(path: &Path, line: &str) -> Result<()> {

--- a/crates/sm-server/src/tool_usage.rs
+++ b/crates/sm-server/src/tool_usage.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
-use anyhow::Result;
-use rusqlite::{Connection, OpenFlags};
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection, OpenFlags};
 use serde::Serialize;
 use serde_json::Value;
 
@@ -10,6 +10,87 @@ pub struct ToolCallRow {
     pub timestamp: Option<String>,
     pub tool_name: String,
     pub hook_type: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ToolUsageEvent<'a> {
+    pub session_id: Option<&'a str>,
+    pub claude_session_id: Option<&'a str>,
+    pub session_name: Option<&'a str>,
+    pub parent_session_id: Option<&'a str>,
+    pub hook_type: &'a str,
+    pub tool_name: &'a str,
+    pub tool_input: Option<&'a Value>,
+    pub tool_response: Option<&'a Value>,
+    pub tool_use_id: Option<&'a str>,
+    pub cwd: Option<&'a str>,
+    pub agent_id: Option<&'a str>,
+}
+
+pub fn log_tool_usage_to_path(db_path: &Path, event: ToolUsageEvent<'_>) -> Result<()> {
+    if let Some(parent) = db_path.parent() {
+        std::fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "failed to create tool usage db directory {}",
+                parent.display()
+            )
+        })?;
+    }
+    let conn = Connection::open(db_path)
+        .with_context(|| format!("failed to open tool usage db {}", db_path.display()))?;
+    conn.pragma_update(None, "journal_mode", "WAL")?;
+    conn.pragma_update(None, "busy_timeout", 5000_i64)?;
+    ensure_tool_usage_schema(&conn)?;
+
+    let (is_destructive, destructive_type) = detect_destructive(event.tool_name, event.tool_input);
+    let (is_sensitive_file, mut target_file) =
+        detect_sensitive_file(event.tool_name, event.tool_input);
+    let bash_command = json_object_string(event.tool_input, "command");
+    let exit_code = json_object_i64(event.tool_response, "exitCode");
+    if target_file.is_none() && matches!(event.tool_name, "Write" | "Edit" | "Read") {
+        target_file = json_object_string(event.tool_input, "file_path");
+    }
+    let project_name = event.cwd.and_then(|cwd| {
+        Path::new(cwd)
+            .file_name()
+            .and_then(|value| value.to_str())
+            .filter(|value| !value.is_empty())
+    });
+    let tool_input_json = non_empty_json_payload(event.tool_input);
+    let tool_response_json = non_empty_json_payload(event.tool_response);
+
+    conn.execute(
+        r#"
+        INSERT INTO tool_usage (
+            session_id, claude_session_id, session_name, parent_session_id,
+            tool_use_id, cwd, project_name, agent_id,
+            hook_type, tool_name, tool_input, tool_response,
+            is_destructive, destructive_type, is_sensitive_file,
+            target_file, bash_command, exit_code
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)
+        "#,
+        params![
+            event.session_id,
+            event.claude_session_id,
+            event.session_name,
+            event.parent_session_id,
+            event.tool_use_id,
+            event.cwd,
+            project_name,
+            event.agent_id,
+            event.hook_type,
+            event.tool_name,
+            tool_input_json,
+            tool_response_json,
+            is_destructive,
+            destructive_type,
+            is_sensitive_file,
+            target_file,
+            bash_command,
+            exit_code,
+        ],
+    )?;
+    Ok(())
 }
 
 pub fn list_recent_tool_calls_from_path(
@@ -25,6 +106,162 @@ pub fn list_recent_tool_calls_from_path(
         Err(_) => return Ok(Vec::new()),
     };
     list_recent_tool_calls_conn(&conn, session_id, limit)
+}
+
+fn ensure_tool_usage_schema(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        r#"
+        CREATE TABLE IF NOT EXISTS tool_usage (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+            session_id TEXT,
+            session_name TEXT,
+            parent_session_id TEXT,
+            claude_session_id TEXT,
+            tool_use_id TEXT,
+            cwd TEXT,
+            project_name TEXT,
+            agent_id TEXT,
+            hook_type TEXT NOT NULL,
+            tool_name TEXT NOT NULL,
+            tool_input TEXT,
+            tool_response TEXT,
+            is_destructive BOOLEAN DEFAULT 0,
+            destructive_type TEXT,
+            is_sensitive_file BOOLEAN DEFAULT 0,
+            target_file TEXT,
+            bash_command TEXT,
+            exit_code INTEGER
+        );
+        CREATE INDEX IF NOT EXISTS idx_session ON tool_usage(session_id);
+        CREATE INDEX IF NOT EXISTS idx_tool ON tool_usage(tool_name);
+        CREATE INDEX IF NOT EXISTS idx_destructive ON tool_usage(is_destructive);
+        CREATE INDEX IF NOT EXISTS idx_timestamp ON tool_usage(timestamp);
+        CREATE INDEX IF NOT EXISTS idx_hook_type ON tool_usage(hook_type);
+        CREATE INDEX IF NOT EXISTS idx_tool_use_id ON tool_usage(tool_use_id);
+        CREATE INDEX IF NOT EXISTS idx_agent_id ON tool_usage(agent_id);
+        CREATE INDEX IF NOT EXISTS idx_project_name ON tool_usage(project_name);
+        CREATE TABLE IF NOT EXISTS telegram_telemetry (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+            direction TEXT NOT NULL CHECK(direction IN ('in', 'out')),
+            session_id TEXT,
+            chat_id TEXT,
+            result TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_tg_timestamp ON telegram_telemetry(timestamp);
+        "#,
+    )?;
+    Ok(())
+}
+
+fn non_empty_json_payload(value: Option<&Value>) -> Option<String> {
+    match value {
+        Some(Value::Object(map)) if map.is_empty() => None,
+        Some(Value::Null) | None => None,
+        Some(value) => serde_json::to_string(value).ok(),
+    }
+}
+
+fn json_object_string(value: Option<&Value>, key: &str) -> Option<String> {
+    value
+        .and_then(Value::as_object)
+        .and_then(|object| object.get(key))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn json_object_i64(value: Option<&Value>, key: &str) -> Option<i64> {
+    value
+        .and_then(Value::as_object)
+        .and_then(|object| object.get(key))
+        .and_then(Value::as_i64)
+}
+
+fn detect_destructive(tool_name: &str, tool_input: Option<&Value>) -> (bool, Option<String>) {
+    let text = if tool_name == "Bash" {
+        json_object_string(tool_input, "command")
+    } else if matches!(tool_name, "Write" | "Edit" | "Read") {
+        json_object_string(tool_input, "file_path")
+    } else {
+        None
+    }
+    .unwrap_or_default();
+    let text = text.to_ascii_lowercase();
+    let destructive_type = if text.contains("git push") && text.contains("main") {
+        Some("git_push_main")
+    } else if text.contains("git push") && text.contains("--force") {
+        Some("git_push_force")
+    } else if text.contains("git reset --hard") {
+        Some("git_reset_hard")
+    } else if text.contains("git branch -d") {
+        Some("git_branch_delete")
+    } else if text.contains("rm -rf /") {
+        Some("rm_root")
+    } else if text.contains("rm -rf") || text.contains("rm -r") {
+        Some("rm_recursive")
+    } else if text.contains("chmod 777") {
+        Some("chmod_777")
+    } else if text.contains("chown") {
+        Some("chown")
+    } else if text.contains("drop table") {
+        Some("drop_table")
+    } else if text.contains("drop database") {
+        Some("drop_database")
+    } else if text.contains("truncate") {
+        Some("truncate")
+    } else if text.contains("npm install -g") {
+        Some("npm_global_install")
+    } else if text.contains("pip install") {
+        Some("pip_install")
+    } else if text.contains("brew install") {
+        Some("brew_install")
+    } else if text.contains("sudo ") {
+        Some("sudo")
+    } else if text.contains(".env") {
+        Some("env_file")
+    } else if text.contains("credentials") {
+        Some("credentials_file")
+    } else if text.contains(".ssh") {
+        Some("ssh_file")
+    } else if text.contains("id_rsa") {
+        Some("ssh_key")
+    } else {
+        None
+    };
+    match destructive_type {
+        Some(value) => (true, Some(value.to_owned())),
+        None => (false, None),
+    }
+}
+
+fn detect_sensitive_file(tool_name: &str, tool_input: Option<&Value>) -> (bool, Option<String>) {
+    let file_path = if matches!(tool_name, "Write" | "Edit" | "Read") {
+        json_object_string(tool_input, "file_path")
+    } else if tool_name == "Bash" {
+        json_object_string(tool_input, "command")
+    } else {
+        None
+    };
+    let Some(file_path) = file_path else {
+        return (false, None);
+    };
+    let lower = file_path.to_ascii_lowercase();
+    let is_sensitive = [
+        ".env",
+        "credentials",
+        "secrets",
+        ".ssh/",
+        "id_rsa",
+        ".aws/",
+        ".npmrc",
+        ".pypirc",
+    ]
+    .iter()
+    .any(|needle| lower.contains(needle));
+    (is_sensitive, is_sensitive.then_some(file_path))
 }
 
 fn list_recent_tool_calls_conn(

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -20,8 +20,8 @@ use sm_server::{
         AppArtifactsConfig, AppConfig, BugReportsConfig, CodexEventsConfig, CodexForkLaunchConfig,
         CodexObservabilityConfig, CodexRequestsConfig, CodexRolloutConfig, EmailConfig,
         ExternalAccessConfig, GoogleAuthConfig, MobileAnalyticsConfig, MobileTerminalConfig,
-        MobileTerminalDeviceKeyConfig, MobileTerminalUserConfig, PathsConfig, ProviderLaunchConfig,
-        QueueRunnerConfig, RustCoreConfig, SmSendConfig, ToolLoggingConfig,
+        MobileTerminalDeviceKeyConfig, MobileTerminalUserConfig, NodeConfig, PathsConfig,
+        ProviderLaunchConfig, QueueRunnerConfig, RustCoreConfig, SmSendConfig, ToolLoggingConfig,
     },
     http::{router, AppState, GitHubReviewComment, GitHubReviewMatch, GitHubReviewPoster},
     runtime::TmuxRuntime,
@@ -7134,6 +7134,419 @@ async fn sessions_lists_running_sessions_and_filters_stopped_by_default() {
         .unwrap()
         .iter()
         .all(|session| session["id"] != "stop1234"));
+}
+
+#[tokio::test]
+async fn claude_stop_hook_marks_session_idle_for_watch_clients() {
+    let state_file = write_session_fixture();
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/hooks/claude",
+        json!({
+            "hook_event_name": "Stop",
+            "session_manager_id": "run12345",
+            "sm_last_message": "done with the turn",
+            "sm_native_title": "Review docs",
+            "sm_transcript_mtime_ns": 424242_i64
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload, json!({ "status": "ok" }));
+
+    let (status, payload) = get_json(app, "/sessions/run12345").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "idle");
+    assert_eq!(payload["activity_state"], "idle");
+
+    let raw_state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let session = raw_state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "run12345")
+        .unwrap();
+    assert_eq!(session["last_action_summary"], "done with the turn");
+    assert_eq!(session["native_title"], "Review docs");
+    assert_eq!(session["native_title_source_mtime_ns"], 424242_i64);
+    assert_eq!(session["native_title_updated_at_ns"], 424242_i64);
+}
+
+#[tokio::test]
+async fn claude_stop_hook_reads_local_transcript_metadata_when_not_inlined() {
+    let state_file = write_session_fixture();
+    let transcript_path = unique_temp_path().with_extension("jsonl");
+    fs::write(
+        &transcript_path,
+        [
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"old output"}]}}"#,
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"latest output"}]}}"#,
+            r#"{"type":"custom-title","customTitle":"Transcript Native Title"}"#,
+        ]
+        .join("\n"),
+    )
+    .unwrap();
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/hooks/claude",
+        json!({
+            "hook_event_name": "Stop",
+            "session_manager_id": "run12345",
+            "transcript_path": transcript_path.display().to_string()
+        }),
+        &[("host", "localhost:8420")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload, json!({ "status": "ok" }));
+
+    let (status, payload) = get_json(app, "/sessions/run12345").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "idle");
+    assert_eq!(payload["activity_state"], "idle");
+
+    let raw_state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let session = raw_state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "run12345")
+        .unwrap();
+    assert_eq!(session["last_action_summary"], "latest output");
+    assert_eq!(session["native_title"], "Transcript Native Title");
+    assert_eq!(
+        session["transcript_path"],
+        transcript_path.display().to_string()
+    );
+    assert_eq!(
+        session["provider_resume_id"],
+        transcript_path.file_stem().unwrap().to_str().unwrap()
+    );
+    assert_eq!(
+        session["native_title_updated_at_ns"],
+        session["native_title_source_mtime_ns"]
+    );
+    assert!(session["native_title_updated_at_ns"].as_i64().unwrap() > 0);
+}
+
+#[tokio::test]
+async fn claude_stop_hook_retries_local_transcript_metadata_read() {
+    let state_file = write_session_fixture();
+    let transcript_path = unique_temp_path().with_extension("jsonl");
+    let delayed_path = transcript_path.clone();
+    std::thread::spawn(move || {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        fs::write(
+            delayed_path,
+            [
+                r#"{"type":"assistant","message":{"content":[{"type":"text","text":"delayed output"}]}}"#,
+                r#"{"type":"agent-name","agentName":"Delayed Native Title"}"#,
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+    });
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/hooks/claude",
+        json!({
+            "hook_event_name": "Stop",
+            "session_manager_id": "run12345",
+            "transcript_path": transcript_path.display().to_string()
+        }),
+        &[("host", "localhost:8420")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload, json!({ "status": "ok" }));
+
+    let raw_state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let session = raw_state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "run12345")
+        .unwrap();
+    assert_eq!(session["last_action_summary"], "delayed output");
+    assert_eq!(session["native_title"], "Delayed Native Title");
+    assert_eq!(
+        session["provider_resume_id"],
+        transcript_path.file_stem().unwrap().to_str().unwrap()
+    );
+}
+
+#[tokio::test]
+async fn tool_use_hook_marks_session_working_and_records_tool_name() {
+    let state_file = write_session_fixture();
+    let tool_db = unique_temp_path().with_extension("tool_usage.db");
+    let mut config = config_with_state_file(&state_file);
+    config.tool_logging = ToolLoggingConfig {
+        db_path: tool_db.display().to_string(),
+    };
+    let app = router(AppState::new(config));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/hooks/tool-use",
+        json!({
+            "hook_event_name": "PreToolUse",
+            "session_manager_id": "oldstate",
+            "session_id": "claude-native-session",
+            "tool_use_id": "toolu_123",
+            "tool_name": "Bash",
+            "cwd": "/repo",
+            "tool_input": {
+                "command": "git branch -D stale"
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload, json!({ "status": "logged" }));
+
+    let (status, payload) = get_json(app, "/sessions/oldstate").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "running");
+    assert_eq!(payload["activity_state"], "working");
+    assert_eq!(payload["last_tool_name"], "Bash");
+    assert!(payload["last_tool_call"].is_string());
+
+    let conn = Connection::open(&tool_db).unwrap();
+    let row = conn
+        .query_row(
+            "SELECT session_id, claude_session_id, hook_type, tool_name, tool_use_id, cwd, project_name, tool_input, bash_command, is_destructive, destructive_type FROM tool_usage",
+            [],
+            |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                    row.get::<_, String>(5)?,
+                    row.get::<_, String>(6)?,
+                    row.get::<_, String>(7)?,
+                    row.get::<_, String>(8)?,
+                    row.get::<_, bool>(9)?,
+                    row.get::<_, String>(10)?,
+                ))
+            },
+        )
+        .unwrap();
+    assert_eq!(
+        row,
+        (
+            "oldstate".to_owned(),
+            "claude-native-session".to_owned(),
+            "PreToolUse".to_owned(),
+            "Bash".to_owned(),
+            "toolu_123".to_owned(),
+            "/repo".to_owned(),
+            "repo".to_owned(),
+            json!({ "command": "git branch -D stale" }).to_string(),
+            "git branch -D stale".to_owned(),
+            true,
+            "git_branch_delete".to_owned(),
+        )
+    );
+}
+
+#[tokio::test]
+async fn tool_use_hook_marks_session_working_before_audit_db_failure() {
+    let state_file = write_session_fixture();
+    let not_a_dir = unique_temp_path().with_extension("not-a-dir");
+    fs::write(&not_a_dir, "not a directory").unwrap();
+    let mut config = config_with_state_file(&state_file);
+    config.tool_logging = ToolLoggingConfig {
+        db_path: not_a_dir.join("tool_usage.db").display().to_string(),
+    };
+    let app = router(AppState::new(config));
+
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/hooks/tool-use",
+        json!({
+            "hook_event_name": "PreToolUse",
+            "session_manager_id": "oldstate",
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": "echo fixture"
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+
+    let (status, payload) = get_json(app, "/sessions/oldstate").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "running");
+    assert_eq!(payload["activity_state"], "working");
+    assert_eq!(payload["last_tool_name"], "Bash");
+}
+
+#[tokio::test]
+async fn claude_stop_hook_does_not_refresh_title_update_time_for_unchanged_title() {
+    let state_file = write_session_fixture();
+    let mut raw_state: Value =
+        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let session = raw_state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "run12345")
+        .unwrap();
+    session["native_title"] = json!("Same Native Title");
+    session["native_title_updated_at_ns"] = json!(2000_i64);
+    session["friendly_name"] = json!("Explicit Name");
+    session["friendly_name_is_explicit"] = json!(true);
+    session["friendly_name_updated_at_ns"] = json!(3000_i64);
+    fs::write(&state_file, serde_json::to_vec_pretty(&raw_state).unwrap()).unwrap();
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/hooks/claude",
+        json!({
+            "hook_event_name": "Stop",
+            "session_manager_id": "run12345",
+            "sm_native_title": "Same Native Title",
+            "sm_transcript_mtime_ns": 5000_i64
+        }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload, json!({ "status": "ok" }));
+
+    let raw_state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let session = raw_state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "run12345")
+        .unwrap();
+    assert_eq!(session["native_title_source_mtime_ns"], 5000_i64);
+    assert_eq!(session["native_title_updated_at_ns"], 2000_i64);
+
+    let (status, payload) = get_json(app, "/sessions/run12345").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["friendly_name"], "Explicit Name");
+}
+
+#[tokio::test]
+async fn remote_hook_secret_is_required_for_remote_node_sessions() {
+    let state_file = write_session_fixture();
+    let mut raw_state: Value =
+        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let session = raw_state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "run12345")
+        .unwrap();
+    session["node"] = json!("macbook");
+    fs::write(&state_file, serde_json::to_vec_pretty(&raw_state).unwrap()).unwrap();
+
+    let mut config = config_with_state_file(&state_file);
+    config.nodes.registry.insert(
+        "macbook".to_owned(),
+        NodeConfig {
+            id: "macbook".to_owned(),
+            hook_secret: Some("secret-hook".to_owned()),
+            ..NodeConfig::default()
+        },
+    );
+    let app = router(AppState::new(config));
+
+    let remote_peer = Some(SocketAddr::from(([203, 0, 113, 8], 49152)));
+    let (status, payload) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/hooks/claude",
+        json!({
+            "hook_event_name": "Stop",
+            "session_manager_id": "run12345"
+        }),
+        &[],
+        remote_peer,
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(payload, json!({ "detail": "Invalid hook secret" }));
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app,
+        "/hooks/claude",
+        json!({
+            "hook_event_name": "Stop",
+            "session_manager_id": "run12345"
+        }),
+        &[("x-sm-hook-secret", "secret-hook")],
+        remote_peer,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload, json!({ "status": "ok" }));
+}
+
+#[tokio::test]
+async fn primary_hooks_require_auth_from_public_remote_requests() {
+    let state_file = write_session_fixture();
+    let app = router(AppState::new(config_with_state_file_and_auth(&state_file)));
+    let remote_peer = Some(SocketAddr::from(([203, 0, 113, 9], 49152)));
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/hooks/claude",
+        json!({
+            "hook_event_name": "Stop",
+            "session_manager_id": "run12345"
+        }),
+        &[("host", "sm.example.com")],
+        remote_peer,
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        payload,
+        json!({
+            "detail": "Authentication required",
+            "login_url": "/auth/google/login?next=%2Fhooks%2Fclaude"
+        })
+    );
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app,
+        "/hooks/tool-use",
+        json!({
+            "hook_event_name": "PreToolUse",
+            "session_manager_id": "run12345",
+            "tool_name": "Bash"
+        }),
+        &[("host", "sm.example.com")],
+        remote_peer,
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        payload,
+        json!({
+            "detail": "Authentication required",
+            "login_url": "/auth/google/login?next=%2Fhooks%2Ftool-use"
+        })
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #1077

## Summary
- add Rust handlers for retained `/hooks/claude` and `/hooks/tool-use` activity hooks
- mark Claude sessions idle on Stop and working on PreToolUse
- preserve remote-node `x-sm-hook-secret` validation for hook posts

## Validation
- `cargo fmt --check`
- `cargo test -p sm-server --test read_only_http hook -- --nocapture`
- `cargo test -p sm-server`
