### PR TITLE
Add sm context command

### DIFF
--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -12,6 +12,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use clap::{Args, Parser, Subcommand};
 use serde_json::{json, Map, Value};
 use sm_server::{config::AppConfig, mobile_devices};
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 const DEFAULT_API_URL: &str = "http://127.0.0.1:8420";
 const CLIENT_CONFIG_ENV: &str = "SM_CLIENT_CONFIG";
@@ -50,6 +51,8 @@ enum Command {
     TaskComplete(EmptyArgs),
     #[command(name = "turn-complete")]
     TurnComplete(EmptyArgs),
+    #[command(alias = "ctx")]
+    Context(ContextArgs),
     #[command(name = "context-monitor")]
     ContextMonitor(ContextMonitorArgs),
     Email(EmailArgs),
@@ -199,6 +202,17 @@ struct TailArgs {
 #[derive(Args)]
 struct HandoffArgs {
     file_path: Option<String>,
+}
+
+#[derive(Args)]
+struct ContextArgs {
+    session_id: Option<String>,
+    #[arg(long, conflicts_with = "detailed")]
+    details: bool,
+    #[arg(long)]
+    detailed: bool,
+    #[arg(long)]
+    json: bool,
 }
 
 #[derive(Args)]
@@ -778,6 +792,9 @@ fn run() -> Result<()> {
                 bail!("Failed to mark turn complete");
             }
             println!("Turn complete. Remind cancelled until new work is assigned.");
+        }
+        Command::Context(args) => {
+            run_context(&client, args)?;
         }
         Command::ContextMonitor(args) => {
             run_context_monitor(&client, args)?;
@@ -2424,6 +2441,132 @@ fn wait_for_session(client: &ApiClient, session_id: &str, seconds: u64) -> Resul
         }
         thread::sleep(Duration::from_millis(200));
     }
+}
+
+fn run_context(client: &ApiClient, args: ContextArgs) -> Result<()> {
+    let target = match args.session_id {
+        Some(session_id) => session_id,
+        None => optional_current_session_id().ok_or_else(|| {
+            anyhow!("sm context requires a managed session or explicit session target")
+        })?,
+    };
+    let payload = client.get_json(&format!("/sessions/{target}/context"))?;
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+        return Ok(());
+    }
+
+    let percentage = format_context_percentage(payload.get("used_percentage"));
+    if !(args.details || args.detailed) {
+        println!("{percentage}");
+        return Ok(());
+    }
+
+    let token_text = payload
+        .get("total_input_tokens")
+        .and_then(Value::as_i64)
+        .map(|tokens| format!(" ({} tokens)", format_int(tokens)))
+        .unwrap_or_default();
+    let session_id = payload["session_id"].as_str().unwrap_or(&target);
+    let label = payload["friendly_name"].as_str().unwrap_or(session_id);
+    let provider = payload["provider"].as_str().unwrap_or("-");
+    let state = payload["state"].as_str().unwrap_or("unknown");
+    let warning = format_context_percentage(payload.get("warning_percentage"));
+    let critical = format_context_percentage(payload.get("critical_percentage"));
+    let notify = payload["notify_session_id"].as_str();
+    let notify_text = match notify {
+        Some(value) if value == session_id => "self".to_owned(),
+        Some(value) => value.to_owned(),
+        None => "none".to_owned(),
+    };
+    let monitor = if payload["context_monitor_enabled"]
+        .as_bool()
+        .unwrap_or(false)
+    {
+        "enabled"
+    } else {
+        "disabled"
+    };
+    let compaction = if payload["compaction_active"].as_bool().unwrap_or(false) {
+        "active"
+    } else {
+        "not active"
+    };
+
+    println!("Context: {percentage}{token_text}");
+    println!(
+        "Sample: {}",
+        format_context_sample_age(payload["sampled_at"].as_str())
+    );
+    println!("State: {state} (warning {warning}, critical {critical})");
+    println!("Monitor: {monitor}, alerts -> {notify_text}");
+    println!("Compaction: {compaction}");
+    println!(
+        "Last handoff: {}",
+        payload["last_handoff_path"].as_str().unwrap_or("-")
+    );
+    println!("Session: {label} [{session_id}] {provider}");
+    Ok(())
+}
+
+fn format_context_percentage(value: Option<&Value>) -> String {
+    let Some(numeric) = value.and_then(Value::as_f64) else {
+        return "unknown".to_owned();
+    };
+    if (numeric.fract()).abs() < f64::EPSILON {
+        format!("{}%", numeric as i64)
+    } else {
+        let mut text = format!("{numeric:.1}");
+        while text.contains('.') && text.ends_with('0') {
+            text.pop();
+        }
+        if text.ends_with('.') {
+            text.pop();
+        }
+        format!("{text}%")
+    }
+}
+
+fn format_context_sample_age(sampled_at: Option<&str>) -> String {
+    let Some(sampled_at) = sampled_at else {
+        return "unknown".to_owned();
+    };
+    let Ok(timestamp) = OffsetDateTime::parse(sampled_at, &Rfc3339) else {
+        return "unknown".to_owned();
+    };
+    let mut seconds = (OffsetDateTime::now_utc() - timestamp).whole_seconds();
+    if seconds < 0 {
+        seconds = 0;
+    }
+    if seconds < 60 {
+        return format!("{seconds}s ago");
+    }
+    let minutes = seconds / 60;
+    if minutes < 60 {
+        return format!("{minutes}min ago");
+    }
+    let hours = minutes / 60;
+    if hours < 24 {
+        return format!("{hours}hr ago");
+    }
+    let days = hours / 24;
+    if days == 1 {
+        "1day ago".to_owned()
+    } else {
+        format!("{days}days ago")
+    }
+}
+
+fn format_int(value: i64) -> String {
+    let raw = value.to_string();
+    let mut output = String::new();
+    for (index, ch) in raw.chars().rev().enumerate() {
+        if index > 0 && index % 3 == 0 {
+            output.push(',');
+        }
+        output.push(ch);
+    }
+    output.chars().rev().collect()
 }
 
 fn run_context_monitor(client: &ApiClient, args: ContextMonitorArgs) -> Result<()> {
@@ -4621,6 +4764,14 @@ mod tests {
             error,
             "Multiple node restore candidates match 'shared-alias': candidate-a, candidate-b. Use a session ID."
         );
+    }
+
+    #[test]
+    fn context_percentage_formatter_matches_terse_contract() {
+        assert_eq!(format_context_percentage(Some(&json!(43))), "43%");
+        assert_eq!(format_context_percentage(Some(&json!(43.5))), "43.5%");
+        assert_eq!(format_context_percentage(Some(&Value::Null)), "unknown");
+        assert_eq!(format_context_percentage(None), "unknown");
     }
 
     fn write_temp_config(content: &str) -> PathBuf {

--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -2450,7 +2450,7 @@ fn run_context(client: &ApiClient, args: ContextArgs) -> Result<()> {
             anyhow!("sm context requires a managed session or explicit session target")
         })?,
     };
-    let payload = client.get_json(&format!("/sessions/{target}/context"))?;
+    let payload = client.get_json(&session_context_path(&target))?;
     if args.json {
         println!("{}", serde_json::to_string_pretty(&payload)?);
         return Ok(());
@@ -2507,6 +2507,10 @@ fn run_context(client: &ApiClient, args: ContextArgs) -> Result<()> {
     );
     println!("Session: {label} [{session_id}] {provider}");
     Ok(())
+}
+
+fn session_context_path(target: &str) -> String {
+    format!("/sessions/{}/context", encode_path_segment(target))
 }
 
 fn format_context_percentage(value: Option<&Value>) -> String {
@@ -4772,6 +4776,14 @@ mod tests {
         assert_eq!(format_context_percentage(Some(&json!(43.5))), "43.5%");
         assert_eq!(format_context_percentage(Some(&Value::Null)), "unknown");
         assert_eq!(format_context_percentage(None), "unknown");
+    }
+
+    #[test]
+    fn context_target_path_segments_are_encoded() {
+        assert_eq!(
+            session_context_path("Runner Native/1"),
+            "/sessions/Runner%20Native%2F1/context"
+        );
     }
 
     fn write_temp_config(content: &str) -> PathBuf {

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -109,15 +109,15 @@ use crate::sessions::{
     claude_hook_gate, codex_fork_status_for_event_line, expand_home, is_primary_node,
     AgentRegistrationResponse, AgentStatusRequest, ArmStopNotifyOutcome, ArmStopNotifyRequest,
     ChildSessionResponse, ClaudeHookGate, ClearSessionRequest, ClientSessionResponse,
-    ContextMonitorOutcome, ContextMonitorRequest, ContextUsageEvent, ContextUsageOutcome,
-    CoreClearOutcome, CoreInputBatchResponse, CoreInputBatchResult, CoreRestoreOutcome,
-    CoreRetireOutcome, CoreReviewOutcome, CreateCoreSessionRequest, HandoffOutcome, HandoffRequest,
-    MaintainerMutationOutcome, RegistryMutationOutcome, RoleRegistrationRequest,
-    SendCoreInputBatchRequest, SendCoreInputRequest, SessionMetadataOutcome, SessionRecord,
-    SessionResponse, SessionStore, SessionsEnvelope, SetMaintainerRequest, SpawnReviewRequest,
-    StartReviewRequest, SubagentStartOutcome, SubagentStartRequest, SubagentStopOutcome,
-    SubagentStopRequest, TaskCompleteOutcome, TaskCompleteRequest, TurnCompleteOutcome,
-    UpdateSessionMetadataRequest,
+    ContextMonitorOutcome, ContextMonitorRequest, ContextSnapshotResponse, ContextUsageEvent,
+    ContextUsageOutcome, CoreClearOutcome, CoreInputBatchResponse, CoreInputBatchResult,
+    CoreRestoreOutcome, CoreRetireOutcome, CoreReviewOutcome, CreateCoreSessionRequest,
+    HandoffOutcome, HandoffRequest, MaintainerMutationOutcome, RegistryMutationOutcome,
+    RoleRegistrationRequest, SendCoreInputBatchRequest, SendCoreInputRequest,
+    SessionMetadataOutcome, SessionRecord, SessionResponse, SessionStore, SessionsEnvelope,
+    SetMaintainerRequest, SpawnReviewRequest, StartReviewRequest, SubagentStartOutcome,
+    SubagentStartRequest, SubagentStopOutcome, SubagentStopRequest, TaskCompleteOutcome,
+    TaskCompleteRequest, TurnCompleteOutcome, UpdateSessionMetadataRequest,
 };
 use crate::studio_ssh::{self, StudioSshStatus};
 use crate::tool_usage::{
@@ -945,6 +945,7 @@ pub fn router(state: AppState) -> Router {
             "/sessions/{session_id}",
             get(get_session).patch(update_session_metadata),
         )
+        .route("/sessions/{session_id}/context", get(get_session_context))
         .route("/sessions/{session_id}/review", post(start_session_review))
         .route(
             "/sessions/{parent_session_id}/children",
@@ -6355,6 +6356,18 @@ async fn set_context_monitor(
     }
 }
 
+async fn get_session_context(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+    request: Request,
+) -> Result<Json<ContextSnapshotResponse>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    match state.session_store.get_context_snapshot(&session_id)? {
+        Some(snapshot) => Ok(Json(snapshot)),
+        None => Err(ApiError::NotFound("Session not found")),
+    }
+}
+
 async fn register_subagent_start(
     State(state): State<Arc<AppState>>,
     Path(session_id): Path<String>,
@@ -7369,6 +7382,26 @@ fn shadow_predict_session_read(
             "parent_session_id": parent_session_id,
             "children": children,
         }))?;
+        return Ok(Some(ShadowPrediction {
+            status: StatusCode::OK.as_u16(),
+            body_sha256: Some(sha256_hex(&body)),
+            support_status: "implemented_read",
+        }));
+    }
+
+    if let Some(session_id) = path
+        .strip_prefix("/sessions/")
+        .and_then(|value| value.strip_suffix("/context"))
+    {
+        let Some(snapshot) = state.session_store.get_context_snapshot(session_id)? else {
+            let body = serde_json::to_vec(&json!({ "detail": "Session not found" }))?;
+            return Ok(Some(ShadowPrediction {
+                status: StatusCode::NOT_FOUND.as_u16(),
+                body_sha256: Some(sha256_hex(&body)),
+                support_status: "implemented_read",
+            }));
+        };
+        let body = serde_json::to_vec(&snapshot)?;
         return Ok(Some(ShadowPrediction {
             status: StatusCode::OK.as_u16(),
             body_sha256: Some(sha256_hex(&body)),

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -5902,14 +5902,17 @@ async fn send_session_input(
             detail: "text is required".to_owned(),
         });
     }
+    let Some(session) = state.session_store.get_session(&session_id)? else {
+        return Err(ApiError::NotFound("Session not found"));
+    };
     let result = if state.config.rust_core.runtime_enabled {
-        ensure_core_runtime_session_node_supported(&state, &session_id)?;
+        ensure_core_runtime_session_node_supported(&state, &session.id)?;
         let runtime = TmuxRuntime::from_app_config(&state.config);
         state
             .session_store
-            .send_core_input_with_runtime(&session_id, payload, &runtime)?
+            .send_core_input_with_runtime(&session.id, payload, &runtime)?
     } else {
-        state.session_store.send_core_input(&session_id, payload)?
+        state.session_store.send_core_input(&session.id, payload)?
     };
     let Some(result) = result else {
         return Err(ApiError::NotFound("Session not found"));
@@ -6633,13 +6636,16 @@ async fn session_output(
     request: Request,
 ) -> Result<Json<SessionOutputResponse>, ApiError> {
     ensure_session_read_allowed(&state, &request)?;
-    if state.session_store.get_session(&session_id)?.is_none() {
+    let Some(session) = state.session_store.get_session(&session_id)? else {
         return Err(ApiError::NotFound("Session not found"));
-    }
+    };
     let output = state
         .session_store
-        .capture_output(&session_id, query.lines.unwrap_or(50))?;
-    Ok(Json(SessionOutputResponse { session_id, output }))
+        .capture_output(&session.id, query.lines.unwrap_or(50))?;
+    Ok(Json(SessionOutputResponse {
+        session_id: session.id,
+        output,
+    }))
 }
 
 async fn session_tool_calls(

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -6666,16 +6666,16 @@ async fn session_tool_calls(
     };
     if session.provider == "codex-fork" {
         let db_path = expand_home(&state.config.codex_observability.db_path);
-        let tool_calls = list_recent_codex_fork_tool_calls_from_path(&db_path, &session_id, limit)?;
+        let tool_calls = list_recent_codex_fork_tool_calls_from_path(&db_path, &session.id, limit)?;
         return Ok(Json(ToolCallsResponse {
-            session_id,
+            session_id: session.id,
             tool_calls,
         }));
     }
     let db_path = expand_home(&state.config.tool_logging.db_path);
-    let tool_calls = list_recent_tool_calls_from_path(&db_path, &session_id, limit)?;
+    let tool_calls = list_recent_tool_calls_from_path(&db_path, &session.id, limit)?;
     Ok(Json(ToolCallsResponse {
-        session_id,
+        session_id: session.id,
         tool_calls,
     }))
 }
@@ -6704,7 +6704,7 @@ async fn session_activity_actions(
         });
     }
     let db_path = expand_home(&state.config.codex_observability.db_path);
-    let response = list_codex_activity_actions_from_path(&db_path, &session_id, query.limit)?;
+    let response = list_codex_activity_actions_from_path(&db_path, &session.id, query.limit)?;
     Ok(Json(response))
 }
 
