### PR TITLE
Restore Claude sessions with transcript resume id

### DIFF
--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -263,11 +263,8 @@ impl TmuxRuntime {
         if let Some(resume_id) = resume_id.map(str::trim).filter(|value| !value.is_empty()) {
             match provider {
                 "claude" => {
-                    runtime.claude_command = format!(
-                        "{} --resume {}",
-                        runtime.claude_command,
-                        shell_quote(resume_id)
-                    );
+                    runtime.claude_args.push("--resume".to_owned());
+                    runtime.claude_args.push(resume_id.to_owned());
                 }
                 "codex-fork" => {
                     runtime.codex_fork_args =
@@ -1173,6 +1170,49 @@ mod tests {
         assert!(!log.contains("set-option -g focus-events on"));
         assert!(!log.contains("terminal-overrides ,*:smcup@:rmcup@"));
         assert!(!log.contains("-L session-manager"));
+    }
+
+    #[test]
+    fn restore_claude_session_preserves_configured_args_before_resume() {
+        let (tmux_binary, log_path, temp_dir) = fake_tmux_binary_with_has_session(false);
+        let mut runtime = TmuxRuntime::from_config(&RustCoreConfig::default());
+        runtime.tmux_binary = tmux_binary.display().to_string();
+        runtime.claude_command = "claude".to_owned();
+        runtime.claude_args = vec![
+            "--dangerously-skip-permissions".to_owned(),
+            "--some flag".to_owned(),
+        ];
+        let working_dir = temp_dir.join("repo");
+        fs::create_dir_all(&working_dir).unwrap();
+        let spec = TmuxSessionSpec {
+            session_id: "abc12345".to_owned(),
+            tmux_session: "sm-test".to_owned(),
+            working_dir: working_dir.display().to_string(),
+            log_file: temp_dir.join("session.log"),
+            provider: "claude".to_owned(),
+            initial_message: None,
+            model: None,
+        };
+
+        runtime
+            .restore_session(&spec, "claude", Some("resume'id"))
+            .unwrap();
+
+        let log = fs::read_to_string(log_path).unwrap();
+        let command_line = log
+            .lines()
+            .find(|line| line.contains("claude") && line.contains("SESSION_MANAGER_ID"))
+            .unwrap_or_else(|| panic!("missing claude restore launch in log: {log}"));
+        let dangerous = command_line
+            .find("'--dangerously-skip-permissions'")
+            .expect(command_line);
+        let custom_arg = command_line.find("'--some flag'").expect(command_line);
+        let resume_flag = command_line.find("'--resume'").expect(command_line);
+        let resume_id = command_line.find("'resume'\\''id'").expect(command_line);
+
+        assert!(dangerous < custom_arg);
+        assert!(custom_arg < resume_flag);
+        assert!(resume_flag < resume_id);
     }
 
     #[test]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -936,14 +936,8 @@ impl SessionStore {
                 record.provider,
             )));
         }
-        if record.provider == "codex-fork"
-            && record
-                .provider_resume_id
-                .as_deref()
-                .map(str::trim)
-                .filter(|value| !value.is_empty())
-                .is_none()
-        {
+        let provider_resume_id = provider_resume_id_for_restore(&record);
+        if provider_resume_id.is_none() {
             return Ok(Some(CoreRestoreOutcome::MissingProviderResumeId(
                 record.provider,
             )));
@@ -971,11 +965,7 @@ impl SessionStore {
             model: record.model.clone(),
         };
         let codex_fork_artifacts = session_runtime.codex_fork_runtime_artifacts(&spec)?;
-        session_runtime.restore_session(
-            &spec,
-            &record.provider,
-            record.provider_resume_id.as_deref(),
-        )?;
+        session_runtime.restore_session(&spec, &record.provider, provider_resume_id.as_deref())?;
 
         let now = now_rfc3339();
         session.insert("status".to_owned(), Value::String("running".to_owned()));
@@ -990,6 +980,20 @@ impl SessionStore {
                 "tmux_socket_name".to_owned(),
                 Value::String(socket_name.to_owned()),
             );
+        }
+        if record
+            .provider_resume_id
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            != provider_resume_id.as_deref()
+        {
+            if let Some(provider_resume_id) = provider_resume_id {
+                session.insert(
+                    "provider_resume_id".to_owned(),
+                    Value::String(provider_resume_id),
+                );
+            }
         }
         let restored = serde_json::from_value::<SessionRecord>(Value::Object(session.clone()))?;
         self.write_raw_json_value(&state)?;
@@ -4673,6 +4677,24 @@ fn provider_resume_id_from_transcript_path(transcript_path: &str) -> Option<Stri
         .map(ToOwned::to_owned)
 }
 
+fn provider_resume_id_for_restore(record: &SessionRecord) -> Option<String> {
+    if record.provider == "claude" {
+        if let Some(resume_id) = record
+            .transcript_path
+            .as_deref()
+            .and_then(provider_resume_id_from_transcript_path)
+        {
+            return Some(resume_id);
+        }
+    }
+    record
+        .provider_resume_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
 fn append_log_line(path: &Path, line: &str) -> Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)
@@ -6078,6 +6100,43 @@ mod tests {
 
         assert!(stale.aliases.is_empty());
         assert_eq!(restorable.aliases, vec!["restorable-role"]);
+    }
+
+    #[test]
+    fn claude_restore_resume_id_falls_back_to_transcript_stem() {
+        let mut session = session_record("stopped");
+        session.provider = "claude".to_owned();
+        session.provider_resume_id = None;
+        session.transcript_path =
+            Some("/Users/rajesh/.claude/projects/repo/resume-uuid.jsonl".to_owned());
+
+        assert_eq!(
+            provider_resume_id_for_restore(&session).as_deref(),
+            Some("resume-uuid")
+        );
+    }
+
+    #[test]
+    fn claude_transcript_path_wins_over_stale_provider_resume_id() {
+        let mut session = session_record("stopped");
+        session.provider = "claude".to_owned();
+        session.provider_resume_id = Some("stale-id".to_owned());
+        session.transcript_path = Some("/tmp/transcript-id.jsonl".to_owned());
+
+        assert_eq!(
+            provider_resume_id_for_restore(&session).as_deref(),
+            Some("transcript-id")
+        );
+    }
+
+    #[test]
+    fn claude_restore_resume_id_is_missing_without_resume_metadata() {
+        let mut session = session_record("stopped");
+        session.provider = "claude".to_owned();
+        session.provider_resume_id = None;
+        session.transcript_path = None;
+
+        assert_eq!(provider_resume_id_for_restore(&session), None);
     }
 
     fn unique_temp_path(label: &str) -> PathBuf {


### PR DESCRIPTION
Fixes #1101\n\n## Summary\n- derive Claude restore resume ids from transcript_path when provider_resume_id is missing\n- persist the derived provider_resume_id after a successful restore\n- append Claude --resume through the configured argv path so configured Claude args are preserved\n- add focused restore tests for transcript fallback, stored-id precedence, missing metadata, and launch arg ordering\n\n## Validation\n- cargo fmt\n- cargo test -p sm-server restore\n- cargo test -p sm-server provider_resume_id