### PR TITLE
Retire Python sm CLI entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dev = [
 
 [project.scripts]
 claude-session-manager = "src.main:run"
-sm = "src.cli.main:main"
+sm = "src.cli.launcher:main"
 sm-node-agent = "src.node_agent:main"
 
 [tool.setuptools.packages.find]

--- a/src/cli/launcher.py
+++ b/src/cli/launcher.py
@@ -1,0 +1,83 @@
+"""Compatibility launcher for the retired Python ``sm`` CLI."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Mapping, Optional, Sequence
+
+
+_RUST_CLI_ENV = "SM_RUST_CLI"
+
+
+def _resolved(path: Path) -> Path:
+    try:
+        return path.expanduser().resolve()
+    except OSError:
+        return path.expanduser().absolute()
+
+
+def _is_python_console_script(path: Path) -> bool:
+    try:
+        with path.open("rb") as candidate:
+            first_line = candidate.readline(256).lower()
+    except OSError:
+        return False
+    return first_line.startswith(b"#!") and b"python" in first_line
+
+
+def find_rust_sm(
+    *,
+    argv0: Optional[str] = None,
+    environ: Optional[Mapping[str, str]] = None,
+    repo_root: Optional[Path] = None,
+) -> Optional[Path]:
+    """Find an executable Rust ``sm`` without resolving back to this launcher."""
+    env = os.environ if environ is None else environ
+    current = _resolved(Path(argv0 or sys.argv[0]))
+    root = _resolved(repo_root or Path(__file__).parents[2])
+
+    candidates: list[Path] = []
+    if explicit := env.get(_RUST_CLI_ENV):
+        candidates.append(Path(explicit))
+    candidates.extend(
+        [
+            root / ".local/bin/sm",
+            root / "target/release/sm",
+            root / "target/debug/sm",
+        ]
+    )
+    for directory in env.get("PATH", "").split(os.pathsep):
+        if directory:
+            candidates.append(Path(directory) / "sm")
+
+    seen: set[Path] = set()
+    for candidate in candidates:
+        resolved = _resolved(candidate)
+        if resolved == current or resolved in seen:
+            continue
+        seen.add(resolved)
+        if (
+            resolved.is_file()
+            and os.access(resolved, os.X_OK)
+            and not _is_python_console_script(resolved)
+        ):
+            return resolved
+    return None
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    """Replace the Python console process with the Rust CLI."""
+    rust_sm = find_rust_sm()
+    if rust_sm is None:
+        print(
+            "Error: Rust sm CLI not found. Build it with "
+            "`cargo build --release -p sm-server --bin sm` or set SM_RUST_CLI.",
+            file=sys.stderr,
+        )
+        return 127
+
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    os.execv(str(rust_sm), [str(rust_sm), *arguments])
+    return 126

--- a/src/cli/launcher.py
+++ b/src/cli/launcher.py
@@ -21,10 +21,17 @@ def _resolved(path: Path) -> Path:
 def _is_python_console_script(path: Path) -> bool:
     try:
         with path.open("rb") as candidate:
-            first_line = candidate.readline(256).lower()
+            content = candidate.read(4096).lower()
     except OSError:
         return False
-    return first_line.startswith(b"#!") and b"python" in first_line
+    first_line = content.splitlines()[0] if content else b""
+    if first_line.startswith(b"#!") and b"python" in first_line:
+        return True
+    return (
+        first_line in {b"#!/bin/sh", b"#!/usr/bin/env sh"}
+        and b"exec" in content
+        and b"python" in content
+    )
 
 
 def find_rust_sm(
@@ -79,5 +86,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         return 127
 
     arguments = list(sys.argv[1:] if argv is None else argv)
-    os.execv(str(rust_sm), [str(rust_sm), *arguments])
+    try:
+        os.execv(str(rust_sm), [str(rust_sm), *arguments])
+    except OSError as error:
+        print(
+            f"Error: failed to execute Rust sm CLI at {rust_sm}: {error}",
+            file=sys.stderr,
+        )
     return 126

--- a/tests/unit/test_cli_launcher.py
+++ b/tests/unit/test_cli_launcher.py
@@ -1,0 +1,97 @@
+import os
+from pathlib import Path
+
+import pytest
+
+from src.cli import launcher
+
+
+def _executable(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/bin/sh\nexit 0\n")
+    path.chmod(0o755)
+    return path
+
+
+def _python_entry_point(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/usr/bin/env python3\nfrom src.cli.launcher import main\n")
+    path.chmod(0o755)
+    return path
+
+
+def test_find_rust_sm_skips_cached_python_entry_point(tmp_path):
+    cached_entry = _executable(tmp_path / "venv/bin/sm")
+    rust_cli = _executable(tmp_path / "target/release/sm")
+
+    found = launcher.find_rust_sm(
+        argv0=str(cached_entry),
+        environ={"PATH": str(cached_entry.parent)},
+        repo_root=tmp_path,
+    )
+
+    assert found == rust_cli.resolve()
+
+
+def test_find_rust_sm_uses_later_path_entry_after_cached_entry(tmp_path):
+    cached_entry = _executable(tmp_path / "venv/bin/sm")
+    rust_cli = _executable(tmp_path / "bin/sm")
+
+    found = launcher.find_rust_sm(
+        argv0=str(cached_entry),
+        environ={
+            "PATH": os.pathsep.join(
+                [str(cached_entry.parent), str(rust_cli.parent)]
+            )
+        },
+        repo_root=tmp_path / "missing-repo",
+    )
+
+    assert found == rust_cli.resolve()
+
+
+def test_find_rust_sm_skips_a_distinct_python_console_script(tmp_path):
+    cached_entry = _python_entry_point(tmp_path / "venv/bin/sm")
+    other_python_entry = _python_entry_point(tmp_path / "other-venv/bin/sm")
+    rust_cli = _executable(tmp_path / "bin/sm")
+
+    found = launcher.find_rust_sm(
+        argv0=str(cached_entry),
+        environ={
+            "PATH": os.pathsep.join(
+                [str(other_python_entry.parent), str(rust_cli.parent)]
+            )
+        },
+        repo_root=tmp_path / "missing-repo",
+    )
+
+    assert found == rust_cli.resolve()
+
+
+def test_main_execs_rust_cli_with_unchanged_arguments(monkeypatch, tmp_path):
+    rust_cli = _executable(tmp_path / "sm")
+    observed = {}
+
+    def fake_execv(path, argv):
+        observed["path"] = path
+        observed["argv"] = argv
+        raise RuntimeError("exec")
+
+    monkeypatch.setattr(launcher, "find_rust_sm", lambda: rust_cli)
+    monkeypatch.setattr(launcher.os, "execv", fake_execv)
+    monkeypatch.setattr(launcher.sys, "argv", ["/cached/venv/bin/sm", "btw", "abc123"])
+
+    with pytest.raises(RuntimeError, match="exec"):
+        launcher.main()
+
+    assert observed == {
+        "path": str(rust_cli),
+        "argv": [str(rust_cli), "btw", "abc123"],
+    }
+
+
+def test_main_fails_clearly_when_rust_cli_is_missing(monkeypatch, capsys):
+    monkeypatch.setattr(launcher, "find_rust_sm", lambda: None)
+
+    assert launcher.main([]) == 127
+    assert "Rust sm CLI not found" in capsys.readouterr().err

--- a/tests/unit/test_cli_launcher.py
+++ b/tests/unit/test_cli_launcher.py
@@ -20,6 +20,18 @@ def _python_entry_point(path: Path) -> Path:
     return path
 
 
+def _shell_wrapped_python_entry_point(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "#!/bin/sh\n"
+        "'''exec' \"/a long path/venv/bin/python3\" \"$0\" \"$@\"\n"
+        "' '''\n"
+        "from src.cli.launcher import main\n"
+    )
+    path.chmod(0o755)
+    return path
+
+
 def test_find_rust_sm_skips_cached_python_entry_point(tmp_path):
     cached_entry = _executable(tmp_path / "venv/bin/sm")
     rust_cli = _executable(tmp_path / "target/release/sm")
@@ -68,6 +80,24 @@ def test_find_rust_sm_skips_a_distinct_python_console_script(tmp_path):
     assert found == rust_cli.resolve()
 
 
+def test_find_rust_sm_skips_a_shell_wrapped_python_console_script(tmp_path):
+    cached_entry = _python_entry_point(tmp_path / "venv/bin/sm")
+    shell_wrapper = _shell_wrapped_python_entry_point(
+        tmp_path / "long path/venv/bin/sm"
+    )
+    rust_cli = _executable(tmp_path / "bin/sm")
+
+    found = launcher.find_rust_sm(
+        argv0=str(cached_entry),
+        environ={
+            "PATH": os.pathsep.join([str(shell_wrapper.parent), str(rust_cli.parent)])
+        },
+        repo_root=tmp_path / "missing-repo",
+    )
+
+    assert found == rust_cli.resolve()
+
+
 def test_main_execs_rust_cli_with_unchanged_arguments(monkeypatch, tmp_path):
     rust_cli = _executable(tmp_path / "sm")
     observed = {}
@@ -95,3 +125,18 @@ def test_main_fails_clearly_when_rust_cli_is_missing(monkeypatch, capsys):
 
     assert launcher.main([]) == 127
     assert "Rust sm CLI not found" in capsys.readouterr().err
+
+
+def test_main_reports_exec_failure_without_a_traceback(monkeypatch, tmp_path, capsys):
+    rust_cli = _executable(tmp_path / "sm")
+    monkeypatch.setattr(launcher, "find_rust_sm", lambda: rust_cli)
+    monkeypatch.setattr(
+        launcher.os,
+        "execv",
+        lambda _path, _argv: (_ for _ in ()).throw(OSError("bad architecture")),
+    )
+
+    assert launcher.main(["what", "abc123"]) == 126
+    error = capsys.readouterr().err
+    assert f"failed to execute Rust sm CLI at {rust_cli}" in error
+    assert "bad architecture" in error


### PR DESCRIPTION
Closes #1150

## Summary
- replace the packaged Python CLI entry point with a thin Rust `sm` launcher
- prefer explicit and repository-built Rust binaries, then search PATH
- skip the cached launcher itself and other Python console scripts
- preserve arguments, exit behavior, and signals through `execv`
- keep the legacy Python parser importable for its remaining migration tests

## Validation
- 210 launcher and legacy CLI tests passed
- real Python-process delegation exposes Rust `sm btw --help`
- Python bytecode compilation passed