### PR TITLE
Studio SSH toggle: Rust server (Workstream A)

### DIFF
--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -322,6 +322,51 @@ pub struct ExternalAccessConfig {
     pub ssh_username: Option<String>,
     #[serde(default)]
     pub ssh_proxy_command: Option<String>,
+    #[serde(default)]
+    pub studio_ssh: StudioSshConfig,
+}
+
+/// Configuration for the on-demand "Studio SSH" toggle. The public toggle drives
+/// two per-user LaunchAgents (a dedicated loopback sshd and a cloudflared tunnel)
+/// via `launchctl`. Plist paths derive from `~/Library/LaunchAgents/<label>.plist`
+/// at runtime.
+#[derive(Debug, Clone, Deserialize)]
+pub struct StudioSshConfig {
+    #[serde(default = "default_studio_ssh_hostname")]
+    pub hostname: String,
+    #[serde(default = "default_studio_ssh_local_sshd_port")]
+    pub local_sshd_port: u16,
+    #[serde(default = "default_studio_ssh_sshd_launch_agent_label")]
+    pub sshd_launch_agent_label: String,
+    #[serde(default = "default_studio_ssh_tunnel_launch_agent_label")]
+    pub tunnel_launch_agent_label: String,
+}
+
+impl Default for StudioSshConfig {
+    fn default() -> Self {
+        Self {
+            hostname: default_studio_ssh_hostname(),
+            local_sshd_port: default_studio_ssh_local_sshd_port(),
+            sshd_launch_agent_label: default_studio_ssh_sshd_launch_agent_label(),
+            tunnel_launch_agent_label: default_studio_ssh_tunnel_launch_agent_label(),
+        }
+    }
+}
+
+fn default_studio_ssh_hostname() -> String {
+    "studio-ssh.rajeshgo.li".to_owned()
+}
+
+fn default_studio_ssh_local_sshd_port() -> u16 {
+    22222
+}
+
+fn default_studio_ssh_sshd_launch_agent_label() -> String {
+    "com.rajesh.sm-studio-ssh-sshd".to_owned()
+}
+
+fn default_studio_ssh_tunnel_launch_agent_label() -> String {
+    "com.rajesh.sm-studio-ssh-tunnel".to_owned()
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -118,6 +118,7 @@ use crate::sessions::{
     SubagentStopRequest, TaskCompleteOutcome, TaskCompleteRequest, TurnCompleteOutcome,
     UpdateSessionMetadataRequest,
 };
+use crate::studio_ssh::{self, StudioSshStatus};
 use crate::tool_usage::{
     list_recent_codex_fork_tool_calls_from_path, list_recent_tool_calls_from_path,
     log_tool_usage_to_path, ToolCallRow, ToolUsageEvent,
@@ -350,6 +351,7 @@ pub struct AppState {
     google_id_token_jwks_cache: Arc<Mutex<Option<GoogleIdTokenJwksCacheEntry>>>,
     mobile_terminal_revoked_keys: Arc<Mutex<BTreeSet<(String, String)>>>,
     mobile_terminal_runtime_disabled: Arc<AtomicBool>,
+    studio_ssh_enabled: Arc<AtomicBool>,
     mobile_terminal_secret: [u8; 32],
 }
 
@@ -361,6 +363,7 @@ impl AppState {
         let mut mobile_terminal_secret = [0u8; 32];
         OsRng.fill_bytes(&mut mobile_terminal_secret);
         let (tmux_client_event_tx, _) = broadcast::channel(128);
+        let studio_ssh_enabled = studio_ssh::status(&config.external_access.studio_ssh).enabled;
         Self {
             config,
             session_store,
@@ -377,6 +380,7 @@ impl AppState {
             google_id_token_jwks_cache: Arc::new(Mutex::new(None)),
             mobile_terminal_revoked_keys: Arc::new(Mutex::new(BTreeSet::new())),
             mobile_terminal_runtime_disabled: Arc::new(AtomicBool::new(false)),
+            studio_ssh_enabled: Arc::new(AtomicBool::new(studio_ssh_enabled)),
             mobile_terminal_secret,
         }
     }
@@ -384,6 +388,16 @@ impl AppState {
     pub fn with_github_review_poster(mut self, poster: Arc<dyn GitHubReviewPoster>) -> Self {
         self.github_review_poster = poster;
         self
+    }
+
+    /// Shared handle to the Studio SSH desired-state flag, for the reconcile loop.
+    pub fn studio_ssh_enabled_flag(&self) -> Arc<AtomicBool> {
+        self.studio_ssh_enabled.clone()
+    }
+
+    /// Read-only access to the loaded configuration (used to launch background tasks).
+    pub fn config(&self) -> &AppConfig {
+        &self.config
     }
 }
 
@@ -862,6 +876,10 @@ pub fn router(state: AppState) -> Router {
             post(disable_mobile_terminal),
         )
         .route(
+            "/admin/studio-ssh",
+            get(get_studio_ssh).post(set_studio_ssh),
+        )
+        .route(
             "/client/mobile-terminal/devices",
             get(list_mobile_terminal_devices),
         )
@@ -998,7 +1016,7 @@ async fn health() -> Json<Value> {
     Json(json!({ "status": "healthy" }))
 }
 
-async fn health_detailed() -> Json<HealthDetailedResponse> {
+async fn health_detailed(State(state): State<Arc<AppState>>) -> Json<HealthDetailedResponse> {
     let mut checks = BTreeMap::new();
     checks.insert(
         "rust_server".to_owned(),
@@ -1014,6 +1032,29 @@ async fn health_detailed() -> Json<HealthDetailedResponse> {
             message: Some("No durable state ownership in this scaffold".to_owned()),
         },
     );
+
+    let studio_cfg = state.config.external_access.studio_ssh.clone();
+    let studio = tokio::task::spawn_blocking(move || studio_ssh::status(&studio_cfg))
+        .await
+        .ok();
+    let studio_check = match studio {
+        Some(status) => HealthCheck {
+            status: if status.status == "error" {
+                "error"
+            } else {
+                "ok"
+            },
+            message: Some(format!(
+                "studio ssh {} (enabled={}, sshd_listening={}, tunnel_running={})",
+                status.status, status.enabled, status.sshd_listening, status.tunnel_running
+            )),
+        },
+        None => HealthCheck {
+            status: "error",
+            message: Some("studio ssh status probe failed".to_owned()),
+        },
+    };
+    checks.insert("studio_ssh".to_owned(), studio_check);
 
     Json(HealthDetailedResponse {
         status: "healthy",
@@ -1558,6 +1599,7 @@ async fn client_bootstrap(
     Ok(Json(client_bootstrap_response(
         &state.config,
         mobile_terminal_runtime_disabled(&state),
+        state.studio_ssh_enabled.load(Ordering::SeqCst),
     )))
 }
 
@@ -4563,6 +4605,111 @@ async fn disable_mobile_terminal(
     }))
 }
 
+#[derive(Debug, Deserialize)]
+struct StudioSshToggleRequest {
+    enabled: bool,
+}
+
+/// Authorize a Studio SSH admin request. Loopback requests skip Access entirely
+/// (local curl tests / internal callers). Non-local requests must satisfy the
+/// exact same gate as `disable_mobile_terminal`: mobile Cloudflare Access +
+/// public-edge assertion + an allowlisted owner who can disable mobile terminal.
+fn ensure_studio_ssh_admin(state: &Arc<AppState>, request: &Request) -> Result<(), ApiError> {
+    let peer_addr = request
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|value| value.0);
+    if is_local_bypass_request(request.headers(), peer_addr, &state.config) {
+        return Ok(());
+    }
+    let access_context = ensure_mobile_cloudflare_access_for_request(state, request)?;
+    ensure_public_edge_assertion_for_request(state, request)?;
+    let actor_email =
+        request_actor_email(&state.config, request).ok_or_else(|| ApiError::Status {
+            status: StatusCode::UNAUTHORIZED,
+            detail: "Authentication required".to_owned(),
+        })?;
+    ensure_mobile_cloudflare_access_context_matches_actor(
+        state,
+        access_context.as_ref(),
+        &actor_email,
+    )?;
+    let Some((_user_id, user_config)) = mobile_terminal_visible_user(&state.config, &actor_email)
+    else {
+        return Err(ApiError::Status {
+            status: StatusCode::FORBIDDEN,
+            detail: "User is not allowed to manage studio ssh".to_owned(),
+        });
+    };
+    if !user_config.interactive_shell_access || !mobile_terminal_user_can_disable(user_config) {
+        return Err(ApiError::Status {
+            status: StatusCode::FORBIDDEN,
+            detail: "User is not allowed to manage studio ssh".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn studio_ssh_error_status(config: &AppConfig, error: String) -> StudioSshStatus {
+    StudioSshStatus {
+        enabled: false,
+        status: "error".to_owned(),
+        host: config.external_access.studio_ssh.hostname.clone(),
+        sshd_listening: false,
+        tunnel_running: false,
+        error: Some(error),
+    }
+}
+
+async fn get_studio_ssh(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+) -> Result<Json<StudioSshStatus>, ApiError> {
+    ensure_studio_ssh_admin(&state, &request)?;
+    let cfg = state.config.external_access.studio_ssh.clone();
+    let status = tokio::task::spawn_blocking(move || studio_ssh::status(&cfg))
+        .await
+        .map_err(|error| ApiError::Status {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            detail: format!("studio ssh status task failed: {error}"),
+        })?;
+    Ok(Json(status))
+}
+
+async fn set_studio_ssh(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+) -> Result<Json<StudioSshStatus>, ApiError> {
+    ensure_studio_ssh_admin(&state, &request)?;
+    let Json(payload) = Json::<StudioSshToggleRequest>::from_request(request, &state)
+        .await
+        .map_err(|error| ApiError::Status {
+            status: error.status(),
+            detail: error.body_text(),
+        })?;
+    let desired = payload.enabled;
+    let cfg = state.config.external_access.studio_ssh.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        if desired {
+            studio_ssh::enable(&cfg)
+        } else {
+            studio_ssh::disable(&cfg)
+        }
+    })
+    .await
+    .map_err(|error| ApiError::Status {
+        status: StatusCode::INTERNAL_SERVER_ERROR,
+        detail: format!("studio ssh toggle task failed: {error}"),
+    })?;
+    // Record the desired state so the reconcile loop repairs toward it, even if
+    // this individual launchctl call reported a benign nonzero exit.
+    state.studio_ssh_enabled.store(desired, Ordering::SeqCst);
+    match result {
+        Ok(status) => Ok(Json(status)),
+        Err(error) => Ok(Json(studio_ssh_error_status(&state.config, error))),
+    }
+}
+
 async fn list_mobile_terminal_devices(
     State(state): State<Arc<AppState>>,
     request: Request,
@@ -7385,6 +7532,7 @@ fn shadow_predict_session_read(
 fn client_bootstrap_response(
     config: &AppConfig,
     mobile_terminal_runtime_disabled: bool,
+    studio_ssh_enabled: bool,
 ) -> ClientBootstrapResponse {
     let auth = &config.google_auth;
     let external = &config.external_access;
@@ -7413,6 +7561,8 @@ fn client_bootstrap_response(
             termux_attach_supported: false,
             mobile_terminal_supported,
             mobile_terminal_ws_url,
+            studio_ssh_enabled,
+            studio_ssh_host: external.studio_ssh.hostname.clone(),
         },
         session_open_defaults: SessionOpenDefaults {
             preferred_action: if mobile_terminal_supported {
@@ -10282,6 +10432,7 @@ fn bug_report_server_state(
         "bootstrap": client_bootstrap_response(
             &state.config,
             mobile_terminal_runtime_disabled(state),
+            state.studio_ssh_enabled.load(Ordering::SeqCst),
         ),
         "health": {
             "status": "healthy",
@@ -11287,6 +11438,8 @@ struct BootstrapExternalAccess {
     termux_attach_supported: bool,
     mobile_terminal_supported: bool,
     mobile_terminal_ws_url: Option<String>,
+    studio_ssh_enabled: bool,
+    studio_ssh_host: String,
 }
 
 #[derive(Serialize)]

--- a/crates/sm-server/src/lib.rs
+++ b/crates/sm-server/src/lib.rs
@@ -13,4 +13,5 @@ pub mod mobile_devices;
 pub mod queue;
 pub mod runtime;
 pub mod sessions;
+pub mod studio_ssh;
 pub mod tool_usage;

--- a/crates/sm-server/src/main.rs
+++ b/crates/sm-server/src/main.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, path::PathBuf, thread};
+use std::{net::SocketAddr, path::PathBuf, sync::atomic::Ordering, thread, time::Duration};
 
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -7,8 +7,12 @@ use sm_server::{
     http::{router, AppState},
     queue::{QueueAdmissionPolicy, QueueRecoverySummary, RetainedQueueStore},
     sessions::expand_home,
+    studio_ssh,
 };
 use tokio::net::TcpListener;
+
+/// How often the Studio SSH reconcile loop repairs toward the desired state.
+const STUDIO_SSH_RECONCILE_INTERVAL: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Parser)]
 #[command(version, about = "Rust Session Manager server scaffold")]
@@ -59,10 +63,35 @@ async fn main() -> Result<()> {
         );
     }
 
+    let state = AppState::new(config);
+
+    // Repair the Studio SSH LaunchAgents toward the desired state every 30s while
+    // the toggle is on. launchctl is synchronous, so run it on a blocking thread.
+    let studio_ssh_flag = state.studio_ssh_enabled_flag();
+    let studio_ssh_config = state.config().external_access.studio_ssh.clone();
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(STUDIO_SSH_RECONCILE_INTERVAL);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            ticker.tick().await;
+            if !studio_ssh_flag.load(Ordering::SeqCst) {
+                continue;
+            }
+            let config = studio_ssh_config.clone();
+            match tokio::task::spawn_blocking(move || studio_ssh::reconcile(&config)).await {
+                Ok(status) if status.status == "error" => {
+                    eprintln!("studio-ssh reconcile error: {:?}", status.error);
+                }
+                Ok(_) => {}
+                Err(error) => eprintln!("studio-ssh reconcile task failed: {error}"),
+            }
+        }
+    });
+
     eprintln!("sm-server listening on http://{address}");
     axum::serve(
         listener,
-        router(AppState::new(config)).into_make_service_with_connect_info::<SocketAddr>(),
+        router(state).into_make_service_with_connect_info::<SocketAddr>(),
     )
     .await?;
     Ok(())

--- a/crates/sm-server/src/studio_ssh.rs
+++ b/crates/sm-server/src/studio_ssh.rs
@@ -1,0 +1,420 @@
+//! On-demand "Studio SSH" toggle.
+//!
+//! Drives two per-user `launchd` agents through `launchctl`:
+//!   * a dedicated loopback `sshd` bound to `127.0.0.1:<local_sshd_port>`, and
+//!   * a `cloudflared` tunnel that publishes it at `<hostname>`.
+//!
+//! The functions here are pure/synchronous (they shell out to `launchctl` and do
+//! a TCP probe) and take a [`StudioSshConfig`] by reference. `launchctl` exits
+//! nonzero for several benign conditions (bootstrapping an already-loaded agent,
+//! booting out an agent that is not loaded); those are treated as non-fatal.
+
+use std::{
+    io::Read,
+    net::{SocketAddr, TcpStream},
+    path::PathBuf,
+    process::{Command, Stdio},
+    sync::OnceLock,
+    time::{Duration, Instant},
+};
+
+use serde::Serialize;
+
+use crate::config::StudioSshConfig;
+
+/// Observed state of the Studio SSH toggle. Field names/values are a frozen JSON
+/// contract shared with the Android app and the web UI — do not rename them.
+#[derive(Debug, Clone, Serialize)]
+pub struct StudioSshStatus {
+    /// Desired state: both LaunchAgents are loaded/enabled in launchd.
+    pub enabled: bool,
+    /// Observed lifecycle: `"off" | "starting" | "on" | "error"`.
+    pub status: String,
+    /// Public hostname the tunnel publishes.
+    pub host: String,
+    /// The loopback sshd is accepting TCP connections.
+    pub sshd_listening: bool,
+    /// The cloudflared tunnel agent is loaded and running.
+    pub tunnel_running: bool,
+    /// Human-readable error, populated only when `status == "error"`.
+    pub error: Option<String>,
+}
+
+const STATUS_OFF: &str = "off";
+const STATUS_STARTING: &str = "starting";
+const STATUS_ON: &str = "on";
+const STATUS_ERROR: &str = "error";
+
+const LAUNCHCTL_TIMEOUT: Duration = Duration::from_secs(10);
+const TCP_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Observe both agents and derive the toggle status. Never fails; on unexpected
+/// `launchctl` trouble it simply reports the agents as not loaded.
+pub fn status(cfg: &StudioSshConfig) -> StudioSshStatus {
+    let uid = current_uid();
+    let sshd_loaded = agent_loaded(uid, &cfg.sshd_launch_agent_label);
+    let tunnel_loaded = agent_loaded(uid, &cfg.tunnel_launch_agent_label);
+    let enabled = sshd_loaded && tunnel_loaded;
+
+    let sshd_listening = sshd_loaded && tcp_listening(cfg.local_sshd_port);
+    let tunnel_running = tunnel_loaded && agent_running(uid, &cfg.tunnel_launch_agent_label);
+
+    let status = if !enabled {
+        STATUS_OFF
+    } else if sshd_listening && tunnel_running {
+        STATUS_ON
+    } else {
+        STATUS_STARTING
+    };
+
+    StudioSshStatus {
+        enabled,
+        status: status.to_owned(),
+        host: cfg.hostname.clone(),
+        sshd_listening,
+        tunnel_running,
+        error: None,
+    }
+}
+
+/// Enable the toggle: enable + bootstrap + kickstart the sshd agent, then the
+/// tunnel agent. Returns the freshly observed status (likely `"starting"` since
+/// the tunnel takes a moment to connect). Errors only on genuinely fatal
+/// `launchctl` failures.
+pub fn enable(cfg: &StudioSshConfig) -> Result<StudioSshStatus, String> {
+    let uid = current_uid();
+    enable_agent(uid, &cfg.sshd_launch_agent_label)?;
+    enable_agent(uid, &cfg.tunnel_launch_agent_label)?;
+    Ok(status(cfg))
+}
+
+/// Disable the toggle: boot out + disable the tunnel agent, then the sshd agent.
+pub fn disable(cfg: &StudioSshConfig) -> Result<StudioSshStatus, String> {
+    let uid = current_uid();
+    disable_agent(uid, &cfg.tunnel_launch_agent_label)?;
+    disable_agent(uid, &cfg.sshd_launch_agent_label)?;
+    Ok(status(cfg))
+}
+
+/// Repair toward the enabled state. Intended to be called only when the desired
+/// flag is on. Re-runs the enable steps whenever the toggle is not fully `"on"`.
+/// Never flips the desired flag.
+pub fn reconcile(cfg: &StudioSshConfig) -> StudioSshStatus {
+    let current = status(cfg);
+    if current.status == STATUS_ON {
+        return current;
+    }
+    match enable(cfg) {
+        Ok(status) => status,
+        Err(error) => error_status(cfg, error),
+    }
+}
+
+fn error_status(cfg: &StudioSshConfig, error: String) -> StudioSshStatus {
+    let mut status = status(cfg);
+    status.status = STATUS_ERROR.to_owned();
+    status.error = Some(error);
+    status
+}
+
+fn enable_agent(uid: u32, label: &str) -> Result<(), String> {
+    let target = service_target(uid, label);
+    let domain = domain_target(uid);
+    let plist = plist_path(label);
+    let plist_str = plist.to_string_lossy().into_owned();
+
+    // `enable` clears a prior `disable`; it is idempotent, so ignore its exit.
+    let _ = run_launchctl(&["enable", &target]);
+
+    // `bootstrap` loads the agent. Booting an already-loaded agent exits nonzero
+    // (typically "5: Input/output error" / "service already loaded") — benign.
+    let bootstrap = run_launchctl(&["bootstrap", &domain, &plist_str]);
+    if !bootstrap.success && !is_benign_bootstrap(&bootstrap.stderr) {
+        return Err(format!(
+            "launchctl bootstrap {label} failed: {}",
+            describe(&bootstrap)
+        ));
+    }
+
+    // `kickstart -k` (re)starts the running instance. If the agent is not loaded
+    // ("No such process") treat it as benign — status() will report reality.
+    let kickstart = run_launchctl(&["kickstart", "-k", &target]);
+    if !kickstart.success && !is_benign_kickstart(&kickstart.stderr) {
+        return Err(format!(
+            "launchctl kickstart {label} failed: {}",
+            describe(&kickstart)
+        ));
+    }
+    Ok(())
+}
+
+fn disable_agent(uid: u32, label: &str) -> Result<(), String> {
+    let target = service_target(uid, label);
+
+    // `bootout` unloads the agent. Booting out one that is not loaded exits
+    // nonzero ("3: No such process" / "Could not find specified service") — benign.
+    let bootout = run_launchctl(&["bootout", &target]);
+    if !bootout.success && !is_benign_bootout(&bootout.stderr) {
+        return Err(format!(
+            "launchctl bootout {label} failed: {}",
+            describe(&bootout)
+        ));
+    }
+
+    // `disable` persists the off state so it will not RunAtLoad on next login.
+    // Idempotent; ignore its exit.
+    let _ = run_launchctl(&["disable", &target]);
+    Ok(())
+}
+
+/// True when `launchctl print gui/<uid>/<label>` succeeds (agent is loaded).
+fn agent_loaded(uid: u32, label: &str) -> bool {
+    run_launchctl(&["print", &service_target(uid, label)]).success
+}
+
+/// True when the agent is loaded AND launchd reports it running (has a live pid /
+/// `state = running`).
+fn agent_running(uid: u32, label: &str) -> bool {
+    let output = run_launchctl(&["print", &service_target(uid, label)]);
+    if !output.success {
+        return false;
+    }
+    let text = format!("{}\n{}", output.stdout, output.stderr).to_ascii_lowercase();
+    text.contains("state = running")
+        || text
+            .lines()
+            .filter_map(|line| line.split_once('='))
+            .any(|(key, value)| {
+                key.trim() == "pid" && value.trim().chars().any(|c| c.is_ascii_digit())
+            })
+}
+
+fn tcp_listening(port: u16) -> bool {
+    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    TcpStream::connect_timeout(&addr, TCP_PROBE_TIMEOUT).is_ok()
+}
+
+fn service_target(uid: u32, label: &str) -> String {
+    format!("gui/{uid}/{label}")
+}
+
+fn domain_target(uid: u32) -> String {
+    format!("gui/{uid}")
+}
+
+fn plist_path(label: &str) -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/rajesh".to_owned());
+    PathBuf::from(home)
+        .join("Library")
+        .join("LaunchAgents")
+        .join(format!("{label}.plist"))
+}
+
+/// Resolve the current uid once. Falls back to `id -u`, then to 501 (the frozen
+/// `gui/501` domain) so behaviour is deterministic even if the lookup fails.
+fn current_uid() -> u32 {
+    static UID: OnceLock<u32> = OnceLock::new();
+    *UID.get_or_init(|| {
+        Command::new("/usr/bin/id")
+            .arg("-u")
+            .output()
+            .ok()
+            .filter(|output| output.status.success())
+            .and_then(|output| String::from_utf8(output.stdout).ok())
+            .and_then(|value| value.trim().parse::<u32>().ok())
+            .unwrap_or(501)
+    })
+}
+
+struct LaunchctlResult {
+    success: bool,
+    stdout: String,
+    stderr: String,
+}
+
+fn describe(result: &LaunchctlResult) -> String {
+    let stderr = result.stderr.trim();
+    if !stderr.is_empty() {
+        return stderr.to_owned();
+    }
+    let stdout = result.stdout.trim();
+    if !stdout.is_empty() {
+        return stdout.to_owned();
+    }
+    "no output".to_owned()
+}
+
+fn run_launchctl(args: &[&str]) -> LaunchctlResult {
+    let mut command = Command::new("launchctl");
+    command.args(args);
+    match run_command_with_timeout(command, LAUNCHCTL_TIMEOUT) {
+        Ok((success, stdout, stderr)) => LaunchctlResult {
+            success,
+            stdout,
+            stderr,
+        },
+        Err(error) => LaunchctlResult {
+            success: false,
+            stdout: String::new(),
+            stderr: error,
+        },
+    }
+}
+
+/// Run a command with a wall-clock timeout, capturing stdout/stderr. Mirrors the
+/// `command_output_with_timeout` pattern used elsewhere in the crate.
+fn run_command_with_timeout(
+    mut command: Command,
+    timeout: Duration,
+) -> Result<(bool, String, String), String> {
+    let mut child = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| error.to_string())?;
+    let start = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let mut stdout = String::new();
+                let mut stderr = String::new();
+                if let Some(mut handle) = child.stdout.take() {
+                    let _ = handle.read_to_string(&mut stdout);
+                }
+                if let Some(mut handle) = child.stderr.take() {
+                    let _ = handle.read_to_string(&mut stderr);
+                }
+                return Ok((status.success(), stdout, stderr));
+            }
+            Ok(None) => {}
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error.to_string());
+            }
+        }
+        if start.elapsed() >= timeout {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(format!("timed out after {}s", timeout.as_secs()));
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn is_benign_bootstrap(stderr: &str) -> bool {
+    let text = stderr.to_ascii_lowercase();
+    text.contains("already")
+        || text.contains("input/output error")
+        || text.contains("service is already loaded")
+}
+
+fn is_benign_kickstart(stderr: &str) -> bool {
+    let text = stderr.to_ascii_lowercase();
+    text.contains("no such process") || text.contains("could not find")
+}
+
+fn is_benign_bootout(stderr: &str) -> bool {
+    let text = stderr.to_ascii_lowercase();
+    text.contains("no such process")
+        || text.contains("could not find")
+        || text.contains("not find service")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> StudioSshConfig {
+        StudioSshConfig::default()
+    }
+
+    #[test]
+    fn status_serializes_frozen_field_names() {
+        let status = StudioSshStatus {
+            enabled: true,
+            status: STATUS_ON.to_owned(),
+            host: "studio-ssh.rajeshgo.li".to_owned(),
+            sshd_listening: true,
+            tunnel_running: true,
+            error: None,
+        };
+        // Serialized field order matches the frozen contract declaration order.
+        let json = serde_json::to_string(&status).unwrap();
+        assert_eq!(
+            json,
+            r#"{"enabled":true,"status":"on","host":"studio-ssh.rajeshgo.li","sshd_listening":true,"tunnel_running":true,"error":null}"#
+        );
+        let value = serde_json::to_value(&status).unwrap();
+        assert_eq!(value["enabled"], serde_json::json!(true));
+        assert_eq!(value["status"], serde_json::json!("on"));
+        assert_eq!(value["host"], serde_json::json!("studio-ssh.rajeshgo.li"));
+        assert_eq!(value["sshd_listening"], serde_json::json!(true));
+        assert_eq!(value["tunnel_running"], serde_json::json!(true));
+        assert_eq!(value["error"], serde_json::Value::Null);
+        // Exactly the frozen snake_case keys, nothing extra.
+        let mut keys: Vec<&str> = value
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec![
+                "enabled",
+                "error",
+                "host",
+                "sshd_listening",
+                "status",
+                "tunnel_running",
+            ]
+        );
+    }
+
+    #[test]
+    fn service_and_domain_targets_use_frozen_domain() {
+        assert_eq!(
+            service_target(501, "com.rajesh.sm-studio-ssh-sshd"),
+            "gui/501/com.rajesh.sm-studio-ssh-sshd"
+        );
+        assert_eq!(domain_target(501), "gui/501");
+    }
+
+    #[test]
+    fn plist_path_is_under_launch_agents() {
+        let path = plist_path("com.rajesh.sm-studio-ssh-tunnel");
+        assert!(path.ends_with("Library/LaunchAgents/com.rajesh.sm-studio-ssh-tunnel.plist"));
+    }
+
+    #[test]
+    fn benign_launchctl_errors_are_recognized() {
+        assert!(is_benign_bootstrap(
+            "Bootstrap failed: 5: Input/output error"
+        ));
+        assert!(is_benign_bootstrap("service already bootstrapped"));
+        assert!(!is_benign_bootstrap(
+            "Bootstrap failed: 2: No such file or directory"
+        ));
+
+        assert!(is_benign_bootout("Boot-out failed: 3: No such process"));
+        assert!(is_benign_bootout("Could not find specified service"));
+        assert!(!is_benign_bootout(
+            "Boot-out failed: 1: Operation not permitted"
+        ));
+
+        assert!(is_benign_kickstart("Could not find service"));
+        assert!(!is_benign_kickstart(
+            "kickstart failed: 1: Operation not permitted"
+        ));
+    }
+
+    #[test]
+    fn error_status_carries_message() {
+        let status = error_status(&cfg(), "boom".to_owned());
+        assert_eq!(status.status, STATUS_ERROR);
+        assert_eq!(status.error.as_deref(), Some("boom"));
+        assert_eq!(status.host, "studio-ssh.rajeshgo.li");
+    }
+}

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -7182,7 +7182,9 @@ async fn bootstrap_preserves_native_schema_without_termux_or_terminal_when_disab
                 "ssh_username": "rajesh",
                 "termux_attach_supported": false,
                 "mobile_terminal_supported": false,
