### PR TITLE
Confirm codex-fork handoff prompt submission

### DIFF
--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -11,6 +11,7 @@ use std::{
 };
 
 use anyhow::{bail, Context, Result};
+use serde_json::Value;
 use sha2::{Digest, Sha256};
 
 use crate::config::{AppConfig, CodexReviewConfig, RustCoreConfig};
@@ -474,6 +475,33 @@ impl TmuxRuntime {
         prompt: Option<&str>,
         wake_completed: bool,
     ) -> Result<bool> {
+        self.clear_session_inner(tmux_session, clear_command, prompt, wake_completed, None)
+    }
+
+    pub fn clear_codex_session_confirming_prompt(
+        &self,
+        tmux_session: &str,
+        prompt: &str,
+        event_stream_path: &Path,
+        initial_event_offset: u64,
+    ) -> Result<bool> {
+        self.clear_session_inner(
+            tmux_session,
+            "/new",
+            Some(prompt),
+            false,
+            Some((event_stream_path, initial_event_offset)),
+        )
+    }
+
+    fn clear_session_inner(
+        &self,
+        tmux_session: &str,
+        clear_command: &str,
+        prompt: Option<&str>,
+        wake_completed: bool,
+        codex_prompt_confirmation: Option<(&Path, u64)>,
+    ) -> Result<bool> {
         let _guard = self.lock_session_input(tmux_session)?;
         if !self.session_exists(tmux_session)? {
             return Ok(false);
@@ -515,6 +543,26 @@ impl TmuxRuntime {
 
         if let Some(prompt) = prompt.map(str::trim).filter(|value| !value.is_empty()) {
             self.send_text_then_enter(tmux_session, prompt)?;
+            if let Some((event_stream_path, initial_event_offset)) = codex_prompt_confirmation {
+                let mut retry_at = Instant::now() + Duration::from_secs(2);
+                loop {
+                    if codex_event_stream_has_user_turn(
+                        event_stream_path,
+                        initial_event_offset,
+                        prompt,
+                    ) {
+                        break;
+                    }
+                    if !self.session_exists(tmux_session)? {
+                        return Ok(false);
+                    }
+                    if Instant::now() >= retry_at {
+                        self.send_key(tmux_session, "Enter")?;
+                        retry_at = Instant::now() + Duration::from_secs(2);
+                    }
+                    thread::sleep(Duration::from_millis(100));
+                }
+            }
         }
         Ok(true)
     }
@@ -999,6 +1047,42 @@ fn codex_composer_after_reset(pane: &str, cursor_y: usize, pre_reset_pane: Optio
             .lines()
             .nth(cursor_y)
             .is_some_and(|line| line.trim_start().starts_with('›'))
+}
+
+fn codex_event_stream_has_user_turn(path: &Path, initial_offset: u64, prompt: &str) -> bool {
+    let Ok(content) = fs::read(path) else {
+        return false;
+    };
+    let Ok(offset) = usize::try_from(initial_offset) else {
+        return false;
+    };
+    let Some(mut start) = (offset <= content.len()).then_some(offset) else {
+        return false;
+    };
+    if start > 0 && content.get(start - 1) != Some(&b'\n') {
+        let Some(relative_newline) = content[start..].iter().position(|byte| *byte == b'\n') else {
+            return false;
+        };
+        start += relative_newline + 1;
+    }
+    let Ok(content) = std::str::from_utf8(&content[start..]) else {
+        return false;
+    };
+    content.lines().any(|line| {
+        let Ok(event) = serde_json::from_str::<Value>(line) else {
+            return false;
+        };
+        event
+            .get("payload")
+            .and_then(|payload| payload.get("UserTurn"))
+            .and_then(|turn| turn.get("items"))
+            .and_then(Value::as_array)
+            .is_some_and(|items| {
+                items
+                    .iter()
+                    .any(|item| item.get("text").and_then(Value::as_str) == Some(prompt))
+            })
+    })
 }
 
 fn split_send_text_chunks(text: &str, max_chunk_chars: usize) -> Vec<&str> {
@@ -1576,6 +1660,40 @@ mod tests {
         assert!(codex_composer_after_reset(pane, 3, None));
         assert!(!codex_composer_after_reset(pane, 5, None));
         assert!(!codex_composer_after_reset(pane, 3, Some(pane)));
+    }
+
+    #[test]
+    fn codex_prompt_confirmation_requires_exact_user_turn_after_offset() {
+        let (_tmux_binary, _log_path, temp_dir) = fake_tmux_binary();
+        let events = temp_dir.join("events.jsonl");
+        let old = r#"{"event_type":"op_submitted","payload":{"UserTurn":{"items":[{"type":"text","text":"handoff prompt"}]}}}"#;
+        fs::write(&events, format!("{old}\n")).unwrap();
+        let offset = fs::metadata(&events).unwrap().len();
+        fs::write(
+            &events,
+            format!(
+                "{old}\n{}\n{}\n",
+                r#"{"event_type":"op_submitted","payload":{"ListSkills":{}}}"#,
+                r#"{"event_type":"op_submitted","payload":{"UserTurn":{"items":[{"type":"text","text":"handoff prompt"}]}}}"#
+            ),
+        )
+        .unwrap();
+
+        assert!(codex_event_stream_has_user_turn(
+            &events,
+            offset,
+            "handoff prompt"
+        ));
+        assert!(!codex_event_stream_has_user_turn(
+            &events,
+            offset,
+            "different prompt"
+        ));
+        assert!(codex_event_stream_has_user_turn(
+            &events,
+            offset - 3,
+            "handoff prompt"
+        ));
     }
 
     #[test]

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -3,6 +3,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::{
     collections::HashMap,
     env, fs,
+    io::{Read, Seek, SeekFrom},
     path::{Path, PathBuf},
     process::{Command, Stdio},
     sync::{Arc, Condvar, Mutex, OnceLock, Weak},
@@ -545,6 +546,7 @@ impl TmuxRuntime {
             self.send_text_then_enter(tmux_session, prompt)?;
             if let Some((event_stream_path, initial_event_offset)) = codex_prompt_confirmation {
                 let mut retry_at = Instant::now() + Duration::from_secs(2);
+                let confirmation_deadline = Instant::now() + Duration::from_secs(30);
                 loop {
                     if codex_event_stream_has_user_turn(
                         event_stream_path,
@@ -555,6 +557,12 @@ impl TmuxRuntime {
                     }
                     if !self.session_exists(tmux_session)? {
                         return Ok(false);
+                    }
+                    if Instant::now() >= confirmation_deadline {
+                        anyhow::bail!(
+                            "timed out confirming Codex handoff prompt in {}",
+                            event_stream_path.display()
+                        );
                     }
                     if Instant::now() >= retry_at {
                         self.send_key(tmux_session, "Enter")?;
@@ -1050,21 +1058,27 @@ fn codex_composer_after_reset(pane: &str, cursor_y: usize, pre_reset_pane: Optio
 }
 
 fn codex_event_stream_has_user_turn(path: &Path, initial_offset: u64, prompt: &str) -> bool {
-    let Ok(content) = fs::read(path) else {
+    let Ok(mut file) = fs::OpenOptions::new().read(true).open(path) else {
         return false;
     };
-    let Ok(offset) = usize::try_from(initial_offset) else {
+    let read_offset = initial_offset.saturating_sub(1);
+    if file.seek(SeekFrom::Start(read_offset)).is_err() {
         return false;
-    };
-    let Some(mut start) = (offset <= content.len()).then_some(offset) else {
+    }
+    let mut content = Vec::new();
+    if file.read_to_end(&mut content).is_err() {
         return false;
-    };
-    if start > 0 && content.get(start - 1) != Some(&b'\n') {
-        let Some(relative_newline) = content[start..].iter().position(|byte| *byte == b'\n') else {
+    }
+    let start = if initial_offset == 0 {
+        0
+    } else if content.first() == Some(&b'\n') {
+        1
+    } else {
+        let Some(relative_newline) = content.iter().position(|byte| *byte == b'\n') else {
             return false;
         };
-        start += relative_newline + 1;
-    }
+        relative_newline + 1
+    };
     let Ok(content) = std::str::from_utf8(&content[start..]) else {
         return false;
     };

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -2000,7 +2000,7 @@ impl SessionStore {
     }
 
     fn execute_pending_codex_fork_handoff(&self, session_id: &str) -> Result<bool> {
-        let (file_path, tmux_session, socket_name) = {
+        let (file_path, tmux_session, socket_name, event_stream_path, event_offset) = {
             let _guard = self.write_guard()?;
             let state = self.load_raw_json_value()?;
             let Some(session) = raw_session_object(&state, session_id) else {
@@ -2009,11 +2009,24 @@ impl SessionStore {
             let Some(file_path) = json_text(session.get("pending_handoff_path")) else {
                 return Ok(false);
             };
+            let runtime = self
+                .delivery_runtime
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("codex-fork handoff requires the tmux runtime"))?;
+            let spec = codex_fork_spec_for_session_raw(session_id, session)?;
+            let artifacts = runtime
+                .codex_fork_runtime_artifacts(&spec)?
+                .ok_or_else(|| anyhow::anyhow!("codex-fork runtime artifacts unavailable"))?;
+            let event_offset = fs::metadata(&artifacts.event_stream_path)
+                .map(|metadata| metadata.len())
+                .unwrap_or(0);
             (
                 file_path,
                 json_text(session.get("tmux_session"))
                     .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?,
                 json_text(session.get("tmux_socket_name")),
+                artifacts.event_stream_path,
+                event_offset,
             )
         };
 
@@ -2027,7 +2040,12 @@ impl SessionStore {
                 .ok_or_else(|| anyhow::anyhow!("codex-fork handoff requires the tmux runtime"))?
                 .for_socket_name(socket_name.as_deref());
             let prompt = format!("Read {file_path} and continue from where you left off.");
-            if !runtime.clear_session(&tmux_session, "/new", Some(&prompt), false)? {
+            if !runtime.clear_codex_session_confirming_prompt(
+                &tmux_session,
+                &prompt,
+                &event_stream_path,
+                event_offset,
+            )? {
                 anyhow::bail!("tmux session is not running");
             }
             Ok(())
@@ -8419,7 +8437,6 @@ mod tests {
             fs::write(&handoff_path, "durable handoff body").unwrap();
             let tmux_socket = format!("sm-handoff-{}-{}", std::process::id(), label);
             let tmux_session = "codex-fork-handoff".to_owned();
-            start_codex_fork_handoff_tmux(&tmux_socket, &tmux_session);
 
             fs::write(
                 &state_file,
@@ -8455,6 +8472,7 @@ mod tests {
                 .unwrap()
                 .event_stream_path;
             fs::write(&event_stream_path, "").unwrap();
+            start_codex_fork_handoff_tmux(&tmux_socket, &tmux_session, &event_stream_path);
             Some(Self {
                 state_file,
                 event_stream_path,
@@ -8528,7 +8546,11 @@ mod tests {
         }
 
         fn start_tmux(&self) {
-            start_codex_fork_handoff_tmux(&self.tmux_socket, &self.tmux_session);
+            start_codex_fork_handoff_tmux(
+                &self.tmux_socket,
+                &self.tmux_session,
+                &self.event_stream_path,
+            );
         }
 
         fn wait_for_handoff_error(&self, store: &SessionStore) {
@@ -8561,13 +8583,22 @@ mod tests {
         }
     }
 
-    fn start_codex_fork_handoff_tmux(socket: &str, session: &str) {
-        let command = r#"/bin/sh -lc 'printf "› "; while IFS= read -r line; do printf "received:%s\n› " "$line"; done' handoff-shell"#;
+    fn start_codex_fork_handoff_tmux(socket: &str, session: &str, event_stream_path: &Path) {
+        let script = r#"event_file=$1; pending=; printf '› '; while IFS= read -r line; do if [ -n "$pending" ]; then printf '{"event_type":"op_submitted","payload":{"UserTurn":{"items":[{"type":"text","text":"%s"}]}}}\n' "$pending" >> "$event_file"; pending=; printf '\n› '; elif [ "${line#Read }" != "$line" ]; then pending=$line; printf 'received:%s\n› %s' "$line" "$line"; else printf 'received:%s\n› ' "$line"; fi; done"#;
+        let command = format!(
+            "/bin/sh -lc {} handoff-shell {}",
+            shell_quote_handoff_fixture(script),
+            shell_quote_handoff_fixture(&event_stream_path.display().to_string())
+        );
         let status = Command::new("tmux")
-            .args(["-L", socket, "new-session", "-d", "-s", session, command])
+            .args(["-L", socket, "new-session", "-d", "-s", session, &command])
             .status()
             .unwrap();
         assert!(status.success());
+    }
+
+    fn shell_quote_handoff_fixture(value: &str) -> String {
+        format!("'{}'", value.replace('\'', "'\\''"))
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- keep the codex-fork tmux input lock until the exact post-handoff prompt appears as a `UserTurn` in the event stream
- retry Enter every two seconds when Codex accepts the pasted prompt during startup but ignores submission
- preserve pending handoff state until submission is confirmed

## Verification
- `cargo test -p sm-server codex_prompt_confirmation_requires_exact_user_turn -- --nocapture`
- `cargo test -p sm-server codex_fork_handoff_ -- --nocapture` (fixture deliberately ignores first Enter)
- `cargo test -p sm-server --lib` (275 passed)
- `cargo check -p sm-server`
- `git diff --check`

Fixes #1180