### PR TITLE
Fix Android terminal scroll in alternate-screen sessions

### DIFF
--- a/android-app/app/src/main/assets/sm_terminal/terminal.html
+++ b/android-app/app/src/main/assets/sm_terminal/terminal.html
@@ -193,7 +193,68 @@
       return byRows > 0 ? byRows : 16;
     }
 
-    function scrollTerminalByPixels(deltaPixels) {
+    function terminalCellWidth() {
+      const viewport = terminalViewport();
+      const byCols = term.cols > 0 ? viewport.clientWidth / term.cols : 0;
+      return byCols > 0 ? byCols : 8;
+    }
+
+    function terminalUsesAlternateBuffer() {
+      const buffers = term && term.buffer ? term.buffer : null;
+      const activeBuffer = buffers ? buffers.active : null;
+      return Boolean(activeBuffer && (
+        activeBuffer.type === "alternate"
+        || (buffers.alternate && activeBuffer === buffers.alternate)
+      ));
+    }
+
+    function terminalMouseTrackingEnabled() {
+      return Boolean(term && term.modes && term.modes.mouseTrackingMode !== "none");
+    }
+
+    function terminalCellFromClient(clientX, clientY) {
+      const rect = terminalElement.getBoundingClientRect();
+      const fallbackX = rect.left + (rect.width / 2);
+      const fallbackY = rect.top + (rect.height / 2);
+      const x = Number.isFinite(clientX) ? clientX : fallbackX;
+      const y = Number.isFinite(clientY) ? clientY : fallbackY;
+      const col = Math.floor((x - rect.left) / terminalCellWidth()) + 1;
+      const row = Math.floor((y - rect.top) / terminalCellHeight()) + 1;
+      return {
+        col: Math.max(1, Math.min(term.cols || 1, col)),
+        row: Math.max(1, Math.min(term.rows || 1, row))
+      };
+    }
+
+    function sendTerminalWheel(lines, clientX, clientY) {
+      if (!ready || !Number.isFinite(lines) || lines === 0) {
+        return false;
+      }
+      if (!terminalMouseTrackingEnabled()) {
+        return false;
+      }
+      const buttonCode = lines < 0 ? 64 : 65;
+      const count = Math.min(Math.abs(lines), 12);
+      const cell = terminalCellFromClient(clientX, clientY);
+      const sequence = `\x1b[<${buttonCode};${cell.col};${cell.row}M`;
+      for (let i = 0; i < count; i += 1) {
+        bridgeCall("input", sequence);
+      }
+      return true;
+    }
+
+    function scrollTerminalByLines(lines, clientX, clientY) {
+      if (!ready || !Number.isFinite(lines) || lines === 0) {
+        return false;
+      }
+      if (terminalUsesAlternateBuffer() && terminalMouseTrackingEnabled()) {
+        return sendTerminalWheel(lines, clientX, clientY);
+      }
+      term.scrollLines(lines);
+      return true;
+    }
+
+    function scrollTerminalByPixels(deltaPixels, clientX, clientY) {
       if (!ready || !Number.isFinite(deltaPixels)) {
         return false;
       }
@@ -204,8 +265,7 @@
       if (lines === 0) {
         return true;
       }
-      term.scrollLines(lines);
-      return true;
+      return scrollTerminalByLines(lines, clientX, clientY);
     }
 
     function installScrollHandlers() {
@@ -214,7 +274,7 @@
       }
       const target = terminalElement;
       const onWheel = (event) => {
-        if (scrollTerminalByPixels(event.deltaY)) {
+        if (scrollTerminalByPixels(event.deltaY, event.clientX, event.clientY)) {
           event.preventDefault();
         }
       };
@@ -234,7 +294,7 @@
         const currentY = event.touches[0].clientY;
         const deltaY = lastTouchY - currentY;
         lastTouchY = currentY;
-        if (scrollTerminalByPixels(deltaY)) {
+        if (scrollTerminalByPixels(deltaY, event.touches[0].clientX, currentY)) {
           event.preventDefault();
         }
       };
@@ -388,17 +448,17 @@
       ensureTerminalOpen();
     };
 
-    window.smScrollPixels = function(deltaPixels) {
-      return scrollTerminalByPixels(Number(deltaPixels) || 0);
+    window.smScrollPixels = function(deltaPixels, clientX, clientY) {
+      return scrollTerminalByPixels(
+        Number(deltaPixels) || 0,
+        Number(clientX),
+        Number(clientY)
+      );
     };
 
-    window.smScrollLines = function(lines) {
+    window.smScrollLines = function(lines, clientX, clientY) {
       const parsed = Number(lines) || 0;
-      if (!ready || parsed === 0) {
-        return false;
-      }
-      term.scrollLines(parsed);
-      return true;
+      return scrollTerminalByLines(parsed, Number(clientX), Number(clientY));
     };
 
     window.smCopySelection = function() {

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
@@ -590,7 +590,10 @@ private fun TerminalWebView(
             .pointerInput(Unit) {
                 detectVerticalDragGestures { change, dragAmount ->
                     change.consume()
-                    webViewRef?.evaluateJavascript("window.smScrollPixels(${-dragAmount});", null)
+                    webViewRef?.evaluateJavascript(
+                        "window.smScrollPixels(${-dragAmount}, ${change.position.x}, ${change.position.y});",
+                        null,
+                    )
                 }
             },
         factory = { context ->

--- a/tests/unit/test_android_terminal_renderer_asset.py
+++ b/tests/unit/test_android_terminal_renderer_asset.py
@@ -41,3 +41,19 @@ def test_terminal_asset_reports_write_acks_and_renderer_errors():
     assert "bridgeCall(\"written\", String(frame.sequence), byteCount)" in source
     assert "bridgeCall(\"error\", message)" in source
     assert "Terminal write failed" in source
+
+
+def test_terminal_asset_forwards_alternate_screen_scroll_as_wheel_input():
+    source = TERMINAL_ASSET.read_text()
+
+    assert "function terminalUsesAlternateBuffer()" in source
+    assert "activeBuffer.type === \"alternate\"" in source
+    assert "function terminalMouseTrackingEnabled()" in source
+    assert "term.modes.mouseTrackingMode !== \"none\"" in source
+    assert "function terminalCellFromClient(clientX, clientY)" in source
+    assert "function sendTerminalWheel(lines, clientX, clientY)" in source
+    assert "const buttonCode = lines < 0 ? 64 : 65;" in source
+    assert "const sequence = `\\x1b[<${buttonCode};${cell.col};${cell.row}M`;" in source
+    assert "bridgeCall(\"input\", sequence)" in source
+    assert "return scrollTerminalByLines(lines, clientX, clientY);" in source
+    assert "return scrollTerminalByLines(parsed, Number(clientX), Number(clientY));" in source


### PR DESCRIPTION
## Summary
- keep normal xterm.js scrollback behavior for normal terminal buffers
- forward bounded SGR wheel input when the renderer is in an alternate-screen buffer, which lets tmux/Claude handle mobile drag scrolls
- add a renderer asset assertion for the alternate-screen scroll path

## Validation
- ./venv/bin/python -m pytest tests/unit/test_android_terminal_renderer_asset.py -q
- cd android-app && ./gradlew assembleDebug
- git diff --check

Fixes #1091