### PR TITLE
Add provider-native sm what and sm btw

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ If `target/release` is on your `PATH`, `sm` resolves to the Rust CLI.
 | `sm all` | List active sessions |
 | `sm spawn <provider> "<prompt>" --name <name>` | Start a new managed agent |
 | `sm send <id> "<text>"` | Send input to an agent |
+| `sm what <id> [prompt]` / `sm btw ...` | Ask an agent for a provider-native context summary |
 | `sm wait <id> <seconds>` | Wait for a session state transition |
 | `sm attach <id>` | Attach to the live tmux session |
 | `sm tail <id>` | Show recent output/tool activity |
@@ -251,9 +252,9 @@ sm send agent "message" --important  # Queue behind current work
 sm send agent "message" --urgent     # Interrupt immediately
 ```
 
-Retired surfaces are intentionally absent rather than half-supported. Use
-`sm tail --raw` or explicit `sm send` prompts instead of old summary helpers.
-Use `sm retire`, not legacy kill aliases.
+The old transcript summarizer and its `--lines`/`--deep` options remain retired.
+`sm what` now delegates to the target provider's native `/btw` command. Use
+`sm retire`, not legacy kill aliases.
 
 ---
 
@@ -453,7 +454,8 @@ cd android-app
 ## Operator Notes
 
 - Prefer `sm status`, `sm all`, `sm tail`, and the Android app for live state.
-- Prefer explicit `sm send` prompts over summary helpers.
+- Use `sm what <agent>` for a bounded context summary without disturbing the
+  target's main conversation.
 - Use `sm retire` for lifecycle stop; avoid legacy kill terminology.
 - Keep app updates and Cloudflare mobile device policy changes auditable through
   Session Manager commands.

--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -36,6 +36,8 @@ enum Command {
     Who(EmptyArgs),
     All(EmptyArgs),
     Send(SendArgs),
+    #[command(alias = "btw")]
+    What(WhatArgs),
     Wait(WaitArgs),
     Spawn(SpawnArgs),
     Fork(ForkArgs),
@@ -107,6 +109,12 @@ struct SendArgs {
     urgent: bool,
     #[arg(long, value_name = "SECONDS")]
     wait: Option<u64>,
+}
+
+#[derive(Args)]
+struct WhatArgs {
+    session_id: String,
+    prompt: Vec<String>,
 }
 
 #[derive(Args)]
@@ -677,6 +685,7 @@ fn run() -> Result<()> {
                 }
             }
         }
+        Command::What(args) => run_what(&client, args)?,
         Command::Output(args) => print_output(&client, &args.session_id, args.lines)?,
         Command::Tail(args) => print_tail(&client, &args.session_id, args.lines, args.raw)?,
         Command::Children(args) => {
@@ -2318,6 +2327,53 @@ fn resolve_send_target(client: &ApiClient, identifier: &str) -> Result<String> {
     }
 }
 
+fn run_what(client: &ApiClient, args: WhatArgs) -> Result<()> {
+    let target_id = lookup_identifier_exact(client, &args.session_id)?
+        .ok_or_else(|| anyhow!("No agent named '{}' is reachable.", args.session_id))?;
+    let requester_session_id = optional_current_session_id();
+    let managed_caller = requester_session_id.is_some();
+    let prompt = args.prompt.join(" ");
+    let response = client.post_json(
+        &format!("/sessions/{}/what", encode_path_segment(&target_id)),
+        json!({
+            "prompt": (!prompt.trim().is_empty()).then_some(prompt),
+            "requester_session_id": requester_session_id,
+            "delivery_mode": if managed_caller { "session" } else { "poll" },
+        }),
+    )?;
+    let request_id = response["request_id"]
+        .as_str()
+        .ok_or_else(|| anyhow!("sm what response missing request_id"))?;
+    if managed_caller {
+        return Ok(());
+    }
+
+    let deadline = Instant::now() + Duration::from_secs(125);
+    loop {
+        let status = client.get_json(&format!(
+            "/btw-requests/{}",
+            encode_path_segment(request_id)
+        ))?;
+        match status["status"].as_str().unwrap_or("unknown") {
+            "completed" => {
+                println!("{}", status["result"].as_str().unwrap_or_default());
+                return Ok(());
+            }
+            "failed" | "timed_out" => {
+                bail!(
+                    "{}",
+                    status["error"].as_str().unwrap_or("sm what request failed")
+                );
+            }
+            _ => {}
+        }
+        if Instant::now() >= deadline {
+            bail!("sm what timed out waiting for request {request_id}");
+        }
+        thread::sleep(Duration::from_millis(250));
+    }
+}
+
 fn send_input_payload(text: String, delivery_mode: &str, wait: Option<u64>) -> Value {
     let mut payload = json!({
         "text": text,
@@ -3689,9 +3745,15 @@ fn home_dir() -> Option<PathBuf> {
 fn retire_removed_surface_if_requested() {
     let args = env::args().skip(1).collect::<Vec<_>>();
     let command = command_tokens_after_globals(&args);
-    let retired = match command.as_slice() {
+    if let Some(message) = retired_command_message(&command) {
+        eprintln!("{message}");
+        process::exit(2);
+    }
+}
+
+fn retired_command_message(command: &[&str]) -> Option<&'static str> {
+    match command {
         ["kill", ..] => Some("removed: use sm retire instead of sm kill"),
-        ["what", ..] => Some("removed: use sm tail --raw or sm send for explicit status"),
         ["dispatch", ..] => Some("removed: dispatch is not part of the Rust cutover scope"),
         ["remind", ..] => Some("removed: reminders are not part of the Rust cutover scope"),
         ["watch-job", ..] => Some("removed: watch-job is not part of the Rust cutover scope"),
@@ -3705,10 +3767,6 @@ fn retire_removed_surface_if_requested() {
             Some("removed: queue policy CI commands are not part of the Rust cutover scope")
         }
         _ => None,
-    };
-    if let Some(message) = retired {
-        eprintln!("{message}");
-        process::exit(2);
     }
 }
 
@@ -3824,6 +3882,21 @@ mod tests {
         };
         assert_eq!(raw_args.lines, 7);
         assert!(raw_args.raw);
+    }
+
+    #[test]
+    fn what_and_btw_parse_to_the_same_command() {
+        for command in ["what", "btw"] {
+            let cli =
+                Cli::try_parse_from(["sm", command, "worker", "Summarize", "current", "work"])
+                    .unwrap();
+            let Command::What(args) = cli.command else {
+                panic!("expected what command");
+            };
+            assert_eq!(args.session_id, "worker");
+            assert_eq!(args.prompt.join(" "), "Summarize current work");
+        }
+        assert_eq!(retired_command_message(&["what", "worker"]), None);
     }
 
     #[test]

--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -2938,7 +2938,20 @@ fn lookup_identifier_exact(client: &ApiClient, identifier: &str) -> Result<Optio
         return bail_ambiguous_lookup(identifier, &exact_matches);
     }
 
-    Ok(None)
+    let prefix_matches = sessions
+        .iter()
+        .filter(|session| {
+            session["id"]
+                .as_str()
+                .is_some_and(|session_id| session_id.starts_with(identifier))
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    match prefix_matches.len() {
+        1 => Ok(prefix_matches[0]["id"].as_str().map(ToOwned::to_owned)),
+        count if count > 1 => bail_ambiguous_lookup(identifier, &prefix_matches),
+        _ => Ok(None),
+    }
 }
 
 fn bail_ambiguous_lookup(identifier: &str, matches: &[Value]) -> Result<Option<String>> {
@@ -4183,6 +4196,36 @@ mod tests {
             server.join().unwrap(),
             vec!["/registry/rajesh", "/sessions/rajesh", "/sessions"]
         );
+    }
+
+    #[test]
+    fn lookup_identifier_exact_accepts_only_unique_session_id_prefixes() {
+        let (client, server) = start_lookup_server([
+            ("/registry/abc1", 404, r#"{"detail":"Role not found"}"#),
+            ("/sessions/abc1", 404, r#"{"detail":"Session not found"}"#),
+            (
+                "/sessions",
+                200,
+                r#"{"sessions":[{"id":"abc12345","friendly_name":"one","aliases":[]},{"id":"def12345","friendly_name":"two","aliases":[]}]}"#,
+            ),
+        ]);
+        assert_eq!(
+            lookup_identifier_exact(&client, "abc1").unwrap().as_deref(),
+            Some("abc12345")
+        );
+        server.join().unwrap();
+
+        let (client, server) = start_lookup_server([
+            ("/registry/abc", 404, r#"{"detail":"Role not found"}"#),
+            ("/sessions/abc", 404, r#"{"detail":"Session not found"}"#),
+            (
+                "/sessions",
+                200,
+                r#"{"sessions":[{"id":"abc12345","friendly_name":"one","aliases":[]},{"id":"abc99999","friendly_name":"two","aliases":[]}]}"#,
+            ),
+        ]);
+        assert!(lookup_identifier_exact(&client, "abc").is_err());
+        server.join().unwrap();
     }
 
     #[test]

--- a/crates/sm-server/src/btw.rs
+++ b/crates/sm-server/src/btw.rs
@@ -255,6 +255,22 @@ impl BtwStore {
         })
     }
 
+    pub fn mark_response_undeliverable(&self, request_id: &str) -> Result<()> {
+        self.with_connection(|conn| {
+            conn.execute(
+                r#"
+                UPDATE btw_requests
+                SET response_undeliverable_at = ?2
+                WHERE request_id = ?1
+                  AND response_delivered_at IS NULL
+                  AND response_undeliverable_at IS NULL
+                "#,
+                params![request_id, now_rfc3339()],
+            )?;
+            Ok(())
+        })
+    }
+
     pub fn fail_for_session(&self, session_id: &str, error: &str) -> Result<Vec<BtwRequestRecord>> {
         let error = bound_utf8(error.trim(), MAX_BTW_RESULT_BYTES);
         let mut conn = self.open()?;
@@ -592,6 +608,16 @@ mod tests {
             )
             .unwrap();
         store.complete(&session.request_id, "done").unwrap();
+        let undeliverable = store
+            .create(
+                Some("retired-requester"),
+                "target-undeliverable",
+                "codex-fork",
+                "session",
+                "summary",
+            )
+            .unwrap();
+        store.complete(&undeliverable.request_id, "done").unwrap();
         let poll = store
             .create(None, "target-poll", "codex-fork", "poll", "summary")
             .unwrap();
@@ -608,10 +634,14 @@ mod tests {
             std::collections::BTreeSet::from([
                 active.request_id.clone(),
                 session.request_id.clone(),
+                undeliverable.request_id.clone(),
             ])
         );
 
         store.mark_response_delivered(&session.request_id).unwrap();
+        store
+            .mark_response_undeliverable(&undeliverable.request_id)
+            .unwrap();
         let recoverable = store.list_recoverable().unwrap();
         assert_eq!(recoverable.len(), 1);
         assert_eq!(recoverable[0].request_id, active.request_id);

--- a/crates/sm-server/src/btw.rs
+++ b/crates/sm-server/src/btw.rs
@@ -388,9 +388,7 @@ pub fn codex_btw_event(line: &str, request_id: &str) -> Option<Result<String, St
 
 pub fn extract_stock_codex_answer(snapshot: &str, prompt: &str) -> Option<String> {
     let lines = snapshot.lines().map(str::trim).collect::<Vec<_>>();
-    let prompt_index = lines
-        .iter()
-        .rposition(|line| *line == prompt || line.ends_with(prompt))?;
+    let prompt_index = stock_codex_prompt_end(&lines, prompt)?;
     let mut answer = Vec::new();
     for line in lines.into_iter().skip(prompt_index + 1) {
         if line.contains("Side from main thread")
@@ -414,6 +412,41 @@ pub fn extract_stock_codex_answer(snapshot: &str, prompt: &str) -> Option<String
     }
     let answer = answer.join("\n").trim().to_owned();
     (!answer.is_empty()).then_some(answer)
+}
+
+fn stock_codex_prompt_end(lines: &[&str], prompt: &str) -> Option<usize> {
+    if let Some(index) = lines
+        .iter()
+        .rposition(|line| *line == prompt || line.ends_with(prompt))
+    {
+        return Some(index);
+    }
+    let prompt = prompt.split_whitespace().collect::<Vec<_>>().join(" ");
+    for start in (0..lines.len()).rev() {
+        let mut candidate = String::new();
+        for (index, line) in lines.iter().enumerate().skip(start) {
+            let part = line
+                .trim_matches(|ch: char| matches!(ch, '│' | '╭' | '╮' | '╰' | '╯' | '─'))
+                .trim()
+                .trim_start_matches(['›', '>'])
+                .trim();
+            if part.is_empty() {
+                continue;
+            }
+            if !candidate.is_empty() {
+                candidate.push(' ');
+            }
+            candidate.push_str(part);
+            let normalized = candidate.split_whitespace().collect::<Vec<_>>().join(" ");
+            if normalized == prompt {
+                return Some(index);
+            }
+            if !prompt.starts_with(&normalized) {
+                break;
+            }
+        }
+    }
+    None
 }
 
 fn init_schema(conn: &Connection) -> Result<()> {
@@ -643,6 +676,23 @@ Side from main thread · Ctrl+C to return\n";
         assert_eq!(
             extract_stock_codex_answer(snapshot, "Summarize now").as_deref(),
             Some("The implementation is complete.\nTests are passing.")
+        );
+    }
+
+    #[test]
+    fn extracts_stock_codex_answer_after_wrapped_prompt() {
+        let snapshot = "\
+› Summarize the implementation and\n\
+  current verification status\n\
+The implementation is complete.\n\
+Side from main thread · Ctrl+C to return\n";
+        assert_eq!(
+            extract_stock_codex_answer(
+                snapshot,
+                "Summarize the implementation and current verification status",
+            )
+            .as_deref(),
+            Some("The implementation is complete.")
         );
     }
 }

--- a/crates/sm-server/src/btw.rs
+++ b/crates/sm-server/src/btw.rs
@@ -1,0 +1,648 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use rand_core::{OsRng, RngCore};
+use rusqlite::{params, Connection, OptionalExtension, TransactionBehavior};
+use serde::Serialize;
+use serde_json::Value;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+pub const DEFAULT_BTW_PROMPT: &str = "Summarize what you've done so far";
+pub const MAX_BTW_PROMPT_BYTES: usize = 4 * 1024;
+pub const MAX_BTW_RESULT_BYTES: usize = 32 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct BtwRequestRecord {
+    pub request_id: String,
+    pub requester_session_id: Option<String>,
+    pub target_session_id: String,
+    pub target_provider: String,
+    pub delivery_mode: String,
+    pub prompt: String,
+    pub status: String,
+    pub provider_correlation: Option<String>,
+    pub created_at: String,
+    pub started_at: Option<String>,
+    pub finished_at: Option<String>,
+    pub result: Option<String>,
+    pub error: Option<String>,
+    pub response_delivered_at: Option<String>,
+    pub response_undeliverable_at: Option<String>,
+}
+
+#[derive(Debug)]
+pub enum CreateBtwRequestError {
+    Active(String),
+    Other(anyhow::Error),
+}
+
+impl From<anyhow::Error> for CreateBtwRequestError {
+    fn from(error: anyhow::Error) -> Self {
+        Self::Other(error)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct BtwStore {
+    db_path: PathBuf,
+}
+
+impl BtwStore {
+    pub fn new(db_path: PathBuf) -> Result<Self> {
+        let store = Self { db_path };
+        let _ = store.open()?;
+        Ok(store)
+    }
+
+    pub fn create(
+        &self,
+        requester_session_id: Option<&str>,
+        target_session_id: &str,
+        target_provider: &str,
+        delivery_mode: &str,
+        prompt: &str,
+    ) -> std::result::Result<BtwRequestRecord, CreateBtwRequestError> {
+        let mut conn = self.open().map_err(CreateBtwRequestError::Other)?;
+        let transaction = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(anyhow::Error::from)
+            .map_err(CreateBtwRequestError::Other)?;
+        let active = transaction
+            .query_row(
+                r#"
+                SELECT request_id
+                FROM btw_requests
+                WHERE target_session_id = ?1
+                  AND status IN ('pending', 'running')
+                ORDER BY created_at ASC
+                LIMIT 1
+                "#,
+                [target_session_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()
+            .map_err(anyhow::Error::from)
+            .map_err(CreateBtwRequestError::Other)?;
+        if let Some(request_id) = active {
+            return Err(CreateBtwRequestError::Active(request_id));
+        }
+
+        let request_id = new_request_id();
+        let created_at = now_rfc3339();
+        transaction
+            .execute(
+                r#"
+                INSERT INTO btw_requests (
+                    request_id,
+                    requester_session_id,
+                    target_session_id,
+                    target_provider,
+                    delivery_mode,
+                    prompt,
+                    status,
+                    created_at
+                )
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'pending', ?7)
+                "#,
+                params![
+                    request_id,
+                    requester_session_id,
+                    target_session_id,
+                    target_provider,
+                    delivery_mode,
+                    prompt,
+                    created_at,
+                ],
+            )
+            .map_err(anyhow::Error::from)
+            .map_err(CreateBtwRequestError::Other)?;
+        transaction
+            .commit()
+            .map_err(anyhow::Error::from)
+            .map_err(CreateBtwRequestError::Other)?;
+        self.get(&request_id)
+            .map_err(CreateBtwRequestError::Other)?
+            .ok_or_else(|| {
+                CreateBtwRequestError::Other(anyhow::anyhow!("created btw request disappeared"))
+            })
+    }
+
+    pub fn get(&self, request_id: &str) -> Result<Option<BtwRequestRecord>> {
+        self.with_connection(|conn| {
+            conn.query_row(
+                r#"
+                SELECT
+                    request_id,
+                    requester_session_id,
+                    target_session_id,
+                    target_provider,
+                    delivery_mode,
+                    prompt,
+                    status,
+                    provider_correlation,
+                    created_at,
+                    started_at,
+                    finished_at,
+                    result,
+                    error,
+                    response_delivered_at,
+                    response_undeliverable_at
+                FROM btw_requests
+                WHERE request_id = ?1
+                "#,
+                [request_id],
+                record_from_row,
+            )
+            .optional()
+            .map_err(anyhow::Error::from)
+        })
+    }
+
+    pub fn list_recoverable(&self) -> Result<Vec<BtwRequestRecord>> {
+        self.with_connection(|conn| {
+            let mut statement = conn.prepare(
+                r#"
+                SELECT
+                    request_id,
+                    requester_session_id,
+                    target_session_id,
+                    target_provider,
+                    delivery_mode,
+                    prompt,
+                    status,
+                    provider_correlation,
+                    created_at,
+                    started_at,
+                    finished_at,
+                    result,
+                    error,
+                    response_delivered_at,
+                    response_undeliverable_at
+                FROM btw_requests
+                WHERE status IN ('pending', 'running')
+                   OR (
+                       delivery_mode = 'session'
+                       AND response_delivered_at IS NULL
+                       AND response_undeliverable_at IS NULL
+                       AND status IN ('completed', 'failed', 'timed_out')
+                   )
+                ORDER BY created_at ASC
+                "#,
+            )?;
+            let records = statement
+                .query_map([], record_from_row)?
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            Ok(records)
+        })
+    }
+
+    pub fn mark_running(&self, request_id: &str, provider_correlation: Option<&str>) -> Result<()> {
+        self.with_connection(|conn| {
+            conn.execute(
+                r#"
+                UPDATE btw_requests
+                SET status = 'running',
+                    provider_correlation = ?2,
+                    started_at = ?3
+                WHERE request_id = ?1 AND status = 'pending'
+                "#,
+                params![request_id, provider_correlation, now_rfc3339()],
+            )?;
+            Ok(())
+        })
+    }
+
+    pub fn set_provider_correlation(&self, request_id: &str, correlation: &str) -> Result<()> {
+        self.with_connection(|conn| {
+            conn.execute(
+                r#"
+                UPDATE btw_requests
+                SET provider_correlation = ?2
+                WHERE request_id = ?1 AND status = 'running'
+                "#,
+                params![request_id, correlation],
+            )?;
+            Ok(())
+        })
+    }
+
+    pub fn complete(&self, request_id: &str, result: &str) -> Result<()> {
+        let result = bound_utf8(result.trim(), MAX_BTW_RESULT_BYTES);
+        self.finish(request_id, "completed", Some(&result), None)
+    }
+
+    pub fn fail(&self, request_id: &str, error: &str) -> Result<()> {
+        let error = bound_utf8(error.trim(), MAX_BTW_RESULT_BYTES);
+        self.finish(request_id, "failed", None, Some(&error))
+    }
+
+    pub fn time_out(&self, request_id: &str, error: &str) -> Result<()> {
+        let error = bound_utf8(error.trim(), MAX_BTW_RESULT_BYTES);
+        self.finish(request_id, "timed_out", None, Some(&error))
+    }
+
+    pub fn mark_response_delivered(&self, request_id: &str) -> Result<()> {
+        self.with_connection(|conn| {
+            conn.execute(
+                r#"
+                UPDATE btw_requests
+                SET response_delivered_at = ?2
+                WHERE request_id = ?1 AND response_delivered_at IS NULL
+                "#,
+                params![request_id, now_rfc3339()],
+            )?;
+            Ok(())
+        })
+    }
+
+    pub fn fail_for_session(&self, session_id: &str, error: &str) -> Result<Vec<BtwRequestRecord>> {
+        let error = bound_utf8(error.trim(), MAX_BTW_RESULT_BYTES);
+        let mut conn = self.open()?;
+        let transaction = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let request_ids = {
+            let mut statement = transaction.prepare(
+                r#"
+                SELECT request_id
+                FROM btw_requests
+                WHERE status IN ('pending', 'running')
+                  AND (
+                      target_session_id = ?1
+                      OR requester_session_id = ?1
+                  )
+                ORDER BY created_at ASC
+                "#,
+            )?;
+            let request_ids = statement
+                .query_map([session_id], |row| row.get::<_, String>(0))?
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            request_ids
+        };
+        let now = now_rfc3339();
+        transaction.execute(
+            r#"
+            UPDATE btw_requests
+            SET status = 'failed',
+                result = NULL,
+                error = ?2,
+                finished_at = ?3,
+                response_undeliverable_at = CASE
+                    WHEN requester_session_id = ?1 THEN ?3
+                    ELSE response_undeliverable_at
+                END
+            WHERE status IN ('pending', 'running')
+              AND (
+                  target_session_id = ?1
+                  OR requester_session_id = ?1
+              )
+            "#,
+            params![session_id, error, now],
+        )?;
+        transaction.commit()?;
+        request_ids
+            .into_iter()
+            .filter_map(|request_id| self.get(&request_id).transpose())
+            .collect()
+    }
+
+    fn finish(
+        &self,
+        request_id: &str,
+        status: &str,
+        result: Option<&str>,
+        error: Option<&str>,
+    ) -> Result<()> {
+        self.with_connection(|conn| {
+            conn.execute(
+                r#"
+                UPDATE btw_requests
+                SET status = ?2,
+                    result = ?3,
+                    error = ?4,
+                    finished_at = ?5
+                WHERE request_id = ?1 AND status IN ('pending', 'running')
+                "#,
+                params![request_id, status, result, error, now_rfc3339()],
+            )?;
+            Ok(())
+        })
+    }
+
+    fn open(&self) -> Result<Connection> {
+        if let Some(parent) = self.db_path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("failed to create {}", parent.display()))?;
+        }
+        let conn = Connection::open(&self.db_path)
+            .with_context(|| format!("failed to open {}", self.db_path.display()))?;
+        conn.busy_timeout(std::time::Duration::from_secs(5))?;
+        init_schema(&conn)?;
+        Ok(conn)
+    }
+
+    fn with_connection<T>(&self, f: impl FnOnce(&Connection) -> Result<T>) -> Result<T> {
+        let conn = self.open()?;
+        f(&conn)
+    }
+}
+
+pub fn validate_prompt(prompt: Option<&str>) -> Result<String> {
+    let prompt = prompt.unwrap_or(DEFAULT_BTW_PROMPT).trim();
+    let prompt = if prompt.is_empty() {
+        DEFAULT_BTW_PROMPT
+    } else {
+        prompt
+    };
+    if prompt.len() > MAX_BTW_PROMPT_BYTES {
+        anyhow::bail!("prompt exceeds {MAX_BTW_PROMPT_BYTES} UTF-8 bytes");
+    }
+    if prompt
+        .chars()
+        .any(|ch| ch == '\n' || ch == '\r' || ch == '\0' || ch.is_control())
+    {
+        anyhow::bail!("prompt must be a single line without control characters");
+    }
+    Ok(prompt.to_owned())
+}
+
+pub fn codex_btw_event(line: &str, request_id: &str) -> Option<Result<String, String>> {
+    let event: Value = serde_json::from_str(line.trim()).ok()?;
+    let event_type = event.get("event_type")?.as_str()?;
+    let payload = event.get("payload")?.as_object()?;
+    if payload.get("request_id")?.as_str()? != request_id {
+        return None;
+    }
+    match event_type {
+        "btw_completed" => Some(Ok(payload
+            .get("result")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_owned())),
+        "btw_failed" => Some(Err(payload
+            .get("error")
+            .and_then(Value::as_str)
+            .unwrap_or("provider_failed")
+            .to_owned())),
+        _ => None,
+    }
+}
+
+pub fn extract_stock_codex_answer(snapshot: &str, prompt: &str) -> Option<String> {
+    let lines = snapshot.lines().map(str::trim).collect::<Vec<_>>();
+    let prompt_index = lines
+        .iter()
+        .rposition(|line| *line == prompt || line.ends_with(prompt))?;
+    let mut answer = Vec::new();
+    for line in lines.into_iter().skip(prompt_index + 1) {
+        if line.contains("Side from main thread")
+            || line.contains("Ctrl+C to return")
+            || line.starts_with("tokens used")
+            || line.starts_with("context left")
+        {
+            continue;
+        }
+        let cleaned = line
+            .trim_matches(|ch: char| matches!(ch, '│' | '╭' | '╮' | '╰' | '╯' | '─'))
+            .trim();
+        if cleaned.is_empty()
+            || cleaned.starts_with('›')
+            || cleaned.starts_with('>')
+            || cleaned.starts_with("esc ")
+        {
+            continue;
+        }
+        answer.push(cleaned);
+    }
+    let answer = answer.join("\n").trim().to_owned();
+    (!answer.is_empty()).then_some(answer)
+}
+
+fn init_schema(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        r#"
+        CREATE TABLE IF NOT EXISTS btw_requests (
+            request_id TEXT PRIMARY KEY,
+            requester_session_id TEXT,
+            target_session_id TEXT NOT NULL,
+            target_provider TEXT NOT NULL,
+            delivery_mode TEXT NOT NULL,
+            prompt TEXT NOT NULL,
+            status TEXT NOT NULL,
+            provider_correlation TEXT,
+            created_at TEXT NOT NULL,
+            started_at TEXT,
+            finished_at TEXT,
+            result TEXT,
+            error TEXT,
+            response_delivered_at TEXT,
+            response_undeliverable_at TEXT
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_btw_one_active_per_target
+            ON btw_requests(target_session_id)
+            WHERE status IN ('pending', 'running');
+        CREATE INDEX IF NOT EXISTS idx_btw_created_at
+            ON btw_requests(created_at);
+        "#,
+    )?;
+    ensure_column(conn, "btw_requests", "response_undeliverable_at", "TEXT")?;
+    Ok(())
+}
+
+fn ensure_column(conn: &Connection, table: &str, column: &str, definition: &str) -> Result<()> {
+    let mut statement = conn.prepare(&format!("PRAGMA table_info({table})"))?;
+    let exists = statement
+        .query_map([], |row| row.get::<_, String>(1))?
+        .filter_map(std::result::Result::ok)
+        .any(|name| name == column);
+    if !exists {
+        conn.execute_batch(&format!(
+            "ALTER TABLE {table} ADD COLUMN {column} {definition}"
+        ))?;
+    }
+    Ok(())
+}
+
+fn record_from_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<BtwRequestRecord> {
+    Ok(BtwRequestRecord {
+        request_id: row.get(0)?,
+        requester_session_id: row.get(1)?,
+        target_session_id: row.get(2)?,
+        target_provider: row.get(3)?,
+        delivery_mode: row.get(4)?,
+        prompt: row.get(5)?,
+        status: row.get(6)?,
+        provider_correlation: row.get(7)?,
+        created_at: row.get(8)?,
+        started_at: row.get(9)?,
+        finished_at: row.get(10)?,
+        result: row.get(11)?,
+        error: row.get(12)?,
+        response_delivered_at: row.get(13)?,
+        response_undeliverable_at: row.get(14)?,
+    })
+}
+
+fn new_request_id() -> String {
+    let mut bytes = [0u8; 16];
+    OsRng.fill_bytes(&mut bytes);
+    let mut value = String::with_capacity(36);
+    value.push_str("btw-");
+    for byte in bytes {
+        use std::fmt::Write as _;
+        let _ = write!(value, "{byte:02x}");
+    }
+    value
+}
+
+fn now_rfc3339() -> String {
+    OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned())
+}
+
+fn bound_utf8(value: &str, max_bytes: usize) -> String {
+    if value.len() <= max_bytes {
+        return value.to_owned();
+    }
+    let mut end = max_bytes;
+    while !value.is_char_boundary(end) {
+        end -= 1;
+    }
+    value[..end].to_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_store() -> (BtwStore, PathBuf) {
+        let path = std::env::temp_dir().join(format!("sm-btw-test-{}.db", new_request_id()));
+        (BtwStore::new(path.clone()).unwrap(), path)
+    }
+
+    #[test]
+    fn prompt_validation_applies_default_and_rejects_multiline() {
+        assert_eq!(validate_prompt(None).unwrap(), DEFAULT_BTW_PROMPT);
+        assert!(validate_prompt(Some("one\ntwo")).is_err());
+        assert!(validate_prompt(Some(&"x".repeat(MAX_BTW_PROMPT_BYTES + 1))).is_err());
+    }
+
+    #[test]
+    fn store_enforces_one_active_request_per_target() {
+        let (store, path) = test_store();
+        let first = store
+            .create(None, "target-1", "codex-fork", "poll", "summary")
+            .unwrap();
+        assert!(matches!(
+            store.create(None, "target-1", "codex-fork", "poll", "again"),
+            Err(CreateBtwRequestError::Active(request_id)) if request_id == first.request_id
+        ));
+        store.complete(&first.request_id, "done").unwrap();
+        assert!(store
+            .create(None, "target-1", "codex-fork", "poll", "again")
+            .is_ok());
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn recovery_includes_active_and_undelivered_session_requests() {
+        let (store, path) = test_store();
+        let active = store
+            .create(None, "target-active", "codex-fork", "poll", "summary")
+            .unwrap();
+        let session = store
+            .create(
+                Some("requester"),
+                "target-session",
+                "codex-fork",
+                "session",
+                "summary",
+            )
+            .unwrap();
+        store.complete(&session.request_id, "done").unwrap();
+        let poll = store
+            .create(None, "target-poll", "codex-fork", "poll", "summary")
+            .unwrap();
+        store.complete(&poll.request_id, "done").unwrap();
+
+        let recoverable = store
+            .list_recoverable()
+            .unwrap()
+            .into_iter()
+            .map(|request| request.request_id)
+            .collect::<std::collections::BTreeSet<_>>();
+        assert_eq!(
+            recoverable,
+            std::collections::BTreeSet::from([
+                active.request_id.clone(),
+                session.request_id.clone(),
+            ])
+        );
+
+        store.mark_response_delivered(&session.request_id).unwrap();
+        let recoverable = store.list_recoverable().unwrap();
+        assert_eq!(recoverable.len(), 1);
+        assert_eq!(recoverable[0].request_id, active.request_id);
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn session_teardown_fails_related_requests_and_suppresses_retired_requester_delivery() {
+        let (store, path) = test_store();
+        let requested = store
+            .create(
+                Some("retired"),
+                "target-a",
+                "codex-fork",
+                "session",
+                "summary",
+            )
+            .unwrap();
+        let targeted = store
+            .create(
+                Some("requester-b"),
+                "retired",
+                "codex-fork",
+                "session",
+                "summary",
+            )
+            .unwrap();
+
+        let affected = store
+            .fail_for_session("retired", "session retired")
+            .unwrap();
+        assert_eq!(affected.len(), 2);
+        let requested = store.get(&requested.request_id).unwrap().unwrap();
+        assert_eq!(requested.status, "failed");
+        assert!(requested.response_undeliverable_at.is_some());
+        let targeted = store.get(&targeted.request_id).unwrap().unwrap();
+        assert_eq!(targeted.status, "failed");
+        assert!(targeted.response_undeliverable_at.is_none());
+        assert!(store.list_recoverable().unwrap().contains(&targeted));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn parses_only_correlated_codex_events() {
+        let completed =
+            r#"{"event_type":"btw_completed","payload":{"request_id":"req-1","result":"done"}}"#;
+        assert_eq!(
+            codex_btw_event(completed, "req-1"),
+            Some(Ok("done".to_owned()))
+        );
+        assert_eq!(codex_btw_event(completed, "req-2"), None);
+    }
+
+    #[test]
+    fn extracts_stock_codex_answer_without_side_chrome() {
+        let snapshot = "\
+Question\n\
+Summarize now\n\
+The implementation is complete.\n\
+Tests are passing.\n\
+Side from main thread · Ctrl+C to return\n";
+        assert_eq!(
+            extract_stock_codex_answer(snapshot, "Summarize now").as_deref(),
+            Some("The implementation is complete.\nTests are passing.")
+        );
+    }
+}

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -6186,10 +6186,6 @@ fn run_claude_btw(
     target: &SessionRecord,
     prompt: &str,
 ) -> anyhow::Result<String> {
-    let _copy_guard = BTW_NATIVE_COPY_LOCK
-        .get_or_init(|| Mutex::new(()))
-        .lock()
-        .map_err(|_| anyhow::anyhow!("native copy lock poisoned"))?;
     let initial = runtime
         .capture_pane_tail(&target.tmux_session, 80)
         .ok_or_else(|| anyhow::anyhow!("unable to inspect Claude pane"))?;
@@ -6203,18 +6199,27 @@ fn run_claude_btw(
         anyhow::bail!("Claude is not ready for a native /btw command");
     }
 
-    let before = runtime
-        .list_buffer_ids()?
-        .into_iter()
-        .collect::<BTreeSet<_>>();
     let command = format!("/btw {prompt}");
     if !runtime.send_input(&target.tmux_session, &command)? {
         anyhow::bail!("target tmux session is not running");
     }
-    capture_claude_btw_result(runtime, target, &before)
+    capture_claude_btw_result(runtime, target)
 }
 
 fn recover_claude_btw(runtime: &TmuxRuntime, target: &SessionRecord) -> anyhow::Result<String> {
+    capture_claude_btw_result(runtime, target)
+}
+
+fn capture_claude_btw_result(
+    runtime: &TmuxRuntime,
+    target: &SessionRecord,
+) -> anyhow::Result<String> {
+    wait_for_pane(
+        runtime,
+        &target.tmux_session,
+        BTW_PROVIDER_TIMEOUT,
+        |pane| pane.contains("c to copy") && pane.contains("Esc to close"),
+    )?;
     let _copy_guard = BTW_NATIVE_COPY_LOCK
         .get_or_init(|| Mutex::new(()))
         .lock()
@@ -6223,20 +6228,6 @@ fn recover_claude_btw(runtime: &TmuxRuntime, target: &SessionRecord) -> anyhow::
         .list_buffer_ids()?
         .into_iter()
         .collect::<BTreeSet<_>>();
-    capture_claude_btw_result(runtime, target, &before)
-}
-
-fn capture_claude_btw_result(
-    runtime: &TmuxRuntime,
-    target: &SessionRecord,
-    before: &BTreeSet<String>,
-) -> anyhow::Result<String> {
-    wait_for_pane(
-        runtime,
-        &target.tmux_session,
-        BTW_PROVIDER_TIMEOUT,
-        |pane| pane.contains("c to copy") && pane.contains("Esc to close"),
-    )?;
     if !runtime.send_key_input(&target.tmux_session, "c")? {
         anyhow::bail!("target tmux session stopped before native copy");
     }

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -10,7 +10,7 @@ use std::{
     process::{Child, Command, Output, Stdio},
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc, Mutex,
+        Arc, Mutex, OnceLock,
     },
     thread,
     time::{Duration, Instant, UNIX_EPOCH},
@@ -74,6 +74,10 @@ use crate::app_artifacts::{
     hashed_path, meta_path, read_metadata, store_artifact, valid_app_name, valid_artifact_hash,
     APP_ARTIFACT_MAX_SIZE_BYTES,
 };
+use crate::btw::{
+    codex_btw_event, extract_stock_codex_answer, validate_prompt, BtwRequestRecord, BtwStore,
+    CreateBtwRequestError,
+};
 use crate::bug_reports::{BugReportStore, CreateBugReport};
 use crate::cloudflare_access::{
     classify_cloudflare_access_assertion_with_jwks, cloudflare_access_application_for_host,
@@ -102,22 +106,22 @@ use crate::mobile_devices::{self, mobile_device_db_path};
 use crate::queue::{
     CodexReviewRequestFilters, CodexReviewRequestRegistration, CompleteCodexReviewRequest,
     CreateCodexReviewRequest, CreateQueueJob, QueueAdmissionPolicy, QueueJobFilters,
-    QueueJobRecord, RetainedQueueStore, RetryCodexReviewRequest,
+    QueueJobRecord, QueueMessageMetadata, RetainedQueueStore, RetryCodexReviewRequest,
 };
 use crate::runtime::TmuxRuntime;
 use crate::sessions::{
     claude_hook_gate, codex_fork_status_for_event_line, expand_home, is_primary_node,
-    AgentRegistrationResponse, AgentStatusRequest, ArmStopNotifyOutcome, ArmStopNotifyRequest,
-    ChildSessionResponse, ClaudeHookGate, ClearSessionRequest, ClientSessionResponse,
-    ContextMonitorOutcome, ContextMonitorRequest, ContextSnapshotResponse, ContextUsageEvent,
-    ContextUsageOutcome, CoreClearOutcome, CoreInputBatchResponse, CoreInputBatchResult,
-    CoreRestoreOutcome, CoreRetireOutcome, CoreReviewOutcome, CreateCoreSessionRequest,
-    HandoffOutcome, HandoffRequest, MaintainerMutationOutcome, RegistryMutationOutcome,
-    RoleRegistrationRequest, SendCoreInputBatchRequest, SendCoreInputRequest,
-    SessionMetadataOutcome, SessionRecord, SessionResponse, SessionStore, SessionsEnvelope,
-    SetMaintainerRequest, SpawnReviewRequest, StartReviewRequest, SubagentStartOutcome,
-    SubagentStartRequest, SubagentStopOutcome, SubagentStopRequest, TaskCompleteOutcome,
-    TaskCompleteRequest, TurnCompleteOutcome, UpdateSessionMetadataRequest,
+    submit_codex_fork_btw, AgentRegistrationResponse, AgentStatusRequest, ArmStopNotifyOutcome,
+    ArmStopNotifyRequest, ChildSessionResponse, ClaudeHookGate, ClearSessionRequest,
+    ClientSessionResponse, ContextMonitorOutcome, ContextMonitorRequest, ContextSnapshotResponse,
+    ContextUsageEvent, ContextUsageOutcome, CoreClearOutcome, CoreInputBatchResponse,
+    CoreInputBatchResult, CoreRestoreOutcome, CoreRetireOutcome, CoreReviewOutcome,
+    CreateCoreSessionRequest, HandoffOutcome, HandoffRequest, MaintainerMutationOutcome,
+    RegistryMutationOutcome, RoleRegistrationRequest, SendCoreInputBatchRequest,
+    SendCoreInputRequest, SessionMetadataOutcome, SessionRecord, SessionResponse, SessionStore,
+    SessionsEnvelope, SetMaintainerRequest, SpawnReviewRequest, StartReviewRequest,
+    SubagentStartOutcome, SubagentStartRequest, SubagentStopOutcome, SubagentStopRequest,
+    TaskCompleteOutcome, TaskCompleteRequest, TurnCompleteOutcome, UpdateSessionMetadataRequest,
 };
 use crate::studio_ssh::{self, StudioSshStatus};
 use crate::tool_usage::{
@@ -150,6 +154,9 @@ const GOOGLE_ID_TOKEN_UNKNOWN_KID_REFRESH_INTERVAL: Duration = Duration::from_se
 const DEVICE_TOKEN_MAX_AGE_SECONDS: i64 = 60 * 60 * 24 * 14;
 const REVIEW_WAIT_IDLE_THRESHOLD: Duration = Duration::from_secs(1);
 const REVIEW_WAIT_POLL_INTERVAL: Duration = Duration::from_millis(250);
+const BTW_PROVIDER_TIMEOUT: Duration = Duration::from_secs(120);
+const BTW_PROVIDER_POLL: Duration = Duration::from_millis(250);
+static BTW_NATIVE_COPY_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
 
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
@@ -866,6 +873,7 @@ pub fn router(state: AppState) -> Router {
         .unwrap_or_else(|| DEFAULT_EMAIL_WEBHOOK_PATH.to_owned());
     let state = Arc::new(state);
     recover_codex_review_request_watchers(state.clone());
+    recover_btw_requests(state.clone());
     let mut app = Router::new()
         .route("/health", get(health))
         .route("/health/detailed", get(health_detailed))
@@ -920,6 +928,7 @@ pub fn router(state: AppState) -> Router {
             "/codex-review-requests/{request_id}",
             get(get_codex_review_request).delete(cancel_codex_review_request),
         )
+        .route("/btw-requests/{request_id}", get(get_btw_request))
         .route("/reviews/pr", post(start_pr_review))
         .route("/nodes", get(list_nodes))
         .route("/nodes/{node_id}/ping", post(ping_node))
@@ -978,6 +987,7 @@ pub fn router(state: AppState) -> Router {
             post(register_subagent_stop),
         )
         .route("/sessions/{session_id}/input", post(send_session_input))
+        .route("/sessions/{session_id}/what", post(create_btw_request))
         .route("/sessions/{session_id}/kill", post(retire_session))
         .route("/sessions/{session_id}/restore", post(restore_session))
         .route("/sessions/{session_id}/clear", post(clear_session))
@@ -5920,6 +5930,563 @@ async fn send_session_input(
     Ok(Json(serde_json::to_value(result)?))
 }
 
+async fn create_btw_request(
+    State(state): State<Arc<AppState>>,
+    Path(target_identifier): Path<String>,
+    ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
+    headers: HeaderMap,
+    Json(payload): Json<CreateBtwHttpRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    ensure_session_allowed_from_parts(
+        &state.config,
+        &headers,
+        Some(peer_addr),
+        &format!("/sessions/{target_identifier}/what"),
+    )?;
+    ensure_core_writes_enabled(&state)?;
+    let Some(target) = resolve_session_or_registry_role(&state, &target_identifier)? else {
+        return Err(ApiError::NotFound("Target session not found"));
+    };
+    ensure_btw_session_live(&target, "Target")?;
+    ensure_core_runtime_session_node_supported(&state, &target.id)?;
+
+    let requester = match payload
+        .requester_session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        Some(identifier) => {
+            let Some(session) = resolve_session_or_registry_role(&state, identifier)? else {
+                return Err(ApiError::NotFound("Requester session not found"));
+            };
+            ensure_btw_session_live(&session, "Requester")?;
+            Some(session)
+        }
+        None => None,
+    };
+    let delivery_mode = payload
+        .delivery_mode
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(if requester.is_some() {
+            "session"
+        } else {
+            "poll"
+        });
+    if !matches!(delivery_mode, "session" | "poll") {
+        return Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: "delivery_mode must be session or poll".to_owned(),
+        });
+    }
+    if delivery_mode == "session" && requester.is_none() {
+        return Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: "session delivery requires requester_session_id".to_owned(),
+        });
+    }
+    let prompt = validate_prompt(payload.prompt.as_deref()).map_err(|error| ApiError::Status {
+        status: StatusCode::BAD_REQUEST,
+        detail: error.to_string(),
+    })?;
+    let store = btw_store(&state)?;
+    let record = match store.create(
+        requester.as_ref().map(|session| session.id.as_str()),
+        &target.id,
+        &target.provider,
+        delivery_mode,
+        &prompt,
+    ) {
+        Ok(record) => record,
+        Err(CreateBtwRequestError::Active(request_id)) => {
+            return Err(ApiError::Status {
+                status: StatusCode::CONFLICT,
+                detail: format!("Target already has active sm what request {request_id}"),
+            });
+        }
+        Err(CreateBtwRequestError::Other(error)) => return Err(error.into()),
+    };
+
+    let worker_state = state.clone();
+    let worker_request_id = record.request_id.clone();
+    tokio::task::spawn_blocking(move || {
+        if let Err(error) = run_btw_request(&worker_state, &worker_request_id) {
+            eprintln!("sm what worker {worker_request_id} failed: {error:#}");
+        }
+    });
+
+    let mut accepted = serde_json::to_value(&record)?;
+    accepted["target_friendly_name"] = json!(target
+        .cached_display_name()
+        .unwrap_or_else(|| target.id.clone()));
+    Ok((StatusCode::ACCEPTED, Json(accepted)))
+}
+
+async fn get_btw_request(
+    State(state): State<Arc<AppState>>,
+    Path(request_id): Path<String>,
+    request: Request,
+) -> Result<Json<BtwRequestRecord>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    let Some(record) = btw_store(&state)?.get(&request_id)? else {
+        return Err(ApiError::NotFound("sm what request not found"));
+    };
+    Ok(Json(record))
+}
+
+fn recover_btw_requests(state: Arc<AppState>) {
+    if !btw_db_path(&state).exists() {
+        return;
+    }
+    let Ok(store) = btw_store(&state) else {
+        return;
+    };
+    let Ok(requests) = store.list_recoverable() else {
+        return;
+    };
+    for request in requests {
+        let worker_state = state.clone();
+        let worker_store = store.clone();
+        thread::spawn(move || {
+            if !matches!(request.status.as_str(), "pending" | "running") {
+                let _ = deliver_btw_response(&worker_state, &worker_store, &request.request_id);
+                return;
+            }
+            if request.target_provider == "codex-fork" {
+                let _ = run_btw_request(&worker_state, &request.request_id);
+                return;
+            }
+            if let Ok(Some(target)) = worker_state
+                .session_store
+                .get_session(&request.target_session_id)
+            {
+                let runtime = TmuxRuntime::from_app_config(&worker_state.config)
+                    .for_socket_name(target.tmux_socket_name.as_deref());
+                let pane = runtime
+                    .capture_pane_tail(&target.tmux_session, 200)
+                    .unwrap_or_default();
+                let recovered = match request.target_provider.as_str() {
+                    "claude" if pane.contains("c to copy") && pane.contains("Esc to close") => {
+                        recover_claude_btw(&runtime, &target).ok()
+                    }
+                    "codex"
+                        if pane.contains("Side from main thread")
+                            && pane.contains("Ctrl+C to return") =>
+                    {
+                        capture_stock_codex_btw_result(&runtime, &target, &request.prompt).ok()
+                    }
+                    _ => None,
+                };
+                if let Some(result) = recovered {
+                    let _ = finish_btw_request(
+                        &worker_state,
+                        &worker_store,
+                        &request.request_id,
+                        Ok(result),
+                    );
+                    return;
+                }
+                let cleanup_key = if request.target_provider == "claude" {
+                    "Escape"
+                } else {
+                    "C-c"
+                };
+                let _ = runtime.send_key_input(&target.tmux_session, cleanup_key);
+            }
+            let _ = worker_store.fail(&request.request_id, "session manager restarted during /btw");
+            let _ = deliver_btw_response(&worker_state, &worker_store, &request.request_id);
+        });
+    }
+}
+
+fn run_btw_request(state: &AppState, request_id: &str) -> anyhow::Result<()> {
+    let store = btw_store(state)?;
+    let Some(request) = store.get(request_id)? else {
+        anyhow::bail!("sm what request {request_id} not found");
+    };
+    store.mark_running(request_id, None)?;
+    let outcome = (|| {
+        let target = state
+            .session_store
+            .get_session(&request.target_session_id)?
+            .ok_or_else(|| anyhow::anyhow!("target session no longer exists"))?;
+        let runtime = TmuxRuntime::from_app_config(&state.config)
+            .for_socket_name(target.tmux_socket_name.as_deref());
+        if matches!(target.provider.as_str(), "claude" | "codex") {
+            store.set_provider_correlation(request_id, &format!("tmux:{}", target.tmux_session))?;
+        }
+
+        match target.provider.as_str() {
+            "claude" => run_claude_btw(&runtime, &target, &request.prompt),
+            "codex" => run_stock_codex_btw(&runtime, &target, &request.prompt),
+            "codex-fork" => {
+                run_codex_fork_btw(&store, &runtime, &target, request_id, &request.prompt)
+            }
+            provider => Err(anyhow::anyhow!(
+                "provider {provider} does not support native /btw"
+            )),
+        }
+    })();
+
+    finish_btw_request(state, &store, request_id, outcome)
+}
+
+fn finish_btw_request(
+    state: &AppState,
+    store: &BtwStore,
+    request_id: &str,
+    outcome: anyhow::Result<String>,
+) -> anyhow::Result<()> {
+    match &outcome {
+        Ok(result) if !result.trim().is_empty() => store.complete(request_id, result)?,
+        Ok(_) => store.fail(request_id, "provider returned an empty summary")?,
+        Err(error) if error.to_string().contains("timed out") => {
+            store.time_out(request_id, &error.to_string())?
+        }
+        Err(error) => store.fail(request_id, &error.to_string())?,
+    }
+    deliver_btw_response(state, &store, request_id)?;
+    Ok(())
+}
+
+fn run_codex_fork_btw(
+    store: &BtwStore,
+    runtime: &TmuxRuntime,
+    target: &SessionRecord,
+    request_id: &str,
+    prompt: &str,
+) -> anyhow::Result<String> {
+    let event_stream_path = submit_codex_fork_btw(target, request_id, prompt, runtime)?;
+    store.set_provider_correlation(request_id, &event_stream_path.display().to_string())?;
+    let deadline = Instant::now() + BTW_PROVIDER_TIMEOUT;
+    let mut offset = 0u64;
+    let mut partial = String::new();
+    loop {
+        if let Ok(chunk) = read_btw_file_from_offset(&event_stream_path, &mut offset) {
+            partial.push_str(&chunk);
+            while let Some(newline) = partial.find('\n') {
+                let line = partial[..newline].to_owned();
+                partial.drain(..=newline);
+                if let Some(outcome) = codex_btw_event(&line, request_id) {
+                    return outcome.map_err(anyhow::Error::msg);
+                }
+            }
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("provider timed out waiting for /btw result");
+        }
+        thread::sleep(BTW_PROVIDER_POLL);
+    }
+}
+
+fn run_claude_btw(
+    runtime: &TmuxRuntime,
+    target: &SessionRecord,
+    prompt: &str,
+) -> anyhow::Result<String> {
+    let _copy_guard = BTW_NATIVE_COPY_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .map_err(|_| anyhow::anyhow!("native copy lock poisoned"))?;
+    let initial = runtime
+        .capture_pane_tail(&target.tmux_session, 80)
+        .ok_or_else(|| anyhow::anyhow!("unable to inspect Claude pane"))?;
+    if initial.contains("c to copy") && initial.contains("Esc to close") {
+        anyhow::bail!("Claude is already displaying a /btw result");
+    }
+    if initial.contains("Do you trust the files")
+        || initial.contains("Allow this action")
+        || initial.contains("Waiting for approval")
+    {
+        anyhow::bail!("Claude is not ready for a native /btw command");
+    }
+
+    let before = runtime
+        .list_buffer_ids()?
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    let command = format!("/btw {prompt}");
+    if !runtime.send_input(&target.tmux_session, &command)? {
+        anyhow::bail!("target tmux session is not running");
+    }
+    capture_claude_btw_result(runtime, target, &before)
+}
+
+fn recover_claude_btw(runtime: &TmuxRuntime, target: &SessionRecord) -> anyhow::Result<String> {
+    let _copy_guard = BTW_NATIVE_COPY_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .map_err(|_| anyhow::anyhow!("native copy lock poisoned"))?;
+    let before = runtime
+        .list_buffer_ids()?
+        .into_iter()
+        .collect::<BTreeSet<_>>();
+    capture_claude_btw_result(runtime, target, &before)
+}
+
+fn capture_claude_btw_result(
+    runtime: &TmuxRuntime,
+    target: &SessionRecord,
+    before: &BTreeSet<String>,
+) -> anyhow::Result<String> {
+    wait_for_pane(
+        runtime,
+        &target.tmux_session,
+        BTW_PROVIDER_TIMEOUT,
+        |pane| pane.contains("c to copy") && pane.contains("Esc to close"),
+    )?;
+    if !runtime.send_key_input(&target.tmux_session, "c")? {
+        anyhow::bail!("target tmux session stopped before native copy");
+    }
+    let result = (|| {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let buffer_id = loop {
+            let after = runtime
+                .list_buffer_ids()?
+                .into_iter()
+                .filter(|buffer_id| !before.contains(buffer_id))
+                .collect::<Vec<_>>();
+            if after.len() == 1 {
+                break after[0].clone();
+            }
+            if after.len() > 1 {
+                anyhow::bail!("Claude native copy created multiple tmux buffers");
+            }
+            if Instant::now() >= deadline {
+                anyhow::bail!("Claude native copy did not create a tmux buffer");
+            }
+            thread::sleep(BTW_PROVIDER_POLL);
+        };
+        let answer = runtime.read_buffer(&buffer_id)?;
+        runtime.delete_buffer(&buffer_id)?;
+        Ok(answer)
+    })();
+    let _ = runtime.send_key_input(&target.tmux_session, "Escape");
+    if result.is_ok() {
+        wait_for_pane(
+            runtime,
+            &target.tmux_session,
+            Duration::from_secs(5),
+            |pane| !(pane.contains("c to copy") && pane.contains("Esc to close")),
+        )?;
+    }
+    result
+}
+
+fn run_stock_codex_btw(
+    runtime: &TmuxRuntime,
+    target: &SessionRecord,
+    prompt: &str,
+) -> anyhow::Result<String> {
+    let command = format!("/btw {prompt}");
+    if !runtime.send_input(&target.tmux_session, &command)? {
+        anyhow::bail!("target tmux session is not running");
+    }
+    capture_stock_codex_btw_result(runtime, target, prompt)
+}
+
+fn capture_stock_codex_btw_result(
+    runtime: &TmuxRuntime,
+    target: &SessionRecord,
+    prompt: &str,
+) -> anyhow::Result<String> {
+    let result = (|| {
+        let deadline = Instant::now() + BTW_PROVIDER_TIMEOUT;
+        let mut previous = String::new();
+        let mut stable_samples = 0usize;
+        loop {
+            let snapshot = runtime
+                .capture_pane_tail(&target.tmux_session, 200)
+                .ok_or_else(|| anyhow::anyhow!("unable to inspect Codex pane"))?;
+            let side_visible =
+                snapshot.contains("Side from main thread") && snapshot.contains("Ctrl+C to return");
+            let still_running = snapshot.contains("esc to interrupt");
+            if side_visible && !still_running && snapshot == previous {
+                stable_samples += 1;
+            } else {
+                stable_samples = 0;
+            }
+            if stable_samples >= 3 {
+                return extract_stock_codex_answer(&snapshot, prompt)
+                    .ok_or_else(|| anyhow::anyhow!("unable to isolate stock Codex /btw answer"));
+            }
+            previous = snapshot;
+            if Instant::now() >= deadline {
+                anyhow::bail!("provider timed out waiting for /btw result");
+            }
+            thread::sleep(Duration::from_millis(500));
+        }
+    })();
+    let _ = runtime.send_key_input(&target.tmux_session, "C-c");
+    if result.is_ok() {
+        wait_for_pane(
+            runtime,
+            &target.tmux_session,
+            Duration::from_secs(5),
+            |pane| !pane.contains("Side from main thread"),
+        )?;
+    }
+    result
+}
+
+fn wait_for_pane(
+    runtime: &TmuxRuntime,
+    tmux_session: &str,
+    timeout: Duration,
+    predicate: impl Fn(&str) -> bool,
+) -> anyhow::Result<String> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        if let Some(pane) = runtime.capture_pane_tail(tmux_session, 200) {
+            if predicate(&pane) {
+                return Ok(pane);
+            }
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("provider UI did not reach the expected /btw state");
+        }
+        thread::sleep(BTW_PROVIDER_POLL);
+    }
+}
+
+fn read_btw_file_from_offset(path: &StdPath, offset: &mut u64) -> anyhow::Result<String> {
+    let mut file = fs::File::open(path)?;
+    let len = file.metadata()?.len();
+    if *offset > len {
+        *offset = 0;
+    }
+    file.seek(SeekFrom::Start(*offset))?;
+    let mut chunk = String::new();
+    file.read_to_string(&mut chunk)?;
+    *offset = file.stream_position()?;
+    Ok(chunk)
+}
+
+fn deliver_btw_response(
+    state: &AppState,
+    store: &BtwStore,
+    request_id: &str,
+) -> anyhow::Result<()> {
+    let Some(request) = store.get(request_id)? else {
+        anyhow::bail!("sm what request {request_id} disappeared");
+    };
+    if request.delivery_mode != "session"
+        || request.response_delivered_at.is_some()
+        || request.response_undeliverable_at.is_some()
+    {
+        return Ok(());
+    }
+    let requester_session_id = request
+        .requester_session_id
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("session delivery missing requester"))?;
+    let target = state
+        .session_store
+        .get_session(&request.target_session_id)?;
+    let target_id = target
+        .as_ref()
+        .map(|session| session.id.as_str())
+        .unwrap_or(request.target_session_id.as_str());
+    let target_name = target
+        .as_ref()
+        .and_then(SessionRecord::cached_display_name)
+        .unwrap_or_else(|| target_id.to_owned());
+    let text = if request.status == "completed" {
+        format!(
+            "[Input from {target_name} ({}) via sm what] {}",
+            target_id,
+            request.result.as_deref().unwrap_or_default()
+        )
+    } else {
+        format!(
+            "[sm what for {target_name} ({}) failed] {}",
+            target_id,
+            request.error.as_deref().unwrap_or("unknown failure")
+        )
+    };
+    let requester = state.session_store.get_session(requester_session_id)?;
+    if requester
+        .as_ref()
+        .is_none_or(|session| ensure_btw_session_live(session, "Requester").is_err())
+    {
+        return Ok(());
+    }
+    let queue = RetainedQueueStore::new(btw_db_path(state));
+    queue.enqueue_message_once_with_metadata(
+        &format!("btw-response-{request_id}"),
+        requester_session_id,
+        &text,
+        "sequential",
+        QueueMessageMetadata {
+            message_category: Some("btw_response".to_owned()),
+            ..QueueMessageMetadata::default()
+        },
+    )?;
+    store.mark_response_delivered(request_id)?;
+    let runtime = TmuxRuntime::from_app_config(&state.config);
+    state
+        .session_store
+        .drain_runtime_pending_messages_for_session_category(
+            requester_session_id,
+            &runtime,
+            Some("btw_response"),
+        )?;
+    Ok(())
+}
+
+fn teardown_btw_requests_for_session(state: &AppState, session_id: &str) -> anyhow::Result<()> {
+    if !btw_db_path(state).exists() {
+        return Ok(());
+    }
+    let store = btw_store(state)?;
+    let requests =
+        store.fail_for_session(session_id, &format!("session {session_id} was torn down"))?;
+    for request in requests {
+        if let Some(target) = state
+            .session_store
+            .get_session(&request.target_session_id)?
+        {
+            let runtime = TmuxRuntime::from_app_config(&state.config)
+                .for_socket_name(target.tmux_socket_name.as_deref());
+            let cleanup_key = match target.provider.as_str() {
+                "claude" => Some("Escape"),
+                "codex" => Some("C-c"),
+                _ => None,
+            };
+            if let Some(cleanup_key) = cleanup_key {
+                let _ = runtime.send_key_input(&target.tmux_session, cleanup_key);
+            }
+        }
+        if request.requester_session_id.as_deref() != Some(session_id) {
+            let _ = deliver_btw_response(state, &store, &request.request_id);
+        }
+    }
+    Ok(())
+}
+
+fn ensure_btw_session_live(session: &SessionRecord, label: &str) -> Result<(), ApiError> {
+    if matches!(
+        session.status.trim().to_ascii_lowercase().as_str(),
+        "stopped" | "killed" | "completed" | "error"
+    ) {
+        return Err(ApiError::Status {
+            status: StatusCode::CONFLICT,
+            detail: format!("{label} session is not live"),
+        });
+    }
+    Ok(())
+}
+
+fn btw_store(state: &AppState) -> anyhow::Result<BtwStore> {
+    BtwStore::new(btw_db_path(state))
+}
+
+fn btw_db_path(state: &AppState) -> PathBuf {
+    expand_home(&state.config.sm_send.db_path)
+}
+
 async fn send_session_input_batch(
     State(state): State<Arc<AppState>>,
     ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
@@ -6213,6 +6780,17 @@ async fn retire_session(
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty());
+    let may_retire = state
+        .session_store
+        .get_session(&session_id)?
+        .is_some_and(|session| {
+            requester_session_id.is_none_or(|requester| {
+                requester.is_empty() || session.parent_session_id.as_deref() == Some(requester)
+            }) && (!state.config.rust_core.runtime_enabled || is_primary_node(&session.node))
+        });
+    if may_retire {
+        teardown_btw_requests_for_session(&state, &session_id)?;
+    }
     let outcome = if state.config.rust_core.runtime_enabled {
         let runtime = TmuxRuntime::from_app_config(&state.config);
         state.session_store.retire_core_session_with_runtime(
@@ -11052,6 +11630,16 @@ struct ListCodexReviewRequestsQuery {
     pr_number: Option<i64>,
     #[serde(default)]
     include_inactive: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct CreateBtwHttpRequest {
+    #[serde(default)]
+    prompt: Option<String>,
+    #[serde(default)]
+    requester_session_id: Option<String>,
+    #[serde(default)]
+    delivery_mode: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -6075,7 +6075,7 @@ fn recover_btw_requests(state: Arc<AppState>) {
                         if pane.contains("Side from main thread")
                             && pane.contains("Ctrl+C to return") =>
                     {
-                        capture_stock_codex_btw_result(&runtime, &target, &request.prompt).ok()
+                        recover_stock_codex_btw(&runtime, &target, &request.prompt).ok()
                     }
                     _ => None,
                 };
@@ -6186,6 +6186,7 @@ fn run_claude_btw(
     target: &SessionRecord,
     prompt: &str,
 ) -> anyhow::Result<String> {
+    let _input_guard = runtime.lock_session_input(&target.tmux_session)?;
     let initial = runtime
         .capture_pane_tail(&target.tmux_session, 80)
         .ok_or_else(|| anyhow::anyhow!("unable to inspect Claude pane"))?;
@@ -6200,13 +6201,14 @@ fn run_claude_btw(
     }
 
     let command = format!("/btw {prompt}");
-    if !runtime.send_input(&target.tmux_session, &command)? {
+    if !runtime.send_input_while_locked(&target.tmux_session, &command)? {
         anyhow::bail!("target tmux session is not running");
     }
     capture_claude_btw_result(runtime, target)
 }
 
 fn recover_claude_btw(runtime: &TmuxRuntime, target: &SessionRecord) -> anyhow::Result<String> {
+    let _input_guard = runtime.lock_session_input(&target.tmux_session)?;
     capture_claude_btw_result(runtime, target)
 }
 
@@ -6228,7 +6230,7 @@ fn capture_claude_btw_result(
         .list_buffer_ids()?
         .into_iter()
         .collect::<BTreeSet<_>>();
-    if !runtime.send_key_input(&target.tmux_session, "c")? {
+    if !runtime.send_key_input_while_locked(&target.tmux_session, "c")? {
         anyhow::bail!("target tmux session stopped before native copy");
     }
     let result = (|| {
@@ -6254,7 +6256,7 @@ fn capture_claude_btw_result(
         runtime.delete_buffer(&buffer_id)?;
         Ok(answer)
     })();
-    let _ = runtime.send_key_input(&target.tmux_session, "Escape");
+    let _ = runtime.send_key_input_while_locked(&target.tmux_session, "Escape");
     if result.is_ok() {
         wait_for_pane(
             runtime,
@@ -6271,8 +6273,9 @@ fn run_stock_codex_btw(
     target: &SessionRecord,
     prompt: &str,
 ) -> anyhow::Result<String> {
+    let _input_guard = runtime.lock_session_input(&target.tmux_session)?;
     let command = format!("/btw {prompt}");
-    if !runtime.send_input(&target.tmux_session, &command)? {
+    if !runtime.send_input_while_locked(&target.tmux_session, &command)? {
         anyhow::bail!("target tmux session is not running");
     }
     capture_stock_codex_btw_result(runtime, target, prompt)
@@ -6310,7 +6313,7 @@ fn capture_stock_codex_btw_result(
             thread::sleep(Duration::from_millis(500));
         }
     })();
-    let _ = runtime.send_key_input(&target.tmux_session, "C-c");
+    let _ = runtime.send_key_input_while_locked(&target.tmux_session, "C-c");
     if result.is_ok() {
         wait_for_pane(
             runtime,
@@ -6320,6 +6323,15 @@ fn capture_stock_codex_btw_result(
         )?;
     }
     result
+}
+
+fn recover_stock_codex_btw(
+    runtime: &TmuxRuntime,
+    target: &SessionRecord,
+    prompt: &str,
+) -> anyhow::Result<String> {
+    let _input_guard = runtime.lock_session_input(&target.tmux_session)?;
+    capture_stock_codex_btw_result(runtime, target, prompt)
 }
 
 fn wait_for_pane(
@@ -6402,6 +6414,7 @@ fn deliver_btw_response(
         .as_ref()
         .is_none_or(|session| ensure_btw_session_live(session, "Requester").is_err())
     {
+        store.mark_response_undeliverable(request_id)?;
         return Ok(());
     }
     let queue = RetainedQueueStore::new(btw_db_path(state));

--- a/crates/sm-server/src/lib.rs
+++ b/crates/sm-server/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app_artifacts;
+pub mod btw;
 pub mod bug_reports;
 pub mod cloudflare_access;
 pub mod codex_activity;

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -897,6 +897,47 @@ impl RetainedQueueStore {
         })
     }
 
+    pub fn enqueue_message_once_with_metadata(
+        &self,
+        id: &str,
+        target_session_id: &str,
+        text: &str,
+        delivery_mode: &str,
+        metadata: QueueMessageMetadata,
+    ) -> Result<()> {
+        self.with_connection(|conn| {
+            let message_category = metadata.message_category.clone();
+            let inserted = enqueue_message_with_id_and_metadata_conn(
+                conn,
+                id,
+                target_session_id,
+                text,
+                delivery_mode,
+                metadata,
+            )?;
+            if inserted {
+                return Ok(());
+            }
+            let existing_matches = conn.query_row(
+                r#"
+                SELECT COUNT(*)
+                FROM message_queue
+                WHERE id = ?1
+                  AND target_session_id = ?2
+                  AND text = ?3
+                  AND delivery_mode = ?4
+                  AND message_category IS ?5
+                "#,
+                params![id, target_session_id, text, delivery_mode, message_category,],
+                |row| row.get::<_, i64>(0),
+            )? > 0;
+            if !existing_matches {
+                anyhow::bail!("queue message id {id} already exists with different content");
+            }
+            Ok(())
+        })
+    }
+
     pub fn active_parent_wake_parent(&self, child_session_id: &str) -> Result<Option<String>> {
         self.with_connection(|conn| {
             conn.query_row(
@@ -1366,13 +1407,35 @@ fn enqueue_message_with_metadata_conn(
     metadata: QueueMessageMetadata,
 ) -> Result<String> {
     let id = generate_record_id("msg");
+    let inserted = enqueue_message_with_id_and_metadata_conn(
+        conn,
+        &id,
+        target_session_id,
+        text,
+        delivery_mode,
+        metadata,
+    )?;
+    if !inserted {
+        anyhow::bail!("generated duplicate queue message id {id}");
+    }
+    Ok(id)
+}
+
+fn enqueue_message_with_id_and_metadata_conn(
+    conn: &Connection,
+    id: &str,
+    target_session_id: &str,
+    text: &str,
+    delivery_mode: &str,
+    metadata: QueueMessageMetadata,
+) -> Result<bool> {
     let timeout_at = timeout_at_rfc3339(metadata.timeout_seconds)?;
     let response_relay_source = metadata
         .response_relay_source
         .or_else(|| metadata.from_sm_send.then(|| "sm-send".to_owned()));
-    conn.execute(
+    let inserted = conn.execute(
         r#"
-        INSERT INTO message_queue
+        INSERT OR IGNORE INTO message_queue
             (id, target_session_id, sender_session_id, sender_name, text,
              delivery_mode, from_sm_send, queued_at, timeout_at, notify_on_delivery,
              notify_after_seconds, notify_on_stop, remind_soft_threshold,
@@ -1402,7 +1465,7 @@ fn enqueue_message_with_metadata_conn(
             response_relay_source,
         ],
     )?;
-    Ok(id)
+    Ok(inserted > 0)
 }
 
 fn mark_delivered_conn(conn: &Connection, message_id: &str) -> Result<bool> {
@@ -3502,6 +3565,50 @@ mod tests {
             )
             .unwrap();
         assert_eq!(stop_notify, ("em002".to_owned(), "other-em".to_owned(), 0));
+    }
+
+    #[test]
+    fn explicit_queue_message_id_is_idempotent_and_rejects_conflicts() {
+        let db_path = unique_temp_path("queue-once");
+        let store = RetainedQueueStore::new(db_path);
+        let metadata = QueueMessageMetadata {
+            message_category: Some("btw_response".to_owned()),
+            ..QueueMessageMetadata::default()
+        };
+        store
+            .enqueue_message_once_with_metadata(
+                "btw-response-request-1",
+                "requester",
+                "summary",
+                "sequential",
+                metadata.clone(),
+            )
+            .unwrap();
+        store
+            .enqueue_message_once_with_metadata(
+                "btw-response-request-1",
+                "requester",
+                "summary",
+                "sequential",
+                metadata.clone(),
+            )
+            .unwrap();
+        assert!(store
+            .enqueue_message_once_with_metadata(
+                "btw-response-request-1",
+                "requester",
+                "different",
+                "sequential",
+                metadata,
+            )
+            .is_err());
+        assert_eq!(
+            store
+                .pending_messages_for_target_by_category("requester", "btw_response", 10)
+                .unwrap()
+                .len(),
+            1
+        );
     }
 
     #[test]

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -637,6 +637,54 @@ impl TmuxRuntime {
         ))
     }
 
+    pub fn send_key_input(&self, tmux_session: &str, key: &str) -> Result<bool> {
+        if !self.session_exists(tmux_session)? {
+            return Ok(false);
+        }
+        self.send_key(tmux_session, key)?;
+        Ok(true)
+    }
+
+    pub fn list_buffer_ids(&self) -> Result<Vec<String>> {
+        let output = self
+            .tmux_command(["list-buffers", "-F", "#{buffer_name}"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .with_context(|| "failed to list tmux buffers")?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if stderr.contains("no buffers") {
+                return Ok(Vec::new());
+            }
+            bail!("tmux list-buffers failed: {}", stderr.trim());
+        }
+        Ok(String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .map(ToOwned::to_owned)
+            .collect())
+    }
+
+    pub fn read_buffer(&self, buffer_id: &str) -> Result<String> {
+        let output = self
+            .tmux_command(["show-buffer", "-b", buffer_id])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .with_context(|| "failed to read tmux buffer")?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("tmux show-buffer failed: {}", stderr.trim());
+        }
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    }
+
+    pub fn delete_buffer(&self, buffer_id: &str) -> Result<()> {
+        self.run_tmux(["delete-buffer", "-b", buffer_id])
+    }
+
     fn capture_pane_last_line(&self, tmux_session: &str) -> Option<String> {
         let text = self.capture_pane_text(tmux_session)?;
         text.trim_end_matches('\n')

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -1,9 +1,11 @@
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::{
+    collections::HashMap,
     env, fs,
     path::{Path, PathBuf},
     process::{Command, Stdio},
+    sync::{Arc, Condvar, Mutex, OnceLock, Weak},
     thread,
     time::{Duration, Instant},
 };
@@ -18,6 +20,28 @@ const DEFAULT_SEND_KEYS_SETTLE_MAX_MS: f64 = 900.0;
 const DEFAULT_SEND_KEYS_SETTLE_PER_KI_MS: f64 = 60.0;
 const DEFAULT_SEND_KEYS_SETTLE_PER_EXTRA_LINE_MS: f64 = 15.0;
 const DEFAULT_SEND_KEYS_MAX_CHUNK_CHARS: usize = 4096;
+static SESSION_INPUT_LOCKS: OnceLock<Mutex<HashMap<String, Weak<SessionInputLock>>>> =
+    OnceLock::new();
+
+#[derive(Debug)]
+struct SessionInputLock {
+    held: Mutex<bool>,
+    available: Condvar,
+}
+
+#[derive(Debug)]
+pub struct SessionInputGuard {
+    lock: Arc<SessionInputLock>,
+}
+
+impl Drop for SessionInputGuard {
+    fn drop(&mut self) {
+        if let Ok(mut held) = self.lock.held.lock() {
+            *held = false;
+            self.lock.available.notify_one();
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct TmuxRuntime {
@@ -293,6 +317,11 @@ impl TmuxRuntime {
     }
 
     pub fn send_input(&self, tmux_session: &str, text: &str) -> Result<bool> {
+        let _guard = self.lock_session_input(tmux_session)?;
+        self.send_input_while_locked(tmux_session, text)
+    }
+
+    pub fn send_input_while_locked(&self, tmux_session: &str, text: &str) -> Result<bool> {
         if !self.session_exists(tmux_session)? {
             return Ok(false);
         }
@@ -301,6 +330,16 @@ impl TmuxRuntime {
     }
 
     pub fn send_urgent_input(
+        &self,
+        tmux_session: &str,
+        text: &str,
+        background_claude_task: bool,
+    ) -> Result<bool> {
+        let _guard = self.lock_session_input(tmux_session)?;
+        self.send_urgent_input_while_locked(tmux_session, text, background_claude_task)
+    }
+
+    fn send_urgent_input_while_locked(
         &self,
         tmux_session: &str,
         text: &str,
@@ -319,6 +358,43 @@ impl TmuxRuntime {
         Ok(true)
     }
 
+    pub fn lock_session_input(&self, tmux_session: &str) -> Result<SessionInputGuard> {
+        let key = format!(
+            "{}:{tmux_session}",
+            self.socket_name.as_deref().unwrap_or("default")
+        );
+        let lock = {
+            let mut locks = SESSION_INPUT_LOCKS
+                .get_or_init(|| Mutex::new(HashMap::new()))
+                .lock()
+                .map_err(|_| anyhow::anyhow!("session input lock registry poisoned"))?;
+            locks.retain(|_, lock| lock.strong_count() > 0);
+            if let Some(lock) = locks.get(&key).and_then(Weak::upgrade) {
+                lock
+            } else {
+                let lock = Arc::new(SessionInputLock {
+                    held: Mutex::new(false),
+                    available: Condvar::new(),
+                });
+                locks.insert(key, Arc::downgrade(&lock));
+                lock
+            }
+        };
+        let mut held = lock
+            .held
+            .lock()
+            .map_err(|_| anyhow::anyhow!("session input lock poisoned"))?;
+        while *held {
+            held = lock
+                .available
+                .wait(held)
+                .map_err(|_| anyhow::anyhow!("session input lock poisoned"))?;
+        }
+        *held = true;
+        drop(held);
+        Ok(SessionInputGuard { lock })
+    }
+
     pub fn send_review_sequence(
         &self,
         tmux_session: &str,
@@ -329,6 +405,7 @@ impl TmuxRuntime {
         branch_position: Option<usize>,
         timing: &CodexReviewConfig,
     ) -> Result<bool> {
+        let _guard = self.lock_session_input(tmux_session)?;
         if !self.session_exists(tmux_session)? {
             return Ok(false);
         }
@@ -379,6 +456,7 @@ impl TmuxRuntime {
     }
 
     pub fn send_steer_text(&self, tmux_session: &str, text: &str) -> Result<bool> {
+        let _guard = self.lock_session_input(tmux_session)?;
         if !self.session_exists(tmux_session)? {
             return Ok(false);
         }
@@ -395,6 +473,7 @@ impl TmuxRuntime {
         prompt: Option<&str>,
         wake_completed: bool,
     ) -> Result<bool> {
+        let _guard = self.lock_session_input(tmux_session)?;
         if !self.session_exists(tmux_session)? {
             return Ok(false);
         }
@@ -638,6 +717,11 @@ impl TmuxRuntime {
     }
 
     pub fn send_key_input(&self, tmux_session: &str, key: &str) -> Result<bool> {
+        let _guard = self.lock_session_input(tmux_session)?;
+        self.send_key_input_while_locked(tmux_session, key)
+    }
+
+    pub fn send_key_input_while_locked(&self, tmux_session: &str, key: &str) -> Result<bool> {
         if !self.session_exists(tmux_session)? {
             return Ok(false);
         }
@@ -1101,6 +1185,27 @@ mod tests {
     fn split_send_text_chunks_preserves_utf8_boundaries() {
         let chunks = split_send_text_chunks("åßçdé", 2);
         assert_eq!(chunks, vec!["åß", "çd", "é"]);
+    }
+
+    #[test]
+    fn session_input_lock_serializes_the_same_tmux_target() {
+        let runtime = TmuxRuntime::from_config(&RustCoreConfig::default());
+        let session = "lock-test".to_owned();
+        let guard = runtime.lock_session_input(&session).unwrap();
+        let (sender, receiver) = std::sync::mpsc::channel();
+        let contender_runtime = runtime.clone();
+        let contender_session = session.clone();
+        let contender = thread::spawn(move || {
+            let _guard = contender_runtime
+                .lock_session_input(&contender_session)
+                .unwrap();
+            sender.send(()).unwrap();
+        });
+
+        assert!(receiver.recv_timeout(Duration::from_millis(50)).is_err());
+        drop(guard);
+        receiver.recv_timeout(Duration::from_secs(1)).unwrap();
+        contender.join().unwrap();
     }
 
     #[test]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -4709,15 +4709,32 @@ pub fn submit_codex_fork_btw(
             artifacts.control_socket_path.display()
         );
     }
-    let request = json!({
-        "request_id": request_id,
-        "command": "submit_btw",
-        "prompt": prompt,
-    });
-    let response = codex_fork_control_roundtrip(&artifacts.control_socket_path, &request)
-        .with_context(|| "submit_btw control command failed")?;
-    ensure_codex_fork_response_ok(&response, "submit_btw control command failed")?;
+    codex_fork_submit_btw(&artifacts.control_socket_path, request_id, prompt)?;
     Ok(artifacts.event_stream_path)
+}
+
+fn codex_fork_submit_btw(control_socket_path: &Path, request_id: &str, prompt: &str) -> Result<()> {
+    let mut epoch = codex_fork_refresh_control_epoch(control_socket_path)?;
+    let mut response = codex_fork_send_control_command_payload_with_request_id(
+        control_socket_path,
+        request_id,
+        "submit_btw",
+        &epoch,
+        json!({ "prompt": prompt }),
+    )?;
+    if !codex_fork_response_ok(&response)
+        && codex_fork_error_code(&response).as_deref() == Some("stale_epoch")
+    {
+        epoch = codex_fork_refresh_control_epoch(control_socket_path)?;
+        response = codex_fork_send_control_command_payload_with_request_id(
+            control_socket_path,
+            request_id,
+            "submit_btw",
+            &epoch,
+            json!({ "prompt": prompt }),
+        )?;
+    }
+    ensure_codex_fork_response_ok(&response, "submit_btw control command failed")
 }
 
 fn codex_fork_set_thread_name(control_socket_path: &Path, friendly_name: &str) -> Result<()> {
@@ -4781,10 +4798,26 @@ fn codex_fork_send_control_command_payload(
     expected_epoch: &str,
     payload: Value,
 ) -> Result<Value> {
+    codex_fork_send_control_command_payload_with_request_id(
+        control_socket_path,
+        &codex_fork_control_request_id(),
+        command,
+        expected_epoch,
+        payload,
+    )
+}
+
+fn codex_fork_send_control_command_payload_with_request_id(
+    control_socket_path: &Path,
+    request_id: &str,
+    command: &str,
+    expected_epoch: &str,
+    payload: Value,
+) -> Result<Value> {
     let mut request = Map::new();
     request.insert(
         "request_id".to_owned(),
-        Value::String(codex_fork_control_request_id()),
+        Value::String(request_id.to_owned()),
     );
     request.insert(
         "expected_epoch".to_owned(),
@@ -7114,6 +7147,71 @@ mod tests {
         assert_eq!(session_id.len(), 8);
         assert!(session_id.chars().all(|ch| ch.is_ascii_hexdigit()));
         assert_eq!(session_id, session_id.to_ascii_lowercase());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn codex_fork_btw_retries_stale_epoch_with_the_same_request_id() {
+        use std::os::unix::net::UnixListener;
+
+        let socket_path =
+            env::temp_dir().join(format!("sm-btw-{}.control.sock", generate_session_id()));
+        let listener = UnixListener::bind(&socket_path).unwrap();
+        let server = thread::spawn(move || {
+            let mut requests = Vec::new();
+            for index in 0..4 {
+                let (mut stream, _) = listener.accept().unwrap();
+                let mut raw_request = String::new();
+                BufReader::new(stream.try_clone().unwrap())
+                    .read_line(&mut raw_request)
+                    .unwrap();
+                let request: Value = serde_json::from_str(&raw_request).unwrap();
+                requests.push(request);
+                let response = match index {
+                    0 => json!({
+                        "ok": true,
+                        "epoch": "epoch-stale",
+                        "result": { "epoch": "epoch-stale" }
+                    }),
+                    1 => json!({
+                        "ok": false,
+                        "error": {
+                            "code": "stale_epoch",
+                            "message": "stale epoch"
+                        }
+                    }),
+                    2 => json!({
+                        "ok": true,
+                        "epoch": "epoch-fresh",
+                        "result": { "epoch": "epoch-fresh" }
+                    }),
+                    3 => json!({
+                        "ok": true,
+                        "epoch": "epoch-fresh",
+                        "result": {}
+                    }),
+                    _ => unreachable!(),
+                };
+                let mut raw_response = serde_json::to_string(&response).unwrap();
+                raw_response.push('\n');
+                stream.write_all(raw_response.as_bytes()).unwrap();
+            }
+            requests
+        });
+
+        codex_fork_submit_btw(&socket_path, "btw-request-1", "summarize").unwrap();
+        let requests = server.join().unwrap();
+        assert_eq!(requests[0]["command"], "get_epoch");
+        assert_eq!(requests[1]["command"], "submit_btw");
+        assert_eq!(requests[1]["request_id"], "btw-request-1");
+        assert_eq!(requests[1]["expected_epoch"], "epoch-stale");
+        assert_eq!(requests[1]["prompt"], "summarize");
+        assert_eq!(requests[2]["command"], "get_epoch");
+        assert_eq!(requests[3]["command"], "submit_btw");
+        assert_eq!(requests[3]["request_id"], "btw-request-1");
+        assert_eq!(requests[3]["expected_epoch"], "epoch-fresh");
+        assert_eq!(requests[3]["prompt"], "summarize");
+        let _ = fs::remove_file(socket_path);
     }
 
     fn session_record(status: &str) -> SessionRecord {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -4678,6 +4678,48 @@ fn codex_fork_submit_message(control_socket_path: &Path, text: &str) -> Result<(
     ensure_codex_fork_response_ok(&response, "control command failed")
 }
 
+pub fn submit_codex_fork_btw(
+    session: &SessionRecord,
+    request_id: &str,
+    prompt: &str,
+    runtime: &TmuxRuntime,
+) -> Result<PathBuf> {
+    if !session.provider.eq_ignore_ascii_case("codex-fork") {
+        anyhow::bail!("session {} is not a codex-fork session", session.id);
+    }
+    let spec = TmuxSessionSpec {
+        session_id: session.id.clone(),
+        tmux_session: session.tmux_session.clone(),
+        working_dir: session.working_dir.clone(),
+        log_file: session
+            .log_file
+            .as_deref()
+            .map(expand_home)
+            .ok_or_else(|| anyhow::anyhow!("session {} missing log_file", session.id))?,
+        provider: "codex-fork".to_owned(),
+        initial_message: None,
+        model: session.model.clone(),
+    };
+    let artifacts = runtime
+        .codex_fork_runtime_artifacts(&spec)?
+        .ok_or_else(|| anyhow::anyhow!("codex-fork runtime artifacts unavailable"))?;
+    if !artifacts.control_socket_path.exists() {
+        anyhow::bail!(
+            "control socket not found: {}",
+            artifacts.control_socket_path.display()
+        );
+    }
+    let request = json!({
+        "request_id": request_id,
+        "command": "submit_btw",
+        "prompt": prompt,
+    });
+    let response = codex_fork_control_roundtrip(&artifacts.control_socket_path, &request)
+        .with_context(|| "submit_btw control command failed")?;
+    ensure_codex_fork_response_ok(&response, "submit_btw control command failed")?;
+    Ok(artifacts.event_stream_path)
+}
+
 fn codex_fork_set_thread_name(control_socket_path: &Path, friendly_name: &str) -> Result<()> {
     if !control_socket_path.exists() {
         return Err(anyhow::anyhow!(

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -13,6 +13,7 @@ use rusqlite::{Connection, OptionalExtension};
 use serde_json::{json, Value};
 use sha1::{Digest, Sha1};
 use sha2::Sha256;
+use sm_server::btw::BtwStore;
 use sm_server::config::RustShadowConfig;
 use sm_server::queue::{QueueAdmissionPolicy, RetainedQueueStore};
 use sm_server::{
@@ -608,6 +609,81 @@ async fn detailed_health_has_required_top_level_fields() {
     assert!(payload["checks"].is_object());
     assert!(payload["resources"].is_object());
     assert!(payload["timestamp"].is_string());
+}
+
+#[tokio::test]
+async fn what_request_is_durably_accepted_and_pollable() {
+    let state_file = write_session_fixture();
+    let mut config = config_with_state_file_and_queue(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, accepted) = post_json(
+        app.clone(),
+        "/sessions/run12345/what",
+        json!({
+            "prompt": "Summarize current work",
+            "delivery_mode": "poll"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::ACCEPTED);
+    assert_eq!(accepted["target_session_id"], "run12345");
+    assert_eq!(accepted["target_provider"], "claude");
+    assert_eq!(accepted["target_friendly_name"], "Runner Native");
+    assert_eq!(accepted["delivery_mode"], "poll");
+    let request_id = accepted["request_id"].as_str().unwrap();
+
+    let (status, record) = get_json(app, &format!("/btw-requests/{request_id}")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(record["request_id"], request_id);
+}
+
+#[tokio::test]
+async fn what_request_rejects_unsafe_prompt_and_stopped_target() {
+    let state_file = write_session_fixture();
+    let mut config = config_with_state_file_and_queue(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/run12345/what",
+        json!({ "prompt": "one\ntwo", "delivery_mode": "poll" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(payload["detail"].as_str().unwrap().contains("single line"));
+
+    let (status, payload) = post_json(
+        app,
+        "/sessions/stop1234/what",
+        json!({ "delivery_mode": "poll" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert_eq!(payload["detail"], "Target session is not live");
+}
+
+#[tokio::test]
+async fn session_teardown_fails_requested_what_and_marks_response_undeliverable() {
+    let state_file = write_session_fixture();
+    let queue_db = queue_db_path_for_state_file(&state_file);
+    let mut config = config_with_state_file_and_queue(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+    let store = BtwStore::new(queue_db).unwrap();
+    let request = store
+        .create(Some("run12345"), "oldstate", "claude", "session", "summary")
+        .unwrap();
+
+    let (status, payload) = post_json(app, "/sessions/run12345/kill", json!({})).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "killed");
+    let request = store.get(&request.request_id).unwrap().unwrap();
+    assert_eq!(request.status, "failed");
+    assert!(request.response_undeliverable_at.is_some());
+    assert!(store.list_recoverable().unwrap().is_empty());
 }
 
 #[tokio::test]

--- a/docs/working/1143_sm_what_btw.md
+++ b/docs/working/1143_sm_what_btw.md
@@ -2,8 +2,7 @@
 
 ## Status
 
-Proposed. This is a specification-only change. Implementation must not begin until
-the owner approves this document.
+Implemented. The owner approved implementation after reviewing the specification PR.
 
 ## Problem
 
@@ -185,6 +184,7 @@ Required fields:
 | `created_at`, `started_at`, `finished_at` | Recovery and latency accounting |
 | `result` or `error` | Bounded terminal outcome |
 | `response_delivered_at` | One-shot requester relay guard |
+| `response_undeliverable_at` | Terminal marker when the requester is torn down |
 
 Lifecycle:
 


### PR DESCRIPTION
## Summary
- add durable `sm what <target> [prompt]` with `sm btw` alias and managed/poll delivery modes
- run exact provider-native `/btw` flows for Claude and stock Codex, plus direct `submit_btw` control for codex-fork
- add idempotent categorized response delivery, restart recovery, and session teardown handling
- document the restored command; native app action remains tracked in #1148

## Validation
- `cargo check -p sm-server --all-targets`
- `cargo test -p sm-server -- --skip runtime_core_restores_codex_session`
- live codex-fork poll delivery: stdout contained only `SM-WHAT-LIVE-OK`
- live codex-fork managed delivery: silent acceptance, exact requester injection, durable `btw_response` queue row, no response-relay metadata
- baseline note: `runtime_core_restores_codex_session` fails unchanged on `main` with HTTP 409 (`provider_resume_id` fixture discovery)

Closes #1143
Closes #1145
Closes #1146