### PR TITLE
Fix Rust tmux scrollback and activity parity

### DIFF
--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -493,10 +493,28 @@ pub struct MobileTerminalDeviceKeyConfig {
     pub enabled: bool,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct TmuxConfig {
     #[serde(default)]
     pub socket_name: Option<String>,
+    #[serde(default = "default_true")]
+    pub native_scrollback: bool,
+    #[serde(default = "default_tmux_history_limit")]
+    pub history_limit: Option<u64>,
+}
+
+fn default_tmux_history_limit() -> Option<u64> {
+    Some(100000)
+}
+
+impl Default for TmuxConfig {
+    fn default() -> Self {
+        Self {
+            socket_name: None,
+            native_scrollback: default_true(),
+            history_limit: default_tmux_history_limit(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -951,6 +969,10 @@ pub struct RustCoreConfig {
     #[serde(default)]
     pub tmux_socket_name: Option<String>,
     #[serde(default)]
+    pub tmux_native_scrollback: Option<bool>,
+    #[serde(default)]
+    pub tmux_history_limit: Option<u64>,
+    #[serde(default)]
     pub runtime_command: Option<String>,
     #[serde(default)]
     pub runtime_prompt_mode: Option<String>,
@@ -1041,6 +1063,12 @@ impl From<RawConfig> for AppConfig {
         let codex_fork = codex_fork_launch_config(raw.codex_fork, &codex);
         if trimmed(&rust_core.tmux_socket_name).is_none() {
             rust_core.tmux_socket_name = trimmed(&raw.tmux.socket_name);
+        }
+        if rust_core.tmux_native_scrollback.is_none() {
+            rust_core.tmux_native_scrollback = Some(raw.tmux.native_scrollback);
+        }
+        if rust_core.tmux_history_limit.is_none() {
+            rust_core.tmux_history_limit = raw.tmux.history_limit.filter(|value| *value > 0);
         }
         let tmux_timeouts = raw.timeouts.tmux;
         if rust_core.send_keys_settle_ms.is_none() {

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -63,7 +63,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha1::{Digest, Sha1};
 use sha2::Sha256;
-use time::{format_description::well_known::Rfc3339, Duration as TimeDuration, OffsetDateTime};
+use time::{
+    format_description::well_known::Rfc3339, macros::format_description, Duration as TimeDuration,
+    OffsetDateTime, PrimitiveDateTime,
+};
 use tokio::sync::{mpsc, Mutex as AsyncMutex};
 use tokio::time::{sleep, timeout};
 
@@ -7504,20 +7507,32 @@ fn live_activity_state(state: &AppState, session: &SessionRecord) -> Option<&'st
         let pane_text = runtime.capture_pane_text(&session.tmux_session);
         return claude_live_activity_state(session, pane_text.as_deref());
     }
-    if session.agent_task_completed_at.is_some() {
-        return None;
-    }
     if session.provider.trim() != "codex-fork" {
         return None;
     }
-    let event_activity = codex_fork_event_stream_activity(state, session);
-    if matches!(event_activity, Some("working" | "stopped")) {
-        return event_activity;
+    let task_completed_at =
+        codex_fork_task_completed_at(session.agent_task_completed_at.as_deref());
+    let event_activity = codex_fork_event_stream_activity(state, session)
+        .filter(|signal| codex_fork_signal_is_newer_than_task_complete(signal, task_completed_at));
+    if matches!(
+        event_activity.as_ref().map(|signal| signal.activity),
+        Some("working" | "stopped")
+    ) {
+        return event_activity.map(|signal| signal.activity);
+    }
+    if matches!(
+        task_completed_at,
+        Some(CodexForkTaskCompletion::Known(_)) | Some(CodexForkTaskCompletion::Unknown)
+    ) {
+        return event_activity.map(|signal| signal.activity);
     }
     let runtime = TmuxRuntime::from_app_config(&state.config)
         .for_socket_name(session.tmux_socket_name.as_deref());
     let pane_title = runtime.pane_title(&session.tmux_session);
-    codex_fork_live_activity_from_signals(event_activity, pane_title.as_deref())
+    codex_fork_live_activity_from_signals(
+        event_activity.as_ref().map(|signal| signal.activity),
+        pane_title.as_deref(),
+    )
 }
 
 fn claude_live_activity_state(
@@ -7613,12 +7628,76 @@ fn codex_fork_live_activity_from_signals(
     event_activity
 }
 
+#[derive(Debug, Clone, Copy)]
+struct CodexForkActivitySignal {
+    activity: &'static str,
+    observed_at: Option<OffsetDateTime>,
+    undated_status_is_latest_event: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CodexForkTaskCompletion {
+    Known(OffsetDateTime),
+    Unknown,
+}
+
+fn codex_fork_task_completed_at(value: Option<&str>) -> Option<CodexForkTaskCompletion> {
+    let value = value?.trim();
+    if value.is_empty() {
+        return None;
+    }
+    parse_github_datetime(value)
+        .or_else(|| parse_python_naive_datetime_local(value))
+        .map(CodexForkTaskCompletion::Known)
+        .or(Some(CodexForkTaskCompletion::Unknown))
+}
+
+fn codex_fork_signal_is_newer_than_task_complete(
+    signal: &CodexForkActivitySignal,
+    task_completed_at: Option<CodexForkTaskCompletion>,
+) -> bool {
+    let Some(task_completed_at) = task_completed_at else {
+        return true;
+    };
+    let CodexForkTaskCompletion::Known(task_completed_at) = task_completed_at else {
+        return false;
+    };
+    signal
+        .observed_at
+        .is_some_and(|observed_at| observed_at > task_completed_at)
+        || (signal.observed_at.is_none() && signal.undated_status_is_latest_event)
+}
+
+fn parse_python_naive_datetime_local(value: &str) -> Option<OffsetDateTime> {
+    let value = value.trim();
+    if value.is_empty() {
+        return None;
+    }
+    PrimitiveDateTime::parse(
+        value,
+        format_description!("[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond]"),
+    )
+    .or_else(|_| {
+        PrimitiveDateTime::parse(
+            value,
+            format_description!("[year]-[month]-[day]T[hour]:[minute]:[second]"),
+        )
+    })
+    .ok()
+    .map(|parsed| {
+        let local_offset = OffsetDateTime::now_local()
+            .unwrap_or_else(|_| OffsetDateTime::now_utc())
+            .offset();
+        parsed.assume_offset(local_offset)
+    })
+}
+
 fn codex_fork_event_stream_activity(
     state: &AppState,
     session: &SessionRecord,
-) -> Option<&'static str> {
+) -> Option<CodexForkActivitySignal> {
     let event_stream_path = codex_fork_event_stream_path_for_session(state, session)?;
-    codex_fork_event_stream_activity_from_path(event_stream_path)
+    codex_fork_event_stream_signal_from_path(event_stream_path)
 }
 
 fn codex_fork_event_stream_path_for_session(
@@ -7645,12 +7724,11 @@ fn codex_fork_event_stream_path_for_session(
         .ok()
         .flatten()
         .map(|artifacts| {
-            if artifacts.event_stream_path.exists() {
-                artifacts.event_stream_path
-            } else {
-                codex_fork_legacy_event_stream_path_from_log_file(&expand_home(log_file))
-                    .unwrap_or(artifacts.event_stream_path)
-            }
+            codex_fork_newest_event_stream_path(
+                &session.id,
+                &expand_home(log_file),
+                &artifacts.event_stream_path,
+            )
         })
 }
 
@@ -7662,9 +7740,39 @@ fn codex_fork_legacy_event_stream_path_from_log_file(log_file: &StdPath) -> Opti
     Some(log_file.with_file_name(format!("{stem}.codex-fork.events.jsonl")))
 }
 
+fn codex_fork_newest_event_stream_path(
+    _session_id: &str,
+    log_file: &StdPath,
+    derived_path: &StdPath,
+) -> PathBuf {
+    let mut candidates = Vec::new();
+    candidates.push(derived_path.to_path_buf());
+    if let Some(legacy_path) = codex_fork_legacy_event_stream_path_from_log_file(log_file) {
+        candidates.push(legacy_path);
+    }
+
+    candidates
+        .iter()
+        .filter_map(|path| {
+            path.metadata()
+                .ok()
+                .and_then(|metadata| metadata.modified().ok())
+                .map(|modified| (modified, path))
+        })
+        .max_by_key(|(modified, _)| *modified)
+        .map(|(_, path)| path.to_path_buf())
+        .unwrap_or_else(|| derived_path.to_path_buf())
+}
+
+#[cfg(test)]
 fn codex_fork_event_stream_activity_from_path(path: PathBuf) -> Option<&'static str> {
+    codex_fork_event_stream_signal_from_path(path).map(|signal| signal.activity)
+}
+
+fn codex_fork_event_stream_signal_from_path(path: PathBuf) -> Option<CodexForkActivitySignal> {
     let mut file = fs::File::open(path).ok()?;
-    let len = file.metadata().ok()?.len();
+    let metadata = file.metadata().ok()?;
+    let len = metadata.len();
     let start = len.saturating_sub(CODEX_FORK_ACTIVITY_EVENT_TAIL_BYTES);
     if start > 0 && file.seek(SeekFrom::Start(start)).is_err() {
         return None;
@@ -7679,13 +7787,46 @@ fn codex_fork_event_stream_activity_from_path(path: PathBuf) -> Option<&'static 
         }
     }
 
-    let mut latest_activity = None;
+    let mut latest_activity: Option<CodexForkActivitySignal> = None;
     for line in chunk.lines() {
-        latest_activity = codex_fork_status_for_event_line(line)
-            .and_then(codex_fork_activity_for_status)
-            .or(latest_activity);
+        if codex_fork_event_line_is_json(line) {
+            if let Some(signal) = latest_activity.as_mut() {
+                signal.undated_status_is_latest_event = false;
+            }
+        }
+        if let Some(activity) =
+            codex_fork_status_for_event_line(line).and_then(codex_fork_activity_for_status)
+        {
+            latest_activity = Some(CodexForkActivitySignal {
+                activity,
+                observed_at: codex_fork_event_line_timestamp(line),
+                undated_status_is_latest_event: true,
+            });
+        }
     }
     latest_activity
+}
+
+fn codex_fork_event_line_is_json(line: &str) -> bool {
+    let Ok(event) = serde_json::from_str::<Value>(line.trim()) else {
+        return false;
+    };
+    event.as_object().is_some()
+}
+
+fn codex_fork_event_line_timestamp(line: &str) -> Option<OffsetDateTime> {
+    let event = serde_json::from_str::<Value>(line.trim()).ok()?;
+    let event = event.as_object()?;
+    for key in ["ts", "timestamp", "created_at"] {
+        if let Some(parsed) = event
+            .get(key)
+            .and_then(Value::as_str)
+            .and_then(parse_github_datetime)
+        {
+            return Some(parsed);
+        }
+    }
+    None
 }
 
 fn codex_fork_activity_for_status(status: &str) -> Option<&'static str> {
@@ -7699,9 +7840,13 @@ fn codex_fork_activity_for_status(status: &str) -> Option<&'static str> {
 
 fn codex_fork_pane_title_indicates_working(pane_title: &str) -> bool {
     let title = pane_title.trim();
-    let Some((first_token, _)) = title.split_once(' ') else {
+    let mut tokens = title.split_whitespace();
+    let Some(first_token) = tokens.next() else {
         return false;
     };
+    if tokens.next().is_none() {
+        return false;
+    }
     let mut chars = first_token.chars();
     let Some(first) = chars.next() else {
         return false;
@@ -11032,11 +11177,11 @@ mod tests {
         assert!(codex_fork_pane_title_indicates_working(
             "  ⠇ fractal-algo-rust  "
         ));
-        assert!(!codex_fork_pane_title_indicates_working(
-            "fractal-algo-rust"
+        assert!(codex_fork_pane_title_indicates_working(
+            "⠏\tfractal-algo-rust"
         ));
         assert!(!codex_fork_pane_title_indicates_working(
-            "⠏\tfractal-algo-rust"
+            "fractal-algo-rust"
         ));
         assert!(!codex_fork_pane_title_indicates_working(
             "⠏⠇ fractal-algo-rust"
@@ -11121,6 +11266,217 @@ mod tests {
         .unwrap();
 
         assert_eq!(live_activity_state(&state, &session), None);
+    }
+
+    #[test]
+    fn codex_fork_live_activity_overrides_stale_task_complete() {
+        let dir = env::temp_dir().join(format!(
+            "sm-rust-codex-stale-task-complete-{}-{}",
+            process::id(),
+            random_urlsafe_token(8)
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let log_file = dir.join("codex-fork-abc12345.log");
+        let session: SessionRecord = serde_json::from_value(json!({
+            "id": "abc12345",
+            "name": "codex-fork-abc12345",
+            "working_dir": "/repo",
+            "tmux_session": "codex-fork-abc12345",
+            "provider": "codex-fork",
+            "status": "running",
+            "created_at": "2026-06-01T00:00:00",
+            "last_activity": "2026-06-01T00:00:00",
+            "agent_task_completed_at": "2026-06-01T00:01:00Z",
+            "log_file": log_file.display().to_string()
+        }))
+        .unwrap();
+        let spec = crate::runtime::TmuxSessionSpec {
+            session_id: session.id.clone(),
+            tmux_session: session.tmux_session.clone(),
+            working_dir: session.working_dir.clone(),
+            log_file: log_file.clone(),
+            provider: session.provider.clone(),
+            initial_message: None,
+            model: session.model.clone(),
+        };
+        let event_stream = TmuxRuntime::from_app_config(&AppConfig::default())
+            .codex_fork_runtime_artifacts(&spec)
+            .unwrap()
+            .unwrap()
+            .event_stream_path;
+        fs::write(
+            &event_stream,
+            "{\"ts\":\"2026-06-01T00:02:00Z\",\"type\":\"thread/status/changed\",\"payload\":{\"status\":{\"type\":\"active\"}}}\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            live_activity_state(&AppState::new(AppConfig::default()), &session),
+            Some("working")
+        );
+    }
+
+    #[test]
+    fn codex_fork_stale_live_activity_does_not_override_task_complete() {
+        let dir = env::temp_dir().join(format!(
+            "sm-rust-codex-completed-before-event-{}-{}",
+            process::id(),
+            random_urlsafe_token(8)
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let log_file = dir.join("codex-fork-abc12345.log");
+        let session: SessionRecord = serde_json::from_value(json!({
+            "id": "abc12345",
+            "name": "codex-fork-abc12345",
+            "working_dir": "/repo",
+            "tmux_session": "codex-fork-abc12345",
+            "provider": "codex-fork",
+            "status": "running",
+            "created_at": "2026-06-01T00:00:00",
+            "last_activity": "2026-06-01T00:00:00",
+            "agent_task_completed_at": "2099-06-01T00:01:00Z",
+            "log_file": log_file.display().to_string()
+        }))
+        .unwrap();
+        let spec = crate::runtime::TmuxSessionSpec {
+            session_id: session.id.clone(),
+            tmux_session: session.tmux_session.clone(),
+            working_dir: session.working_dir.clone(),
+            log_file: log_file.clone(),
+            provider: session.provider.clone(),
+            initial_message: None,
+            model: session.model.clone(),
+        };
+        let event_stream = TmuxRuntime::from_app_config(&AppConfig::default())
+            .codex_fork_runtime_artifacts(&spec)
+            .unwrap()
+            .unwrap()
+            .event_stream_path;
+        fs::write(
+            &event_stream,
+            concat!(
+                "{\"ts\":\"2026-06-01T00:00:30Z\",\"type\":\"thread/status/changed\",\"payload\":{\"status\":{\"type\":\"active\"}}}\n",
+                "{\"ts\":\"2099-06-01T00:02:00Z\",\"event_type\":\"thread/tokenUsage/updated\",\"payload\":{}}\n"
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(
+            live_activity_state(&AppState::new(AppConfig::default()), &session),
+            None
+        );
+    }
+
+    #[test]
+    fn codex_fork_latest_undated_status_overrides_task_complete() {
+        let dir = env::temp_dir().join(format!(
+            "sm-rust-codex-latest-undated-status-{}-{}",
+            process::id(),
+            random_urlsafe_token(8)
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let log_file = dir.join("codex-fork-abc12345.log");
+        let session: SessionRecord = serde_json::from_value(json!({
+            "id": "abc12345",
+            "name": "codex-fork-abc12345",
+            "working_dir": "/repo",
+            "tmux_session": "codex-fork-abc12345",
+            "provider": "codex-fork",
+            "status": "running",
+            "created_at": "2026-06-01T00:00:00",
+            "last_activity": "2026-06-01T00:00:00",
+            "agent_task_completed_at": "2026-06-01T00:01:00",
+            "log_file": log_file.display().to_string()
+        }))
+        .unwrap();
+        let spec = crate::runtime::TmuxSessionSpec {
+            session_id: session.id.clone(),
+            tmux_session: session.tmux_session.clone(),
+            working_dir: session.working_dir.clone(),
+            log_file: log_file.clone(),
+            provider: session.provider.clone(),
+            initial_message: None,
+            model: session.model.clone(),
+        };
+        let event_stream = TmuxRuntime::from_app_config(&AppConfig::default())
+            .codex_fork_runtime_artifacts(&spec)
+            .unwrap()
+            .unwrap()
+            .event_stream_path;
+        fs::write(
+            &event_stream,
+            "{\"type\":\"thread/status/changed\",\"payload\":{\"status\":{\"type\":\"active\"}}}\n",
+        )
+        .unwrap();
+
+        assert_eq!(
+            live_activity_state(&AppState::new(AppConfig::default()), &session),
+            Some("working")
+        );
+    }
+
+    #[test]
+    fn codex_fork_completion_fence_parses_python_naive_timestamps() {
+        let task_completed_at = codex_fork_task_completed_at(Some("2026-06-01T00:01:00")).unwrap();
+        let CodexForkTaskCompletion::Known(task_completed_instant) = task_completed_at else {
+            panic!("expected parsed local task completion timestamp");
+        };
+        let local_offset = OffsetDateTime::now_local()
+            .unwrap_or_else(|_| OffsetDateTime::now_utc())
+            .offset();
+        let expected_local = PrimitiveDateTime::parse(
+            "2026-06-01T00:01:00",
+            format_description!("[year]-[month]-[day]T[hour]:[minute]:[second]"),
+        )
+        .unwrap()
+        .assume_offset(local_offset);
+        assert_eq!(
+            task_completed_instant.unix_timestamp(),
+            expected_local.unix_timestamp()
+        );
+
+        let older = CodexForkActivitySignal {
+            activity: "working",
+            observed_at: Some(task_completed_instant - TimeDuration::seconds(1)),
+            undated_status_is_latest_event: false,
+        };
+        let newer = CodexForkActivitySignal {
+            activity: "working",
+            observed_at: Some(task_completed_instant + TimeDuration::seconds(1)),
+            undated_status_is_latest_event: false,
+        };
+        let undated_latest = CodexForkActivitySignal {
+            activity: "working",
+            observed_at: None,
+            undated_status_is_latest_event: true,
+        };
+        let undated_not_latest = CodexForkActivitySignal {
+            activity: "working",
+            observed_at: None,
+            undated_status_is_latest_event: false,
+        };
+        let unknown = codex_fork_task_completed_at(Some("not-a-timestamp")).unwrap();
+
+        assert!(!codex_fork_signal_is_newer_than_task_complete(
+            &older,
+            Some(task_completed_at)
+        ));
+        assert!(codex_fork_signal_is_newer_than_task_complete(
+            &newer,
+            Some(task_completed_at)
+        ));
+        assert!(codex_fork_signal_is_newer_than_task_complete(
+            &undated_latest,
+            Some(task_completed_at)
+        ));
+        assert!(!codex_fork_signal_is_newer_than_task_complete(
+            &undated_not_latest,
+            Some(task_completed_at)
+        ));
+        assert!(!codex_fork_signal_is_newer_than_task_complete(
+            &newer,
+            Some(unknown)
+        ));
     }
 
     #[test]
@@ -11224,6 +11580,27 @@ mod tests {
             Some(PathBuf::from(
                 "/tmp/claude-sessions/session-random.codex-fork.events.jsonl"
             ))
+        );
+    }
+
+    #[test]
+    fn codex_fork_event_stream_path_prefers_newer_derived_over_legacy() {
+        let dir = env::temp_dir().join(format!(
+            "sm-rust-codex-newest-stream-{}-{}",
+            process::id(),
+            random_urlsafe_token(8)
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let log_file = dir.join("codex-fork-abc12345.log");
+        let legacy = dir.join("codex-fork-abc12345.codex-fork.events.jsonl");
+        let derived = dir.join("abc12345-safehash.codex-fork.events.jsonl");
+        fs::write(&legacy, "old\n").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        fs::write(&derived, "new\n").unwrap();
+
+        assert_eq!(
+            codex_fork_newest_event_stream_path("abc12345", &log_file, &derived),
+            derived
         );
     }
 

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -33,6 +33,8 @@ pub struct TmuxRuntime {
     codex_fork_default_model: Option<String>,
     codex_fork_event_schema_version: u32,
     codex_fork_control_tmux_fallback_enabled: bool,
+    tmux_native_scrollback: bool,
+    tmux_history_limit: Option<u64>,
     prompt_mode: String,
     start_settle_ms: u64,
     send_keys_settle_ms: f64,
@@ -88,6 +90,8 @@ impl TmuxRuntime {
             codex_fork_default_model: None,
             codex_fork_event_schema_version: 2,
             codex_fork_control_tmux_fallback_enabled: true,
+            tmux_native_scrollback: config.tmux_native_scrollback.unwrap_or(false),
+            tmux_history_limit: config.tmux_history_limit.filter(|value| *value > 0),
             prompt_mode: config
                 .runtime_prompt_mode
                 .as_deref()
@@ -121,6 +125,12 @@ impl TmuxRuntime {
 
     pub fn from_app_config(config: &AppConfig) -> Self {
         let mut runtime = Self::from_config(&config.rust_core);
+        if config.rust_core.tmux_native_scrollback.is_none() {
+            runtime.tmux_native_scrollback = config.tmux.native_scrollback;
+        }
+        if config.rust_core.tmux_history_limit.is_none() {
+            runtime.tmux_history_limit = config.tmux.history_limit.filter(|value| *value > 0);
+        }
         if config
             .rust_core
             .runtime_command
@@ -200,19 +210,41 @@ impl TmuxRuntime {
         if prompt_mode != "argv" && prompt_mode != "stdin" {
             bail!("unsupported runtime prompt mode: {}", self.prompt_mode);
         }
+        let has_initial_stdin_prompt = prompt_mode == "stdin"
+            && spec
+                .initial_message
+                .as_deref()
+                .map(str::trim)
+                .is_some_and(|value| !value.is_empty());
 
         let mut command = self.launch_command(spec, &prompt_mode)?;
         command = managed_session_command(&command, &spec.session_id);
 
-        self.run_tmux([
-            "new-session",
-            "-d",
-            "-s",
-            spec.tmux_session.as_str(),
-            "-c",
-            spec.working_dir.as_str(),
-            command.as_str(),
-        ])?;
+        let create_result = if self.tmux_history_limit.is_some()
+            || (self.socket_name.is_some() && self.tmux_native_scrollback)
+        {
+            self.create_session_with_bootstrap(spec, &command)
+        } else {
+            let result = self.run_tmux([
+                "new-session",
+                "-d",
+                "-s",
+                spec.tmux_session.as_str(),
+                "-c",
+                spec.working_dir.as_str(),
+                command.as_str(),
+            ]);
+            if result.is_ok() {
+                self.ensure_server_options();
+            }
+            result
+        };
+        if let Err(error) = create_result {
+            if has_initial_stdin_prompt && is_tmux_session_gone_error(&error) {
+                bail!("tmux session exited before initial prompt could be delivered");
+            }
+            return Err(error);
+        }
 
         if let Err(error) = self.attach_session_log(spec, &prompt_mode) {
             let _ = self.kill_session(&spec.tmux_session);
@@ -410,6 +442,82 @@ impl TmuxRuntime {
             .output()
             .with_context(|| "failed to run tmux has-session")?;
         Ok(output.status.success())
+    }
+
+    fn create_session_with_bootstrap(&self, spec: &TmuxSessionSpec, command: &str) -> Result<()> {
+        self.run_tmux([
+            "new-session",
+            "-d",
+            "-s",
+            spec.tmux_session.as_str(),
+            "-c",
+            spec.working_dir.as_str(),
+            "-n",
+            "__sm_bootstrap",
+        ])?;
+
+        let result = (|| {
+            self.ensure_server_options();
+            if let Some(history_limit) = self.tmux_history_limit {
+                let history_limit = history_limit.to_string();
+                self.run_tmux([
+                    "set-option",
+                    "-t",
+                    spec.tmux_session.as_str(),
+                    "history-limit",
+                    history_limit.as_str(),
+                ])?;
+            }
+            self.run_tmux([
+                "new-window",
+                "-d",
+                "-t",
+                spec.tmux_session.as_str(),
+                "-n",
+                "main",
+                "-c",
+                spec.working_dir.as_str(),
+                command,
+            ])?;
+            let bootstrap_window = format!("{}:__sm_bootstrap", spec.tmux_session);
+            self.run_tmux(["kill-window", "-t", bootstrap_window.as_str()])?;
+            let main_window = format!("{}:main", spec.tmux_session);
+            self.run_tmux(["select-window", "-t", main_window.as_str()])?;
+            Ok(())
+        })();
+
+        if result.is_err() {
+            let _ = self.kill_session(&spec.tmux_session);
+        }
+        result
+    }
+
+    fn ensure_server_options(&self) {
+        if self.socket_name.is_none() {
+            return;
+        }
+        let _ = self.run_tmux(["set-option", "-g", "focus-events", "on"]);
+        if !self.tmux_native_scrollback {
+            return;
+        }
+        let current = self
+            .tmux_command(["show-options", "-gqv", "terminal-overrides"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .output()
+            .ok()
+            .filter(|output| output.status.success())
+            .map(|output| String::from_utf8_lossy(&output.stdout).to_string())
+            .unwrap_or_default();
+        if current.contains("smcup@:rmcup@") {
+            return;
+        }
+        let _ = self.run_tmux([
+            "set-option",
+            "-as",
+            "terminal-overrides",
+            ",*:smcup@:rmcup@",
+        ]);
     }
 
     fn pane_in_mode(&self, tmux_session: &str) -> Option<i32> {
@@ -699,7 +807,9 @@ fn duration_from_seconds(seconds: f64) -> Duration {
 
 fn is_tmux_session_gone_error(error: &anyhow::Error) -> bool {
     let message = error.to_string();
-    message.contains("no server running") || message.contains("can't find session")
+    message.contains("no server running")
+        || message.contains("can't find session")
+        || message.contains("server exited unexpectedly")
 }
 
 fn shell_quote_path(path: &Path) -> String {
@@ -929,6 +1039,146 @@ mod tests {
     }
 
     #[test]
+    fn create_session_applies_native_scrollback_and_history_before_provider_window() {
+        let (tmux_binary, log_path, temp_dir) = fake_tmux_binary_with_has_session(false);
+        let mut runtime = TmuxRuntime::from_config(&RustCoreConfig {
+            tmux_socket_name: Some("session-manager".to_owned()),
+            tmux_native_scrollback: Some(true),
+            tmux_history_limit: Some(100000),
+            ..RustCoreConfig::default()
+        });
+        runtime.tmux_binary = tmux_binary.display().to_string();
+        let working_dir = temp_dir.join("repo");
+        fs::create_dir_all(&working_dir).unwrap();
+        let spec = TmuxSessionSpec {
+            session_id: "abc12345".to_owned(),
+            tmux_session: "sm-test".to_owned(),
+            working_dir: working_dir.display().to_string(),
+            log_file: temp_dir.join("session.log"),
+            provider: "claude".to_owned(),
+            initial_message: None,
+            model: None,
+        };
+
+        runtime.create_session(&spec).unwrap();
+
+        let log = fs::read_to_string(log_path).unwrap();
+        let lines = log.lines().collect::<Vec<_>>();
+        let bootstrap = position_after(&lines, "-L session-manager new-session -d -s sm-test", 0);
+        let focus_events = position_after(
+            &lines,
+            "-L session-manager set-option -g focus-events on",
+            bootstrap + 1,
+        );
+        let terminal_overrides = position_after(
+            &lines,
+            "-L session-manager set-option -as terminal-overrides ,*:smcup@:rmcup@",
+            focus_events + 1,
+        );
+        let history_limit = position_after(
+            &lines,
+            "-L session-manager set-option -t sm-test history-limit 100000",
+            terminal_overrides + 1,
+        );
+        let provider_window = position_after(
+            &lines,
+            "-L session-manager new-window -d -t sm-test -n main",
+            history_limit + 1,
+        );
+        let pipe_pane = position_after(
+            &lines,
+            "-L session-manager pipe-pane -t sm-test",
+            provider_window + 1,
+        );
+
+        assert!(bootstrap < focus_events);
+        assert!(focus_events < terminal_overrides);
+        assert!(terminal_overrides < history_limit);
+        assert!(history_limit < provider_window);
+        assert!(provider_window < pipe_pane);
+    }
+
+    #[test]
+    fn runtime_from_default_app_config_uses_tmux_defaults() {
+        let runtime = TmuxRuntime::from_app_config(&AppConfig::default());
+
+        assert!(runtime.tmux_native_scrollback);
+        assert_eq!(runtime.tmux_history_limit, Some(100000));
+    }
+
+    #[test]
+    fn create_session_initializes_socket_options_without_bootstrap() {
+        let (tmux_binary, log_path, temp_dir) = fake_tmux_binary_with_has_session(false);
+        let mut runtime = TmuxRuntime::from_config(&RustCoreConfig {
+            tmux_socket_name: Some("session-manager".to_owned()),
+            tmux_native_scrollback: Some(false),
+            tmux_history_limit: None,
+            ..RustCoreConfig::default()
+        });
+        runtime.tmux_binary = tmux_binary.display().to_string();
+        let working_dir = temp_dir.join("repo");
+        fs::create_dir_all(&working_dir).unwrap();
+        let spec = TmuxSessionSpec {
+            session_id: "abc12345".to_owned(),
+            tmux_session: "sm-test".to_owned(),
+            working_dir: working_dir.display().to_string(),
+            log_file: temp_dir.join("session.log"),
+            provider: "claude".to_owned(),
+            initial_message: None,
+            model: None,
+        };
+
+        runtime.create_session(&spec).unwrap();
+
+        let log = fs::read_to_string(log_path).unwrap();
+        let lines = log.lines().collect::<Vec<_>>();
+        let direct_session =
+            position_after(&lines, "-L session-manager new-session -d -s sm-test", 0);
+        let focus_events = position_after(
+            &lines,
+            "-L session-manager set-option -g focus-events on",
+            direct_session + 1,
+        );
+
+        assert!(direct_session < focus_events);
+        assert!(!log.contains("__sm_bootstrap"));
+        assert!(!log.contains("terminal-overrides ,*:smcup@:rmcup@"));
+        assert!(!log.contains("history-limit"));
+    }
+
+    #[test]
+    fn create_session_does_not_mutate_default_tmux_server_options() {
+        let (tmux_binary, log_path, temp_dir) = fake_tmux_binary_with_has_session(false);
+        let mut runtime = TmuxRuntime::from_config(&RustCoreConfig {
+            tmux_socket_name: None,
+            tmux_native_scrollback: Some(true),
+            tmux_history_limit: None,
+            ..RustCoreConfig::default()
+        });
+        runtime.tmux_binary = tmux_binary.display().to_string();
+        let working_dir = temp_dir.join("repo");
+        fs::create_dir_all(&working_dir).unwrap();
+        let spec = TmuxSessionSpec {
+            session_id: "abc12345".to_owned(),
+            tmux_session: "sm-test".to_owned(),
+            working_dir: working_dir.display().to_string(),
+            log_file: temp_dir.join("session.log"),
+            provider: "claude".to_owned(),
+            initial_message: None,
+            model: None,
+        };
+
+        runtime.create_session(&spec).unwrap();
+
+        let log = fs::read_to_string(log_path).unwrap();
+
+        assert!(log.contains("new-session -d -s sm-test"));
+        assert!(!log.contains("set-option -g focus-events on"));
+        assert!(!log.contains("terminal-overrides ,*:smcup@:rmcup@"));
+        assert!(!log.contains("-L session-manager"));
+    }
+
+    #[test]
     fn clear_session_interrupts_waits_and_prompts_before_success() {
         let (tmux_binary, log_path, _temp_dir) = fake_tmux_binary();
         let mut runtime = TmuxRuntime::from_config(&RustCoreConfig {
@@ -999,6 +1249,10 @@ mod tests {
     }
 
     fn fake_tmux_binary() -> (PathBuf, PathBuf, PathBuf) {
+        fake_tmux_binary_with_has_session(true)
+    }
+
+    fn fake_tmux_binary_with_has_session(has_session: bool) -> (PathBuf, PathBuf, PathBuf) {
         let unique = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
@@ -1015,14 +1269,19 @@ mod tests {
             format!(
                 r#"#!/bin/sh
 printf '%s\n' "$*" >> "{}"
+if [ "$1" = "-L" ]; then
+  shift 2
+fi
 case "$1" in
-  has-session) exit 0 ;;
+  has-session) exit {} ;;
   display-message) echo 0; exit 0 ;;
   capture-pane) printf 'ready\n>\n'; exit 0 ;;
+  show-options) exit 0 ;;
   *) exit 0 ;;
 esac
 "#,
-                log_path.display()
+                log_path.display(),
+                if has_session { 0 } else { 1 }
             ),
         )
         .unwrap();

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -8537,6 +8537,8 @@ fn runtime_core_inherits_existing_tmux_socket_config() {
         r#"
 tmux:
   socket_name: "session-manager"
+  native_scrollback: true
+  history_limit: 100000
 timeouts:
   tmux:
     send_keys_settle_seconds: 0.25
@@ -8555,6 +8557,8 @@ rust_core:
         config.rust_core.tmux_socket_name.as_deref(),
         Some("session-manager")
     );
+    assert_eq!(config.rust_core.tmux_native_scrollback, Some(true));
+    assert_eq!(config.rust_core.tmux_history_limit, Some(100000));
     assert_eq!(config.rust_core.send_keys_settle_ms, Some(250.0));
     assert_eq!(config.rust_core.send_keys_settle_max_ms, Some(1250.0));
     assert_eq!(config.rust_core.send_keys_settle_per_ki_ms, Some(70.0));
@@ -8572,6 +8576,8 @@ tmux:
 rust_core:
   runtime_enabled: true
   tmux_socket_name: "rust-core-only"
+  tmux_native_scrollback: false
+  tmux_history_limit: 50000
 "#,
     )
     .unwrap();
@@ -8581,6 +8587,45 @@ rust_core:
         config.rust_core.tmux_socket_name.as_deref(),
         Some("rust-core-only")
     );
+    assert_eq!(config.rust_core.tmux_native_scrollback, Some(false));
+    assert_eq!(config.rust_core.tmux_history_limit, Some(50000));
+
+    fs::write(
+        &config_path,
+        r#"
+tmux:
+  socket_name: "session-manager"
+rust_core:
+  runtime_enabled: true
+"#,
+    )
+    .unwrap();
+    let config =
+        AppConfig::load_from_path_with_local_env(&config_path, Some(&missing_env_path)).unwrap();
+    assert_eq!(
+        config.rust_core.tmux_socket_name.as_deref(),
+        Some("session-manager")
+    );
+    assert_eq!(config.rust_core.tmux_native_scrollback, Some(true));
+    assert_eq!(config.rust_core.tmux_history_limit, Some(100000));
+
+    fs::write(
+        &config_path,
+        r#"
+rust_core:
+  runtime_enabled: true
+  tmux_socket_name: "session-manager"
+"#,
+    )
+    .unwrap();
+    let config =
+        AppConfig::load_from_path_with_local_env(&config_path, Some(&missing_env_path)).unwrap();
+    assert_eq!(
+        config.rust_core.tmux_socket_name.as_deref(),
+        Some("session-manager")
+    );
+    assert_eq!(config.rust_core.tmux_native_scrollback, Some(true));
+    assert_eq!(config.rust_core.tmux_history_limit, Some(100000));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #1085

## Summary
- read `tmux.native_scrollback` and `tmux.history_limit` into the Rust runtime config while preserving rust_core overrides
- create configured tmux sessions through a bootstrap window so server options/history-limit are applied before the provider pane starts
- initialize SM-owned tmux sockets with focus-events for named-socket launches and no-alt-screen terminal overrides for native scrollback
- make Codex-fork activity use the newer canonical/legacy event stream, ignore stale `agent_task_completed_at` when live activity exists, and accept spinner titles separated by normal whitespace

## Validation
- `cargo fmt --check`
- `cargo test -p sm-server create_session_initializes_socket_options_without_bootstrap -- --nocapture`
- `cargo test -p sm-server create_session_applies_native_scrollback_and_history_before_provider_window -- --nocapture`
- `cargo test -p sm-server codex_fork_event_stream_path_prefers_newer_derived_over_legacy -- --nocapture`
- `cargo test -p sm-server codex_fork_live_activity_overrides_stale_task_complete -- --nocapture`
- `cargo test -p sm-server codex_fork_pane_title_spinner_indicates_working -- --nocapture`
- `cargo test -p sm-server runtime_core_inherits_existing_tmux_socket_config -- --nocapture`
- `cargo test -p sm-server`
- `git diff --check main..HEAD`