### PR TITLE
Add Android terminal page-scroll fallback

### DIFF
--- a/android-app/app/src/main/assets/sm_terminal/terminal.html
+++ b/android-app/app/src/main/assets/sm_terminal/terminal.html
@@ -243,12 +243,27 @@
       return true;
     }
 
+    function sendTerminalPageScroll(lines) {
+      if (!ready || !Number.isFinite(lines) || lines === 0) {
+        return false;
+      }
+      const sequence = lines < 0 ? "\x1b[5~" : "\x1b[6~";
+      const count = Math.min(Math.max(1, Math.ceil(Math.abs(lines) / 6)), 3);
+      for (let i = 0; i < count; i += 1) {
+        bridgeCall("input", sequence);
+      }
+      return true;
+    }
+
     function scrollTerminalByLines(lines, clientX, clientY) {
       if (!ready || !Number.isFinite(lines) || lines === 0) {
         return false;
       }
-      if (terminalUsesAlternateBuffer() && terminalMouseTrackingEnabled()) {
-        return sendTerminalWheel(lines, clientX, clientY);
+      if (terminalUsesAlternateBuffer()) {
+        if (terminalMouseTrackingEnabled()) {
+          return sendTerminalWheel(lines, clientX, clientY);
+        }
+        return sendTerminalPageScroll(lines);
       }
       term.scrollLines(lines);
       return true;

--- a/tests/unit/test_android_terminal_renderer_asset.py
+++ b/tests/unit/test_android_terminal_renderer_asset.py
@@ -66,6 +66,9 @@ def test_terminal_asset_forwards_alternate_screen_scroll_as_wheel_input():
     assert "term.modes.mouseTrackingMode !== \"none\"" in source
     assert "function terminalCellFromClient(clientX, clientY)" in source
     assert "function sendTerminalWheel(lines, clientX, clientY)" in source
+    assert "function sendTerminalPageScroll(lines)" in source
+    assert "const sequence = lines < 0 ? \"\\x1b[5~\" : \"\\x1b[6~\";" in source
+    assert "Math.ceil(Math.abs(lines) / 6)" in source
     assert "function wheelDeltaPixels(event)" in source
     assert "event.deltaMode === WheelEvent.DOM_DELTA_LINE" in source
     assert "event.deltaMode === WheelEvent.DOM_DELTA_PAGE" in source
@@ -76,6 +79,7 @@ def test_terminal_asset_forwards_alternate_screen_scroll_as_wheel_input():
     assert "bridgeCall(\"input\", sequence)" in source
     assert "event.stopPropagation()" in source
     assert "scrollTerminalByPixels(wheelDeltaPixels(event), event.clientX, event.clientY)" in source
+    assert "return sendTerminalPageScroll(lines);" in source
     assert "return scrollTerminalByLines(lines, clientX, clientY);" in source
     assert "return scrollTerminalByLines(parsed, Number(clientX), Number(clientY));" in source
 


### PR DESCRIPTION
## Summary
- fall back to PageUp/PageDown terminal key sequences for alternate-screen sessions without mouse tracking
- keep mouse-aware alternate-screen scrolling on SGR wheel events and normal-buffer scrolling on xterm local scrollback
- add renderer asset assertions for the fallback path

## Validation
- `./venv/bin/python -m pytest tests/unit/test_android_terminal_renderer_asset.py -q`
- `cd android-app && SM_VERSION_CODE=1075 SM_VERSION_NAME=0.1.5-terminal-scroll-page-fallback ./gradlew assembleDebug`
- `git diff --check`

Fixes #1095