### PR TITLE
Fix Android terminal scroll coordinate scaling

### DIFF
--- a/android-app/app/src/main/assets/sm_terminal/terminal.html
+++ b/android-app/app/src/main/assets/sm_terminal/terminal.html
@@ -268,14 +268,27 @@
       return scrollTerminalByLines(lines, clientX, clientY);
     }
 
+    function wheelDeltaPixels(event) {
+      if (event.deltaMode === WheelEvent.DOM_DELTA_LINE) {
+        return event.deltaY * terminalCellHeight();
+      }
+      if (event.deltaMode === WheelEvent.DOM_DELTA_PAGE) {
+        return event.deltaY * terminalViewport().clientHeight;
+      }
+      return event.deltaY;
+    }
+
     function installScrollHandlers() {
       if (scrollHandlersInstalled || !opened) {
         return;
       }
       const target = terminalElement;
       const onWheel = (event) => {
-        if (scrollTerminalByPixels(event.deltaY, event.clientX, event.clientY)) {
+        if (scrollTerminalByPixels(wheelDeltaPixels(event), event.clientX, event.clientY)) {
           event.preventDefault();
+          if (terminalUsesAlternateBuffer() && terminalMouseTrackingEnabled()) {
+            event.stopPropagation();
+          }
         }
       };
       const onTouchStart = (event) => {

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
@@ -75,6 +75,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -576,6 +577,7 @@ private fun TerminalWebView(
     var deliveredCopyRequest by remember { mutableStateOf(0L) }
     var terminalReady by remember { mutableStateOf(false) }
     var webViewRef by remember { mutableStateOf<WebView?>(null) }
+    val density = LocalDensity.current.density
 
     androidx.compose.runtime.DisposableEffect(Unit) {
         onDispose {
@@ -587,11 +589,14 @@ private fun TerminalWebView(
     AndroidView(
         modifier = Modifier
             .fillMaxSize()
-            .pointerInput(Unit) {
+            .pointerInput(density) {
                 detectVerticalDragGestures { change, dragAmount ->
                     change.consume()
+                    val cssDelta = -dragAmount / density
+                    val cssX = change.position.x / density
+                    val cssY = change.position.y / density
                     webViewRef?.evaluateJavascript(
-                        "window.smScrollPixels(${-dragAmount}, ${change.position.x}, ${change.position.y});",
+                        "window.smScrollPixels($cssDelta, $cssX, $cssY);",
                         null,
                     )
                 }

--- a/tests/unit/test_android_terminal_renderer_asset.py
+++ b/tests/unit/test_android_terminal_renderer_asset.py
@@ -11,6 +11,20 @@ TERMINAL_ASSET = (
     / "sm_terminal"
     / "terminal.html"
 )
+WATCH_SCREEN = (
+    Path(__file__).resolve().parents[2]
+    / "android-app"
+    / "app"
+    / "src"
+    / "main"
+    / "java"
+    / "li"
+    / "rajeshgo"
+    / "sm"
+    / "ui"
+    / "watch"
+    / "WatchScreen.kt"
+)
 
 
 def test_terminal_asset_waits_for_layout_before_reporting_ready():
@@ -52,8 +66,26 @@ def test_terminal_asset_forwards_alternate_screen_scroll_as_wheel_input():
     assert "term.modes.mouseTrackingMode !== \"none\"" in source
     assert "function terminalCellFromClient(clientX, clientY)" in source
     assert "function sendTerminalWheel(lines, clientX, clientY)" in source
+    assert "function wheelDeltaPixels(event)" in source
+    assert "event.deltaMode === WheelEvent.DOM_DELTA_LINE" in source
+    assert "event.deltaMode === WheelEvent.DOM_DELTA_PAGE" in source
+    assert "return event.deltaY * terminalCellHeight();" in source
+    assert "return event.deltaY * terminalViewport().clientHeight;" in source
     assert "const buttonCode = lines < 0 ? 64 : 65;" in source
     assert "const sequence = `\\x1b[<${buttonCode};${cell.col};${cell.row}M`;" in source
     assert "bridgeCall(\"input\", sequence)" in source
+    assert "event.stopPropagation()" in source
+    assert "scrollTerminalByPixels(wheelDeltaPixels(event), event.clientX, event.clientY)" in source
     assert "return scrollTerminalByLines(lines, clientX, clientY);" in source
     assert "return scrollTerminalByLines(parsed, Number(clientX), Number(clientY));" in source
+
+
+def test_terminal_webview_converts_compose_drag_coordinates_to_css_pixels():
+    source = WATCH_SCREEN.read_text()
+
+    assert "import androidx.compose.ui.platform.LocalDensity" in source
+    assert "val density = LocalDensity.current.density" in source
+    assert "val cssDelta = -dragAmount / density" in source
+    assert "val cssX = change.position.x / density" in source
+    assert "val cssY = change.position.y / density" in source
+    assert "\"window.smScrollPixels($cssDelta, $cssX, $cssY);\"" in source


### PR DESCRIPTION
## Summary
- convert Compose drag delta and coordinates from physical px to WebView CSS px before calling the terminal renderer
- stop propagation when the renderer forwards a real mouse-tracking wheel event, avoiding duplicate xterm wheel delivery
- add source assertions for the density conversion and wheel forwarding behavior

## Validation
- `./venv/bin/python -m pytest tests/unit/test_android_terminal_renderer_asset.py -q`
- `cd android-app && SM_VERSION_CODE=1074 SM_VERSION_NAME=0.1.4-terminal-scroll-coords ./gradlew assembleDebug`
- `git diff --check`

Fixes #1093