### PR TITLE
Send Claude mobile drag scroll directly

### DIFF
--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
@@ -396,6 +396,7 @@ fun WatchScreen(
                 onEnter = { viewModel.sendTerminalKey("enter") },
                 onTerminalInput = viewModel::sendTerminalData,
                 onTerminalResize = viewModel::resizeTerminal,
+                onTerminalPageScroll = viewModel::sendTerminalPageScroll,
                 onRendererStatus = viewModel::markTerminalRendererStatus,
                 onRendererReady = viewModel::markTerminalRendererReady,
                 onRendererError = viewModel::markTerminalRendererError,
@@ -422,6 +423,7 @@ private fun MobileTerminalOverlay(
     onEnter: () -> Unit,
     onTerminalInput: (String) -> Unit,
     onTerminalResize: (cols: Int, rows: Int) -> Unit,
+    onTerminalPageScroll: (up: Boolean) -> Unit,
     onRendererStatus: (String) -> Unit,
     onRendererReady: (cols: Int, rows: Int) -> Unit,
     onRendererError: (String) -> Unit,
@@ -503,6 +505,7 @@ private fun MobileTerminalOverlay(
                     copyRequest = copyRequest,
                     onInput = onTerminalInput,
                     onResize = onTerminalResize,
+                    onPageScroll = onTerminalPageScroll,
                     onRendererStatus = onRendererStatus,
                     onRendererReady = onRendererReady,
                     onRendererError = onRendererError,
@@ -567,6 +570,7 @@ private fun TerminalWebView(
     copyRequest: Long,
     onInput: (String) -> Unit,
     onResize: (cols: Int, rows: Int) -> Unit,
+    onPageScroll: (up: Boolean) -> Unit,
     onRendererStatus: (String) -> Unit,
     onRendererReady: (cols: Int, rows: Int) -> Unit,
     onRendererError: (String) -> Unit,
@@ -577,7 +581,9 @@ private fun TerminalWebView(
     var deliveredCopyRequest by remember { mutableStateOf(0L) }
     var terminalReady by remember { mutableStateOf(false) }
     var webViewRef by remember { mutableStateOf<WebView?>(null) }
+    var claudePageScrollRemainder by remember { mutableStateOf(0f) }
     val density = LocalDensity.current.density
+    val claudeDirectPageScroll = terminal.provider == "claude"
 
     androidx.compose.runtime.DisposableEffect(Unit) {
         onDispose {
@@ -589,16 +595,32 @@ private fun TerminalWebView(
     AndroidView(
         modifier = Modifier
             .fillMaxSize()
-            .pointerInput(density) {
-                detectVerticalDragGestures { change, dragAmount ->
-                    change.consume()
-                    val cssDelta = -dragAmount / density
-                    val cssX = change.position.x / density
-                    val cssY = change.position.y / density
-                    webViewRef?.evaluateJavascript(
-                        "window.smScrollPixels($cssDelta, $cssX, $cssY);",
-                        null,
-                    )
+            .pointerInput(density, claudeDirectPageScroll) {
+                detectVerticalDragGestures(
+                    onDragStart = { claudePageScrollRemainder = 0f },
+                    onDragEnd = { claudePageScrollRemainder = 0f },
+                    onDragCancel = { claudePageScrollRemainder = 0f },
+                ) { change, dragAmount ->
+                        change.consume()
+                        val cssDelta = -dragAmount / density
+                        if (claudeDirectPageScroll) {
+                            claudePageScrollRemainder += cssDelta
+                            val threshold = 72f
+                            if (claudePageScrollRemainder <= -threshold) {
+                                onPageScroll(true)
+                                claudePageScrollRemainder = 0f
+                            } else if (claudePageScrollRemainder >= threshold) {
+                                onPageScroll(false)
+                                claudePageScrollRemainder = 0f
+                            }
+                            return@detectVerticalDragGestures
+                        }
+                        val cssX = change.position.x / density
+                        val cssY = change.position.y / density
+                        webViewRef?.evaluateJavascript(
+                            "window.smScrollPixels($cssDelta, $cssX, $cssY);",
+                            null,
+                        )
                 }
             },
         factory = { context ->

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchViewModel.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchViewModel.kt
@@ -27,6 +27,7 @@ import li.rajeshgo.sm.data.security.DeviceKeyManager
 data class TerminalUiState(
     val sessionId: String,
     val title: String,
+    val provider: String? = null,
     val status: String = "connecting",
     val rendererCols: Int = 0,
     val rendererRows: Int = 0,
@@ -274,6 +275,7 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
                 terminal = TerminalUiState(
                     sessionId = session.id,
                     title = sessionDisplayName(session),
+                    provider = session.provider,
                     status = "requesting ticket",
                 )
             )
@@ -510,6 +512,10 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
 
     fun sendTerminalKey(key: String) {
         terminalSocket?.send(JSONObject().put("type", "key").put("key", key).toString())
+    }
+
+    fun sendTerminalPageScroll(up: Boolean) {
+        sendTerminalData(if (up) "\u001b[5~" else "\u001b[6~")
     }
 
     fun resizeTerminal(cols: Int, rows: Int) {

--- a/tests/unit/test_android_terminal_renderer_asset.py
+++ b/tests/unit/test_android_terminal_renderer_asset.py
@@ -89,7 +89,14 @@ def test_terminal_webview_converts_compose_drag_coordinates_to_css_pixels():
 
     assert "import androidx.compose.ui.platform.LocalDensity" in source
     assert "val density = LocalDensity.current.density" in source
+    assert "val claudeDirectPageScroll = terminal.provider == \"claude\"" in source
+    assert "onDragStart = { claudePageScrollRemainder = 0f }" in source
+    assert "onDragEnd = { claudePageScrollRemainder = 0f }" in source
+    assert "onDragCancel = { claudePageScrollRemainder = 0f }" in source
     assert "val cssDelta = -dragAmount / density" in source
+    assert "claudePageScrollRemainder += cssDelta" in source
+    assert "onPageScroll(true)" in source
+    assert "onPageScroll(false)" in source
     assert "val cssX = change.position.x / density" in source
     assert "val cssY = change.position.y / density" in source
     assert "\"window.smScrollPixels($cssDelta, $cssX, $cssY);\"" in source


### PR DESCRIPTION
## Summary
- carry the session provider into the mobile terminal state
- for Claude mobile terminal attaches, convert drag gestures into bounded PageUp/PageDown sequences sent directly over the terminal WebSocket
- keep the WebView/xterm scroll paths for non-Claude sessions

## Validation
- `./venv/bin/python -m pytest tests/unit/test_android_terminal_renderer_asset.py -q`
- `cd android-app && SM_VERSION_CODE=1076 SM_VERSION_NAME=0.1.6-claude-direct-scroll ./gradlew assembleDebug`
- `git diff --check`

Fixes #1097