@@ -6733,7 +6733,7 @@ async fn session_codex_events(
     }
     let db_path = expand_home(&state.config.codex_events.db_path);
     let response =
-        list_codex_events_from_path(&db_path, &session_id, query.since_seq, query.limit)?;
+        list_codex_events_from_path(&db_path, &session.id, query.since_seq, query.limit)?;
     Ok(Json(response))
 }
 
@@ -6762,7 +6762,7 @@ async fn session_codex_pending_requests(
     }
     let db_path = expand_home(&state.config.codex_requests.db_path);
     let response =
-        list_codex_pending_requests_from_path(&db_path, &session_id, query.include_orphaned)?;
+        list_codex_pending_requests_from_path(&db_path, &session.id, query.include_orphaned)?;
     Ok(Json(response))
 }
 

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -817,6 +817,7 @@ fn is_tmux_session_gone_error(error: &anyhow::Error) -> bool {
     let message = error.to_string();
     message.contains("no server running")
         || message.contains("can't find session")
+        || message.contains("no current target")
         || message.contains("server exited unexpectedly")
 }
 
@@ -1031,6 +1032,12 @@ mod tests {
         assert!(command.contains("unset CLAUDECODE"));
         assert!(command.contains("export ENABLE_TOOL_SEARCH=false"));
         assert!(command.ends_with("; claude"));
+    }
+
+    #[test]
+    fn tmux_no_current_target_counts_as_session_gone() {
+        let error = anyhow::anyhow!("tmux command failed: no current target");
+        assert!(is_tmux_session_gone_error(&error));
     }
 
     #[test]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1522,7 +1522,10 @@ impl SessionStore {
             let changed = previous_used != Some(tokens_used)
                 || previous_pct != Some(used_percentage)
                 || previous_context_tokens != Some(tokens_used)
-                || json_text(session.get("context_sampled_at")).is_none();
+                || json_text(session.get("context_sampled_at")).is_none()
+                || event.emitted_at.is_some()
+                    && json_text(session.get("context_sampled_at")).as_deref()
+                        != Some(sampled_at.as_str());
             if changed {
                 session.insert("tokens_used".to_owned(), json!(tokens_used));
                 session.insert("context_used_percentage".to_owned(), json!(used_percentage));
@@ -7881,6 +7884,42 @@ mod tests {
         assert_eq!(session.context_used_percentage, Some(60.0));
         assert_eq!(session.context_total_input_tokens, Some(120_000));
         assert_eq!(session.tokens_used, 120_000);
+    }
+
+    #[test]
+    fn identical_stamped_usage_samples_advance_the_ordering_watermark() {
+        let store = store_with_monitored_child("ctxsamewatermark", false, Some("parent01"));
+        store
+            .apply_context_usage_event(
+                &usage_event_at("child001", 60.0, 120_000, "2026-07-28T10:00:00.000000Z"),
+                None,
+            )
+            .unwrap();
+
+        store
+            .apply_context_usage_event(
+                &usage_event_at("child001", 60.0, 120_000, "2026-07-28T10:01:00.000000Z"),
+                None,
+            )
+            .unwrap();
+
+        assert_eq!(
+            store
+                .apply_context_usage_event(
+                    &usage_event_at("child001", 45.0, 90_000, "2026-07-28T10:00:30.000000Z",),
+                    None,
+                )
+                .unwrap(),
+            ContextUsageOutcome::StaleSample
+        );
+
+        let session = store.get_session("child001").unwrap().unwrap();
+        assert_eq!(session.context_used_percentage, Some(60.0));
+        assert_eq!(session.context_total_input_tokens, Some(120_000));
+        assert_eq!(
+            session.context_sampled_at.as_deref(),
+            Some("2026-07-28T10:01:00.000000Z")
+        );
     }
 
     #[test]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -196,6 +196,19 @@ impl SessionStore {
             }))
     }
 
