### PR TITLE
Studio SSH toggle: reach the workstation from anywhere

### DIFF
--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/model/ApiModels.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/model/ApiModels.kt
@@ -124,6 +124,23 @@ data class AppArtifactMetadata(
 )
 
 @Serializable
+data class StudioSshToggleRequest(
+    val enabled: Boolean,
+)
+
+@Serializable
+data class StudioSshStatusResponse(
+    val enabled: Boolean = false,
+    val status: String = "off",
+    val host: String = "",
+    @SerialName("sshd_listening")
+    val sshdListening: Boolean = false,
+    @SerialName("tunnel_running")
+    val tunnelRunning: Boolean = false,
+    val error: String? = null,
+)
+
+@Serializable
 data class SessionListResponse(
     val sessions: List<ClientSession> = emptyList(),
 )

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/remote/ApiService.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/remote/ApiService.kt
@@ -17,6 +17,8 @@ import li.rajeshgo.sm.data.model.MobileAttachTicketResponse
 import li.rajeshgo.sm.data.model.OutputResponse
 import li.rajeshgo.sm.data.model.RequestStatusResponse
 import li.rajeshgo.sm.data.model.SessionListResponse
+import li.rajeshgo.sm.data.model.StudioSshStatusResponse
+import li.rajeshgo.sm.data.model.StudioSshToggleRequest
 import li.rajeshgo.sm.data.model.ToolCallsResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
@@ -56,6 +58,12 @@ interface ApiService {
         @Header("X-SM-Device-Signature") signature: String,
         @Body request: MobileAttachTicketRequest = MobileAttachTicketRequest(),
     ): MobileAttachTicketResponse
+
+    @GET("admin/studio-ssh")
+    suspend fun getStudioSshStatus(): StudioSshStatusResponse
+
+    @POST("admin/studio-ssh")
+    suspend fun setStudioSsh(@Body request: StudioSshToggleRequest): StudioSshStatusResponse
 
     @POST("client/request-status")
     suspend fun requestStatus(): RequestStatusResponse

--- a/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SessionManagerRepository.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/data/repository/SessionManagerRepository.kt
@@ -18,6 +18,7 @@ import li.rajeshgo.sm.data.model.EnsureMaintainerResponse
 import li.rajeshgo.sm.data.model.MobileAttachTicketResponse
 import li.rajeshgo.sm.data.model.RequestStatusResponse
 import li.rajeshgo.sm.data.model.SessionDetail
+import li.rajeshgo.sm.data.model.StudioSshStatusResponse
 import li.rajeshgo.sm.data.model.ToolCallRow
 import li.rajeshgo.sm.data.remote.ApiService
 import li.rajeshgo.sm.data.remote.HttpClientFactory
@@ -269,6 +270,16 @@ class SessionManagerRepository(
     suspend fun requestStatus(baseUrl: String, token: String): Result<RequestStatusResponse> = withContext(Dispatchers.IO) {
         runCatching {
             api(baseUrl, token).requestStatus()
+        }.mapFailure(::classifyWriteFailure)
+    }
+
+    suspend fun fetchStudioSshStatus(baseUrl: String, token: String): StudioSshStatusResponse = withContext(Dispatchers.IO) {
+        executeReadRequest(baseUrl, token) { it.getStudioSshStatus() }
+    }
+
+    suspend fun setStudioSsh(baseUrl: String, token: String, enabled: Boolean): Result<StudioSshStatusResponse> = withContext(Dispatchers.IO) {
+        runCatching {
+            api(baseUrl, token).setStudioSsh(li.rajeshgo.sm.data.model.StudioSshToggleRequest(enabled))
         }.mapFailure(::classifyWriteFailure)
     }
 

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
@@ -61,6 +61,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -172,10 +173,12 @@ fun WatchScreen(
             return@LaunchedEffect
         }
         viewModel.refresh()
+        viewModel.refreshStudioSshStatus()
         updateViewModel.refresh()
         while (coroutineContext.isActive) {
             delay(WATCH_AUTO_REFRESH_MS)
             viewModel.refresh()
+            viewModel.refreshStudioSshStatus()
         }
     }
 
@@ -224,6 +227,21 @@ fun WatchScreen(
                         }
                     },
                     onOpenSettings = onNavigateToSettings,
+                )
+            }
+
+            item {
+                StudioSshToggleCard(
+                    enabled = state.studioSshEnabled,
+                    status = state.studioSshStatus,
+                    host = state.studioSshHost,
+                    busy = state.studioSshBusy,
+                    error = state.studioSshError,
+                    onToggle = { desired ->
+                        viewModel.toggleStudioSsh(desired) { result ->
+                            toast = result.exceptionOrNull()?.message ?: result.getOrNull()
+                        }
+                    },
                 )
             }
 
@@ -808,6 +826,87 @@ private class TerminalJavascriptBridge(
 }
 
 private fun jsString(value: String): String = JSONObject.quote(value)
