### PR TITLE
[codex] Fix human email fallback and roster lookup

### DIFF
--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -615,12 +615,12 @@ fn run() -> Result<()> {
             }
             let delivery_mode = if args.urgent { "urgent" } else { "sequential" };
             let targets = split_send_targets(&args.session_id);
-            let targets = targets
-                .iter()
-                .map(|target| resolve_send_target(&client, target))
-                .collect::<Result<Vec<_>>>()?;
-            let mut payload = send_input_payload(text, delivery_mode, args.wait);
+            let mut payload = send_input_payload(text.clone(), delivery_mode, args.wait);
             if targets.len() > 1 {
+                let targets = targets
+                    .iter()
+                    .map(|target| resolve_send_target(&client, target))
+                    .collect::<Result<Vec<_>>>()?;
                 payload["recipients"] = json!(targets);
                 let payload = client.post_json("/sessions/input-batch", payload)?;
                 print_batch_send_result(&payload)?;
@@ -632,15 +632,25 @@ fn run() -> Result<()> {
                     .first()
                     .map(String::as_str)
                     .unwrap_or(args.session_id.as_str());
-                let payload = client.post_json(&format!("/sessions/{target}/input"), payload)?;
-                println!(
-                    "{}",
-                    if payload["delivered"].as_bool().unwrap_or(false) {
-                        "delivered"
-                    } else {
-                        "not delivered"
+                if let Some(session_id) = lookup_identifier_exact(&client, target)? {
+                    let payload =
+                        client.post_json(&format!("/sessions/{session_id}/input"), payload)?;
+                    println!(
+                        "{}",
+                        if payload["delivered"].as_bool().unwrap_or(false) {
+                            "delivered"
+                        } else {
+                            "not delivered"
+                        }
+                    );
+                } else {
+                    if args.urgent || args.wait.is_some() {
+                        bail!(
+                            "email fallback only supports plain sequential sends without --wait/--urgent"
+                        );
                     }
-                );
+                    send_registered_email_fallback(&client, target, &text)?;
+                }
             }
         }
         Command::Output(args) => print_output(&client, &args.session_id, args.lines)?,
@@ -813,7 +823,9 @@ fn run() -> Result<()> {
         }
         Command::Lookup(args) => {
             let identifier = required_positional(args.role, "role")?;
-            if let Some(session_id) = lookup_identifier(&client, &identifier)? {
+            if let Some(human) = lookup_human(&client, &identifier)? {
+                print_human_lookup(&human);
+            } else if let Some(session_id) = lookup_identifier(&client, &identifier)? {
                 println!("{session_id}");
             } else {
                 bail!("Role not registered");
@@ -2126,6 +2138,59 @@ fn send_input_payload(text: String, delivery_mode: &str, wait: Option<u64>) -> V
     payload
 }
 
+fn send_registered_email_fallback(client: &ApiClient, recipient: &str, text: &str) -> Result<()> {
+    let requester_session_id = optional_current_session_id()
+        .ok_or_else(|| anyhow!("Managed sender session is required for email fallback"))?;
+    let human_response = client.request(
+        "GET",
+        &format!("/humans/{}", encode_path_segment(recipient)),
+        None,
+    )?;
+    if (200..300).contains(&human_response.status) {
+        let human = human_response.into_json()?;
+        let canonical = human["recipient"].as_str().unwrap_or(recipient);
+        let payload = client.post_json(
+            &format!("/humans/{}/email", encode_path_segment(canonical)),
+            json!({
+                "requester_session_id": requester_session_id,
+                "text": text,
+                "auto_subject": true
+            }),
+        )?;
+        println!(
+            "Email sent to {}",
+            payload["recipient"].as_str().unwrap_or(canonical)
+        );
+        return Ok(());
+    }
+    if human_response.status != 404 {
+        return Err(human_response.into_status_error());
+    }
+    let payload = client.post_json(
+        "/email/send",
+        json!({
+            "requester_session_id": requester_session_id,
+            "recipients": [recipient],
+            "cc": [],
+            "body_text": text,
+            "auto_subject": true
+        }),
+    )?;
+    let recipient_summary = payload["to"]
+        .as_array()
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|item| item["username"].as_str().or_else(|| item["email"].as_str()))
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| recipient.to_owned());
+    println!("Email sent to {recipient_summary}");
+    Ok(())
+}
+
 fn launch_provider_for_alias(alias: &str) -> Result<&'static str> {
     match alias {
         "new" | "claude" => Ok("claude"),
@@ -2414,6 +2479,32 @@ fn run_context_monitor(client: &ApiClient, args: ContextMonitorArgs) -> Result<(
 }
 
 fn lookup_identifier(client: &ApiClient, identifier: &str) -> Result<Option<String>> {
+    if let Some(session_id) = lookup_identifier_exact(client, identifier)? {
+        return Ok(Some(session_id));
+    }
+
+    let payload = client.get_json("/sessions")?;
+    let sessions = payload["sessions"].as_array().cloned().unwrap_or_default();
+    let needle = identifier.to_ascii_lowercase();
+    let matches = sessions
+        .iter()
+        .filter(|session| {
+            ["friendly_name", "name"].iter().any(|field| {
+                session[*field]
+                    .as_str()
+                    .is_some_and(|value| value.to_ascii_lowercase().contains(&needle))
+            })
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    match matches.len() {
+        1 => Ok(matches[0]["id"].as_str().map(ToOwned::to_owned)),
+        count if count > 1 => bail_ambiguous_lookup(identifier, &matches),
+        _ => Ok(None),
+    }
+}
+
+fn lookup_identifier_exact(client: &ApiClient, identifier: &str) -> Result<Option<String>> {
     let registry_path = format!("/registry/{}", encode_path_segment(identifier));
     let response = client.request("GET", &registry_path, None)?;
     if (200..300).contains(&response.status) {
@@ -2459,23 +2550,7 @@ fn lookup_identifier(client: &ApiClient, identifier: &str) -> Result<Option<Stri
         return bail_ambiguous_lookup(identifier, &exact_matches);
     }
 
-    let needle = identifier.to_ascii_lowercase();
-    let matches = sessions
-        .iter()
-        .filter(|session| {
-            ["friendly_name", "name"].iter().any(|field| {
-                session[*field]
-                    .as_str()
-                    .is_some_and(|value| value.to_ascii_lowercase().contains(&needle))
-            })
-        })
-        .cloned()
-        .collect::<Vec<_>>();
-    match matches.len() {
-        1 => Ok(matches[0]["id"].as_str().map(ToOwned::to_owned)),
-        count if count > 1 => bail_ambiguous_lookup(identifier, &matches),
-        _ => Ok(None),
-    }
+    Ok(None)
 }
 
 fn bail_ambiguous_lookup(identifier: &str, matches: &[Value]) -> Result<Option<String>> {
@@ -2506,34 +2581,128 @@ fn print_roster(client: &ApiClient) -> Result<()> {
         .as_array()
         .cloned()
         .unwrap_or_default();
-    if registrations.is_empty() {
+    let humans_payload = client.get_json("/humans")?;
+    let humans = humans_payload["humans"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    if registrations.is_empty() && humans.is_empty() {
         println!("No registered roles or humans.");
         return Ok(());
     }
 
-    println!("Agents");
-    let rows = registrations
-        .iter()
-        .map(|entry| {
-            vec![
-                json_string(entry, "role"),
-                json_string(entry, "session_id"),
-                json_string(entry, "friendly_name"),
-                json_string(entry, "provider"),
-                entry["activity_state"]
-                    .as_str()
-                    .or_else(|| entry["status"].as_str())
-                    .unwrap_or("")
-                    .to_owned(),
-            ]
-        })
-        .collect::<Vec<_>>();
-    print_table(&["Role", "Session ID", "Name", "Provider", "State"], &rows);
+    if !registrations.is_empty() {
+        println!("Agents");
+        let rows = registrations
+            .iter()
+            .map(|entry| {
+                vec![
+                    json_string(entry, "role"),
+                    json_string(entry, "session_id"),
+                    json_string(entry, "friendly_name"),
+                    json_string(entry, "provider"),
+                    entry["activity_state"]
+                        .as_str()
+                        .or_else(|| entry["status"].as_str())
+                        .unwrap_or("")
+                        .to_owned(),
+                ]
+            })
+            .collect::<Vec<_>>();
+        print_table(&["Role", "Session ID", "Name", "Provider", "State"], &rows);
+    }
+
+    if !humans.is_empty() {
+        if !registrations.is_empty() {
+            println!();
+        }
+        println!("Humans");
+        let rows = humans.iter().map(human_roster_row).collect::<Vec<_>>();
+        print_table(
+            &["Name", "Display", "Aliases", "Default", "Channels"],
+            &rows,
+        );
+    }
     Ok(())
 }
 
 fn json_string(value: &Value, key: &str) -> String {
     value[key].as_str().unwrap_or("").to_owned()
+}
+
+fn lookup_human(client: &ApiClient, identifier: &str) -> Result<Option<Value>> {
+    let response = client.request(
+        "GET",
+        &format!("/humans/{}", encode_path_segment(identifier)),
+        None,
+    )?;
+    if (200..300).contains(&response.status) {
+        return Ok(Some(response.into_json()?));
+    }
+    if response.status == 404 {
+        return Ok(None);
+    }
+    Err(response.into_status_error())
+}
+
+fn print_human_lookup(payload: &Value) {
+    let recipient = payload["recipient"].as_str().unwrap_or("<unknown>");
+    let aliases = payload["aliases"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .filter(|alias| *alias != recipient)
+        .collect::<Vec<_>>();
+    println!("Human recipient: {recipient}");
+    if !aliases.is_empty() {
+        println!("Aliases: {}", aliases.join(", "));
+    }
+    println!(
+        "Default delivery: {}",
+        payload["default_channel"].as_str().unwrap_or("unknown")
+    );
+    let channels = payload["available_channels"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .collect::<Vec<_>>();
+    if !channels.is_empty() {
+        println!("Available delivery: {}", channels.join(", "));
+    }
+    if channels.contains(&"telegram") {
+        println!("Telegram delivery posts into the sending agent's SM-managed Telegram thread.");
+    }
+    if channels.contains(&"email") {
+        println!("Email is available as fallback/explicit only; use email sparingly.");
+    }
+}
+
+fn human_roster_row(entry: &Value) -> Vec<String> {
+    let recipient = json_string(entry, "recipient");
+    let aliases = entry["aliases"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .filter(|alias| *alias != recipient)
+        .collect::<Vec<_>>()
+        .join(",");
+    let channels = entry["available_channels"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .collect::<Vec<_>>()
+        .join(",");
+    vec![
+        recipient,
+        json_string(entry, "display_name"),
+        aliases,
+        json_string(entry, "default_channel"),
+        channels,
+    ]
 }
 
 fn print_table(headers: &[&str], rows: &[Vec<String>]) {
@@ -3235,6 +3404,7 @@ mod tests {
     use super::*;
     use std::{
         ffi::OsString,
+        io::{BufRead, BufReader},
         net::TcpListener,
         sync::Mutex,
         thread,
@@ -3276,6 +3446,34 @@ mod tests {
         });
         let client = ApiClient::parse(&format!("http://{address}")).unwrap();
         (client, server)
+    }
+
+    fn read_test_request(stream: &mut std::net::TcpStream) -> (String, String, String) {
+        let mut reader = BufReader::new(stream.try_clone().unwrap());
+        let mut request_line = String::new();
+        reader.read_line(&mut request_line).unwrap();
+        let mut parts = request_line.split_whitespace();
+        let method = parts.next().unwrap_or_default().to_owned();
+        let path = parts.next().unwrap_or_default().to_owned();
+        let mut content_length = 0_usize;
+        loop {
+            let mut line = String::new();
+            reader.read_line(&mut line).unwrap();
+            let trimmed = line.trim_end_matches(['\r', '\n']);
+            if trimmed.is_empty() {
+                break;
+            }
+            if let Some((name, value)) = trimmed.split_once(':') {
+                if name.eq_ignore_ascii_case("content-length") {
+                    content_length = value.trim().parse().unwrap();
+                }
+            }
+        }
+        let mut body = vec![0_u8; content_length];
+        if content_length > 0 {
+            reader.read_exact(&mut body).unwrap();
+        }
+        (method, path, String::from_utf8(body).unwrap())
     }
 
     #[test]
@@ -3375,6 +3573,160 @@ mod tests {
         assert_eq!(payload["notify_after_seconds"], 7);
         assert_eq!(payload["from_sm_send"], true);
         assert_eq!(payload["sender_session_id"], "sender001");
+    }
+
+    #[test]
+    fn send_registered_email_fallback_posts_auto_subject_payload() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _env = EnvRestore::new(&["SESSION_MANAGER_ID", "CLAUDE_SESSION_MANAGER_ID"]);
+        env::set_var("SESSION_MANAGER_ID", "sender001");
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            stream
+                .set_read_timeout(Some(std::time::Duration::from_secs(2)))
+                .unwrap();
+            let (method, path, _) = read_test_request(&mut stream);
+            assert_eq!(method, "GET");
+            assert_eq!(path, "/humans/teammate");
+            let response_body = r#"{"detail":"Human recipient not configured"}"#;
+            let response = format!(
+                "HTTP/1.1 404 Not Found\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{response_body}",
+                response_body.len()
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+            drop(stream);
+
+            let (mut stream, _) = listener.accept().unwrap();
+            stream
+                .set_read_timeout(Some(std::time::Duration::from_secs(2)))
+                .unwrap();
+            let (method, path, body) = read_test_request(&mut stream);
+            assert_eq!(method, "POST");
+            assert_eq!(path, "/email/send");
+            let payload: Value = serde_json::from_str(&body).unwrap();
+            assert_eq!(payload["requester_session_id"], "sender001");
+            assert_eq!(payload["recipients"], json!(["teammate"]));
+            assert_eq!(payload["cc"], json!([]));
+            assert_eq!(payload["body_text"], "hello via fallback");
+            assert_eq!(payload["auto_subject"], true);
+
+            let response_body =
+                r#"{"to":[{"username":"teammate","email":"teammate@example.test"}]}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{response_body}",
+                response_body.len()
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+        });
+        let client = ApiClient::parse(&format!("http://{address}")).unwrap();
+
+        send_registered_email_fallback(&client, "teammate", "hello via fallback").unwrap();
+
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn send_registered_email_fallback_uses_human_email_endpoint() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _env = EnvRestore::new(&["SESSION_MANAGER_ID", "CLAUDE_SESSION_MANAGER_ID"]);
+        env::set_var("SESSION_MANAGER_ID", "sender001");
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let (method, path, _) = read_test_request(&mut stream);
+            assert_eq!(method, "GET");
+            assert_eq!(path, "/humans/rajeshgoli");
+            let response_body = r#"{"recipient":"rajesh"}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{response_body}",
+                response_body.len()
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+            drop(stream);
+
+            let (mut stream, _) = listener.accept().unwrap();
+            let (method, path, body) = read_test_request(&mut stream);
+            assert_eq!(method, "POST");
+            assert_eq!(path, "/humans/rajesh/email");
+            let payload: Value = serde_json::from_str(&body).unwrap();
+            assert_eq!(payload["requester_session_id"], "sender001");
+            assert_eq!(payload["text"], "hello human fallback");
+            assert_eq!(payload["auto_subject"], true);
+
+            let response_body = r#"{"recipient":"rajesh","status":"sent"}"#;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{response_body}",
+                response_body.len()
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+            drop(stream);
+        });
+        let client = ApiClient::parse(&format!("http://{address}")).unwrap();
+
+        send_registered_email_fallback(&client, "rajeshgoli", "hello human fallback").unwrap();
+
+        server.join().unwrap();
+    }
+
+    #[test]
+    fn lookup_human_resolves_configured_alias() {
+        let (client, server) = start_lookup_server([(
+            "/humans/rajeshgoli",
+            200,
+            r#"{"recipient":"rajesh","display_name":"Human operator","aliases":["rajesh","rajeshgoli"],"default_channel":"telegram","available_channels":["email","telegram"]}"#,
+        )]);
+
+        let human = lookup_human(&client, "rajeshgoli").unwrap().unwrap();
+
+        assert_eq!(human["recipient"], "rajesh");
+        assert_eq!(human["default_channel"], "telegram");
+        assert_eq!(server.join().unwrap(), vec!["/humans/rajeshgoli"]);
+    }
+
+    #[test]
+    fn lookup_identifier_exact_ignores_fuzzy_session_name_match() {
+        let (client, server) = start_lookup_server([
+            ("/registry/rajesh", 404, r#"{"detail":"Role not found"}"#),
+            ("/sessions/rajesh", 404, r#"{"detail":"Session not found"}"#),
+            (
+                "/sessions",
+                200,
+                r#"{"sessions":[{"id":"helper001","friendly_name":"rajesh-helper","name":"codex-fork-helper001","aliases":[]}]}"#,
+            ),
+        ]);
+
+        assert_eq!(lookup_identifier_exact(&client, "rajesh").unwrap(), None);
+        assert_eq!(
+            server.join().unwrap(),
+            vec!["/registry/rajesh", "/sessions/rajesh", "/sessions"]
+        );
+    }
+
+    #[test]
+    fn human_roster_row_formats_aliases_and_channels() {
+        let row = human_roster_row(&json!({
+            "recipient": "rajesh",
+            "display_name": "Human operator",
+            "aliases": ["rajesh", "rajeshgoli", "user"],
+            "default_channel": "telegram",
+            "available_channels": ["email", "telegram"]
+        }));
+
+        assert_eq!(
+            row,
+            vec![
+                "rajesh".to_owned(),
+                "Human operator".to_owned(),
+                "rajeshgoli,user".to_owned(),
+                "telegram".to_owned(),
+                "email,telegram".to_owned(),
+            ]
+        );
     }
 
     #[test]

--- a/crates/sm-server/src/email.rs
+++ b/crates/sm-server/src/email.rs
@@ -25,7 +25,7 @@ pub struct EmailBridge {
 impl EmailBridge {
     pub fn load(config: &AppConfig) -> Result<Self> {
         let path = expand_email_config_path(&config.email.bridge_config);
-        let config = match fs::read_to_string(&path) {
+        let mut bridge_config = match fs::read_to_string(&path) {
             Ok(content) => serde_yaml::from_str(&content).with_context(|| {
                 format!("failed to parse email bridge config {}", path.display())
             })?,
@@ -38,11 +38,50 @@ impl EmailBridge {
                 })
             }
         };
-        Ok(Self { path, config })
+        for (username, user_config) in &config.mobile_terminal.allowed_users {
+            let Some(email) = trimmed(&user_config.email) else {
+                continue;
+            };
+            bridge_config
+                .users
+                .entry(username.clone())
+                .or_insert_with(|| {
+                    UserSpec::Details(UserDetails {
+                        email: Some(email),
+                        name: Some(username.clone()),
+                        aliases: StringList::Many(user_config.aliases.clone()),
+                    })
+                });
+        }
+        Ok(Self {
+            path,
+            config: bridge_config,
+        })
     }
 
     pub fn bridge_is_available(&self) -> bool {
         self.api_key().is_some() && self.domain().is_some()
+    }
+
+    pub fn availability_error_detail(&self) -> String {
+        let mut missing = Vec::new();
+        if !self.path.exists() {
+            missing.push(format!("config file {} not found", self.path.display()));
+        }
+        if self.api_key().is_none() {
+            missing.push("resend.api_key".to_owned());
+        }
+        if self.domain().is_none() {
+            missing.push("resend.domain".to_owned());
+        }
+        if missing.is_empty() {
+            "Email bridge is unavailable".to_owned()
+        } else {
+            format!(
+                "Email bridge is unavailable: missing {}",
+                missing.join(", ")
+            )
+        }
     }
 
     pub fn webhook_path(&self) -> String {
@@ -175,10 +214,7 @@ impl EmailBridge {
 
     pub fn send_agent_email(&self, request: SendAgentEmailRequest) -> Result<SentEmail> {
         if !self.bridge_is_available() {
-            bail!(
-                "Email bridge config is unavailable at {}",
-                self.path.display()
-            );
+            bail!("{}", self.availability_error_detail());
         }
         let sender_session_id = request.sender_session_id.trim();
         if sender_session_id.is_empty() {
@@ -327,18 +363,23 @@ pub struct HumanRecipientResponse {
 
 impl From<HumanRecipient> for HumanRecipientResponse {
     fn from(human: HumanRecipient) -> Self {
-        let telegram_delivery = human
-            .channel("telegram")
-            .and_then(|channel| channel.delivery);
         let email_use = human.channel("email").and_then(|channel| channel.use_);
-        let available_channels = human.available_channels();
+        let available_channels = human.supported_available_channels();
+        let default_channel = if available_channels
+            .iter()
+            .any(|channel| channel == &human.default_channel)
+        {
+            human.default_channel
+        } else {
+            available_channels.first().cloned().unwrap_or_default()
+        };
         Self {
             recipient: human.name,
             display_name: human.display_name,
             aliases: human.aliases,
-            default_channel: human.default_channel,
+            default_channel,
             available_channels,
-            telegram_delivery,
+            telegram_delivery: None,
             email_use,
         }
     }
@@ -401,6 +442,13 @@ impl HumanRecipient {
             .values()
             .filter(|channel| channel.enabled)
             .map(|channel| channel.name.clone())
+            .collect()
+    }
+
+    fn supported_available_channels(&self) -> Vec<String> {
+        self.available_channels()
+            .into_iter()
+            .filter(|channel| channel == "email")
             .collect()
     }
 }

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -2208,7 +2208,7 @@ fn email_bridge_or_503(config: &AppConfig) -> Result<EmailBridge, ApiError> {
     if !bridge.bridge_is_available() {
         return Err(ApiError::Status {
             status: StatusCode::SERVICE_UNAVAILABLE,
-            detail: "Email bridge is unavailable".to_owned(),
+            detail: bridge.availability_error_detail(),
         });
     }
     Ok(bridge)

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -1466,6 +1466,92 @@ async fn human_lookup_lists_capabilities_without_email_addresses() {
 }
 
 #[tokio::test]
+async fn human_lookup_hides_unsupported_telegram_delivery_in_rust() {
+    let state_file = write_session_fixture();
+    let bridge_config = write_email_bridge_config(None, None);
+    fs::write(
+        &bridge_config,
+        r#"resend:
+  api_key: "test-api-key"
+  domain: "example.com"
+  reply_address: "reply@example.com"
+humans:
+  rajesh:
+    display_name: "Human operator"
+    aliases: ["rajeshgoli"]
+    default_channel: "telegram"
+    channels:
+      telegram:
+        enabled: true
+        delivery: "sender_session_topic"
+      email:
+        enabled: true
+        address: "operator@example.com"
+        use: "fallback_only"
+users:
+  rajesh:
+    email: "operator@example.com"
+    name: "Human operator"
+email_bridge:
+  authorized_senders: ["operator@example.com"]
+  webhook_path: "/api/email-inbound"
+"#,
+    )
+    .unwrap();
+    let app = router(AppState::new(config_with_state_file_and_email(
+        &state_file,
+        &bridge_config,
+        false,
+    )));
+
+    let (status, payload) = get_json(app, "/humans/rajeshgoli").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["recipient"], "rajesh");
+    assert_eq!(payload["default_channel"], "email");
+    assert_eq!(payload["available_channels"], json!(["email"]));
+    assert_eq!(payload["telegram_delivery"], Value::Null);
+}
+
+#[tokio::test]
+async fn human_lookup_uses_empty_default_when_no_supported_channels_exist() {
+    let state_file = write_session_fixture();
+    let bridge_config = write_email_bridge_config(None, None);
+    fs::write(
+        &bridge_config,
+        r#"resend:
+  api_key: "test-api-key"
+  domain: "example.com"
+  reply_address: "reply@example.com"
+humans:
+  rajesh:
+    display_name: "Human operator"
+    aliases: ["rajeshgoli"]
+    default_channel: "telegram"
+    channels:
+      telegram:
+        enabled: true
+        delivery: "sender_session_topic"
+email_bridge:
+  webhook_path: "/api/email-inbound"
+"#,
+    )
+    .unwrap();
+    let app = router(AppState::new(config_with_state_file_and_email(
+        &state_file,
+        &bridge_config,
+        false,
+    )));
+
+    let (status, payload) = get_json(app, "/humans/rajesh").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["default_channel"], "");
+    assert_eq!(payload["available_channels"], json!([]));
+    assert_eq!(payload["telegram_delivery"], Value::Null);
+}
+
+#[tokio::test]
 async fn registered_email_send_posts_resend_payload_with_routing_footer() {
     let (resend_url, request_rx) = spawn_resend_server(200, r#"{"id":"email_123"}"#);
     let state_file = write_session_fixture();

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -2059,7 +2059,12 @@ def _try_send_human_telegram(
 
     sender = getattr(client, "send_human_telegram_result", None)
     if not callable(sender):
-        return None
+        return _try_send_human_email_fallback(
+            client,
+            identifier,
+            text,
+            sender_session_id=sender_session_id,
+        )
     result = sender(
         requester_session_id=sender_session_id,
         recipient=identifier,
@@ -2072,12 +2077,53 @@ def _try_send_human_telegram(
         print(UNAVAILABLE_MESSAGE, file=sys.stderr)
         return 2
     if not result.get("ok"):
+        if result.get("status_code") in (404, 405, 503):
+            email_rc = _try_send_human_email_fallback(
+                client,
+                identifier,
+                text,
+                sender_session_id=sender_session_id,
+            )
+            if email_rc is not None:
+                return email_rc
         print(f"Error: {result.get('detail') or 'Failed to send Telegram message'}", file=sys.stderr)
         return 1
 
     payload = result.get("data") or {}
     print(f"Telegram sent to {payload.get('recipient') or identifier}")
     print(f"Thread: {payload.get('thread') or 'sender session topic'}")
+    return 0
+
+
+def _try_send_human_email_fallback(
+    client: SessionManagerClient,
+    identifier: str,
+    text: str,
+    *,
+    sender_session_id: Optional[str],
+) -> Optional[int]:
+    """Send to a configured human recipient through explicit email fallback."""
+    sender = getattr(client, "send_human_email_result", None)
+    if not callable(sender):
+        return None
+    result = sender(
+        requester_session_id=sender_session_id,
+        recipient=identifier,
+        text=text,
+        auto_subject=True,
+    )
+    if not isinstance(result, dict):
+        print("Error: Failed to send human email fallback", file=sys.stderr)
+        return 1
+    if result.get("unavailable"):
+        print(UNAVAILABLE_MESSAGE, file=sys.stderr)
+        return 2
+    if not result.get("ok"):
+        print(f"Error: {result.get('detail') or 'Failed to send human email fallback'}", file=sys.stderr)
+        return 1
+
+    payload = result.get("data") or {}
+    print(f"Email sent to {payload.get('recipient') or identifier}")
     return 0
 
 

--- a/tests/unit/test_email_commands.py
+++ b/tests/unit/test_email_commands.py
@@ -106,6 +106,42 @@ def test_cmd_send_human_alias_defaults_to_telegram(capsys):
     assert "Thread: sender session topic" in output
 
 
+def test_cmd_send_human_alias_falls_back_to_email_when_telegram_unavailable(capsys):
+    client = Mock()
+    client.session_id = "sender123"
+    client.get_session.return_value = None
+    client.list_sessions.return_value = []
+    client.lookup_human.return_value = {
+        "ok": True,
+        "unavailable": False,
+        "data": _human_lookup_payload(),
+    }
+    client.send_human_telegram_result.return_value = {
+        "ok": False,
+        "unavailable": False,
+        "status_code": 503,
+        "detail": "Telegram delivery unavailable",
+    }
+    client.send_human_email_result.return_value = {
+        "ok": True,
+        "unavailable": False,
+        "data": {"recipient": "rajesh", "status": "sent"},
+    }
+
+    rc = cmd_send(client, "user", "status for the human")
+
+    assert rc == 0
+    client.send_human_email_result.assert_called_once_with(
+        requester_session_id="sender123",
+        recipient="user",
+        text="status for the human",
+        auto_subject=True,
+    )
+    client.ensure_role.assert_not_called()
+    output = capsys.readouterr().out
+    assert "Email sent to rajesh" in output
+
+
 @pytest.mark.parametrize(
     "session_identity",
     [


### PR DESCRIPTION
## Summary
- Route Rust `sm send <human>` fallback through `/humans/{id}/email` before generic `/email/send`.
- Teach Rust `sm lookup` and `sm roster` to include configured human recipients from `/humans`.
- Hide unsupported human Telegram delivery from the Rust server response so lookup/roster report email-only when Telegram is configured in legacy bridge config.
- Let the Python CLI fall back to explicit human email when the human Telegram endpoint is unavailable or returns 503.
- Avoid fuzzy session-name matching before email fallback, so a human/email target cannot be misdelivered to a similarly named live session.

## Root Cause
The live Rust server did expose `/humans`, but the Rust CLI only looked up roles/sessions for `lookup` and only printed registry roles for `roster`. Separately, `sm send rajesh` needed to distinguish configured human recipients from generic registered email users. The copied legacy bridge config advertised Telegram as the human default, but Rust does not implement `/humans/{id}/telegram`, so agents saw a misleading default delivery channel.

The first implementation reused fuzzy session lookup in single-recipient `sm send`; this could resolve a substring session name before email fallback. The updated implementation uses exact role/session lookup before falling through to human/registered email fallback. It also ensures Rust never reports an unsupported default channel when no supported human channels exist.

## Validation
- `cargo test -p sm-server --bin sm lookup_identifier_exact -- --nocapture`
- `cargo test -p sm-server --bin sm send_registered_email_fallback -- --nocapture`
- `cargo test -p sm-server --bin sm human -- --nocapture`
- `cargo test -p sm-server human_lookup_hides_unsupported_telegram_delivery_in_rust -- --nocapture`
- `cargo test -p sm-server human_lookup_uses_empty_default_when_no_supported_channels_exist -- --nocapture`
- `cargo test -p sm-server registered_email_send_posts_resend_payload_with_routing_footer -- --nocapture`
- `cargo test -p sm-server explicit_human_email_is_required_for_human_recipients -- --nocapture`
- `./venv/bin/python -m pytest tests/unit/test_email_commands.py tests/unit/test_email_handler.py tests/unit/test_maintainer_alias.py -q`
- Live: `sm lookup rajesh`, `sm lookup rajeshgoli`, `sm roster`, `sm send rajesh ...`