### PR TITLE
[codex] Fix Rust tmux client event state

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -67,7 +67,7 @@ use time::{
     format_description::well_known::Rfc3339, macros::format_description, Duration as TimeDuration,
     OffsetDateTime, PrimitiveDateTime,
 };
-use tokio::sync::{mpsc, Mutex as AsyncMutex};
+use tokio::sync::{broadcast, mpsc, Mutex as AsyncMutex};
 use tokio::time::{sleep, timeout};
 
 use crate::app_artifacts::{
@@ -340,6 +340,8 @@ pub struct AppState {
     github_review_poster: Arc<dyn GitHubReviewPoster>,
     codex_review_creation_locks: Arc<AsyncMutex<BTreeSet<String>>>,
     codex_review_watcher_ids: Arc<Mutex<BTreeSet<String>>>,
+    tmux_client_event_state: Arc<Mutex<TmuxClientEventState>>,
+    tmux_client_event_tx: broadcast::Sender<Value>,
     mobile_terminal_tickets: Arc<Mutex<BTreeMap<String, MobileTerminalTicket>>>,
     mobile_terminal_active_attaches: Arc<Mutex<BTreeMap<String, MobileTerminalActiveAttach>>>,
     mobile_terminal_proof_nonces: Arc<Mutex<BTreeMap<String, i64>>>,
@@ -358,12 +360,15 @@ impl AppState {
         let session_store = SessionStore::new_with_queue(state_file, queue_db_path);
         let mut mobile_terminal_secret = [0u8; 32];
         OsRng.fill_bytes(&mut mobile_terminal_secret);
+        let (tmux_client_event_tx, _) = broadcast::channel(128);
         Self {
             config,
             session_store,
             github_review_poster: Arc::new(GhCliReviewPoster),
             codex_review_creation_locks: Arc::new(AsyncMutex::new(BTreeSet::new())),
             codex_review_watcher_ids: Arc::new(Mutex::new(BTreeSet::new())),
+            tmux_client_event_state: Arc::new(Mutex::new(TmuxClientEventState::default())),
+            tmux_client_event_tx,
             mobile_terminal_tickets: Arc::new(Mutex::new(BTreeMap::new())),
             mobile_terminal_active_attaches: Arc::new(Mutex::new(BTreeMap::new())),
             mobile_terminal_proof_nonces: Arc::new(Mutex::new(BTreeMap::new())),
@@ -1177,9 +1182,39 @@ async fn tmux_client_hook(
     } else {
         None
     };
+    let tmux_session = query
+        .session
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            query
+                .client_session
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+        });
+    let event_payload = state.record_tmux_client_event(
+        event_name,
+        tmux_session,
+        query
+            .tty
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty()),
+        query
+            .client_pid
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty()),
+        revived_session_id.as_deref(),
+    );
     let mut response = json!({
         "status": "ok",
-        "tmux_client_event_version": 0,
+        "tmux_client_event_version": event_payload
+            .get("version")
+            .and_then(Value::as_i64)
+            .unwrap_or(0),
     });
     if let Some(session_id) = revived_session_id {
         response["revived_session_id"] = Value::String(session_id);
@@ -2425,7 +2460,7 @@ async fn events_state(
     request: Request,
 ) -> Result<Json<EventStateResponse>, ApiError> {
     ensure_session_read_allowed(&state, &request)?;
-    Ok(Json(event_state_payload()))
+    Ok(Json(state.event_state_payload()))
 }
 
 async fn events_stream(
@@ -2433,12 +2468,33 @@ async fn events_stream(
     request: Request,
 ) -> Result<Response, ApiError> {
     ensure_session_read_allowed(&state, &request)?;
-    let data = serde_json::to_string(&event_state_payload())?;
+    let receiver = state.tmux_client_event_tx.subscribe();
+    let data = serde_json::to_string(&state.event_state_payload())?;
+    let updates = stream::unfold(receiver, |mut receiver| async move {
+        loop {
+            match receiver.recv().await {
+                Ok(payload) => {
+                    let event_type = payload
+                        .get("type")
+                        .and_then(Value::as_str)
+                        .unwrap_or("message")
+                        .to_owned();
+                    let data = serde_json::to_string(&payload).unwrap_or_else(|_| "{}".to_owned());
+                    return Some((
+                        Ok::<Event, Infallible>(Event::default().event(event_type).data(data)),
+                        receiver,
+                    ));
+                }
+                Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                Err(broadcast::error::RecvError::Closed) => return None,
+            }
+        }
+    });
     let stream =
         stream::once(
             async move { Ok::<Event, Infallible>(Event::default().event("hello").data(data)) },
         )
-        .chain(stream::pending());
+        .chain(updates);
     Ok((
         [("x-accel-buffering", "no")],
         Sse::new(stream).keep_alive(
@@ -10721,6 +10777,10 @@ struct TmuxClientHookQuery {
     session: Option<String>,
     #[serde(default, rename = "client_session")]
     client_session: Option<String>,
+    #[serde(default)]
+    tty: Option<String>,
+    #[serde(default)]
+    client_pid: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -11069,10 +11129,53 @@ struct EventStateResponse {
     last_tmux_client_event: Option<Value>,
 }
 
-fn event_state_payload() -> EventStateResponse {
-    EventStateResponse {
-        tmux_client_event_version: 0,
-        last_tmux_client_event: None,
+#[derive(Default)]
+struct TmuxClientEventState {
+    version: i64,
+    last_event: Option<Value>,
+}
+
+impl AppState {
+    fn record_tmux_client_event(
+        &self,
+        event_name: &str,
+        tmux_session: Option<&str>,
+        tty: Option<&str>,
+        client_pid: Option<&str>,
+        revived_session_id: Option<&str>,
+    ) -> Value {
+        let mut state = self
+            .tmux_client_event_state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        state.version += 1;
+        let mut payload = json!({
+            "type": "tmux_client_event",
+            "event": event_name,
+            "tmux_session": tmux_session,
+            "tty": tty,
+            "client_pid": client_pid,
+            "version": state.version,
+            "received_at": now_rfc3339(),
+        });
+        if let Some(session_id) = revived_session_id {
+            payload["revived_session_id"] = Value::String(session_id.to_owned());
+        }
+        state.last_event = Some(payload.clone());
+        drop(state);
+        let _ = self.tmux_client_event_tx.send(payload.clone());
+        payload
+    }
+
+    fn event_state_payload(&self) -> EventStateResponse {
+        let state = self
+            .tmux_client_event_state
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        EventStateResponse {
+            tmux_client_event_version: state.version,
+            last_tmux_client_event: state.last_event.clone(),
+        }
     }
 }
 

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -5088,7 +5088,7 @@ async fn tmux_client_hook_preserves_local_only_and_event_validation() {
 
     let (status, payload) = post_json_with_headers_and_peer(
         app.clone(),
-        "/hooks/tmux-client?event=client-session-changed&session=tmux-test",
+        "/hooks/tmux-client?event=client-session-changed&session=tmux-test&tty=%2Fdev%2Fttys008&client_pid=123",
         json!({}),
         &[("host", "127.0.0.1:8421")],
         Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
@@ -5096,7 +5096,38 @@ async fn tmux_client_hook_preserves_local_only_and_event_validation() {
     .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "ok");
-    assert_eq!(payload["tmux_client_event_version"], 0);
+    assert_eq!(payload["tmux_client_event_version"], 1);
+
+    let (status, payload) = get_json(app.clone(), "/events/state").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["tmux_client_event_version"], 1);
+    assert_eq!(
+        payload["last_tmux_client_event"]["type"],
+        "tmux_client_event"
+    );
+    assert_eq!(
+        payload["last_tmux_client_event"]["event"],
+        "client-session-changed"
+    );
+    assert_eq!(
+        payload["last_tmux_client_event"]["tmux_session"],
+        "tmux-test"
+    );
+    assert_eq!(payload["last_tmux_client_event"]["tty"], "/dev/ttys008");
+    assert_eq!(payload["last_tmux_client_event"]["client_pid"], "123");
+    assert_eq!(payload["last_tmux_client_event"]["version"], 1);
+    assert!(payload["last_tmux_client_event"]["received_at"].is_string());
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/hooks/tmux-client?event=client-detached&session=tmux-test",
+        json!({}),
+        &[("host", "127.0.0.1:8421")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["tmux_client_event_version"], 2);
 
     let (status, payload) = post_json_with_headers_and_peer(
         app,
@@ -7177,6 +7208,7 @@ async fn events_stream_emits_hello_frame_with_sse_headers() {
     let app = router(AppState::new(AppConfig::default()));
 
     let response = app
+        .clone()
         .oneshot(
             Request::builder()
                 .uri("/events")
@@ -7218,6 +7250,111 @@ async fn events_stream_emits_hello_frame_with_sse_headers() {
             .await
             .is_err(),
         "SSE stream closed before the keepalive interval"
+    );
+}
+
+#[tokio::test]
+async fn events_stream_broadcasts_tmux_client_hook_events() {
+    let app = router(AppState::new(AppConfig::default()));
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/events")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let mut body_stream = response.into_body().into_data_stream();
+    let first_chunk = body_stream.next().await.unwrap().unwrap();
+    assert_eq!(
+        String::from_utf8(first_chunk.to_vec()).unwrap(),
+        "event: hello\ndata: {\"tmux_client_event_version\":0,\"last_tmux_client_event\":null}\n\n"
+    );
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app,
+        "/hooks/tmux-client?event=client-attached&session=tmux-live&tty=%2Fdev%2Fttys008&client_pid=456",
+        json!({}),
+        &[("host", "127.0.0.1:8421")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["tmux_client_event_version"], 1);
+
+    let event_chunk = tokio::time::timeout(Duration::from_secs(1), body_stream.next())
+        .await
+        .expect("timed out waiting for tmux client event")
+        .unwrap()
+        .unwrap();
+    let event_text = String::from_utf8(event_chunk.to_vec()).unwrap();
+    assert!(
+        event_text.starts_with("event: tmux_client_event\n"),
+        "{event_text}"
+    );
+    assert!(
+        event_text.contains("\"event\":\"client-attached\""),
+        "{event_text}"
+    );
+    assert!(
+        event_text.contains("\"tmux_session\":\"tmux-live\""),
+        "{event_text}"
+    );
+    assert!(
+        event_text.contains("\"tty\":\"/dev/ttys008\""),
+        "{event_text}"
+    );
+    assert!(
+        event_text.contains("\"client_pid\":\"456\""),
+        "{event_text}"
+    );
+    assert!(event_text.contains("\"version\":1"), "{event_text}");
+}
+
+#[tokio::test]
+async fn events_stream_hello_includes_latest_tmux_client_event_state() {
+    let app = router(AppState::new(AppConfig::default()));
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/hooks/tmux-client?event=client-attached&session=tmux-before-stream",
+        json!({}),
+        &[("host", "127.0.0.1:8421")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["tmux_client_event_version"], 1);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/events")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let mut body_stream = response.into_body().into_data_stream();
+    let first_chunk = body_stream.next().await.unwrap().unwrap();
+    let hello_text = String::from_utf8(first_chunk.to_vec()).unwrap();
+    assert!(hello_text.starts_with("event: hello\n"), "{hello_text}");
+    assert!(
+        hello_text.contains("\"tmux_client_event_version\":1"),
+        "{hello_text}"
+    );
+    assert!(
+        hello_text.contains("\"event\":\"client-attached\""),
+        "{hello_text}"
+    );
+    assert!(
+        hello_text.contains("\"tmux_session\":\"tmux-before-stream\""),
+        "{hello_text}"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes #1105.

Rust preserved the `/hooks/tmux-client` and `/events/state` routes, but the hook still behaved like a validation stub: every accepted event returned `tmux_client_event_version: 0`, and `/events/state` always exposed the empty fallback state. Deskbar depends on this version changing to force Terminal tab remapping after tmux attach/detach/session-change hooks, so stale mappings could leave an SM agent displayed as a plain Terminal window.

This PR adds in-memory tmux client event state to the Rust server and records Python-compatible event payloads for accepted local tmux hook calls, including event name, tmux session, tty, client pid, version, timestamp, and revived session id when present. `/events/state` and the SSE hello frame now read the current state, and connected `/events` clients receive accepted tmux hook payloads as `tmux_client_event` frames.

## Validation

- `cargo fmt --check`
- `cargo test -p sm-server --test read_only_http tmux_client_hook_preserves_local_only_and_event_validation -- --nocapture`
- `cargo test -p sm-server --test read_only_http events_state -- --nocapture`
- `cargo test -p sm-server --test read_only_http events_stream -- --nocapture`
- `./venv/bin/python -m pytest tests/unit/test_rust_migration_contracts.py -q`
- `git diff --check`

Full `cargo test -p sm-server` was also run before the SSE broadcast follow-up. It passed unit/bin tests but the `read_only_http` integration target has two existing runtime-core restore failures returning 409 instead of 200: `runtime_core_lifecycle_uses_tmux_backend_when_enabled` and `runtime_core_expands_bare_home_working_dir_for_tmux`. Those failures reproduce when run individually and are outside this tmux event-state change.
