### PR TITLE
Workstream C: Studio SSH toggle card (Android app)

### DIFF
--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/model/ApiModels.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/model/ApiModels.kt
@@ -124,6 +124,23 @@ data class AppArtifactMetadata(
 )
 
 @Serializable
+data class StudioSshToggleRequest(
+    val enabled: Boolean,
+)
+
+@Serializable
+data class StudioSshStatusResponse(
+    val enabled: Boolean = false,
+    val status: String = "off",
+    val host: String = "",
+    @SerialName("sshd_listening")
+    val sshdListening: Boolean = false,
+    @SerialName("tunnel_running")
+    val tunnelRunning: Boolean = false,
+    val error: String? = null,
+)
+
+@Serializable
 data class SessionListResponse(
     val sessions: List<ClientSession> = emptyList(),
 )

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/remote/ApiService.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/remote/ApiService.kt
@@ -17,6 +17,8 @@ import li.rajeshgo.sm.data.model.MobileAttachTicketResponse
 import li.rajeshgo.sm.data.model.OutputResponse
 import li.rajeshgo.sm.data.model.RequestStatusResponse
 import li.rajeshgo.sm.data.model.SessionListResponse
+import li.rajeshgo.sm.data.model.StudioSshStatusResponse
+import li.rajeshgo.sm.data.model.StudioSshToggleRequest
 import li.rajeshgo.sm.data.model.ToolCallsResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -56,6 +58,12 @@ interface ApiService {
         @Header("X-SM-Device-Signature") signature: String,
         @Body request: MobileAttachTicketRequest = MobileAttachTicketRequest(),
     ): MobileAttachTicketResponse
+
+    @GET("admin/studio-ssh")
+    suspend fun getStudioSshStatus(): StudioSshStatusResponse
+
+    @POST("admin/studio-ssh")
+    suspend fun setStudioSsh(@Body request: StudioSshToggleRequest): StudioSshStatusResponse
 
     @POST("client/request-status")
     suspend fun requestStatus(): RequestStatusResponse

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SessionManagerRepository.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SessionManagerRepository.kt
@@ -18,6 +18,7 @@ import li.rajeshgo.sm.data.model.EnsureMaintainerResponse
 import li.rajeshgo.sm.data.model.MobileAttachTicketResponse
 import li.rajeshgo.sm.data.model.RequestStatusResponse
 import li.rajeshgo.sm.data.model.SessionDetail
+import li.rajeshgo.sm.data.model.StudioSshStatusResponse
 import li.rajeshgo.sm.data.model.ToolCallRow
 import li.rajeshgo.sm.data.remote.ApiService
 import li.rajeshgo.sm.data.remote.HttpClientFactory
@@ -269,6 +270,16 @@ class SessionManagerRepository(
     suspend fun requestStatus(baseUrl: String, token: String): Result<RequestStatusResponse> = withContext(Dispatchers.IO) {
         runCatching {
             api(baseUrl, token).requestStatus()
+        }.mapFailure(::classifyWriteFailure)
+    }
+
+    suspend fun fetchStudioSshStatus(baseUrl: String, token: String): StudioSshStatusResponse = withContext(Dispatchers.IO) {
+        executeReadRequest(baseUrl, token) { it.getStudioSshStatus() }
+    }
+
+    suspend fun setStudioSsh(baseUrl: String, token: String, enabled: Boolean): Result<StudioSshStatusResponse> = withContext(Dispatchers.IO) {
+        runCatching {
+            api(baseUrl, token).setStudioSsh(li.rajeshgo.sm.data.model.StudioSshToggleRequest(enabled))
         }.mapFailure(::classifyWriteFailure)
     }
 

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
@@ -61,6 +61,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -172,10 +173,12 @@ fun WatchScreen(
             return@LaunchedEffect
         }
         viewModel.refresh()
+        viewModel.refreshStudioSshStatus()
         updateViewModel.refresh()
         while (coroutineContext.isActive) {
             delay(WATCH_AUTO_REFRESH_MS)
             viewModel.refresh()
+            viewModel.refreshStudioSshStatus()
         }
     }
 
@@ -224,6 +227,21 @@ fun WatchScreen(
                         }
                     },
                     onOpenSettings = onNavigateToSettings,
+                )
+            }
+
+            item {
+                StudioSshToggleCard(
+                    enabled = state.studioSshEnabled,
+                    status = state.studioSshStatus,
+                    host = state.studioSshHost,
+                    busy = state.studioSshBusy,
+                    error = state.studioSshError,
+                    onToggle = { desired ->
+                        viewModel.toggleStudioSsh(desired) { result ->
+                            toast = result.exceptionOrNull()?.message ?: result.getOrNull()
+                        }
+                    },
                 )
             }
 
