### PR TITLE
Fix sm what main-thread summaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ sm send agent "message" --urgent     # Interrupt immediately
 
 The old transcript summarizer and its `--lines`/`--deep` options remain retired.
 `sm what` now delegates to the target provider's native `/btw` command. Use
+`sm what <agent>` to summarize the agent's main conversation thread; an optional
+prompt replaces that default. Use
 `sm retire`, not legacy kill aliases.
 
 ---

--- a/crates/sm-server/src/btw.rs
+++ b/crates/sm-server/src/btw.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use serde_json::Value;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
-pub const DEFAULT_BTW_PROMPT: &str = "Summarize what you've done so far";
+pub const DEFAULT_BTW_PROMPT: &str = "Summarize what you have done so far in the main conversation thread. Do not summarize this /btw side conversation.";
 pub const MAX_BTW_PROMPT_BYTES: usize = 4 * 1024;
 pub const MAX_BTW_RESULT_BYTES: usize = 32 * 1024;
 
@@ -571,6 +571,12 @@ mod tests {
     #[test]
     fn prompt_validation_applies_default_and_rejects_multiline() {
         assert_eq!(validate_prompt(None).unwrap(), DEFAULT_BTW_PROMPT);
+        assert!(DEFAULT_BTW_PROMPT.contains("main conversation thread"));
+        assert!(DEFAULT_BTW_PROMPT.contains("Do not summarize this /btw side conversation"));
+        assert_eq!(
+            validate_prompt(Some("Summarize the current blocker")).unwrap(),
+            "Summarize the current blocker"
+        );
         assert!(validate_prompt(Some("one\ntwo")).is_err());
         assert!(validate_prompt(Some(&"x".repeat(MAX_BTW_PROMPT_BYTES + 1))).is_err());
     }

--- a/docs/product/lessons.md
+++ b/docs/product/lessons.md
@@ -4,6 +4,7 @@ Durable lessons from maintainer sessions. Read this before handling the maintain
 
 ## Current Lessons
 
+- Provider-native `/btw` runs in an isolated side conversation. Default `sm what` prompts must explicitly ask for the main conversation thread and exclude the `/btw` side conversation, or the summary can truthfully but uselessly report that no work happened.
 - Cutover removal decisions must be revisited when live agent workflows prove a surface is still operationally required. Durable `sm remind --recurring` belongs in the Rust queue database and scheduler; launchd timers are not an acceptable substitute because they bypass session teardown, cancellation, restart recovery, and queue observability.
 - Claude Code UI forks can create a new Session Manager session ID while continuing in the same tmux runtime. When that happens, inherited recurring reminders need to be self-identifying so the active fork can cancel them directly.
 - The repo already supports generic file-driven service-role bootstrap via `service_roles.<role>.bootstrap_prompt_file` in `config.yaml`. Prefer that path over hard-coded prompt text when workflow instructions need to evolve.

--- a/docs/working/1143_sm_what_btw.md
+++ b/docs/working/1143_sm_what_btw.md
@@ -88,7 +88,7 @@ responses say `via sm what`.
 When `prompt` is omitted, use:
 
 ```text
-Summarize what you've done so far
+Summarize what you have done so far in the main conversation thread. Do not summarize this /btw side conversation.
 ```
 
 The provider receives a literal native command equivalent to:
@@ -343,7 +343,7 @@ Request:
 ```json
 {
   "requester_session_id": "<managed-session-id-or-null>",
-  "prompt": "Summarize what you've done so far"
+  "prompt": "Summarize what you have done so far in the main conversation thread. Do not summarize this /btw side conversation."
 }
 ```
 


### PR DESCRIPTION
## Summary

- make the default `sm what` / `sm btw` prompt explicitly summarize the main conversation thread
- tell the provider-native `/btw` worker not to summarize its isolated side conversation
- preserve explicit custom prompts and document the corrected default

Fixes #1168

## Verification

- `cargo test -p sm-server --lib` (268 passed)
- `cargo test -p sm-server --test read_only_http what_request_ -- --nocapture` (2 passed)
- `rustfmt --edition 2021 --check crates/sm-server/src/btw.rs`
- `git diff --check`

## Baseline failures

- `cargo fmt --all --check` fails on unchanged `crates/sm-server/src/main.rs:93`; tracked in #1169.
- Full `cargo test -p sm-server` reaches 502 passes but `runtime_core_restores_codex_session` fails with the existing 409-vs-200 issue tracked in #1165 and #1140.