### PR TITLE
Add stock Codex launch alias

### DIFF
--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -78,6 +78,8 @@ enum Command {
     Subagents(SessionIdArgs),
     Claude(ProviderLaunchArgs),
     Codex(ProviderLaunchArgs),
+    #[command(name = "codex-original", alias = "codex-stock")]
+    CodexOriginal(ProviderLaunchArgs),
     #[command(name = "codex-app")]
     CodexApp(ProviderLaunchArgs),
     #[command(name = "codex-fork", alias = "codex_fork")]
@@ -601,6 +603,12 @@ fn run() -> Result<()> {
         Command::Codex(args) => launch_provider_session(
             &client,
             launch_provider_for_alias("codex")?,
+            args.working_dir,
+            args.node,
+        )?,
+        Command::CodexOriginal(args) => launch_provider_session(
+            &client,
+            launch_provider_for_alias("codex-original")?,
             args.working_dir,
             args.node,
         )?,
@@ -2211,6 +2219,7 @@ fn send_registered_email_fallback(client: &ApiClient, recipient: &str, text: &st
 fn launch_provider_for_alias(alias: &str) -> Result<&'static str> {
     match alias {
         "new" | "claude" => Ok("claude"),
+        "codex-original" | "codex-stock" => Ok("codex"),
         "codex" | "codex-fork" | "codex_fork" | "codex-2" => Ok("codex-fork"),
         "codex-app" => Ok("codex-app"),
         _ => bail!("unsupported launch alias {alias}"),
@@ -4584,6 +4593,11 @@ mod tests {
         assert_eq!(launch_provider_for_alias("claude").unwrap(), "claude");
         assert_eq!(launch_provider_for_alias("codex").unwrap(), "codex-fork");
         assert_eq!(
+            launch_provider_for_alias("codex-original").unwrap(),
+            "codex"
+        );
+        assert_eq!(launch_provider_for_alias("codex-stock").unwrap(), "codex");
+        assert_eq!(
             launch_provider_for_alias("codex-fork").unwrap(),
             "codex-fork"
         );
@@ -4622,6 +4636,12 @@ mod tests {
             launch_provider_for_alias(&args.provider).unwrap(),
             "codex-fork"
         );
+
+        let cli = Cli::try_parse_from(["sm", "spawn", "codex-original", "review this"]).unwrap();
+        let Command::Spawn(args) = cli.command else {
+            panic!("expected spawn command");
+        };
+        assert_eq!(launch_provider_for_alias(&args.provider).unwrap(), "codex");
 
         let cli = Cli::try_parse_from(["sm", "spawn", "codex-2", "review this"]).unwrap();
         let Command::Spawn(args) = cli.command else {

--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -66,8 +66,14 @@ impl Default for AppConfig {
                 "claude".to_owned(),
                 Vec::new(),
                 Some("sonnet".to_owned()),
+                None,
             ),
-            codex: ProviderLaunchConfig::new("codex".to_owned(), Vec::new(), None),
+            codex: ProviderLaunchConfig::new(
+                "codex".to_owned(),
+                Vec::new(),
+                None,
+                Some("~/.codex/session_index.jsonl".to_owned()),
+            ),
             codex_review: CodexReviewConfig::default(),
             codex_fork: CodexForkLaunchConfig::default(),
             nodes: NodesConfig::default(),
@@ -660,21 +666,33 @@ pub struct ProviderLaunchConfig {
     pub command: String,
     pub args: Vec<String>,
     pub default_model: Option<String>,
+    pub session_index_path: Option<String>,
 }
 
 impl ProviderLaunchConfig {
-    fn new(command: String, args: Vec<String>, default_model: Option<String>) -> Self {
+    fn new(
+        command: String,
+        args: Vec<String>,
+        default_model: Option<String>,
+        session_index_path: Option<String>,
+    ) -> Self {
         Self {
             command,
             args,
             default_model,
+            session_index_path,
         }
     }
 }
 
 impl Default for ProviderLaunchConfig {
     fn default() -> Self {
-        Self::new("claude".to_owned(), Vec::new(), Some("sonnet".to_owned()))
+        Self::new(
+            "claude".to_owned(),
+            Vec::new(),
+            Some("sonnet".to_owned()),
+            None,
+        )
     }
 }
 
@@ -1134,9 +1152,15 @@ impl From<RawConfig> for AppConfig {
             codex_observability_config(raw.codex_observability, &paths.state_file);
         let codex_requests = codex_requests_config(raw.codex_requests, &paths.state_file);
         let codex_events = codex_events_config(raw.codex_events, &paths.state_file);
-        let claude = provider_launch_config(raw.claude, "claude", Some("sonnet"), Vec::new());
+        let claude = provider_launch_config(raw.claude, "claude", Some("sonnet"), Vec::new(), None);
         let codex_review = raw.codex.review;
-        let codex = provider_launch_config(raw.codex.provider, "codex", None, Vec::new());
+        let codex = provider_launch_config(
+            raw.codex.provider,
+            "codex",
+            None,
+            Vec::new(),
+            Some("~/.codex/session_index.jsonl"),
+        );
         let codex_fork = codex_fork_launch_config(raw.codex_fork, &codex);
         if trimmed(&rust_core.tmux_socket_name).is_none() {
             rust_core.tmux_socket_name = trimmed(&raw.tmux.socket_name);
@@ -1263,6 +1287,8 @@ struct RawProviderLaunchConfig {
     args: Option<Vec<String>>,
     #[serde(default)]
     default_model: Option<String>,
+    #[serde(default)]
+    session_index_path: Option<String>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -1326,6 +1352,7 @@ fn provider_launch_config(
     default_command: &str,
     default_model: Option<&str>,
     default_args: Vec<String>,
+    default_session_index_path: Option<&str>,
 ) -> ProviderLaunchConfig {
     ProviderLaunchConfig::new(
         raw.command
@@ -1341,6 +1368,10 @@ fn provider_launch_config(
             .as_ref()
             .and_then(|value| trimmed(&Some(value.clone())))
             .or_else(|| default_model.map(ToOwned::to_owned)),
+        raw.session_index_path
+            .as_ref()
+            .and_then(|value| trimmed(&Some(value.clone())))
+            .or_else(|| default_session_index_path.map(ToOwned::to_owned)),
     )
 }
 
@@ -2262,6 +2293,7 @@ codex:
   command: "/opt/bin/codex"
   args: ["--dangerously-bypass-approvals-and-sandbox"]
   default_model: "gpt-5"
+  session_index_path: "/tmp/codex/session_index.jsonl"
   review:
     default_wait: 42
     menu_settle_seconds: 0.25
@@ -2278,6 +2310,10 @@ codex:
             vec!["--dangerously-bypass-approvals-and-sandbox"]
         );
         assert_eq!(config.codex.default_model.as_deref(), Some("gpt-5"));
+        assert_eq!(
+            config.codex.session_index_path.as_deref(),
+            Some("/tmp/codex/session_index.jsonl")
+        );
         assert_eq!(config.codex_review.default_wait, 42);
         assert_eq!(config.codex_review.menu_settle_seconds, 0.25);
         assert_eq!(config.codex_review.branch_settle_seconds, 0.5);

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -362,7 +362,6 @@ impl AppState {
         let queue_db_path = expand_home(&config.sm_send.db_path);
         let session_store = SessionStore::new_with_queue(state_file, queue_db_path)
             .with_context_monitor_config(config.context_monitor.clone())
-            .with_codex_session_index_path(config.codex.session_index_path.as_deref())
             .with_delivery_runtime(
                 config
                     .rust_core

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -362,6 +362,7 @@ impl AppState {
         let queue_db_path = expand_home(&config.sm_send.db_path);
         let session_store = SessionStore::new_with_queue(state_file, queue_db_path)
             .with_context_monitor_config(config.context_monitor.clone())
+            .with_codex_session_index_path(config.codex.session_index_path.as_deref())
             .with_delivery_runtime(
                 config
                     .rust_core

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -282,11 +282,7 @@ impl TmuxRuntime {
                         prepend_arg_pair("resume", resume_id, &runtime.codex_fork_args);
                 }
                 "codex" => {
-                    runtime.claude_command = format!(
-                        "{} resume {}",
-                        runtime.claude_command,
-                        shell_quote(resume_id)
-                    );
+                    runtime.codex_args = prepend_arg_pair("resume", resume_id, &runtime.codex_args);
                 }
                 _ => {}
             };

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1102,7 +1102,7 @@ impl SessionStore {
         if !is_primary_node(&record.node) {
             return Ok(Some(CoreRestoreOutcome::UnsupportedNode(record.node)));
         }
-        if !matches!(record.provider.as_str(), "claude" | "codex-fork") {
+        if !matches!(record.provider.as_str(), "claude" | "codex" | "codex-fork") {
             return Ok(Some(CoreRestoreOutcome::UnsupportedProvider(
                 record.provider,
             )));

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -89,19 +89,6 @@ impl SessionStore {
         self
     }
 
-    pub(crate) fn with_codex_session_index_path(
-        mut self,
-        session_index_path: Option<&str>,
-    ) -> Self {
-        if let Some(index_parent) = session_index_path
-            .map(expand_home)
-            .and_then(|path| path.parent().map(Path::to_path_buf))
-        {
-            self.codex_sessions_root = index_parent.join("sessions");
-        }
-        self
-    }
-
     /// Drop context alerts this session raised about context it no longer has.
     /// An undelivered warning describes the discarded cycle, so delivering it
     /// after a clear tells the monitor about a problem that no longer exists.

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -562,7 +562,8 @@ impl SessionStore {
             initial_message: request.initial_message.clone(),
             model: request.model.clone(),
         };
-        let codex_cli_excluded_ids = (record.provider == "codex").then(|| {
+        let codex_fork_artifacts = runtime.codex_fork_runtime_artifacts(&spec)?;
+        let codex_cli_creation_binding = (record.provider == "codex").then(|| {
             let mut excluded_ids = sessions
                 .iter()
                 .filter_map(|session| json_text(session.get("provider_resume_id")))
@@ -571,15 +572,18 @@ impl SessionStore {
                 &record,
                 &self.codex_sessions_root,
             ));
-            excluded_ids
+            (
+                excluded_ids,
+                OffsetDateTime::now_utc().unix_timestamp_nanos(),
+            )
         });
-        let codex_fork_artifacts = runtime.codex_fork_runtime_artifacts(&spec)?;
         runtime.create_session(&spec)?;
-        if let Some(excluded_ids) = codex_cli_excluded_ids {
+        if let Some((excluded_ids, launched_at_ns)) = codex_cli_creation_binding {
             record.provider_resume_id = wait_for_codex_cli_provider_resume_id(
                 &record,
                 &self.codex_sessions_root,
                 &excluded_ids,
+                launched_at_ns,
                 CODEX_CLI_SESSION_BIND_TIMEOUT,
             );
         }
@@ -1152,8 +1156,12 @@ impl SessionStore {
                 .filter(|session| session.id != record.id)
                 .filter_map(|session| session.provider_resume_id.clone())
                 .collect::<BTreeSet<_>>();
-            record.provider_resume_id =
-                discover_codex_cli_resume_id(&record, &self.codex_sessions_root, &claimed_ids);
+            record.provider_resume_id = discover_codex_cli_resume_id(
+                &record,
+                &self.codex_sessions_root,
+                &claimed_ids,
+                CodexCliSessionDiscoveryMode::Restore,
+            );
         }
         if record.provider == "claude"
             && record
@@ -5601,11 +5609,17 @@ fn wait_for_codex_cli_provider_resume_id(
     record: &SessionRecord,
     sessions_root: &Path,
     excluded_ids: &BTreeSet<String>,
+    launched_at_ns: i128,
     timeout: Duration,
 ) -> Option<String> {
     let started = Instant::now();
     loop {
-        if let Some(resume_id) = discover_codex_cli_resume_id(record, sessions_root, excluded_ids) {
+        if let Some(resume_id) = discover_codex_cli_resume_id(
+            record,
+            sessions_root,
+            excluded_ids,
+            CodexCliSessionDiscoveryMode::Creation { launched_at_ns },
+        ) {
             return Some(resume_id);
         }
         if started.elapsed() >= timeout {
@@ -5615,10 +5629,17 @@ fn wait_for_codex_cli_provider_resume_id(
     }
 }
 
+#[derive(Clone, Copy)]
+enum CodexCliSessionDiscoveryMode {
+    Creation { launched_at_ns: i128 },
+    Restore,
+}
+
 fn discover_codex_cli_resume_id(
     record: &SessionRecord,
     sessions_root: &Path,
     excluded_ids: &BTreeSet<String>,
+    mode: CodexCliSessionDiscoveryMode,
 ) -> Option<String> {
     if record.provider != "codex" || record.working_dir.trim().is_empty() {
         return None;
@@ -5628,7 +5649,12 @@ fn discover_codex_cli_resume_id(
     }
 
     let resolved_working_dir = resolve_path_lossy(expand_home(&record.working_dir));
-    let target_time_ns = session_time_ns(record).unwrap_or(0);
+    let target_time_ns = match mode {
+        CodexCliSessionDiscoveryMode::Creation { launched_at_ns } => launched_at_ns,
+        CodexCliSessionDiscoveryMode::Restore => {
+            parse_timestamp_ns(&record.created_at).unwrap_or(0)
+        }
+    };
     let mut candidates = Vec::new();
 
     for path in codex_cli_session_files(record, sessions_root) {
@@ -5642,7 +5668,15 @@ fn discover_codex_cli_resume_id(
         {
             continue;
         }
-        let started_at_ns = started_at_ns.unwrap_or(0);
+        let started_at_ns = match (mode, started_at_ns) {
+            (CodexCliSessionDiscoveryMode::Creation { launched_at_ns }, Some(started_at_ns))
+                if started_at_ns >= launched_at_ns =>
+            {
+                started_at_ns
+            }
+            (CodexCliSessionDiscoveryMode::Creation { .. }, _) => continue,
+            (CodexCliSessionDiscoveryMode::Restore, started_at_ns) => started_at_ns.unwrap_or(0),
+        };
         let distance = if started_at_ns == 0 {
             i128::MAX
         } else {
@@ -7858,11 +7892,17 @@ mod tests {
         session.provider = "codex".to_owned();
         session.working_dir = working_dir.display().to_string();
         session.created_at = "2026-07-28T20:00:00Z".to_owned();
-        session.last_activity = "2026-07-28T20:00:00Z".to_owned();
+        session.last_activity = "2026-07-28T20:09:00Z".to_owned();
         let claimed_ids = BTreeSet::from(["claimed-id".to_owned()]);
 
         assert_eq!(
-            discover_codex_cli_resume_id(&session, &sessions_root, &claimed_ids).as_deref(),
+            discover_codex_cli_resume_id(
+                &session,
+                &sessions_root,
+                &claimed_ids,
+                CodexCliSessionDiscoveryMode::Restore,
+            )
+            .as_deref(),
             Some("closest-id")
         );
 
@@ -7904,10 +7944,19 @@ mod tests {
         session.last_activity = "2026-07-28T20:00:00Z".to_owned();
         let excluded_ids = codex_cli_existing_session_ids(&session, &sessions_root);
 
+        rollout("delayed-earlier-id", "2026-07-28T19:59:59Z");
         rollout("new-id", "2026-07-28T20:00:01Z");
 
         assert_eq!(
-            discover_codex_cli_resume_id(&session, &sessions_root, &excluded_ids).as_deref(),
+            discover_codex_cli_resume_id(
+                &session,
+                &sessions_root,
+                &excluded_ids,
+                CodexCliSessionDiscoveryMode::Creation {
+                    launched_at_ns: parse_timestamp_ns("2026-07-28T20:00:00Z").unwrap(),
+                },
+            )
+            .as_deref(),
             Some("new-id")
         );
 

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -562,17 +562,24 @@ impl SessionStore {
             initial_message: request.initial_message.clone(),
             model: request.model.clone(),
         };
-        let codex_fork_artifacts = runtime.codex_fork_runtime_artifacts(&spec)?;
-        runtime.create_session(&spec)?;
-        if record.provider == "codex" {
-            let claimed_ids = sessions
+        let codex_cli_excluded_ids = (record.provider == "codex").then(|| {
+            let mut excluded_ids = sessions
                 .iter()
                 .filter_map(|session| json_text(session.get("provider_resume_id")))
                 .collect::<BTreeSet<_>>();
+            excluded_ids.extend(codex_cli_existing_session_ids(
+                &record,
+                &self.codex_sessions_root,
+            ));
+            excluded_ids
+        });
+        let codex_fork_artifacts = runtime.codex_fork_runtime_artifacts(&spec)?;
+        runtime.create_session(&spec)?;
+        if let Some(excluded_ids) = codex_cli_excluded_ids {
             record.provider_resume_id = wait_for_codex_cli_provider_resume_id(
                 &record,
                 &self.codex_sessions_root,
-                &claimed_ids,
+                &excluded_ids,
                 CODEX_CLI_SESSION_BIND_TIMEOUT,
             );
         }
@@ -5593,12 +5600,12 @@ fn provider_resume_id_for_restore(record: &SessionRecord) -> Option<String> {
 fn wait_for_codex_cli_provider_resume_id(
     record: &SessionRecord,
     sessions_root: &Path,
-    claimed_ids: &BTreeSet<String>,
+    excluded_ids: &BTreeSet<String>,
     timeout: Duration,
 ) -> Option<String> {
     let started = Instant::now();
     loop {
-        if let Some(resume_id) = discover_codex_cli_resume_id(record, sessions_root, claimed_ids) {
+        if let Some(resume_id) = discover_codex_cli_resume_id(record, sessions_root, excluded_ids) {
             return Some(resume_id);
         }
         if started.elapsed() >= timeout {
@@ -5611,7 +5618,7 @@ fn wait_for_codex_cli_provider_resume_id(
 fn discover_codex_cli_resume_id(
     record: &SessionRecord,
     sessions_root: &Path,
-    claimed_ids: &BTreeSet<String>,
+    excluded_ids: &BTreeSet<String>,
 ) -> Option<String> {
     if record.provider != "codex" || record.working_dir.trim().is_empty() {
         return None;
@@ -5622,11 +5629,52 @@ fn discover_codex_cli_resume_id(
 
     let resolved_working_dir = resolve_path_lossy(expand_home(&record.working_dir));
     let target_time_ns = session_time_ns(record).unwrap_or(0);
+    let mut candidates = Vec::new();
+
+    for path in codex_cli_session_files(record, sessions_root) {
+        let Some((candidate_id, candidate_cwd, started_at_ns)) =
+            read_codex_cli_session_metadata(&path)
+        else {
+            continue;
+        };
+        if excluded_ids.contains(&candidate_id)
+            || resolve_path_lossy(expand_home(&candidate_cwd)) != resolved_working_dir
+        {
+            continue;
+        }
+        let started_at_ns = started_at_ns.unwrap_or(0);
+        let distance = if started_at_ns == 0 {
+            i128::MAX
+        } else {
+            (target_time_ns - started_at_ns).abs()
+        };
+        candidates.push((distance, -started_at_ns, candidate_id));
+    }
+
+    candidates.sort();
+    candidates
+        .into_iter()
+        .next()
+        .map(|(_, _, candidate_id)| candidate_id)
+}
+
+fn codex_cli_existing_session_ids(
+    record: &SessionRecord,
+    sessions_root: &Path,
+) -> BTreeSet<String> {
+    codex_cli_session_files(record, sessions_root)
+        .into_iter()
+        .filter_map(|path| {
+            read_codex_cli_session_metadata(&path).map(|(session_id, _, _)| session_id)
+        })
+        .collect()
+}
+
+fn codex_cli_session_files(record: &SessionRecord, sessions_root: &Path) -> Vec<PathBuf> {
     let base_date = parse_timestamp(&record.created_at)
         .unwrap_or_else(OffsetDateTime::now_utc)
         .date();
-    let mut candidates = Vec::new();
-
+    let mut session_files = Vec::new();
     for day_offset in [-1, 0, 1] {
         let Some(date) = base_date.checked_add(TimeDuration::days(day_offset)) else {
             continue;
@@ -5638,41 +5686,14 @@ fn discover_codex_cli_resume_id(
         let Ok(entries) = fs::read_dir(day_dir) else {
             continue;
         };
-        for entry in entries.flatten() {
-            let path = entry.path();
-            let Some(file_name) = path.file_name().and_then(|value| value.to_str()) else {
-                continue;
-            };
-            if !file_name.starts_with("rollout-")
-                || path.extension().and_then(|value| value.to_str()) != Some("jsonl")
-            {
-                continue;
-            }
-            let Some((candidate_id, candidate_cwd, started_at_ns)) =
-                read_codex_cli_session_metadata(&path)
-            else {
-                continue;
-            };
-            if claimed_ids.contains(&candidate_id)
-                || resolve_path_lossy(expand_home(&candidate_cwd)) != resolved_working_dir
-            {
-                continue;
-            }
-            let started_at_ns = started_at_ns.unwrap_or(0);
-            let distance = if started_at_ns == 0 {
-                i128::MAX
-            } else {
-                (target_time_ns - started_at_ns).abs()
-            };
-            candidates.push((distance, -started_at_ns, candidate_id));
-        }
+        session_files.extend(entries.flatten().map(|entry| entry.path()).filter(|path| {
+            path.file_name()
+                .and_then(|value| value.to_str())
+                .is_some_and(|file_name| file_name.starts_with("rollout-"))
+                && path.extension().and_then(|value| value.to_str()) == Some("jsonl")
+        }));
     }
-
-    candidates.sort();
-    candidates
-        .into_iter()
-        .next()
-        .map(|(_, _, candidate_id)| candidate_id)
+    session_files
 }
 
 fn read_codex_cli_session_metadata(path: &Path) -> Option<(String, String, Option<i128>)> {
@@ -7843,6 +7864,51 @@ mod tests {
         assert_eq!(
             discover_codex_cli_resume_id(&session, &sessions_root, &claimed_ids).as_deref(),
             Some("closest-id")
+        );
+
+        let _ = fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn codex_creation_binding_excludes_preexisting_rollouts() {
+        let temp_dir = unique_temp_path("codex-creation-binding");
+        let working_dir = temp_dir.join("repo");
+        let sessions_root = temp_dir.join("codex-home").join("sessions");
+        let day_dir = sessions_root.join("2026").join("07").join("28");
+        fs::create_dir_all(&working_dir).unwrap();
+        fs::create_dir_all(&day_dir).unwrap();
+
+        let rollout = |id: &str, timestamp: &str| {
+            fs::write(
+                day_dir.join(format!("rollout-{id}.jsonl")),
+                format!(
+                    "{}\n",
+                    json!({
+                        "type": "session_meta",
+                        "payload": {
+                            "id": id,
+                            "cwd": working_dir.display().to_string(),
+                            "timestamp": timestamp
+                        }
+                    })
+                ),
+            )
+            .unwrap();
+        };
+        rollout("stale-id", "2026-07-28T20:00:00Z");
+
+        let mut session = session_record("stopped");
+        session.provider = "codex".to_owned();
+        session.working_dir = working_dir.display().to_string();
+        session.created_at = "2026-07-28T20:00:00Z".to_owned();
+        session.last_activity = "2026-07-28T20:00:00Z".to_owned();
+        let excluded_ids = codex_cli_existing_session_ids(&session, &sessions_root);
+
+        rollout("new-id", "2026-07-28T20:00:01Z");
+
+        assert_eq!(
+            discover_codex_cli_resume_id(&session, &sessions_root, &excluded_ids).as_deref(),
+            Some("new-id")
         );
 
         let _ = fs::remove_dir_all(temp_dir);

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -36,6 +36,8 @@ const LEGACY_TMP_SESSION_STATE_FILE: &str = "/tmp/claude-sessions/sessions.json"
 const OUTPUT_TAIL_BYTES_PER_LINE: u64 = 4096;
 const MIN_OUTPUT_TAIL_BYTES: u64 = 16 * 1024;
 const MAX_OUTPUT_TAIL_BYTES: u64 = 1024 * 1024;
+const CODEX_CLI_SESSION_BIND_TIMEOUT: Duration = Duration::from_secs(1);
+const CODEX_CLI_SESSION_BIND_POLL: Duration = Duration::from_millis(50);
 const CODEX_FORK_THREAD_STARTED_TIMEOUT: Duration = Duration::from_secs(10);
 const CODEX_FORK_EVENT_MONITOR_POLL: Duration = Duration::from_millis(250);
 const CODEX_FORK_CONTROL_TIMEOUT: Duration = Duration::from_secs(3);
@@ -45,6 +47,7 @@ static STATE_WRITE_COUNTER: AtomicU64 = AtomicU64::new(0);
 pub struct SessionStore {
     state_file: PathBuf,
     legacy_state_file: Option<PathBuf>,
+    codex_sessions_root: PathBuf,
     write_lock: Arc<Mutex<()>>,
     queue_store: Option<RetainedQueueStore>,
     /// Carried on the store rather than read per-request because the codex-fork
@@ -67,6 +70,7 @@ impl SessionStore {
         Self {
             state_file,
             legacy_state_file,
+            codex_sessions_root: expand_home("~/.codex/sessions"),
             write_lock: Arc::new(Mutex::new(())),
             queue_store: None,
             context_monitor: ContextMonitorConfig::default(),
@@ -82,6 +86,19 @@ impl SessionStore {
 
     pub fn with_context_monitor_config(mut self, config: ContextMonitorConfig) -> Self {
         self.context_monitor = config;
+        self
+    }
+
+    pub(crate) fn with_codex_session_index_path(
+        mut self,
+        session_index_path: Option<&str>,
+    ) -> Self {
+        if let Some(index_parent) = session_index_path
+            .map(expand_home)
+            .and_then(|path| path.parent().map(Path::to_path_buf))
+        {
+            self.codex_sessions_root = index_parent.join("sessions");
+        }
         self
     }
 
@@ -107,6 +124,7 @@ impl SessionStore {
         Self {
             state_file,
             legacy_state_file: Some(legacy_state_file),
+            codex_sessions_root: expand_home("~/.codex/sessions"),
             write_lock: Arc::new(Mutex::new(())),
             queue_store: None,
             context_monitor: ContextMonitorConfig::default(),
@@ -546,6 +564,18 @@ impl SessionStore {
         };
         let codex_fork_artifacts = runtime.codex_fork_runtime_artifacts(&spec)?;
         runtime.create_session(&spec)?;
+        if record.provider == "codex" {
+            let claimed_ids = sessions
+                .iter()
+                .filter_map(|session| json_text(session.get("provider_resume_id")))
+                .collect::<BTreeSet<_>>();
+            record.provider_resume_id = wait_for_codex_cli_provider_resume_id(
+                &record,
+                &self.codex_sessions_root,
+                &claimed_ids,
+                CODEX_CLI_SESSION_BIND_TIMEOUT,
+            );
+        }
         if let Some(artifacts) = &codex_fork_artifacts {
             match wait_for_codex_fork_provider_resume_id(
                 &artifacts.event_stream_path,
@@ -1107,6 +1137,17 @@ impl SessionStore {
                 record.provider,
             )));
         }
+        let stored_provider_resume_id = record.provider_resume_id.clone();
+        if record.provider == "codex" && provider_resume_id_for_restore(&record).is_none() {
+            let claimed_ids = snapshot
+                .sessions
+                .iter()
+                .filter(|session| session.id != record.id)
+                .filter_map(|session| session.provider_resume_id.clone())
+                .collect::<BTreeSet<_>>();
+            record.provider_resume_id =
+                discover_codex_cli_resume_id(&record, &self.codex_sessions_root, &claimed_ids);
+        }
         if record.provider == "claude"
             && record
                 .transcript_path
@@ -1168,8 +1209,7 @@ impl SessionStore {
                 Value::String(socket_name.to_owned()),
             );
         }
-        if record
-            .provider_resume_id
+        if stored_provider_resume_id
             .as_deref()
             .map(str::trim)
             .filter(|value| !value.is_empty())
@@ -5550,6 +5590,121 @@ fn provider_resume_id_for_restore(record: &SessionRecord) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
+fn wait_for_codex_cli_provider_resume_id(
+    record: &SessionRecord,
+    sessions_root: &Path,
+    claimed_ids: &BTreeSet<String>,
+    timeout: Duration,
+) -> Option<String> {
+    let started = Instant::now();
+    loop {
+        if let Some(resume_id) = discover_codex_cli_resume_id(record, sessions_root, claimed_ids) {
+            return Some(resume_id);
+        }
+        if started.elapsed() >= timeout {
+            return None;
+        }
+        thread::sleep(CODEX_CLI_SESSION_BIND_POLL);
+    }
+}
+
+fn discover_codex_cli_resume_id(
+    record: &SessionRecord,
+    sessions_root: &Path,
+    claimed_ids: &BTreeSet<String>,
+) -> Option<String> {
+    if record.provider != "codex" || record.working_dir.trim().is_empty() {
+        return None;
+    }
+    if !sessions_root.is_dir() {
+        return None;
+    }
+
+    let resolved_working_dir = resolve_path_lossy(expand_home(&record.working_dir));
+    let target_time_ns = session_time_ns(record).unwrap_or(0);
+    let base_date = parse_timestamp(&record.created_at)
+        .unwrap_or_else(OffsetDateTime::now_utc)
+        .date();
+    let mut candidates = Vec::new();
+
+    for day_offset in [-1, 0, 1] {
+        let Some(date) = base_date.checked_add(TimeDuration::days(day_offset)) else {
+            continue;
+        };
+        let day_dir = sessions_root
+            .join(format!("{:04}", date.year()))
+            .join(format!("{:02}", date.month() as u8))
+            .join(format!("{:02}", date.day()));
+        let Ok(entries) = fs::read_dir(day_dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Some(file_name) = path.file_name().and_then(|value| value.to_str()) else {
+                continue;
+            };
+            if !file_name.starts_with("rollout-")
+                || path.extension().and_then(|value| value.to_str()) != Some("jsonl")
+            {
+                continue;
+            }
+            let Some((candidate_id, candidate_cwd, started_at_ns)) =
+                read_codex_cli_session_metadata(&path)
+            else {
+                continue;
+            };
+            if claimed_ids.contains(&candidate_id)
+                || resolve_path_lossy(expand_home(&candidate_cwd)) != resolved_working_dir
+            {
+                continue;
+            }
+            let started_at_ns = started_at_ns.unwrap_or(0);
+            let distance = if started_at_ns == 0 {
+                i128::MAX
+            } else {
+                (target_time_ns - started_at_ns).abs()
+            };
+            candidates.push((distance, -started_at_ns, candidate_id));
+        }
+    }
+
+    candidates.sort();
+    candidates
+        .into_iter()
+        .next()
+        .map(|(_, _, candidate_id)| candidate_id)
+}
+
+fn read_codex_cli_session_metadata(path: &Path) -> Option<(String, String, Option<i128>)> {
+    let first_line = BufReader::new(fs::File::open(path).ok()?)
+        .lines()
+        .next()?
+        .ok()?;
+    let record = serde_json::from_str::<Value>(&first_line).ok()?;
+    if record.get("type").and_then(Value::as_str) != Some("session_meta") {
+        return None;
+    }
+    let payload = record.get("payload")?.as_object()?;
+    let session_id = payload
+        .get("id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?
+        .to_owned();
+    let cwd = payload
+        .get("cwd")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())?
+        .to_owned();
+    let started_at_ns = payload
+        .get("timestamp")
+        .or_else(|| record.get("timestamp"))
+        .and_then(Value::as_str)
+        .and_then(parse_timestamp_ns);
+    Some((session_id, cwd, started_at_ns))
+}
+
 #[derive(Debug, Default)]
 struct ClaudeTranscriptMetadata {
     mtime_ns: i128,
@@ -5681,14 +5836,18 @@ fn session_time_ns(record: &SessionRecord) -> Option<i128> {
 }
 
 fn parse_timestamp_ns(value: &str) -> Option<i128> {
+    parse_timestamp(value).map(OffsetDateTime::unix_timestamp_nanos)
+}
+
+fn parse_timestamp(value: &str) -> Option<OffsetDateTime> {
     let value = value.trim();
     if value.is_empty() {
         return None;
     }
     if let Ok(parsed) = OffsetDateTime::parse(value, &Rfc3339) {
-        return Some(parsed.unix_timestamp_nanos());
+        return Some(parsed);
     }
-    parse_python_naive_datetime(value).map(|parsed| parsed.assume_utc().unix_timestamp_nanos())
+    parse_python_naive_datetime(value).map(PrimitiveDateTime::assume_utc)
 }
 
 fn file_mtime_ns(path: impl AsRef<Path>) -> Result<i128> {
@@ -7634,6 +7793,59 @@ mod tests {
         session.transcript_path = None;
 
         assert_eq!(provider_resume_id_for_restore(&session), None);
+    }
+
+    #[test]
+    fn codex_resume_discovery_matches_cwd_time_and_unclaimed_id() {
+        let temp_dir = unique_temp_path("codex-resume-discovery");
+        let working_dir = temp_dir.join("repo");
+        let other_working_dir = temp_dir.join("other-repo");
+        let sessions_root = temp_dir.join("codex-home").join("sessions");
+        let day_dir = sessions_root.join("2026").join("07").join("28");
+        fs::create_dir_all(&working_dir).unwrap();
+        fs::create_dir_all(&other_working_dir).unwrap();
+        fs::create_dir_all(&day_dir).unwrap();
+
+        for (id, cwd, timestamp) in [
+            (
+                "wrong-cwd",
+                other_working_dir.as_path(),
+                "2026-07-28T20:00:00Z",
+            ),
+            ("claimed-id", working_dir.as_path(), "2026-07-28T20:00:01Z"),
+            ("closest-id", working_dir.as_path(), "2026-07-28T20:00:02Z"),
+            ("farther-id", working_dir.as_path(), "2026-07-28T20:10:00Z"),
+        ] {
+            fs::write(
+                day_dir.join(format!("rollout-{id}.jsonl")),
+                format!(
+                    "{}\n",
+                    json!({
+                        "type": "session_meta",
+                        "payload": {
+                            "id": id,
+                            "cwd": cwd.display().to_string(),
+                            "timestamp": timestamp
+                        }
+                    })
+                ),
+            )
+            .unwrap();
+        }
+
+        let mut session = session_record("stopped");
+        session.provider = "codex".to_owned();
+        session.working_dir = working_dir.display().to_string();
+        session.created_at = "2026-07-28T20:00:00Z".to_owned();
+        session.last_activity = "2026-07-28T20:00:00Z".to_owned();
+        let claimed_ids = BTreeSet::from(["claimed-id".to_owned()]);
+
+        assert_eq!(
+            discover_codex_cli_resume_id(&session, &sessions_root, &claimed_ids).as_deref(),
+            Some("closest-id")
+        );
+
+        let _ = fs::remove_dir_all(temp_dir);
     }
 
     #[test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -13337,6 +13337,7 @@ async fn runtime_core_restores_codex_session() {
     .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["provider"], "codex");
+    let created_at = payload["created_at"].as_str().unwrap().to_owned();
     let tmux_session = payload["tmux_session"].as_str().unwrap().to_owned();
     wait_for_output_contains(app.clone(), "runtimecodex", "stock codex initial prompt").await;
 
@@ -13345,14 +13346,34 @@ async fn runtime_core_restores_codex_session() {
     assert_eq!(payload["status"], "killed");
     assert!(!tmux_session_exists(&tmux_socket, &tmux_session));
 
-    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
-    state["sessions"][0]["provider_resume_id"] = json!("stock-thread-123");
-    fs::write(&state_file, state.to_string()).unwrap();
+    let day_dir = state_file
+        .with_extension("codex-home")
+        .join("sessions")
+        .join(&created_at[0..4])
+        .join(&created_at[5..7])
+        .join(&created_at[8..10]);
+    fs::create_dir_all(&day_dir).unwrap();
+    fs::write(
+        day_dir.join("rollout-stock-thread-123.jsonl"),
+        format!(
+            "{}\n",
+            json!({
+                "type": "session_meta",
+                "payload": {
+                    "id": "stock-thread-123",
+                    "cwd": working_dir.display().to_string(),
+                    "timestamp": created_at
+                }
+            })
+        ),
+    )
+    .unwrap();
 
     let (status, payload) =
         post_json(app.clone(), "/sessions/runtimecodex/restore", json!({})).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["provider"], "codex");
+    assert_eq!(payload["provider_resume_id"], "stock-thread-123");
     assert_eq!(payload["status"], "running");
     assert!(tmux_session_exists(&tmux_socket, &tmux_session));
     let (status, payload) = post_json(
@@ -15764,6 +15785,13 @@ fn runtime_app_with_command(
             command: runtime_command.to_owned(),
             args: Vec::new(),
             default_model: None,
+            session_index_path: Some(
+                state_file
+                    .with_extension("codex-home")
+                    .join("session_index.jsonl")
+                    .display()
+                    .to_string(),
+            ),
         },
         ..AppConfig::default()
     }))

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -13305,6 +13305,76 @@ async fn runtime_core_rejects_unsupported_provider() {
 }
 
 #[tokio::test]
+async fn runtime_core_restores_codex_session() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let working_dir = unique_temp_path();
+    fs::create_dir_all(&working_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-test-codex-restore-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app(&state_file, &log_dir, &tmux_socket);
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimecodex",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "codex",
+            "initial_message": "stock codex initial prompt"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["provider"], "codex");
+    let tmux_session = payload["tmux_session"].as_str().unwrap().to_owned();
+    wait_for_output_contains(app.clone(), "runtimecodex", "stock codex initial prompt").await;
+
+    let (status, payload) = post_json(app.clone(), "/sessions/runtimecodex/kill", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "killed");
+    assert!(!tmux_session_exists(&tmux_socket, &tmux_session));
+
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    state["sessions"][0]["provider_resume_id"] = json!("stock-thread-123");
+    fs::write(&state_file, state.to_string()).unwrap();
+
+    let (status, payload) =
+        post_json(app.clone(), "/sessions/runtimecodex/restore", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["provider"], "codex");
+    assert_eq!(payload["status"], "running");
+    assert!(tmux_session_exists(&tmux_socket, &tmux_session));
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/runtimecodex/input",
+        json!({
+            "text": "restored stock codex prompt",
+            "delivery_mode": "sequential"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["delivered"], true);
+    let output =
+        wait_for_output_contains(app, "runtimecodex", "argv:resume stock-thread-123").await;
+    assert!(output["output"]
+        .as_str()
+        .unwrap()
+        .contains("argv:resume stock-thread-123"));
+}
+
+#[tokio::test]
 async fn runtime_core_starts_review_on_existing_codex_session() {
     if !tmux_available() {
         return;


### PR DESCRIPTION
## Summary

- keep `sm codex`, `sm codex-2`, and `sm codex-fork` mapped to the Codex fork
- add `sm codex-original` with `codex-stock` as an alias for launching stock Codex
- cover both direct launch and `sm spawn` provider resolution

## Why

The fork is the intended default Codex provider, but there was no explicit CLI surface for launching the stock Codex provider after separating the two binaries.

## Impact

Existing Codex launch commands continue to use codex-fork. Stock Codex remains available through an explicit, unambiguous command.

## Validation

- `cargo test --manifest-path crates/sm-server/Cargo.toml --bin sm` (45 passed)
- `git diff --check origin/main...HEAD`