+    pub fn get_context_snapshot(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<ContextSnapshotResponse>> {
+        let Some(session) = self.get_session(session_id)? else {
+            return Ok(None);
+        };
+        Ok(Some(ContextSnapshotResponse::from_session(
+            session,
+            &self.context_monitor,
+        )))
+    }
+
     /// `hooks/notify_server.sh` dispatches every lifecycle hook through its own
     /// detached curl, so neither HTTP arrival order nor handler completion order
     /// matches the order the events actually happened in. Two independent guards
@@ -1346,8 +1359,17 @@ impl SessionStore {
             // secret and nothing else, and this route already accepts exactly
             // that.
             "compaction_complete" => Ok(ContextUsageOutcome::CompactionCompleteLogged {
-                last_handoff_path: raw_session_object(&state, session_id)
-                    .and_then(|session| json_text(session.get("last_handoff_path"))),
+                last_handoff_path: {
+                    let sessions = ensure_sessions_array_mut(&mut state)?;
+                    let Some(session) = session_object_mut(sessions, session_id) else {
+                        return Ok(ContextUsageOutcome::UnknownSession);
+                    };
+                    session.insert("context_compaction_active".to_owned(), Value::Bool(false));
+                    clear_context_snapshot(session);
+                    let last_handoff_path = json_text(session.get("last_handoff_path"));
+                    self.write_raw_json_value(&state)?;
+                    last_handoff_path
+                },
             }),
             "context_reset" => self.apply_context_reset_event(&mut state, session_id, emitted_at),
             _ => self.apply_context_usage_update(&mut state, session_id, event, runtime),
@@ -1372,6 +1394,7 @@ impl SessionStore {
             // context can legitimately land above it.
             reset_context_oneshot_flags(session);
             set_context_cycle_boundary(session, emitted_at);
+            session.insert("context_compaction_active".to_owned(), Value::Bool(true));
             let notify_target = json_text(session.get("context_monitor_notify"))
                 // Fall back to the parent so an unregistered child still reports
                 // its own context loss upward (#210).
@@ -1411,6 +1434,8 @@ impl SessionStore {
             };
             reset_context_oneshot_flags(session);
             set_context_cycle_boundary(session, emitted_at);
+            session.insert("context_compaction_active".to_owned(), Value::Bool(false));
+            clear_context_snapshot(session);
             // The discarded context is what the previous status was describing.
             session.insert("agent_status_text".to_owned(), Value::Null);
             session.insert("agent_status_at".to_owned(), Value::Null);
@@ -1433,9 +1458,6 @@ impl SessionStore {
             .and_then(|session| session.get("context_monitor_enabled"))
             .and_then(Value::as_bool)
             .unwrap_or(false);
-        if !enabled {
-            return Ok(ContextUsageOutcome::NotRegistered);
-        }
         // A sample emitted before the current cycle began describes context that
         // no longer exists. Both stamps come from the session's own host, so this
         // never compares clocks across machines. Samples from a hook too old to
@@ -1455,15 +1477,40 @@ impl SessionStore {
             return Ok(ContextUsageOutcome::NoUsage);
         };
 
-        let (alert, mut changed) = {
+        let (alert, changed) = {
             let sessions = ensure_sessions_array_mut(state)?;
             let Some(session) = session_object_mut(sessions, session_id) else {
                 return Ok(ContextUsageOutcome::UnknownSession);
             };
             let tokens_used = event.total_input_tokens.unwrap_or(0);
-            let changed = session.get("tokens_used").and_then(Value::as_i64) != Some(tokens_used);
+            let sampled_at = event
+                .emitted_at
+                .as_deref()
+                .filter(|value| !value.trim().is_empty())
+                .map(ToOwned::to_owned)
+                .unwrap_or_else(now_rfc3339);
+            let previous_used = session.get("tokens_used").and_then(Value::as_i64);
+            let previous_pct = session
+                .get("context_used_percentage")
+                .and_then(Value::as_f64);
+            let previous_context_tokens = session
+                .get("context_total_input_tokens")
+                .and_then(Value::as_i64);
+            let changed = previous_used != Some(tokens_used)
+                || previous_pct != Some(used_percentage)
+                || previous_context_tokens != Some(tokens_used)
+                || json_text(session.get("context_sampled_at")).is_none();
             if changed {
                 session.insert("tokens_used".to_owned(), json!(tokens_used));
+                session.insert("context_used_percentage".to_owned(), json!(used_percentage));
+                session.insert("context_total_input_tokens".to_owned(), json!(tokens_used));
+                session.insert("context_sampled_at".to_owned(), Value::String(sampled_at));
+            }
+            if !enabled {
+                if changed {
+                    self.write_raw_json_value(state)?;
+                }
+                return Ok(ContextUsageOutcome::NotRegistered);
             }
             (
                 self.latch_context_alert(session, session_id, used_percentage, tokens_used),
@@ -1471,6 +1518,7 @@ impl SessionStore {
             )
         };
 
+        let mut changed = changed;
         if let Some(alert) = alert {
             self.queue_context_monitor_message(
                 state,
@@ -2767,6 +2815,10 @@ impl SessionStore {
             last_tool_call: None,
             last_tool_name: None,
             tokens_used: 0,
+            context_used_percentage: None,
+            context_total_input_tokens: None,
+            context_sampled_at: None,
+            context_compaction_active: false,
             context_monitor_enabled: false,
             context_monitor_notify: None,
             context_warning_sent: false,
@@ -3463,6 +3515,61 @@ pub struct ContextMonitorStatus {
 }
 
 #[derive(Debug, Clone, Serialize)]
+pub struct ContextSnapshotResponse {
+    pub session_id: String,
+    pub friendly_name: Option<String>,
+    pub provider: Option<String>,
+    pub used_percentage: Option<f64>,
+    pub total_input_tokens: Option<i64>,
+    pub sampled_at: Option<String>,
+    pub state: String,
+    pub warning_percentage: f64,
+    pub critical_percentage: f64,
+    pub context_monitor_enabled: bool,
+    pub notify_session_id: Option<String>,
+    pub compaction_active: bool,
+    pub last_handoff_path: Option<String>,
+}
+
+impl ContextSnapshotResponse {
+    fn from_session(session: SessionRecord, config: &ContextMonitorConfig) -> Self {
+        let used_percentage = session.context_used_percentage;
+        let compaction_active = session.context_compaction_active;
+        let friendly_name = session.cached_display_name();
+        let state = if compaction_active {
+            "compacting"
+        } else if let Some(used_percentage) = used_percentage {
+            if used_percentage >= config.critical_percentage {
+                "critical"
+            } else if used_percentage >= config.warning_percentage {
+                "warning"
+            } else {
+                "normal"
+            }
+        } else {
+            "unknown"
+        }
+        .to_owned();
+
+        Self {
+            session_id: session.id,
+            friendly_name,
+            provider: Some(non_empty_or(session.provider, "claude")),
+            used_percentage,
+            total_input_tokens: session.context_total_input_tokens,
+            sampled_at: session.context_sampled_at,
+            state,
+            warning_percentage: config.warning_percentage,
+            critical_percentage: config.critical_percentage,
+            context_monitor_enabled: session.context_monitor_enabled,
+            notify_session_id: session.context_monitor_notify,
+            compaction_active,
+            last_handoff_path: session.last_handoff_path,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
 pub struct ContextMonitorResult {
     pub status: String,
     pub enabled: bool,
@@ -3716,6 +3823,12 @@ fn reset_context_oneshot_flags(session: &mut Map<String, Value>) {
     session.insert("context_warning_sent".to_owned(), Value::Bool(false));
     session.insert("context_critical_sent".to_owned(), Value::Bool(false));
     session.insert("context_cycle_reset_emitted_at".to_owned(), Value::Null);
+}
+
+fn clear_context_snapshot(session: &mut Map<String, Value>) {
+    session.insert("context_used_percentage".to_owned(), Value::Null);
+    session.insert("context_total_input_tokens".to_owned(), Value::Null);
+    session.insert("context_sampled_at".to_owned(), Value::Null);
 }
 
 /// Record where the new cycle begins, in the producer's own clock.
@@ -5126,7 +5239,7 @@ fn recover_missing_maintainer_registration_raw(state: &mut Value) -> Result<bool
         let Some(session) = sessions.iter().find(|session| session.id == session_id) else {
             continue;
         };
-        if !session.is_restorable_for_registry() {
+        if !session.is_live_for_registry() {
             continue;
         }
         if !from_legacy_field && !session_has_maintainer_identity(session) {
@@ -5153,10 +5266,10 @@ fn session_has_maintainer_identity(session: &SessionRecord) -> bool {
 }
 
 fn prune_agent_registrations_raw(state: &mut Value) -> Result<bool> {
-    let restorable_session_ids = snapshot_from_raw_value(state)?
+    let live_session_ids = snapshot_from_raw_value(state)?
         .into_sessions()
         .into_iter()
-        .filter(SessionRecord::is_restorable_for_registry)
+        .filter(SessionRecord::is_live_for_registry)
         .map(|session| session.id)
         .collect::<BTreeSet<_>>();
     let mut removed = Vec::<AgentRegistrationRecord>::new();
@@ -5166,7 +5279,7 @@ fn prune_agent_registrations_raw(state: &mut Value) -> Result<bool> {
             let Some(registration) = raw_registration_record(entry) else {
                 return false;
             };
-            if restorable_session_ids.contains(&registration.session_id) {
+            if live_session_ids.contains(&registration.session_id) {
                 return true;
             }
             removed.push(registration);
@@ -5283,6 +5396,8 @@ fn reset_session_after_clear(session: &mut Map<String, Value>, now: &str) {
     // this a cleared codex session's latches would stay set and suppress every
     // warning in the new cycle.
     reset_context_oneshot_flags(session);
+    clear_context_snapshot(session);
+    session.insert("context_compaction_active".to_owned(), Value::Bool(false));
     session.insert("agent_status_text".to_owned(), Value::Null);
     session.insert("agent_status_at".to_owned(), Value::Null);
     session.insert("agent_task_completed_at".to_owned(), Value::Null);
@@ -5730,7 +5845,7 @@ impl StateSnapshot {
             .as_deref()
             .map(str::trim)
             .filter(|value| !value.is_empty())
-            .filter(|session_id| self.session_is_restorable_for_registry(session_id))
+            .filter(|session_id| self.session_is_live_for_registry(session_id))
         {
             aliases
                 .entry(session_id.to_owned())
@@ -5743,7 +5858,7 @@ impl StateSnapshot {
             if role.is_empty() || session_id.is_empty() {
                 continue;
             }
-            if !self.session_is_restorable_for_registry(session_id) {
+            if !self.session_is_live_for_registry(session_id) {
                 continue;
             }
             aliases
@@ -5754,11 +5869,11 @@ impl StateSnapshot {
         aliases
     }
 
-    fn session_is_restorable_for_registry(&self, session_id: &str) -> bool {
+    fn session_is_live_for_registry(&self, session_id: &str) -> bool {
         self.sessions
             .iter()
             .find(|session| session.id == session_id)
-            .is_some_and(SessionRecord::is_restorable_for_registry)
+            .is_some_and(SessionRecord::is_live_for_registry)
     }
 
     fn pending_proposal_map(
@@ -5936,6 +6051,14 @@ pub struct SessionRecord {
     #[serde(default)]
     pub tokens_used: i64,
     #[serde(default)]
+    pub context_used_percentage: Option<f64>,
+    #[serde(default)]
+    pub context_total_input_tokens: Option<i64>,
+    #[serde(default)]
+    pub context_sampled_at: Option<String>,
+    #[serde(default)]
+    pub context_compaction_active: bool,
+    #[serde(default)]
     pub context_monitor_enabled: bool,
     #[serde(default)]
     pub context_monitor_notify: Option<String>,
@@ -5958,17 +6081,8 @@ impl SessionRecord {
         normalized_status(&self.status) == "stopped"
     }
 
-    fn is_restorable_for_registry(&self) -> bool {
-        if !self.is_stopped() {
-            return true;
-        }
-        let has_provider_resume_id = has_text(self.provider_resume_id.as_deref());
-        match self.provider.as_str() {
-            "claude" => has_provider_resume_id || has_text(self.transcript_path.as_deref()),
-            "codex-app" => has_provider_resume_id || has_text(self.codex_thread_id.as_deref()),
-            "codex" | "codex-fork" => has_provider_resume_id,
-            _ => has_provider_resume_id,
-        }
+    fn is_live_for_registry(&self) -> bool {
+        !self.is_stopped()
     }
 
     pub(crate) fn cached_display_name(&self) -> Option<String> {
@@ -6669,6 +6783,10 @@ mod tests {
             last_tool_call: None,
             last_tool_name: None,
             tokens_used: 0,
+            context_used_percentage: None,
+            context_total_input_tokens: None,
+            context_sampled_at: None,
+            context_compaction_active: false,
             context_monitor_enabled: false,
             context_monitor_notify: None,
             context_warning_sent: false,
@@ -7378,7 +7496,7 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_prunes_stale_aliases_but_keeps_restorable_stopped_aliases() {
+    fn snapshot_prunes_stopped_aliases_even_when_restorable() {
         let snapshot = StateSnapshot {
             sessions: vec![
                 SessionRecord {
@@ -7420,7 +7538,7 @@ mod tests {
             .unwrap();
 
         assert!(stale.aliases.is_empty());
-        assert_eq!(restorable.aliases, vec!["restorable-role"]);
+        assert!(restorable.aliases.is_empty());
     }
 
     #[test]
@@ -7617,9 +7735,33 @@ mod tests {
 
         let session = store.get_session("child001").unwrap().unwrap();
         assert_eq!(session.tokens_used, 120_000);
+        assert_eq!(session.context_used_percentage, Some(60.0));
+        assert_eq!(session.context_total_input_tokens, Some(120_000));
+        assert!(session.context_sampled_at.is_some());
         assert!(session.context_warning_sent);
         assert!(!session.context_critical_sent);
         assert_eq!(context_monitor_messages(&store).len(), 1);
+    }
+
+    #[test]
+    fn context_snapshot_reports_latest_cached_usage() {
+        let store = store_with_monitored_child("ctxsnapshot", true, Some("parent01"));
+        store
+            .apply_context_usage_event(&usage_event("child001", 43.0, 86_214), None)
+            .unwrap();
+
+        let snapshot = store.get_context_snapshot("child001").unwrap().unwrap();
+
+        assert_eq!(snapshot.session_id, "child001");
+        assert_eq!(snapshot.friendly_name.as_deref(), Some("worker"));
+        assert_eq!(snapshot.used_percentage, Some(43.0));
+        assert_eq!(snapshot.total_input_tokens, Some(86_214));
+        assert_eq!(snapshot.state, "normal");
+        assert_eq!(snapshot.warning_percentage, 50.0);
+        assert_eq!(snapshot.critical_percentage, 65.0);
+        assert!(snapshot.context_monitor_enabled);
+        assert_eq!(snapshot.notify_session_id.as_deref(), Some("parent01"));
+        assert!(!snapshot.compaction_active);
     }
 
     #[test]
@@ -7872,7 +8014,7 @@ mod tests {
 
     #[test]
     fn context_usage_is_suppressed_for_unregistered_sessions() {
-        // #206: usage reporting is opt-in.
+        // #206: alerting is opt-in, but cached context readout is passive.
         let store = store_with_monitored_child("ctxgate", false, None);
 
         assert_eq!(
@@ -7883,7 +8025,18 @@ mod tests {
         );
 
         let session = store.get_session("child001").unwrap().unwrap();
-        assert_eq!(session.tokens_used, 0);
+        assert_eq!(session.tokens_used, 180_000);
+        assert_eq!(session.context_used_percentage, Some(90.0));
+        assert_eq!(session.context_total_input_tokens, Some(180_000));
+        assert!(session.context_sampled_at.is_some());
+        assert_eq!(
+            store
+                .get_context_snapshot("child001")
+                .unwrap()
+                .unwrap()
+                .state,
+            "critical"
+        );
         assert!(context_monitor_messages(&store).is_empty());
     }
 

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1519,18 +1519,24 @@ impl SessionStore {
             let previous_context_tokens = session
                 .get("context_total_input_tokens")
                 .and_then(Value::as_i64);
+            let previous_compaction_active = session
+                .get("context_compaction_active")
+                .and_then(Value::as_bool)
+                .unwrap_or(false);
             let changed = previous_used != Some(tokens_used)
                 || previous_pct != Some(used_percentage)
                 || previous_context_tokens != Some(tokens_used)
                 || json_text(session.get("context_sampled_at")).is_none()
                 || event.emitted_at.is_some()
                     && json_text(session.get("context_sampled_at")).as_deref()
-                        != Some(sampled_at.as_str());
+                        != Some(sampled_at.as_str())
+                || previous_compaction_active;
             if changed {
                 session.insert("tokens_used".to_owned(), json!(tokens_used));
                 session.insert("context_used_percentage".to_owned(), json!(used_percentage));
                 session.insert("context_total_input_tokens".to_owned(), json!(tokens_used));
                 session.insert("context_sampled_at".to_owned(), Value::String(sampled_at));
+                session.insert("context_compaction_active".to_owned(), Value::Bool(false));
             }
             if !enabled {
                 if changed {
@@ -8211,6 +8217,30 @@ mod tests {
             .unwrap();
         // compaction notice + the two warnings
         assert_eq!(context_monitor_messages(&store).len(), 3);
+    }
+
+    #[test]
+    fn fresh_usage_sample_clears_stale_compaction_state() {
+        let store = store_with_monitored_child("ctxcompactfresh", true, Some("parent01"));
+        let mut compaction = lifecycle_event("child001", "compaction");
+        compaction.emitted_at = Some("2026-07-28T10:00:00.000000Z".to_owned());
+        store.apply_context_usage_event(&compaction, None).unwrap();
+
+        let compacting = store.get_context_snapshot("child001").unwrap().unwrap();
+        assert_eq!(compacting.state, "compacting");
+        assert!(compacting.compaction_active);
+
+        store
+            .apply_context_usage_event(
+                &usage_event_at("child001", 43.0, 86_214, "2026-07-28T10:00:01.000000Z"),
+                None,
+            )
+            .unwrap();
+
+        let snapshot = store.get_context_snapshot("child001").unwrap().unwrap();
+        assert_eq!(snapshot.state, "normal");
+        assert!(!snapshot.compaction_active);
+        assert_eq!(snapshot.used_percentage, Some(43.0));
     }
 
     #[test]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1486,6 +1486,15 @@ impl SessionStore {
                 return Ok(ContextUsageOutcome::StaleSample);
             }
         }
+        let stored_sample_at =
+            session_snapshot.and_then(|session| json_text(session.get("context_sampled_at")));
+        if let (Some(emitted_at), Some(stored_sample_at)) =
+            (event.emitted_at.as_deref(), stored_sample_at.as_deref())
+        {
+            if !timestamp_is_after(emitted_at, stored_sample_at) {
+                return Ok(ContextUsageOutcome::StaleSample);
+            }
+        }
         // Null until the first API call of a session — nothing to record yet.
         let Some(used_percentage) = event.used_percentage else {
             return Ok(ContextUsageOutcome::NoUsage);
@@ -7727,6 +7736,18 @@ mod tests {
         }
     }
 
+    fn usage_event_at(
+        session_id: &str,
+        used_percentage: f64,
+        tokens: i64,
+        emitted_at: &str,
+    ) -> ContextUsageEvent {
+        ContextUsageEvent {
+            emitted_at: Some(emitted_at.to_owned()),
+            ..usage_event(session_id, used_percentage, tokens)
+        }
+    }
+
     fn lifecycle_event(session_id: &str, event: &str) -> ContextUsageEvent {
         ContextUsageEvent {
             session_id: session_id.to_owned(),
@@ -7834,6 +7855,32 @@ mod tests {
             store.get_session("child001").unwrap().unwrap().tokens_used,
             42_000
         );
+    }
+
+    #[test]
+    fn out_of_order_usage_samples_do_not_regress_the_cached_snapshot() {
+        let store = store_with_monitored_child("ctxoldsample", false, Some("parent01"));
+        store
+            .apply_context_usage_event(
+                &usage_event_at("child001", 60.0, 120_000, "2026-07-28T10:01:00.000000Z"),
+                None,
+            )
+            .unwrap();
+
+        assert_eq!(
+            store
+                .apply_context_usage_event(
+                    &usage_event_at("child001", 45.0, 90_000, "2026-07-28T10:00:30.000000Z",),
+                    None,
+                )
+                .unwrap(),
+            ContextUsageOutcome::StaleSample
+        );
+
+        let session = store.get_session("child001").unwrap().unwrap();
+        assert_eq!(session.context_used_percentage, Some(60.0));
+        assert_eq!(session.context_total_input_tokens, Some(120_000));
+        assert_eq!(session.tokens_used, 120_000);
     }
 
     #[test]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -187,13 +187,27 @@ impl SessionStore {
         if session_id.is_empty() {
             return Ok(None);
         }
-        Ok(self
-            .load_snapshot()?
-            .into_sessions()
-            .into_iter()
-            .find(|session| {
-                session.id == session_id || session.aliases.iter().any(|alias| alias == session_id)
-            }))
+        let sessions = self.load_snapshot()?.into_sessions();
+        if let Some(session) = sessions
+            .iter()
+            .find(|session| session.id == session_id)
+            .cloned()
+        {
+            return Ok(Some(session));
+        }
+        if let Some(session) = sessions
+            .iter()
+            .find(|session| session.aliases.iter().any(|alias| alias == session_id))
+            .cloned()
+        {
+            return Ok(Some(session));
+        }
+        Ok(sessions.into_iter().find(|session| {
+            session.cached_display_name().as_deref() == Some(session_id)
+                || session.friendly_name.as_deref() == Some(session_id)
+                || session.native_title.as_deref() == Some(session_id)
+                || session.name == session_id
+        }))
     }
 
     pub fn get_context_snapshot(
@@ -2661,13 +2675,38 @@ impl SessionStore {
 
         // Codex reports token usage on its own event rather than through a
         // status line, so this is the codex-fork equivalent of the Claude
-        // `/hooks/context-usage` usage update — same gate, same thresholds,
-        // same one-shot latches.
+        // `/hooks/context-usage` usage update. The snapshot is always cached;
+        // the registration gate only controls warning/critical alerts.
         let mut context_alert = None;
         if let Some(usage) = codex_fork_context_usage(event) {
-            if flag_is_set(session, "context_monitor_enabled") {
+            let previous_used = session.get("tokens_used").and_then(Value::as_i64);
+            let previous_pct = session
+                .get("context_used_percentage")
+                .and_then(Value::as_f64);
+            let previous_context_tokens = session
+                .get("context_total_input_tokens")
+                .and_then(Value::as_i64);
+            let snapshot_changed = previous_used != Some(usage.tokens_used)
+                || previous_pct != Some(usage.used_percentage)
+                || previous_context_tokens != Some(usage.tokens_used)
+                || json_text(session.get("context_sampled_at")).is_none();
+            if snapshot_changed {
                 session.insert("tokens_used".to_owned(), json!(usage.tokens_used));
+                session.insert(
+                    "context_used_percentage".to_owned(),
+                    json!(usage.used_percentage),
+                );
+                session.insert(
+                    "context_total_input_tokens".to_owned(),
+                    json!(usage.tokens_used),
+                );
+                session.insert(
+                    "context_sampled_at".to_owned(),
+                    Value::String(now_rfc3339()),
+                );
                 changed = true;
+            }
+            if flag_is_set(session, "context_monitor_enabled") {
                 context_alert = self.latch_context_alert(
                     session,
                     session_id,
@@ -8182,6 +8221,9 @@ mod tests {
 
         let session = store.get_session("codex001").unwrap().unwrap();
         assert_eq!(session.tokens_used, 181_000);
+        assert_eq!(session.context_total_input_tokens, Some(181_000));
+        assert!((session.context_used_percentage.unwrap() - 70.046_439_628_482_98).abs() < 1e-9);
+        assert!(session.context_sampled_at.is_some());
         // 181000/258400 = 70%, past the default 65% critical line.
         assert!(session.context_critical_sent);
         assert_eq!(context_monitor_messages(&store).len(), 1);
@@ -8192,7 +8234,7 @@ mod tests {
     }
 
     #[test]
-    fn codex_token_usage_respects_the_registration_gate() {
+    fn codex_token_usage_caches_snapshot_without_registration() {
         let state_file = unique_temp_path("ctxcodexgate");
         fs::write(
             &state_file,
@@ -8221,10 +8263,11 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(
-            store.get_session("codex001").unwrap().unwrap().tokens_used,
-            0
-        );
+        let session = store.get_session("codex001").unwrap().unwrap();
+        assert_eq!(session.tokens_used, 181_000);
+        assert_eq!(session.context_total_input_tokens, Some(181_000));
+        assert!((session.context_used_percentage.unwrap() - 70.046_439_628_482_98).abs() < 1e-9);
+        assert!(session.context_sampled_at.is_some());
         assert!(context_monitor_messages(&store).is_empty());
     }
 

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -6491,16 +6491,7 @@ fn timestamp_is_within(value: &str, seconds: i64) -> bool {
 /// format, so both encodings are accepted. Returns false when either side is
 /// unparseable — an unknown ordering must never supersede anything.
 fn timestamp_is_after(value: &str, other: &str) -> bool {
-    if let (Ok(value), Ok(other)) = (
-        OffsetDateTime::parse(value.trim(), &Rfc3339),
-        OffsetDateTime::parse(other.trim(), &Rfc3339),
-    ) {
-        return value > other;
-    }
-    match (
-        parse_python_naive_datetime(value),
-        parse_python_naive_datetime(other),
-    ) {
+    match (parse_timestamp_ns(value), parse_timestamp_ns(other)) {
         (Some(value), Some(other)) => value > other,
         _ => false,
     }
@@ -7106,6 +7097,16 @@ mod tests {
         assert!(timestamp_is_after(
             "2026-07-27T18:30:56.000001Z",
             "2026-07-27T18:30:55.999999999Z"
+        ));
+        // Python-era state may have a naive ISO stamp while newer hooks carry
+        // RFC3339. Both accepted encodings must compare on one timeline.
+        assert!(timestamp_is_after(
+            "2026-07-27T18:30:56.000001Z",
+            "2026-07-27T18:30:55.999999"
+        ));
+        assert!(!timestamp_is_after(
+            "2026-07-27T18:30:55.999999",
+            "2026-07-27T18:30:56.000001Z"
         ));
         // An unparseable side must never supersede anything.
         assert!(!timestamp_is_after("not-a-timestamp", nanos));

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -7512,6 +7512,14 @@ async fn context_usage_hook_is_served_and_records_tokens() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["tokens_used"], json!(83_000));
 
+    let (status, payload) = get_json(app.clone(), "/sessions/run12345/context").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["session_id"], "run12345");
+    assert_eq!(payload["used_percentage"], json!(41.5));
+    assert_eq!(payload["total_input_tokens"], json!(83_000));
+    assert_eq!(payload["state"], "normal");
+    assert_eq!(payload["context_monitor_enabled"], true);
+
     // Before the first API call Claude reports a null percentage on every
     // render; that must not clobber the last real reading.
     let (status, payload) = post_json(
@@ -10760,9 +10768,13 @@ async fn fixture_registry_prunes_stale_roles_and_updates_maintainer_alias() {
         .iter()
         .map(|entry| entry["role"].as_str().unwrap())
         .collect::<Vec<_>>();
-    assert_eq!(roles, vec!["live-role", "restorable-role"]);
+    assert_eq!(roles, vec!["live-role"]);
 
     let (status, payload) = get_json(app.clone(), "/registry/stale-role").await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+    assert_eq!(payload, json!({ "detail": "Role not registered" }));
+
+    let (status, payload) = get_json(app.clone(), "/registry/restorable-role").await;
     assert_eq!(status, StatusCode::NOT_FOUND);
     assert_eq!(payload, json!({ "detail": "Role not registered" }));
 
@@ -10772,11 +10784,15 @@ async fn fixture_registry_prunes_stale_roles_and_updates_maintainer_alias() {
         raw_state["agent_role_last_session_ids"]["stale-role"],
         "staleagent"
     );
+    assert_eq!(
+        raw_state["agent_role_last_session_ids"]["restorable-role"],
+        "restorable"
+    );
     assert!(raw_state["agent_registrations"]
         .as_array()
         .unwrap()
         .iter()
-        .all(|entry| entry["role"] != "stale-role"));
+        .all(|entry| entry["role"] != "stale-role" && entry["role"] != "restorable-role"));
 }
 
 #[tokio::test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -8298,6 +8298,18 @@ async fn session_detail_returns_one_projected_session() {
 }
 
 #[tokio::test]
+async fn session_detail_resolves_exact_friendly_name() {
+    let state_file = write_session_fixture();
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+
+    let (status, payload) = get_json(app, "/sessions/Runner").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["id"], "run12345");
+    assert_eq!(payload["friendly_name"], "Runner Native");
+}
+
+#[tokio::test]
 async fn session_detail_returns_404_for_unknown_session() {
     let state_file = write_session_fixture();
     let app = router(AppState::new(config_with_state_file(&state_file)));
@@ -8395,6 +8407,21 @@ async fn session_output_tails_fixture_log_file() {
     let app = router(AppState::new(config_with_state_file(&state_file)));
 
     let (status, payload) = get_json(app, "/sessions/run12345/output?lines=2").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["session_id"], "run12345");
+    assert_eq!(
+        payload["output"],
+        "fixture log line 2\nfixture log line 3\n"
+    );
+}
+
+#[tokio::test]
+async fn session_output_resolves_exact_friendly_name() {
+    let state_file = write_session_fixture();
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+
+    let (status, payload) = get_json(app, "/sessions/Runner/output?lines=2").await;
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["session_id"], "run12345");
@@ -11438,6 +11465,14 @@ async fn runtime_core_delivers_sm_send_metadata_rows() {
     )
     .await;
     assert_eq!(status, StatusCode::OK);
+    let (status, payload) = patch_json(
+        app.clone(),
+        "/sessions/runtimesmsend",
+        json!({"friendly_name": "runtime-sm-send"}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["friendly_name"], "runtime-sm-send");
     let (status, _payload) = post_json(
         app.clone(),
         "/sessions",
@@ -11455,7 +11490,7 @@ async fn runtime_core_delivers_sm_send_metadata_rows() {
 
     let (status, payload) = post_json(
         app.clone(),
-        "/sessions/runtimesmsend/input",
+        "/sessions/runtime-sm-send/input",
         json!({
             "text": "ordinary sm send metadata delivered",
             "sender_session_id": "runtimesender",
@@ -11502,6 +11537,7 @@ async fn runtime_core_delivers_sm_send_metadata_rows() {
                    response_relay_source, delivered_at
             FROM message_queue
             WHERE target_session_id = 'runtimesmsend'
+              AND text LIKE '%ordinary sm send metadata delivered'
             "#,
             [],
             |row| {

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -8446,7 +8446,7 @@ async fn session_tool_calls_reads_pre_tool_use_rows() {
         ..AppConfig::default()
     }));
 
-    let (status, payload) = get_json(app, "/sessions/run12345/tool-calls?limit=2").await;
+    let (status, payload) = get_json(app.clone(), "/sessions/run12345/tool-calls?limit=2").await;
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["session_id"], "run12345");
@@ -8465,6 +8465,12 @@ async fn session_tool_calls_reads_pre_tool_use_rows() {
             }
         ])
     );
+
+    let (status, payload) = get_json(app, "/sessions/Runner/tool-calls?limit=2").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["session_id"], "run12345");
+    assert_eq!(payload["tool_calls"].as_array().unwrap().len(), 2);
 }
 
 #[tokio::test]
@@ -8485,7 +8491,8 @@ async fn session_tool_calls_projects_codex_fork_observability_rows() {
                     "log_file": "/tmp/forktools.log",
                     "status": "running",
                     "created_at": "2026-06-01T00:00:00",
-                    "last_activity": "2026-06-01T00:01:00"
+                    "last_activity": "2026-06-01T00:01:00",
+                    "friendly_name": "fork-tools"
                 }
             ]
         })
@@ -8504,7 +8511,7 @@ async fn session_tool_calls_projects_codex_fork_observability_rows() {
         ..AppConfig::default()
     }));
 
-    let (status, payload) = get_json(app, "/sessions/forktools/tool-calls?limit=2").await;
+    let (status, payload) = get_json(app.clone(), "/sessions/forktools/tool-calls?limit=2").await;
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["session_id"], "forktools");
@@ -8523,6 +8530,12 @@ async fn session_tool_calls_projects_codex_fork_observability_rows() {
             }
         ])
     );
+
+    let (status, payload) = get_json(app, "/sessions/fork-tools/tool-calls?limit=2").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["session_id"], "forktools");
+    assert_eq!(payload["tool_calls"].as_array().unwrap().len(), 2);
 }
 
 #[tokio::test]
@@ -8586,7 +8599,7 @@ async fn session_activity_actions_projects_codex_observability_rows() {
     }));
 
     let (status, payload) = get_json(
-        app,
+        app.clone(),
         "/sessions/codexproj/activity-actions?limit=%32&limit=3",
     )
     .await;
@@ -8625,6 +8638,16 @@ async fn session_activity_actions_projects_codex_observability_rows() {
         "Approval decision: accept"
     );
     assert_eq!(payload["actions"][2]["status"], "completed");
+
+    let (status, payload) = get_json(
+        app,
+        "/sessions/codex-app-codexproj/activity-actions?limit=3",
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["actions"].as_array().unwrap().len(), 3);
+    assert_eq!(payload["actions"][0]["session_id"], "codexproj");
 }
 
 #[tokio::test]
@@ -8686,7 +8709,7 @@ async fn session_codex_events_reads_recent_events_with_python_cursor_shape() {
         ..AppConfig::default()
     }));
 
-    let (status, payload) = get_json(app, "/sessions/codexapp1/codex-events?limit=2").await;
+    let (status, payload) = get_json(app.clone(), "/sessions/codexapp1/codex-events?limit=2").await;
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["earliest_seq"], 1);
@@ -8717,6 +8740,14 @@ async fn session_codex_events_reads_recent_events_with_python_cursor_shape() {
             }
         ])
     );
+
+    let (status, payload) =
+        get_json(app, "/sessions/codex-app-codexapp1/codex-events?limit=2").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["latest_seq"], 4);
+    assert_eq!(payload["events"].as_array().unwrap().len(), 2);
+    assert_eq!(payload["events"][0]["session_id"], "codexapp1");
 }
 
 #[tokio::test]
@@ -8941,7 +8972,7 @@ async fn session_codex_pending_requests_reads_pending_and_optional_orphaned_rows
     );
 
     let (status, payload) = get_json(
-        app,
+        app.clone(),
         "/sessions/codexpending/codex-pending-requests?include_orphaned=false&include_orphaned=%74",
     )
     .await;
@@ -8953,6 +8984,16 @@ async fn session_codex_pending_requests_reads_pending_and_optional_orphaned_rows
     assert_eq!(requests[1]["status"], "orphaned");
     assert_eq!(requests[1]["resolution_source"], "policy");
     assert_eq!(requests[1]["error_code"], "server_restarted");
+
+    let (status, payload) = get_json(
+        app,
+        "/sessions/codex-app-codexpending/codex-pending-requests",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let requests = payload["requests"].as_array().unwrap();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0]["session_id"], "codexpending");
 }
 
 #[tokio::test]

--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -1777,6 +1777,14 @@ class SessionManagerClient:
             return data.get("monitored", [])
         return None
 
+    def get_context_snapshot(self, session_id: str) -> Optional[dict]:
+        """Get the latest cached context usage snapshot for a session."""
+        session_path = urllib.parse.quote(session_id, safe="")
+        data, success, unavailable = self._request("GET", f"/sessions/{session_path}/context")
+        if unavailable or not success or not data:
+            return None
+        return data
+
     def get_rollout_flags(self) -> Optional[dict]:
         """Get server rollout feature flags."""
         data, success, unavailable = self._request("GET", "/admin/rollout-flags")

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -5691,6 +5691,13 @@ def cmd_context(
         print("Error: sm context requires a managed session or explicit session target", file=sys.stderr)
         return 2
 
+    if target:
+        target_session_id, _ = resolve_session_id(client, target)
+        if not target_session_id:
+            print("Error: Session manager unavailable, request timed out, or session not found", file=sys.stderr)
+            return 1
+        resolved_target = target_session_id
+
     snapshot = client.get_context_snapshot(resolved_target)
     if snapshot is None:
         print("Error: Session manager unavailable, request timed out, or session not found", file=sys.stderr)

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -5638,6 +5638,102 @@ def cmd_context_monitor(
     return 1
 
 
+def _format_context_percentage(value) -> str:
+    """Format a context percentage for terse CLI output."""
+    if value is None:
+        return "unknown"
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return "unknown"
+    if numeric.is_integer():
+        return f"{int(numeric)}%"
+    return f"{numeric:.1f}".rstrip("0").rstrip(".") + "%"
+
+
+def _format_context_sample_age(sampled_at: Optional[str]) -> str:
+    """Format the context sample timestamp as a relative age."""
+    if not sampled_at:
+        return "unknown"
+    try:
+        timestamp = datetime.fromisoformat(str(sampled_at).replace("Z", "+00:00"))
+        now = datetime.now(timestamp.tzinfo) if timestamp.tzinfo else datetime.now()
+        seconds = int((now - timestamp).total_seconds())
+    except Exception:
+        return "unknown"
+    if seconds < 0:
+        seconds = 0
+    if seconds < 60:
+        return f"{seconds}s ago"
+    minutes = seconds // 60
+    if minutes < 60:
+        return f"{minutes}min ago"
+    hours = minutes // 60
+    if hours < 24:
+        return f"{hours}hr ago"
+    return f"{hours // 24}day ago" if hours < 48 else f"{hours // 24}days ago"
+
+
+def cmd_context(
+    client: SessionManagerClient,
+    session_id: Optional[str],
+    target: Optional[str] = None,
+    details: bool = False,
+    json_output: bool = False,
+) -> int:
+    """
+    Show the latest cached context usage snapshot for a session.
+
+    Default output is terse: "43%" or "unknown".
+    """
+    resolved_target = target or session_id
+    if not resolved_target:
+        print("Error: sm context requires a managed session or explicit session target", file=sys.stderr)
+        return 2
+
+    snapshot = client.get_context_snapshot(resolved_target)
+    if snapshot is None:
+        print("Error: Session manager unavailable, request timed out, or session not found", file=sys.stderr)
+        return 1
+
+    if json_output:
+        print(json.dumps(snapshot, indent=2, sort_keys=True))
+        return 0
+
+    used_percentage = snapshot.get("used_percentage")
+    if not details:
+        print(_format_context_percentage(used_percentage))
+        return 0
+
+    percent_text = _format_context_percentage(used_percentage)
+    token_count = snapshot.get("total_input_tokens")
+    token_text = f" ({int(token_count):,} tokens)" if isinstance(token_count, int) else ""
+    state = snapshot.get("state") or "unknown"
+    warning = _format_context_percentage(snapshot.get("warning_percentage"))
+    critical = _format_context_percentage(snapshot.get("critical_percentage"))
+    monitor_enabled = bool(snapshot.get("context_monitor_enabled"))
+    notify = snapshot.get("notify_session_id")
+    session_label = snapshot.get("friendly_name") or snapshot.get("session_id") or resolved_target
+    actual_session_id = snapshot.get("session_id") or resolved_target
+    provider = snapshot.get("provider") or "-"
+
+    if notify == actual_session_id:
+        notify_text = "self"
+    elif notify:
+        notify_text = str(notify)
+    else:
+        notify_text = "none"
+
+    print(f"Context: {percent_text}{token_text}")
+    print(f"Sample: {_format_context_sample_age(snapshot.get('sampled_at'))}")
+    print(f"State: {state} (warning {warning}, critical {critical})")
+    print(f"Monitor: {'enabled' if monitor_enabled else 'disabled'}, alerts -> {notify_text}")
+    print(f"Compaction: {'active' if snapshot.get('compaction_active') else 'not active'}")
+    print(f"Last handoff: {snapshot.get('last_handoff_path') or '-'}")
+    print(f"Session: {session_label} [{actual_session_id}] {provider}")
+    return 0
+
+
 def cmd_em(
     client: SessionManagerClient,
     session_id: Optional[str],

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -970,7 +970,7 @@ def main():
         "lock", "unlock", "subagent-start", "subagent-stop", "all", "send", "wait", "what",
         "subagents", "children", "kill", "retire", "restore", "unkill", "fork", "new", "claude", "codex", "codex-legacy", "codex-fork", "codex_fork",
         "codex-2", "codex-app", "codex-server", "nodes", "node",
-        "attach", "output", "codex-tui", "codex-fork-info", "codex-rollout-gates", "watch", "tail", "clear", "review", "context-monitor", "remind", "setup", "lookup", "roster", "email", "request-codex-review", None
+        "attach", "output", "codex-tui", "codex-fork-info", "codex-rollout-gates", "watch", "tail", "clear", "review", "context", "ctx", "context-monitor", "remind", "setup", "lookup", "roster", "email", "request-codex-review", None
     ]
     # Commands that require session_id: self-directed managed-session actions
     requires_session_id = ["spawn", "adopt", "maintainer", "register", "unregister"]

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -292,6 +292,27 @@ def main():
         help='Self-report status text (e.g., sm status "investigating bug")',
     )
 
+    # sm context [session] [--details|--detailed] [--json]
+    context_parser = subparsers.add_parser("context", aliases=["ctx"], help="Show current context usage")
+    context_parser.add_argument(
+        "session",
+        nargs="?",
+        default=None,
+        help="Session ID, friendly name, or registry alias (default: self)",
+    )
+    context_detail_group = context_parser.add_mutually_exclusive_group()
+    context_detail_group.add_argument(
+        "--details",
+        action="store_true",
+        help="Show detailed context snapshot",
+    )
+    context_detail_group.add_argument(
+        "--detailed",
+        action="store_true",
+        help="Alias for --details",
+    )
+    context_parser.add_argument("--json", action="store_true", help="Output JSON")
+
     # sm subagent-start (called by SubagentStart hook)
     subparsers.add_parser("subagent-start", help="Register subagent start (called by hook)")
 
@@ -1004,6 +1025,14 @@ def main():
             sys.exit(commands.cmd_agent_status(client, session_id, args.text))
         else:
             sys.exit(commands.cmd_status(client, session_id))
+    elif args.command in ("context", "ctx"):
+        sys.exit(commands.cmd_context(
+            client,
+            session_id,
+            target=args.session,
+            details=bool(args.details or args.detailed),
+            json_output=bool(args.json),
+        ))
     elif args.command == "subagent-start":
         sys.exit(commands.cmd_subagent_start(client, session_id))
     elif args.command == "subagent-stop":

--- a/src/models.py
+++ b/src/models.py
@@ -355,6 +355,7 @@ class Session:
     context_used_percentage: Optional[float] = None  # Last statusLine context usage percentage
     context_total_input_tokens: Optional[int] = None  # Last statusLine input token count
     context_sampled_at: Optional[datetime] = None  # When the last context usage sample was emitted
+    context_cycle_reset_emitted_at: Optional[datetime] = None  # Latest reset hook emission time
     # Runtime-only flags — not persisted (reset to False on server restart / new cycle)
     _context_warning_sent: bool = field(default=False, init=False, repr=False)
     _context_critical_sent: bool = field(default=False, init=False, repr=False)
@@ -452,6 +453,7 @@ class Session:
             "context_used_percentage": self.context_used_percentage,
             "context_total_input_tokens": self.context_total_input_tokens,
             "context_sampled_at": self.context_sampled_at.isoformat() if self.context_sampled_at else None,
+            "context_cycle_reset_emitted_at": self.context_cycle_reset_emitted_at.isoformat() if self.context_cycle_reset_emitted_at else None,
             # Context monitor registration (#206)
             "context_monitor_enabled": self.context_monitor_enabled,
             "context_monitor_notify": self.context_monitor_notify,
@@ -554,6 +556,7 @@ class Session:
             context_used_percentage=data.get("context_used_percentage"),
             context_total_input_tokens=data.get("context_total_input_tokens"),
             context_sampled_at=datetime.fromisoformat(data["context_sampled_at"]) if data.get("context_sampled_at") else None,
+            context_cycle_reset_emitted_at=datetime.fromisoformat(data["context_cycle_reset_emitted_at"]) if data.get("context_cycle_reset_emitted_at") else None,
             # Context monitor registration (#206)
             context_monitor_enabled=data.get("context_monitor_enabled", False),
             context_monitor_notify=data.get("context_monitor_notify"),

--- a/src/models.py
+++ b/src/models.py
@@ -352,6 +352,9 @@ class Session:
 
     # Context monitor fields (#203)
     last_handoff_path: Optional[str] = None  # Last successfully executed handoff doc path (#196/#203)
+    context_used_percentage: Optional[float] = None  # Last statusLine context usage percentage
+    context_total_input_tokens: Optional[int] = None  # Last statusLine input token count
+    context_sampled_at: Optional[datetime] = None  # When the last context usage sample was emitted
     # Runtime-only flags — not persisted (reset to False on server restart / new cycle)
     _context_warning_sent: bool = field(default=False, init=False, repr=False)
     _context_critical_sent: bool = field(default=False, init=False, repr=False)
@@ -446,6 +449,9 @@ class Session:
             "recovery_count": self.recovery_count,
             # Context monitor fields (#203)
             "last_handoff_path": self.last_handoff_path,
+            "context_used_percentage": self.context_used_percentage,
+            "context_total_input_tokens": self.context_total_input_tokens,
+            "context_sampled_at": self.context_sampled_at.isoformat() if self.context_sampled_at else None,
             # Context monitor registration (#206)
             "context_monitor_enabled": self.context_monitor_enabled,
             "context_monitor_notify": self.context_monitor_notify,
@@ -545,6 +551,9 @@ class Session:
             recovery_count=data.get("recovery_count", 0),
             # Context monitor fields (#203)
             last_handoff_path=data.get("last_handoff_path"),
+            context_used_percentage=data.get("context_used_percentage"),
+            context_total_input_tokens=data.get("context_total_input_tokens"),
+            context_sampled_at=datetime.fromisoformat(data["context_sampled_at"]) if data.get("context_sampled_at") else None,
             # Context monitor registration (#206)
             context_monitor_enabled=data.get("context_monitor_enabled", False),
             context_monitor_notify=data.get("context_monitor_notify"),

--- a/src/server.py
+++ b/src/server.py
@@ -2386,7 +2386,7 @@ def create_app(
         )
 
     def _resolve_session_or_registry_role(session_id: str):
-        """Resolve a direct session id first, then fall back to a live registry role."""
+        """Resolve API-facing session identifiers to a concrete live session."""
         if not app.state.session_manager:
             return None
 
@@ -2395,12 +2395,27 @@ def create_app(
             return session
 
         getter = getattr(app.state.session_manager, "lookup_agent_registration", None)
-        if not callable(getter):
+        if callable(getter):
+            registration = getter(session_id)
+            if registration is not None:
+                return app.state.session_manager.get_session(registration.session_id)
+
+        lister = getattr(app.state.session_manager, "list_sessions", None)
+        if not callable(lister):
             return None
-        registration = getter(session_id)
-        if registration is None:
-            return None
-        return app.state.session_manager.get_session(registration.session_id)
+        try:
+            sessions = lister(include_stopped=False)
+        except TypeError:
+            sessions = lister()
+        alias_getter = getattr(app.state.session_manager, "get_session_aliases", None)
+        for candidate in sessions or []:
+            aliases = alias_getter(candidate.id) if callable(alias_getter) else []
+            if session_id in aliases:
+                return candidate
+        for candidate in sessions or []:
+            if _effective_session_name(candidate, sync_native_title=False) == session_id:
+                return candidate
+        return None
 
     def _job_watch_to_response(registration) -> JobWatchResponse:
         target_session = app.state.session_manager.get_session(registration.target_session_id)
@@ -9027,6 +9042,7 @@ Provide ONLY the summary, no preamble or questions."""
             session.context_used_percentage = None
             session.context_total_input_tokens = None
             session.context_sampled_at = None
+            await _save_session_manager_state(app.state.session_manager)
             if queue_mgr:
                 queue_mgr.reset_remind(session_id, force_tracked=True)
             logger.info(
@@ -9087,6 +9103,7 @@ Provide ONLY the summary, no preamble or questions."""
             or session.context_used_percentage != used_pct
             or session.context_total_input_tokens != total_input_tokens
             or session.context_sampled_at is None
+            or (parsed_emitted_at is not None and session.context_sampled_at != sampled_at)
         )
         if changed:
             session.tokens_used = total_input_tokens

--- a/src/server.py
+++ b/src/server.py
@@ -179,6 +179,13 @@ def _parse_hook_emitted_at(value: object) -> Optional[datetime]:
         return None
 
 
+def _datetime_is_after(value: datetime, other: datetime) -> Optional[bool]:
+    try:
+        return value > other
+    except TypeError:
+        return None
+
+
 def _is_valid_app_artifact_hash(artifact_hash: str) -> bool:
     return bool(APP_ARTIFACT_HASH_PATTERN.fullmatch(artifact_hash))
 
@@ -9060,7 +9067,18 @@ Provide ONLY the summary, no preamble or questions."""
         emitted_at = data.get("sm_hook_emitted_at")
         parsed_emitted_at = _parse_hook_emitted_at(emitted_at)
         reset_boundary = getattr(session, "context_cycle_reset_emitted_at", None)
-        if parsed_emitted_at and reset_boundary and parsed_emitted_at <= reset_boundary:
+        if (
+            parsed_emitted_at
+            and reset_boundary
+            and _datetime_is_after(parsed_emitted_at, reset_boundary) is False
+        ):
+            return {"status": "stale_sample"}
+        stored_sampled_at = getattr(session, "context_sampled_at", None)
+        if (
+            parsed_emitted_at
+            and stored_sampled_at
+            and _datetime_is_after(parsed_emitted_at, stored_sampled_at) is False
+        ):
             return {"status": "stale_sample"}
 
         sampled_at = parsed_emitted_at or datetime.now()

--- a/src/server.py
+++ b/src/server.py
@@ -9062,6 +9062,7 @@ Provide ONLY the summary, no preamble or questions."""
             # Covers: TUI /clear and sm clear CLI (both trigger SessionStart source=clear).
             session._context_warning_sent = False
             session._context_critical_sent = False
+            session._is_compacting = False
             # Clear stale status from previous task (#283)
             session.agent_status_text = None
             session.agent_status_at = None

--- a/src/server.py
+++ b/src/server.py
@@ -170,6 +170,15 @@ async def _save_session_manager_state(session_manager: object) -> bool:
     return False
 
 
+def _parse_hook_emitted_at(value: object) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
 def _is_valid_app_artifact_hash(artifact_hash: str) -> bool:
     return bool(APP_ARTIFACT_HASH_PATTERN.fullmatch(artifact_hash))
 
@@ -8974,6 +8983,9 @@ Provide ONLY the summary, no preamble or questions."""
             logger.warning(
                 f"Compaction fired for {_effective_session_name(session)} (trigger={trigger})"
             )
+            session.context_cycle_reset_emitted_at = _parse_hook_emitted_at(
+                data.get("sm_hook_emitted_at")
+            )
             # Set compaction flag — suppress remind delivery until compaction_complete (#249).
             session._is_compacting = True
             # Reset one-shot flags — PreCompact fires before context is refreshed,
@@ -9019,6 +9031,9 @@ Provide ONLY the summary, no preamble or questions."""
         # Must be before the registration gate — unregistered sessions still receive
         # compaction notifications and need cancellation on context reset (#241).
         if data.get("event") == "context_reset":
+            session.context_cycle_reset_emitted_at = _parse_hook_emitted_at(
+                data.get("sm_hook_emitted_at")
+            )
             # Re-arm one-shot flags so warnings fire correctly in the new cycle.
             # Covers: TUI /clear and sm clear CLI (both trigger SessionStart source=clear).
             session._context_warning_sent = False
@@ -9042,20 +9057,29 @@ Provide ONLY the summary, no preamble or questions."""
             return {"status": "ok", "used_percentage": None}
 
         total_input_tokens = data.get("total_input_tokens", 0)
-        session.tokens_used = total_input_tokens
-        session.context_used_percentage = used_pct
-        session.context_total_input_tokens = total_input_tokens
         emitted_at = data.get("sm_hook_emitted_at")
-        sampled_at = datetime.now()
-        if emitted_at:
-            try:
-                sampled_at = datetime.fromisoformat(str(emitted_at).replace("Z", "+00:00"))
-            except ValueError:
-                sampled_at = datetime.now()
-        session.context_sampled_at = sampled_at
+        parsed_emitted_at = _parse_hook_emitted_at(emitted_at)
+        reset_boundary = getattr(session, "context_cycle_reset_emitted_at", None)
+        if parsed_emitted_at and reset_boundary and parsed_emitted_at <= reset_boundary:
+            return {"status": "stale_sample"}
+
+        sampled_at = parsed_emitted_at or datetime.now()
+        changed = (
+            session.tokens_used != total_input_tokens
+            or session.context_used_percentage != used_pct
+            or session.context_total_input_tokens != total_input_tokens
+            or session.context_sampled_at is None
+        )
+        if changed:
+            session.tokens_used = total_input_tokens
+            session.context_used_percentage = used_pct
+            session.context_total_input_tokens = total_input_tokens
+            session.context_sampled_at = sampled_at
 
         # Gate: skip unregistered sessions for warning/critical alerts (#206).
         if not session.context_monitor_enabled:
+            if changed:
+                await _save_session_manager_state(app.state.session_manager)
             return {"status": "not_registered", "used_percentage": used_pct}
 
         config = (app.state.config or {}).get("context_monitor", {})
@@ -9065,6 +9089,7 @@ Provide ONLY the summary, no preamble or questions."""
         if used_pct >= critical_pct:
             if not session._context_critical_sent:
                 session._context_critical_sent = True
+                changed = True
                 if queue_mgr:
                     is_self_alert = (session.context_monitor_notify == session.id)
                     if is_self_alert:
@@ -9089,6 +9114,7 @@ Provide ONLY the summary, no preamble or questions."""
         elif used_pct >= warning_pct:
             if not session._context_warning_sent:
                 session._context_warning_sent = True
+                changed = True
                 if queue_mgr:
                     is_self_alert = (session.context_monitor_notify == session.id)
                     if is_self_alert:
@@ -9107,6 +9133,9 @@ Provide ONLY the summary, no preamble or questions."""
                         sender_session_id=session_id,
                         message_category="context_monitor",
                     )
+
+        if changed:
+            await _save_session_manager_state(app.state.session_manager)
 
         return {"status": "ok", "used_percentage": used_pct}
 

--- a/src/server.py
+++ b/src/server.py
@@ -9106,12 +9106,14 @@ Provide ONLY the summary, no preamble or questions."""
             or session.context_total_input_tokens != total_input_tokens
             or session.context_sampled_at is None
             or (parsed_emitted_at is not None and session.context_sampled_at != sampled_at)
+            or getattr(session, "_is_compacting", False)
         )
         if changed:
             session.tokens_used = total_input_tokens
             session.context_used_percentage = used_pct
             session.context_total_input_tokens = total_input_tokens
             session.context_sampled_at = sampled_at
+            session._is_compacting = False
 
         # Gate: skip unregistered sessions for warning/critical alerts (#206).
         if not session.context_monitor_enabled:

--- a/src/server.py
+++ b/src/server.py
@@ -1158,6 +1158,23 @@ class ContextMonitorRequest(BaseModel):
     requester_session_id: str  # Required — caller's session ID for ownership check
 
 
+class ContextSnapshotResponse(BaseModel):
+    """Cached context usage snapshot for one session."""
+    session_id: str
+    friendly_name: Optional[str] = None
+    provider: Optional[str] = None
+    used_percentage: Optional[float] = None
+    total_input_tokens: Optional[int] = None
+    sampled_at: Optional[str] = None
+    state: str
+    warning_percentage: float
+    critical_percentage: float
+    context_monitor_enabled: bool = False
+    notify_session_id: Optional[str] = None
+    compaction_active: bool = False
+    last_handoff_path: Optional[str] = None
+
+
 class ArmStopNotifyRequest(BaseModel):
     """Request to arm stop notification for a session without a queued message (sm#277)."""
     sender_session_id: str  # Session to notify when target stops
@@ -5702,6 +5719,48 @@ def create_app(
         ]
         return {"monitored": monitored}
 
+    @app.get("/sessions/{session_id}/context", response_model=ContextSnapshotResponse)
+    async def get_session_context(session_id: str):
+        """Return the latest cached context usage snapshot for one session."""
+        if not app.state.session_manager:
+            raise HTTPException(status_code=503, detail="Session manager not configured")
+
+        session = _resolve_session_or_registry_role(session_id)
+        if not session:
+            raise HTTPException(status_code=404, detail="Session not found")
+
+        config = (app.state.config or {}).get("context_monitor", {})
+        warning_pct = float(config.get("warning_percentage", 50))
+        critical_pct = float(config.get("critical_percentage", 65))
+        used_pct = getattr(session, "context_used_percentage", None)
+        if getattr(session, "_is_compacting", False):
+            state = "compacting"
+        elif used_pct is None:
+            state = "unknown"
+        elif used_pct >= critical_pct:
+            state = "critical"
+        elif used_pct >= warning_pct:
+            state = "warning"
+        else:
+            state = "normal"
+
+        sampled_at = getattr(session, "context_sampled_at", None)
+        return ContextSnapshotResponse(
+            session_id=session.id,
+            friendly_name=_effective_session_name(session, sync_native_title=False),
+            provider=getattr(session, "provider", None),
+            used_percentage=used_pct,
+            total_input_tokens=getattr(session, "context_total_input_tokens", None),
+            sampled_at=sampled_at.isoformat() if sampled_at else None,
+            state=state,
+            warning_percentage=warning_pct,
+            critical_percentage=critical_pct,
+            context_monitor_enabled=bool(getattr(session, "context_monitor_enabled", False)),
+            notify_session_id=getattr(session, "context_monitor_notify", None),
+            compaction_active=bool(getattr(session, "_is_compacting", False)),
+            last_handoff_path=getattr(session, "last_handoff_path", None),
+        )
+
     @app.post("/sessions/{session_id}/fork")
     async def fork_session(session_id: str, request: ForkSessionRequest):
         """Fork a provider-native session into a new SM-owned session."""
@@ -8946,6 +9005,9 @@ Provide ONLY the summary, no preamble or questions."""
         # soft-threshold window exactly when it wakes (#249).
         if data.get("event") == "compaction_complete":
             session._is_compacting = False
+            session.context_used_percentage = None
+            session.context_total_input_tokens = None
+            session.context_sampled_at = None
             if queue_mgr:
                 queue_mgr.reset_remind(session_id, force_tracked=True)
             logger.info(
@@ -8965,14 +9027,13 @@ Provide ONLY the summary, no preamble or questions."""
             session.agent_status_text = None
             session.agent_status_at = None
             session.agent_task_completed_at = None
+            session.context_used_percentage = None
+            session.context_total_input_tokens = None
+            session.context_sampled_at = None
             await _save_session_manager_state(app.state.session_manager)
             if queue_mgr:
                 queue_mgr.cancel_context_monitor_messages_from(session_id)
             return {"status": "flags_reset"}
-
-        # Gate: skip unregistered sessions for usage/warning/critical events (#206)
-        if not session.context_monitor_enabled:
-            return {"status": "not_registered"}
 
         # Handle context usage update (from status line script)
         used_pct = data.get("used_percentage")
@@ -8980,7 +9041,22 @@ Provide ONLY the summary, no preamble or questions."""
             # used_percentage is null before first API call — ignore
             return {"status": "ok", "used_percentage": None}
 
-        session.tokens_used = data.get("total_input_tokens", 0)
+        total_input_tokens = data.get("total_input_tokens", 0)
+        session.tokens_used = total_input_tokens
+        session.context_used_percentage = used_pct
+        session.context_total_input_tokens = total_input_tokens
+        emitted_at = data.get("sm_hook_emitted_at")
+        sampled_at = datetime.now()
+        if emitted_at:
+            try:
+                sampled_at = datetime.fromisoformat(str(emitted_at).replace("Z", "+00:00"))
+            except ValueError:
+                sampled_at = datetime.now()
+        session.context_sampled_at = sampled_at
+
+        # Gate: skip unregistered sessions for warning/critical alerts (#206).
+        if not session.context_monitor_enabled:
+            return {"status": "not_registered", "used_percentage": used_pct}
 
         config = (app.state.config or {}).get("context_monitor", {})
         warning_pct = config.get("warning_percentage", 50)

--- a/src/server.py
+++ b/src/server.py
@@ -9032,6 +9032,7 @@ Provide ONLY the summary, no preamble or questions."""
                     sender_session_id=session_id,
                     message_category="context_monitor",
                 )
+            await _save_session_manager_state(app.state.session_manager)
             return {"status": "compaction_logged"}
 
         # Handle compaction_complete event (from post_compact_recovery.sh SessionStart hook)

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -3902,25 +3902,8 @@ done
         return session
 
     def get_session(self, session_id: str) -> Optional[Session]:
-        """Get a session by ID, durable alias, or exact user-visible name."""
-        if not session_id:
-            return None
-        session = self.sessions.get(session_id)
-        if session is not None:
-            return session
-
-        for candidate in self.sessions.values():
-            if session_id in self.get_session_aliases(candidate.id):
-                return candidate
-
-        for candidate in self.sessions.values():
-            if session_id in {
-                candidate.friendly_name,
-                candidate.native_title,
-                candidate.name,
-            }:
-                return candidate
-        return None
+        """Get a session by canonical ID."""
+        return self.sessions.get(session_id)
 
     def _default_fork_friendly_name(self, source: Session) -> str:
         """Derive a short explicit name for a fork session."""

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -4128,24 +4128,11 @@ done
         self.maintainer_session_id = registration.session_id if registration else None
 
     def _get_live_registered_session(self, session_id: str) -> Optional[Session]:
-        """Return the owning session when it is still usable for registry purposes."""
+        """Return the owning session when it is still live for registry purposes."""
         session = self.sessions.get(session_id)
-        if not session or not self._session_is_restorable_for_registry(session):
+        if not session or session.status == SessionStatus.STOPPED:
             return None
         return session
-
-    @staticmethod
-    def _session_is_restorable_for_registry(session: Session) -> bool:
-        """Return whether a stopped session still has enough provider state to restore."""
-        if session.status != SessionStatus.STOPPED:
-            return True
-        if session.provider == "claude":
-            return bool(session.provider_resume_id or session.transcript_path)
-        if session.provider == "codex-app":
-            return bool(session.codex_thread_id or session.provider_resume_id)
-        if session.provider in {"codex", "codex-fork"}:
-            return bool(session.provider_resume_id)
-        return bool(session.provider_resume_id)
 
     def _recover_missing_maintainer_registration(self) -> bool:
         """Recover a missing maintainer role when persisted history still points to it."""
@@ -4161,7 +4148,7 @@ done
             if not session_id:
                 continue
             session = self.sessions.get(session_id)
-            if not session or not self._session_is_restorable_for_registry(session):
+            if not session or session.status == SessionStatus.STOPPED:
                 continue
             session_identity = {
                 str(session.friendly_name or "").strip().lower(),

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -3902,8 +3902,25 @@ done
         return session
 
     def get_session(self, session_id: str) -> Optional[Session]:
-        """Get a session by ID."""
-        return self.sessions.get(session_id)
+        """Get a session by ID, durable alias, or exact user-visible name."""
+        if not session_id:
+            return None
+        session = self.sessions.get(session_id)
+        if session is not None:
+            return session
+
+        for candidate in self.sessions.values():
+            if session_id in self.get_session_aliases(candidate.id):
+                return candidate
+
+        for candidate in self.sessions.values():
+            if session_id in {
+                candidate.friendly_name,
+                candidate.native_title,
+                candidate.name,
+            }:
+                return candidate
+        return None
 
     def _default_fork_friendly_name(self, source: Session) -> str:
         """Derive a short explicit name for a fork session."""

--- a/tests/unit/test_agent_registry.py
+++ b/tests/unit/test_agent_registry.py
@@ -100,7 +100,7 @@ def test_load_state_recovers_missing_maintainer_registration_from_live_last_hold
     assert state_data["agent_registrations"][0]["session_id"] == session.id
 
 
-def test_load_state_recovers_missing_maintainer_registration_for_restorable_holder(tmp_path):
+def test_load_state_does_not_recover_missing_maintainer_registration_for_stopped_holder(tmp_path):
     session = _session("maint123", tmp_path)
     session.friendly_name = "maintainer"
     session.status = SessionStatus.STOPPED
@@ -126,8 +126,12 @@ def test_load_state_recovers_missing_maintainer_registration_for_restorable_hold
     )
 
     registration = manager.lookup_agent_registration("maintainer")
-    assert registration is not None
-    assert registration.session_id == session.id
+    assert registration is None
+    assert manager.maintainer_session_id is None
+
+    state_data = json.loads(state_path.read_text())
+    assert state_data["agent_registrations"] == []
+    assert state_data["maintainer_session_id"] is None
 
 
 def test_explicit_unregister_clears_last_role_hint(tmp_path):

--- a/tests/unit/test_cli_parsing.py
+++ b/tests/unit/test_cli_parsing.py
@@ -640,6 +640,40 @@ class TestCodexCommandRouting:
         assert mock_cmd_new.call_args.kwargs["provider"] == "codex"
 
 
+class TestContextCommandRouting:
+    """Tests for user-facing context command routing."""
+
+    def test_main_context_with_explicit_target_does_not_require_session(self):
+        mock_client = MagicMock()
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(sys, "argv", ["sm", "context", "agent-1"]):
+                with patch("src.cli.main.SessionManagerClient", return_value=mock_client):
+                    with patch("src.cli.main.commands.cmd_context", return_value=0) as mock_cmd:
+                        with pytest.raises(SystemExit) as exc_info:
+                            main()
+
+        assert exc_info.value.code == 0
+        mock_cmd.assert_called_once()
+        assert mock_cmd.call_args.args[1] is None
+        assert mock_cmd.call_args.kwargs["target"] == "agent-1"
+
+    def test_main_ctx_alias_with_explicit_target_does_not_require_session(self):
+        mock_client = MagicMock()
+
+        with patch.dict(os.environ, {}, clear=True):
+            with patch.object(sys, "argv", ["sm", "ctx", "agent-1"]):
+                with patch("src.cli.main.SessionManagerClient", return_value=mock_client):
+                    with patch("src.cli.main.commands.cmd_context", return_value=0) as mock_cmd:
+                        with pytest.raises(SystemExit) as exc_info:
+                            main()
+
+        assert exc_info.value.code == 0
+        mock_cmd.assert_called_once()
+        assert mock_cmd.call_args.args[1] is None
+        assert mock_cmd.call_args.kwargs["target"] == "agent-1"
+
+
 class TestWatchCommand:
     """Tests for 'sm watch' parsing."""
 

--- a/tests/unit/test_context_command.py
+++ b/tests/unit/test_context_command.py
@@ -1,0 +1,83 @@
+from unittest.mock import Mock
+
+from src.cli.commands import cmd_context
+
+
+def _snapshot(**overrides):
+    payload = {
+        "session_id": "abc12345",
+        "friendly_name": "agent-1",
+        "provider": "claude",
+        "used_percentage": 43,
+        "total_input_tokens": 86_214,
+        "sampled_at": "2026-07-28T10:00:00",
+        "state": "normal",
+        "warning_percentage": 50,
+        "critical_percentage": 65,
+        "context_monitor_enabled": True,
+        "notify_session_id": "abc12345",
+        "compaction_active": False,
+        "last_handoff_path": "specs/handoff.md",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_context_default_prints_terse_percentage(capsys):
+    client = Mock()
+    client.get_context_snapshot.return_value = _snapshot()
+
+    rc = cmd_context(client, "abc12345")
+
+    assert rc == 0
+    assert capsys.readouterr().out == "43%\n"
+    client.get_context_snapshot.assert_called_once_with("abc12345")
+
+
+def test_context_default_prints_unknown_without_sample(capsys):
+    client = Mock()
+    client.get_context_snapshot.return_value = _snapshot(used_percentage=None)
+
+    rc = cmd_context(client, "abc12345")
+
+    assert rc == 0
+    assert capsys.readouterr().out == "unknown\n"
+
+
+def test_context_details_prints_operational_snapshot(capsys):
+    client = Mock()
+    client.get_context_snapshot.return_value = _snapshot()
+
+    rc = cmd_context(client, "abc12345", details=True)
+
+    assert rc == 0
+    output = capsys.readouterr().out
+    assert "Context: 43% (86,214 tokens)" in output
+    assert "State: normal (warning 50%, critical 65%)" in output
+    assert "Monitor: enabled, alerts -> self" in output
+    assert "Compaction: not active" in output
+    assert "Last handoff: specs/handoff.md" in output
+    assert "Session: agent-1 [abc12345] claude" in output
+
+
+def test_context_json_prints_payload(capsys):
+    client = Mock()
+    client.get_context_snapshot.return_value = _snapshot()
+
+    rc = cmd_context(client, "abc12345", json_output=True)
+
+    assert rc == 0
+    output = capsys.readouterr().out
+    assert '"session_id": "abc12345"' in output
+    assert '"used_percentage": 43' in output
+
+
+def test_context_requires_target_without_session_context(capsys):
+    client = Mock()
+
+    rc = cmd_context(client, None)
+
+    assert rc == 2
+    assert "requires a managed session or explicit session target" in capsys.readouterr().err
+    client.get_context_snapshot.assert_not_called()
+

--- a/tests/unit/test_context_command.py
+++ b/tests/unit/test_context_command.py
@@ -34,6 +34,21 @@ def test_context_default_prints_terse_percentage(capsys):
     client.get_context_snapshot.assert_called_once_with("abc12345")
 
 
+def test_context_explicit_target_resolves_friendly_name(capsys):
+    client = Mock()
+    client.get_session.return_value = None
+    client.list_sessions.return_value = [
+        {"id": "abc12345", "friendly_name": "agent-1", "aliases": []}
+    ]
+    client.get_context_snapshot.return_value = _snapshot()
+
+    rc = cmd_context(client, None, target="agent-1")
+
+    assert rc == 0
+    assert capsys.readouterr().out == "43%\n"
+    client.get_context_snapshot.assert_called_once_with("abc12345")
+
+
 def test_context_default_prints_unknown_without_sample(capsys):
     client = Mock()
     client.get_context_snapshot.return_value = _snapshot(used_percentage=None)
@@ -80,4 +95,3 @@ def test_context_requires_target_without_session_context(capsys):
     assert rc == 2
     assert "requires a managed session or explicit session target" in capsys.readouterr().err
     client.get_context_snapshot.assert_not_called()
-

--- a/tests/unit/test_context_monitor.py
+++ b/tests/unit/test_context_monitor.py
@@ -117,6 +117,57 @@ class TestWarningThreshold:
         assert session._context_warning_sent is False
 
 
+class TestContextSnapshot:
+    """Cached context snapshot read path."""
+
+    def test_context_usage_is_cached_even_when_monitor_disabled(self, client, mock_session_manager, session):
+        session.context_monitor_enabled = False
+
+        resp = _post_context(
+            client,
+            session.id,
+            used_pct=43,
+            total_input_tokens=86_214,
+            sm_hook_emitted_at="2026-07-28T10:00:00Z",
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "not_registered"
+        assert session.context_used_percentage == 43
+        assert session.context_total_input_tokens == 86_214
+        assert session.context_sampled_at is not None
+        assert not mock_session_manager.message_queue_manager.queue_message.called
+
+        context_resp = client.get(f"/sessions/{session.id}/context")
+        assert context_resp.status_code == 200
+        payload = context_resp.json()
+        assert payload["session_id"] == session.id
+        assert payload["used_percentage"] == 43
+        assert payload["total_input_tokens"] == 86_214
+        assert payload["state"] == "normal"
+        assert payload["context_monitor_enabled"] is False
+
+    def test_context_snapshot_unknown_before_first_sample(self, client, session):
+        resp = client.get(f"/sessions/{session.id}/context")
+
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["used_percentage"] is None
+        assert payload["total_input_tokens"] is None
+        assert payload["sampled_at"] is None
+        assert payload["state"] == "unknown"
+
+    def test_context_reset_clears_cached_snapshot(self, client, session):
+        _post_context(client, session.id, used_pct=55, total_input_tokens=110_000)
+
+        resp = _post_event(client, session.id, "context_reset")
+
+        assert resp.status_code == 200
+        assert session.context_used_percentage is None
+        assert session.context_total_input_tokens is None
+        assert session.context_sampled_at is None
+
+
 # ---------------------------------------------------------------------------
 # 2. Critical at 65% (one-shot, urgent)
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_context_monitor.py
+++ b/tests/unit/test_context_monitor.py
@@ -1017,6 +1017,21 @@ class TestCompactionSuppressRemind:
         _post_event(client, session.id, event="compaction", trigger="auto")
         assert session._is_compacting is True
 
+    def test_compaction_persists_cycle_boundary(self, client, mock_session_manager, session):
+        """compaction event saves the reset watermark before returning."""
+        resp = _post_event(
+            client,
+            session.id,
+            event="compaction",
+            trigger="auto",
+            sm_hook_emitted_at="2026-07-28T10:01:00Z",
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "compaction_logged"
+        assert session.context_cycle_reset_emitted_at is not None
+        mock_session_manager._save_state.assert_called_once()
+
     def test_compaction_complete_clears_is_compacting_flag(self, client, session):
         """compaction_complete event clears _is_compacting=False on session."""
         session._is_compacting = True

--- a/tests/unit/test_context_monitor.py
+++ b/tests/unit/test_context_monitor.py
@@ -226,6 +226,31 @@ class TestContextSnapshot:
         assert session.context_sampled_at is None
         mock_session_manager._save_state.assert_not_called()
 
+    def test_out_of_order_context_usage_sample_is_ignored(self, client, mock_session_manager, session):
+        _post_context(
+            client,
+            session.id,
+            used_pct=60,
+            total_input_tokens=120_000,
+            sm_hook_emitted_at="2026-07-28T10:01:00Z",
+        )
+        mock_session_manager._save_state.reset_mock()
+
+        stale_resp = _post_context(
+            client,
+            session.id,
+            used_pct=45,
+            total_input_tokens=90_000,
+            sm_hook_emitted_at="2026-07-28T10:00:30Z",
+        )
+
+        assert stale_resp.status_code == 200
+        assert stale_resp.json()["status"] == "stale_sample"
+        assert session.context_used_percentage == 60
+        assert session.context_total_input_tokens == 120_000
+        assert session.tokens_used == 120_000
+        mock_session_manager._save_state.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # 2. Critical at 65% (one-shot, urgent)

--- a/tests/unit/test_context_monitor.py
+++ b/tests/unit/test_context_monitor.py
@@ -276,6 +276,30 @@ class TestContextSnapshot:
         assert session.tokens_used == 120_000
         mock_session_manager._save_state.assert_not_called()
 
+    def test_context_usage_clears_stale_compaction_state(self, client, mock_session_manager, session):
+        session.context_monitor_enabled = False
+        session._is_compacting = True
+        session.context_cycle_reset_emitted_at = None
+
+        resp = _post_context(
+            client,
+            session.id,
+            used_pct=43,
+            total_input_tokens=86_214,
+            sm_hook_emitted_at="2026-07-28T10:00:00Z",
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "not_registered"
+        assert session._is_compacting is False
+        mock_session_manager._save_state.assert_called_once()
+
+        context_resp = client.get(f"/sessions/{session.id}/context")
+        assert context_resp.status_code == 200
+        payload = context_resp.json()
+        assert payload["state"] == "normal"
+        assert payload["compaction_active"] is False
+
 
 # ---------------------------------------------------------------------------
 # 2. Critical at 65% (one-shot, urgent)

--- a/tests/unit/test_context_monitor.py
+++ b/tests/unit/test_context_monitor.py
@@ -49,6 +49,7 @@ def mock_session_manager(session):
     mock = MagicMock()
     mock.sessions = {session.id: session}
     mock.get_session = MagicMock(return_value=session)
+    mock._save_state_async = None
     mock._save_state = MagicMock()
     mock.message_queue_manager = MagicMock()
     return mock
@@ -136,6 +137,7 @@ class TestContextSnapshot:
         assert session.context_used_percentage == 43
         assert session.context_total_input_tokens == 86_214
         assert session.context_sampled_at is not None
+        mock_session_manager._save_state.assert_called_once()
         assert not mock_session_manager.message_queue_manager.queue_message.called
 
         context_resp = client.get(f"/sessions/{session.id}/context")
@@ -166,6 +168,63 @@ class TestContextSnapshot:
         assert session.context_used_percentage is None
         assert session.context_total_input_tokens is None
         assert session.context_sampled_at is None
+
+    def test_context_usage_unchanged_sample_is_not_resaved(self, client, mock_session_manager, session):
+        session.context_monitor_enabled = False
+
+        _post_context(
+            client,
+            session.id,
+            used_pct=43,
+            total_input_tokens=86_214,
+            sm_hook_emitted_at="2026-07-28T10:00:00Z",
+        )
+        mock_session_manager._save_state.reset_mock()
+
+        resp = _post_context(
+            client,
+            session.id,
+            used_pct=43,
+            total_input_tokens=86_214,
+            sm_hook_emitted_at="2026-07-28T10:00:30Z",
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "not_registered"
+        mock_session_manager._save_state.assert_not_called()
+
+    def test_context_usage_before_latest_reset_is_ignored(self, client, mock_session_manager, session):
+        _post_context(
+            client,
+            session.id,
+            used_pct=55,
+            total_input_tokens=110_000,
+            sm_hook_emitted_at="2026-07-28T10:00:00Z",
+        )
+
+        resp = _post_event(
+            client,
+            session.id,
+            "context_reset",
+            sm_hook_emitted_at="2026-07-28T10:01:00Z",
+        )
+        assert resp.status_code == 200
+        mock_session_manager._save_state.reset_mock()
+
+        stale_resp = _post_context(
+            client,
+            session.id,
+            used_pct=60,
+            total_input_tokens=120_000,
+            sm_hook_emitted_at="2026-07-28T10:00:30Z",
+        )
+
+        assert stale_resp.status_code == 200
+        assert stale_resp.json()["status"] == "stale_sample"
+        assert session.context_used_percentage is None
+        assert session.context_total_input_tokens is None
+        assert session.context_sampled_at is None
+        mock_session_manager._save_state.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_context_monitor.py
+++ b/tests/unit/test_context_monitor.py
@@ -169,7 +169,7 @@ class TestContextSnapshot:
         assert session.context_total_input_tokens is None
         assert session.context_sampled_at is None
 
-    def test_context_usage_unchanged_sample_is_not_resaved(self, client, mock_session_manager, session):
+    def test_context_usage_unstamped_unchanged_sample_is_not_resaved(self, client, mock_session_manager, session):
         session.context_monitor_enabled = False
 
         _post_context(
@@ -186,12 +186,37 @@ class TestContextSnapshot:
             session.id,
             used_pct=43,
             total_input_tokens=86_214,
-            sm_hook_emitted_at="2026-07-28T10:00:30Z",
         )
 
         assert resp.status_code == 200
         assert resp.json()["status"] == "not_registered"
         mock_session_manager._save_state.assert_not_called()
+
+    def test_context_usage_unchanged_sample_advances_watermark(self, client, mock_session_manager, session):
+        session.context_monitor_enabled = False
+
+        _post_context(
+            client,
+            session.id,
+            used_pct=43,
+            total_input_tokens=86_214,
+            sm_hook_emitted_at="2026-07-28T10:00:00Z",
+        )
+        first_sampled_at = session.context_sampled_at
+        mock_session_manager._save_state.reset_mock()
+
+        resp = _post_context(
+            client,
+            session.id,
+            used_pct=43,
+            total_input_tokens=86_214,
+            sm_hook_emitted_at="2026-07-28T10:00:30Z",
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "not_registered"
+        assert session.context_sampled_at > first_sampled_at
+        mock_session_manager._save_state.assert_called_once()
 
     def test_context_usage_before_latest_reset_is_ignored(self, client, mock_session_manager, session):
         _post_context(
@@ -1004,6 +1029,7 @@ class TestCompactionSuppressRemind:
         _post_event(client, session.id, event="compaction_complete")
         queue_mgr = mock_session_manager.message_queue_manager
         queue_mgr.reset_remind.assert_called_once_with(session.id, force_tracked=True)
+        mock_session_manager._save_state.assert_called_once()
 
     def test_compaction_complete_returns_logged_status(self, client, session):
         """compaction_complete returns compaction_complete_logged status."""

--- a/tests/unit/test_context_monitor.py
+++ b/tests/unit/test_context_monitor.py
@@ -1038,6 +1038,12 @@ class TestCompactionSuppressRemind:
         _post_event(client, session.id, event="compaction_complete")
         assert session._is_compacting is False
 
+    def test_context_reset_clears_is_compacting_flag(self, client, session):
+        """context_reset event clears stale compaction state."""
+        session._is_compacting = True
+        _post_event(client, session.id, event="context_reset")
+        assert session._is_compacting is False
+
     def test_compaction_complete_resets_remind_timer(self, client, mock_session_manager, session):
         """compaction_complete calls reset_remind on queue manager."""
         session._is_compacting = True

--- a/tests/unit/test_maintainer_alias.py
+++ b/tests/unit/test_maintainer_alias.py
@@ -79,6 +79,21 @@ def test_get_session_resolves_maintainer_alias(tmp_path):
     assert payload["aliases"] == ["maintainer"]
 
 
+def test_get_session_resolves_friendly_name(tmp_path):
+    manager = _manager(tmp_path)
+    session = _session("arch1234", tmp_path)
+    session.friendly_name = "arch-orch-4"
+    manager.sessions[session.id] = session
+
+    assert manager.get_session("arch-orch-4") is session
+
+    client = TestClient(create_app(session_manager=manager))
+    response = client.get("/sessions/arch-orch-4")
+
+    assert response.status_code == 200
+    assert response.json()["id"] == "arch1234"
+
+
 def test_get_client_session_resolves_maintainer_alias(tmp_path):
     manager = _manager(tmp_path)
     session = _session("maint123", tmp_path)

--- a/tests/unit/test_maintainer_alias.py
+++ b/tests/unit/test_maintainer_alias.py
@@ -85,7 +85,7 @@ def test_get_session_resolves_friendly_name(tmp_path):
     session.friendly_name = "arch-orch-4"
     manager.sessions[session.id] = session
 
-    assert manager.get_session("arch-orch-4") is session
+    assert manager.get_session("arch-orch-4") is None
 
     client = TestClient(create_app(session_manager=manager))
     response = client.get("/sessions/arch-orch-4")


### PR DESCRIPTION
## Summary
- Add `sm context` / `sm ctx` with terse default output plus `--details`, `--detailed`, and `--json` modes.
- Add cached `GET /sessions/{session_id}/context` support in both Python and Rust servers.
- Cache context usage samples passively even when alert monitoring is disabled, while keeping warning/critical alerts opt-in.
- Treat registry aliases, including `maintainer`, as live-session ownership only so stopped/restorable sessions do not block new maintainer registration.

## Root Cause
A stopped but restorable maintainer session could remain the active `maintainer` registry owner because registry pruning considered restorable stopped sessions valid owners. That left `/registry/maintainer` and `sm maintainer` blocked by stale state.

## Validation
- `./venv/bin/python -m pytest tests/ -q` -> 2412 passed
- `cargo test -p sm-server --quiet` -> passed
- `git diff --check` -> passed
- Live restart via `./scripts/restart-rust-server.sh` completed healthy on pid 74508
- Live checks: `sm context`, `sm context --details`, `sm lookup maintainer`

## Operational Note
During implementation I initially restarted the live service from this feature branch before running the PR review loop. This PR is the remediation path; after review/merge, the service should be restarted again from merged `main`.

No issue is linked; this came from a direct maintainer-session request.