### PR TITLE
[codex] Detect Claude thinking-with-effort activity

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -7654,7 +7654,7 @@ fn claude_line_indicates_working(line: &str) -> bool {
         || line.contains("Running…")
         || line.contains("Reviewing…")
         || line.contains("Herding…")
-        || line.contains("still thinking with")
+        || line.contains("thinking with")
 }
 
 fn claude_spinner_status_line_indicates_working(line: &str) -> bool {
@@ -11339,6 +11339,22 @@ mod tests {
 
 ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── leg-behavior-spec ──
 ❯
+"#;
+        assert_eq!(claude_live_activity_from_pane(Some(pane)), Some("working"));
+    }
+
+    #[test]
+    fn claude_pane_activity_detects_thinking_status_with_task_punctuation() {
+        let pane = r#"
+  4 tasks (3 done, 1 in progress, 0 open)
+  ✔ Verify claims 1-4 (guard removal + index leak) against code
+  ✔ Item-5 broader audit: other close-without-cleanup leaks
+  ✔ Update fib_journey_spec.md (§2.7 dual-role + index lifecycle)
+  ◼ Converge spec changes with reviewer 72a27cdb; advise 176448dc
+
+✽ Converge spec changes with reviewer 72a27cdb; advise 176448dc… (2m 10s · ↓ 8.5k tokens · thinking with high effort)
+  ⎿  ✔ Verify claims 1-4 (guard removal + index leak) against code
+     ◼ Converge spec changes with reviewer 72a27cdb; advise 176448dc
 "#;
         assert_eq!(claude_live_activity_from_pane(Some(pane)), Some("working"));
     }


### PR DESCRIPTION
## Summary

Fixes #1109.

Rust activity projection now treats Claude status lines containing `thinking with` as working, not only the longer `still thinking with` form. This covers live Claude pane lines whose task titles contain punctuation or hex IDs before the ellipsis, which the generic spinner-status parser intentionally rejects.

## Root cause

A live Claude pane for `3c38b683` showed:

```text
✽ Converge spec changes with reviewer 72a27cdb; advise 176448dc… (2m 10s · ↓ 8.5k tokens · thinking with high effort)
```

The Rust parser only matched `still thinking with`, and the generic spinner parser rejected the task label before `…` because it contains punctuation and digits. The line therefore fell through and `/sessions` reported `activity_state=idle`, which deskbar and the Android app displayed correctly from bad server state.

## Validation

- `cargo fmt --check`
- `cargo test -p sm-server claude_pane_activity -- --nocapture`
- `git diff --check`

Unrelated local untracked files were left untouched.