### PR TITLE
Persistently disable legacy Python service during Rust cutover

### DIFF
--- a/scripts/rust-service-cutover.sh
+++ b/scripts/rust-service-cutover.sh
@@ -51,8 +51,8 @@ Commands:
   plan             Show Rust service command, launchd paths, port owners, and blockers.
   render-plist     Print the Rust launchd plist to stdout.
   write-plist      Write the Rust launchd plist, but do not load it.
-  stop-python      Unload known Python Session Manager launchd labels, then verify the port is free.
-  start-rust       Write/load the Rust launchd plist. Refuses if the port is occupied.
+  stop-python      Disable/unload known Python Session Manager launchd labels, then verify the port is free.
+  start-rust       Write/load the Rust launchd plist. Refuses if the port is occupied or Python is loaded.
   stop-rust        Unload the Rust launchd label.
   restart-rust     stop-rust then start-rust.
   rollback-python  Stop Rust and bootstrap the existing Python launchd plist if present.
@@ -192,6 +192,46 @@ collect_blockers() {
   printf '%s\n' "${blockers[@]}"
 }
 
+loaded_python_labels() {
+  for label in "${PYTHON_LABELS[@]}"; do
+    if launchctl_print_label "$label"; then
+      printf '%s\n' "$label"
+    fi
+  done
+}
+
+is_label_disabled() {
+  local label="$1"
+  launchctl print-disabled "$DOMAIN" 2>/dev/null \
+    | grep -F "\"$label\" => disabled" >/dev/null
+}
+
+disable_python_label() {
+  local label="$1"
+  if ! launchctl disable "$DOMAIN/$label"; then
+    echo "failed to disable $label in $DOMAIN" >&2
+    exit 1
+  fi
+  if ! is_label_disabled "$label"; then
+    echo "failed to verify disabled override for $label in $DOMAIN" >&2
+    exit 1
+  fi
+}
+
+require_no_python_labels() {
+  local labels
+  labels="$(loaded_python_labels)"
+  if [[ -n "$labels" ]]; then
+    echo "known Python Session Manager launchd labels are still loaded:" >&2
+    while IFS= read -r label; do
+      [[ -z "$label" ]] && continue
+      echo "  - $label" >&2
+    done <<< "$labels"
+    echo "run: $0 stop-python" >&2
+    exit 1
+  fi
+}
+
 print_plan() {
   echo "Rust Session Manager service cutover plan"
   echo "repo_root: $REPO_ROOT"
@@ -299,6 +339,7 @@ stop_rust() {
 
 start_rust() {
   require_no_blockers
+  require_no_python_labels
   write_plist
   if launchctl_print_label "$RUST_LABEL"; then
     launchctl bootout "$DOMAIN/$RUST_LABEL" || true
@@ -310,9 +351,12 @@ start_rust() {
 
 stop_python() {
   for label in "${PYTHON_LABELS[@]}"; do
+    disable_python_label "$label"
     if launchctl_print_label "$label"; then
       launchctl bootout "$DOMAIN/$label" || true
-      echo "stopped $label"
+      echo "disabled and stopped $label"
+    else
+      echo "disabled $label"
     fi
   done
   sleep 1
@@ -341,9 +385,10 @@ rollback_python() {
     echo "no Python Session Manager plist found in ~/Library/LaunchAgents" >&2
     exit 1
   fi
-  launchctl bootstrap "$DOMAIN" "$python_plist" 2>/dev/null || true
   local label
   label="$(/usr/libexec/PlistBuddy -c 'Print :Label' "$python_plist")"
+  launchctl enable "$DOMAIN/$label" 2>/dev/null || true
+  launchctl bootstrap "$DOMAIN" "$python_plist" 2>/dev/null || true
   launchctl kickstart -k "$DOMAIN/$label" || true
   echo "bootstrapped Python service from $python_plist"
 }

--- a/specs/762_stage5_artifacts/rust_service_cutover_runbook.md
+++ b/specs/762_stage5_artifacts/rust_service_cutover_runbook.md
@@ -11,7 +11,8 @@ freeze/drain ledger, Rust launchd ownership, and rollback commands explicit.
 
 - Rust owns the service port (`127.0.0.1:8420`) through launchd label
   `com.rajeshgoli.session-manager-rust`.
-- Python launchd labels are stopped only by label, not by arbitrary port kill.
+- Python launchd labels are disabled/stopped only by label, not by arbitrary
+  port kill.
 - Rust refuses to start when the target port is already occupied.
 - Final backup is copied only after Python is stopped and the health probe is
   connection-refused for the configured hold window.
@@ -63,7 +64,7 @@ stopped-origin final backup.
 
 ## Stop Python And Create Final Backup
 
-Stop only known Python Session Manager launchd labels:
+Disable and stop only known Python Session Manager launchd labels:
 
 ```bash
 ./scripts/rust-service-cutover.sh stop-python
@@ -82,7 +83,9 @@ Create the final stopped-origin backup and ledger:
 ```
 
 Do not start Rust if this command blocks. Fix the blocker or restart Python
-with `./scripts/rust-service-cutover.sh rollback-python`.
+with `./scripts/rust-service-cutover.sh rollback-python`. The stop command
+persists the Python label disablement so a reboot does not bring Python up
+beside Rust.
 
 ## Start Rust
 
@@ -98,6 +101,9 @@ The helper writes:
 - plist: `~/Library/LaunchAgents/com.rajeshgoli.session-manager-rust.plist`
 - stdout: `logs/rust-launchd.out.log`
 - stderr: `logs/rust-launchd.err.log`
+
+`start-rust` refuses to proceed while any known Python Session Manager launchd
+label is still loaded, even if Rust could bind the configured host/port.
 
 ## Protected Public Tunnel
 

--- a/tests/unit/test_rust_service_cutover_script.py
+++ b/tests/unit/test_rust_service_cutover_script.py
@@ -87,3 +87,14 @@ def test_rust_service_cutover_render_plist_uses_rust_binary_and_config(tmp_path)
         str(config),
     ]
     assert plist["WorkingDirectory"] == str(REPO_ROOT)
+
+
+def test_rust_service_cutover_persistently_disables_python_and_reenables_on_rollback():
+    script = SCRIPT.read_text(encoding="utf-8")
+
+    assert 'launchctl disable "$DOMAIN/$label"; then' in script
+    assert 'is_label_disabled "$label"' in script
+    assert 'failed to verify disabled override for $label' in script
+    assert 'echo "disabled and stopped $label"' in script
+    assert 'require_no_python_labels' in script
+    assert 'launchctl enable "$DOMAIN/$label"' in script


### PR DESCRIPTION
Fixes #1099\n\n## Summary\n- make stop-python persistently disable known Python launchd labels before bootout\n- make start-rust refuse to proceed while a known Python label is still loaded\n- make rollback-python explicitly re-enable the Python label\n- update the Rust service cutover runbook and focused tests\n\n## Validation\n- ./venv/bin/python -m pytest tests/unit/test_rust_service_cutover_script.py -q\n- bash -n scripts/rust-service-cutover.sh\n- ./scripts/rust-service-cutover.sh status\n- git diff --check -- scripts/rust-service-cutover.sh tests/unit/test_rust_service_cutover_script.py specs/762_stage5_artifacts/rust_service_cutover_runbook.md