### PR TITLE
Drain native rename after metadata update

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -4225,6 +4225,13 @@ async fn update_session_metadata(
                 if state.config.rust_core.runtime_enabled && !session.tmux_session.trim().is_empty()
                 {
                     let runtime = TmuxRuntime::from_app_config(&state.config);
+                    let _ = state
+                        .session_store
+                        .drain_runtime_pending_messages_for_session_category(
+                            &session.id,
+                            &runtime,
+                            Some("native_rename"),
+                        );
                     let _ = runtime.set_status_bar(&session.tmux_session, friendly_name);
                 }
             }

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -1044,6 +1044,74 @@ impl RetainedQueueStore {
         })
     }
 
+    pub fn pending_messages_for_target_by_category(
+        &self,
+        target_session_id: &str,
+        message_category: &str,
+        limit: usize,
+    ) -> Result<Vec<PendingMessage>> {
+        self.with_connection(|conn| {
+            expire_pending_messages_for_target(conn, target_session_id)?;
+            let mut statement = conn.prepare(
+                r#"
+                SELECT id, target_session_id, text, delivery_mode,
+                    CASE WHEN
+                        notify_on_delivery != 0
+                        OR notify_after_seconds IS NOT NULL
+                        OR notify_on_stop != 0
+                        OR remind_soft_threshold IS NOT NULL
+                        OR remind_hard_threshold IS NOT NULL
+                        OR (
+                            remind_cancel_on_reply_session_id IS NOT NULL
+                            AND trim(remind_cancel_on_reply_session_id) != ''
+                        )
+                        OR (
+                            parent_session_id IS NOT NULL
+                            AND trim(parent_session_id) != ''
+                        )
+                    THEN 1 ELSE 0 END AS has_delivery_side_effects,
+                    sender_session_id, sender_name, from_sm_send, notify_on_delivery,
+                    notify_after_seconds, notify_on_stop, remind_soft_threshold,
+                    remind_hard_threshold, remind_cancel_on_reply_session_id,
+                    parent_session_id, message_category, response_relay_source
+                FROM message_queue
+                WHERE target_session_id = ?1
+                    AND message_category = ?2
+                    AND delivered_at IS NULL
+                ORDER BY queued_at ASC, id ASC
+                LIMIT ?3
+                "#,
+            )?;
+            let rows = statement
+                .query_map(
+                    params![target_session_id, message_category, limit.max(1) as i64],
+                    |row| {
+                        Ok(PendingMessage {
+                            id: row.get(0)?,
+                            target_session_id: row.get(1)?,
+                            text: row.get(2)?,
+                            delivery_mode: row.get(3)?,
+                            has_delivery_side_effects: row.get::<_, i64>(4)? != 0,
+                            sender_session_id: row.get(5)?,
+                            sender_name: row.get(6)?,
+                            from_sm_send: row.get::<_, Option<i64>>(7)?.unwrap_or(0) != 0,
+                            notify_on_delivery: row.get::<_, Option<i64>>(8)?.unwrap_or(0) != 0,
+                            notify_after_seconds: row.get::<_, Option<i64>>(9)?.map(i64_to_u64),
+                            notify_on_stop: row.get::<_, Option<i64>>(10)?.unwrap_or(0) != 0,
+                            remind_soft_threshold: row.get::<_, Option<i64>>(11)?.map(i64_to_u64),
+                            remind_hard_threshold: row.get::<_, Option<i64>>(12)?.map(i64_to_u64),
+                            remind_cancel_on_reply_session_id: row.get(13)?,
+                            parent_session_id: row.get(14)?,
+                            message_category: row.get(15)?,
+                            response_relay_source: row.get(16)?,
+                        })
+                    },
+                )?
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            Ok(rows)
+        })
+    }
+
     pub fn mark_delivered(&self, message_id: &str) -> Result<()> {
         self.with_connection(|conn| {
             let _ = mark_delivered_conn(conn, message_id)?;

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -513,6 +513,7 @@ impl SessionStore {
                         } else {
                             None
                         },
+                        None,
                         Some(&message_id),
                     )?
                 };
@@ -740,11 +741,27 @@ impl SessionStore {
         session_id: &str,
         runtime: &TmuxRuntime,
     ) -> Result<()> {
+        self.drain_runtime_pending_messages_for_session_category(session_id, runtime, None)
+    }
+
+    pub fn drain_runtime_pending_messages_for_session_category(
+        &self,
+        session_id: &str,
+        runtime: &TmuxRuntime,
+        message_category: Option<&str>,
+    ) -> Result<()> {
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
         if let Some(queue) = &self.queue_store {
             drain_pending_runtime_messages_raw(
-                self, &mut state, session_id, runtime, queue, None, None,
+                self,
+                &mut state,
+                session_id,
+                runtime,
+                queue,
+                None,
+                message_category,
+                None,
             )?;
             self.write_raw_json_value(&state)?;
         }
@@ -1667,6 +1684,7 @@ impl SessionStore {
                                 runtime,
                                 queue,
                                 Some("important"),
+                                None,
                                 Some(&message_id),
                             )?;
                             if drain
@@ -3866,17 +3884,21 @@ fn drain_pending_runtime_messages_raw(
     runtime: &TmuxRuntime,
     queue: &RetainedQueueStore,
     delivery_mode_filter: Option<&str>,
+    message_category_filter: Option<&str>,
     stop_after_message_id: Option<&str>,
 ) -> Result<QueueDrainResult> {
     let mut status =
         runtime_session_status_raw(state, session_id)?.unwrap_or_else(|| "stopped".to_owned());
     let mut delivered_message_ids = Vec::new();
     loop {
-        let messages = match delivery_mode_filter {
-            Some(delivery_mode) => {
+        let messages = match (delivery_mode_filter, message_category_filter) {
+            (_, Some(message_category)) => {
+                queue.pending_messages_for_target_by_category(session_id, message_category, 10)?
+            }
+            (Some(delivery_mode), None) => {
                 queue.pending_messages_for_target_by_mode(session_id, delivery_mode, 10)?
             }
-            None => queue.pending_messages_for_target(session_id, 10)?,
+            (None, None) => queue.pending_messages_for_target(session_id, 10)?,
         };
         if messages.is_empty() {
             break;
@@ -4004,6 +4026,7 @@ fn complete_runtime_message_delivery_raw(
                 runtime,
                 queue,
                 Some("sequential"),
+                None,
                 None,
             )?;
         }
@@ -4143,6 +4166,7 @@ fn enqueue_stop_notification_raw(
             runtime,
             queue,
             Some("important"),
+            None,
             None,
         )?;
     }

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -9881,6 +9881,102 @@ async fn patch_session_metadata_updates_friendly_name_and_em_state() {
 }
 
 #[tokio::test]
+async fn patch_session_metadata_drains_native_rename_when_runtime_enabled() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let queue_db_path = queue_db_path_for_state_file(&state_file);
+    let log_dir = unique_temp_path();
+    let working_dir = unique_temp_path();
+    fs::create_dir_all(&working_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-name-test-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        sm_send: SmSendConfig {
+            db_path: queue_db_path.display().to_string(),
+        },
+        rust_core: RustCoreConfig {
+            runtime_enabled: true,
+            log_dir: Some(log_dir.display().to_string()),
+            tmux_socket_name: Some(tmux_socket),
+            runtime_command: Some(
+                r#"/bin/sh -lc 'while IFS= read -r line; do printf "line:%s\n" "$line"; done'"#
+                    .to_owned(),
+            ),
+            runtime_prompt_mode: Some("stdin".to_owned()),
+            runtime_start_settle_ms: Some(100),
+            send_keys_settle_ms: Some(10.0),
+            send_keys_settle_max_ms: Some(50.0),
+            ..RustCoreConfig::default()
+        },
+        ..AppConfig::default()
+    }));
+
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "rename-runtime",
+            "name": "rename-runtime",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let queue = RetainedQueueStore::new(queue_db_path.clone());
+    queue
+        .enqueue_message(
+            "rename-runtime",
+            "ordinary queued input",
+            "sequential",
+            None,
+        )
+        .unwrap();
+
+    let (status, payload) = patch_json(
+        app.clone(),
+        "/sessions/rename-runtime",
+        json!({ "friendly_name": "runtime-name" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["friendly_name"], "runtime-name");
+
+    wait_for_output_contains(app.clone(), "rename-runtime", "line:/rename runtime-name").await;
+    let delivered_native_renames: i64 = Connection::open(&queue_db_path)
+        .unwrap()
+        .query_row(
+            "SELECT COUNT(*) FROM message_queue WHERE target_session_id = 'rename-runtime' AND message_category = 'native_rename' AND delivered_at IS NOT NULL",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(delivered_native_renames, 1);
+    let pending_ordinary_messages: i64 = Connection::open(&queue_db_path)
+        .unwrap()
+        .query_row(
+            "SELECT COUNT(*) FROM message_queue WHERE target_session_id = 'rename-runtime' AND message_category IS NULL AND delivered_at IS NULL",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(pending_ordinary_messages, 1);
+}
+
+#[tokio::test]
 async fn patch_session_metadata_rejects_invalid_and_reserved_friendly_names() {
     let state_file = unique_temp_path();
     let log_dir = unique_temp_path();


### PR DESCRIPTION
Fixes #1089

## Summary
- drain queued provider-native `native_rename` messages immediately after `PATCH /sessions/{id}` friendly-name updates when Rust runtime ownership is enabled
- preserve fixture/non-runtime behavior where metadata updates only enqueue the retained message
- add a runtime-enabled tmux regression proving Claude receives `/rename <name>` and the queue row is marked delivered

## Validation
- `cargo fmt --check`
- `cargo test -p sm-server --test read_only_http patch_session_metadata -- --nocapture`
- `cargo test -p sm-server`
- `git diff --check`