@@ -808,6 +826,87 @@ private class TerminalJavascriptBridge(
 }
 
 private fun jsString(value: String): String = JSONObject.quote(value)
+
+@Composable
+private fun StudioSshToggleCard(
+    enabled: Boolean,
+    status: String,
+    host: String,
+    busy: Boolean,
+    error: String?,
+    onToggle: (Boolean) -> Unit,
+) {
+    val displayHost = host.ifBlank { "studio-ssh.rajeshgo.li" }
+    Surface(
+        shape = RoundedCornerShape(18.dp),
+        color = Panel,
+        border = androidx.compose.foundation.BorderStroke(1.dp, Border),
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Row(modifier = Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically) {
+                    Box(modifier = Modifier.size(9.dp).background(studioSshStatusTint(status), CircleShape))
+                    Spacer(Modifier.width(10.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = "Studio SSH",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.onSurface,
+                        )
+                        Spacer(Modifier.height(2.dp))
+                        Text(
+                            text = displayHost,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = TextMuted,
+                            fontFamily = FontFamily.Monospace,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+                Spacer(Modifier.width(10.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    StatusChip(label = status, tint = studioSshStatusTint(status))
+                    Spacer(Modifier.width(10.dp))
+                    Switch(
+                        checked = enabled,
+                        onCheckedChange = { desired -> if (!busy) onToggle(desired) },
+                        enabled = !busy,
+                    )
+                }
+            }
+            Text(
+                text = "ssh studio-away",
+                style = MaterialTheme.typography.labelSmall,
+                color = Cyan,
+                fontFamily = FontFamily.Monospace,
+            )
+            error?.let { message ->
+                Text(
+                    text = message,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Rose,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+private fun studioSshStatusTint(status: String): Color = when (status.lowercase()) {
+    "on" -> Emerald
+    "starting" -> Amber
+    "error" -> Rose
+    else -> TextMuted
+}
 
 @Composable
 private fun HeaderBar(

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchViewModel.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchViewModel.kt
@@ -60,6 +60,11 @@ data class WatchUiState(
     val refreshing: Boolean = false,
     val requestingStatus: Boolean = false,
     val ensuringMaintainer: Boolean = false,
+    val studioSshEnabled: Boolean = false,
+    val studioSshStatus: String = "off",
+    val studioSshHost: String = "",
+    val studioSshBusy: Boolean = false,
+    val studioSshError: String? = null,
     val terminal: TerminalUiState? = null,
     val lastSync: String? = null,
     val error: String? = null,
@@ -686,6 +691,83 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
             } finally {
                 _uiState.value = _uiState.value.copy(ensuringMaintainer = false)
             }
+        }
+    }
+
+    fun refreshStudioSshStatus() {
+        viewModelScope.launch {
+            val serverUrl = settingsRepository.serverUrl.first()
+            val accessToken = settingsRepository.accessToken.first()
+            if (serverUrl.isBlank() || accessToken.isBlank()) {
+                return@launch
+            }
+            if (_uiState.value.studioSshBusy) {
+                return@launch
+            }
+            runCatching { sessionRepository.fetchStudioSshStatus(serverUrl, accessToken) }
+                .onSuccess { status ->
+                    // A user toggle may have started while the read was in flight; don't stomp it.
+                    if (_uiState.value.studioSshBusy) {
+                        return@onSuccess
+                    }
+                    _uiState.value = _uiState.value.copy(
+                        studioSshEnabled = status.enabled,
+                        studioSshStatus = status.status,
+                        studioSshHost = status.host.ifBlank { _uiState.value.studioSshHost },
+                        studioSshError = status.error,
+                    )
+                }
+        }
+    }
+
+    fun toggleStudioSsh(enabled: Boolean, onComplete: (Result<String>) -> Unit) {
+        viewModelScope.launch {
+            if (_uiState.value.studioSshBusy) {
+                return@launch
+            }
+            val serverUrl = settingsRepository.serverUrl.first()
+            val accessToken = settingsRepository.accessToken.first()
+            if (serverUrl.isBlank() || accessToken.isBlank()) {
+                onComplete(Result.failure(IllegalStateException("Sign in to toggle Studio SSH")))
+                return@launch
+            }
+            // Optimistic: reflect the desired state immediately.
+            _uiState.value = _uiState.value.copy(
+                studioSshBusy = true,
+                studioSshEnabled = enabled,
+                studioSshStatus = if (enabled) "starting" else "off",
+                studioSshError = null,
+            )
+            val result = sessionRepository.setStudioSsh(serverUrl, accessToken, enabled)
+                .map { status ->
+                    _uiState.value = _uiState.value.copy(
+                        studioSshEnabled = status.enabled,
+                        studioSshStatus = status.status,
+                        studioSshHost = status.host.ifBlank { _uiState.value.studioSshHost },
+                        studioSshError = status.error,
+                    )
+                    if (enabled) "Studio SSH starting" else "Studio SSH off"
+                }
+            if (result.exceptionOrNull() is SessionManagerAuthException) {
+                settingsRepository.clearAuth()
+                _uiState.value = _uiState.value.copy(
+                    sessions = emptyList(),
+                    expandedSessionIds = emptySet(),
+                    detailsBySessionId = emptyMap(),
+                    lastSync = null,
+                    userEmail = "",
+                )
+            }
+            result.onFailure { error ->
+                // Revert the optimistic desired state; the next poll reconciles from the server.
+                _uiState.value = _uiState.value.copy(
+                    studioSshEnabled = !enabled,
+                    studioSshStatus = "error",
+                    studioSshError = error.message,
+                )
+            }
+            _uiState.value = _uiState.value.copy(studioSshBusy = false)
+            onComplete(result)
         }
     }
 }

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchViewModel.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchViewModel.kt
@@ -79,6 +79,9 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
     private val sessionRepository = SessionManagerRepository(settingsRepository)
     private val deviceKeyManager = DeviceKeyManager()
     private var refreshJob: Job? = null
+    // Bumped on every Studio SSH toggle so status reads that began before the
+    // latest toggle can be discarded instead of applying stale pre-toggle data.
+    private var studioSshStatusGeneration = 0
     private var terminalSocket: WebSocket? = null
     private var terminalAttachToken: String? = null
     private var pendingTerminalResize: Pair<Int, Int>? = null
@@ -704,10 +707,12 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
             if (_uiState.value.studioSshBusy) {
                 return@launch
             }
+            val generation = studioSshStatusGeneration
             runCatching { sessionRepository.fetchStudioSshStatus(serverUrl, accessToken) }
                 .onSuccess { status ->
-                    // A user toggle may have started while the read was in flight; don't stomp it.
-                    if (_uiState.value.studioSshBusy) {
+                    // A user toggle may have started (and possibly finished) while this
+                    // read was in flight; discard responses older than the latest toggle.
+                    if (_uiState.value.studioSshBusy || studioSshStatusGeneration != generation) {
                         return@onSuccess
                     }
                     _uiState.value = _uiState.value.copy(
@@ -731,6 +736,8 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
                 onComplete(Result.failure(IllegalStateException("Sign in to toggle Studio SSH")))
                 return@launch
             }
+            // Invalidate any status read already in flight so its (pre-toggle) result is dropped.
+            studioSshStatusGeneration++
             // Optimistic: reflect the desired state immediately.
             _uiState.value = _uiState.value.copy(
                 studioSshBusy = true,


### PR DESCRIPTION
## Summary
Workstream C of the Studio SSH toggle feature (spec: `specs/900_studio_ssh_toggle.md`). Adds a Studio SSH toggle card to the Android Watch screen, wired to the frozen `GET`/`POST /admin/studio-ssh` HTTP contract.

## Changes (android-app only)
- **ApiModels.kt**: `StudioSshToggleRequest(enabled)` + `StudioSshStatusResponse(enabled, status, host, sshdListening, tunnelRunning, error)` with `@SerialName` matching frozen snake_case (`sshd_listening`, `tunnel_running`).
- **ApiService.kt**: `@GET("admin/studio-ssh")` + `@POST("admin/studio-ssh")`.
- **SessionManagerRepository.kt**: `fetchStudioSshStatus` (via `executeReadRequest`) + `setStudioSsh` (via `classifyWriteFailure`), mirroring `requestStatus()`.
- **WatchViewModel.kt**: `studioSshEnabled/Status/Host/Busy/Error` state; optimistic `toggleStudioSsh()` + `refreshStudioSshStatus()` hooked into the existing 5s poll.
- **WatchScreen.kt**: `StudioSshToggleCard` (Material3 `Switch` + status chip for off/starting/on/error, shows host + `ssh studio-away` hint), inserted as a `LazyColumn` item right after `HeaderBar`.

## Build & deploy
- `./gradlew :app:assembleDebug -PSM_VERSION_CODE=1077 -PSM_VERSION_NAME=0.2.0-studio-ssh` → **BUILD SUCCESSFUL**.
- Published via `scripts/deploy_android_app.sh`; server `meta.json` now reports `version_code=1077`, `version_name=0.2.0-studio-ssh`, `artifact_hash=4ef8cea8` (was 1076 / `61f874d6`). The phone's in-app updater will offer it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)