### PR TITLE
Make Claude activity hooks authoritative, add waiting state (#1130)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,25 @@
 {
   "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/hooks/notify_server.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/hooks/notify_server.sh"
+          }
+        ]
+      }
+    ],
     "SubagentStart": [
       {
         "hooks": [

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchModels.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchModels.kt
@@ -64,7 +64,7 @@ fun isOperationallyActive(session: ClientSession): Boolean {
     val rawActivity = session.activityState?.trim()
     val activity = activityLabel(rawActivity)
     return when {
-        activity == "working" || activity == "thinking" || activity == "waiting" -> true
+        activity == "working" || activity == "thinking" || activity == "waiting" || activity == "bg-wait" -> true
         !rawActivity.isNullOrEmpty() -> false
         else -> session.status == "running"
     }
@@ -267,7 +267,10 @@ fun formatDateTime(value: String?): String {
 
 fun activityLabel(state: String?): String {
     return when (state) {
-        "waiting_permission", "waiting_input", "waiting" -> "waiting"
+        // The agent's turn stopped but background shells/monitors are still
+        // running — distinct from waiting on a human.
+        "waiting" -> "bg-wait"
+        "waiting_permission", "waiting_input" -> "waiting"
         null, "" -> "idle"
         else -> state
     }

--- a/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
+++ b/android-app/app/src/main/java/li/rajeshgo/sm/ui/watch/WatchScreen.kt
@@ -1436,6 +1436,7 @@ private fun statusTint(session: ClientSession): Color = when (projectedStatusLab
 private fun activityTint(state: String?): Color = when (activityLabel(state)) {
     "working" -> Emerald
     "thinking" -> Cyan
+    "bg-wait" -> Violet
     "waiting" -> Amber
     "stopped" -> Rose
     else -> TextSecondary

--- a/android-app/app/src/test/java/li/rajeshgo/sm/ui/watch/WatchModelsTest.kt
+++ b/android-app/app/src/test/java/li/rajeshgo/sm/ui/watch/WatchModelsTest.kt
@@ -25,6 +25,21 @@ class WatchModelsTest {
     }
 
     @Test
+    fun backgroundWaitIsLabelledDistinctlyFromWaitingOnAHuman() {
+        assertEquals("bg-wait", activityLabel("waiting"))
+        assertEquals("waiting", activityLabel("waiting_input"))
+        assertEquals("waiting", activityLabel("waiting_permission"))
+    }
+
+    @Test
+    fun backgroundWaitCountsAsOperationallyActive() {
+        val session = session(status = "idle", activityState = "waiting")
+
+        assertTrue(isOperationallyActive(session))
+        assertEquals("bg-wait", projectedStatusLabel(session))
+    }
+
+    @Test
     fun runningFilterIncludesOperationallyActiveIdleSession() {
         val session = session(status = "idle", activityState = "working")
         val sections = buildSections(listOf(session))

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -7827,7 +7827,14 @@ struct ClaudePaneObservation {
 
 fn claude_live_activity_from_pane(pane_text: Option<&str>) -> Option<&'static str> {
     let observation = claude_pane_observation(pane_text);
-    match observation.turn? {
+    let Some(turn) = observation.turn else {
+        // No status line left in the window — the completion line has scrolled
+        // away. The footer's "N shell" count is still live, and the spinner would
+        // sit just above that footer if the agent were generating, so its absence
+        // plus outstanding background work is exactly the `waiting` shape.
+        return observation.background_work.then_some("waiting");
+    };
+    match turn {
         ClaudePaneTurn::Completed => Some(if observation.background_work {
             "waiting"
         } else {
@@ -11815,6 +11822,33 @@ mod tests {
 ✽ Incubating… (3m 3s · ↓ 9.9k tokens)
 "#;
         assert_eq!(claude_live_activity_from_pane(Some(pane)), Some("working"));
+    }
+
+    #[test]
+    fn claude_pane_activity_reports_waiting_when_only_the_footer_remains() {
+        // The completion line has scrolled out of the window, but the footer's
+        // shell count is still live. Background work must not vanish just because
+        // the status line it was attached to is gone.
+        let mut pane = String::new();
+        for index in 0..40 {
+            pane.push_str(&format!("⏺ Background command {index} completed\n"));
+        }
+        pane.push_str(
+            "─────────────\n❯\n  ⏵⏵ bypass permissions on · 1 shell, 1 monitor · ← for agents\n",
+        );
+
+        assert_eq!(claude_live_activity_from_pane(Some(&pane)), Some("waiting"));
+    }
+
+    #[test]
+    fn claude_pane_activity_stays_unknown_without_a_turn_line_or_background_work() {
+        let mut pane = String::new();
+        for index in 0..40 {
+            pane.push_str(&format!("⏺ Background command {index} completed\n"));
+        }
+        pane.push_str("─────────────\n❯\n  ⏵⏵ bypass permissions on · ← for agents\n");
+
+        assert_eq!(claude_live_activity_from_pane(Some(&pane)), None);
     }
 
     #[test]

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -1285,10 +1285,13 @@ async fn claude_hook(
         .get("hook_event_name")
         .and_then(Value::as_str)
         .unwrap_or("unknown");
+    // Stamped by the hook script before it detached its curl, so it describes when
+    // the event happened rather than when it reached us.
+    let emitted_at = hook_emitted_at(&payload);
     if hook_event == "UserPromptSubmit" {
         state
             .session_store
-            .apply_claude_user_prompt_submit_hook(&session_id)?;
+            .apply_claude_user_prompt_submit_hook(&session_id, emitted_at)?;
     }
     if hook_event == "Stop" {
         // Stamped before the transcript retry sleep below, so a turn-start that
@@ -1343,10 +1346,21 @@ async fn claude_hook(
             native_title_mtime_ns,
             transcript_path,
             Some(&received_at),
+            emitted_at,
         )?;
     }
 
     Ok(Json(json!({ "status": "ok" })).into_response())
+}
+
+/// Emission stamp taken by `hooks/notify_server.sh` before it detached the curl
+/// that delivered this payload. Absent for hook scripts predating that change.
+fn hook_emitted_at(payload: &Value) -> Option<&str> {
+    payload
+        .get("sm_hook_emitted_at")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
 }
 
 async fn tool_use_hook(
@@ -7721,9 +7735,8 @@ fn live_activity_state(state: &AppState, session: &SessionRecord) -> Option<&'st
         return None;
     }
     if session.provider.trim() == "claude" {
-        if !is_primary_node(&session.node) {
-            return None;
-        }
+        // Hook state is posted to the primary from every node, so it is answered
+        // before the node check — only the pane is node-local.
         if claude_hook_gate(session) == ClaudeHookGate::TurnRunning {
             // Hooks bracket the turn, so a fresh "turn in flight" signal is
             // authoritative. Skip the pane capture entirely and state the answer
@@ -7731,6 +7744,9 @@ fn live_activity_state(state: &AppState, session: &SessionRecord) -> Option<&'st
             // once `last_activity` is 30s old, which is exactly what happens
             // during a long tool-free response.
             return Some("working");
+        }
+        if !is_primary_node(&session.node) {
+            return None;
         }
         let runtime = TmuxRuntime::from_app_config(&state.config)
             .for_socket_name(session.tmux_socket_name.as_deref());
@@ -7769,12 +7785,19 @@ fn claude_live_activity_state(
     session: &SessionRecord,
     pane_text: Option<&str>,
 ) -> Option<&'static str> {
+    let gate = claude_hook_gate(session);
+    // Hooks reach the primary from every node, and the hook signal outranks both
+    // the pane and the default projection's 30s `last_activity` heuristic. Answer
+    // it before the node check so remote sessions are not stranded on the default
+    // projection for the rest of the freshness window.
+    if gate == ClaudeHookGate::TurnRunning {
+        return Some("working");
+    }
+    // Everything below needs the pane, which only the owning node can capture.
     if !is_primary_node(&session.node) {
         return None;
     }
-    match claude_hook_gate(session) {
-        // Hooks bracket the turn, and the hook signal outranks both the pane and
-        // the default projection's 30s `last_activity` heuristic.
+    match gate {
         ClaudeHookGate::TurnRunning => Some("working"),
         // The Stop hook is authoritative: the agent's turn is over. Outstanding
         // background work may only downgrade idle -> waiting, never upgrade to
@@ -11809,6 +11832,22 @@ mod tests {
 
         assert_eq!(
             claude_live_activity_state(&session, Some(pane)),
+            Some("working")
+        );
+    }
+
+    #[test]
+    fn claude_live_activity_reports_working_for_remote_sessions_from_hook_state() {
+        // Hooks are posted to the primary from every node; only the pane is
+        // node-local. A remote session must not be stranded on the default
+        // projection, which calls it idle 30s in.
+        let mut session = claude_session_with_hook_state("running", Some(&now_rfc3339()));
+        session.node = "macbook".to_owned();
+        session.last_activity = "2026-06-01T00:00:00Z".to_owned();
+
+        assert_eq!(claude_live_activity_state(&session, None), Some("working"));
+        assert_eq!(
+            live_activity_state(&AppState::new(AppConfig::default()), &session),
             Some("working")
         );
     }

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -1291,6 +1291,9 @@ async fn claude_hook(
             .apply_claude_user_prompt_submit_hook(&session_id)?;
     }
     if hook_event == "Stop" {
+        // Stamped before the transcript retry sleep below, so a turn-start that
+        // lands during that wait is recognised as the newer signal.
+        let received_at = now_rfc3339();
         let mut last_message = payload
             .get("sm_last_message")
             .and_then(Value::as_str)
@@ -1339,6 +1342,7 @@ async fn claude_hook(
             native_title,
             native_title_mtime_ns,
             transcript_path,
+            Some(&received_at),
         )?;
     }
 
@@ -11858,7 +11862,19 @@ mod tests {
         );
     }
 
+    /// Both ends of the turn are hooked — the fully wired case.
     fn claude_session_with_hook_state(
+        status: &str,
+        activity_hook_at: Option<&str>,
+    ) -> SessionRecord {
+        let mut session = claude_session_with_stop_hook_only(status, activity_hook_at);
+        session.activity_turn_start_hook_at = activity_hook_at.map(str::to_owned);
+        session
+    }
+
+    /// Only the `Stop` hook is wired — a session running outside a repo that
+    /// installs `UserPromptSubmit`.
+    fn claude_session_with_stop_hook_only(
         status: &str,
         activity_hook_at: Option<&str>,
     ) -> SessionRecord {
@@ -11875,6 +11891,20 @@ mod tests {
             "activity_hook_at": activity_hook_at
         }))
         .unwrap()
+    }
+
+    #[test]
+    fn claude_live_activity_still_reads_the_pane_when_only_the_stop_hook_is_wired() {
+        // With no turn-start hook, a stored idle cannot be trusted to still hold:
+        // the next turn produces no signal until the first PreToolUse, and a
+        // tool-free response produces none at all. The pane has to stay in play.
+        let session = claude_session_with_stop_hook_only("idle", Some(&now_rfc3339()));
+        let pane = "✽ Incubating… (3m 3s · ↓ 9.9k tokens)\n";
+
+        assert_eq!(
+            claude_live_activity_state(&session, Some(pane)),
+            Some("working")
+        );
     }
 
     #[test]

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -106,17 +106,17 @@ use crate::queue::{
 };
 use crate::runtime::TmuxRuntime;
 use crate::sessions::{
-    codex_fork_status_for_event_line, expand_home, is_primary_node, AgentRegistrationResponse,
-    AgentStatusRequest, ArmStopNotifyOutcome, ArmStopNotifyRequest, ChildSessionResponse,
-    ClearSessionRequest, ClientSessionResponse, ContextMonitorOutcome, ContextMonitorRequest,
-    CoreClearOutcome, CoreInputBatchResponse, CoreInputBatchResult, CoreRestoreOutcome,
-    CoreRetireOutcome, CoreReviewOutcome, CreateCoreSessionRequest, HandoffOutcome, HandoffRequest,
-    MaintainerMutationOutcome, RegistryMutationOutcome, RoleRegistrationRequest,
-    SendCoreInputBatchRequest, SendCoreInputRequest, SessionMetadataOutcome, SessionRecord,
-    SessionResponse, SessionStore, SessionsEnvelope, SetMaintainerRequest, SpawnReviewRequest,
-    StartReviewRequest, SubagentStartOutcome, SubagentStartRequest, SubagentStopOutcome,
-    SubagentStopRequest, TaskCompleteOutcome, TaskCompleteRequest, TurnCompleteOutcome,
-    UpdateSessionMetadataRequest,
+    claude_hook_gate, codex_fork_status_for_event_line, expand_home, is_primary_node,
+    AgentRegistrationResponse, AgentStatusRequest, ArmStopNotifyOutcome, ArmStopNotifyRequest,
+    ChildSessionResponse, ClaudeHookGate, ClearSessionRequest, ClientSessionResponse,
+    ContextMonitorOutcome, ContextMonitorRequest, CoreClearOutcome, CoreInputBatchResponse,
+    CoreInputBatchResult, CoreRestoreOutcome, CoreRetireOutcome, CoreReviewOutcome,
+    CreateCoreSessionRequest, HandoffOutcome, HandoffRequest, MaintainerMutationOutcome,
+    RegistryMutationOutcome, RoleRegistrationRequest, SendCoreInputBatchRequest,
+    SendCoreInputRequest, SessionMetadataOutcome, SessionRecord, SessionResponse, SessionStore,
+    SessionsEnvelope, SetMaintainerRequest, SpawnReviewRequest, StartReviewRequest,
+    SubagentStartOutcome, SubagentStartRequest, SubagentStopOutcome, SubagentStopRequest,
+    TaskCompleteOutcome, TaskCompleteRequest, TurnCompleteOutcome, UpdateSessionMetadataRequest,
 };
 use crate::studio_ssh::{self, StudioSshStatus};
 use crate::tool_usage::{
@@ -1285,6 +1285,11 @@ async fn claude_hook(
         .get("hook_event_name")
         .and_then(Value::as_str)
         .unwrap_or("unknown");
+    if hook_event == "UserPromptSubmit" {
+        state
+            .session_store
+            .apply_claude_user_prompt_submit_hook(&session_id)?;
+    }
     if hook_event == "Stop" {
         let mut last_message = payload
             .get("sm_last_message")
@@ -7715,6 +7720,11 @@ fn live_activity_state(state: &AppState, session: &SessionRecord) -> Option<&'st
         if !is_primary_node(&session.node) {
             return None;
         }
+        if claude_hook_gate(session) == ClaudeHookGate::TurnRunning {
+            // Hooks bracket the turn, so a fresh "turn in flight" signal is
+            // authoritative. Skip the pane capture entirely.
+            return None;
+        }
         let runtime = TmuxRuntime::from_app_config(&state.config)
             .for_socket_name(session.tmux_socket_name.as_deref());
         let pane_text = runtime.capture_pane_text(&session.tmux_session);
@@ -7755,11 +7765,58 @@ fn claude_live_activity_state(
     if !is_primary_node(&session.node) {
         return None;
     }
-    claude_live_activity_from_pane(pane_text)
+    match claude_hook_gate(session) {
+        // Hooks bracket the turn; the stored state already says what it needs to.
+        ClaudeHookGate::TurnRunning => None,
+        // The Stop hook is authoritative: the agent's turn is over. Outstanding
+        // background work may only downgrade idle -> waiting, never upgrade to
+        // working.
+        ClaudeHookGate::TurnStopped => claude_pane_observation(pane_text)
+            .background_work
+            .then_some("waiting"),
+        // Last resort: the hook signal is missing or stale, so re-derive the
+        // state from the pane.
+        ClaudeHookGate::Untracked | ClaudeHookGate::Stale => {
+            claude_live_activity_from_pane(pane_text)
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClaudePaneTurn {
+    Completed,
+    Working,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct ClaudePaneObservation {
+    turn: Option<ClaudePaneTurn>,
+    background_work: bool,
 }
 
 fn claude_live_activity_from_pane(pane_text: Option<&str>) -> Option<&'static str> {
-    let pane_text = pane_text?;
+    let observation = claude_pane_observation(pane_text);
+    match observation.turn? {
+        ClaudePaneTurn::Completed => Some(if observation.background_work {
+            "waiting"
+        } else {
+            "idle"
+        }),
+        ClaudePaneTurn::Working => Some("working"),
+    }
+}
+
+/// Classifies the tail of the tmux pane into a turn state plus an
+/// outstanding-background-work flag.
+///
+/// Background work is only read from the newest status line and the chrome
+/// below it (the footer mode line). Older status lines scroll up with stale
+/// "N shell still running" segments attached, and counting those would resurrect
+/// long-finished background work.
+fn claude_pane_observation(pane_text: Option<&str>) -> ClaudePaneObservation {
+    let Some(pane_text) = pane_text else {
+        return ClaudePaneObservation::default();
+    };
     let mut relevant_lines = Vec::new();
     for line in pane_text
         .lines()
@@ -7771,32 +7828,99 @@ fn claude_live_activity_from_pane(pane_text: Option<&str>) -> Option<&'static st
             relevant_lines.remove(0);
         }
     }
-    for line in relevant_lines.iter().rev().take(30) {
+
+    let window_start = relevant_lines.len().saturating_sub(30);
+    let window = &relevant_lines[window_start..];
+    // When no status line is visible at all, `turn_index` stays at 0 so the whole
+    // window is searched for background work — the footer mode line still carries
+    // a reliable "N shell, N monitor" count.
+    let mut turn = None;
+    let mut turn_index = 0;
+    for (index, line) in window.iter().enumerate().rev() {
         if claude_line_indicates_completed(line) {
-            return Some("idle");
+            turn = Some(ClaudePaneTurn::Completed);
+            turn_index = index;
+            break;
         }
         if claude_line_indicates_working(line) {
-            return Some("working");
+            turn = Some(ClaudePaneTurn::Working);
+            turn_index = index;
+            break;
         }
     }
-    None
+
+    let background_work = window[turn_index..]
+        .iter()
+        .any(|line| claude_line_indicates_background_work(line));
+
+    ClaudePaneObservation {
+        turn,
+        background_work,
+    }
 }
 
+/// Structural match for a finished turn: a status glyph, a single completion
+/// verb, `for`, and a duration — with no spinner ellipsis and no interrupt hint.
+///
+/// Deliberately verb-agnostic. Claude cycles through a large and growing set of
+/// completion verbs (Brewed, Baked, Churned, Crunched, Cooked, Simmered, …), and
+/// an allowlist silently fails to detect idle on every verb it has not seen.
 fn claude_line_indicates_completed(line: &str) -> bool {
     let line = line.trim();
-    !claude_line_indicates_background_work(line)
-        && (line.contains("Brewed for")
-            || line.contains("Baked for")
-            || line.contains("Churned for"))
+    if line.contains('…') || line.contains("esc to interrupt") {
+        return false;
+    }
+    let Some(rest) = claude_strip_status_glyph(line) else {
+        return false;
+    };
+    let mut tokens = rest.split_whitespace();
+    let Some(verb) = tokens.next() else {
+        return false;
+    };
+    if !verb.chars().all(char::is_alphabetic)
+        || !verb.chars().next().is_some_and(char::is_uppercase)
+    {
+        return false;
+    }
+    if tokens.next() != Some("for") {
+        return false;
+    }
+    tokens.next().is_some_and(claude_duration_token)
+}
+
+/// Strips the leading status glyph (`·` or the dingbat block Claude draws its
+/// spinner from), returning the remainder of the line.
+///
+/// Todo/checkbox glyphs live in the same block, so they are rejected explicitly:
+/// a todo entry such as `✔ Waited for 30s` must not read as a finished turn.
+fn claude_strip_status_glyph(line: &str) -> Option<&str> {
+    const TODO_GLYPHS: [char; 6] = ['✔', '✗', '✘', '✓', '❯', '❮'];
+    let mut chars = line.chars();
+    let first = chars.next()?;
+    if TODO_GLYPHS.contains(&first) {
+        return None;
+    }
+    if first != '·' && !(0x2700..=0x27bf).contains(&(first as u32)) {
+        return None;
+    }
+    Some(chars.as_str().trim_start())
+}
+
+/// `41s`, `9m`, `1h` — the duration segments Claude prints after `for`.
+fn claude_duration_token(token: &str) -> bool {
+    let digits_end = token
+        .find(|ch: char| !ch.is_ascii_digit())
+        .unwrap_or(token.len());
+    if digits_end == 0 {
+        return false;
+    }
+    matches!(&token[digits_end..], "s" | "m" | "h" | "ms")
 }
 
 fn claude_line_indicates_working(line: &str) -> bool {
     let line = line.trim();
     if claude_line_indicates_completed(line) {
         return false;
-    }
-    if claude_line_indicates_background_work(line) {
-        return true;
     }
     if claude_spinner_status_line_indicates_working(line) {
         return true;
@@ -11542,7 +11666,7 @@ mod tests {
     }
 
     #[test]
-    fn claude_pane_activity_detects_background_shell_monitor_work_at_prompt() {
+    fn claude_pane_activity_waits_on_background_shell_monitor_work_at_prompt() {
         let pane = r#"
 ⏺ Building/running. Let me wait for the monitor to surface the serve session-create number.
 
@@ -11558,11 +11682,11 @@ mod tests {
   Opus 4.8 (1M context)  [█████░░░░░░░░░░░░░░░] 27%
   ⏵⏵ bypass permissions on · 1 shell, 1 monitor · ← for agents
 "#;
-        assert_eq!(claude_live_activity_from_pane(Some(pane)), Some("working"));
+        assert_eq!(claude_live_activity_from_pane(Some(pane)), Some("waiting"));
     }
 
     #[test]
-    fn claude_pane_activity_detects_baked_background_work_at_prompt() {
+    fn claude_pane_activity_waits_on_baked_background_work_at_prompt() {
         let pane = r#"
 ⏺ Report delivered to the orchestrator.
 
@@ -11571,7 +11695,7 @@ mod tests {
 ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 ❯
 "#;
-        assert_eq!(claude_live_activity_from_pane(Some(pane)), Some("working"));
+        assert_eq!(claude_live_activity_from_pane(Some(pane)), Some("waiting"));
     }
 
     #[test]
@@ -11633,6 +11757,124 @@ mod tests {
         ⏵⏵ auto mode on · PR #48
 "#;
         assert_eq!(claude_live_activity_from_pane(Some(pane)), Some("idle"));
+    }
+
+    #[test]
+    fn claude_pane_activity_detects_unlisted_completion_verbs() {
+        // "Crunched" (and every other verb Claude cycles through) was invisible
+        // to the old three-verb allowlist, so idle was never detected.
+        for verb in ["Crunched", "Cooked", "Simmered", "Sautéed", "Percolated"] {
+            let pane = format!(
+                "⏺ Type-checks clean.\n✻ {verb} for 41s\n❯\n────────\n  ⏵⏵ bypass permissions on · ← for agents\n"
+            );
+            assert_eq!(
+                claude_live_activity_from_pane(Some(&pane)),
+                Some("idle"),
+                "expected idle for completion verb {verb}"
+            );
+        }
+    }
+
+    #[test]
+    fn claude_pane_activity_ignores_completion_shaped_todo_entries() {
+        // Todo glyphs live in the same dingbat block as the status glyph; a todo
+        // entry that happens to read like a completion must not end the turn.
+        let pane = r#"
+  ✔ Waited for 30s
+✽ Incubating… (3m 3s · ↓ 9.9k tokens)
+"#;
+        assert_eq!(claude_live_activity_from_pane(Some(pane)), Some("working"));
+    }
+
+    #[test]
+    fn claude_pane_activity_ignores_interrupted_completion_line() {
+        let pane = r#"
+✻ Crunching for 41s (esc to interrupt)
+"#;
+        assert_eq!(claude_live_activity_from_pane(Some(pane)), None);
+    }
+
+    #[test]
+    fn claude_live_activity_trusts_fresh_turn_running_hook_over_pane() {
+        let session = claude_session_with_hook_state("running", Some(&now_rfc3339()));
+        let pane = "✻ Crunched for 41s\n";
+
+        assert_eq!(claude_live_activity_state(&session, Some(pane)), None);
+    }
+
+    #[test]
+    fn claude_live_activity_recovers_idle_when_turn_running_hook_goes_stale() {
+        // The Stop hook is lossy (restarts, event-loop stalls, watchdog kills).
+        // Once the "turn in flight" signal ages out, the pane has to correct it.
+        let session = claude_session_with_hook_state("running", Some("2026-06-01T00:00:00Z"));
+        let pane = "✻ Crunched for 41s\n❯\n";
+
+        assert_eq!(
+            claude_live_activity_state(&session, Some(pane)),
+            Some("idle")
+        );
+    }
+
+    #[test]
+    fn claude_live_activity_downgrades_stopped_turn_to_waiting_on_background_work() {
+        let session = claude_session_with_hook_state("idle", Some(&now_rfc3339()));
+        let pane = "✻ Baked for 24m 12s · 1 shell still running\n❯\n";
+
+        assert_eq!(
+            claude_live_activity_state(&session, Some(pane)),
+            Some("waiting")
+        );
+    }
+
+    #[test]
+    fn claude_live_activity_keeps_stopped_turn_idle_without_background_work() {
+        let session = claude_session_with_hook_state("idle", Some(&now_rfc3339()));
+        let pane = "✻ Baked for 24m 12s\n❯\n";
+
+        assert_eq!(claude_live_activity_state(&session, Some(pane)), None);
+    }
+
+    #[test]
+    fn claude_live_activity_never_upgrades_stopped_turn_to_working() {
+        // Bug 2: a background-work segment used to flip a correct hook-idle back
+        // to active. It may only ever downgrade idle -> waiting.
+        let session = claude_session_with_hook_state("idle", Some(&now_rfc3339()));
+        let pane = "✽ Incubating… (3m 3s · ↓ 9.9k tokens)\n  ⏵⏵ bypass permissions on · 1 shell · ← for agents\n";
+
+        assert_eq!(
+            claude_live_activity_state(&session, Some(pane)),
+            Some("waiting")
+        );
+    }
+
+    #[test]
+    fn claude_live_activity_falls_back_to_pane_when_hooks_were_never_observed() {
+        let session = claude_session_with_hook_state("running", None);
+        let pane = "✻ Crunched for 41s\n❯\n";
+
+        assert_eq!(
+            claude_live_activity_state(&session, Some(pane)),
+            Some("idle")
+        );
+    }
+
+    fn claude_session_with_hook_state(
+        status: &str,
+        activity_hook_at: Option<&str>,
+    ) -> SessionRecord {
+        serde_json::from_value(json!({
+            "id": "claudehooked",
+            "name": "claude-claudehooked",
+            "working_dir": "/repo",
+            "tmux_session": "claudehooked",
+            "node": "primary",
+            "provider": "claude",
+            "status": status,
+            "created_at": "2026-06-01T00:00:00",
+            "last_activity": "2026-06-01T00:00:00",
+            "activity_hook_at": activity_hook_at
+        }))
+        .unwrap()
     }
 
     #[test]

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -7726,8 +7726,11 @@ fn live_activity_state(state: &AppState, session: &SessionRecord) -> Option<&'st
         }
         if claude_hook_gate(session) == ClaudeHookGate::TurnRunning {
             // Hooks bracket the turn, so a fresh "turn in flight" signal is
-            // authoritative. Skip the pane capture entirely.
-            return None;
+            // authoritative. Skip the pane capture entirely and state the answer
+            // outright — the default projection would otherwise call this idle
+            // once `last_activity` is 30s old, which is exactly what happens
+            // during a long tool-free response.
+            return Some("working");
         }
         let runtime = TmuxRuntime::from_app_config(&state.config)
             .for_socket_name(session.tmux_socket_name.as_deref());
@@ -7770,8 +7773,9 @@ fn claude_live_activity_state(
         return None;
     }
     match claude_hook_gate(session) {
-        // Hooks bracket the turn; the stored state already says what it needs to.
-        ClaudeHookGate::TurnRunning => None,
+        // Hooks bracket the turn, and the hook signal outranks both the pane and
+        // the default projection's 30s `last_activity` heuristic.
+        ClaudeHookGate::TurnRunning => Some("working"),
         // The Stop hook is authoritative: the agent's turn is over. Outstanding
         // background work may only downgrade idle -> waiting, never upgrade to
         // working.
@@ -11803,7 +11807,35 @@ mod tests {
         let session = claude_session_with_hook_state("running", Some(&now_rfc3339()));
         let pane = "✻ Crunched for 41s\n";
 
-        assert_eq!(claude_live_activity_state(&session, Some(pane)), None);
+        assert_eq!(
+            claude_live_activity_state(&session, Some(pane)),
+            Some("working")
+        );
+    }
+
+    #[test]
+    fn claude_live_activity_holds_working_through_a_long_tool_free_response() {
+        // `last_activity` is only refreshed by hooks, and none fire during a
+        // tool-free response. The default projection calls a running session idle
+        // after 30s, so the fresh turn-start hook has to say `working` outright.
+        let mut session = claude_session_with_hook_state("running", Some(&now_rfc3339()));
+        session.last_activity = "2026-06-01T00:00:00Z".to_owned();
+        assert_eq!(
+            projected_activity_state_for_test(&session),
+            "idle",
+            "precondition: the default projection has already gone stale"
+        );
+
+        assert_eq!(claude_live_activity_state(&session, None), Some("working"));
+    }
+
+    /// The default projection, read back off the serialized response so the test
+    /// does not need `SessionResponse`'s private fields widened.
+    fn projected_activity_state_for_test(session: &SessionRecord) -> String {
+        serde_json::to_value(SessionResponse::from(session.clone())).unwrap()["activity_state"]
+            .as_str()
+            .unwrap()
+            .to_owned()
     }
 
     #[test]

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -11837,6 +11837,34 @@ mod tests {
     }
 
     #[test]
+    fn claude_live_activity_recovers_working_when_a_turn_start_hook_is_lost() {
+        // notify_server.sh posts through a detached curl with no retry, so a
+        // UserPromptSubmit can simply never arrive. The preceding Stop then
+        // leaves a stored idle behind; once it ages out the pane has to be able
+        // to recognise the live turn, or the session reads idle for the whole of
+        // it. This is the original bug relocated from Stop to the turn-start.
+        let session = claude_session_with_hook_state("idle", Some("2026-06-01T00:00:00Z"));
+        let pane = "✽ Incubating… (3m 3s · ↓ 9.9k tokens)\n";
+
+        assert_eq!(claude_hook_gate(&session), ClaudeHookGate::Stale);
+        assert_eq!(
+            claude_live_activity_state(&session, Some(pane)),
+            Some("working")
+        );
+    }
+
+    #[test]
+    fn claude_live_activity_keeps_a_fresh_stopped_turn_conclusive() {
+        // The flip side: while the Stop signal is fresh it still outranks the
+        // pane, so a spinner mid-redraw cannot resurrect a finished turn.
+        let session = claude_session_with_hook_state("idle", Some(&now_rfc3339()));
+        let pane = "✽ Incubating… (3m 3s · ↓ 9.9k tokens)\n";
+
+        assert_eq!(claude_hook_gate(&session), ClaudeHookGate::TurnStopped);
+        assert_eq!(claude_live_activity_state(&session, Some(pane)), None);
+    }
+
+    #[test]
     fn claude_live_activity_reports_working_for_remote_sessions_from_hook_state() {
         // Hooks are posted to the primary from every node; only the pane is
         // node-local. A remote session must not be stranded on the default

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -162,11 +162,18 @@ impl SessionStore {
             }))
     }
 
-    /// `received_at` is stamped when the hook request arrives, *before* the
-    /// handler's transcript retry sleep. `hooks/notify_server.sh` dispatches every
-    /// lifecycle hook through a detached curl, so a `Stop` that waited on its
-    /// retry can land after the next turn's `UserPromptSubmit`. Comparing against
-    /// `received_at` keeps the older signal from overwriting the newer one.
+    /// `hooks/notify_server.sh` dispatches every lifecycle hook through its own
+    /// detached curl, so neither HTTP arrival order nor handler completion order
+    /// matches the order the events actually happened in. Two independent guards
+    /// keep an older `Stop` from overwriting a newer turn-start:
+    ///
+    /// - `emitted_at` — stamped in the hook script before it detaches, and
+    ///   compared against the turn-start's own emission stamp. This is the
+    ///   authoritative ordering, and it catches a `Stop` whose curl was delayed
+    ///   past the next turn's `UserPromptSubmit` entirely.
+    /// - `received_at` — stamped on arrival, before the handler's transcript
+    ///   retry sleep. This catches a `Stop` that arrived first but applied late,
+    ///   and covers hooks emitted by a script too old to send `emitted_at`.
     pub fn apply_claude_stop_hook(
         &self,
         session_id: &str,
@@ -175,6 +182,7 @@ impl SessionStore {
         native_title_mtime_ns: Option<i64>,
         transcript_path: Option<&str>,
         received_at: Option<&str>,
+        emitted_at: Option<&str>,
     ) -> Result<bool> {
         let session_id = session_id.trim();
         if session_id.is_empty() {
@@ -190,19 +198,36 @@ impl SessionStore {
             return Ok(false);
         }
 
-        // A lifecycle hook newer than this request already decided the state.
-        // The turn transition is superseded, but the transcript metadata this
-        // Stop carries is still the freshest we have, so it is applied either way.
-        let superseded = received_at.is_some_and(|received_at| {
+        // A lifecycle hook newer than this one already decided the state. The
+        // turn transition is superseded, but the transcript metadata this Stop
+        // carries is still the freshest we have, so it is applied either way.
+        //
+        // Emission stamps come from the node that owns the session, so a turn
+        // start and its Stop are always compared on a single clock.
+        let superseded_by_emission = match (
+            emitted_at,
+            json_text(session.get("activity_hook_emitted_at")),
+        ) {
+            (Some(emitted_at), Some(stored)) => timestamp_is_after(&stored, emitted_at),
+            _ => false,
+        };
+        let superseded_by_arrival = received_at.is_some_and(|received_at| {
             json_text(session.get("activity_hook_at"))
                 .is_some_and(|stored| timestamp_is_after(&stored, received_at))
         });
+        let superseded = superseded_by_emission || superseded_by_arrival;
 
         let now = now_rfc3339();
         if !superseded {
             session.insert("status".to_owned(), Value::String("idle".to_owned()));
             session.insert("last_activity".to_owned(), Value::String(now.clone()));
             session.insert("activity_hook_at".to_owned(), Value::String(now.clone()));
+            session.insert(
+                "activity_hook_emitted_at".to_owned(),
+                emitted_at.map_or(Value::Null, |emitted_at| {
+                    Value::String(emitted_at.to_owned())
+                }),
+            );
             session.insert("agent_status_text".to_owned(), Value::Null);
             session.insert("agent_status_at".to_owned(), Value::Null);
         }
@@ -292,7 +317,11 @@ impl SessionStore {
     /// `UserPromptSubmit` brackets the start of a turn. Together with the `Stop`
     /// hook it makes active/idle a pure function of hook signals, so the pane
     /// scraper never has to guess from spinners or completion verbs.
-    pub fn apply_claude_user_prompt_submit_hook(&self, session_id: &str) -> Result<bool> {
+    pub fn apply_claude_user_prompt_submit_hook(
+        &self,
+        session_id: &str,
+        emitted_at: Option<&str>,
+    ) -> Result<bool> {
         let session_id = session_id.trim();
         if session_id.is_empty() {
             return Ok(false);
@@ -314,6 +343,14 @@ impl SessionStore {
         // Records that turn-start hooks are actually wired for this session. Only
         // then is a stored idle strong enough to suppress the pane fallback.
         session.insert("activity_turn_start_hook_at".to_owned(), Value::String(now));
+        // The stamp the hook script took before detaching. A Stop carrying an
+        // older emission stamp is recognised as belonging to the previous turn.
+        session.insert(
+            "activity_hook_emitted_at".to_owned(),
+            emitted_at.map_or(Value::Null, |emitted_at| {
+                Value::String(emitted_at.to_owned())
+            }),
+        );
         session.insert("agent_task_completed_at".to_owned(), Value::Null);
         self.write_raw_json_value(&state)?;
         Ok(true)
@@ -6201,7 +6238,7 @@ mod tests {
         // memory a restart would revert a finished session to stale active.
         let store = store_with_running_claude_session("stopdurable");
         assert!(store
-            .apply_claude_stop_hook("stopdurable", None, None, None, None, None)
+            .apply_claude_stop_hook("stopdurable", None, None, None, None, None, None)
             .unwrap());
 
         // A fresh store over the same state file stands in for a restarted server.
@@ -6221,7 +6258,7 @@ mod tests {
         // PreToolUse, so a stored idle must not gate the pane off.
         let store = store_with_running_claude_session("stoponly");
         assert!(store
-            .apply_claude_stop_hook("stoponly", None, None, None, None, None)
+            .apply_claude_stop_hook("stoponly", None, None, None, None, None, None)
             .unwrap());
 
         let session = store.get_session("stoponly").unwrap().unwrap();
@@ -6234,10 +6271,10 @@ mod tests {
     fn claude_stop_hook_is_conclusive_once_both_ends_of_the_turn_are_hooked() {
         let store = store_with_running_claude_session("bothends");
         assert!(store
-            .apply_claude_user_prompt_submit_hook("bothends")
+            .apply_claude_user_prompt_submit_hook("bothends", None)
             .unwrap());
         assert!(store
-            .apply_claude_stop_hook("bothends", None, None, None, None, None)
+            .apply_claude_stop_hook("bothends", None, None, None, None, None, None)
             .unwrap());
 
         let session = store.get_session("bothends").unwrap().unwrap();
@@ -6253,7 +6290,9 @@ mod tests {
         // still land after that prompt's UserPromptSubmit.
         let store = store_with_running_claude_session("raced");
         let stop_received_at = now_rfc3339();
-        assert!(store.apply_claude_user_prompt_submit_hook("raced").unwrap());
+        assert!(store
+            .apply_claude_user_prompt_submit_hook("raced", None)
+            .unwrap());
 
         assert!(!store
             .apply_claude_stop_hook(
@@ -6262,7 +6301,8 @@ mod tests {
                 None,
                 None,
                 None,
-                Some(&stop_received_at)
+                Some(&stop_received_at),
+                None
             )
             .unwrap());
 
@@ -6284,15 +6324,105 @@ mod tests {
     }
 
     #[test]
+    fn hook_emission_stamps_from_both_shell_clock_paths_are_comparable() {
+        // notify_server.sh emits 9 fractional digits via GNU-style `date +%N` and
+        // 6 via the perl Time::HiRes fallback. An unparseable stamp makes
+        // `timestamp_is_after` return false, silently disabling the ordering
+        // guard rather than failing loudly — so both shapes are pinned here.
+        let nanos = "2026-07-27T18:30:55.266446000Z";
+        let micros = "2026-07-27T18:30:55.266447Z";
+
+        assert!(timestamp_is_after(micros, nanos));
+        assert!(!timestamp_is_after(nanos, micros));
+        assert!(!timestamp_is_after(nanos, nanos));
+        // Mixed resolutions across the two paths must still order correctly.
+        assert!(timestamp_is_after(
+            "2026-07-27T18:30:56.000001Z",
+            "2026-07-27T18:30:55.999999999Z"
+        ));
+        // An unparseable side must never supersede anything.
+        assert!(!timestamp_is_after("not-a-timestamp", nanos));
+        assert!(!timestamp_is_after(nanos, "not-a-timestamp"));
+    }
+
+    #[test]
+    fn stop_hook_delivered_after_the_next_turn_is_ordered_by_emission_time() {
+        // Each hook gets its own detached curl, so a Stop can be delayed until
+        // after the next turn's UserPromptSubmit has already been delivered. By
+        // arrival order the Stop looks newest; only the emission stamps, taken
+        // before either curl detached, reveal the real order.
+        let store = store_with_running_claude_session("latecurl");
+        let stop_emitted_at = "2026-06-01T00:00:10.000000Z";
+        let turn_start_emitted_at = "2026-06-01T00:00:11.000000Z";
+
+        assert!(store
+            .apply_claude_user_prompt_submit_hook("latecurl", Some(turn_start_emitted_at))
+            .unwrap());
+
+        // Arrival is now, i.e. after the turn start was stored, so the arrival
+        // guard alone would let this stale Stop through.
+        let stop_received_at = now_rfc3339();
+        assert!(!store
+            .apply_claude_stop_hook(
+                "latecurl",
+                None,
+                None,
+                None,
+                None,
+                Some(&stop_received_at),
+                Some(stop_emitted_at)
+            )
+            .unwrap());
+
+        let session = store.get_session("latecurl").unwrap().unwrap();
+
+        assert_eq!(session.status, "running");
+        assert_eq!(claude_hook_gate(&session), ClaudeHookGate::TurnRunning);
+    }
+
+    #[test]
+    fn stop_hook_emitted_after_the_last_turn_start_still_applies() {
+        let store = store_with_running_claude_session("orderok");
+        assert!(store
+            .apply_claude_user_prompt_submit_hook("orderok", Some("2026-06-01T00:00:10.000000Z"))
+            .unwrap());
+
+        assert!(store
+            .apply_claude_stop_hook(
+                "orderok",
+                None,
+                None,
+                None,
+                None,
+                Some(&now_rfc3339()),
+                Some("2026-06-01T00:00:11.000000Z")
+            )
+            .unwrap());
+
+        assert_eq!(
+            store.get_session("orderok").unwrap().unwrap().status,
+            "idle"
+        );
+    }
+
+    #[test]
     fn stop_hook_applies_normally_when_no_newer_lifecycle_hook_raced_it() {
         let store = store_with_running_claude_session("unraced");
         assert!(store
-            .apply_claude_user_prompt_submit_hook("unraced")
+            .apply_claude_user_prompt_submit_hook("unraced", None)
             .unwrap());
         let stop_received_at = now_rfc3339();
 
         assert!(store
-            .apply_claude_stop_hook("unraced", None, None, None, None, Some(&stop_received_at))
+            .apply_claude_stop_hook(
+                "unraced",
+                None,
+                None,
+                None,
+                None,
+                Some(&stop_received_at),
+                None
+            )
             .unwrap());
 
         assert_eq!(
@@ -6305,10 +6435,10 @@ mod tests {
     fn claude_user_prompt_submit_hook_marks_the_turn_running() {
         let store = store_with_running_claude_session("turnstart");
         assert!(store
-            .apply_claude_stop_hook("turnstart", None, None, None, None, None)
+            .apply_claude_stop_hook("turnstart", None, None, None, None, None, None)
             .unwrap());
         assert!(store
-            .apply_claude_user_prompt_submit_hook("turnstart")
+            .apply_claude_user_prompt_submit_hook("turnstart", None)
             .unwrap());
 
         let session = store.get_session("turnstart").unwrap().unwrap();
@@ -6331,7 +6461,7 @@ mod tests {
         }
 
         assert!(!store
-            .apply_claude_user_prompt_submit_hook("stoppedsess")
+            .apply_claude_user_prompt_submit_hook("stoppedsess", None)
             .unwrap());
         assert_eq!(
             store.get_session("stoppedsess").unwrap().unwrap().status,

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -162,6 +162,11 @@ impl SessionStore {
             }))
     }
 
+    /// `received_at` is stamped when the hook request arrives, *before* the
+    /// handler's transcript retry sleep. `hooks/notify_server.sh` dispatches every
+    /// lifecycle hook through a detached curl, so a `Stop` that waited on its
+    /// retry can land after the next turn's `UserPromptSubmit`. Comparing against
+    /// `received_at` keeps the older signal from overwriting the newer one.
     pub fn apply_claude_stop_hook(
         &self,
         session_id: &str,
@@ -169,6 +174,7 @@ impl SessionStore {
         native_title: Option<&str>,
         native_title_mtime_ns: Option<i64>,
         transcript_path: Option<&str>,
+        received_at: Option<&str>,
     ) -> Result<bool> {
         let session_id = session_id.trim();
         if session_id.is_empty() {
@@ -184,12 +190,22 @@ impl SessionStore {
             return Ok(false);
         }
 
+        // A lifecycle hook newer than this request already decided the state.
+        // The turn transition is superseded, but the transcript metadata this
+        // Stop carries is still the freshest we have, so it is applied either way.
+        let superseded = received_at.is_some_and(|received_at| {
+            json_text(session.get("activity_hook_at"))
+                .is_some_and(|stored| timestamp_is_after(&stored, received_at))
+        });
+
         let now = now_rfc3339();
-        session.insert("status".to_owned(), Value::String("idle".to_owned()));
-        session.insert("last_activity".to_owned(), Value::String(now.clone()));
-        session.insert("activity_hook_at".to_owned(), Value::String(now.clone()));
-        session.insert("agent_status_text".to_owned(), Value::Null);
-        session.insert("agent_status_at".to_owned(), Value::Null);
+        if !superseded {
+            session.insert("status".to_owned(), Value::String("idle".to_owned()));
+            session.insert("last_activity".to_owned(), Value::String(now.clone()));
+            session.insert("activity_hook_at".to_owned(), Value::String(now.clone()));
+            session.insert("agent_status_text".to_owned(), Value::Null);
+            session.insert("agent_status_at".to_owned(), Value::Null);
+        }
         if let Some(last_message) = last_message {
             session.insert(
                 "last_action_summary".to_owned(),
@@ -235,7 +251,7 @@ impl SessionStore {
             }
         }
         self.write_raw_json_value(&state)?;
-        Ok(true)
+        Ok(!superseded)
     }
 
     pub fn apply_claude_pre_tool_use_hook(
@@ -294,7 +310,10 @@ impl SessionStore {
         let now = now_rfc3339();
         session.insert("status".to_owned(), Value::String("running".to_owned()));
         session.insert("last_activity".to_owned(), Value::String(now.clone()));
-        session.insert("activity_hook_at".to_owned(), Value::String(now));
+        session.insert("activity_hook_at".to_owned(), Value::String(now.clone()));
+        // Records that turn-start hooks are actually wired for this session. Only
+        // then is a stored idle strong enough to suppress the pane fallback.
+        session.insert("activity_turn_start_hook_at".to_owned(), Value::String(now));
         session.insert("agent_task_completed_at".to_owned(), Value::Null);
         self.write_raw_json_value(&state)?;
         Ok(true)
@@ -2312,6 +2331,7 @@ impl SessionStore {
             created_at: now.clone(),
             last_activity: now,
             activity_hook_at: None,
+            activity_turn_start_hook_at: None,
             last_tool_call: None,
             last_tool_name: None,
             tokens_used: 0,
@@ -5301,6 +5321,11 @@ pub struct SessionRecord {
     /// stored activity state is fresh enough to trust without scraping the pane.
     #[serde(default)]
     pub activity_hook_at: Option<String>,
+    /// Timestamp of the most recent `UserPromptSubmit`. Its presence is the only
+    /// evidence that turn-start hooks are wired for this session, which decides
+    /// whether a stored idle may suppress the pane fallback.
+    #[serde(default)]
+    pub activity_turn_start_hook_at: Option<String>,
     #[serde(default)]
     pub last_tool_call: Option<String>,
     #[serde(default)]
@@ -5685,6 +5710,26 @@ fn timestamp_is_within(value: &str, seconds: i64) -> bool {
     parse_python_naive_datetime(value).is_some_and(|parsed| now_local - parsed < window)
 }
 
+/// True when `value` is strictly newer than `other`. Both timestamps are written
+/// by `now_rfc3339()`, but older records may still carry the Python-era naive
+/// format, so both encodings are accepted. Returns false when either side is
+/// unparseable — an unknown ordering must never supersede anything.
+fn timestamp_is_after(value: &str, other: &str) -> bool {
+    if let (Ok(value), Ok(other)) = (
+        OffsetDateTime::parse(value.trim(), &Rfc3339),
+        OffsetDateTime::parse(other.trim(), &Rfc3339),
+    ) {
+        return value > other;
+    }
+    match (
+        parse_python_naive_datetime(value),
+        parse_python_naive_datetime(other),
+    ) {
+        (Some(value), Some(other)) => value > other,
+        _ => false,
+    }
+}
+
 /// How long a "turn in flight" hook signal is trusted before the pane scraper is
 /// allowed to second-guess it. Long enough to cover a slow tool call or a long
 /// stretch of pure thinking (no `PreToolUse` fires during either).
@@ -5698,7 +5743,8 @@ pub(crate) enum ClaudeHookGate {
     /// pane is the only signal available.
     Untracked,
     /// The `Stop` hook fired and no turn has started since. Authoritative: the
-    /// agent's turn is over.
+    /// agent's turn is over. Only reachable once a `UserPromptSubmit` has been
+    /// seen, so both ends of the turn are known to be observable.
     TurnStopped,
     /// A turn is in flight and the hook signal is recent enough to trust.
     TurnRunning,
@@ -5716,8 +5762,17 @@ pub(crate) fn claude_hook_gate(session: &SessionRecord) -> ClaudeHookGate {
     else {
         return ClaudeHookGate::Untracked;
     };
+    // A stored idle is only conclusive when the *start* of a turn is observable
+    // too. With only the Stop hook wired — the common case for sessions outside a
+    // repo that installs both — the first Stop would otherwise pin the session to
+    // idle for every later turn, right through a tool-free response.
+    let turn_start_hook_wired = session
+        .activity_turn_start_hook_at
+        .as_deref()
+        .map(str::trim)
+        .is_some_and(|value| !value.is_empty());
     match normalized_status(session.status.trim()) {
-        "idle" => ClaudeHookGate::TurnStopped,
+        "idle" if turn_start_hook_wired => ClaudeHookGate::TurnStopped,
         "running" if timestamp_is_within(hook_at, CLAUDE_HOOK_STATE_FRESH_SECONDS) => {
             ClaudeHookGate::TurnRunning
         }
@@ -5977,6 +6032,7 @@ mod tests {
             created_at: "2026-06-01T00:00:00".to_owned(),
             last_activity: "2026-06-01T00:01:00".to_owned(),
             activity_hook_at: None,
+            activity_turn_start_hook_at: None,
             last_tool_call: None,
             last_tool_name: None,
             tokens_used: 0,
@@ -6145,7 +6201,7 @@ mod tests {
         // memory a restart would revert a finished session to stale active.
         let store = store_with_running_claude_session("stopdurable");
         assert!(store
-            .apply_claude_stop_hook("stopdurable", None, None, None, None)
+            .apply_claude_stop_hook("stopdurable", None, None, None, None, None)
             .unwrap());
 
         // A fresh store over the same state file stands in for a restarted server.
@@ -6157,14 +6213,99 @@ mod tests {
 
         assert_eq!(session.status, "idle");
         assert_eq!(projected_activity_state(&session, &session.status), "idle");
+    }
+
+    #[test]
+    fn claude_stop_hook_alone_does_not_suppress_the_pane_fallback() {
+        // Without a turn-start hook the next turn is invisible until its first
+        // PreToolUse, so a stored idle must not gate the pane off.
+        let store = store_with_running_claude_session("stoponly");
+        assert!(store
+            .apply_claude_stop_hook("stoponly", None, None, None, None, None)
+            .unwrap());
+
+        let session = store.get_session("stoponly").unwrap().unwrap();
+
+        assert!(session.activity_turn_start_hook_at.is_none());
+        assert_eq!(claude_hook_gate(&session), ClaudeHookGate::Stale);
+    }
+
+    #[test]
+    fn claude_stop_hook_is_conclusive_once_both_ends_of_the_turn_are_hooked() {
+        let store = store_with_running_claude_session("bothends");
+        assert!(store
+            .apply_claude_user_prompt_submit_hook("bothends")
+            .unwrap());
+        assert!(store
+            .apply_claude_stop_hook("bothends", None, None, None, None, None)
+            .unwrap());
+
+        let session = store.get_session("bothends").unwrap().unwrap();
+
+        assert_eq!(session.status, "idle");
         assert_eq!(claude_hook_gate(&session), ClaudeHookGate::TurnStopped);
+    }
+
+    #[test]
+    fn stale_stop_hook_does_not_overwrite_a_newer_turn_start() {
+        // notify_server.sh dispatches detached curls and the Stop path can sleep
+        // on its transcript retry, so a Stop received before the next prompt can
+        // still land after that prompt's UserPromptSubmit.
+        let store = store_with_running_claude_session("raced");
+        let stop_received_at = now_rfc3339();
+        assert!(store.apply_claude_user_prompt_submit_hook("raced").unwrap());
+
+        assert!(!store
+            .apply_claude_stop_hook(
+                "raced",
+                Some("summary from the previous turn"),
+                None,
+                None,
+                None,
+                Some(&stop_received_at)
+            )
+            .unwrap());
+
+        let session = store.get_session("raced").unwrap().unwrap();
+
+        assert_eq!(session.status, "running");
+        assert_eq!(claude_hook_gate(&session), ClaudeHookGate::TurnRunning);
+
+        let raw = store.load_raw_json_value().unwrap();
+        let sessions = raw["sessions"].as_array().unwrap();
+        let raw_session = sessions
+            .iter()
+            .find(|session| session["id"] == "raced")
+            .unwrap();
+        assert_eq!(
+            raw_session["last_action_summary"], "summary from the previous turn",
+            "a superseded Stop still carries the freshest transcript metadata"
+        );
+    }
+
+    #[test]
+    fn stop_hook_applies_normally_when_no_newer_lifecycle_hook_raced_it() {
+        let store = store_with_running_claude_session("unraced");
+        assert!(store
+            .apply_claude_user_prompt_submit_hook("unraced")
+            .unwrap());
+        let stop_received_at = now_rfc3339();
+
+        assert!(store
+            .apply_claude_stop_hook("unraced", None, None, None, None, Some(&stop_received_at))
+            .unwrap());
+
+        assert_eq!(
+            store.get_session("unraced").unwrap().unwrap().status,
+            "idle"
+        );
     }
 
     #[test]
     fn claude_user_prompt_submit_hook_marks_the_turn_running() {
         let store = store_with_running_claude_session("turnstart");
         assert!(store
-            .apply_claude_stop_hook("turnstart", None, None, None, None)
+            .apply_claude_stop_hook("turnstart", None, None, None, None, None)
             .unwrap());
         assert!(store
             .apply_claude_user_prompt_submit_hook("turnstart")

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -187,6 +187,7 @@ impl SessionStore {
         let now = now_rfc3339();
         session.insert("status".to_owned(), Value::String("idle".to_owned()));
         session.insert("last_activity".to_owned(), Value::String(now.clone()));
+        session.insert("activity_hook_at".to_owned(), Value::String(now.clone()));
         session.insert("agent_status_text".to_owned(), Value::Null);
         session.insert("agent_status_at".to_owned(), Value::Null);
         if let Some(last_message) = last_message {
@@ -259,6 +260,7 @@ impl SessionStore {
         let now = now_rfc3339();
         session.insert("status".to_owned(), Value::String("running".to_owned()));
         session.insert("last_activity".to_owned(), Value::String(now.clone()));
+        session.insert("activity_hook_at".to_owned(), Value::String(now.clone()));
         session.insert("agent_task_completed_at".to_owned(), Value::Null);
         if let Some(tool_name) = tool_name {
             session.insert(
@@ -267,6 +269,33 @@ impl SessionStore {
             );
             session.insert("last_tool_call".to_owned(), Value::String(now));
         }
+        self.write_raw_json_value(&state)?;
+        Ok(true)
+    }
+
+    /// `UserPromptSubmit` brackets the start of a turn. Together with the `Stop`
+    /// hook it makes active/idle a pure function of hook signals, so the pane
+    /// scraper never has to guess from spinners or completion verbs.
+    pub fn apply_claude_user_prompt_submit_hook(&self, session_id: &str) -> Result<bool> {
+        let session_id = session_id.trim();
+        if session_id.is_empty() {
+            return Ok(false);
+        }
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let Some(session) = session_object_mut(sessions, session_id) else {
+            return Ok(false);
+        };
+        if normalized_status(&json_text(session.get("status")).unwrap_or_default()) == "stopped" {
+            return Ok(false);
+        }
+
+        let now = now_rfc3339();
+        session.insert("status".to_owned(), Value::String("running".to_owned()));
+        session.insert("last_activity".to_owned(), Value::String(now.clone()));
+        session.insert("activity_hook_at".to_owned(), Value::String(now));
+        session.insert("agent_task_completed_at".to_owned(), Value::Null);
         self.write_raw_json_value(&state)?;
         Ok(true)
     }
@@ -2282,6 +2311,7 @@ impl SessionStore {
             spawned_at: Some(now.clone()),
             created_at: now.clone(),
             last_activity: now,
+            activity_hook_at: None,
             last_tool_call: None,
             last_tool_name: None,
             tokens_used: 0,
@@ -5266,6 +5296,11 @@ pub struct SessionRecord {
     pub spawned_at: Option<String>,
     pub created_at: String,
     pub last_activity: String,
+    /// Timestamp of the most recent authoritative Claude lifecycle hook
+    /// (`UserPromptSubmit`, `PreToolUse`, `Stop`). Used to decide whether the
+    /// stored activity state is fresh enough to trust without scraping the pane.
+    #[serde(default)]
+    pub activity_hook_at: Option<String>,
     #[serde(default)]
     pub last_tool_call: Option<String>,
     #[serde(default)]
@@ -5637,13 +5672,57 @@ fn projected_activity_state(session: &SessionRecord, status: &str) -> String {
 }
 
 fn session_activity_is_recent(last_activity: &str) -> bool {
+    timestamp_is_within(last_activity, 30)
+}
+
+fn timestamp_is_within(value: &str, seconds: i64) -> bool {
+    let window = TimeDuration::seconds(seconds);
     let now_utc = OffsetDateTime::now_utc();
-    if let Ok(parsed) = OffsetDateTime::parse(last_activity.trim(), &Rfc3339) {
-        return now_utc - parsed < TimeDuration::seconds(30);
+    if let Ok(parsed) = OffsetDateTime::parse(value.trim(), &Rfc3339) {
+        return now_utc - parsed < window;
     }
     let now_local = local_now_naive(now_utc);
-    parse_python_naive_datetime(last_activity)
-        .is_some_and(|last_activity| now_local - last_activity < TimeDuration::seconds(30))
+    parse_python_naive_datetime(value).is_some_and(|parsed| now_local - parsed < window)
+}
+
+/// How long a "turn in flight" hook signal is trusted before the pane scraper is
+/// allowed to second-guess it. Long enough to cover a slow tool call or a long
+/// stretch of pure thinking (no `PreToolUse` fires during either).
+const CLAUDE_HOOK_STATE_FRESH_SECONDS: i64 = 180;
+
+/// How much the hook-derived activity state can be trusted, and therefore
+/// whether the tmux pane needs to be consulted at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ClaudeHookGate {
+    /// No Claude lifecycle hook has ever been recorded for this session, so the
+    /// pane is the only signal available.
+    Untracked,
+    /// The `Stop` hook fired and no turn has started since. Authoritative: the
+    /// agent's turn is over.
+    TurnStopped,
+    /// A turn is in flight and the hook signal is recent enough to trust.
+    TurnRunning,
+    /// A turn was reported in flight but the hook signal has gone stale — the
+    /// `Stop` hook was probably lost (restart, event-loop stall, watchdog kill).
+    Stale,
+}
+
+pub(crate) fn claude_hook_gate(session: &SessionRecord) -> ClaudeHookGate {
+    let Some(hook_at) = session
+        .activity_hook_at
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return ClaudeHookGate::Untracked;
+    };
+    match normalized_status(session.status.trim()) {
+        "idle" => ClaudeHookGate::TurnStopped,
+        "running" if timestamp_is_within(hook_at, CLAUDE_HOOK_STATE_FRESH_SECONDS) => {
+            ClaudeHookGate::TurnRunning
+        }
+        _ => ClaudeHookGate::Stale,
+    }
 }
 
 fn parse_python_naive_datetime(value: &str) -> Option<PrimitiveDateTime> {
@@ -5897,6 +5976,7 @@ mod tests {
             spawned_at: Some("2026-06-01T00:00:00".to_owned()),
             created_at: "2026-06-01T00:00:00".to_owned(),
             last_activity: "2026-06-01T00:01:00".to_owned(),
+            activity_hook_at: None,
             last_tool_call: None,
             last_tool_name: None,
             tokens_used: 0,
@@ -6033,6 +6113,105 @@ mod tests {
         let response = SessionResponse::from(session);
 
         assert_eq!(response.friendly_name.as_deref(), Some("abc12345"));
+    }
+
+    fn store_with_running_claude_session(session_id: &str) -> SessionStore {
+        let state_file = unique_temp_path(session_id);
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [
+                    {
+                        "id": session_id,
+                        "name": format!("claude-{session_id}"),
+                        "working_dir": "/repo",
+                        "tmux_session": format!("claude-{session_id}"),
+                        "log_file": format!("/tmp/{session_id}.log"),
+                        "status": "running",
+                        "created_at": "2026-06-01T00:00:00",
+                        "last_activity": "2026-06-01T00:01:00"
+                    }
+                ]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        SessionStore::new_with_legacy_fallback(state_file.clone(), state_file)
+    }
+
+    #[test]
+    fn claude_stop_hook_idle_survives_a_server_restart() {
+        // The Stop hook is the authoritative idle signal; if it only lived in
+        // memory a restart would revert a finished session to stale active.
+        let store = store_with_running_claude_session("stopdurable");
+        assert!(store
+            .apply_claude_stop_hook("stopdurable", None, None, None, None)
+            .unwrap());
+
+        // A fresh store over the same state file stands in for a restarted server.
+        let restarted = SessionStore::new_with_legacy_fallback(
+            store.state_file.clone(),
+            store.state_file.clone(),
+        );
+        let session = restarted.get_session("stopdurable").unwrap().unwrap();
+
+        assert_eq!(session.status, "idle");
+        assert_eq!(projected_activity_state(&session, &session.status), "idle");
+        assert_eq!(claude_hook_gate(&session), ClaudeHookGate::TurnStopped);
+    }
+
+    #[test]
+    fn claude_user_prompt_submit_hook_marks_the_turn_running() {
+        let store = store_with_running_claude_session("turnstart");
+        assert!(store
+            .apply_claude_stop_hook("turnstart", None, None, None, None)
+            .unwrap());
+        assert!(store
+            .apply_claude_user_prompt_submit_hook("turnstart")
+            .unwrap());
+
+        let session = store.get_session("turnstart").unwrap().unwrap();
+
+        assert_eq!(session.status, "running");
+        assert!(session.agent_task_completed_at.is_none());
+        assert_eq!(claude_hook_gate(&session), ClaudeHookGate::TurnRunning);
+    }
+
+    #[test]
+    fn claude_user_prompt_submit_hook_leaves_stopped_sessions_alone() {
+        let store = store_with_running_claude_session("stoppedsess");
+        {
+            let mut state = store.load_raw_json_value().unwrap();
+            let sessions = ensure_sessions_array_mut(&mut state).unwrap();
+            session_object_mut(sessions, "stoppedsess")
+                .unwrap()
+                .insert("status".to_owned(), Value::String("stopped".to_owned()));
+            store.write_raw_json_value(&state).unwrap();
+        }
+
+        assert!(!store
+            .apply_claude_user_prompt_submit_hook("stoppedsess")
+            .unwrap());
+        assert_eq!(
+            store.get_session("stoppedsess").unwrap().unwrap().status,
+            "stopped"
+        );
+    }
+
+    #[test]
+    fn claude_hook_gate_falls_back_to_the_pane_when_hooks_were_never_observed() {
+        let session = session_record("running");
+
+        assert!(session.activity_hook_at.is_none());
+        assert_eq!(claude_hook_gate(&session), ClaudeHookGate::Untracked);
+    }
+
+    #[test]
+    fn claude_hook_gate_goes_stale_when_a_running_turn_signal_ages_out() {
+        let mut session = session_record("running");
+        session.activity_hook_at = Some("2026-06-01T00:01:00Z".to_owned());
+
+        assert_eq!(claude_hook_gate(&session), ClaudeHookGate::Stale);
     }
 
     #[test]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -317,6 +317,13 @@ impl SessionStore {
     /// `UserPromptSubmit` brackets the start of a turn. Together with the `Stop`
     /// hook it makes active/idle a pure function of hook signals, so the pane
     /// scraper never has to guess from spinners or completion verbs.
+    ///
+    /// `emitted_at` orders this against the newest lifecycle signal already
+    /// stored, mirroring the `Stop` path. Each hook rides its own detached curl,
+    /// so a turn-start delayed past its own turn's `Stop` would otherwise
+    /// resurrect a finished turn as active. Only emission order is checked here:
+    /// this handler applies on arrival with no intervening sleep, so an
+    /// arrival-time comparison could never fire.
     pub fn apply_claude_user_prompt_submit_hook(
         &self,
         session_id: &str,
@@ -333,6 +340,19 @@ impl SessionStore {
             return Ok(false);
         };
         if normalized_status(&json_text(session.get("status")).unwrap_or_default()) == "stopped" {
+            return Ok(false);
+        }
+
+        // A newer lifecycle signal already decided the state; this turn-start
+        // belongs to a turn that has since finished.
+        let superseded = match (
+            emitted_at,
+            json_text(session.get("activity_hook_emitted_at")),
+        ) {
+            (Some(emitted_at), Some(stored)) => timestamp_is_after(&stored, emitted_at),
+            _ => false,
+        };
+        if superseded {
             return Ok(false);
         }
 
@@ -5767,10 +5787,23 @@ fn timestamp_is_after(value: &str, other: &str) -> bool {
     }
 }
 
-/// How long a "turn in flight" hook signal is trusted before the pane scraper is
-/// allowed to second-guess it. Long enough to cover a slow tool call or a long
-/// stretch of pure thinking (no `PreToolUse` fires during either).
+/// How long a hook-derived state is trusted before the pane is allowed to
+/// second-guess it. Long enough to cover a slow tool call or a long stretch of
+/// pure thinking (no `PreToolUse` fires during either).
+///
+/// This bounds *both* directions. Every lifecycle hook is delivered by a
+/// detached, un-retried curl, so `UserPromptSubmit` is exactly as losable as
+/// `Stop` — the very lossiness this ticket exists to work around. Treating
+/// either as conclusive forever just relocates the original bug.
 const CLAUDE_HOOK_STATE_FRESH_SECONDS: i64 = 180;
+
+/// Sessions owned by another node have no pane to reconcile against, so this
+/// window is the *only* bound on a lost hook. It is sized to outlast any
+/// plausible turn: for a remote session the realistic failure is reporting idle
+/// while a long turn is still running, whereas reporting working requires an
+/// actual lost `Stop`. Past this window the session degrades to the default
+/// projection, which is where remote sessions sat before hooks were introduced.
+const CLAUDE_HOOK_STATE_FRESH_SECONDS_WITHOUT_PANE: i64 = 900;
 
 /// How much the hook-derived activity state can be trusted, and therefore
 /// whether the tmux pane needs to be consulted at all.
@@ -5808,11 +5841,20 @@ pub(crate) fn claude_hook_gate(session: &SessionRecord) -> ClaudeHookGate {
         .as_deref()
         .map(str::trim)
         .is_some_and(|value| !value.is_empty());
+    // Only the owning node can capture the pane, so a remote session has nothing
+    // to reconcile against and has to lean on the hook signal for longer.
+    let fresh_seconds = if is_primary_node(&session.node) {
+        CLAUDE_HOOK_STATE_FRESH_SECONDS
+    } else {
+        CLAUDE_HOOK_STATE_FRESH_SECONDS_WITHOUT_PANE
+    };
+    let hook_state_is_fresh = timestamp_is_within(hook_at, fresh_seconds);
     match normalized_status(session.status.trim()) {
-        "idle" if turn_start_hook_wired => ClaudeHookGate::TurnStopped,
-        "running" if timestamp_is_within(hook_at, CLAUDE_HOOK_STATE_FRESH_SECONDS) => {
-            ClaudeHookGate::TurnRunning
-        }
+        // Conclusive only while fresh. A turn-start lost in transit would
+        // otherwise pin the session to idle for the whole of the next turn, with
+        // the pane unable to say anything but `waiting`.
+        "idle" if turn_start_hook_wired && hook_state_is_fresh => ClaudeHookGate::TurnStopped,
+        "running" if hook_state_is_fresh => ClaudeHookGate::TurnRunning,
         _ => ClaudeHookGate::Stale,
     }
 }
@@ -6378,6 +6420,74 @@ mod tests {
 
         assert_eq!(session.status, "running");
         assert_eq!(claude_hook_gate(&session), ClaudeHookGate::TurnRunning);
+    }
+
+    #[test]
+    fn turn_start_delivered_after_its_own_stop_does_not_resurrect_the_turn() {
+        // Mirror of the delayed-Stop case: each hook has its own detached curl,
+        // so a turn-start can also lose the race against the Stop that ended it.
+        let store = store_with_running_claude_session("lateprompt");
+        assert!(store
+            .apply_claude_stop_hook(
+                "lateprompt",
+                None,
+                None,
+                None,
+                None,
+                Some(&now_rfc3339()),
+                Some("2026-06-01T00:00:11.000000Z")
+            )
+            .unwrap());
+
+        assert!(!store
+            .apply_claude_user_prompt_submit_hook("lateprompt", Some("2026-06-01T00:00:10.000000Z"))
+            .unwrap());
+
+        assert_eq!(
+            store.get_session("lateprompt").unwrap().unwrap().status,
+            "idle"
+        );
+    }
+
+    #[test]
+    fn turn_start_emitted_after_the_last_stop_still_applies() {
+        let store = store_with_running_claude_session("nextturn");
+        assert!(store
+            .apply_claude_stop_hook(
+                "nextturn",
+                None,
+                None,
+                None,
+                None,
+                Some(&now_rfc3339()),
+                Some("2026-06-01T00:00:10.000000Z")
+            )
+            .unwrap());
+
+        assert!(store
+            .apply_claude_user_prompt_submit_hook("nextturn", Some("2026-06-01T00:00:11.000000Z"))
+            .unwrap());
+
+        assert_eq!(
+            store.get_session("nextturn").unwrap().unwrap().status,
+            "running"
+        );
+    }
+
+    #[test]
+    fn remote_sessions_trust_a_running_hook_past_the_pane_reconciliation_window() {
+        // A remote session has no pane to reconcile against, so the shorter
+        // primary-node window would drop it onto the default projection — which
+        // calls a running session idle after 30s — mid-turn.
+        let stale_for_primary = OffsetDateTime::now_utc() - TimeDuration::seconds(300);
+        let mut session = session_record("running");
+        session.node = "macbook".to_owned();
+        session.activity_hook_at = Some(stale_for_primary.format(&Rfc3339).unwrap());
+
+        assert_eq!(claude_hook_gate(&session), ClaudeHookGate::TurnRunning);
+
+        session.node = "primary".to_owned();
+        assert_eq!(claude_hook_gate(&session), ClaudeHookGate::Stale);
     }
 
     #[test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -7535,6 +7535,37 @@ async fn claude_user_prompt_submit_hook_marks_session_working_at_turn_start() {
         .unwrap();
     assert_eq!(session["status"], "running");
     assert!(session["activity_hook_at"].is_string());
+    assert!(session["activity_turn_start_hook_at"].is_string());
+}
+
+#[tokio::test]
+async fn claude_stop_hook_alone_leaves_the_pane_fallback_in_charge() {
+    // A session outside a repo that installs UserPromptSubmit only ever sees
+    // Stop. Its stored idle must not be treated as conclusive, or every later
+    // turn would read idle until the first PreToolUse.
+    let state_file = write_session_fixture();
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+
+    let (status, _) = post_json(
+        app.clone(),
+        "/hooks/claude",
+        json!({
+            "hook_event_name": "Stop",
+            "session_manager_id": "run12345"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let raw_state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let session = raw_state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "run12345")
+        .unwrap();
+    assert_eq!(session["status"], "idle");
+    assert!(session["activity_turn_start_hook_at"].is_null());
 }
 
 #[tokio::test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -7539,6 +7539,42 @@ async fn claude_user_prompt_submit_hook_marks_session_working_at_turn_start() {
 }
 
 #[tokio::test]
+async fn claude_stop_hook_delivered_after_the_next_turn_does_not_reset_it_to_idle() {
+    let state_file = write_session_fixture();
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+
+    let (status, _) = post_json(
+        app.clone(),
+        "/hooks/claude",
+        json!({
+            "hook_event_name": "UserPromptSubmit",
+            "session_manager_id": "run12345",
+            "sm_hook_emitted_at": "2026-06-01T00:00:11.000000Z"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    // The previous turn's Stop finally arrives, emitted a second earlier.
+    let (status, _) = post_json(
+        app.clone(),
+        "/hooks/claude",
+        json!({
+            "hook_event_name": "Stop",
+            "session_manager_id": "run12345",
+            "sm_hook_emitted_at": "2026-06-01T00:00:10.000000Z"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, payload) = get_json(app, "/sessions/run12345").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "running");
+    assert_eq!(payload["activity_state"], "working");
+}
+
+#[tokio::test]
 async fn claude_stop_hook_alone_leaves_the_pane_fallback_in_charge() {
     // A session outside a repo that installs UserPromptSubmit only ever sees
     // Stop. Its stored idle must not be treated as conclusive, or every later

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -7488,6 +7488,56 @@ async fn sessions_lists_running_sessions_and_filters_stopped_by_default() {
 }
 
 #[tokio::test]
+async fn claude_user_prompt_submit_hook_marks_session_working_at_turn_start() {
+    let state_file = write_session_fixture();
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/hooks/claude",
+        json!({
+            "hook_event_name": "Stop",
+            "session_manager_id": "run12345"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload, json!({ "status": "ok" }));
+
+    let (status, payload) = get_json(app.clone(), "/sessions/run12345").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["activity_state"], "idle");
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/hooks/claude",
+        json!({
+            "hook_event_name": "UserPromptSubmit",
+            "session_manager_id": "run12345",
+            "prompt": "please review the diff"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload, json!({ "status": "ok" }));
+
+    let (status, payload) = get_json(app, "/sessions/run12345").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "running");
+    assert_eq!(payload["activity_state"], "working");
+
+    let raw_state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let session = raw_state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "run12345")
+        .unwrap();
+    assert_eq!(session["status"], "running");
+    assert!(session["activity_hook_at"].is_string());
+}
+
+#[tokio::test]
 async fn claude_stop_hook_marks_session_idle_for_watch_clients() {
     let state_file = write_session_fixture();
     let app = router(AppState::new(config_with_state_file(&state_file)));

--- a/docs/working/1130_session_activity_detection.md
+++ b/docs/working/1130_session_activity_detection.md
@@ -40,6 +40,25 @@ active/idle no longer depends on spinners or completion verbs.
 `Untracked` keeps sessions on nodes without hook wiring working exactly as
 before, so this is a safe rollout rather than a flag day.
 
+`TurnStopped` additionally requires `activity_turn_start_hook_at` — evidence
+that a `UserPromptSubmit` has actually been observed for this session. A stored
+idle is only conclusive when the *start* of a turn is observable too. Sessions
+run in arbitrary working directories and never load this repo's project-scoped
+settings, so a session with only the global `Stop` hook would otherwise be
+pinned to idle for every later turn, right through a tool-free response. Without
+that evidence the gate falls through to `Stale` and the pane stays in play.
+
+## Hook ordering
+
+`hooks/notify_server.sh` dispatches every lifecycle hook through a detached
+curl, and the `Stop` handler may sleep on its transcript retry before applying
+state. A `Stop` received before the next prompt can therefore land *after* that
+prompt's `UserPromptSubmit`. The handler stamps `received_at` when the request
+arrives, before the retry sleep; `apply_claude_stop_hook` skips the turn
+transition when the stored `activity_hook_at` is newer than that stamp. The
+transcript metadata the superseded `Stop` carries is still the freshest
+available, so it is applied either way.
+
 **The fallback no longer lies.** Completion detection is structural instead of
 an allowlist: a status glyph, one capitalised verb, `for`, and a duration, with
 no `…` spinner and no `(esc to interrupt)`. Todo glyphs (`✔`, `✗`, `❯`, …) share
@@ -63,10 +82,15 @@ to `working` — that was bug 2.
 
 ## Wiring
 
-`.claude/settings.json` routes both `UserPromptSubmit` and `Stop` to
-`hooks/notify_server.sh`, which posts to `/hooks/claude`. The script skips its
-transcript `tail | jq` pass for `UserPromptSubmit` (no transcript payload there,
-and it runs before every single turn).
+`scripts/install_notify_server_hook.sh` registers both `UserPromptSubmit` and
+`Stop` in `~/.claude/settings.json` (merging into whatever is already there, and
+idempotent on re-run). That user-level registration is what covers sessions in
+arbitrary working directories; this repo's `.claude/settings.json` carries the
+same two entries so the repo is self-contained.
+
+Both route to `hooks/notify_server.sh`, which posts to `/hooks/claude`. The
+script skips its transcript `tail | jq` pass for `UserPromptSubmit` (no
+transcript payload there, and it runs before every single turn).
 
 ## Clients
 

--- a/docs/working/1130_session_activity_detection.md
+++ b/docs/working/1130_session_activity_detection.md
@@ -60,6 +60,29 @@ settings, so a session with only the global `Stop` hook would otherwise be
 pinned to idle for every later turn, right through a tool-free response. Without
 that evidence the gate falls through to `Stale` and the pane stays in play.
 
+## Nothing is conclusive forever
+
+The freshness window bounds **both** directions, not just `running`.
+
+Every lifecycle hook is delivered by a detached curl with no retry, so
+`UserPromptSubmit` is exactly as losable as `Stop` — the lossiness this ticket
+exists to work around. Treating a stored idle as conclusive indefinitely would
+just relocate the original bug: one dropped turn-start, and the session reports
+idle for the entire next turn while the pane, restricted to the background-work
+signal, is unable to say otherwise. So `TurnStopped` expires too, and the pane
+reconciles afterwards.
+
+That reconciliation is safe now in a way it was not before: background work no
+longer implies `working`, so letting the pane speak again cannot resurrect bug 2.
+
+Sessions owned by another node have no pane, so for them the window is the only
+bound on a lost hook and is correspondingly longer
+(`CLAUDE_HOOK_STATE_FRESH_SECONDS_WITHOUT_PANE`). For a remote session the
+realistic failure is reporting idle during a long live turn, whereas reporting
+working requires an actual lost `Stop`. Past that window a remote session
+degrades to the default projection — where it sat before hooks existed. Fully
+closing that gap needs node-side pane capture, which is out of scope here.
+
 ## Hook ordering
 
 `hooks/notify_server.sh` dispatches every lifecycle hook through its own
@@ -70,9 +93,11 @@ two independent guards prevent it:
 
 - **Emission ordering** (authoritative). The hook script stamps
   `sm_hook_emitted_at` before detaching, and the server compares it against the
-  turn-start's own emission stamp. This catches a `Stop` whose curl was delayed
+  newest stored lifecycle stamp. This catches a `Stop` whose curl was delayed
   past the next turn's `UserPromptSubmit` entirely. Both stamps come from the
-  node that owns the session, so they are always compared on one clock.
+  node that owns the session, so they are always compared on one clock. The
+  check is symmetric — a turn-start delayed past its own turn's `Stop` is
+  rejected the same way, so neither hook can resurrect the other's turn.
 - **Arrival ordering** (fallback). `received_at` is stamped when the request
   arrives, before the handler's transcript retry sleep. This catches a `Stop`
   that arrived first but applied late, and covers hook scripts too old to send

--- a/docs/working/1130_session_activity_detection.md
+++ b/docs/working/1130_session_activity_detection.md
@@ -1,0 +1,77 @@
+# 1130 — Session activity detection: hooks are the source of truth
+
+Tracking issue: #1130. Continues #1117 / #1119 / #1121.
+
+## Problem
+
+`activity_state` was derived by scraping the tmux pane on **every** dashboard
+read, and the scraper both missed idle and manufactured active:
+
+1. **Stuck active while idle.** `claude_line_indicates_completed` matched an
+   allowlist of exactly three completion verbs (`Brewed for`, `Baked for`,
+   `Churned for`). Claude cycles through many more (`Crunched`, `Cooked`,
+   `Simmered`, `Sautéed`, …), so a turn ending on any other verb classified as
+   neither completed nor working, the overlay returned `None`, and a stale
+   active status persisted.
+2. **False active from background work.** `✻ Baked for 24m · 1 shell still
+   running` was classified `working`, flipping a correct hook-derived idle back
+   to active even though the agent's turn was done.
+
+Root cause: the `Stop` hook is authoritative when it arrives but is lossy
+(server restarts, event-loop stalls, watchdog kills), and the scraper that
+backstopped it was too weak to re-derive the truth.
+
+## Design
+
+**Hooks bracket the turn.** `UserPromptSubmit` marks the session `running` at
+turn start; `Stop` marks it `idle` at turn end. Both write a durable
+`activity_hook_at` timestamp to the session store alongside the status, so
+active/idle no longer depends on spinners or completion verbs.
+
+`claude_hook_gate()` (`sessions.rs`) turns the stored state into one of:
+
+| Gate          | Meaning                                            | Pane consulted?              |
+| ------------- | -------------------------------------------------- | ---------------------------- |
+| `TurnRunning` | turn in flight, hook signal fresh (< 180s)          | no — capture skipped entirely |
+| `TurnStopped` | `Stop` fired, no turn started since                 | background-work signal only  |
+| `Stale`       | turn reported in flight but the signal aged out     | yes — last resort            |
+| `Untracked`   | no lifecycle hook ever seen for this session        | yes — legacy behaviour        |
+
+`Untracked` keeps sessions on nodes without hook wiring working exactly as
+before, so this is a safe rollout rather than a flag day.
+
+**The fallback no longer lies.** Completion detection is structural instead of
+an allowlist: a status glyph, one capitalised verb, `for`, and a duration, with
+no `…` spinner and no `(esc to interrupt)`. Todo glyphs (`✔`, `✗`, `❯`, …) share
+the dingbat block with the status glyph and are rejected explicitly, so a todo
+entry like `✔ Waited for 30s` cannot end a turn.
+
+Background work no longer implies `working`. It is read only from the newest
+status line and the chrome below it — older status lines scroll up with stale
+`N shell still running` segments attached, and counting those would resurrect
+long-finished background work.
+
+**New `waiting` state.**
+
+- `working` — agent is generating (between `UserPromptSubmit` and `Stop`).
+- `waiting` — `Stop` fired but background shells/monitors are still running; the
+  agent is parked and will be re-invoked when they finish.
+- `idle` — stopped, nothing pending.
+
+Background work may only ever downgrade `idle → waiting`. It can never upgrade
+to `working` — that was bug 2.
+
+## Wiring
+
+`.claude/settings.json` routes both `UserPromptSubmit` and `Stop` to
+`hooks/notify_server.sh`, which posts to `/hooks/claude`. The script skips its
+transcript `tail | jq` pass for `UserPromptSubmit` (no transcript payload there,
+and it runs before every single turn).
+
+## Clients
+
+`waiting` renders as `bg-wait` in violet, distinct from the amber `waiting` used
+for `waiting_input` / `waiting_permission`:
+
+- web `sm-watch`: `stateLabel()` / `activityTone()`
+- Android watch screen: `activityLabel()` / `activityTint()`

--- a/docs/working/1130_session_activity_detection.md
+++ b/docs/working/1130_session_activity_detection.md
@@ -32,13 +32,20 @@ active/idle no longer depends on spinners or completion verbs.
 
 | Gate          | Meaning                                            | Pane consulted?              |
 | ------------- | -------------------------------------------------- | ---------------------------- |
-| `TurnRunning` | turn in flight, hook signal fresh (< 180s)          | no — capture skipped entirely |
+| `TurnRunning` | turn in flight, hook signal fresh (< 180s)          | no — overlays `working` outright |
 | `TurnStopped` | `Stop` fired, no turn started since                 | background-work signal only  |
 | `Stale`       | turn reported in flight but the signal aged out     | yes — last resort            |
 | `Untracked`   | no lifecycle hook ever seen for this session        | yes — legacy behaviour        |
 
 `Untracked` keeps sessions on nodes without hook wiring working exactly as
 before, so this is a safe rollout rather than a flag day.
+
+`TurnRunning` states `working` outright rather than deferring to the default
+projection. `projected_activity_state` calls a `running` session idle once
+`last_activity` is 30s old, and `last_activity` is only refreshed by hooks — so
+a long tool-free response (no `PreToolUse` fires) would otherwise read idle from
+second 30 through second 180, exactly the window the fresh hook is supposed to
+cover.
 
 `TurnStopped` additionally requires `activity_turn_start_hook_at` — evidence
 that a `UserPromptSubmit` has actually been observed for this session. A stored

--- a/docs/working/1130_session_activity_detection.md
+++ b/docs/working/1130_session_activity_detection.md
@@ -40,6 +40,11 @@ active/idle no longer depends on spinners or completion verbs.
 `Untracked` keeps sessions on nodes without hook wiring working exactly as
 before, so this is a safe rollout rather than a flag day.
 
+`TurnRunning` is answered *before* the primary-node check. Hooks are posted to
+the primary from every node; only the pane is node-local. Gating hook state on
+the node check would strand remote sessions on the default projection for the
+rest of the freshness window.
+
 `TurnRunning` states `working` outright rather than deferring to the default
 projection. `projected_activity_state` calls a `running` session idle once
 `last_activity` is 30s old, and `last_activity` is only refreshed by hooks — so
@@ -57,14 +62,30 @@ that evidence the gate falls through to `Stale` and the pane stays in play.
 
 ## Hook ordering
 
-`hooks/notify_server.sh` dispatches every lifecycle hook through a detached
-curl, and the `Stop` handler may sleep on its transcript retry before applying
-state. A `Stop` received before the next prompt can therefore land *after* that
-prompt's `UserPromptSubmit`. The handler stamps `received_at` when the request
-arrives, before the retry sleep; `apply_claude_stop_hook` skips the turn
-transition when the stored `activity_hook_at` is newer than that stamp. The
-transcript metadata the superseded `Stop` carries is still the freshest
-available, so it is applied either way.
+`hooks/notify_server.sh` dispatches every lifecycle hook through its own
+detached curl, so neither HTTP arrival order nor handler completion order
+matches the order the events actually happened in. An older `Stop` overwriting a
+newer turn-start would park a live session at idle for the rest of the turn, so
+two independent guards prevent it:
+
+- **Emission ordering** (authoritative). The hook script stamps
+  `sm_hook_emitted_at` before detaching, and the server compares it against the
+  turn-start's own emission stamp. This catches a `Stop` whose curl was delayed
+  past the next turn's `UserPromptSubmit` entirely. Both stamps come from the
+  node that owns the session, so they are always compared on one clock.
+- **Arrival ordering** (fallback). `received_at` is stamped when the request
+  arrives, before the handler's transcript retry sleep. This catches a `Stop`
+  that arrived first but applied late, and covers hook scripts too old to send
+  an emission stamp.
+
+Sub-second resolution matters — a `Stop` and the next turn's `UserPromptSubmit`
+routinely land in the same second. The script uses `date -u +…%N` where
+available and falls back to perl's `Time::HiRes` on BSD `date`, which has no
+`%N`. Both shapes (9 and 6 fractional digits) are pinned by a test, because an
+unparseable stamp would silently disable the guard rather than fail loudly.
+
+The transcript metadata a superseded `Stop` carries is still the freshest
+available, so it is applied either way — only the turn transition is skipped.
 
 **The fallback no longer lies.** Completion detection is structural instead of
 an allowlist: a status glyph, one capitalised verb, `for`, and a duration, with

--- a/hooks/notify_server.sh
+++ b/hooks/notify_server.sh
@@ -7,6 +7,34 @@ HOOK_BASE_URL="${SM_HOOK_BASE_URL:-http://localhost:8420}"
 HOOK_URL="${SM_HOOK_URL:-${HOOK_BASE_URL%/}/hooks/claude}"
 HOOK_LOG_PATH="${CLAUDE_HOOK_LOG_PATH:-/tmp/claude-hooks.log}"
 
+# Emission timestamp, stamped before the curl is detached. Lifecycle hooks are
+# posted from independent background processes, so HTTP arrival order does not
+# match the order the events actually happened in; the server orders Stop against
+# the newest turn-start using these stamps. Sub-second resolution matters: a Stop
+# and the next turn's UserPromptSubmit routinely land in the same second.
+hook_emitted_at() {
+  local stamp
+  stamp=$(date -u +%Y-%m-%dT%H:%M:%S.%N 2>/dev/null || true)
+  case "$stamp" in
+    *%N*|'')
+      # BSD date without %N. Time::HiRes ships with every stock perl.
+      stamp=$(perl -MTime::HiRes=time -e '
+        my $t = time;
+        my @g = gmtime(int($t));
+        printf("%04d-%02d-%02dT%02d:%02d:%02d.%06dZ",
+          $g[5]+1900, $g[4]+1, $g[3], $g[2], $g[1], $g[0], ($t-int($t))*1000000);
+      ' 2>/dev/null || true)
+      ;;
+    *)
+      stamp="${stamp}Z"
+      ;;
+  esac
+  if [ -z "$stamp" ]; then
+    stamp=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)
+  fi
+  printf '%s' "$stamp"
+}
+
 extract_transcript_metadata() {
   local transcript_path="$1"
   if [ -z "$transcript_path" ] || [ ! -f "$transcript_path" ]; then
@@ -70,6 +98,11 @@ if [ -z "$INPUT" ]; then
   exit 0
 fi
 
+# Stamped here, before the transcript retry sleeps below. Those sleeps are
+# precisely what lets a Stop land after the next turn's UserPromptSubmit, so the
+# stamp has to predate them to describe when the event actually happened.
+EMITTED_AT="$(hook_emitted_at)"
+
 # Inline transcript metadata for remote delivery. When the hook is posting to a
 # non-local primary, that primary cannot safely read the node-local transcript.
 # UserPromptSubmit is a turn-start signal only and carries no transcript payload,
@@ -99,10 +132,14 @@ if [ -n "$SM_HOOK_BASE_URL" ] || [ -n "$SM_HOOK_URL" ]; then
   fi
 fi
 
-# If CLAUDE_SESSION_MANAGER_ID is set (from environment), inject it into the payload.
-if [ -n "$CLAUDE_SESSION_MANAGER_ID" ]; then
-  INPUT=$(echo "$INPUT" | jq -c --arg sid "$CLAUDE_SESSION_MANAGER_ID" '. + {session_manager_id: $sid}')
-fi
+# Attach the emission stamp, plus CLAUDE_SESSION_MANAGER_ID when the environment
+# provides it. Done in one jq pass to keep this off the per-turn hot path.
+INPUT=$(jq -c \
+  --arg sid "${CLAUDE_SESSION_MANAGER_ID:-}" \
+  --arg emitted "$EMITTED_AT" \
+  '. + (if $emitted != "" then {sm_hook_emitted_at: $emitted} else {} end)
+     + (if $sid != "" then {session_manager_id: $sid} else {} end)' \
+  <<< "$INPUT" 2>/dev/null || echo "$INPUT")
 
 # Post to local server asynchronously (don't block Claude).
 # Close inherited FDs so Claude Code does not keep waiting on the background curl.

--- a/hooks/notify_server.sh
+++ b/hooks/notify_server.sh
@@ -72,9 +72,14 @@ fi
 
 # Inline transcript metadata for remote delivery. When the hook is posting to a
 # non-local primary, that primary cannot safely read the node-local transcript.
+# UserPromptSubmit is a turn-start signal only and carries no transcript payload,
+# so skip the tail+jq work there — it runs before every single turn.
 if [ -n "$SM_HOOK_BASE_URL" ] || [ -n "$SM_HOOK_URL" ]; then
   TRANSCRIPT_PATH=$(echo "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null)
   HOOK_EVENT=$(echo "$INPUT" | jq -r '.hook_event_name // empty' 2>/dev/null)
+  if [ "$HOOK_EVENT" = "UserPromptSubmit" ]; then
+    TRANSCRIPT_PATH=""
+  fi
   if [ -n "$TRANSCRIPT_PATH" ] && [ -f "$TRANSCRIPT_PATH" ]; then
     METADATA=$(extract_transcript_metadata "$TRANSCRIPT_PATH" || true)
     if [ "$HOOK_EVENT" = "Stop" ]; then

--- a/scripts/install_notify_server_hook.sh
+++ b/scripts/install_notify_server_hook.sh
@@ -6,9 +6,61 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 SOURCE_SCRIPT="$REPO_ROOT/hooks/notify_server.sh"
 TARGET_DIR="$HOME/.claude/hooks"
 TARGET_SCRIPT="$TARGET_DIR/notify_server.sh"
+SETTINGS="$HOME/.claude/settings.json"
 
 mkdir -p "$TARGET_DIR"
 cp "$SOURCE_SCRIPT" "$TARGET_SCRIPT"
 chmod +x "$TARGET_SCRIPT"
 
 echo "Installed notify_server hook to $TARGET_SCRIPT"
+
+# Register both ends of the turn. Stop alone is not enough: the server treats a
+# stored idle as conclusive only when turn-start is observable too, and sessions
+# run in arbitrary working directories that never load this repo's
+# .claude/settings.json.
+python3 - "$SETTINGS" "$TARGET_SCRIPT" <<'PY'
+import json
+import os
+import sys
+
+settings_path, hook_script = sys.argv[1], sys.argv[2]
+
+try:
+    with open(settings_path) as handle:
+        settings = json.load(handle)
+except FileNotFoundError:
+    settings = {}
+except json.JSONDecodeError:
+    sys.exit(f"{settings_path} is not valid JSON; register the hooks manually")
+
+if not isinstance(settings, dict):
+    sys.exit(f"{settings_path} is not a JSON object; register the hooks manually")
+
+hooks = settings.setdefault("hooks", {})
+added = []
+for event in ("UserPromptSubmit", "Stop"):
+    matchers = hooks.setdefault(event, [])
+    already = any(
+        entry.get("command") == hook_script
+        for matcher in matchers
+        if isinstance(matcher, dict)
+        for entry in matcher.get("hooks", [])
+        if isinstance(entry, dict)
+    )
+    if already:
+        continue
+    matchers.append({"hooks": [{"type": "command", "command": hook_script}]})
+    added.append(event)
+
+if not added:
+    print(f"{settings_path} already registers notify_server for UserPromptSubmit and Stop")
+    sys.exit(0)
+
+os.makedirs(os.path.dirname(settings_path), exist_ok=True)
+tmp_path = f"{settings_path}.tmp"
+with open(tmp_path, "w") as handle:
+    json.dump(settings, handle, indent=2)
+    handle.write("\n")
+os.replace(tmp_path, settings_path)
+print(f"Registered notify_server for {', '.join(added)} in {settings_path}")
+PY

--- a/scripts/install_notify_server_hook.sh
+++ b/scripts/install_notify_server_hook.sh
@@ -57,10 +57,21 @@ if not added:
     sys.exit(0)
 
 os.makedirs(os.path.dirname(settings_path), exist_ok=True)
+
+# Settings can hold hook credentials and environment values. Writing a fresh
+# temp file and replacing would hand the result whatever the umask says
+# (commonly 0644), silently widening a 0600 file, so carry the original mode
+# across — and default a brand-new file to owner-only.
+try:
+    mode = os.stat(settings_path).st_mode & 0o777
+except FileNotFoundError:
+    mode = 0o600
+
 tmp_path = f"{settings_path}.tmp"
 with open(tmp_path, "w") as handle:
     json.dump(settings, handle, indent=2)
     handle.write("\n")
+os.chmod(tmp_path, mode)
 os.replace(tmp_path, settings_path)
 print(f"Registered notify_server for {', '.join(added)} in {settings_path}")
 PY

--- a/web/sm-watch/src/components/WatchTable.tsx
+++ b/web/sm-watch/src/components/WatchTable.tsx
@@ -56,15 +56,17 @@ function attachCommand(session: Session): string | null {
   return `ssh -t ${target} 'tmux attach-session -t ${quotedTmux}'`;
 }
 
-function activityTone(activityState?: string): string {
-  switch (activityState) {
+/** Takes a `stateLabel()` result, not a raw `activity_state`. */
+function activityTone(activityLabel?: string): string {
+  switch (activityLabel) {
     case 'working':
       return 'text-emerald-300';
     case 'thinking':
       return 'text-sky-300';
+    // Stopped, but background shells/monitors are still running.
+    case 'bg-wait':
+      return 'text-violet-300';
     case 'waiting':
-    case 'waiting_input':
-    case 'waiting_permission':
       return 'text-amber-300';
     case 'node-unreachable':
       return 'text-orange-300';

--- a/web/sm-watch/src/watchModel.ts
+++ b/web/sm-watch/src/watchModel.ts
@@ -2,7 +2,10 @@ import { Session, SessionDetail, WatchRepoRef, WatchRow, WatchSection, WatchSess
 
 export type StatusFilter = 'all' | Session['status'];
 
-const WAITING_STATES = new Set(['waiting', 'waiting_permission', 'waiting_input']);
+// `waiting` means "the agent's turn stopped but background shells/monitors are
+// still running" — it is not the same thing as waiting on a human, so it gets
+// its own label and colour.
+const INPUT_WAITING_STATES = new Set(['waiting_permission', 'waiting_input']);
 
 function sortSessions(left: Session, right: Session): number {
   return sessionDisplayName(left).localeCompare(sessionDisplayName(right), undefined, { sensitivity: 'base' })
@@ -133,7 +136,10 @@ export function stateLabel(activityState?: string | null): string {
   if (!activityState) {
     return 'idle';
   }
-  if (WAITING_STATES.has(activityState)) {
+  if (activityState === 'waiting') {
+    return 'bg-wait';
+  }
+  if (INPUT_WAITING_STATES.has(activityState)) {
     return 'waiting';
   }
   return activityState;


### PR DESCRIPTION
Fixes #1130.

## Problem

`activity_state` was derived by scraping the tmux pane on **every** dashboard read, and the scraper both missed idle and manufactured active:

1. **Stuck active while idle.** `claude_line_indicates_completed` matched an allowlist of exactly three completion verbs (`Brewed for`, `Baked for`, `Churned for`). Claude cycles through many more (`Crunched`, `Cooked`, `Simmered`, `Sautéed`, …), so a turn ending on any other verb classified as neither completed nor working, the overlay returned `None`, and a stale active status persisted.
2. **False active from background work.** `✻ Baked for 24m · 1 shell still running` was classified `working`, flipping a correct hook-derived idle back to active even though the turn was done.

Root cause: the `Stop` hook is authoritative when it arrives but is lossy (restarts, event-loop stalls, watchdog kills), and the scraper backstopping it was too weak to re-derive the truth.

## Changes

**Hooks bracket the turn.** `UserPromptSubmit` marks the session `running` at turn start; `Stop` marks it `idle` at turn end. Both write a durable `activity_hook_at` timestamp to the session store alongside the status.

`claude_hook_gate()` turns the stored state into one of:

| Gate | Meaning | Pane consulted? |
| --- | --- | --- |
| `TurnRunning` | turn in flight, hook signal fresh (< 180s) | no — capture skipped entirely |
| `TurnStopped` | `Stop` fired, no turn started since | background-work signal only |
| `Stale` | turn reported in flight but the signal aged out | yes — last resort |
| `Untracked` | no lifecycle hook ever seen for this session | yes — legacy behaviour |

`Untracked` keeps sessions on nodes without hook wiring behaving exactly as before, so this is a safe rollout rather than a flag day.

**The fallback no longer lies.** Completion detection is structural instead of an allowlist: a status glyph, one capitalised verb, `for`, and a duration, with no `…` spinner and no `(esc to interrupt)`. Todo glyphs (`✔`, `✗`, `❯`, …) share the dingbat block with the status glyph and are rejected explicitly, so `✔ Waited for 30s` cannot end a turn. Background work is read only from the newest status line and the chrome below it — older status lines scroll up with stale `N shell still running` segments attached.

**New `waiting` state.** `Stop` fired but background shells/monitors are still running. Background work may only downgrade `idle → waiting`; it can never upgrade to `working` (that was bug 2). Renders as violet `bg-wait` in web `sm-watch` and the Android watch screen, distinct from the amber `waiting` used for `waiting_input` / `waiting_permission`.

## Acceptance criteria

- [x] A turn ending on any completion verb is detected as not-active — `claude_pane_activity_detects_unlisted_completion_verbs` covers Crunched / Cooked / Simmered / Sautéed / Percolated
- [x] `working` is set at turn start via `UserPromptSubmit`, not spinner scraping
- [x] A finished turn with a live monitor/background shell shows `waiting`, never active, never plain idle
- [x] A server restart never reverts a finished session to stale active — `claude_stop_hook_idle_survives_a_server_restart`
- [x] Pane-scraper only consulted when the hook state is stale; background work only downgrades idle→waiting — `claude_live_activity_trusts_fresh_turn_running_hook_over_pane`, `claude_live_activity_never_upgrades_stopped_turn_to_working`
- [x] `waiting` renders distinctly in web and Android

## Testing

- `cargo test -p sm-server` — 220 pass, including 11 new tests
- `./gradlew :app:testDebugUnitTest` — pass, 2 new tests
- `npm run lint && npm run build` in `web/sm-watch` — clean

Note: `activityTone()` in `WatchTable.tsx` receives a `stateLabel()` result, not a raw `activity_state`, so its `waiting_input` / `waiting_permission` cases were already dead. Fixed while adding the new tone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)