### PR TITLE
Detect codex-fork launchd spinner fallback

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -7861,6 +7861,9 @@ fn codex_fork_pane_title_indicates_working(pane_title: &str) -> bool {
     if chars.next().is_some() {
         return false;
     }
+    if first == '_' {
+        return true;
+    }
     (0x2801..=0x28ff).contains(&(first as u32))
 }
 
@@ -11187,6 +11190,7 @@ mod tests {
         assert!(codex_fork_pane_title_indicates_working(
             "⠏\tfractal-algo-rust"
         ));
+        assert!(codex_fork_pane_title_indicates_working("_ session-manager"));
         assert!(!codex_fork_pane_title_indicates_working(
             "fractal-algo-rust"
         ));


### PR DESCRIPTION
Fixes #1103\n\n## Summary\n- treat the launchd/tmux ASCII underscore spinner fallback as codex-fork working activity\n- add focused coverage for the fallback title form\n\n## Validation\n- cargo fmt\n- cargo test -p sm-server codex_fork_pane_title_spinner_indicates_working\n- cargo test -p sm-server codex_fork_live_activity_prefers_spinner_over_idle_event\n- git diff --check -- crates/sm-server/src/http.rs