### PR TITLE
Fix sequential review wake delivery

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -3667,6 +3667,7 @@ async fn run_codex_review_request_watcher(
         {
             Ok(Some(review_match)) => {
                 complete_codex_review_request(
+                    &state,
                     &queue_db_path,
                     &request_id,
                     &registration,
@@ -3791,6 +3792,7 @@ async fn github_post_review_request(
 }
 
 fn complete_codex_review_request(
+    state: &AppState,
     queue_db_path: &std::path::Path,
     request_id: &str,
     registration: &CodexReviewRequestRegistration,
@@ -3802,6 +3804,18 @@ fn complete_codex_review_request(
     queue
         .enqueue_message(&registration.notify_session_id, &text, "sequential", None)
         .map_err(|error| error.to_string())?;
+    if state.config.rust_core.runtime_enabled {
+        let runtime = TmuxRuntime::from_app_config(&state.config);
+        if let Err(error) = state
+            .session_store
+            .drain_runtime_pending_messages_for_session(&registration.notify_session_id, &runtime)
+        {
+            eprintln!(
+                "failed to immediately deliver Codex review completion message {request_id} to {}: {error:#}",
+                registration.notify_session_id
+            );
+        }
+    }
     RetainedQueueStore::complete_codex_review_request_in_path(
         queue_db_path,
         request_id,

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -17,7 +17,10 @@ use rand_core::{OsRng, RngCore};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256};
-use time::{format_description::well_known::Rfc3339, macros::format_description, OffsetDateTime};
+use time::{
+    format_description::well_known::Rfc3339, macros::format_description, Duration as TimeDuration,
+    OffsetDateTime, PrimitiveDateTime,
+};
 
 use crate::queue::{
     followup_notification_text, PendingMessage, QueueMessageMetadata, RetainedQueueStore,
@@ -5399,12 +5402,48 @@ fn projected_activity_state(session: &SessionRecord, status: &str) -> String {
         return "idle".to_owned();
     }
     if matches!(status, "running" | "working") {
-        return "working".to_owned();
+        if session_activity_is_recent(&session.last_activity) {
+            return "working".to_owned();
+        }
+        return "idle".to_owned();
     }
     if status == "idle" {
         return "idle".to_owned();
     }
     fallback_activity_state(status)
+}
+
+fn session_activity_is_recent(last_activity: &str) -> bool {
+    let now_utc = OffsetDateTime::now_utc();
+    if let Ok(parsed) = OffsetDateTime::parse(last_activity.trim(), &Rfc3339) {
+        return now_utc - parsed < TimeDuration::seconds(30);
+    }
+    let now_local = local_now_naive(now_utc);
+    parse_python_naive_datetime(last_activity)
+        .is_some_and(|last_activity| now_local - last_activity < TimeDuration::seconds(30))
+}
+
+fn parse_python_naive_datetime(value: &str) -> Option<PrimitiveDateTime> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    PrimitiveDateTime::parse(
+        value,
+        format_description!("[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond]"),
+    )
+    .or_else(|_| {
+        PrimitiveDateTime::parse(
+            value,
+            format_description!("[year]-[month]-[day]T[hour]:[minute]:[second]"),
+        )
+    })
+    .ok()
+}
+
+fn local_now_naive(now_utc: OffsetDateTime) -> PrimitiveDateTime {
+    let local = OffsetDateTime::now_local().unwrap_or(now_utc);
+    PrimitiveDateTime::new(local.date(), local.time())
 }
 
 fn non_empty_or(value: String, fallback: &str) -> String {
@@ -5669,6 +5708,20 @@ mod tests {
         recent_activity_session.last_activity = now_rfc3339();
         let response = SessionResponse::from(recent_activity_session);
         assert_eq!(response.activity_state, "idle");
+
+        let stale_running_session = session_record("running");
+        let response = SessionResponse::from(stale_running_session);
+        assert_eq!(response.activity_state, "idle");
+
+        let mut recent_running_session = session_record("running");
+        recent_running_session.last_activity = now_rfc3339();
+        let response = SessionResponse::from(recent_running_session);
+        assert_eq!(response.activity_state, "working");
+
+        let mut recent_naive_running_session = session_record("running");
+        recent_naive_running_session.last_activity = now_python_naive_iso();
+        let response = SessionResponse::from(recent_naive_running_session);
+        assert_eq!(response.activity_state, "working");
     }
 
     #[test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -9,7 +9,7 @@ use base64::{
 };
 use futures_util::{future::join, StreamExt as _};
 use hmac::{Hmac, Mac};
-use rusqlite::Connection;
+use rusqlite::{Connection, OptionalExtension};
 use serde_json::{json, Value};
 use sha1::{Digest, Sha1};
 use sha2::Sha256;
@@ -2578,6 +2578,132 @@ async fn codex_review_request_watcher_completes_and_queues_wake() {
         message,
         "[sm review] Codex comment for PR #967 is here. https://github.com/rajeshgoli/session-manager/pull/967#issuecomment-4701300000"
     );
+}
+
+#[tokio::test]
+async fn codex_review_request_watcher_delivers_sequential_wake_to_runtime_session() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let working_dir = unique_temp_path();
+    fs::create_dir_all(&working_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-review-wake-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let queue_db = queue_db_path_for_state_file(&state_file);
+    let poster = StubGitHubReviewPoster::successful().with_fresh_review(GitHubReviewMatch {
+        source: "pull_review".to_owned(),
+        created_at: "2026-06-14T02:31:00Z".to_owned(),
+        id: Some(json!("PRR_kwRuntimeWake")),
+        url: Some(
+            "https://github.com/rajeshgoli/session-manager/pull/978#pullrequestreview-1".to_owned(),
+        ),
+    });
+    let app = router(
+        AppState::new(AppConfig {
+            paths: PathsConfig {
+                state_file: state_file.display().to_string(),
+            },
+            sm_send: SmSendConfig {
+                db_path: queue_db.display().to_string(),
+            },
+            rust_core: RustCoreConfig {
+                runtime_enabled: true,
+                log_dir: Some(log_dir.display().to_string()),
+                tmux_socket_name: Some(tmux_socket),
+                runtime_command: Some(
+                    r#"/bin/sh -lc 'while IFS= read -r line; do printf "runtime:%s\n" "$line"; done'"#
+                        .to_owned(),
+                ),
+                runtime_prompt_mode: Some("stdin".to_owned()),
+                runtime_start_settle_ms: Some(100),
+                send_keys_settle_ms: Some(10.0),
+                send_keys_settle_max_ms: Some(50.0),
+                send_keys_max_chunk_chars: Some(128),
+                ..RustCoreConfig::default()
+            },
+            ..AppConfig::default()
+        })
+        .with_github_review_poster(Arc::new(poster)),
+    );
+
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "notifyruntime",
+            "name": "notify-runtime",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude",
+            "initial_message": "review wake initial"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    wait_for_output_contains(app.clone(), "notifyruntime", "runtime:review wake initial").await;
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/codex-review-requests",
+        json!({
+            "pr_number": 978,
+            "repo": "rajeshgoli/session-manager",
+            "notify_target": "notifyruntime",
+            "poll_interval_seconds": 1,
+            "retry_interval_seconds": 900
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let request_id = payload["id"].as_str().unwrap().to_owned();
+    let expected_message = "[sm review] Codex review for PR #978 is here. https://github.com/rajeshgoli/session-manager/pull/978#pullrequestreview-1";
+
+    let mut completed = None;
+    for _ in 0..30 {
+        let conn = Connection::open(&queue_db).unwrap();
+        let row: (String, Option<String>) = conn
+            .query_row(
+                r#"
+                SELECT state, review_url
+                FROM codex_review_request_registrations
+                WHERE id = ?1
+                "#,
+                [&request_id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        let delivered_at: Option<String> = match conn
+            .query_row(
+                "SELECT delivered_at FROM message_queue WHERE target_session_id = 'notifyruntime' AND text = ?1",
+                [expected_message],
+                |row| row.get(0),
+            )
+            .optional()
+        {
+            Ok(value) => value.flatten(),
+            Err(error) if error.to_string().contains("no such table: message_queue") => None,
+            Err(error) => panic!("failed to query review wake message: {error}"),
+        };
+        if row.0 == "completed" && delivered_at.is_some() {
+            completed = Some(row);
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    let completed = completed.expect("watcher should complete and deliver retained request");
+    assert_eq!(
+        completed.1.as_deref(),
+        Some("https://github.com/rajeshgoli/session-manager/pull/978#pullrequestreview-1")
+    );
+    wait_for_output_contains(app, "notifyruntime", expected_message).await;
 }
 
 #[tokio::test]
@@ -7123,7 +7249,7 @@ async fn sessions_lists_running_sessions_and_filters_stopped_by_default() {
     assert_eq!(payload["sessions"].as_array().unwrap().len(), 2);
     assert_eq!(payload["sessions"][0]["id"], "run12345");
     assert_eq!(payload["sessions"][0]["friendly_name"], "Runner Native");
-    assert_eq!(payload["sessions"][0]["activity_state"], "working");
+    assert_eq!(payload["sessions"][0]["activity_state"], "idle");
     assert_eq!(payload["sessions"][0]["provider"], "claude");
     assert_eq!(payload["sessions"][1]["id"], "oldstate");
     assert_eq!(payload["sessions"][1]["friendly_name"], "claude-oldstate");
@@ -7643,7 +7769,7 @@ async fn session_detail_returns_one_projected_session() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["id"], "run12345");
     assert_eq!(payload["friendly_name"], "Runner Native");
-    assert_eq!(payload["activity_state"], "working");
+    assert_eq!(payload["activity_state"], "idle");
     assert_eq!(payload["provider"], "claude");
 }
 


### PR DESCRIPTION
Fixes #1081

## Summary
- drain pending sequential queue rows into the runtime session immediately after Codex review completion wake enqueue, preserving queue-before-complete ordering
- keep the delivery path non-interrupting: it sends text + Enter through the normal tmux runtime buffer, matching Python sequential semantics
- project stale Claude `running`/`working` records as idle unless `last_activity` is recent, matching the Python stale-activity fallback

## Validation
- `cargo fmt --check`
- `cargo test -p sm-server`
- local sidecar on `127.0.0.1:18420` projected `34764bf3 playback-UI claude running idle` from live state

## Production context
- review request `a9d992ece545` completed and queued `[sm review]` for notify session `34764bf3`, but the queue row stayed undelivered because the watcher never drained the sequential runtime queue
- `34764bf3` had stale `last_activity` while status remained `running`, so Rust showed it as `working` indefinitely