+
+@Composable
+private fun StudioSshToggleCard(
+    enabled: Boolean,
+    status: String,
+    host: String,
+    busy: Boolean,
+    error: String?,
+    onToggle: (Boolean) -> Unit,
+) {
+    val displayHost = host.ifBlank { "studio-ssh.rajeshgo.li" }
+    Surface(
+        shape = RoundedCornerShape(18.dp),
+        color = Panel,
+        border = androidx.compose.foundation.BorderStroke(1.dp, Border),
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 14.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Row(modifier = Modifier.weight(1f), verticalAlignment = Alignment.CenterVertically) {
+                    Box(modifier = Modifier.size(9.dp).background(studioSshStatusTint(status), CircleShape))
+                    Spacer(Modifier.width(10.dp))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = "Studio SSH",
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.onSurface,
+                        )
+                        Spacer(Modifier.height(2.dp))
+                        Text(
+                            text = displayHost,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = TextMuted,
+                            fontFamily = FontFamily.Monospace,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+                Spacer(Modifier.width(10.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    StatusChip(label = status, tint = studioSshStatusTint(status))
+                    Spacer(Modifier.width(10.dp))
+                    Switch(
+                        checked = enabled,
+                        onCheckedChange = { desired -> if (!busy) onToggle(desired) },
+                        enabled = !busy,
+                    )
+                }
+            }
+            Text(
+                text = "ssh studio-away",
+                style = MaterialTheme.typography.labelSmall,
+                color = Cyan,
+                fontFamily = FontFamily.Monospace,
+            )
+            error?.let { message ->
+                Text(
+                    text = message,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Rose,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+private fun studioSshStatusTint(status: String): Color = when (status.lowercase()) {
+    "on" -> Emerald
+    "starting" -> Amber
+    "error" -> Rose
+    else -> TextMuted
+}
 
 @Composable
 private fun HeaderBar(

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchViewModel.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchViewModel.kt
@@ -60,6 +60,11 @@ data class WatchUiState(
     val refreshing: Boolean = false,
     val requestingStatus: Boolean = false,
     val ensuringMaintainer: Boolean = false,
+    val studioSshEnabled: Boolean = false,
+    val studioSshStatus: String = "off",
+    val studioSshHost: String = "",
+    val studioSshBusy: Boolean = false,
+    val studioSshError: String? = null,
     val terminal: TerminalUiState? = null,
     val lastSync: String? = null,
     val error: String? = null,
@@ -74,6 +79,9 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
     private val sessionRepository = SessionManagerRepository(settingsRepository)
     private val deviceKeyManager = DeviceKeyManager()
     private var refreshJob: Job? = null
+    // Bumped on every Studio SSH toggle so status reads that began before the
+    // latest toggle can be discarded instead of applying stale pre-toggle data.
+    private var studioSshStatusGeneration = 0
     private var terminalSocket: WebSocket? = null
     private var terminalAttachToken: String? = null
     private var pendingTerminalResize: Pair<Int, Int>? = null
@@ -686,6 +694,87 @@ class WatchViewModel(application: Application) : AndroidViewModel(application) {
             } finally {
                 _uiState.value = _uiState.value.copy(ensuringMaintainer = false)
             }
+        }
+    }
+
+    fun refreshStudioSshStatus() {
+        viewModelScope.launch {
+            val serverUrl = settingsRepository.serverUrl.first()
+            val accessToken = settingsRepository.accessToken.first()
+            if (serverUrl.isBlank() || accessToken.isBlank()) {
+                return@launch
+            }
+            if (_uiState.value.studioSshBusy) {
+                return@launch
+            }
+            val generation = studioSshStatusGeneration
+            runCatching { sessionRepository.fetchStudioSshStatus(serverUrl, accessToken) }
+                .onSuccess { status ->
+                    // A user toggle may have started (and possibly finished) while this
+                    // read was in flight; discard responses older than the latest toggle.
+                    if (_uiState.value.studioSshBusy || studioSshStatusGeneration != generation) {
+                        return@onSuccess
+                    }
+                    _uiState.value = _uiState.value.copy(
+                        studioSshEnabled = status.enabled,
+                        studioSshStatus = status.status,
+                        studioSshHost = status.host.ifBlank { _uiState.value.studioSshHost },
+                        studioSshError = status.error,
+                    )
+                }
+        }
+    }
+
+    fun toggleStudioSsh(enabled: Boolean, onComplete: (Result<String>) -> Unit) {
+        viewModelScope.launch {
+            if (_uiState.value.studioSshBusy) {
+                return@launch
+            }
+            val serverUrl = settingsRepository.serverUrl.first()
+            val accessToken = settingsRepository.accessToken.first()
+            if (serverUrl.isBlank() || accessToken.isBlank()) {
+                onComplete(Result.failure(IllegalStateException("Sign in to toggle Studio SSH")))
+                return@launch
+            }
+            // Invalidate any status read already in flight so its (pre-toggle) result is dropped.
+            studioSshStatusGeneration++
+            // Optimistic: reflect the desired state immediately.
+            _uiState.value = _uiState.value.copy(
+                studioSshBusy = true,
+                studioSshEnabled = enabled,
+                studioSshStatus = if (enabled) "starting" else "off",
+                studioSshError = null,
+            )
+            val result = sessionRepository.setStudioSsh(serverUrl, accessToken, enabled)
+                .map { status ->
+                    _uiState.value = _uiState.value.copy(
+                        studioSshEnabled = status.enabled,
+                        studioSshStatus = status.status,
+                        studioSshHost = status.host.ifBlank { _uiState.value.studioSshHost },
+                        studioSshError = status.error,
+                    )
+                    if (enabled) "Studio SSH starting" else "Studio SSH off"
+                }
+            if (result.exceptionOrNull() is SessionManagerAuthException) {
+                settingsRepository.clearAuth()
+                _uiState.value = _uiState.value.copy(
+                    sessions = emptyList(),
+                    expandedSessionIds = emptySet(),
+                    detailsBySessionId = emptyMap(),
+                    lastSync = null,
+                    userEmail = "",
+                )
+            }
+            result.onFailure { error ->
+                // Revert the optimistic desired state; the next poll reconciles from the server.
+                _uiState.value = _uiState.value.copy(
+                    studioSshEnabled = !enabled,
+                    studioSshStatus = "error",
+                    studioSshError = error.message,
+                )
+            }
+            _uiState.value = _uiState.value.copy(studioSshBusy = false)
+            onComplete(result)
         }
     }
 }

--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -322,6 +322,51 @@ pub struct ExternalAccessConfig {
     pub ssh_username: Option<String>,
     #[serde(default)]
     pub ssh_proxy_command: Option<String>,
+    #[serde(default)]
+    pub studio_ssh: StudioSshConfig,
+}
+
+/// Configuration for the on-demand "Studio SSH" toggle. The public toggle drives
+/// two per-user LaunchAgents (a dedicated loopback sshd and a cloudflared tunnel)
+/// via `launchctl`. Plist paths derive from `~/Library/LaunchAgents/<label>.plist`
+/// at runtime.
+#[derive(Debug, Clone, Deserialize)]
+pub struct StudioSshConfig {
+    #[serde(default = "default_studio_ssh_hostname")]
+    pub hostname: String,
+    #[serde(default = "default_studio_ssh_local_sshd_port")]
+    pub local_sshd_port: u16,
+    #[serde(default = "default_studio_ssh_sshd_launch_agent_label")]
+    pub sshd_launch_agent_label: String,
+    #[serde(default = "default_studio_ssh_tunnel_launch_agent_label")]
+    pub tunnel_launch_agent_label: String,
+}
+
+impl Default for StudioSshConfig {
+    fn default() -> Self {
+        Self {
+            hostname: default_studio_ssh_hostname(),
+            local_sshd_port: default_studio_ssh_local_sshd_port(),
+            sshd_launch_agent_label: default_studio_ssh_sshd_launch_agent_label(),
+            tunnel_launch_agent_label: default_studio_ssh_tunnel_launch_agent_label(),
+        }
+    }
+}
+
+fn default_studio_ssh_hostname() -> String {
+    "studio-ssh.rajeshgo.li".to_owned()
+}
+
+fn default_studio_ssh_local_sshd_port() -> u16 {
+    22222
+}
+
+fn default_studio_ssh_sshd_launch_agent_label() -> String {
+    "com.rajesh.sm-studio-ssh-sshd".to_owned()
+}
+
+fn default_studio_ssh_tunnel_launch_agent_label() -> String {
+    "com.rajesh.sm-studio-ssh-tunnel".to_owned()
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -118,6 +118,7 @@ use crate::sessions::{
     SubagentStopRequest, TaskCompleteOutcome, TaskCompleteRequest, TurnCompleteOutcome,
     UpdateSessionMetadataRequest,
 };
+use crate::studio_ssh::{self, StudioSshStatus};
 use crate::tool_usage::{
     list_recent_codex_fork_tool_calls_from_path, list_recent_tool_calls_from_path,
     log_tool_usage_to_path, ToolCallRow, ToolUsageEvent,
@@ -350,6 +351,7 @@ pub struct AppState {
     google_id_token_jwks_cache: Arc<Mutex<Option<GoogleIdTokenJwksCacheEntry>>>,
     mobile_terminal_revoked_keys: Arc<Mutex<BTreeSet<(String, String)>>>,
     mobile_terminal_runtime_disabled: Arc<AtomicBool>,
+    studio_ssh_enabled: Arc<AtomicBool>,
     mobile_terminal_secret: [u8; 32],
 }
 
@@ -361,6 +363,7 @@ impl AppState {
         let mut mobile_terminal_secret = [0u8; 32];
         OsRng.fill_bytes(&mut mobile_terminal_secret);
         let (tmux_client_event_tx, _) = broadcast::channel(128);
+        let studio_ssh_enabled = studio_ssh::status(&config.external_access.studio_ssh).enabled;
         Self {
             config,
             session_store,
@@ -377,6 +380,7 @@ impl AppState {
             google_id_token_jwks_cache: Arc::new(Mutex::new(None)),
             mobile_terminal_revoked_keys: Arc::new(Mutex::new(BTreeSet::new())),
             mobile_terminal_runtime_disabled: Arc::new(AtomicBool::new(false)),
+            studio_ssh_enabled: Arc::new(AtomicBool::new(studio_ssh_enabled)),
             mobile_terminal_secret,
         }
     }
@@ -384,6 +388,16 @@ impl AppState {
     pub fn with_github_review_poster(mut self, poster: Arc<dyn GitHubReviewPoster>) -> Self {
         self.github_review_poster = poster;
         self
+    }
+
+    /// Shared handle to the Studio SSH desired-state flag, for the reconcile loop.
+    pub fn studio_ssh_enabled_flag(&self) -> Arc<AtomicBool> {
+        self.studio_ssh_enabled.clone()
+    }
+
+    /// Read-only access to the loaded configuration (used to launch background tasks).
+    pub fn config(&self) -> &AppConfig {
+        &self.config
     }
 }
 
@@ -862,6 +876,10 @@ pub fn router(state: AppState) -> Router {
             post(disable_mobile_terminal),
         )
         .route(
+            "/admin/studio-ssh",
+            get(get_studio_ssh).post(set_studio_ssh),
+        )
+        .route(
             "/client/mobile-terminal/devices",
             get(list_mobile_terminal_devices),
         )
@@ -998,7 +1016,7 @@ async fn health() -> Json<Value> {
     Json(json!({ "status": "healthy" }))
 }
 
-async fn health_detailed() -> Json<HealthDetailedResponse> {
+async fn health_detailed(State(state): State<Arc<AppState>>) -> Json<HealthDetailedResponse> {
     let mut checks = BTreeMap::new();
     checks.insert(
         "rust_server".to_owned(),
@@ -1014,6 +1032,29 @@ async fn health_detailed() -> Json<HealthDetailedResponse> {
             message: Some("No durable state ownership in this scaffold".to_owned()),
         },
     );
+
+    let studio_cfg = state.config.external_access.studio_ssh.clone();
+    let studio = tokio::task::spawn_blocking(move || studio_ssh::status(&studio_cfg))
+        .await
+        .ok();
+    let studio_check = match studio {
+        Some(status) => HealthCheck {
+            status: if status.status == "error" {
+                "error"
+            } else {
+                "ok"
+            },
+            message: Some(format!(
+                "studio ssh {} (enabled={}, sshd_listening={}, tunnel_running={})",
+                status.status, status.enabled, status.sshd_listening, status.tunnel_running
+            )),
+        },
+        None => HealthCheck {
+            status: "error",
+            message: Some("studio ssh status probe failed".to_owned()),
+        },
+    };
+    checks.insert("studio_ssh".to_owned(), studio_check);
 
     Json(HealthDetailedResponse {
         status: "healthy",
@@ -1558,6 +1599,7 @@ async fn client_bootstrap(
     Ok(Json(client_bootstrap_response(
         &state.config,
         mobile_terminal_runtime_disabled(&state),
+        state.studio_ssh_enabled.load(Ordering::SeqCst),
     )))
 }
 
@@ -4563,6 +4605,111 @@ async fn disable_mobile_terminal(
     }))
 }
 
+#[derive(Debug, Deserialize)]
+struct StudioSshToggleRequest {
+    enabled: bool,
+}
+
+/// Authorize a Studio SSH admin request. Loopback requests skip Access entirely
+/// (local curl tests / internal callers). Non-local requests must satisfy the
+/// exact same gate as `disable_mobile_terminal`: mobile Cloudflare Access +
+/// public-edge assertion + an allowlisted owner who can disable mobile terminal.
+fn ensure_studio_ssh_admin(state: &Arc<AppState>, request: &Request) -> Result<(), ApiError> {
+    let peer_addr = request
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|value| value.0);
+    if is_local_bypass_request(request.headers(), peer_addr, &state.config) {
+        return Ok(());
+    }
+    let access_context = ensure_mobile_cloudflare_access_for_request(state, request)?;
+    ensure_public_edge_assertion_for_request(state, request)?;
+    let actor_email =
+        request_actor_email(&state.config, request).ok_or_else(|| ApiError::Status {
+            status: StatusCode::UNAUTHORIZED,
+            detail: "Authentication required".to_owned(),
+        })?;
+    ensure_mobile_cloudflare_access_context_matches_actor(
+        state,
+        access_context.as_ref(),
+        &actor_email,
+    )?;
+    let Some((_user_id, user_config)) = mobile_terminal_visible_user(&state.config, &actor_email)
+    else {
+        return Err(ApiError::Status {
+            status: StatusCode::FORBIDDEN,
+            detail: "User is not allowed to manage studio ssh".to_owned(),
+        });
+    };
+    if !user_config.interactive_shell_access || !mobile_terminal_user_can_disable(user_config) {
+        return Err(ApiError::Status {
+            status: StatusCode::FORBIDDEN,
+            detail: "User is not allowed to manage studio ssh".to_owned(),
+        });
+    }
+    Ok(())
+}
+
+fn studio_ssh_error_status(config: &AppConfig, error: String) -> StudioSshStatus {
+    StudioSshStatus {
+        enabled: false,
+        status: "error".to_owned(),
+        host: config.external_access.studio_ssh.hostname.clone(),
+        sshd_listening: false,
+        tunnel_running: false,
+        error: Some(error),
+    }
+}
+
+async fn get_studio_ssh(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+) -> Result<Json<StudioSshStatus>, ApiError> {
+    ensure_studio_ssh_admin(&state, &request)?;
+    let cfg = state.config.external_access.studio_ssh.clone();
+    let status = tokio::task::spawn_blocking(move || studio_ssh::status(&cfg))
+        .await
+        .map_err(|error| ApiError::Status {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            detail: format!("studio ssh status task failed: {error}"),
+        })?;
+    Ok(Json(status))
+}
+
+async fn set_studio_ssh(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+) -> Result<Json<StudioSshStatus>, ApiError> {
+    ensure_studio_ssh_admin(&state, &request)?;
+    let Json(payload) = Json::<StudioSshToggleRequest>::from_request(request, &state)
+        .await
+        .map_err(|error| ApiError::Status {
+            status: error.status(),
+            detail: error.body_text(),
+        })?;
+    let desired = payload.enabled;
+    let cfg = state.config.external_access.studio_ssh.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        if desired {
+            studio_ssh::enable(&cfg)
+        } else {
+            studio_ssh::disable(&cfg)
+        }
+    })
+    .await
+    .map_err(|error| ApiError::Status {
+        status: StatusCode::INTERNAL_SERVER_ERROR,
+        detail: format!("studio ssh toggle task failed: {error}"),
+    })?;
+    // Record the desired state so the reconcile loop repairs toward it, even if
+    // this individual launchctl call reported a benign nonzero exit.
+    state.studio_ssh_enabled.store(desired, Ordering::SeqCst);
+    match result {
+        Ok(status) => Ok(Json(status)),
+        Err(error) => Ok(Json(studio_ssh_error_status(&state.config, error))),
+    }
+}
+
 async fn list_mobile_terminal_devices(
     State(state): State<Arc<AppState>>,
     request: Request,
@@ -7385,6 +7532,7 @@ fn shadow_predict_session_read(
 fn client_bootstrap_response(
     config: &AppConfig,
     mobile_terminal_runtime_disabled: bool,
+    studio_ssh_enabled: bool,
 ) -> ClientBootstrapResponse {
     let auth = &config.google_auth;
     let external = &config.external_access;
@@ -7413,6 +7561,8 @@ fn client_bootstrap_response(
             termux_attach_supported: false,
             mobile_terminal_supported,
             mobile_terminal_ws_url,
+            studio_ssh_enabled,
+            studio_ssh_host: external.studio_ssh.hostname.clone(),
         },
         session_open_defaults: SessionOpenDefaults {
             preferred_action: if mobile_terminal_supported {
@@ -10282,6 +10432,7 @@ fn bug_report_server_state(
         "bootstrap": client_bootstrap_response(
             &state.config,
             mobile_terminal_runtime_disabled(state),
+            state.studio_ssh_enabled.load(Ordering::SeqCst),
         ),
         "health": {
             "status": "healthy",
@@ -11287,6 +11438,8 @@ struct BootstrapExternalAccess {
     termux_attach_supported: bool,
     mobile_terminal_supported: bool,
     mobile_terminal_ws_url: Option<String>,
+    studio_ssh_enabled: bool,
+    studio_ssh_host: String,
 }
 
 #[derive(Serialize)]

--- a/crates/sm-server/src/lib.rs
+++ b/crates/sm-server/src/lib.rs
@@ -13,4 +13,5 @@ pub mod mobile_devices;
 pub mod queue;
 pub mod runtime;
 pub mod sessions;
+pub mod studio_ssh;
 pub mod tool_usage;

--- a/crates/sm-server/src/main.rs
+++ b/crates/sm-server/src/main.rs
@@ -1,4 +1,4 @@
-use std::{net::SocketAddr, path::PathBuf, thread};
+use std::{net::SocketAddr, path::PathBuf, sync::atomic::Ordering, thread, time::Duration};
 
 use anyhow::{Context, Result};
 use clap::Parser;
@@ -7,8 +7,12 @@ use sm_server::{
     http::{router, AppState},
     queue::{QueueAdmissionPolicy, QueueRecoverySummary, RetainedQueueStore},
     sessions::expand_home,
+    studio_ssh,
 };
 use tokio::net::TcpListener;
+
+/// How often the Studio SSH reconcile loop repairs toward the desired state.
+const STUDIO_SSH_RECONCILE_INTERVAL: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Parser)]
 #[command(version, about = "Rust Session Manager server scaffold")]
@@ -59,10 +63,35 @@ async fn main() -> Result<()> {
         );
     }
 
+    let state = AppState::new(config);
+
+    // Repair the Studio SSH LaunchAgents toward the desired state every 30s while
+    // the toggle is on. launchctl is synchronous, so run it on a blocking thread.
+    let studio_ssh_flag = state.studio_ssh_enabled_flag();
+    let studio_ssh_config = state.config().external_access.studio_ssh.clone();
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(STUDIO_SSH_RECONCILE_INTERVAL);
+        ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            ticker.tick().await;
+            if !studio_ssh_flag.load(Ordering::SeqCst) {
+                continue;
+            }
+            let config = studio_ssh_config.clone();
+            match tokio::task::spawn_blocking(move || studio_ssh::reconcile(&config)).await {
+                Ok(status) if status.status == "error" => {
+                    eprintln!("studio-ssh reconcile error: {:?}", status.error);
+                }
+                Ok(_) => {}
+                Err(error) => eprintln!("studio-ssh reconcile task failed: {error}"),
+            }
+        }
+    });
+
     eprintln!("sm-server listening on http://{address}");
     axum::serve(
         listener,
-        router(AppState::new(config)).into_make_service_with_connect_info::<SocketAddr>(),
+        router(state).into_make_service_with_connect_info::<SocketAddr>(),
     )
     .await?;
     Ok(())

--- a/crates/sm-server/src/main.rs
+++ b/crates/sm-server/src/main.rs
@@ -74,11 +74,11 @@ async fn main() -> Result<()> {
         ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         loop {
             ticker.tick().await;
-            if !studio_ssh_flag.load(Ordering::SeqCst) {
-                continue;
-            }
+            // Drive toward the desired state in BOTH directions so "off" is
+            // enforced too (a stray enable that raced a disable gets corrected).
+            let desired = studio_ssh_flag.load(Ordering::SeqCst);
             let config = studio_ssh_config.clone();
-            match tokio::task::spawn_blocking(move || studio_ssh::reconcile(&config)).await {
+            match tokio::task::spawn_blocking(move || studio_ssh::reconcile(&config, desired)).await {
                 Ok(status) if status.status == "error" => {
                     eprintln!("studio-ssh reconcile error: {:?}", status.error);
                 }

--- a/crates/sm-server/src/studio_ssh.rs
+++ b/crates/sm-server/src/studio_ssh.rs
@@ -126,26 +126,30 @@ fn enable_agent(uid: u32, label: &str) -> Result<(), String> {
     // `enable` clears a prior `disable`; it is idempotent, so ignore its exit.
     let _ = run_launchctl(&["enable", &target]);
 
-    // `bootstrap` loads the agent. Booting an already-loaded agent exits nonzero
-    // (typically "5: Input/output error" / "service already loaded") — benign.
+    // `bootstrap` loads + starts the agent (RunAtLoad). Its exit code is NOT a
+    // reliable success signal: it returns nonzero both for the benign
+    // "already loaded" case and for genuine failures (a malformed or unreadable
+    // plist) — both of which can surface as "5: Input/output error". So we do not
+    // trust the exit here; the authoritative check is `agent_loaded` below.
     let bootstrap = run_launchctl(&["bootstrap", &domain, &plist_str]);
-    if !bootstrap.success && !is_benign_bootstrap(&bootstrap.stderr) {
-        return Err(format!(
-            "launchctl bootstrap {label} failed: {}",
-            describe(&bootstrap)
-        ));
-    }
 
-    // `kickstart -k` (re)starts the running instance. If the agent is not loaded
-    // ("No such process") treat it as benign — status() will report reality.
-    let kickstart = run_launchctl(&["kickstart", "-k", &target]);
-    if !kickstart.success && !is_benign_kickstart(&kickstart.stderr) {
-        return Err(format!(
-            "launchctl kickstart {label} failed: {}",
-            describe(&kickstart)
-        ));
+    // `kickstart -k` force-restarts an already-loaded agent. It is best-effort:
+    // `bootstrap` already started the service, and kickstart can legitimately time
+    // out while a slow child (cloudflared) shuts down before respawning. Never
+    // fail `enable` on kickstart alone — a bootstrapped agent is up regardless.
+    let _ = run_launchctl(&["kickstart", "-k", &target]);
+
+    // Authoritative success signal: the agent is actually loaded. This surfaces a
+    // genuine bootstrap failure (plist problem => not loaded) while tolerating the
+    // benign already-loaded and kickstart-timeout cases.
+    if agent_loaded(uid, label) {
+        Ok(())
+    } else {
+        Err(format!(
+            "launchctl bootstrap {label} did not load the agent: {}",
+            describe(&bootstrap)
+        ))
     }
-    Ok(())
 }
 
 fn disable_agent(uid: u32, label: &str) -> Result<(), String> {
@@ -161,9 +165,17 @@ fn disable_agent(uid: u32, label: &str) -> Result<(), String> {
         ));
     }
 
-    // `disable` persists the off state so it will not RunAtLoad on next login.
-    // Idempotent; ignore its exit.
-    let _ = run_launchctl(&["disable", &target]);
+    // `disable` persists the off state so the agent will NOT RunAtLoad on next
+    // login. This is the step that makes "off" durable across reboots, so a
+    // failure here matters: report it rather than claiming the toggle is off while
+    // the RunAtLoad agent could return after a reboot.
+    let disable = run_launchctl(&["disable", &target]);
+    if !disable.success {
+        return Err(format!(
+            "launchctl disable {label} failed: {}",
+            describe(&disable)
+        ));
+    }
     Ok(())
 }
 
@@ -302,18 +314,6 @@ fn run_command_with_timeout(
     }
 }
 
-fn is_benign_bootstrap(stderr: &str) -> bool {
-    let text = stderr.to_ascii_lowercase();
-    text.contains("already")
-        || text.contains("input/output error")
-        || text.contains("service is already loaded")
-}
-
-fn is_benign_kickstart(stderr: &str) -> bool {
-    let text = stderr.to_ascii_lowercase();
-    text.contains("no such process") || text.contains("could not find")
-}
-
 fn is_benign_bootout(stderr: &str) -> bool {
     let text = stderr.to_ascii_lowercase();
     text.contains("no such process")
@@ -389,24 +389,13 @@ mod tests {
     }
 
     #[test]
-    fn benign_launchctl_errors_are_recognized() {
-        assert!(is_benign_bootstrap(
-            "Bootstrap failed: 5: Input/output error"
-        ));
-        assert!(is_benign_bootstrap("service already bootstrapped"));
-        assert!(!is_benign_bootstrap(
-            "Bootstrap failed: 2: No such file or directory"
-        ));
-
+    fn benign_bootout_errors_are_recognized() {
+        // bootout of an agent that is not loaded is benign (nothing to unload).
         assert!(is_benign_bootout("Boot-out failed: 3: No such process"));
         assert!(is_benign_bootout("Could not find specified service"));
+        // a real permission failure is NOT benign and must surface.
         assert!(!is_benign_bootout(
             "Boot-out failed: 1: Operation not permitted"
-        ));
-
-        assert!(is_benign_kickstart("Could not find service"));
-        assert!(!is_benign_kickstart(
-            "kickstart failed: 1: Operation not permitted"
         ));
     }
 

--- a/crates/sm-server/src/studio_ssh.rs
+++ b/crates/sm-server/src/studio_ssh.rs
@@ -1,0 +1,420 @@
+//! On-demand "Studio SSH" toggle.
+//!
+//! Drives two per-user `launchd` agents through `launchctl`:
+//!   * a dedicated loopback `sshd` bound to `127.0.0.1:<local_sshd_port>`, and
+//!   * a `cloudflared` tunnel that publishes it at `<hostname>`.
+//!
+//! The functions here are pure/synchronous (they shell out to `launchctl` and do
+//! a TCP probe) and take a [`StudioSshConfig`] by reference. `launchctl` exits
+//! nonzero for several benign conditions (bootstrapping an already-loaded agent,
+//! booting out an agent that is not loaded); those are treated as non-fatal.
+
+use std::{
+    io::Read,
+    net::{SocketAddr, TcpStream},
+    path::PathBuf,
+    process::{Command, Stdio},
+    sync::OnceLock,
+    time::{Duration, Instant},
+};
+
+use serde::Serialize;
+
+use crate::config::StudioSshConfig;
+
+/// Observed state of the Studio SSH toggle. Field names/values are a frozen JSON
+/// contract shared with the Android app and the web UI — do not rename them.
+#[derive(Debug, Clone, Serialize)]
+pub struct StudioSshStatus {
+    /// Desired state: both LaunchAgents are loaded/enabled in launchd.
+    pub enabled: bool,
+    /// Observed lifecycle: `"off" | "starting" | "on" | "error"`.
+    pub status: String,
+    /// Public hostname the tunnel publishes.
+    pub host: String,
+    /// The loopback sshd is accepting TCP connections.
+    pub sshd_listening: bool,
+    /// The cloudflared tunnel agent is loaded and running.
+    pub tunnel_running: bool,
+    /// Human-readable error, populated only when `status == "error"`.
+    pub error: Option<String>,
+}
+
+const STATUS_OFF: &str = "off";
+const STATUS_STARTING: &str = "starting";
+const STATUS_ON: &str = "on";
+const STATUS_ERROR: &str = "error";
+
+const LAUNCHCTL_TIMEOUT: Duration = Duration::from_secs(10);
+const TCP_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Observe both agents and derive the toggle status. Never fails; on unexpected
+/// `launchctl` trouble it simply reports the agents as not loaded.
+pub fn status(cfg: &StudioSshConfig) -> StudioSshStatus {
+    let uid = current_uid();
+    let sshd_loaded = agent_loaded(uid, &cfg.sshd_launch_agent_label);
+    let tunnel_loaded = agent_loaded(uid, &cfg.tunnel_launch_agent_label);
+    let enabled = sshd_loaded && tunnel_loaded;
+
+    let sshd_listening = sshd_loaded && tcp_listening(cfg.local_sshd_port);
+    let tunnel_running = tunnel_loaded && agent_running(uid, &cfg.tunnel_launch_agent_label);
+
+    let status = if !enabled {
+        STATUS_OFF
+    } else if sshd_listening && tunnel_running {
+        STATUS_ON
+    } else {
+        STATUS_STARTING
+    };
+
+    StudioSshStatus {
+        enabled,
+        status: status.to_owned(),
+        host: cfg.hostname.clone(),
+        sshd_listening,
+        tunnel_running,
+        error: None,
+    }
+}
+
+/// Enable the toggle: enable + bootstrap + kickstart the sshd agent, then the
+/// tunnel agent. Returns the freshly observed status (likely `"starting"` since
+/// the tunnel takes a moment to connect). Errors only on genuinely fatal
+/// `launchctl` failures.
+pub fn enable(cfg: &StudioSshConfig) -> Result<StudioSshStatus, String> {
+    let uid = current_uid();
+    enable_agent(uid, &cfg.sshd_launch_agent_label)?;
+    enable_agent(uid, &cfg.tunnel_launch_agent_label)?;
+    Ok(status(cfg))
+}
+
+/// Disable the toggle: boot out + disable the tunnel agent, then the sshd agent.
+pub fn disable(cfg: &StudioSshConfig) -> Result<StudioSshStatus, String> {
+    let uid = current_uid();
+    disable_agent(uid, &cfg.tunnel_launch_agent_label)?;
+    disable_agent(uid, &cfg.sshd_launch_agent_label)?;
+    Ok(status(cfg))
+}
+
+/// Repair toward the enabled state. Intended to be called only when the desired
+/// flag is on. Re-runs the enable steps whenever the toggle is not fully `"on"`.
+/// Never flips the desired flag.
+pub fn reconcile(cfg: &StudioSshConfig) -> StudioSshStatus {
+    let current = status(cfg);
+    if current.status == STATUS_ON {
+        return current;
+    }
+    match enable(cfg) {
+        Ok(status) => status,
+        Err(error) => error_status(cfg, error),
+    }
+}
+
+fn error_status(cfg: &StudioSshConfig, error: String) -> StudioSshStatus {
+    let mut status = status(cfg);
+    status.status = STATUS_ERROR.to_owned();
+    status.error = Some(error);
+    status
+}
+
+fn enable_agent(uid: u32, label: &str) -> Result<(), String> {
+    let target = service_target(uid, label);
+    let domain = domain_target(uid);
+    let plist = plist_path(label);
+    let plist_str = plist.to_string_lossy().into_owned();
+
+    // `enable` clears a prior `disable`; it is idempotent, so ignore its exit.
+    let _ = run_launchctl(&["enable", &target]);
+
+    // `bootstrap` loads the agent. Booting an already-loaded agent exits nonzero
+    // (typically "5: Input/output error" / "service already loaded") — benign.
+    let bootstrap = run_launchctl(&["bootstrap", &domain, &plist_str]);
+    if !bootstrap.success && !is_benign_bootstrap(&bootstrap.stderr) {
+        return Err(format!(
+            "launchctl bootstrap {label} failed: {}",
+            describe(&bootstrap)
+        ));
+    }
+
+    // `kickstart -k` (re)starts the running instance. If the agent is not loaded
+    // ("No such process") treat it as benign — status() will report reality.
+    let kickstart = run_launchctl(&["kickstart", "-k", &target]);
+    if !kickstart.success && !is_benign_kickstart(&kickstart.stderr) {
+        return Err(format!(
+            "launchctl kickstart {label} failed: {}",
+            describe(&kickstart)
+        ));
+    }
+    Ok(())
+}
+
+fn disable_agent(uid: u32, label: &str) -> Result<(), String> {
+    let target = service_target(uid, label);
+
+    // `bootout` unloads the agent. Booting out one that is not loaded exits
+    // nonzero ("3: No such process" / "Could not find specified service") — benign.
+    let bootout = run_launchctl(&["bootout", &target]);
+    if !bootout.success && !is_benign_bootout(&bootout.stderr) {
+        return Err(format!(
+            "launchctl bootout {label} failed: {}",
+            describe(&bootout)
+        ));
+    }
+
+    // `disable` persists the off state so it will not RunAtLoad on next login.
+    // Idempotent; ignore its exit.
+    let _ = run_launchctl(&["disable", &target]);
+    Ok(())
+}
+
+/// True when `launchctl print gui/<uid>/<label>` succeeds (agent is loaded).
+fn agent_loaded(uid: u32, label: &str) -> bool {
+    run_launchctl(&["print", &service_target(uid, label)]).success
+}
+
+/// True when the agent is loaded AND launchd reports it running (has a live pid /
+/// `state = running`).
+fn agent_running(uid: u32, label: &str) -> bool {
+    let output = run_launchctl(&["print", &service_target(uid, label)]);
+    if !output.success {
+        return false;
+    }
+    let text = format!("{}\n{}", output.stdout, output.stderr).to_ascii_lowercase();
+    text.contains("state = running")
+        || text
+            .lines()
+            .filter_map(|line| line.split_once('='))
+            .any(|(key, value)| {
+                key.trim() == "pid" && value.trim().chars().any(|c| c.is_ascii_digit())
+            })
+}
+
+fn tcp_listening(port: u16) -> bool {
+    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    TcpStream::connect_timeout(&addr, TCP_PROBE_TIMEOUT).is_ok()
+}
+
+fn service_target(uid: u32, label: &str) -> String {
+    format!("gui/{uid}/{label}")
+}
+
+fn domain_target(uid: u32) -> String {
+    format!("gui/{uid}")
+}
+
+fn plist_path(label: &str) -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/Users/rajesh".to_owned());
+    PathBuf::from(home)
+        .join("Library")
+        .join("LaunchAgents")
+        .join(format!("{label}.plist"))
+}
+
+/// Resolve the current uid once. Falls back to `id -u`, then to 501 (the frozen
+/// `gui/501` domain) so behaviour is deterministic even if the lookup fails.
+fn current_uid() -> u32 {
+    static UID: OnceLock<u32> = OnceLock::new();
+    *UID.get_or_init(|| {
+        Command::new("/usr/bin/id")
+            .arg("-u")
+            .output()
+            .ok()
+            .filter(|output| output.status.success())
+            .and_then(|output| String::from_utf8(output.stdout).ok())
+            .and_then(|value| value.trim().parse::<u32>().ok())
+            .unwrap_or(501)
+    })
+}
+
+struct LaunchctlResult {
+    success: bool,
+    stdout: String,
+    stderr: String,
+}
+
+fn describe(result: &LaunchctlResult) -> String {
+    let stderr = result.stderr.trim();
+    if !stderr.is_empty() {
+        return stderr.to_owned();
+    }
+    let stdout = result.stdout.trim();
+    if !stdout.is_empty() {
+        return stdout.to_owned();
+    }
+    "no output".to_owned()
+}
+
+fn run_launchctl(args: &[&str]) -> LaunchctlResult {
+    let mut command = Command::new("launchctl");
+    command.args(args);
+    match run_command_with_timeout(command, LAUNCHCTL_TIMEOUT) {
+        Ok((success, stdout, stderr)) => LaunchctlResult {
+            success,
+            stdout,
+            stderr,
+        },
+        Err(error) => LaunchctlResult {
+            success: false,
+            stdout: String::new(),
+            stderr: error,
+        },
+    }
+}
+
+/// Run a command with a wall-clock timeout, capturing stdout/stderr. Mirrors the
+/// `command_output_with_timeout` pattern used elsewhere in the crate.
+fn run_command_with_timeout(
+    mut command: Command,
+    timeout: Duration,
+) -> Result<(bool, String, String), String> {
+    let mut child = command
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| error.to_string())?;
+    let start = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let mut stdout = String::new();
+                let mut stderr = String::new();
+                if let Some(mut handle) = child.stdout.take() {
+                    let _ = handle.read_to_string(&mut stdout);
+                }
+                if let Some(mut handle) = child.stderr.take() {
+                    let _ = handle.read_to_string(&mut stderr);
+                }
+                return Ok((status.success(), stdout, stderr));
+            }
+            Ok(None) => {}
+            Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(error.to_string());
+            }
+        }
+        if start.elapsed() >= timeout {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(format!("timed out after {}s", timeout.as_secs()));
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+}
+
+fn is_benign_bootstrap(stderr: &str) -> bool {
+    let text = stderr.to_ascii_lowercase();
+    text.contains("already")
+        || text.contains("input/output error")
+        || text.contains("service is already loaded")
+}
+
+fn is_benign_kickstart(stderr: &str) -> bool {
+    let text = stderr.to_ascii_lowercase();
+    text.contains("no such process") || text.contains("could not find")
+}
+
+fn is_benign_bootout(stderr: &str) -> bool {
+    let text = stderr.to_ascii_lowercase();
+    text.contains("no such process")
+        || text.contains("could not find")
+        || text.contains("not find service")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn cfg() -> StudioSshConfig {
+        StudioSshConfig::default()
+    }
+
+    #[test]
+    fn status_serializes_frozen_field_names() {
+        let status = StudioSshStatus {
+            enabled: true,
+            status: STATUS_ON.to_owned(),
+            host: "studio-ssh.rajeshgo.li".to_owned(),
+            sshd_listening: true,
+            tunnel_running: true,
+            error: None,
+        };
+        // Serialized field order matches the frozen contract declaration order.
+        let json = serde_json::to_string(&status).unwrap();
+        assert_eq!(
+            json,
+            r#"{"enabled":true,"status":"on","host":"studio-ssh.rajeshgo.li","sshd_listening":true,"tunnel_running":true,"error":null}"#
+        );
+        let value = serde_json::to_value(&status).unwrap();
+        assert_eq!(value["enabled"], serde_json::json!(true));
+        assert_eq!(value["status"], serde_json::json!("on"));
+        assert_eq!(value["host"], serde_json::json!("studio-ssh.rajeshgo.li"));
+        assert_eq!(value["sshd_listening"], serde_json::json!(true));
+        assert_eq!(value["tunnel_running"], serde_json::json!(true));
+        assert_eq!(value["error"], serde_json::Value::Null);
+        // Exactly the frozen snake_case keys, nothing extra.
+        let mut keys: Vec<&str> = value
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec![
+                "enabled",
+                "error",
+                "host",
+                "sshd_listening",
+                "status",
+                "tunnel_running",
+            ]
+        );
+    }
+
+    #[test]
+    fn service_and_domain_targets_use_frozen_domain() {
+        assert_eq!(
+            service_target(501, "com.rajesh.sm-studio-ssh-sshd"),
+            "gui/501/com.rajesh.sm-studio-ssh-sshd"
+        );
+        assert_eq!(domain_target(501), "gui/501");
+    }
+
+    #[test]
+    fn plist_path_is_under_launch_agents() {
+        let path = plist_path("com.rajesh.sm-studio-ssh-tunnel");
+        assert!(path.ends_with("Library/LaunchAgents/com.rajesh.sm-studio-ssh-tunnel.plist"));
+    }
+
+    #[test]
+    fn benign_launchctl_errors_are_recognized() {
+        assert!(is_benign_bootstrap(
+            "Bootstrap failed: 5: Input/output error"
+        ));
+        assert!(is_benign_bootstrap("service already bootstrapped"));
+        assert!(!is_benign_bootstrap(
+            "Bootstrap failed: 2: No such file or directory"
+        ));
+
+        assert!(is_benign_bootout("Boot-out failed: 3: No such process"));
+        assert!(is_benign_bootout("Could not find specified service"));
+        assert!(!is_benign_bootout(
+            "Boot-out failed: 1: Operation not permitted"
+        ));
+
+        assert!(is_benign_kickstart("Could not find service"));
+        assert!(!is_benign_kickstart(
+            "kickstart failed: 1: Operation not permitted"
+        ));
+    }
+
+    #[test]
+    fn error_status_carries_message() {
+        let status = error_status(&cfg(), "boom".to_owned());
+        assert_eq!(status.status, STATUS_ERROR);
+        assert_eq!(status.error.as_deref(), Some("boom"));
+        assert_eq!(status.host, "studio-ssh.rajeshgo.li");
+    }
+}

--- a/crates/sm-server/src/studio_ssh.rs
+++ b/crates/sm-server/src/studio_ssh.rs
@@ -96,17 +96,29 @@ pub fn disable(cfg: &StudioSshConfig) -> Result<StudioSshStatus, String> {
     Ok(status(cfg))
 }
 
-/// Repair toward the enabled state. Intended to be called only when the desired
-/// flag is on. Re-runs the enable steps whenever the toggle is not fully `"on"`.
-/// Never flips the desired flag.
-pub fn reconcile(cfg: &StudioSshConfig) -> StudioSshStatus {
+/// Repair toward the `desired` state. Called on every reconcile tick, so it drives
+/// BOTH directions: when `desired` is true it re-enables a toggle that drifted off
+/// (e.g. a crashed agent); when `desired` is false it re-disables one that drifted
+/// on (e.g. a stray enable that raced a disable). This makes the in-memory desired
+/// flag authoritative — "off" stays off. Never flips the desired flag itself.
+pub fn reconcile(cfg: &StudioSshConfig, desired: bool) -> StudioSshStatus {
     let current = status(cfg);
-    if current.status == STATUS_ON {
-        return current;
-    }
-    match enable(cfg) {
-        Ok(status) => status,
-        Err(error) => error_status(cfg, error),
+    if desired {
+        if current.status == STATUS_ON {
+            return current;
+        }
+        match enable(cfg) {
+            Ok(status) => status,
+            Err(error) => error_status(cfg, error),
+        }
+    } else {
+        if current.status == STATUS_OFF {
+            return current;
+        }
+        match disable(cfg) {
+            Ok(status) => status,
+            Err(error) => error_status(cfg, error),
+        }
     }
 }
 

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -7182,7 +7182,9 @@ async fn bootstrap_preserves_native_schema_without_termux_or_terminal_when_disab
                 "ssh_username": "rajesh",
                 "termux_attach_supported": false,
                 "mobile_terminal_supported": false,
-                "mobile_terminal_ws_url": null
+                "mobile_terminal_ws_url": null,
+                "studio_ssh_enabled": false,
+                "studio_ssh_host": "studio-ssh.rajeshgo.li"
             },
             "session_open_defaults": {
                 "preferred_action": "details",

--- a/docs/working/pr_review_process.md
+++ b/docs/working/pr_review_process.md
@@ -1,0 +1,61 @@
+# PR Review Process
+
+Use this process whenever a pull request needs Codex review and merge handling.
+
+## Review Loop
+
+Preferred path:
+
+1. Run `sm request-codex-review <pr-number>`.
+2. Treat the command response as registration only. Keep working on the PR or go idle.
+3. Wait for Session Manager to wake you with a factual message that the review/comment has landed.
+4. When you receive the wake, inspect only Codex activity that was posted after the current request.
+
+Fallback path:
+
+1. If `sm request-codex-review` is unavailable in the current Session Manager deployment, post `@codex review` as a PR comment.
+2. Wait about 5 minutes.
+3. Poll the PR for a Codex review.
+4. If no review was posted, wait 5 more minutes.
+5. Poll again.
+6. If there is still no review after 10 minutes total, post another `@codex review` comment.
+7. Repeat the cycle until a fresh review is posted.
+
+## Review Triage
+
+When Codex review lands:
+
+1. Collect all review feedback.
+2. Categorize each item by severity.
+3. Decide whether you agree with each item.
+
+## Exit Criteria
+
+- If there are any important feedback items (`P1`), exit criteria are **not met**.
+- If there are no important feedback items (`P2` or lower only), exit criteria are **met**.
+- If the review is clean, exit criteria are **met**.
+
+## After Feedback
+
+1. Fix any feedback you choose to address.
+2. Commit the changes.
+
+If exit criteria are not met:
+
+1. Push the fixes.
+2. Repeat the review loop until exit criteria are met.
+
+If exit criteria are met:
+
+1. Merge the PR.
+2. Delete the branch.
+3. Delete the worktree if one was created for the branch.
+4. Clean up local state and return to the appropriate base branch.
+
+## Notes
+
+- Prefer Session Manager ownership of the review loop when available. It handles retries, restart recovery, and "fresh review after current request" disambiguation better than ad-hoc shell polling.
+- Do not treat “a review exists” as sufficient by itself.
+- When using Session Manager wakeups, still verify that the landed review/comment is tied to the current request cycle before acting on it.
+- The blocking threshold is whether unresolved feedback contains any `P1` items.
+- `P2` or lower feedback can still be worth fixing before merge, but it does not block exit criteria.

--- a/scripts/setup_studio_ssh.sh
+++ b/scripts/setup_studio_ssh.sh
@@ -1,0 +1,391 @@
+#!/usr/bin/env bash
+#
+# setup_studio_ssh.sh — Idempotent installer for the Studio SSH toggle (Workstream B).
+#
+# Provisions everything needed to expose `ssh studio-away` (-> studio-ssh.rajeshgo.li),
+# key-only, over a dedicated cloudflared tunnel, and leaves both LaunchAgents installed
+# but DISABLED so the default state is OFF. The Rust server (Workstream A) flips them
+# on/off via launchctl at runtime.
+#
+# Steps (all idempotent):
+#   1. Create the `studio-ssh` cloudflared tunnel (if absent) + write its config.yml.
+#   2. Route DNS studio-ssh.rajeshgo.li -> the tunnel.
+#   3. Generate a dedicated ed25519 host key + write the key-only, loopback sshd_config.
+#   4. Write both LaunchAgent plists (sshd + tunnel).
+#   5. Bootout (if loaded) + disable both agents  => default OFF.
+#
+# Usage:
+#   scripts/setup_studio_ssh.sh            # real run (orchestrator runs this)
+#   scripts/setup_studio_ssh.sh --dry-run  # print every action, touch nothing outward-facing
+#   scripts/setup_studio_ssh.sh --sshd-assets-only   # only step 3 (local sshd assets); used for verification
+#
+# Test/override env vars (all default to the frozen spec constants; the orchestrator's
+# plain run uses the defaults and produces spec-exact output):
+#   STUDIO_SSH_ASSETS_DIR   sshd assets dir      (default ~/.local/share/session-manager/studio-ssh)
+#   STUDIO_SSH_AUTHORIZED_KEYS  AuthorizedKeysFile (default /Users/rajesh/.ssh/authorized_keys)
+#   STUDIO_SSH_PORT         loopback sshd port   (default 22222)
+#   STUDIO_SSH_LA_DIR       LaunchAgents dir     (default ~/Library/LaunchAgents)
+#
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Frozen shared constants (see specs/900_studio_ssh_toggle.md)
+# ---------------------------------------------------------------------------
+TUNNEL_NAME="studio-ssh"
+PUBLIC_HOSTNAME="studio-ssh.rajeshgo.li"
+SSHD_LABEL="com.rajesh.sm-studio-ssh-sshd"
+TUNNEL_LABEL="com.rajesh.sm-studio-ssh-tunnel"
+CLOUDFLARED_BIN="/opt/homebrew/bin/cloudflared"
+SSHD_BIN="/usr/sbin/sshd"
+
+# ---------------------------------------------------------------------------
+# Derived / overridable paths
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+UID_NUM="$(/usr/bin/id -u)"
+LAUNCHD_DOMAIN="gui/${UID_NUM}"
+
+SSHD_PORT="${STUDIO_SSH_PORT:-22222}"
+ASSETS_DIR="${STUDIO_SSH_ASSETS_DIR:-${HOME}/.local/share/session-manager/studio-ssh}"
+AUTHORIZED_KEYS="${STUDIO_SSH_AUTHORIZED_KEYS:-/Users/rajesh/.ssh/authorized_keys}"
+LA_DIR="${STUDIO_SSH_LA_DIR:-${HOME}/Library/LaunchAgents}"
+
+CF_DIR="${REPO_DIR}/.local/studio-ssh/cloudflared"
+CF_CONFIG="${CF_DIR}/config.yml"
+
+HOST_KEY="${ASSETS_DIR}/ssh_host_ed25519_key"
+SSHD_CONFIG="${ASSETS_DIR}/sshd_config"
+SSHD_PID="${ASSETS_DIR}/sshd.pid"
+
+SSHD_PLIST="${LA_DIR}/${SSHD_LABEL}.plist"
+TUNNEL_PLIST="${LA_DIR}/${TUNNEL_LABEL}.plist"
+
+DRY_RUN=0
+SSHD_ASSETS_ONLY=0
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+log()  { printf '  %s\n' "$*"; }
+step() { printf '\n==> %s\n' "$*"; }
+warn() { printf 'WARN: %s\n' "$*" >&2; }
+
+# Run a command, or just print it under --dry-run. Use for anything OUTWARD-FACING
+# (tunnel create, DNS route, launchctl). Local file writes are gated separately.
+run() {
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    printf '  [dry-run] %s\n' "$*"
+    return 0
+  fi
+  "$@"
+}
+
+# Write a file (heredoc via stdin), or print intent under --dry-run.
+write_file() {
+  local dest="$1"
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    printf '  [dry-run] write %s:\n' "${dest}"
+    sed 's/^/      | /'
+    return 0
+  fi
+  cat > "${dest}"
+}
+
+mkdirp() {
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    printf '  [dry-run] mkdir -p %s\n' "$1"
+  else
+    mkdir -p "$1"
+  fi
+}
+
+# Print the UUID of the `studio-ssh` tunnel, or empty if it does not exist.
+# Read-only; safe in dry-run. cloudflared returns JSON `null` when nothing matches.
+tunnel_uuid() {
+  command -v "${CLOUDFLARED_BIN}" >/dev/null 2>&1 || return 0
+  "${CLOUDFLARED_BIN}" tunnel list --name "${TUNNEL_NAME}" --output json 2>/dev/null \
+    | jq -r 'if type=="array" then (.[0].id // "") else "" end' 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Step 1 — cloudflared tunnel + config.yml
+# ---------------------------------------------------------------------------
+setup_tunnel() {
+  step "Step 1: cloudflared tunnel '${TUNNEL_NAME}' + config.yml"
+  mkdirp "${CF_DIR}"
+
+  local uuid=""
+  # Look up an existing tunnel by name (works in both real + dry-run). cloudflared
+  # returns `null` (not `[]`) when no tunnel matches, hence the array-type guard.
+  uuid="$(tunnel_uuid || true)"
+
+  if [[ -n "${uuid}" ]]; then
+    log "Tunnel '${TUNNEL_NAME}' already exists: ${uuid}"
+  else
+    if [[ "${DRY_RUN}" -eq 1 ]]; then
+      log "[dry-run] ${CLOUDFLARED_BIN} tunnel create ${TUNNEL_NAME}"
+      uuid="<uuid>"
+    else
+      log "Creating tunnel '${TUNNEL_NAME}'..."
+      "${CLOUDFLARED_BIN}" tunnel create "${TUNNEL_NAME}"
+      uuid="$(tunnel_uuid || true)"
+      if [[ -z "${uuid}" ]]; then
+        warn "Could not determine tunnel UUID after create"; exit 1
+      fi
+    fi
+  fi
+
+  # cloudflared writes creds to ~/.cloudflared/<uuid>.json on create. Mirror it into the
+  # repo-local cloudflared dir so the tunnel plist is self-contained.
+  local src_creds="${HOME}/.cloudflared/${uuid}.json"
+  local dst_creds="${CF_DIR}/${uuid}.json"
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    log "[dry-run] copy creds ${src_creds} -> ${dst_creds}"
+  else
+    if [[ -f "${src_creds}" ]]; then
+      cp -f "${src_creds}" "${dst_creds}"
+      chmod 600 "${dst_creds}"
+      log "Credentials: ${dst_creds}"
+    elif [[ -f "${dst_creds}" ]]; then
+      log "Credentials already present: ${dst_creds}"
+    else
+      warn "Tunnel credentials ${src_creds} not found (expected after create)"
+    fi
+  fi
+
+  write_file "${CF_CONFIG}" <<EOF
+tunnel: ${uuid}
+credentials-file: ${CF_DIR}/${uuid}.json
+ingress:
+  - hostname: ${PUBLIC_HOSTNAME}
+    service: ssh://127.0.0.1:${SSHD_PORT}
+  - service: http_status:404
+EOF
+  log "Wrote ${CF_CONFIG}"
+}
+
+# ---------------------------------------------------------------------------
+# Step 2 — DNS route
+# ---------------------------------------------------------------------------
+setup_dns() {
+  step "Step 2: DNS route ${PUBLIC_HOSTNAME} -> ${TUNNEL_NAME}"
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    log "[dry-run] ${CLOUDFLARED_BIN} tunnel route dns ${TUNNEL_NAME} ${PUBLIC_HOSTNAME}"
+    return 0
+  fi
+  # Idempotent: cloudflared errors if the record already exists — treat that as success.
+  local out
+  if out="$("${CLOUDFLARED_BIN}" tunnel route dns "${TUNNEL_NAME}" "${PUBLIC_HOSTNAME}" 2>&1)"; then
+    log "DNS route created."
+  else
+    if grep -qiE 'already|exists|record with that host' <<<"${out}"; then
+      log "DNS route already exists (ok)."
+    else
+      warn "DNS route failed: ${out}"; exit 1
+    fi
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Step 3 — sshd assets (host key + sshd_config). Purely local, no outward-facing calls.
+# ---------------------------------------------------------------------------
+setup_sshd_assets() {
+  step "Step 3: dedicated sshd assets in ${ASSETS_DIR}"
+  mkdirp "${ASSETS_DIR}"
+
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    log "[dry-run] ssh-keygen -t ed25519 -f ${HOST_KEY} -N '' (if absent)"
+  else
+    if [[ -f "${HOST_KEY}" ]]; then
+      log "Host key already exists: ${HOST_KEY}"
+    else
+      /usr/bin/ssh-keygen -t ed25519 -f "${HOST_KEY}" -N "" -C "studio-ssh-host" >/dev/null
+      log "Generated host key: ${HOST_KEY}"
+    fi
+    chmod 600 "${HOST_KEY}" 2>/dev/null || true
+  fi
+
+  write_file "${SSHD_CONFIG}" <<EOF
+Port ${SSHD_PORT}
+ListenAddress 127.0.0.1
+HostKey ${HOST_KEY}
+PidFile ${SSHD_PID}
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+ChallengeResponseAuthentication no
+PubkeyAuthentication yes
+AuthorizedKeysFile ${AUTHORIZED_KEYS}
+AllowUsers rajesh
+PermitRootLogin no
+UsePAM no
+LogLevel VERBOSE
+EOF
+  log "Wrote ${SSHD_CONFIG}"
+}
+
+# ---------------------------------------------------------------------------
+# Step 4 — LaunchAgent plists
+# ---------------------------------------------------------------------------
+setup_plists() {
+  step "Step 4: LaunchAgent plists in ${LA_DIR}"
+  mkdirp "${LA_DIR}"
+
+  write_file "${SSHD_PLIST}" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${SSHD_LABEL}</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>${SSHD_BIN}</string>
+        <string>-D</string>
+        <string>-f</string>
+        <string>${SSHD_CONFIG}</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>${ASSETS_DIR}/sshd.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>${ASSETS_DIR}/sshd.err.log</string>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+</dict>
+</plist>
+EOF
+  log "Wrote ${SSHD_PLIST}"
+
+  write_file "${TUNNEL_PLIST}" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${TUNNEL_LABEL}</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>${CLOUDFLARED_BIN}</string>
+        <string>tunnel</string>
+        <string>--config</string>
+        <string>${CF_CONFIG}</string>
+        <string>run</string>
+        <string>${TUNNEL_NAME}</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>${CF_DIR}/tunnel.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>${CF_DIR}/tunnel.err.log</string>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>${HOME}</string>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+</dict>
+</plist>
+EOF
+  log "Wrote ${TUNNEL_PLIST}"
+}
+
+# ---------------------------------------------------------------------------
+# Step 5 — leave both agents installed but DISABLED (default OFF)
+# ---------------------------------------------------------------------------
+disable_agents() {
+  step "Step 5: leave both LaunchAgents installed but DISABLED (default OFF)"
+  local label
+  for label in "${SSHD_LABEL}" "${TUNNEL_LABEL}"; do
+    # bootout if currently loaded (ignore "not loaded"); then disable.
+    run launchctl bootout "${LAUNCHD_DOMAIN}/${label}" || true
+    run launchctl disable "${LAUNCHD_DOMAIN}/${label}"
+    log "${label}: booted out (if loaded) + disabled"
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+summary() {
+  step "Summary"
+  cat <<EOF
+  Tunnel name        : ${TUNNEL_NAME}
+  Public hostname    : ${PUBLIC_HOSTNAME}
+  cloudflared config : ${CF_CONFIG}
+  sshd config        : ${SSHD_CONFIG}
+  sshd host key      : ${HOST_KEY}
+  authorized_keys    : ${AUTHORIZED_KEYS}
+  loopback bind      : 127.0.0.1:${SSHD_PORT}
+  sshd plist         : ${SSHD_PLIST}  (${SSHD_LABEL})
+  tunnel plist       : ${TUNNEL_PLIST}  (${TUNNEL_LABEL})
+  launchd domain     : ${LAUNCHD_DOMAIN}
+  default state      : OFF (both agents disabled)
+
+  The Rust server enables/disables these agents at runtime. To toggle manually:
+    launchctl enable ${LAUNCHD_DOMAIN}/${SSHD_LABEL}    && launchctl bootstrap ${LAUNCHD_DOMAIN} ${SSHD_PLIST}
+    launchctl enable ${LAUNCHD_DOMAIN}/${TUNNEL_LABEL}  && launchctl bootstrap ${LAUNCHD_DOMAIN} ${TUNNEL_PLIST}
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Arg parsing + main
+# ---------------------------------------------------------------------------
+usage() {
+  sed -n '2,40p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+main() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --dry-run)          DRY_RUN=1 ;;
+      --sshd-assets-only) SSHD_ASSETS_ONLY=1 ;;
+      -h|--help)          usage; exit 0 ;;
+      *) warn "Unknown argument: $1"; usage; exit 2 ;;
+    esac
+    shift
+  done
+
+  if [[ "${DRY_RUN}" -eq 1 ]]; then
+    printf '### DRY RUN — no outward-facing actions will be taken ###\n'
+  fi
+
+  if [[ "${SSHD_ASSETS_ONLY}" -eq 1 ]]; then
+    setup_sshd_assets
+    step "Done (sshd assets only)."
+    exit 0
+  fi
+
+  setup_tunnel
+  setup_dns
+  setup_sshd_assets
+  setup_plists
+  disable_agents
+  summary
+  step "Done. Default state is OFF; the server toggles it on demand."
+}
+
+main "$@"

--- a/specs/900_studio_ssh_toggle.md
+++ b/specs/900_studio_ssh_toggle.md
@@ -1,0 +1,202 @@
+# Studio SSH Toggle — Implementation Contract (frozen)
+
+Integration branch: `feat/studio-ssh-toggle`. Every worker branches off it and PRs back into it.
+Full design/rationale: `/Users/rajesh/.claude/plans/prancy-prancing-fern.md` (approved).
+
+## Goal
+
+A phone/web toggle that exposes `ssh studio-away` (→ `studio-ssh.rajeshgo.li`) from any network,
+key-only, over a dedicated cloudflared tunnel. OFF tears everything down. This doc PINS every
+shared name so the four workstreams can proceed in parallel without re-exploring.
+
+## Frozen shared constants
+
+| Thing | Value |
+|---|---|
+| Public hostname | `studio-ssh.rajeshgo.li` |
+| cloudflared tunnel name | `studio-ssh` |
+| Dedicated sshd bind | `127.0.0.1:22222` (loopback only) |
+| sshd LaunchAgent label | `com.rajesh.sm-studio-ssh-sshd` |
+| tunnel LaunchAgent label | `com.rajesh.sm-studio-ssh-tunnel` |
+| Plist path (each) | `~/Library/LaunchAgents/<label>.plist` |
+| launchd domain | `gui/501` (uid 501) |
+| cloudflared assets dir | `<repo>/.local/studio-ssh/cloudflared/` (`config.yml` + `<uuid>.json`) |
+| sshd assets dir | `~/.local/share/session-manager/studio-ssh/` (`sshd_config`, host key, logs) |
+| authorized_keys | `/Users/rajesh/.ssh/authorized_keys` (already contains the MacBook key) |
+| server | Rust `sm-server`, axum 0.8, `127.0.0.1:8420` (crates/sm-server) — Python `src/` is LEGACY, do not touch |
+
+## Frozen HTTP API (server ↔ Android ↔ web)
+
+- `GET /admin/studio-ssh` → 200 JSON `StudioSshStatus`
+- `POST /admin/studio-ssh` body `{ "enabled": true|false }` → 200 JSON `StudioSshStatus`
+
+`StudioSshStatus` (exact field names):
+```json
+{
+  "enabled": true,
+  "status": "off",            // one of: "off" | "starting" | "on" | "error"
+  "host": "studio-ssh.rajeshgo.li",
+  "sshd_listening": false,
+  "tunnel_running": false,
+  "error": null               // string when status=="error", else null
+}
+```
+Semantics: `enabled` = desired state (both LaunchAgents enabled in launchd). `status` = observed:
+`on` only when `sshd_listening && tunnel_running`; `starting` when enabled but not yet both up;
+`off` when disabled; `error` with `error` message on failure. POST enable returns immediately after
+kicking off enable() — it may return `starting`; clients poll GET.
+
+Auth (both routes): reuse the EXACT preamble of `disable_mobile_terminal` in `http.rs` — Cloudflare
+Access mobile-app JWT + public-edge assertion + `request_actor_email` + owner gate
+(`mobile_terminal_owner` via the `mobile_terminal_user_can_disable`-style check). Loopback requests
+(`is_local_bypass_request`) skip Access — required for local curl tests and the reconcile loop.
+
+## Workstream A — Rust server (`crates/sm-server/`)
+
+Files: `src/config.rs`, `src/studio_ssh.rs` (new), `src/http.rs`, `src/lib.rs` (module decl),
+`src/main.rs` (spawn reconcile task).
+
+1. **config.rs**: add `StudioSshConfig` nested in `ExternalAccessConfig` as field `studio_ssh`
+   (`#[serde(default)] pub studio_ssh: StudioSshConfig`). `ExternalAccessConfig` is passed through
+   unchanged in `From<RawConfig>` (`external_access: raw.external_access`), so nesting here needs no
+   other wiring. `StudioSshConfig` (`#[derive(Debug,Clone,Deserialize)]` + manual `Default`) fields:
+   `hostname` (default `studio-ssh.rajeshgo.li`), `local_sshd_port: u16` (default `22222`),
+   `sshd_launch_agent_label` (default `com.rajesh.sm-studio-ssh-sshd`),
+   `tunnel_launch_agent_label` (default `com.rajesh.sm-studio-ssh-tunnel`). Plist paths derive from
+   `~/Library/LaunchAgents/<label>.plist` at runtime.
+2. **studio_ssh.rs** (new module, declared in `lib.rs`): pure functions taking `&StudioSshConfig`:
+   - `pub fn status(cfg) -> StudioSshStatus` — check both agents via
+     `launchctl print gui/<uid>/<label>` (loaded?) and TCP-connect `127.0.0.1:<port>`; derive status.
+   - `pub fn enable(cfg) -> Result<StudioSshStatus>` — for sshd THEN tunnel:
+     `launchctl enable gui/<uid>/<label>` then `launchctl bootstrap gui/<uid> <plist>`
+     (ignore "already bootstrapped" errors) then `launchctl kickstart -k gui/<uid>/<label>`.
+   - `pub fn disable(cfg) -> Result<StudioSshStatus>` — tunnel THEN sshd:
+     `launchctl bootout gui/<uid>/<label>` (ignore not-loaded) then `launchctl disable gui/<uid>/<label>`.
+   - `pub fn reconcile(cfg) -> StudioSshStatus` — if enabled-but-not-healthy, re-run the enable steps.
+   - Get uid from `/usr/bin/id -u` (cache once) or `nix::unistd::getuid()`. Run launchctl via the
+     established `command_output_with_timeout` pattern (see `http.rs:406`); treat launchctl's benign
+     nonzero exits (already-loaded / not-loaded) as non-fatal.
+   - Return type `StudioSshStatus` should be a `#[derive(Serialize)]` struct matching the frozen JSON
+     — define it here and reuse in the handler.
+3. **http.rs**:
+   - `AppState` (struct ~`:337`, init ~`:379`): add `studio_ssh_enabled: Arc<AtomicBool>`, seeded
+     from `studio_ssh::status(...).enabled` at construction.
+   - Handlers modeled on `disable_mobile_terminal` (~`:4501`): `set_studio_ssh` (POST) and
+     `get_studio_ssh` (GET). Copy the auth preamble verbatim (lines ~4505-4529). POST calls
+     enable/disable, updates the AtomicBool, returns status JSON.
+   - Register routes in the `router()` chain (~`:847`): `.route("/admin/studio-ssh",
+     get(get_studio_ssh).post(set_studio_ssh))`.
+   - Request struct `StudioSshToggleRequest { enabled: bool }`.
+   - **Status surfacing**: add `studio_ssh` entry to the `health_detailed` checks map (~`:1001`),
+     and add `studio_ssh_enabled: bool` + `studio_ssh_host: String` to `BootstrapExternalAccess`
+     (~`:11283`) populated in `client_bootstrap_response` (~`:7385`).
+4. **main.rs**: after the server/AppState is built, `tokio::spawn` a loop: every 30s, if
+   `studio_ssh_enabled` is true, call `studio_ssh::reconcile(cfg)` (spawn_blocking since launchctl is
+   sync). Never flip the desired flag; only repair toward it.
+
+Build gate: `cargo build --release -p sm-server` must pass; add/adjust unit tests where the crate
+already has them (`crates/sm-server/tests/`). Do NOT restart the running server or run any setup
+script — the orchestrator handles deploy.
+
+## Workstream B — Setup script + launchd/sshd/cloudflared assets
+
+Files: `scripts/setup_studio_ssh.sh` (new, idempotent), plist + config TEMPLATES it writes.
+The orchestrator RUNS this; the worker writes and locally UNIT-tests the sshd piece only.
+
+The script must (idempotently):
+1. `cloudflared tunnel create studio-ssh` if absent (parse/create `<uuid>.json` creds; cert is
+   `~/.cloudflared/cert.pem`). Write `<repo>/.local/studio-ssh/cloudflared/config.yml`:
+   ```yaml
+   tunnel: <uuid>
+   credentials-file: <repo>/.local/studio-ssh/cloudflared/<uuid>.json
+   ingress:
+     - hostname: studio-ssh.rajeshgo.li
+       service: ssh://127.0.0.1:22222
+     - service: http_status:404
+   ```
+2. `cloudflared tunnel route dns studio-ssh studio-ssh.rajeshgo.li` (idempotent; ignore "already
+   exists").
+3. Create `~/.local/share/session-manager/studio-ssh/`, generate a dedicated ed25519 HOST key
+   (`ssh-keygen -t ed25519 -f .../ssh_host_ed25519_key -N ""`), and write `sshd_config`:
+   ```
+   Port 22222
+   ListenAddress 127.0.0.1
+   HostKey <dir>/ssh_host_ed25519_key
+   PidFile <dir>/sshd.pid
+   PasswordAuthentication no
+   KbdInteractiveAuthentication no
+   ChallengeResponseAuthentication no
+   PubkeyAuthentication yes
+   AuthorizedKeysFile /Users/rajesh/.ssh/authorized_keys
+   AllowUsers rajesh
+   PermitRootLogin no
+   UsePAM no
+   LogLevel VERBOSE
+   ```
+   NOTE: a non-root user-run sshd only permits login as the running user (rajesh) — that is exactly
+   our single-user case and needs no root. **You MUST prove it**: launch
+   `/usr/sbin/sshd -D -f <sshd_config>` in the background and confirm
+   `ssh -p 22222 -o StrictHostKeyChecking=no -i ~/.ssh/id_ed25519 rajesh@127.0.0.1 true` succeeds AND
+   `ssh -p 22222 -o PubkeyAuthentication=no rajesh@127.0.0.1 true` is REFUSED (key-only). If the
+   dedicated sshd cannot be made to work as non-root, STOP and report — do not silently fall back.
+4. Write both LaunchAgent plists to `~/Library/LaunchAgents/`:
+   - sshd plist: ProgramArguments `[/usr/sbin/sshd, -D, -f, <sshd_config>]`, `RunAtLoad` true,
+     `KeepAlive` true, std out/err to the sshd dir.
+   - tunnel plist: ProgramArguments `[/opt/homebrew/bin/cloudflared, tunnel, --config,
+     <repo>/.local/studio-ssh/cloudflared/config.yml, run, studio-ssh]`, `RunAtLoad` true,
+     `KeepAlive` true, logs under the cloudflared dir.
+5. Leave BOTH agents **installed but disabled** (`launchctl bootout` if loaded, then
+   `launchctl disable gui/501/<label>`) so default state is OFF. Print a summary.
+
+The script takes `--dry-run` (print actions, touch nothing outward-facing) so the orchestrator can
+inspect before the real run.
+
+## Workstream C — Android app (`android-app/`, Kotlin/Compose) + BUILD & DEPLOY
+
+Base URL is `https://sm.rajeshgo.li` → relative Retrofit paths. Files:
+`data/model/ApiModels.kt`, `data/remote/ApiService.kt`, `data/repository/SessionManagerRepository.kt`,
+`ui/watch/WatchViewModel.kt`, `ui/watch/WatchScreen.kt`.
+
+- DTOs: `StudioSshToggleRequest(enabled: Boolean)`, `StudioSshStatusResponse(enabled, status, host,
+  sshdListening, tunnelRunning, error)` with `@SerialName` matching the frozen snake_case JSON
+  (`sshd_listening`, `tunnel_running`).
+- `ApiService`: `@GET("admin/studio-ssh") suspend fun getStudioSshStatus(): StudioSshStatusResponse`
+  and `@POST("admin/studio-ssh") suspend fun setStudioSsh(@Body req): StudioSshStatusResponse`.
+- Repository: `fetchStudioSshStatus(...)` via `executeReadRequest`, `setStudioSsh(...)` via
+  `classifyWriteFailure` — mirror `requestStatus()`.
+- ViewModel: add `studioSshEnabled/studioSshStatus/studioSshBusy/studioSshError` to `WatchUiState`;
+  `toggleStudioSsh(enabled, onComplete)` (optimistic "starting", toast result) and
+  `refreshStudioSshStatus()`; hook the status refresh into the existing 5s poll loop.
+- UI: a `StudioSshToggleCard` (Material3 `Switch` + `StatusChip`/`statusDot` for
+  off/starting/on/error, and show the `host` + a one-line hint "ssh studio-away") inserted as a
+  `LazyColumn` item right after `HeaderBar` on the Watch screen.
+- **Build & deploy**: build the release APK and PUSH the in-app update so a phone can pull it
+  tomorrow. Investigate `scripts/deploy_android_app.sh` and the app-update path
+  (`AppUpdateRepository`, server `app_artifacts`); run whatever that pipeline needs so the new
+  version is the one the updater serves. Report the exact version/build you published and how the
+  phone will receive it. If the build toolchain is unavailable, report immediately with specifics.
+
+## Workstream D — Web (`web/sm-watch/`, React/Vite)
+
+Add a Studio SSH toggle + status chip in `src/App.tsx` (near the pause control) hitting
+`GET`/`POST /admin/studio-ssh` (same origin as `/watch`). Reflect `enabled`/`status`. Run
+`npm run build` so `web/sm-watch/dist/` is updated (served by the Rust static mount).
+
+## Per-worker git + review workflow (all workstreams)
+
+1. `cd /Users/rajesh/projects/session-manager && git fetch origin`
+2. Create your OWN worktree off the integration branch (isolates you from siblings):
+   `git worktree add /Users/rajesh/projects/sm-wt-<chunk> -b feat/studio-ssh-<chunk> origin/feat/studio-ssh-toggle`
+   then `cd` into it. (If `origin/feat/studio-ssh-toggle` isn't fetched yet, base off local
+   `feat/studio-ssh-toggle`.)
+3. Implement ONLY your workstream's files. Keep commits scoped.
+4. Self-review to clean per `docs/working/pr_review_process.md`: push your branch, open a PR
+   with `gh pr create --base feat/studio-ssh-toggle`, run the review loop
+   (`sm request-codex-review <pr#>` or the fallback), and address any **P1** feedback. P2/lower is
+   optional.
+5. When your PR is clean (no P1s) and your build gate passes, MERGE it into the integration branch
+   (`gh pr merge <pr#> --squash --delete-branch`), remove your worktree
+   (`git worktree remove <path>`), and report back: PR URL, merge status, build/test results, and
+   anything the orchestrator must do.
+6. Do NOT touch other workstreams' files, do NOT restart the running server, do NOT run
+   `setup_studio_ssh.sh` (workstream B is written but run by the orchestrator).

--- a/web/sm-watch/src/App.tsx
+++ b/web/sm-watch/src/App.tsx
@@ -4,16 +4,19 @@ import {
   Bug,
   Cable,
   Layers3,
+  Loader2,
   Pause,
   Play,
+  Power,
   Search,
   Shield,
   Sparkles,
+  TerminalSquare,
   Wifi,
   WifiOff,
   X,
 } from 'lucide-react';
-import { Session, SessionDetail, ToolCallRow, ActivityActionRow, EnsureMaintainerResponse } from './types';
+import { Session, SessionDetail, ToolCallRow, ActivityActionRow, EnsureMaintainerResponse, StudioSshStatus } from './types';
 import {
   StatusFilter,
   ageFromIso,
@@ -32,6 +35,7 @@ const DETAIL_STALE_MS = 12000;
 const KILL_PATH = '/sessions/{id}/kill';
 const BUG_REPORT_PATH = '/client/bug-reports';
 const MAINTAINER_ENSURE_PATH = '/maintainer/ensure';
+const STUDIO_SSH_PATH = '/admin/studio-ssh';
 
 async function fetchJson<T>(paths: string[]): Promise<T | null> {
   for (const path of paths) {
@@ -51,6 +55,18 @@ async function fetchJson<T>(paths: string[]): Promise<T | null> {
     }
   }
   return null;
+}
+
+async function fetchStudioSshStatus(): Promise<StudioSshStatus | null> {
+  try {
+    const response = await fetch(STUDIO_SSH_PATH, { cache: 'no-store' });
+    if (!response.ok) {
+      return null;
+    }
+    return (await response.json()) as StudioSshStatus;
+  } catch {
+    return null;
+  }
 }
 
 function summarizeActionRows(session: Session, payload: { tool_calls?: ToolCallRow[]; actions?: ActivityActionRow[] } | null): string[] {
@@ -154,6 +170,19 @@ export default function App() {
   const [bugReportSessionId, setBugReportSessionId] = useState<string | null>(null);
   const [isSubmittingBugReport, setIsSubmittingBugReport] = useState(false);
   const [isEnsuringMaintainer, setIsEnsuringMaintainer] = useState(false);
+  const [studioSsh, setStudioSsh] = useState<StudioSshStatus | null>(null);
+  const [studioSshBusy, setStudioSshBusy] = useState(false);
+  const [studioSshError, setStudioSshError] = useState<string | null>(null);
+
+  const refreshStudioSsh = async () => {
+    const status = await fetchStudioSshStatus();
+    if (status) {
+      setStudioSsh(status);
+      setStudioSshError(null);
+    } else {
+      setStudioSshError('Studio SSH status unavailable.');
+    }
+  };
 
   const pollSessions = async () => {
     if (isPaused) {
@@ -173,8 +202,10 @@ export default function App() {
 
   useEffect(() => {
     void pollSessions();
+    void refreshStudioSsh();
     const timer = window.setInterval(() => {
       void pollSessions();
+      void refreshStudioSsh();
     }, POLL_MS);
     return () => window.clearInterval(timer);
   }, [isPaused]);
@@ -478,6 +509,60 @@ export default function App() {
     }
   };
 
+  const handleToggleStudioSsh = async () => {
+    if (studioSshBusy) {
+      return;
+    }
+    const desired = !(studioSsh?.enabled ?? false);
+    setStudioSshBusy(true);
+    setStudioSsh((prev) =>
+      prev ? { ...prev, enabled: desired, status: desired ? 'starting' : 'off' } : prev,
+    );
+    try {
+      const response = await fetch(STUDIO_SSH_PATH, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: desired }),
+      });
+
+      if (response.status === 401) {
+        const nextPath = window.location.pathname || '/watch/';
+        window.location.assign(`/auth/google/login?next=${encodeURIComponent(nextPath)}`);
+        return;
+      }
+
+      if (!response.ok) {
+        showToast(`Studio SSH ${desired ? 'enable' : 'disable'} rejected (${response.status}).`);
+        void refreshStudioSsh();
+        return;
+      }
+
+      const payload = (await response.json()) as StudioSshStatus;
+      setStudioSsh(payload);
+      setStudioSshError(null);
+      showToast(`Studio SSH ${desired ? 'enabling' : 'disabling'}: ${payload.status}.`);
+    } catch {
+      showToast('Studio SSH request failed.');
+      void refreshStudioSsh();
+    } finally {
+      setStudioSshBusy(false);
+    }
+  };
+
+  const studioSshState = studioSsh?.status ?? 'off';
+  const studioSshEnabled = studioSsh?.enabled ?? false;
+  const studioSshDotClass = {
+    off: 'bg-zinc-500',
+    starting: 'bg-amber-400 animate-pulse',
+    on: 'bg-emerald-400',
+    error: 'bg-rose-400',
+  }[studioSshState];
+  const studioSshTitle = studioSsh
+    ? `${studioSsh.host} - sshd ${studioSsh.sshd_listening ? 'listening' : 'down'}, tunnel ${
+        studioSsh.tunnel_running ? 'running' : 'down'
+      }${studioSsh.error ? ` - ${studioSsh.error}` : ''}`
+    : studioSshError || 'Studio SSH status unavailable';
+
   const bugReportSession = bugReportSessionId ? sessionsById.get(bugReportSessionId) || null : null;
 
   return (
@@ -516,6 +601,28 @@ export default function App() {
                 {isPaused ? <Play size={13} /> : <Pause size={13} />}
                 {isPaused ? 'resume polling' : 'pause polling'}
               </button>
+              <div
+                title={studioSshTitle}
+                className="inline-flex items-center gap-2 rounded-full border border-zinc-800 bg-zinc-900/80 px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.18em] text-zinc-300"
+              >
+                <TerminalSquare size={13} className="text-cyan-200" />
+                <span className={`h-2 w-2 rounded-full ${studioSshDotClass}`} />
+                studio ssh - {studioSshState}
+                {studioSshError ? <span className="text-amber-300" title={studioSshError}>(stale)</span> : null}
+                <button
+                  type="button"
+                  onClick={() => void handleToggleStudioSsh()}
+                  disabled={studioSshBusy}
+                  className={`ml-1 inline-flex items-center gap-1 rounded-full border px-2 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] transition disabled:cursor-not-allowed disabled:opacity-60 ${
+                    studioSshEnabled
+                      ? 'border-emerald-500/40 bg-emerald-500/10 text-emerald-200 hover:border-emerald-400/60'
+                      : 'border-zinc-700 bg-zinc-900 text-zinc-300 hover:border-cyan-400/40 hover:text-cyan-100'
+                  }`}
+                >
+                  {studioSshBusy ? <Loader2 size={12} className="animate-spin" /> : <Power size={12} />}
+                  {studioSshEnabled ? 'on' : 'off'}
+                </button>
+              </div>
               <button
                 type="button"
                 onClick={() => void handleEnsureMaintainer()}
@@ -535,6 +642,23 @@ export default function App() {
               </button>
             </div>
           </div>
+
+          {studioSsh ? (
+            <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 border-t border-zinc-800/70 pt-3 text-[11px] text-zinc-400">
+              <span className="inline-flex items-center gap-1.5 font-semibold uppercase tracking-[0.18em] text-zinc-500">
+                <TerminalSquare size={12} className="text-cyan-200" />
+                Studio SSH
+              </span>
+              <span className="font-mono text-zinc-200">{studioSsh.host}</span>
+              <span className="rounded-md bg-zinc-900/80 px-2 py-0.5 font-mono text-cyan-200">ssh studio-away</span>
+              <span>sshd {studioSsh.sshd_listening ? 'listening' : 'down'}</span>
+              <span>tunnel {studioSsh.tunnel_running ? 'running' : 'down'}</span>
+              {studioSsh.error ? <span className="text-rose-300">{studioSsh.error}</span> : null}
+              {studioSshError ? <span className="text-amber-300">{studioSshError} (showing last known)</span> : null}
+            </div>
+          ) : studioSshError ? (
+            <div className="mt-3 border-t border-zinc-800/70 pt-3 text-[11px] text-zinc-500">{studioSshError}</div>
+          ) : null}
         </header>
 
         <section className="mb-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">

--- a/web/sm-watch/src/types.ts
+++ b/web/sm-watch/src/types.ts
@@ -105,6 +105,17 @@ export interface EnsureMaintainerResponse {
   session: Session;
 }
 
+export type StudioSshState = 'off' | 'starting' | 'on' | 'error';
+
+export interface StudioSshStatus {
+  enabled: boolean;
+  status: StudioSshState;
+  host: string;
+  sshd_listening: boolean;
+  tunnel_running: boolean;
+  error?: string | null;
+}
+
 export interface WatchSection {
   repoKey: string;
   repoLabel: string;


### PR DESCRIPTION
## What

A phone/web toggle that exposes \`ssh studio-away\` (→ \`studio-ssh.rajeshgo.li\`) from any network, key-only, over a dedicated cloudflared tunnel. OFF tears both the sshd and the tunnel down. Design doc: \`specs/900_studio_ssh_toggle.md\`.

Built by four parallel workstreams (all merged here): Rust server (#1128), setup/launchd assets (#1126), Android app (#1127), web UI (#1125), plus a follow-up robustness fix.

## Status (verified live tonight on studio)

- Infra provisioned: \`studio-ssh\` cloudflared tunnel + DNS, dedicated key-only sshd on \`127.0.0.1:22222\`, both LaunchAgents installed **disabled** (default OFF).
- Server deployed (Rust \`sm-server\` rebuilt + restarted). \`POST /admin/studio-ssh {enabled:true}\` → both agents up; \`ssh\` through Cloudflare lands a shell as \`rajesh@studio\`; \`{enabled:false}\` → fully off. Reconcile loop + \`health/detailed\` + bootstrap fields all wired.
- Android app **deployed**: versionCode 1077 / 0.2.0-studio-ssh published to the updater (the phone will offer it).
- Auth: same Cloudflare-Access + owner gate as the mobile-terminal kill switch; loopback bypass for local calls.

## Notes

- Web toggle is built/merged but the Rust server is API-only and does not currently serve \`/watch\` (pre-existing; the legacy Python server served it). Phone is the primary surface. Wiring a static mount is an easy follow-up.
- Default state is OFF; nothing is exposed until you toggle it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)