-                "mobile_terminal_ws_url": null
+                "mobile_terminal_ws_url": null,
+                "studio_ssh_enabled": false,
+                "studio_ssh_host": "studio-ssh.rajeshgo.li"
             },
             "session_open_defaults": {
                 "preferred_action": "details",


### PR DESCRIPTION
Implements Workstream A (Rust `sm-server`) of the Studio SSH toggle, per `specs/900_studio_ssh_toggle.md`.

## What
- **config.rs**: `StudioSshConfig` nested in `ExternalAccessConfig` as `studio_ssh` (frozen defaults: `studio-ssh.rajeshgo.li`, port `22222`, LaunchAgent labels). Passed through unchanged in `From<RawConfig>` — no other wiring.
- **studio_ssh.rs** (new, declared in `lib.rs`): `status/enable/disable/reconcile` driving `launchctl` on both the sshd and cloudflared tunnel LaunchAgents in the `gui/<uid>` domain. `StudioSshStatus` serializes to the FROZEN snake_case JSON (`enabled, status, host, sshd_listening, tunnel_running, error`). launchctl's benign nonzero exits (already-loaded on `bootstrap`, not-loaded on `bootout`) are treated as non-fatal.
- **http.rs**: `studio_ssh_enabled: Arc<AtomicBool>` on `AppState` seeded from `status().enabled`; `GET`/`POST /admin/studio-ssh` handlers reusing the `disable_mobile_terminal` auth preamble verbatim (mobile Cloudflare Access + public-edge assertion + owner gate), with loopback requests skipping Access via `is_local_bypass_request` (for curl tests). `studio_ssh` surfaced in `health/detailed`; `studio_ssh_enabled` + `studio_ssh_host` added to `BootstrapExternalAccess`.
- **main.rs**: 30s tokio reconcile loop calling `studio_ssh::reconcile` via `spawn_blocking` while the flag is on; never flips the desired flag.

## Contract
The `StudioSshStatus` JSON and the two `BootstrapExternalAccess` fields are the frozen contract Android (Workstream C) and web (Workstream D) build against — field names unchanged.

## Build gate
- `cargo build --release -p sm-server`: passes
- `cargo test -p sm-server`: 219 passed (added unit tests in `studio_ssh.rs`; updated the bootstrap golden-schema test)
- `cargo fmt`: clean; `cargo clippy`: no new warnings from this change

## Orchestrator notes
- Does NOT restart the server or run `scripts/setup_studio_ssh.sh` (Workstream B installs the plists; default state is installed-but-disabled → toggle reads OFF).
- Optional `config.yaml` override under `external_access.studio_ssh` (all fields default to the frozen constants, so no config change is required).