### PR TITLE
[codex] Handle disabled Telegram human email fallback

### DIFF
--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -2077,7 +2077,7 @@ def _try_send_human_telegram(
         print(UNAVAILABLE_MESSAGE, file=sys.stderr)
         return 2
     if not result.get("ok"):
-        if result.get("status_code") in (404, 405, 503):
+        if _should_try_human_email_fallback(result):
             email_rc = _try_send_human_email_fallback(
                 client,
                 identifier,
@@ -2093,6 +2093,17 @@ def _try_send_human_telegram(
     print(f"Telegram sent to {payload.get('recipient') or identifier}")
     print(f"Thread: {payload.get('thread') or 'sender session topic'}")
     return 0
+
+
+def _should_try_human_email_fallback(result: dict) -> bool:
+    """Return True when Telegram failure means human email fallback may still work."""
+    status_code = result.get("status_code")
+    if status_code in (404, 405, 503):
+        return True
+    if status_code != 400:
+        return False
+    detail = str(result.get("detail") or "").lower()
+    return "no enabled telegram channel" in detail
 
 
 def _try_send_human_email_fallback(

--- a/tests/unit/test_email_commands.py
+++ b/tests/unit/test_email_commands.py
@@ -142,6 +142,42 @@ def test_cmd_send_human_alias_falls_back_to_email_when_telegram_unavailable(caps
     assert "Email sent to rajesh" in output
 
 
+def test_cmd_send_human_alias_falls_back_to_email_when_telegram_channel_disabled(capsys):
+    client = Mock()
+    client.session_id = "sender123"
+    client.get_session.return_value = None
+    client.list_sessions.return_value = []
+    client.lookup_human.return_value = {
+        "ok": True,
+        "unavailable": False,
+        "data": _human_lookup_payload(),
+    }
+    client.send_human_telegram_result.return_value = {
+        "ok": False,
+        "unavailable": False,
+        "status_code": 400,
+        "detail": 'Human recipient "rajesh" has no enabled Telegram channel',
+    }
+    client.send_human_email_result.return_value = {
+        "ok": True,
+        "unavailable": False,
+        "data": {"recipient": "rajesh", "status": "sent"},
+    }
+
+    rc = cmd_send(client, "rajeshgoli", "status for the human")
+
+    assert rc == 0
+    client.send_human_email_result.assert_called_once_with(
+        requester_session_id="sender123",
+        recipient="rajeshgoli",
+        text="status for the human",
+        auto_subject=True,
+    )
+    client.ensure_role.assert_not_called()
+    output = capsys.readouterr().out
+    assert "Email sent to rajesh" in output
+
+
 @pytest.mark.parametrize(
     "session_identity",
     [


### PR DESCRIPTION
## Summary
- fall back to explicit human email when the Python human Telegram endpoint returns 400 for a disabled Telegram channel
- keep other Telegram 400 failures surfaced as Telegram errors
- add regression coverage for email-only human aliases

## Validation
- `./venv/bin/python -m pytest tests/unit/test_email_commands.py -q`
- `./venv/bin/python -m pytest tests/unit/test_email_commands.py tests/unit/test_email_handler.py tests/unit/test_maintainer_alias.py -q`

Follow-up to late Codex review on #1123.