### PR TITLE
Phase 0: chain provider session identities

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -255,6 +255,9 @@ claude:
     - "--bypass-permissions"
   # Default model for spawned sessions (agent can override with --model flag)
   default_model: "sonnet"
+  # Optional Claude transcript project root; environment and default roots are
+  # also scanned for historical session chaining.
+  transcript_root: "~/.claude/projects"
 
 # Codex CLI + app-server settings
 codex:

--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -67,12 +67,14 @@ impl Default for AppConfig {
                 Vec::new(),
                 Some("sonnet".to_owned()),
                 None,
+                None,
             ),
             codex: ProviderLaunchConfig::new(
                 "codex".to_owned(),
                 Vec::new(),
                 None,
                 Some("~/.codex/session_index.jsonl".to_owned()),
+                None,
             ),
             codex_review: CodexReviewConfig::default(),
             codex_fork: CodexForkLaunchConfig::default(),
@@ -667,6 +669,7 @@ pub struct ProviderLaunchConfig {
     pub args: Vec<String>,
     pub default_model: Option<String>,
     pub session_index_path: Option<String>,
+    pub transcript_root: Option<String>,
 }
 
 impl ProviderLaunchConfig {
@@ -675,12 +678,14 @@ impl ProviderLaunchConfig {
         args: Vec<String>,
         default_model: Option<String>,
         session_index_path: Option<String>,
+        transcript_root: Option<String>,
     ) -> Self {
         Self {
             command,
             args,
             default_model,
             session_index_path,
+            transcript_root,
         }
     }
 }
@@ -691,6 +696,7 @@ impl Default for ProviderLaunchConfig {
             "claude".to_owned(),
             Vec::new(),
             Some("sonnet".to_owned()),
+            None,
             None,
         )
     }
@@ -1289,6 +1295,8 @@ struct RawProviderLaunchConfig {
     default_model: Option<String>,
     #[serde(default)]
     session_index_path: Option<String>,
+    #[serde(default)]
+    transcript_root: Option<String>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]
@@ -1372,6 +1380,9 @@ fn provider_launch_config(
             .as_ref()
             .and_then(|value| trimmed(&Some(value.clone())))
             .or_else(|| default_session_index_path.map(ToOwned::to_owned)),
+        raw.transcript_root
+            .as_ref()
+            .and_then(|value| trimmed(&Some(value.clone()))),
     )
 }
 
@@ -2283,6 +2294,23 @@ codex_fork:
         let config = AppConfig::from(raw);
 
         assert!(config.codex_fork.control_tmux_fallback_enabled);
+    }
+
+    #[test]
+    fn raw_config_reads_claude_transcript_root() {
+        let raw: RawConfig = serde_yaml::from_str(
+            r#"
+claude:
+  transcript_root: "/tmp/claude-projects"
+"#,
+        )
+        .unwrap();
+        let config = AppConfig::from(raw);
+
+        assert_eq!(
+            config.claude.transcript_root.as_deref(),
+            Some("/tmp/claude-projects")
+        );
     }
 
     #[test]

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -118,11 +118,12 @@ use crate::sessions::{
     ContextUsageEvent, ContextUsageOutcome, CoreClearOutcome, CoreInputBatchResponse,
     CoreInputBatchResult, CoreRestoreOutcome, CoreRetireOutcome, CoreReviewOutcome,
     CreateCoreSessionRequest, HandoffOutcome, HandoffRequest, MaintainerMutationOutcome,
-    RegistryMutationOutcome, RoleRegistrationRequest, SendCoreInputBatchRequest,
-    SendCoreInputRequest, SessionMetadataOutcome, SessionRecord, SessionResponse, SessionStore,
-    SessionsEnvelope, SetMaintainerRequest, SpawnReviewRequest, StartReviewRequest,
-    SubagentStartOutcome, SubagentStartRequest, SubagentStopOutcome, SubagentStopRequest,
-    TaskCompleteOutcome, TaskCompleteRequest, TurnCompleteOutcome, UpdateSessionMetadataRequest,
+    RegistryMutationOutcome, RoleRegistrationRequest, SeatSessionReconciliationSnapshot,
+    SendCoreInputBatchRequest, SendCoreInputRequest, SessionMetadataOutcome, SessionRecord,
+    SessionResponse, SessionStore, SessionsEnvelope, SetMaintainerRequest, SpawnReviewRequest,
+    StartReviewRequest, SubagentStartOutcome, SubagentStartRequest, SubagentStopOutcome,
+    SubagentStopRequest, TaskCompleteOutcome, TaskCompleteRequest, TurnCompleteOutcome,
+    UpdateSessionMetadataRequest,
 };
 
 use crate::studio_ssh::{self, StudioSshStatus};
@@ -424,6 +425,21 @@ impl AppState {
 
     pub fn reconcile_current_seat_sessions(&self) -> anyhow::Result<()> {
         self.session_store.reconcile_current_seat_sessions()
+    }
+
+    pub fn prepare_seat_session_reconciliation(
+        &self,
+        artifact_cutoff_ns: i128,
+    ) -> anyhow::Result<SeatSessionReconciliationSnapshot> {
+        self.session_store
+            .prepare_seat_session_reconciliation(artifact_cutoff_ns)
+    }
+
+    pub fn reconcile_seat_sessions(
+        &self,
+        snapshot: SeatSessionReconciliationSnapshot,
+    ) -> anyhow::Result<()> {
+        self.session_store.reconcile_seat_sessions(snapshot)
     }
 }
 

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -421,6 +421,10 @@ impl AppState {
     pub fn config(&self) -> &AppConfig {
         &self.config
     }
+
+    pub fn reconcile_current_seat_sessions(&self) -> anyhow::Result<()> {
+        self.session_store.reconcile_current_seat_sessions()
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -373,6 +373,7 @@ impl AppState {
         let queue_db_path = expand_home(&config.sm_send.db_path);
         let session_store = SessionStore::new_with_queue(state_file, queue_db_path)
             .with_codex_session_index_path(config.codex.session_index_path.as_deref())
+            .with_claude_transcript_root(config.claude.transcript_root.as_deref())
             .with_context_monitor_config(config.context_monitor.clone())
             .with_delivery_runtime(
                 config

--- a/crates/sm-server/src/lib.rs
+++ b/crates/sm-server/src/lib.rs
@@ -13,6 +13,7 @@ pub mod mobile_analytics;
 pub mod mobile_devices;
 pub mod queue;
 pub mod runtime;
+pub mod seat_sessions;
 pub mod sessions;
 pub mod studio_ssh;
 pub mod tool_usage;

--- a/crates/sm-server/src/main.rs
+++ b/crates/sm-server/src/main.rs
@@ -79,9 +79,12 @@ async fn main() -> Result<()> {
     }
 
     let state = AppState::new(config);
-    if let Err(error) = state.reconcile_current_seat_sessions() {
-        eprintln!("usage ledger session reconciliation failed: {error:#}");
-    }
+    let reconciliation_state = state.clone();
+    tokio::task::spawn_blocking(move || {
+        if let Err(error) = reconciliation_state.reconcile_current_seat_sessions() {
+            eprintln!("usage ledger session reconciliation failed: {error:#}");
+        }
+    });
 
     // Repair the Studio SSH LaunchAgents toward the desired state every 30s while
     // the toggle is on. launchctl is synchronous, so run it on a blocking thread.

--- a/crates/sm-server/src/main.rs
+++ b/crates/sm-server/src/main.rs
@@ -79,9 +79,16 @@ async fn main() -> Result<()> {
     }
 
     let state = AppState::new(config);
+    // Capture the artifact boundary before serving. The background scan may run
+    // alongside live creates, but it must not attribute their new artifacts
+    // against this startup snapshot of the seat registry.
+    let reconciliation_cutoff_ns = time::OffsetDateTime::now_utc().unix_timestamp_nanos();
+    let reconciliation_snapshot = state
+        .prepare_seat_session_reconciliation(reconciliation_cutoff_ns)
+        .context("failed to snapshot sessions for usage ledger reconciliation")?;
     let reconciliation_state = state.clone();
     tokio::task::spawn_blocking(move || {
-        if let Err(error) = reconciliation_state.reconcile_current_seat_sessions() {
+        if let Err(error) = reconciliation_state.reconcile_seat_sessions(reconciliation_snapshot) {
             eprintln!("usage ledger session reconciliation failed: {error:#}");
         }
     });

--- a/crates/sm-server/src/main.rs
+++ b/crates/sm-server/src/main.rs
@@ -79,6 +79,9 @@ async fn main() -> Result<()> {
     }
 
     let state = AppState::new(config);
+    if let Err(error) = state.reconcile_current_seat_sessions() {
+        eprintln!("usage ledger session reconciliation failed: {error:#}");
+    }
 
     // Repair the Studio SSH LaunchAgents toward the desired state every 30s while
     // the toggle is on. launchctl is synchronous, so run it on a blocking thread.
@@ -93,7 +96,8 @@ async fn main() -> Result<()> {
             // enforced too (a stray enable that raced a disable gets corrected).
             let desired = studio_ssh_flag.load(Ordering::SeqCst);
             let config = studio_ssh_config.clone();
-            match tokio::task::spawn_blocking(move || studio_ssh::reconcile(&config, desired)).await {
+            match tokio::task::spawn_blocking(move || studio_ssh::reconcile(&config, desired)).await
+            {
                 Ok(status) if status.status == "error" => {
                     eprintln!("studio-ssh reconcile error: {:?}", status.error);
                 }

--- a/crates/sm-server/src/seat_sessions.rs
+++ b/crates/sm-server/src/seat_sessions.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, Transaction};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 const DEFAULT_USAGE_DB_PATH: &str = "~/.local/share/claude-sessions/usage.db";
@@ -46,35 +46,27 @@ impl SeatSessionStore {
             .map(str::trim)
             .filter(|value| !value.is_empty());
 
-        let connection = self.open()?;
+        let mut connection = self.open()?;
+        let transaction = connection
+            .transaction()
+            .context("failed to start seat session append")?;
         let observed_at = OffsetDateTime::now_utc()
             .format(&Rfc3339)
             .context("failed to format seat session timestamp")?;
-        connection
-            .execute(
-                r#"
-                INSERT OR IGNORE INTO seat_sessions (
-                    seat_id,
-                    provider,
-                    provider_session_id,
-                    artifact_path,
-                    first_seen,
-                    last_seen
-                ) VALUES (?1, ?2, ?3, ?4, ?5, ?5)
-                "#,
-                params![
-                    seat_id,
-                    provider,
-                    provider_session_id,
-                    artifact_path,
-                    observed_at
-                ],
-            )
-            .with_context(|| {
-                format!(
-                    "failed to append provider session {provider_session_id} for seat {seat_id}"
-                )
-            })?;
+        append_identity(
+            &transaction,
+            seat_id,
+            provider,
+            provider_session_id,
+            artifact_path,
+            &observed_at,
+        )
+        .with_context(|| {
+            format!("failed to append provider session {provider_session_id} for seat {seat_id}")
+        })?;
+        transaction
+            .commit()
+            .context("failed to commit seat session append")?;
         Ok(())
     }
 
@@ -90,32 +82,20 @@ impl SeatSessionStore {
             .format(&Rfc3339)
             .context("failed to format seat session timestamp")?;
         for session in sessions {
-            transaction
-                .execute(
-                    r#"
-                    INSERT OR IGNORE INTO seat_sessions (
-                        seat_id,
-                        provider,
-                        provider_session_id,
-                        artifact_path,
-                        first_seen,
-                        last_seen
-                    ) VALUES (?1, ?2, ?3, ?4, ?5, ?5)
-                    "#,
-                    params![
-                        session.seat_id,
-                        session.provider,
-                        session.provider_session_id,
-                        session.artifact_path,
-                        observed_at
-                    ],
+            append_identity(
+                &transaction,
+                &session.seat_id,
+                &session.provider,
+                &session.provider_session_id,
+                session.artifact_path.as_deref(),
+                &observed_at,
+            )
+            .with_context(|| {
+                format!(
+                    "failed to reconcile provider session {} for seat {}",
+                    session.provider_session_id, session.seat_id
                 )
-                .with_context(|| {
-                    format!(
-                        "failed to reconcile provider session {} for seat {}",
-                        session.provider_session_id, session.seat_id
-                    )
-                })?;
+            })?;
             if session.artifact_path.is_some() {
                 transaction
                     .execute(
@@ -197,6 +177,56 @@ impl SeatSessionStore {
             .context("failed to initialize seat session schema")?;
         Ok(connection)
     }
+}
+
+fn append_identity(
+    transaction: &Transaction<'_>,
+    seat_id: &str,
+    provider: &str,
+    provider_session_id: &str,
+    artifact_path: Option<&str>,
+    observed_at: &str,
+) -> rusqlite::Result<()> {
+    if seat_id != "unassigned" {
+        transaction.execute(
+            r#"
+            DELETE FROM seat_sessions
+            WHERE seat_id = 'unassigned'
+              AND provider = ?1
+              AND provider_session_id = ?2
+            "#,
+            params![provider, provider_session_id],
+        )?;
+    }
+    transaction.execute(
+        r#"
+        INSERT OR IGNORE INTO seat_sessions (
+            seat_id,
+            provider,
+            provider_session_id,
+            artifact_path,
+            first_seen,
+            last_seen
+        )
+        SELECT ?1, ?2, ?3, ?4, ?5, ?5
+        WHERE ?1 != 'unassigned'
+           OR NOT EXISTS (
+                SELECT 1
+                FROM seat_sessions
+                WHERE seat_id != 'unassigned'
+                  AND provider = ?2
+                  AND provider_session_id = ?3
+           )
+        "#,
+        params![
+            seat_id,
+            provider,
+            provider_session_id,
+            artifact_path,
+            observed_at
+        ],
+    )?;
+    Ok(())
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -336,6 +366,47 @@ mod tests {
                 ("existing-path".to_owned(), "/tmp/original.jsonl".to_owned(),),
                 ("missing-path".to_owned(), "/tmp/recovered.jsonl".to_owned(),),
             ]
+        );
+    }
+
+    #[test]
+    fn definitive_binding_replaces_and_blocks_provisional_unassigned_rows() {
+        let state_file = test_path("provisional-binding");
+        let db_path = state_file.with_extension("usage.db");
+        let store = SeatSessionStore::for_state_file(&state_file);
+        let provisional = SeatSessionIdentity {
+            seat_id: "unassigned".to_owned(),
+            provider: "claude".to_owned(),
+            provider_session_id: "provider-a".to_owned(),
+            artifact_path: Some("/tmp/provisional.jsonl".to_owned()),
+        };
+
+        store.append_batch(&[provisional.clone()]).unwrap();
+        store
+            .append(
+                "seat-1",
+                "claude",
+                "provider-a",
+                Some("/tmp/definitive.jsonl"),
+            )
+            .unwrap();
+        store.append_batch(&[provisional]).unwrap();
+
+        let connection = Connection::open(&db_path).unwrap();
+        let rows = connection
+            .prepare(
+                "SELECT seat_id, artifact_path FROM seat_sessions WHERE provider_session_id = 'provider-a'",
+            )
+            .unwrap()
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![("seat-1".to_owned(), "/tmp/definitive.jsonl".to_owned())]
         );
     }
 

--- a/crates/sm-server/src/seat_sessions.rs
+++ b/crates/sm-server/src/seat_sessions.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeSet,
     path::{Path, PathBuf},
     time::Duration,
 };
@@ -120,6 +121,19 @@ impl SeatSessionStore {
             .commit()
             .context("failed to commit seat session reconciliation")?;
         Ok(())
+    }
+
+    pub fn claimed_provider_sessions(&self) -> Result<BTreeSet<(String, String)>> {
+        let connection = self.open()?;
+        let mut statement = connection
+            .prepare("SELECT provider, provider_session_id FROM seat_sessions")
+            .context("failed to prepare seat session claim query")?;
+        let claims = statement
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))
+            .context("failed to query claimed provider sessions")?
+            .collect::<rusqlite::Result<BTreeSet<_>>>()
+            .context("failed to read claimed provider sessions")?;
+        Ok(claims)
     }
 
     fn open(&self) -> Result<Connection> {

--- a/crates/sm-server/src/seat_sessions.rs
+++ b/crates/sm-server/src/seat_sessions.rs
@@ -8,6 +8,7 @@ use rusqlite::{params, Connection};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 const DEFAULT_USAGE_DB_PATH: &str = "~/.local/share/claude-sessions/usage.db";
+const USAGE_DB_BUSY_TIMEOUT: Duration = Duration::from_millis(250);
 
 /// Append-only mapping from an sm seat to every provider session identity it
 /// has used. The rest of the usage ledger can consume this chain without
@@ -88,7 +89,7 @@ impl SeatSessionStore {
         let connection = Connection::open(&self.db_path)
             .with_context(|| format!("failed to open usage database {}", self.db_path.display()))?;
         connection
-            .busy_timeout(Duration::from_secs(5))
+            .busy_timeout(USAGE_DB_BUSY_TIMEOUT)
             .context("failed to configure usage database busy timeout")?;
         connection
             .pragma_update(None, "journal_mode", "WAL")

--- a/crates/sm-server/src/seat_sessions.rs
+++ b/crates/sm-server/src/seat_sessions.rs
@@ -77,6 +77,51 @@ impl SeatSessionStore {
         Ok(())
     }
 
+    pub fn append_batch(&self, sessions: &[SeatSessionIdentity]) -> Result<()> {
+        if sessions.is_empty() {
+            return Ok(());
+        }
+        let mut connection = self.open()?;
+        let transaction = connection
+            .transaction()
+            .context("failed to start seat session reconciliation")?;
+        let observed_at = OffsetDateTime::now_utc()
+            .format(&Rfc3339)
+            .context("failed to format seat session timestamp")?;
+        for session in sessions {
+            transaction
+                .execute(
+                    r#"
+                    INSERT OR IGNORE INTO seat_sessions (
+                        seat_id,
+                        provider,
+                        provider_session_id,
+                        artifact_path,
+                        first_seen,
+                        last_seen
+                    ) VALUES (?1, ?2, ?3, ?4, ?5, ?5)
+                    "#,
+                    params![
+                        session.seat_id,
+                        session.provider,
+                        session.provider_session_id,
+                        session.artifact_path,
+                        observed_at
+                    ],
+                )
+                .with_context(|| {
+                    format!(
+                        "failed to reconcile provider session {} for seat {}",
+                        session.provider_session_id, session.seat_id
+                    )
+                })?;
+        }
+        transaction
+            .commit()
+            .context("failed to commit seat session reconciliation")?;
+        Ok(())
+    }
+
     fn open(&self) -> Result<Connection> {
         if let Some(parent) = self.db_path.parent() {
             std::fs::create_dir_all(parent).with_context(|| {
@@ -113,6 +158,14 @@ impl SeatSessionStore {
             .context("failed to initialize seat session schema")?;
         Ok(connection)
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SeatSessionIdentity {
+    pub seat_id: String,
+    pub provider: String,
+    pub provider_session_id: String,
+    pub artifact_path: Option<String>,
 }
 
 fn required_text<'a>(value: &'a str, field: &str) -> Result<&'a str> {

--- a/crates/sm-server/src/seat_sessions.rs
+++ b/crates/sm-server/src/seat_sessions.rs
@@ -116,6 +116,31 @@ impl SeatSessionStore {
                         session.provider_session_id, session.seat_id
                     )
                 })?;
+            if session.artifact_path.is_some() {
+                transaction
+                    .execute(
+                        r#"
+                        UPDATE seat_sessions
+                        SET artifact_path = ?4
+                        WHERE seat_id = ?1
+                          AND provider = ?2
+                          AND provider_session_id = ?3
+                          AND artifact_path IS NULL
+                        "#,
+                        params![
+                            session.seat_id,
+                            session.provider,
+                            session.provider_session_id,
+                            session.artifact_path
+                        ],
+                    )
+                    .with_context(|| {
+                        format!(
+                            "failed to repair artifact path for provider session {} on seat {}",
+                            session.provider_session_id, session.seat_id
+                        )
+                    })?;
+            }
         }
         transaction
             .commit()
@@ -254,6 +279,62 @@ mod tests {
             vec![
                 ("provider-a".to_owned(), "/tmp/a.jsonl".to_owned()),
                 ("provider-b".to_owned(), "/tmp/b.jsonl".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn append_batch_repairs_only_missing_artifact_paths() {
+        let state_file = test_path("batch-artifact-repair");
+        let db_path = state_file.with_extension("usage.db");
+        let store = SeatSessionStore::for_state_file(&state_file);
+
+        store
+            .append("seat-1", "codex-fork", "missing-path", None)
+            .unwrap();
+        store
+            .append(
+                "seat-1",
+                "codex-fork",
+                "existing-path",
+                Some("/tmp/original.jsonl"),
+            )
+            .unwrap();
+        store
+            .append_batch(&[
+                SeatSessionIdentity {
+                    seat_id: "seat-1".to_owned(),
+                    provider: "codex-fork".to_owned(),
+                    provider_session_id: "missing-path".to_owned(),
+                    artifact_path: Some("/tmp/recovered.jsonl".to_owned()),
+                },
+                SeatSessionIdentity {
+                    seat_id: "seat-1".to_owned(),
+                    provider: "codex-fork".to_owned(),
+                    provider_session_id: "existing-path".to_owned(),
+                    artifact_path: Some("/tmp/replayed.jsonl".to_owned()),
+                },
+            ])
+            .unwrap();
+
+        let connection = Connection::open(&db_path).unwrap();
+        let mut statement = connection
+            .prepare(
+                "SELECT provider_session_id, artifact_path FROM seat_sessions ORDER BY provider_session_id",
+            )
+            .unwrap();
+        let rows = statement
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                ("existing-path".to_owned(), "/tmp/original.jsonl".to_owned(),),
+                ("missing-path".to_owned(), "/tmp/recovered.jsonl".to_owned(),),
             ]
         );
     }

--- a/crates/sm-server/src/seat_sessions.rs
+++ b/crates/sm-server/src/seat_sessions.rs
@@ -1,0 +1,200 @@
+use std::{
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection};
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+const DEFAULT_USAGE_DB_PATH: &str = "~/.local/share/claude-sessions/usage.db";
+
+/// Append-only mapping from an sm seat to every provider session identity it
+/// has used. The rest of the usage ledger can consume this chain without
+/// depending on the mutable current pointers in sessions.json.
+#[derive(Debug, Clone)]
+pub struct SeatSessionStore {
+    db_path: PathBuf,
+}
+
+impl SeatSessionStore {
+    pub fn for_state_file(state_file: &Path) -> Self {
+        let default_state_file = expand_home("~/.local/share/claude-sessions/sessions.json");
+        let db_path = if state_file == default_state_file {
+            expand_home(DEFAULT_USAGE_DB_PATH)
+        } else {
+            // Alternate registries (including tests) get an isolated ledger.
+            // The default production registry still uses the spec's usage.db.
+            state_file.with_extension("usage.db")
+        };
+        Self { db_path }
+    }
+
+    pub fn append(
+        &self,
+        seat_id: &str,
+        provider: &str,
+        provider_session_id: &str,
+        artifact_path: Option<&str>,
+    ) -> Result<()> {
+        let seat_id = required_text(seat_id, "seat_id")?;
+        let provider = required_text(provider, "provider")?;
+        let provider_session_id = required_text(provider_session_id, "provider_session_id")?;
+        let artifact_path = artifact_path
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+
+        let connection = self.open()?;
+        let observed_at = OffsetDateTime::now_utc()
+            .format(&Rfc3339)
+            .context("failed to format seat session timestamp")?;
+        connection
+            .execute(
+                r#"
+                INSERT OR IGNORE INTO seat_sessions (
+                    seat_id,
+                    provider,
+                    provider_session_id,
+                    artifact_path,
+                    first_seen,
+                    last_seen
+                ) VALUES (?1, ?2, ?3, ?4, ?5, ?5)
+                "#,
+                params![
+                    seat_id,
+                    provider,
+                    provider_session_id,
+                    artifact_path,
+                    observed_at
+                ],
+            )
+            .with_context(|| {
+                format!(
+                    "failed to append provider session {provider_session_id} for seat {seat_id}"
+                )
+            })?;
+        Ok(())
+    }
+
+    fn open(&self) -> Result<Connection> {
+        if let Some(parent) = self.db_path.parent() {
+            std::fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "failed to create usage database directory {}",
+                    parent.display()
+                )
+            })?;
+        }
+        let connection = Connection::open(&self.db_path)
+            .with_context(|| format!("failed to open usage database {}", self.db_path.display()))?;
+        connection
+            .busy_timeout(Duration::from_secs(5))
+            .context("failed to configure usage database busy timeout")?;
+        connection
+            .pragma_update(None, "journal_mode", "WAL")
+            .context("failed to enable WAL mode for usage database")?;
+        connection
+            .execute_batch(
+                r#"
+                CREATE TABLE IF NOT EXISTS seat_sessions (
+                    seat_id             TEXT NOT NULL,
+                    provider            TEXT NOT NULL,
+                    provider_session_id TEXT NOT NULL,
+                    artifact_path       TEXT,
+                    first_seen          TEXT NOT NULL,
+                    last_seen           TEXT NOT NULL,
+                    PRIMARY KEY (seat_id, provider_session_id)
+                );
+                CREATE INDEX IF NOT EXISTS idx_seat_sessions_provider
+                    ON seat_sessions(provider_session_id);
+                "#,
+            )
+            .context("failed to initialize seat session schema")?;
+        Ok(connection)
+    }
+}
+
+fn required_text<'a>(value: &'a str, field: &str) -> Result<&'a str> {
+    let value = value.trim();
+    if value.is_empty() {
+        anyhow::bail!("{field} must not be empty");
+    }
+    Ok(value)
+}
+
+fn expand_home(path: &str) -> PathBuf {
+    if path == "~" {
+        return std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(path));
+    }
+    let Some(rest) = path.strip_prefix("~/") else {
+        return PathBuf::from(path);
+    };
+    match std::env::var_os("HOME") {
+        Some(home) => Path::new(&home).join(rest),
+        None => PathBuf::from(path),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use rusqlite::Connection;
+
+    use super::*;
+
+    static TEST_PATH_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    #[test]
+    fn append_keeps_distinct_provider_sessions_and_ignores_duplicates() {
+        let state_file = test_path("append");
+        let db_path = state_file.with_extension("usage.db");
+        let store = SeatSessionStore::for_state_file(&state_file);
+
+        store
+            .append("seat-1", "claude", "provider-a", Some("/tmp/a.jsonl"))
+            .unwrap();
+        store
+            .append("seat-1", "claude", "provider-b", Some("/tmp/b.jsonl"))
+            .unwrap();
+        store
+            .append(
+                "seat-1",
+                "claude",
+                "provider-a",
+                Some("/tmp/replayed-a.jsonl"),
+            )
+            .unwrap();
+
+        let connection = Connection::open(&db_path).unwrap();
+        let mut statement = connection
+            .prepare(
+                "SELECT provider_session_id, artifact_path FROM seat_sessions ORDER BY provider_session_id",
+            )
+            .unwrap();
+        let rows = statement
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                ("provider-a".to_owned(), "/tmp/a.jsonl".to_owned()),
+                ("provider-b".to_owned(), "/tmp/b.jsonl".to_owned()),
+            ]
+        );
+    }
+
+    fn test_path(label: &str) -> PathBuf {
+        let counter = TEST_PATH_COUNTER.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!(
+            "sm-seat-sessions-{label}-{}-{counter}.json",
+            std::process::id()
+        ))
+    }
+}

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -109,6 +109,23 @@ impl SessionStore {
         self
     }
 
+    fn append_seat_session(
+        &self,
+        seat_id: &str,
+        provider: &str,
+        provider_session_id: &str,
+        artifact_path: Option<&str>,
+    ) {
+        if let Err(error) =
+            self.seat_session_store
+                .append(seat_id, provider, provider_session_id, artifact_path)
+        {
+            eprintln!(
+                "usage ledger failed to append provider session {provider_session_id} for seat {seat_id}: {error:#}"
+            );
+        }
+    }
+
     /// Drop context alerts this session raised about context it no longer has.
     /// An undelivered warning describes the discarded cycle, so delivering it
     /// after a clear tells the monitor about a problem that no longer exists.
@@ -302,12 +319,7 @@ impl SessionStore {
             None
         };
         if let Some(provider_resume_id) = provider_resume_id.as_deref() {
-            self.seat_session_store.append(
-                session_id,
-                &provider,
-                provider_resume_id,
-                transcript_path,
-            )?;
+            self.append_seat_session(session_id, &provider, provider_resume_id, transcript_path);
         }
         if normalized_status(&json_text(session.get("status")).unwrap_or_default()) == "stopped" {
             return Ok(false);
@@ -652,12 +664,7 @@ impl SessionStore {
         }
         if record.provider == "codex" {
             if let Some(provider_resume_id) = record.provider_resume_id.as_deref() {
-                self.seat_session_store.append(
-                    &record.id,
-                    &record.provider,
-                    provider_resume_id,
-                    None,
-                )?;
+                self.append_seat_session(&record.id, &record.provider, provider_resume_id, None);
             }
         }
         if let Some(artifacts) = codex_fork_artifacts {
@@ -1301,12 +1308,12 @@ impl SessionStore {
         let restored = serde_json::from_value::<SessionRecord>(Value::Object(session.clone()))?;
         self.write_raw_json_value(&state)?;
         if let Some(provider_resume_id) = provider_resume_id_for_restore(&restored) {
-            self.seat_session_store.append(
+            self.append_seat_session(
                 &restored.id,
                 &restored.provider,
                 &provider_resume_id,
                 restored.transcript_path.as_deref(),
-            )?;
+            );
         }
         if let Some(artifacts) = codex_fork_artifacts {
             self.start_codex_fork_event_monitor(restored.id.clone(), artifacts.event_stream_path)?;
@@ -3099,12 +3106,12 @@ impl SessionStore {
 
         let mut changed = false;
         if let Some(provider_resume_id) = codex_fork_provider_resume_id(event) {
-            self.seat_session_store.append(
+            self.append_seat_session(
                 session_id,
                 &provider,
                 &provider_resume_id,
                 artifact_path.and_then(Path::to_str),
-            )?;
+            );
             if json_text(session.get("provider_resume_id")).as_deref()
                 != Some(provider_resume_id.as_str())
             {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1404,6 +1404,12 @@ impl SessionStore {
         };
 
         let session_runtime = runtime.for_socket_name(session_socket_name.as_deref());
+        // Classic Codex rollouts are discovered by root and cwd, so that whole
+        // discovery domain must remain exclusive from the snapshot through bind.
+        let codex_cli_binding_guard = codex_cli_record
+            .as_ref()
+            .map(|record| self.lock_codex_cli_binding_operation(record))
+            .transpose()?;
         let codex_cli_clear_binding = codex_cli_record
             .map(|mut record| -> Result<_> {
                 let launched_at = OffsetDateTime::now_utc();
@@ -1548,6 +1554,7 @@ impl SessionStore {
                     ))
                     .spawn(move || {
                         let _clear_guard = clear_guard;
+                        let _binding_guard = codex_cli_binding_guard;
                         if let Err(error) = store.complete_deferred_codex_cli_rebind(
                             &deferred_session_id,
                             &record,
@@ -1618,20 +1625,35 @@ impl SessionStore {
     }
 
     fn lock_clear_operation(&self, session_id: &str) -> Result<SessionClearGuard> {
+        self.lock_named_clear_operation(session_id)
+    }
+
+    fn lock_codex_cli_binding_operation(
+        &self,
+        record: &SessionRecord,
+    ) -> Result<SessionClearGuard> {
+        let sessions_root = resolve_path_lossy(self.codex_sessions_root.clone());
+        let working_dir = resolve_path_lossy(expand_home(&record.working_dir));
+        self.lock_named_clear_operation(&format!(
+            "codex-cli-binding:{sessions_root}\0{working_dir}"
+        ))
+    }
+
+    fn lock_named_clear_operation(&self, operation_key: &str) -> Result<SessionClearGuard> {
         let lock = {
             let mut locks = self
                 .clear_operation_locks
                 .lock()
                 .map_err(|_| anyhow::anyhow!("clear operation lock registry poisoned"))?;
             locks.retain(|_, lock| lock.strong_count() > 0);
-            if let Some(lock) = locks.get(session_id).and_then(Weak::upgrade) {
+            if let Some(lock) = locks.get(operation_key).and_then(Weak::upgrade) {
                 lock
             } else {
                 let lock = Arc::new(SessionClearLock {
                     held: Mutex::new(false),
                     available: Condvar::new(),
                 });
-                locks.insert(session_id.to_owned(), Arc::downgrade(&lock));
+                locks.insert(operation_key.to_owned(), Arc::downgrade(&lock));
                 lock
             }
         };
@@ -9940,6 +9962,51 @@ mod tests {
         drop(first_guard);
         acquired_rx.recv_timeout(Duration::from_secs(1)).unwrap();
         second.join().unwrap();
+    }
+
+    #[test]
+    fn concurrent_codex_cli_bindings_for_the_same_discovery_domain_are_serialized() {
+        let temp_dir = unique_temp_path("codex-binding-operation-lock");
+        let state_file = temp_dir.join("sessions.json");
+        let sessions_root = temp_dir.join("codex-home").join("sessions");
+        let working_dir = temp_dir.join("repo");
+        fs::create_dir_all(&sessions_root).unwrap();
+        fs::create_dir_all(&working_dir).unwrap();
+        let mut store =
+            SessionStore::new_with_legacy_fallback(state_file.clone(), state_file.clone());
+        store.codex_sessions_root = sessions_root;
+        let mut first_record = session_record("running");
+        first_record.id = "codex001".to_owned();
+        first_record.provider = "codex".to_owned();
+        first_record.working_dir = working_dir.display().to_string();
+        let mut second_record = first_record.clone();
+        second_record.id = "codex002".to_owned();
+        let mut unrelated_record = first_record.clone();
+        unrelated_record.id = "codex003".to_owned();
+        unrelated_record.working_dir = temp_dir.join("other-repo").display().to_string();
+
+        let first_guard = store
+            .lock_codex_cli_binding_operation(&first_record)
+            .unwrap();
+        let second_store = store.clone();
+        let (acquired_tx, acquired_rx) = std::sync::mpsc::channel();
+        let second = thread::spawn(move || {
+            let _guard = second_store
+                .lock_codex_cli_binding_operation(&second_record)
+                .unwrap();
+            acquired_tx.send(()).unwrap();
+        });
+
+        assert!(acquired_rx
+            .recv_timeout(Duration::from_millis(100))
+            .is_err());
+        let _unrelated_guard = store
+            .lock_codex_cli_binding_operation(&unrelated_record)
+            .unwrap();
+        drop(first_guard);
+        acquired_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        second.join().unwrap();
+        let _ = fs::remove_dir_all(temp_dir);
     }
 
     #[test]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -210,6 +210,19 @@ impl SessionStore {
                 Err(error) => return Err(error),
             }
         };
+        let fork_artifact_paths = self
+            .delivery_runtime
+            .as_ref()
+            .map(|runtime| {
+                records
+                    .iter()
+                    .filter_map(|session| {
+                        codex_fork_event_stream_path(session, runtime)
+                            .map(|path| (session.id.clone(), path))
+                    })
+                    .collect::<BTreeMap<_, _>>()
+            })
+            .unwrap_or_default();
         let mut sessions = records
             .iter()
             .filter_map(|session| {
@@ -219,7 +232,10 @@ impl SessionStore {
                         seat_id: session.id.clone(),
                         provider: session.provider.clone(),
                         provider_session_id,
-                        artifact_path: session.transcript_path.clone(),
+                        artifact_path: fork_artifact_paths
+                            .get(&session.id)
+                            .map(|path| path.display().to_string())
+                            .or_else(|| session.transcript_path.clone()),
                     }
                 })
             })
@@ -227,6 +243,11 @@ impl SessionStore {
         sessions.extend(historical_claude_seat_sessions(
             &records,
             &self.claude_projects_root,
+            &mut claimed,
+        ));
+        sessions.extend(historical_codex_cli_seat_sessions(
+            &records,
+            &self.codex_sessions_root,
             &mut claimed,
         ));
         if let Some(runtime) = self.delivery_runtime.as_ref() {
@@ -6849,6 +6870,113 @@ fn historical_claude_seat_sessions(
     identities
 }
 
+fn historical_codex_cli_seat_sessions(
+    sessions: &[SessionRecord],
+    sessions_root: &Path,
+    claimed: &mut BTreeSet<(String, String)>,
+) -> Vec<SeatSessionIdentity> {
+    let codex_seats = sessions
+        .iter()
+        .filter(|session| session.provider == "codex")
+        .collect::<Vec<_>>();
+    if codex_seats.is_empty() {
+        return Vec::new();
+    }
+
+    let mut identities = Vec::new();
+    for path in jsonl_files_recursive(sessions_root) {
+        let Some((provider_session_id, cwd, started_at_ns)) =
+            read_codex_cli_session_metadata(&path)
+        else {
+            continue;
+        };
+        let claim = ("codex".to_owned(), provider_session_id.clone());
+        if claimed.contains(&claim) {
+            continue;
+        }
+
+        let cwd = resolve_path_lossy(expand_home(&cwd));
+        let matching_cwd_seats = codex_seats
+            .iter()
+            .copied()
+            .filter(|session| resolve_path_lossy(expand_home(&session.working_dir)) == cwd)
+            .collect::<Vec<_>>();
+        if matching_cwd_seats.is_empty() {
+            continue;
+        }
+
+        let started_at_ns = started_at_ns
+            .or_else(|| file_mtime_ns(&path).ok())
+            .unwrap_or(0);
+        let ended_at_ns = codex_transcript_end_ns(&path, started_at_ns);
+        let matching_seats = matching_cwd_seats
+            .into_iter()
+            .filter(|session| session_lifetime_overlaps(session, started_at_ns, ended_at_ns))
+            .map(|session| session.id.as_str())
+            .collect::<BTreeSet<_>>();
+        if matching_seats.is_empty() {
+            continue;
+        }
+        let seat_id = if matching_seats.len() == 1 {
+            matching_seats.into_iter().next().unwrap().to_owned()
+        } else {
+            "unassigned".to_owned()
+        };
+        claimed.insert(claim);
+        identities.push(SeatSessionIdentity {
+            seat_id,
+            provider: "codex".to_owned(),
+            provider_session_id,
+            artifact_path: Some(resolve_path_lossy(path)),
+        });
+    }
+    identities
+}
+
+fn codex_transcript_end_ns(path: &Path, started_at_ns: i128) -> i128 {
+    let mut ended_at_ns = started_at_ns;
+    let Ok(file) = fs::File::open(path) else {
+        return ended_at_ns;
+    };
+    for line in BufReader::new(file).lines().map_while(|line| line.ok()) {
+        let Some(timestamp) = serde_json::from_str::<Value>(&line).ok().and_then(|value| {
+            value
+                .get("timestamp")
+                .and_then(Value::as_str)
+                .and_then(parse_timestamp_ns)
+        }) else {
+            continue;
+        };
+        ended_at_ns = ended_at_ns.max(timestamp);
+    }
+    ended_at_ns
+}
+
+fn jsonl_files_recursive(root: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(directory) = pending.pop() {
+        let Ok(entries) = fs::read_dir(directory) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_dir() {
+                pending.push(path);
+            } else if file_type.is_file()
+                && path.extension().and_then(|value| value.to_str()) == Some("jsonl")
+            {
+                files.push(path);
+            }
+        }
+    }
+    files.sort();
+    files
+}
+
 fn historical_codex_fork_seat_sessions(
     sessions: &[SessionRecord],
     runtime: &TmuxRuntime,
@@ -6859,23 +6987,10 @@ fn historical_codex_fork_seat_sessions(
         .iter()
         .filter(|session| session.provider == "codex-fork")
     {
-        let Some(log_file) = session.log_file.as_deref().map(expand_home) else {
+        let Some(event_stream_path) = codex_fork_event_stream_path(session, runtime) else {
             continue;
         };
-        let spec = TmuxSessionSpec {
-            session_id: session.id.clone(),
-            tmux_session: session.tmux_session.clone(),
-            working_dir: session.working_dir.clone(),
-            log_file,
-            provider: session.provider.clone(),
-            initial_message: None,
-            model: session.model.clone(),
-            reasoning_effort: session.reasoning_effort.clone(),
-        };
-        let Ok(Some(artifacts)) = runtime.codex_fork_runtime_artifacts(&spec) else {
-            continue;
-        };
-        let Ok(file) = fs::File::open(&artifacts.event_stream_path) else {
+        let Ok(file) = fs::File::open(&event_stream_path) else {
             continue;
         };
         for line in BufReader::new(file).lines().map_while(|line| line.ok()) {
@@ -6896,11 +7011,32 @@ fn historical_codex_fork_seat_sessions(
                 seat_id: session.id.clone(),
                 provider: "codex-fork".to_owned(),
                 provider_session_id,
-                artifact_path: Some(artifacts.event_stream_path.display().to_string()),
+                artifact_path: Some(event_stream_path.display().to_string()),
             });
         }
     }
     identities
+}
+
+fn codex_fork_event_stream_path(session: &SessionRecord, runtime: &TmuxRuntime) -> Option<PathBuf> {
+    if session.provider != "codex-fork" {
+        return None;
+    }
+    let spec = TmuxSessionSpec {
+        session_id: session.id.clone(),
+        tmux_session: session.tmux_session.clone(),
+        working_dir: session.working_dir.clone(),
+        log_file: session.log_file.as_deref().map(expand_home)?,
+        provider: session.provider.clone(),
+        initial_message: None,
+        model: session.model.clone(),
+        reasoning_effort: session.reasoning_effort.clone(),
+    };
+    runtime
+        .codex_fork_runtime_artifacts(&spec)
+        .ok()
+        .flatten()
+        .map(|artifacts| artifacts.event_stream_path)
 }
 
 fn session_lifetime_overlaps(
@@ -9318,18 +9454,97 @@ mod tests {
             ),
         )
         .unwrap();
+        store.append_seat_session("codex001", "codex-fork", "current-thread", None);
 
         store.reconcile_current_seat_sessions().unwrap();
 
-        let count: i64 = rusqlite::Connection::open(usage_db_path)
-            .unwrap()
+        let connection = rusqlite::Connection::open(usage_db_path).unwrap();
+        let count: i64 = connection
             .query_row(
                 "SELECT COUNT(*) FROM seat_sessions WHERE seat_id = 'codex001'",
                 [],
                 |row| row.get(0),
             )
             .unwrap();
+        let paths: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM seat_sessions WHERE seat_id = 'codex001' AND artifact_path IS NOT NULL",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
         assert_eq!(count, 2);
+        assert_eq!(paths, 2);
+    }
+
+    #[test]
+    fn startup_reconciliation_backfills_historical_codex_cli_rollouts() {
+        let temp_dir = unique_temp_path("seat-session-codex-backfill");
+        let state_file = temp_dir.join("sessions.json");
+        let working_dir = temp_dir.join("repo");
+        let sessions_root = temp_dir.join("codex-home").join("sessions");
+        let day_dir = sessions_root.join("2026").join("01").join("02");
+        fs::create_dir_all(&working_dir).unwrap();
+        fs::create_dir_all(&day_dir).unwrap();
+        let rollout = |id: &str, timestamp: &str| {
+            fs::write(
+                day_dir.join(format!("rollout-{id}.jsonl")),
+                format!(
+                    "{}\n",
+                    json!({
+                        "type": "session_meta",
+                        "timestamp": timestamp,
+                        "payload": {
+                            "id": id,
+                            "cwd": working_dir.display().to_string(),
+                            "timestamp": timestamp
+                        }
+                    })
+                ),
+            )
+            .unwrap();
+        };
+        rollout("historical-thread", "2026-01-02T00:00:00Z");
+        rollout("current-thread", "2026-01-03T00:00:00Z");
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [{
+                    "id": "codex001",
+                    "name": "codex-codex001",
+                    "provider": "codex",
+                    "provider_resume_id": "current-thread",
+                    "working_dir": working_dir.display().to_string(),
+                    "tmux_session": "codex-codex001",
+                    "status": "running",
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "last_activity": "2026-01-03T00:00:00Z"
+                }]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let mut store =
+            SessionStore::new_with_legacy_fallback(state_file.clone(), state_file.clone());
+        store.codex_sessions_root = sessions_root;
+
+        store.reconcile_current_seat_sessions().unwrap();
+
+        let connection = rusqlite::Connection::open(state_file.with_extension("usage.db")).unwrap();
+        let mut statement = connection
+            .prepare(
+                "SELECT provider_session_id FROM seat_sessions WHERE seat_id = 'codex001' ORDER BY provider_session_id",
+            )
+            .unwrap();
+        let ids = statement
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(
+            ids,
+            vec!["current-thread".to_owned(), "historical-thread".to_owned()]
+        );
     }
 
     #[test]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1100,6 +1100,10 @@ impl SessionStore {
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
         let sessions = ensure_sessions_array_mut(&mut state)?;
+        let claimed_provider_resume_ids = sessions
+            .iter()
+            .filter_map(|session| json_text(session.get("provider_resume_id")))
+            .collect::<BTreeSet<_>>();
         let Some(session) = session_object_mut(sessions, session_id) else {
             return Ok(CoreClearOutcome::NotFound);
         };
@@ -1120,6 +1124,20 @@ impl SessionStore {
         } else {
             "/clear"
         };
+        let codex_cli_clear_binding = (provider == "codex").then(|| -> Result<_> {
+            let record = serde_json::from_value::<SessionRecord>(Value::Object(session.clone()))?;
+            let mut excluded_ids = claimed_provider_resume_ids;
+            excluded_ids.extend(codex_cli_existing_session_ids(
+                &record,
+                &self.codex_sessions_root,
+            ));
+            Ok((
+                record,
+                excluded_ids,
+                OffsetDateTime::now_utc().unix_timestamp_nanos(),
+            ))
+        });
+        let codex_cli_clear_binding = codex_cli_clear_binding.transpose()?;
         let prompt = request
             .prompt
             .as_deref()
@@ -1136,6 +1154,23 @@ impl SessionStore {
         )?;
         if !delivered {
             return Err(anyhow::anyhow!("tmux session is not running"));
+        }
+        if let Some((record, excluded_ids, launched_at_ns)) = codex_cli_clear_binding {
+            if let Some(provider_resume_id) = wait_for_codex_cli_provider_resume_id(
+                &record,
+                &self.codex_sessions_root,
+                &excluded_ids,
+                launched_at_ns,
+                CODEX_CLI_SESSION_BIND_TIMEOUT,
+            ) {
+                session.insert(
+                    "provider_resume_id".to_owned(),
+                    Value::String(provider_resume_id.clone()),
+                );
+                self.append_seat_session(session_id, &provider, &provider_resume_id, None);
+            } else {
+                eprintln!("failed to discover replacement Codex thread for seat {session_id}");
+            }
         }
         let now = now_rfc3339();
         reset_session_after_clear(session, &now);

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -3502,9 +3502,10 @@ fn wait_for_codex_fork_provider_resume_id_after_offset(
 ) -> Result<String> {
     let started = Instant::now();
     let mut offset = initial_offset;
+    let mut buffer = String::new();
     loop {
-        if let Ok(content) = read_file_from_offset(event_stream_path, &mut offset) {
-            for line in content.lines() {
+        if let Ok(chunk) = read_file_from_offset(event_stream_path, &mut offset) {
+            for line in split_complete_event_lines(&mut buffer, &chunk) {
                 let Ok(event) = serde_json::from_str::<Value>(line.trim()) else {
                     continue;
                 };
@@ -8555,6 +8556,41 @@ mod tests {
             .unwrap(),
             "new-thread"
         );
+        let _ = fs::remove_file(event_stream_path);
+    }
+
+    #[test]
+    fn codex_fork_clear_rebind_buffers_partial_events_between_polls() {
+        let event_stream_path = unique_temp_path("codex-clear-rebind-partial-events");
+        fs::write(
+            &event_stream_path,
+            r#"{"event_type":"thread/started","payload":{"thread":{"#,
+        )
+        .unwrap();
+        let writer_path = event_stream_path.clone();
+        let writer = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(25));
+            fs::OpenOptions::new()
+                .append(true)
+                .open(writer_path)
+                .unwrap()
+                .write_all(
+                    br#""id":"new-thread"}}}
+"#,
+                )
+                .unwrap();
+        });
+
+        assert_eq!(
+            wait_for_codex_fork_provider_resume_id_after_offset(
+                &event_stream_path,
+                0,
+                Duration::from_secs(1),
+            )
+            .unwrap(),
+            "new-thread"
+        );
+        writer.join().unwrap();
         let _ = fs::remove_file(event_stream_path);
     }
 

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -7465,11 +7465,13 @@ fn claude_projects_roots(configured_transcript_root: Option<&str>) -> Vec<PathBu
     {
         push(expand_home(root));
     }
-    if let Some(config_dir) = env::var_os("CLAUDE_CONFIG_DIR")
-        .map(PathBuf::from)
-        .filter(|path| !path.as_os_str().is_empty())
-    {
-        push(config_dir.join("projects"));
+    if let Some(config_dirs) = env::var_os("CLAUDE_CONFIG_DIR") {
+        for config_dir in config_dirs.to_string_lossy().split(',') {
+            let config_dir = config_dir.trim();
+            if !config_dir.is_empty() {
+                push(expand_home(config_dir).join("projects"));
+            }
+        }
     }
     if let Some(xdg_config_home) = env::var_os("XDG_CONFIG_HOME")
         .map(PathBuf::from)
@@ -8495,18 +8497,23 @@ mod tests {
         let _guard = TEST_ENV_LOCK.lock().unwrap();
         let root = unique_temp_path("claude-project-roots");
         let home = root.join("home");
-        let config_dir = root.join("claude-config");
+        let config_dir_a = root.join("claude-config-a");
+        let config_dir_b = root.join("claude-config-b");
         let xdg_dir = root.join("xdg");
         let configured = root.join("configured-projects");
         let _home = EnvVarRestore::set("HOME", &home);
-        let _config = EnvVarRestore::set("CLAUDE_CONFIG_DIR", &config_dir);
+        let _config = EnvVarRestore::set(
+            "CLAUDE_CONFIG_DIR",
+            format!("{}, {}", config_dir_a.display(), config_dir_b.display()),
+        );
         let _xdg = EnvVarRestore::set("XDG_CONFIG_HOME", &xdg_dir);
 
         assert_eq!(
             claude_projects_roots(Some(configured.to_str().unwrap())),
             vec![
                 configured,
-                config_dir.join("projects"),
+                config_dir_a.join("projects"),
+                config_dir_b.join("projects"),
                 xdg_dir.join("claude").join("projects"),
                 home.join(".claude").join("projects"),
             ]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -29,6 +29,7 @@ use crate::queue::{
 use crate::{
     config::{CodexReviewConfig, ContextMonitorConfig},
     runtime::{TmuxRuntime, TmuxSessionSpec},
+    seat_sessions::SeatSessionStore,
 };
 
 const DEFAULT_SESSION_STATE_FILE: &str = "~/.local/share/claude-sessions/sessions.json";
@@ -59,6 +60,7 @@ pub struct SessionStore {
     /// an unrelated request to happen to flush it.
     delivery_runtime: Option<TmuxRuntime>,
     codex_fork_handoff_monitors: Arc<Mutex<BTreeSet<String>>>,
+    seat_session_store: SeatSessionStore,
 }
 
 impl SessionStore {
@@ -68,6 +70,7 @@ impl SessionStore {
         } else {
             None
         };
+        let seat_session_store = SeatSessionStore::for_state_file(&state_file);
         Self {
             state_file,
             legacy_state_file,
@@ -77,6 +80,7 @@ impl SessionStore {
             context_monitor: ContextMonitorConfig::default(),
             delivery_runtime: None,
             codex_fork_handoff_monitors: Arc::new(Mutex::new(BTreeSet::new())),
+            seat_session_store,
         }
     }
 
@@ -123,6 +127,7 @@ impl SessionStore {
 
     #[cfg(test)]
     fn new_with_legacy_fallback(state_file: PathBuf, legacy_state_file: PathBuf) -> Self {
+        let seat_session_store = SeatSessionStore::for_state_file(&state_file);
         Self {
             state_file,
             legacy_state_file: Some(legacy_state_file),
@@ -132,6 +137,7 @@ impl SessionStore {
             context_monitor: ContextMonitorConfig::default(),
             delivery_runtime: None,
             codex_fork_handoff_monitors: Arc::new(Mutex::new(BTreeSet::new())),
+            seat_session_store,
         }
     }
 
@@ -276,6 +282,20 @@ impl SessionStore {
         let Some(session) = session_object_mut(sessions, session_id) else {
             return Ok(false);
         };
+        let provider = json_text(session.get("provider")).unwrap_or_else(|| "claude".to_owned());
+        let provider_resume_id = if provider == "claude" {
+            transcript_path.and_then(provider_resume_id_from_transcript_path)
+        } else {
+            None
+        };
+        if let Some(provider_resume_id) = provider_resume_id.as_deref() {
+            self.seat_session_store.append(
+                session_id,
+                &provider,
+                provider_resume_id,
+                transcript_path,
+            )?;
+        }
         if normalized_status(&json_text(session.get("status")).unwrap_or_default()) == "stopped" {
             return Ok(false);
         }
@@ -324,12 +344,11 @@ impl SessionStore {
                 "transcript_path".to_owned(),
                 Value::String(transcript_path.to_owned()),
             );
-            let provider =
-                json_text(session.get("provider")).unwrap_or_else(|| "claude".to_owned());
-            if provider == "claude" {
-                if let Some(resume_id) = provider_resume_id_from_transcript_path(transcript_path) {
-                    session.insert("provider_resume_id".to_owned(), Value::String(resume_id));
-                }
+            if let Some(provider_resume_id) = provider_resume_id {
+                session.insert(
+                    "provider_resume_id".to_owned(),
+                    Value::String(provider_resume_id),
+                );
             }
         }
         if let Some(native_title) = native_title {
@@ -617,6 +636,16 @@ impl SessionStore {
         if let Err(error) = self.write_raw_json_value(&state) {
             let _ = runtime.kill_session(&record.tmux_session);
             return Err(error);
+        }
+        if record.provider == "codex" {
+            if let Some(provider_resume_id) = record.provider_resume_id.as_deref() {
+                self.seat_session_store.append(
+                    &record.id,
+                    &record.provider,
+                    provider_resume_id,
+                    None,
+                )?;
+            }
         }
         if let Some(artifacts) = codex_fork_artifacts {
             self.start_codex_fork_event_monitor(record.id.clone(), artifacts.event_stream_path)?;
@@ -1258,6 +1287,14 @@ impl SessionStore {
         }
         let restored = serde_json::from_value::<SessionRecord>(Value::Object(session.clone()))?;
         self.write_raw_json_value(&state)?;
+        if let Some(provider_resume_id) = provider_resume_id_for_restore(&restored) {
+            self.seat_session_store.append(
+                &restored.id,
+                &restored.provider,
+                &provider_resume_id,
+                restored.transcript_path.as_deref(),
+            )?;
+        }
         if let Some(artifacts) = codex_fork_artifacts {
             self.start_codex_fork_event_monitor(restored.id.clone(), artifacts.event_stream_path)?;
         }
@@ -2973,7 +3010,11 @@ impl SessionStore {
 
             if let Ok(chunk) = read_file_from_offset(&event_stream_path, &mut offset) {
                 for line in split_complete_event_lines(&mut buffer, &chunk) {
-                    let _ = self.apply_codex_fork_event_line(&session_id, &line);
+                    let _ = self.apply_codex_fork_event_line_with_artifact(
+                        &session_id,
+                        &line,
+                        Some(&event_stream_path),
+                    );
                 }
             }
             thread::sleep(CODEX_FORK_EVENT_MONITOR_POLL);
@@ -3006,7 +3047,17 @@ impl SessionStore {
         Ok(normalized_status(&status) != "stopped")
     }
 
+    #[cfg(test)]
     fn apply_codex_fork_event_line(&self, session_id: &str, line: &str) -> Result<()> {
+        self.apply_codex_fork_event_line_with_artifact(session_id, line, None)
+    }
+
+    fn apply_codex_fork_event_line_with_artifact(
+        &self,
+        session_id: &str,
+        line: &str,
+        artifact_path: Option<&Path>,
+    ) -> Result<()> {
         let raw = line.trim();
         if raw.is_empty() {
             return Ok(());
@@ -3035,6 +3086,12 @@ impl SessionStore {
 
         let mut changed = false;
         if let Some(provider_resume_id) = codex_fork_provider_resume_id(event) {
+            self.seat_session_store.append(
+                session_id,
+                &provider,
+                &provider_resume_id,
+                artifact_path.and_then(Path::to_str),
+            )?;
             if json_text(session.get("provider_resume_id")).as_deref()
                 != Some(provider_resume_id.as_str())
             {
@@ -8232,6 +8289,73 @@ mod tests {
         assert_eq!(
             store.get_session("codex001").unwrap().unwrap().status,
             "running"
+        );
+    }
+
+    #[test]
+    fn codex_fork_thread_identity_events_append_the_provider_session_chain() {
+        let state_file = unique_temp_path("codex-session-chain");
+        let usage_db_path = state_file.with_extension("usage.db");
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [{
+                    "id": "codex001",
+                    "name": "codex-codex001",
+                    "provider": "codex-fork",
+                    "working_dir": "/repo",
+                    "tmux_session": "codex-codex001",
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00Z",
+                    "last_activity": "2026-06-01T00:01:00Z"
+                }]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let store = SessionStore::new_with_legacy_fallback(state_file.clone(), state_file);
+
+        store
+            .apply_codex_fork_event_line(
+                "codex001",
+                r#"{"event_type":"thread/started","payload":{"thread":{"id":"thread-before-handoff"}}}"#,
+            )
+            .unwrap();
+        store
+            .apply_codex_fork_event_line(
+                "codex001",
+                r#"{"event_type":"thread/started","payload":{"thread":{"id":"thread-after-handoff"}}}"#,
+            )
+            .unwrap();
+
+        let connection = rusqlite::Connection::open(usage_db_path).unwrap();
+        let mut statement = connection
+            .prepare(
+                "SELECT provider, provider_session_id FROM seat_sessions WHERE seat_id = 'codex001' ORDER BY provider_session_id",
+            )
+            .unwrap();
+        let rows = statement
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                ("codex-fork".to_owned(), "thread-after-handoff".to_owned()),
+                ("codex-fork".to_owned(), "thread-before-handoff".to_owned()),
+            ]
+        );
+        assert_eq!(
+            store
+                .get_session("codex001")
+                .unwrap()
+                .unwrap()
+                .provider_resume_id
+                .as_deref(),
+            Some("thread-after-handoff")
         );
     }
 

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1125,17 +1125,23 @@ impl SessionStore {
             "/clear"
         };
         let codex_cli_clear_binding = (provider == "codex").then(|| -> Result<_> {
-            let record = serde_json::from_value::<SessionRecord>(Value::Object(session.clone()))?;
+            let mut record =
+                serde_json::from_value::<SessionRecord>(Value::Object(session.clone()))?;
+            if let Some(previous_provider_resume_id) = record.provider_resume_id.as_deref() {
+                self.append_seat_session(session_id, &provider, previous_provider_resume_id, None);
+            }
+            let launched_at = OffsetDateTime::now_utc();
+            // `/new` writes under today's rollout directory, which may be far
+            // from the seat's original creation date.
+            record.created_at = launched_at
+                .format(&Rfc3339)
+                .context("failed to format Codex clear timestamp")?;
             let mut excluded_ids = claimed_provider_resume_ids;
             excluded_ids.extend(codex_cli_existing_session_ids(
                 &record,
                 &self.codex_sessions_root,
             ));
-            Ok((
-                record,
-                excluded_ids,
-                OffsetDateTime::now_utc().unix_timestamp_nanos(),
-            ))
+            Ok((record, excluded_ids, launched_at.unix_timestamp_nanos()))
         });
         let codex_cli_clear_binding = codex_cli_clear_binding.transpose()?;
         let prompt = request

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -827,6 +827,21 @@ impl SessionStore {
         log_dir: Option<PathBuf>,
         runtime: &TmuxRuntime,
     ) -> Result<SessionRecord> {
+        let codex_cli_working_dir = {
+            let _guard = self.write_guard()?;
+            let state = self.load_raw_json_value()?;
+            let sessions = state
+                .get("sessions")
+                .and_then(Value::as_array)
+                .map(Vec::as_slice)
+                .unwrap_or_default();
+            let (provider, working_dir) = core_session_provider_and_working_dir(sessions, &request);
+            (provider == "codex").then_some(working_dir)
+        };
+        let codex_cli_binding_guard = codex_cli_working_dir
+            .as_deref()
+            .map(|working_dir| self.lock_codex_cli_binding_working_dir(working_dir))
+            .transpose()?;
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
         let sessions = ensure_sessions_array_mut(&mut state)?;
@@ -837,6 +852,11 @@ impl SessionStore {
             true,
             runtime.socket_name(),
         )?;
+        if record.provider == "codex"
+            && codex_cli_working_dir.as_deref() != Some(record.working_dir.as_str())
+        {
+            anyhow::bail!("session creation context changed while waiting for Codex binding");
+        }
         ensure_runtime_local_node(&record.node)?;
         let log_file = record
             .log_file
@@ -869,12 +889,12 @@ impl SessionStore {
             )
         });
         runtime.create_session(&spec)?;
-        if let Some((excluded_ids, launched_at_ns)) = codex_cli_creation_binding {
+        if let Some((excluded_ids, launched_at_ns)) = codex_cli_creation_binding.as_ref() {
             record.provider_resume_id = wait_for_codex_cli_provider_resume_id(
                 &record,
                 &self.codex_sessions_root,
-                &excluded_ids,
-                launched_at_ns,
+                excluded_ids,
+                *launched_at_ns,
                 CODEX_CLI_SESSION_BIND_TIMEOUT,
             );
         }
@@ -912,6 +932,36 @@ impl SessionStore {
                         .as_ref()
                         .and_then(|artifacts| artifacts.event_stream_path.to_str()),
                 );
+            }
+        }
+        if record.provider_resume_id.is_none() {
+            if let Some((excluded_ids, launched_at_ns)) = codex_cli_creation_binding {
+                let store = self.clone();
+                let deferred_record = record.clone();
+                let deferred_session_id = record.id.clone();
+                let spawn_result = thread::Builder::new()
+                    .name(format!(
+                        "sm-codex-create-bind-{}",
+                        sanitize_path_component(&record.id)
+                    ))
+                    .spawn(move || {
+                        let _binding_guard = codex_cli_binding_guard;
+                        if let Err(error) = store.complete_deferred_codex_cli_rebind(
+                            &deferred_session_id,
+                            &deferred_record,
+                            &excluded_ids,
+                            launched_at_ns,
+                            None,
+                            CODEX_CLI_DEFERRED_BIND_TIMEOUT,
+                        ) {
+                            eprintln!(
+                                "deferred initial Codex thread discovery failed for seat {deferred_session_id}: {error:#}"
+                            );
+                        }
+                    });
+                if let Err(error) = spawn_result {
+                    eprintln!("failed to start deferred initial Codex thread discovery: {error}");
+                }
             }
         }
         if let Some(artifacts) = codex_fork_artifacts {
@@ -1632,8 +1682,12 @@ impl SessionStore {
         &self,
         record: &SessionRecord,
     ) -> Result<SessionClearGuard> {
+        self.lock_codex_cli_binding_working_dir(&record.working_dir)
+    }
+
+    fn lock_codex_cli_binding_working_dir(&self, working_dir: &str) -> Result<SessionClearGuard> {
         let sessions_root = resolve_path_lossy(self.codex_sessions_root.clone());
-        let working_dir = resolve_path_lossy(expand_home(&record.working_dir));
+        let working_dir = resolve_path_lossy(expand_home(working_dir));
         self.lock_named_clear_operation(&format!(
             "codex-cli-binding:{sessions_root}\0{working_dir}"
         ))
@@ -3806,16 +3860,8 @@ impl SessionStore {
                 .iter()
                 .find(|value| value.get("id").and_then(Value::as_str) == Some(parent_id))
         });
-        let parent_working_dir =
-            parent_session.and_then(|value| json_text(value.get("working_dir")));
         let parent_node = parent_session.and_then(|value| json_text(value.get("node")));
-        let provider = request
-            .provider
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .unwrap_or("claude")
-            .to_owned();
+        let (provider, working_dir) = core_session_provider_and_working_dir(sessions, request);
         let name = request
             .name
             .as_deref()
@@ -3823,14 +3869,6 @@ impl SessionStore {
             .filter(|value| !value.is_empty())
             .map(ToOwned::to_owned)
             .unwrap_or_else(|| format!("{provider}-{session_id}"));
-        let working_dir = request
-            .working_dir
-            .as_deref()
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .or(parent_working_dir.as_deref())
-            .unwrap_or(".")
-            .to_owned();
         let node = request
             .node
             .as_deref()
@@ -7225,6 +7263,11 @@ fn discover_claude_transcript_path(
         .filter(|path| has_text(Some(path)))
         .map(|path| resolve_path_lossy(expand_home(path)))
         .collect::<BTreeSet<_>>();
+    let claimed_provider_session_ids = sessions
+        .iter()
+        .filter(|session| session.id != record.id && session.provider == "claude")
+        .filter_map(provider_resume_id_for_restore)
+        .collect::<BTreeSet<_>>();
     let target_time_ns = session_time_ns(record)
         .or_else(|| file_mtime_ns(expand_home(&record.log_file.clone().unwrap_or_default())).ok())
         .unwrap_or(0);
@@ -7238,6 +7281,16 @@ fn discover_claude_transcript_path(
                 continue;
             }
             let metadata = read_claude_transcript_metadata(&path).unwrap_or_default();
+            let candidate_provider_session_id = metadata
+                .session_id
+                .clone()
+                .or_else(|| provider_resume_id_from_transcript_path(&resolved_transcript));
+            if candidate_provider_session_id
+                .as_ref()
+                .is_some_and(|session_id| claimed_provider_session_ids.contains(session_id))
+            {
+                continue;
+            }
             if let Some(cwd) = metadata.cwd.as_deref() {
                 if cwd != resolved_working_dir {
                     continue;
@@ -7378,6 +7431,34 @@ fn append_log_line(path: &Path, line: &str) -> Result<()> {
     writeln!(file, "{line}")
         .with_context(|| format!("failed to append session log {}", path.display()))?;
     Ok(())
+}
+
+fn core_session_provider_and_working_dir(
+    sessions: &[Value],
+    request: &CreateCoreSessionRequest,
+) -> (String, String) {
+    let parent_working_dir = request.parent_session_id.as_deref().and_then(|parent_id| {
+        sessions
+            .iter()
+            .find(|value| value.get("id").and_then(Value::as_str) == Some(parent_id))
+            .and_then(|value| json_text(value.get("working_dir")))
+    });
+    let provider = request
+        .provider
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("claude")
+        .to_owned();
+    let working_dir = request
+        .working_dir
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .or(parent_working_dir.as_deref())
+        .unwrap_or(".")
+        .to_owned();
+    (provider, working_dir)
 }
 
 fn core_log_file_path(state_file: &Path, log_dir: Option<&Path>, session_id: &str) -> PathBuf {
@@ -10901,6 +10982,57 @@ mod tests {
         assert_eq!(
             provider_resume_id_for_restore(&session).as_deref(),
             Some(transcript_id)
+        );
+
+        let _ = fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn claude_restore_excludes_sibling_artifacts_of_a_claimed_provider_session() {
+        let temp_dir = unique_temp_path("claude-claimed-transcript-siblings");
+        let projects_root = temp_dir.join("projects");
+        let working_dir = temp_dir.join("repo");
+        let transcript_id = "49d072b4-4080-4702-9215-b6e7f04aa2c8";
+        let transcript_dir = projects_root
+            .join(claude_project_dir_name(working_dir.to_str().unwrap()))
+            .join(transcript_id);
+        let chat_path = transcript_dir.join("chat.jsonl");
+        let subagent_path = transcript_dir.join("subagents").join("agent-worker.jsonl");
+        fs::create_dir_all(subagent_path.parent().unwrap()).unwrap();
+        let transcript_line = |timestamp: &str| {
+            format!(
+                "{}\n",
+                json!({
+                    "type": "user",
+                    "sessionId": transcript_id,
+                    "cwd": working_dir.display().to_string(),
+                    "timestamp": timestamp
+                })
+            )
+        };
+        fs::write(&chat_path, transcript_line("2026-06-23T01:20:00Z")).unwrap();
+        fs::write(&subagent_path, transcript_line("2026-06-23T01:21:00Z")).unwrap();
+
+        let mut claimed = session_record("running");
+        claimed.id = "claimed1".to_owned();
+        claimed.provider = "claude".to_owned();
+        claimed.working_dir = working_dir.display().to_string();
+        claimed.transcript_path = Some(chat_path.display().to_string());
+        let mut restoring = session_record("stopped");
+        restoring.id = "restore1".to_owned();
+        restoring.provider = "claude".to_owned();
+        restoring.working_dir = working_dir.display().to_string();
+        restoring.transcript_path = None;
+        restoring.provider_resume_id = None;
+        restoring.last_activity = "2026-06-23T01:22:00Z".to_owned();
+
+        assert_eq!(
+            discover_claude_transcript_path(
+                &restoring,
+                &[restoring.clone(), claimed],
+                &[projects_root],
+            ),
+            None
         );
 
         let _ = fs::remove_dir_all(temp_dir);

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -3991,7 +3991,7 @@ fn wait_for_codex_fork_provider_resume_id_after_offset(
                 let Some(event) = event.as_object() else {
                     continue;
                 };
-                if let Some(provider_resume_id) = codex_fork_provider_resume_id(event) {
+                if let Some(provider_resume_id) = extract_codex_fork_thread_started(event) {
                     return Ok(provider_resume_id);
                 }
             }
@@ -9973,7 +9973,8 @@ mod tests {
             .open(&event_stream_path)
             .unwrap()
             .write_all(
-                br#"{"event_type":"thread/started","payload":{"thread":{"id":"new-thread"}}}
+                br#"{"event_type":"turn_aborted","session_id":"old-thread","payload":{"session_id":"old-thread"}}
+{"event_type":"thread/started","payload":{"thread":{"id":"new-thread"}}}
 "#,
             )
             .unwrap();

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -268,11 +268,10 @@ impl SessionStore {
             .collect::<BTreeSet<_>>();
         let codex_artifact_paths =
             codex_cli_artifact_paths(&self.codex_sessions_root, &current_codex_ids);
-        let mut sessions = records
+        let current_identities = records
             .iter()
             .filter_map(|session| {
                 provider_resume_id_for_restore(session).map(|provider_session_id| {
-                    claimed.insert((session.provider.clone(), provider_session_id.clone()));
                     let artifact_path = fork_artifact_paths
                         .get(&session.id)
                         .map(|path| path.display().to_string())
@@ -292,6 +291,38 @@ impl SessionStore {
                 })
             })
             .collect::<Vec<_>>();
+        let mut current_by_provider_session = BTreeMap::<_, Vec<_>>::new();
+        for identity in current_identities {
+            current_by_provider_session
+                .entry((
+                    identity.provider.clone(),
+                    identity.provider_session_id.clone(),
+                ))
+                .or_default()
+                .push(identity);
+        }
+        let mut sessions = Vec::with_capacity(current_by_provider_session.len());
+        for ((provider, provider_session_id), mut identities) in current_by_provider_session {
+            claimed.insert((provider.clone(), provider_session_id.clone()));
+            if identities.len() == 1 {
+                sessions.push(identities.pop().expect("one current identity"));
+                continue;
+            }
+            let artifact_path = identities
+                .first()
+                .and_then(|identity| identity.artifact_path.clone())
+                .filter(|path| {
+                    identities
+                        .iter()
+                        .all(|identity| identity.artifact_path.as_deref() == Some(path))
+                });
+            sessions.push(SeatSessionIdentity {
+                seat_id: "unassigned".to_owned(),
+                provider,
+                provider_session_id,
+                artifact_path,
+            });
+        }
         sessions.extend(historical_claude_seat_sessions(
             &records,
             &self.claude_projects_roots,
@@ -9625,6 +9656,75 @@ mod tests {
             )
             .unwrap();
         assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn startup_reconciliation_marks_duplicate_current_identity_unassigned() {
+        let state_file = unique_temp_path("seat-session-duplicate-current");
+        let usage_db_path = state_file.with_extension("usage.db");
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [
+                    {
+                        "id": "claude001",
+                        "name": "claude-claude001",
+                        "provider": "claude",
+                        "provider_resume_id": "shared-thread",
+                        "transcript_path": "/repo/one/shared-thread.jsonl",
+                        "working_dir": "/repo",
+                        "tmux_session": "claude-claude001",
+                        "status": "running",
+                        "created_at": "2026-06-01T00:00:00Z",
+                        "last_activity": "2026-06-01T00:01:00Z"
+                    },
+                    {
+                        "id": "claude002",
+                        "name": "claude-claude002",
+                        "provider": "claude",
+                        "provider_resume_id": "shared-thread",
+                        "transcript_path": "/repo/two/shared-thread.jsonl",
+                        "working_dir": "/repo",
+                        "tmux_session": "claude-claude002",
+                        "status": "running",
+                        "created_at": "2026-06-01T00:00:00Z",
+                        "last_activity": "2026-06-01T00:01:00Z"
+                    }
+                ]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let store = SessionStore::new_with_legacy_fallback(state_file.clone(), state_file);
+
+        store.reconcile_current_seat_sessions().unwrap();
+
+        let connection = rusqlite::Connection::open(usage_db_path).unwrap();
+        let rows = connection
+            .prepare(
+                "SELECT seat_id, provider, provider_session_id, artifact_path FROM seat_sessions",
+            )
+            .unwrap()
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, String>(1)?,
+                    row.get::<_, String>(2)?,
+                    row.get::<_, Option<String>>(3)?,
+                ))
+            })
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![(
+                "unassigned".to_owned(),
+                "claude".to_owned(),
+                "shared-thread".to_owned(),
+                None,
+            )]
+        );
     }
 
     #[test]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -7,7 +7,7 @@ use std::{
     path::{Path, PathBuf},
     process::Command,
     sync::atomic::{AtomicU64, Ordering},
-    sync::{Arc, Mutex},
+    sync::{Arc, Condvar, Mutex, Weak},
     thread,
     time::{Duration, Instant, UNIX_EPOCH},
 };
@@ -29,7 +29,7 @@ use crate::queue::{
 use crate::{
     config::{CodexReviewConfig, ContextMonitorConfig},
     runtime::{TmuxRuntime, TmuxSessionSpec},
-    seat_sessions::SeatSessionStore,
+    seat_sessions::{SeatSessionIdentity, SeatSessionStore},
 };
 
 const DEFAULT_SESSION_STATE_FILE: &str = "~/.local/share/claude-sessions/sessions.json";
@@ -62,7 +62,27 @@ pub struct SessionStore {
     /// an unrelated request to happen to flush it.
     delivery_runtime: Option<TmuxRuntime>,
     codex_fork_handoff_monitors: Arc<Mutex<BTreeSet<String>>>,
+    clear_operation_locks: Arc<Mutex<BTreeMap<String, Weak<SessionClearLock>>>>,
     seat_session_store: SeatSessionStore,
+}
+
+#[derive(Debug)]
+struct SessionClearLock {
+    held: Mutex<bool>,
+    available: Condvar,
+}
+
+struct SessionClearGuard {
+    lock: Arc<SessionClearLock>,
+}
+
+impl Drop for SessionClearGuard {
+    fn drop(&mut self) {
+        if let Ok(mut held) = self.lock.held.lock() {
+            *held = false;
+            self.lock.available.notify_one();
+        }
+    }
 }
 
 impl SessionStore {
@@ -82,6 +102,7 @@ impl SessionStore {
             context_monitor: ContextMonitorConfig::default(),
             delivery_runtime: None,
             codex_fork_handoff_monitors: Arc::new(Mutex::new(BTreeSet::new())),
+            clear_operation_locks: Arc::new(Mutex::new(BTreeMap::new())),
             seat_session_store,
         }
     }
@@ -171,18 +192,34 @@ impl SessionStore {
     }
 
     pub fn reconcile_current_seat_sessions(&self) -> Result<()> {
-        for session in self.load_snapshot()?.into_sessions() {
-            let provider_resume_id = provider_resume_id_for_restore(&session);
-            if let Some(provider_resume_id) = provider_resume_id {
-                self.append_seat_session(
-                    &session.id,
-                    &session.provider,
-                    &provider_resume_id,
-                    session.transcript_path.as_deref(),
-                );
+        let sessions = self
+            .load_snapshot()?
+            .into_sessions()
+            .into_iter()
+            .filter_map(|session| {
+                provider_resume_id_for_restore(&session).map(|provider_session_id| {
+                    SeatSessionIdentity {
+                        seat_id: session.id,
+                        provider: session.provider,
+                        provider_session_id,
+                        artifact_path: session.transcript_path,
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+        for attempt in 0..=SEAT_SESSION_RETRY_ATTEMPTS {
+            match self.seat_session_store.append_batch(&sessions) {
+                Ok(()) => return Ok(()),
+                Err(error)
+                    if usage_ledger_error_is_transient(&error)
+                        && attempt < SEAT_SESSION_RETRY_ATTEMPTS =>
+                {
+                    thread::sleep(SEAT_SESSION_RETRY_DELAY);
+                }
+                Err(error) => return Err(error),
             }
         }
-        Ok(())
+        unreachable!("bounded reconciliation loop always returns")
     }
 
     /// Drop context alerts this session raised about context it no longer has.
@@ -226,6 +263,7 @@ impl SessionStore {
             context_monitor: ContextMonitorConfig::default(),
             delivery_runtime: None,
             codex_fork_handoff_monitors: Arc::new(Mutex::new(BTreeSet::new())),
+            clear_operation_locks: Arc::new(Mutex::new(BTreeMap::new())),
             seat_session_store,
         }
     }
@@ -1195,6 +1233,7 @@ impl SessionStore {
         request: ClearSessionRequest,
         runtime: &TmuxRuntime,
     ) -> Result<CoreClearOutcome> {
+        let _clear_guard = self.lock_clear_operation(session_id)?;
         let prompt = request
             .prompt
             .as_deref()
@@ -1390,6 +1429,39 @@ impl SessionStore {
             status: "cleared".to_owned(),
             session_id: session_id.to_owned(),
         }))
+    }
+
+    fn lock_clear_operation(&self, session_id: &str) -> Result<SessionClearGuard> {
+        let lock = {
+            let mut locks = self
+                .clear_operation_locks
+                .lock()
+                .map_err(|_| anyhow::anyhow!("clear operation lock registry poisoned"))?;
+            locks.retain(|_, lock| lock.strong_count() > 0);
+            if let Some(lock) = locks.get(session_id).and_then(Weak::upgrade) {
+                lock
+            } else {
+                let lock = Arc::new(SessionClearLock {
+                    held: Mutex::new(false),
+                    available: Condvar::new(),
+                });
+                locks.insert(session_id.to_owned(), Arc::downgrade(&lock));
+                lock
+            }
+        };
+        let mut held = lock
+            .held
+            .lock()
+            .map_err(|_| anyhow::anyhow!("clear operation lock poisoned"))?;
+        while *held {
+            held = lock
+                .available
+                .wait(held)
+                .map_err(|_| anyhow::anyhow!("clear operation lock poisoned"))?;
+        }
+        *held = true;
+        drop(held);
+        Ok(SessionClearGuard { lock })
     }
 
     pub fn restore_core_session(&self, session_id: &str) -> Result<Option<CoreRestoreOutcome>> {
@@ -8951,6 +9023,26 @@ mod tests {
         );
         writer.join().unwrap();
         let _ = fs::remove_file(event_stream_path);
+    }
+
+    #[test]
+    fn concurrent_clears_for_the_same_seat_are_serialized() {
+        let state_file = unique_temp_path("clear-operation-lock");
+        let store = SessionStore::new_with_legacy_fallback(state_file.clone(), state_file);
+        let first_guard = store.lock_clear_operation("codex001").unwrap();
+        let second_store = store.clone();
+        let (acquired_tx, acquired_rx) = std::sync::mpsc::channel();
+        let second = thread::spawn(move || {
+            let _guard = second_store.lock_clear_operation("codex001").unwrap();
+            acquired_tx.send(()).unwrap();
+        });
+
+        assert!(acquired_rx
+            .recv_timeout(Duration::from_millis(100))
+            .is_err());
+        drop(first_guard);
+        acquired_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        second.join().unwrap();
     }
 
     #[test]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -42,6 +42,8 @@ const CODEX_CLI_SESSION_BIND_POLL: Duration = Duration::from_millis(50);
 const CODEX_FORK_THREAD_STARTED_TIMEOUT: Duration = Duration::from_secs(10);
 const CODEX_FORK_EVENT_MONITOR_POLL: Duration = Duration::from_millis(250);
 const CODEX_FORK_CONTROL_TIMEOUT: Duration = Duration::from_secs(3);
+const SEAT_SESSION_RETRY_ATTEMPTS: usize = 20;
+const SEAT_SESSION_RETRY_DELAY: Duration = Duration::from_millis(100);
 static STATE_WRITE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone)]
@@ -116,14 +118,71 @@ impl SessionStore {
         provider_session_id: &str,
         artifact_path: Option<&str>,
     ) {
-        if let Err(error) =
+        let Err(error) =
             self.seat_session_store
                 .append(seat_id, provider, provider_session_id, artifact_path)
-        {
-            eprintln!(
-                "usage ledger failed to append provider session {provider_session_id} for seat {seat_id}: {error:#}"
-            );
+        else {
+            return;
+        };
+        eprintln!(
+            "usage ledger failed to append provider session {provider_session_id} for seat {seat_id}: {error:#}"
+        );
+        if !usage_ledger_error_is_transient(&error) {
+            return;
         }
+
+        let store = self.seat_session_store.clone();
+        let seat_id = seat_id.to_owned();
+        let provider = provider.to_owned();
+        let provider_session_id = provider_session_id.to_owned();
+        let artifact_path = artifact_path.map(ToOwned::to_owned);
+        let thread_name = format!(
+            "sm-seat-session-retry-{}",
+            sanitize_path_component(&seat_id)
+        );
+        if let Err(error) = thread::Builder::new().name(thread_name).spawn(move || {
+            for attempt in 1..=SEAT_SESSION_RETRY_ATTEMPTS {
+                thread::sleep(SEAT_SESSION_RETRY_DELAY);
+                match store.append(
+                    &seat_id,
+                    &provider,
+                    &provider_session_id,
+                    artifact_path.as_deref(),
+                ) {
+                    Ok(()) => return,
+                    Err(error) if usage_ledger_error_is_transient(&error) => {
+                        if attempt == SEAT_SESSION_RETRY_ATTEMPTS {
+                            eprintln!(
+                                "usage ledger exhausted retries for provider session {provider_session_id} on seat {seat_id}: {error:#}"
+                            );
+                        }
+                    }
+                    Err(error) => {
+                        eprintln!(
+                            "usage ledger retry failed permanently for provider session {provider_session_id} on seat {seat_id}: {error:#}"
+                        );
+                        return;
+                    }
+                }
+            }
+        }) {
+            eprintln!("failed to start usage ledger retry thread: {error}");
+        }
+    }
+
+    pub fn reconcile_current_seat_sessions(&self) -> Result<()> {
+        for session in self.load_snapshot()?.into_sessions() {
+            let provider_resume_id = provider_resume_id_for_restore(&session);
+            if let Some(provider_resume_id) = provider_resume_id {
+                self.append_seat_session(
+                    &session.id,
+                    &session.provider,
+                    &provider_resume_id,
+                    session.transcript_path.as_deref(),
+                );
+            }
+        }
+        Ok(())
     }
 
     /// Drop context alerts this session raised about context it no longer has.
@@ -3260,19 +3319,12 @@ impl SessionStore {
         }
 
         let mut changed = false;
-        if let Some(provider_resume_id) = codex_fork_provider_resume_id(event) {
-            self.append_seat_session(
-                session_id,
-                &provider,
-                &provider_resume_id,
-                artifact_path.and_then(Path::to_str),
-            );
-            if json_text(session.get("provider_resume_id")).as_deref()
-                != Some(provider_resume_id.as_str())
-            {
+        let provider_resume_id = codex_fork_provider_resume_id(event);
+        if let Some(provider_resume_id) = provider_resume_id.as_deref() {
+            if json_text(session.get("provider_resume_id")).as_deref() != Some(provider_resume_id) {
                 session.insert(
                     "provider_resume_id".to_owned(),
-                    Value::String(provider_resume_id),
+                    Value::String(provider_resume_id.to_owned()),
                 );
                 changed = true;
             }
@@ -3371,6 +3423,15 @@ impl SessionStore {
 
         if changed {
             self.write_raw_json_value(&state)?;
+        }
+        drop(_guard);
+        if let Some(provider_resume_id) = provider_resume_id {
+            self.append_seat_session(
+                session_id,
+                &provider,
+                &provider_resume_id,
+                artifact_path.and_then(Path::to_str),
+            );
         }
         Ok(())
     }
@@ -3510,6 +3571,24 @@ fn wait_for_codex_fork_provider_resume_id(
     timeout: Duration,
 ) -> Result<String> {
     wait_for_codex_fork_provider_resume_id_after_offset(event_stream_path, 0, timeout)
+}
+
+fn usage_ledger_error_is_transient(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        cause
+            .downcast_ref::<rusqlite::Error>()
+            .is_some_and(|error| {
+                matches!(
+                    error,
+                    rusqlite::Error::SqliteFailure(code, _)
+                        if matches!(
+                            code.code,
+                            rusqlite::ErrorCode::DatabaseBusy
+                                | rusqlite::ErrorCode::DatabaseLocked
+                        )
+                )
+            })
+    })
 }
 
 fn wait_for_codex_fork_provider_resume_id_after_offset(
@@ -8603,6 +8682,146 @@ mod tests {
                 .provider_resume_id
                 .as_deref(),
             Some("thread-after-handoff")
+        );
+    }
+
+    #[test]
+    fn transient_seat_session_append_is_retried_after_the_writer_unlocks() {
+        let state_file = unique_temp_path("seat-session-retry");
+        let usage_db_path = state_file.with_extension("usage.db");
+        let store = SessionStore::new_with_legacy_fallback(state_file.clone(), state_file);
+        store
+            .seat_session_store
+            .append("seed", "codex", "seed-thread", None)
+            .unwrap();
+        let connection = rusqlite::Connection::open(&usage_db_path).unwrap();
+        connection.execute_batch("BEGIN IMMEDIATE").unwrap();
+
+        store.append_seat_session("codex001", "codex", "retry-thread", None);
+        connection.execute_batch("ROLLBACK").unwrap();
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let count: i64 = rusqlite::Connection::open(&usage_db_path)
+                .unwrap()
+                .query_row(
+                    "SELECT COUNT(*) FROM seat_sessions WHERE seat_id = 'codex001' AND provider_session_id = 'retry-thread'",
+                    [],
+                    |row| row.get(0),
+                )
+                .unwrap();
+            if count == 1 {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "transient usage ledger append was not retried"
+            );
+            thread::sleep(Duration::from_millis(20));
+        }
+    }
+
+    #[test]
+    fn startup_reconciliation_restores_a_missing_current_codex_identity() {
+        let state_file = unique_temp_path("seat-session-reconcile");
+        let usage_db_path = state_file.with_extension("usage.db");
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [{
+                    "id": "codex001",
+                    "name": "codex-codex001",
+                    "provider": "codex",
+                    "provider_resume_id": "persisted-thread",
+                    "working_dir": "/repo",
+                    "tmux_session": "codex-codex001",
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00Z",
+                    "last_activity": "2026-06-01T00:01:00Z"
+                }]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let store = SessionStore::new_with_legacy_fallback(state_file.clone(), state_file);
+
+        store.reconcile_current_seat_sessions().unwrap();
+
+        let count: i64 = rusqlite::Connection::open(usage_db_path)
+            .unwrap()
+            .query_row(
+                "SELECT COUNT(*) FROM seat_sessions WHERE seat_id = 'codex001' AND provider_session_id = 'persisted-thread'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn codex_fork_identity_event_releases_session_lock_before_ledger_write() {
+        let state_file = unique_temp_path("codex-event-ledger-lock");
+        let usage_db_path = state_file.with_extension("usage.db");
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [{
+                    "id": "codex001",
+                    "name": "codex-codex001",
+                    "provider": "codex-fork",
+                    "working_dir": "/repo",
+                    "tmux_session": "codex-codex001",
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00Z",
+                    "last_activity": "2026-06-01T00:01:00Z"
+                }]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let store = SessionStore::new_with_legacy_fallback(state_file.clone(), state_file);
+        store
+            .seat_session_store
+            .append("seed", "codex-fork", "seed-thread", None)
+            .unwrap();
+        let connection = rusqlite::Connection::open(usage_db_path).unwrap();
+        connection.execute_batch("BEGIN IMMEDIATE").unwrap();
+
+        let event_store = store.clone();
+        let event = thread::spawn(move || {
+            event_store.apply_codex_fork_event_line(
+                "codex001",
+                r#"{"event_type":"thread/started","payload":{"thread":{"id":"new-thread"}}}"#,
+            )
+        });
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            if store
+                .get_session("codex001")
+                .unwrap()
+                .and_then(|session| session.provider_resume_id)
+                .as_deref()
+                == Some("new-thread")
+            {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "fork identity state remained behind the blocked usage ledger"
+            );
+            thread::sleep(Duration::from_millis(10));
+        }
+        let started = Instant::now();
+        assert!(store
+            .apply_claude_pre_tool_use_hook("codex001", Some("Read"))
+            .unwrap());
+        let mutation_elapsed = started.elapsed();
+
+        connection.execute_batch("ROLLBACK").unwrap();
+        event.join().unwrap().unwrap();
+        assert!(
+            mutation_elapsed < Duration::from_secs(1),
+            "the global session lock remained held during the fork ledger wait"
         );
     }
 

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -52,7 +52,7 @@ pub struct SessionStore {
     state_file: PathBuf,
     legacy_state_file: Option<PathBuf>,
     codex_sessions_root: PathBuf,
-    claude_projects_root: PathBuf,
+    claude_projects_roots: Vec<PathBuf>,
     write_lock: Arc<Mutex<()>>,
     queue_store: Option<RetainedQueueStore>,
     /// Carried on the store rather than read per-request because the codex-fork
@@ -105,7 +105,7 @@ impl SessionStore {
             state_file,
             legacy_state_file,
             codex_sessions_root: expand_home("~/.codex/sessions"),
-            claude_projects_root: expand_home("~/.claude/projects"),
+            claude_projects_roots: claude_projects_roots(None),
             write_lock: Arc::new(Mutex::new(())),
             queue_store: None,
             context_monitor: ContextMonitorConfig::default(),
@@ -138,6 +138,11 @@ impl SessionStore {
                 self.codex_sessions_root = parent.join("sessions");
             }
         }
+        self
+    }
+
+    pub fn with_claude_transcript_root(mut self, transcript_root: Option<&str>) -> Self {
+        self.claude_projects_roots = claude_projects_roots(transcript_root);
         self
     }
 
@@ -289,7 +294,7 @@ impl SessionStore {
             .collect::<Vec<_>>();
         sessions.extend(historical_claude_seat_sessions(
             &records,
-            &self.claude_projects_root,
+            &self.claude_projects_roots,
             artifact_cutoff_ns,
             &mut claimed,
         ));
@@ -357,7 +362,7 @@ impl SessionStore {
             state_file,
             legacy_state_file: Some(legacy_state_file),
             codex_sessions_root: expand_home("~/.codex/sessions"),
-            claude_projects_root: expand_home("~/.claude/projects"),
+            claude_projects_roots: claude_projects_roots(None),
             write_lock: Arc::new(Mutex::new(())),
             queue_store: None,
             context_monitor: ContextMonitorConfig::default(),
@@ -370,7 +375,7 @@ impl SessionStore {
 
     #[cfg(test)]
     fn with_claude_projects_root(mut self, projects_root: PathBuf) -> Self {
-        self.claude_projects_root = projects_root;
+        self.claude_projects_roots = vec![projects_root];
         self
     }
 
@@ -1725,7 +1730,11 @@ impl SessionStore {
                 .filter(|value| !value.is_empty())
                 .is_none()
         {
-            record.transcript_path = discover_claude_transcript_path(&record, &snapshot.sessions);
+            record.transcript_path = discover_claude_transcript_path(
+                &record,
+                &snapshot.sessions,
+                &self.claude_projects_roots,
+            );
         }
         let provider_resume_id = provider_resume_id_for_restore(&record);
         let session_runtime = runtime.for_socket_name(record.tmux_socket_name.as_deref());
@@ -6657,12 +6666,55 @@ fn subagent_response_from_value(value: &Value) -> Result<SubagentResponse> {
 }
 
 fn provider_resume_id_from_transcript_path(transcript_path: &str) -> Option<String> {
-    Path::new(transcript_path)
-        .file_stem()
-        .and_then(|value| value.to_str())
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned)
+    claude_session_id_from_transcript(transcript_path).or_else(|| {
+        let path = Path::new(transcript_path);
+        let nested_session_dir = if path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .is_some_and(|name| name == "chat.jsonl")
+        {
+            path.parent()
+        } else if path
+            .parent()
+            .and_then(Path::file_name)
+            .and_then(|value| value.to_str())
+            == Some("subagents")
+        {
+            path.parent().and_then(Path::parent)
+        } else {
+            None
+        };
+        nested_session_dir
+            .and_then(Path::file_name)
+            .and_then(|value| value.to_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+            .or_else(|| {
+                path.file_stem()
+                    .and_then(|value| value.to_str())
+                    .map(str::trim)
+                    .filter(|value| !value.is_empty())
+                    .map(ToOwned::to_owned)
+            })
+    })
+}
+
+fn claude_session_id_from_transcript(transcript_path: &str) -> Option<String> {
+    let file = fs::File::open(expand_home(transcript_path)).ok()?;
+    BufReader::new(file)
+        .lines()
+        .map_while(|line| line.ok())
+        .take(128)
+        .filter_map(|line| serde_json::from_str::<Value>(&line).ok())
+        .find_map(|value| {
+            value
+                .get("sessionId")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned)
+        })
 }
 
 fn provider_resume_id_for_restore(record: &SessionRecord) -> Option<String> {
@@ -6849,32 +6901,27 @@ struct ClaudeTranscriptMetadata {
 
 fn historical_claude_seat_sessions(
     sessions: &[SessionRecord],
-    projects_root: &Path,
+    projects_roots: &[PathBuf],
     artifact_cutoff_ns: i128,
     claimed: &mut BTreeSet<(String, String)>,
 ) -> Vec<SeatSessionIdentity> {
     let mut project_dirs = BTreeMap::<PathBuf, BTreeSet<String>>::new();
-    for session in sessions
-        .iter()
-        .filter(|session| session.provider == "claude")
-        .filter(|session| has_text(Some(&session.working_dir)))
-    {
-        project_dirs
-            .entry(projects_root.join(claude_project_dir_name(&session.working_dir)))
-            .or_default()
-            .insert(resolve_path_lossy(expand_home(&session.working_dir)));
+    for projects_root in projects_roots {
+        for session in sessions
+            .iter()
+            .filter(|session| session.provider == "claude")
+            .filter(|session| has_text(Some(&session.working_dir)))
+        {
+            project_dirs
+                .entry(projects_root.join(claude_project_dir_name(&session.working_dir)))
+                .or_default()
+                .insert(resolve_path_lossy(expand_home(&session.working_dir)));
+        }
     }
 
     let mut identities = Vec::new();
     for (project_dir, project_working_dirs) in project_dirs {
-        let Ok(entries) = fs::read_dir(project_dir) else {
-            continue;
-        };
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().and_then(|value| value.to_str()) != Some("jsonl") {
-                continue;
-            }
+        for path in jsonl_files_recursive(&project_dir) {
             let Ok(metadata) = read_claude_transcript_metadata(&path) else {
                 continue;
             };
@@ -7139,6 +7186,7 @@ fn session_lifetime_overlaps(
 fn discover_claude_transcript_path(
     record: &SessionRecord,
     sessions: &[SessionRecord],
+    projects_roots: &[PathBuf],
 ) -> Option<String> {
     if record.provider != "claude" || !has_text(Some(record.working_dir.as_str())) {
         return record.transcript_path.clone();
@@ -7147,11 +7195,6 @@ fn discover_claude_transcript_path(
         return record.transcript_path.clone();
     }
 
-    let project_dir =
-        expand_home("~/.claude/projects").join(claude_project_dir_name(&record.working_dir));
-    if !project_dir.is_dir() {
-        return None;
-    }
     let resolved_working_dir = resolve_path_lossy(expand_home(&record.working_dir));
     let claimed_paths = sessions
         .iter()
@@ -7164,45 +7207,45 @@ fn discover_claude_transcript_path(
         .or_else(|| file_mtime_ns(expand_home(&record.log_file.clone().unwrap_or_default())).ok())
         .unwrap_or(0);
 
-    let mut candidates: Vec<(i128, i128, i128, String)> = Vec::new();
-    let Ok(entries) = fs::read_dir(&project_dir) else {
-        return None;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.extension().and_then(|value| value.to_str()) != Some("jsonl") {
-            continue;
-        }
-        let resolved_transcript = resolve_path_lossy(path.clone());
-        if claimed_paths.contains(&resolved_transcript) {
-            continue;
-        }
-        let metadata = read_claude_transcript_metadata(&path).unwrap_or_default();
-        if let Some(cwd) = metadata.cwd.as_deref() {
-            if cwd != resolved_working_dir {
+    let mut candidates: Vec<(bool, i128, i128, i128, String)> = Vec::new();
+    for projects_root in projects_roots {
+        let project_dir = projects_root.join(claude_project_dir_name(&record.working_dir));
+        for path in jsonl_files_recursive(&project_dir) {
+            let resolved_transcript = resolve_path_lossy(path.clone());
+            if claimed_paths.contains(&resolved_transcript) {
                 continue;
             }
+            let metadata = read_claude_transcript_metadata(&path).unwrap_or_default();
+            if let Some(cwd) = metadata.cwd.as_deref() {
+                if cwd != resolved_working_dir {
+                    continue;
+                }
+            }
+            let comparison_time = if metadata.mtime_ns > 0 {
+                metadata.mtime_ns
+            } else {
+                metadata.started_at_ns.unwrap_or(0)
+            };
+            let distance = (target_time_ns - comparison_time).abs();
+            let start_distance = metadata
+                .started_at_ns
+                .map(|started_at_ns| (target_time_ns - started_at_ns).abs())
+                .unwrap_or(distance);
+            candidates.push((
+                path.parent()
+                    .and_then(Path::file_name)
+                    .and_then(|value| value.to_str())
+                    == Some("subagents"),
+                distance,
+                start_distance,
+                -metadata.mtime_ns,
+                resolved_transcript,
+            ));
         }
-        let comparison_time = if metadata.mtime_ns > 0 {
-            metadata.mtime_ns
-        } else {
-            metadata.started_at_ns.unwrap_or(0)
-        };
-        let distance = (target_time_ns - comparison_time).abs();
-        let start_distance = metadata
-            .started_at_ns
-            .map(|started_at_ns| (target_time_ns - started_at_ns).abs())
-            .unwrap_or(distance);
-        candidates.push((
-            distance,
-            start_distance,
-            -metadata.mtime_ns,
-            resolved_transcript,
-        ));
     }
 
     candidates.sort();
-    candidates.into_iter().next().map(|(_, _, _, path)| path)
+    candidates.into_iter().next().map(|(_, _, _, _, path)| path)
 }
 
 fn read_claude_transcript_metadata(path: &Path) -> Result<ClaudeTranscriptMetadata> {
@@ -7406,6 +7449,38 @@ fn now_python_naive_iso() -> String {
             "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:6]"
         ))
         .unwrap_or_else(|_| "1970-01-01T00:00:00.000000".to_owned())
+}
+
+fn claude_projects_roots(configured_transcript_root: Option<&str>) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    let mut push = |path: PathBuf| {
+        if !roots.contains(&path) {
+            roots.push(path);
+        }
+    };
+
+    if let Some(root) = configured_transcript_root
+        .map(str::trim)
+        .filter(|root| !root.is_empty())
+    {
+        push(expand_home(root));
+    }
+    if let Some(config_dir) = env::var_os("CLAUDE_CONFIG_DIR")
+        .map(PathBuf::from)
+        .filter(|path| !path.as_os_str().is_empty())
+    {
+        push(config_dir.join("projects"));
+    }
+    if let Some(xdg_config_home) = env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .filter(|path| !path.as_os_str().is_empty())
+    {
+        push(xdg_config_home.join("claude").join("projects"));
+    } else {
+        push(expand_home("~/.config/claude/projects"));
+    }
+    push(expand_home("~/.claude/projects"));
+    roots
 }
 
 pub fn expand_home(path: &str) -> PathBuf {
@@ -8377,6 +8452,65 @@ mod tests {
         assert_eq!(expand_home("~"), home);
         assert_eq!(expand_home("~/work"), home.join("work"));
         assert_eq!(expand_home("/tmp/work"), PathBuf::from("/tmp/work"));
+    }
+
+    #[test]
+    fn claude_transcript_identity_prefers_metadata_for_nested_layouts() {
+        let root = unique_temp_path("nested-claude-transcript");
+        let transcript = root
+            .join("path-session")
+            .join("subagents")
+            .join("agent-child.jsonl");
+        fs::create_dir_all(transcript.parent().unwrap()).unwrap();
+        fs::write(
+            &transcript,
+            json!({
+                "type": "user",
+                "sessionId": "metadata-session",
+                "timestamp": "2026-01-01T00:00:00Z"
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            provider_resume_id_from_transcript_path(transcript.to_str().unwrap()).as_deref(),
+            Some("metadata-session")
+        );
+        assert_eq!(
+            provider_resume_id_from_transcript_path(
+                root.join("fallback-session")
+                    .join("chat.jsonl")
+                    .to_str()
+                    .unwrap()
+            )
+            .as_deref(),
+            Some("fallback-session")
+        );
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn claude_project_roots_include_config_environment_and_defaults() {
+        let _guard = TEST_ENV_LOCK.lock().unwrap();
+        let root = unique_temp_path("claude-project-roots");
+        let home = root.join("home");
+        let config_dir = root.join("claude-config");
+        let xdg_dir = root.join("xdg");
+        let configured = root.join("configured-projects");
+        let _home = EnvVarRestore::set("HOME", &home);
+        let _config = EnvVarRestore::set("CLAUDE_CONFIG_DIR", &config_dir);
+        let _xdg = EnvVarRestore::set("XDG_CONFIG_HOME", &xdg_dir);
+
+        assert_eq!(
+            claude_projects_roots(Some(configured.to_str().unwrap())),
+            vec![
+                configured,
+                config_dir.join("projects"),
+                xdg_dir.join("claude").join("projects"),
+                home.join(".claude").join("projects"),
+            ]
+        );
     }
 
     #[test]
@@ -9393,9 +9527,15 @@ mod tests {
         let project_dir =
             projects_root.join(claude_project_dir_name(working_dir.to_str().unwrap()));
         fs::create_dir_all(&project_dir).unwrap();
-        let current_path = project_dir.join("current-thread.jsonl");
-        let historical_path = project_dir.join("historical.jsonl");
+        let current_path = project_dir.join("current-thread").join("chat.jsonl");
+        let historical_path = project_dir.join("historical-thread").join("chat.jsonl");
+        let historical_sidechain_path = project_dir
+            .join("historical-thread")
+            .join("subagents")
+            .join("agent-child.jsonl");
         let ambiguous_path = project_dir.join("ambiguous.jsonl");
+        fs::create_dir_all(current_path.parent().unwrap()).unwrap();
+        fs::create_dir_all(historical_sidechain_path.parent().unwrap()).unwrap();
         let transcript = |session_id: &str, timestamp: &str| {
             json!({
                 "type": "user",
@@ -9413,6 +9553,11 @@ mod tests {
         fs::write(
             &historical_path,
             transcript("historical-thread", "2026-01-02T00:00:00Z"),
+        )
+        .unwrap();
+        fs::write(
+            &historical_sidechain_path,
+            transcript("historical-thread", "2026-01-02T00:01:00Z"),
         )
         .unwrap();
         fs::write(
@@ -10668,7 +10813,11 @@ mod tests {
         session.transcript_path = None;
         session.last_activity = "2026-06-23T01:27:23Z".to_owned();
 
-        let discovered = discover_claude_transcript_path(&session, &[session.clone()]);
+        let discovered = discover_claude_transcript_path(
+            &session,
+            &[session.clone()],
+            &[home.join(".claude").join("projects")],
+        );
 
         assert_eq!(
             discovered.as_deref(),

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -677,9 +677,16 @@ impl SessionStore {
             let _ = runtime.kill_session(&record.tmux_session);
             return Err(error);
         }
-        if record.provider == "codex" {
+        if matches!(record.provider.as_str(), "codex" | "codex-fork") {
             if let Some(provider_resume_id) = record.provider_resume_id.as_deref() {
-                self.append_seat_session(&record.id, &record.provider, provider_resume_id, None);
+                self.append_seat_session(
+                    &record.id,
+                    &record.provider,
+                    provider_resume_id,
+                    codex_fork_artifacts
+                        .as_ref()
+                        .and_then(|artifacts| artifacts.event_stream_path.to_str()),
+                );
             }
         }
         if let Some(artifacts) = codex_fork_artifacts {
@@ -2158,7 +2165,14 @@ impl SessionStore {
     }
 
     fn execute_pending_codex_fork_handoff(&self, session_id: &str) -> Result<bool> {
-        let (file_path, tmux_session, socket_name, event_stream_path, event_offset) = {
+        let (
+            file_path,
+            tmux_session,
+            socket_name,
+            event_stream_path,
+            event_offset,
+            previous_provider_resume_id,
+        ) = {
             let _guard = self.write_guard()?;
             let state = self.load_raw_json_value()?;
             let Some(session) = raw_session_object(&state, session_id) else {
@@ -2185,6 +2199,7 @@ impl SessionStore {
                 json_text(session.get("tmux_socket_name")),
                 artifacts.event_stream_path,
                 event_offset,
+                json_text(session.get("provider_resume_id")),
             )
         };
 
@@ -2206,7 +2221,11 @@ impl SessionStore {
             )? {
                 anyhow::bail!("tmux session is not running");
             }
-            Ok(())
+            wait_for_codex_fork_provider_resume_id_after_offset(
+                &event_stream_path,
+                event_offset,
+                CODEX_FORK_THREAD_STARTED_TIMEOUT,
+            )
         })();
 
         let _guard = self.write_guard()?;
@@ -2216,7 +2235,25 @@ impl SessionStore {
             return Ok(false);
         };
         match result {
-            Ok(()) => {
+            Ok(provider_resume_id) => {
+                if let Some(previous_provider_resume_id) = previous_provider_resume_id.as_deref() {
+                    self.append_seat_session(
+                        session_id,
+                        "codex-fork",
+                        previous_provider_resume_id,
+                        event_stream_path.to_str(),
+                    );
+                }
+                self.append_seat_session(
+                    session_id,
+                    "codex-fork",
+                    &provider_resume_id,
+                    event_stream_path.to_str(),
+                );
+                session.insert(
+                    "provider_resume_id".to_owned(),
+                    Value::String(provider_resume_id),
+                );
                 session.insert(
                     "last_handoff_path".to_owned(),
                     Value::String(file_path.clone()),
@@ -8557,17 +8594,19 @@ mod tests {
             session.last_handoff_path.as_deref(),
             Some(fixture.handoff_path.to_str().unwrap())
         );
-        assert_eq!(session.provider_resume_id.as_deref(), Some("old-thread"));
-        store
-            .apply_codex_fork_event_line(
-                "codex001",
-                r#"{"event_type":"thread/started","payload":{"thread":{"id":"new-thread"}}}"#,
-            )
-            .unwrap();
-        let session = store.get_session("codex001").unwrap().unwrap();
-        assert_eq!(session.id, "codex001");
-        assert_eq!(session.friendly_name.as_deref(), Some("stable-agent"));
         assert_eq!(session.provider_resume_id.as_deref(), Some("new-thread"));
+        let connection =
+            rusqlite::Connection::open(fixture.state_file.with_extension("usage.db")).unwrap();
+        let provider_session_ids = connection
+            .prepare(
+                "SELECT provider_session_id FROM seat_sessions WHERE seat_id = 'codex001' ORDER BY provider_session_id",
+            )
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(provider_session_ids, vec!["new-thread", "old-thread"]);
         let state = store.load_raw_json_value().unwrap();
         let session = raw_session_object(&state, "codex001").unwrap();
         assert!(json_text(session.get("pending_handoff_path")).is_none());
@@ -8617,6 +8656,15 @@ mod tests {
                 .last_handoff_path
                 .as_deref(),
             Some(fixture.handoff_path.to_str().unwrap())
+        );
+        assert_eq!(
+            restarted
+                .get_session("codex001")
+                .unwrap()
+                .unwrap()
+                .provider_resume_id
+                .as_deref(),
+            Some("new-thread")
         );
     }
 
@@ -8870,7 +8918,7 @@ mod tests {
     }
 
     fn start_codex_fork_handoff_tmux(socket: &str, session: &str, event_stream_path: &Path) {
-        let script = r#"event_file=$1; pending=; printf '› '; while IFS= read -r line; do if [ -n "$pending" ]; then printf '{"event_type":"op_submitted","payload":{"UserTurn":{"items":[{"type":"text","text":"%s"}]}}}\n' "$pending" >> "$event_file"; pending=; printf '\n› '; elif [ "${line#Read }" != "$line" ]; then pending=$line; printf 'received:%s\n› %s' "$line" "$line"; else printf 'received:%s\n› ' "$line"; fi; done"#;
+        let script = r#"event_file=$1; pending=; printf '› '; while IFS= read -r line; do if [ "${line%/new}" != "$line" ]; then printf '{"event_type":"thread/started","payload":{"thread":{"id":"new-thread"}}}\n' >> "$event_file"; printf 'received:%s\n› ' "$line"; elif [ -n "$pending" ]; then printf '{"event_type":"op_submitted","payload":{"UserTurn":{"items":[{"type":"text","text":"%s"}]}}}\n' "$pending" >> "$event_file"; pending=; printf '\n› '; elif [ "${line#Read }" != "$line" ]; then pending=$line; printf 'received:%s\n› %s' "$line" "$line"; else printf 'received:%s\n› ' "$line"; fi; done"#;
         let command = format!(
             "/bin/sh -lc {} handoff-shell {}",
             shell_quote_handoff_fixture(script),

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -38,6 +38,7 @@ const OUTPUT_TAIL_BYTES_PER_LINE: u64 = 4096;
 const MIN_OUTPUT_TAIL_BYTES: u64 = 16 * 1024;
 const MAX_OUTPUT_TAIL_BYTES: u64 = 1024 * 1024;
 const CODEX_CLI_SESSION_BIND_TIMEOUT: Duration = Duration::from_secs(1);
+const CODEX_CLI_DEFERRED_BIND_TIMEOUT: Duration = Duration::from_secs(30);
 const CODEX_CLI_SESSION_BIND_POLL: Duration = Duration::from_millis(50);
 const CODEX_FORK_THREAD_STARTED_TIMEOUT: Duration = Duration::from_secs(10);
 const CODEX_FORK_EVENT_MONITOR_POLL: Duration = Duration::from_millis(250);
@@ -1268,7 +1269,7 @@ impl SessionStore {
         request: ClearSessionRequest,
         runtime: &TmuxRuntime,
     ) -> Result<CoreClearOutcome> {
-        let _clear_guard = self.lock_clear_operation(session_id)?;
+        let clear_guard = self.lock_clear_operation(session_id)?;
         let prompt = request
             .prompt
             .as_deref()
@@ -1382,13 +1383,13 @@ impl SessionStore {
             return Err(anyhow::anyhow!("tmux session is not running"));
         }
         let replacement_provider_resume_id = if let Some((record, excluded_ids, launched_at_ns)) =
-            codex_cli_clear_binding
+            codex_cli_clear_binding.as_ref()
         {
             let provider_resume_id = wait_for_codex_cli_provider_resume_id(
-                &record,
+                record,
                 &self.codex_sessions_root,
-                &excluded_ids,
-                launched_at_ns,
+                excluded_ids,
+                *launched_at_ns,
                 CODEX_CLI_SESSION_BIND_TIMEOUT,
             );
             if provider_resume_id.is_none() {
@@ -1452,18 +1453,93 @@ impl SessionStore {
             reset_session_after_clear(session, &now);
             self.write_raw_json_value(&state)?;
         }
-        if let Some((provider_resume_id, artifact_path)) = replacement_provider_resume_id {
+        if let Some((provider_resume_id, artifact_path)) = replacement_provider_resume_id.as_ref() {
             self.append_seat_session(
                 session_id,
                 &provider,
-                &provider_resume_id,
+                provider_resume_id,
                 artifact_path.as_deref(),
             );
+        }
+        if replacement_provider_resume_id.is_none() {
+            if let Some((record, excluded_ids, launched_at_ns)) = codex_cli_clear_binding {
+                let store = self.clone();
+                let deferred_session_id = session_id.to_owned();
+                let expected_provider_resume_id = previous_provider_resume_id;
+                let spawn_result = thread::Builder::new()
+                    .name(format!(
+                        "sm-codex-clear-rebind-{}",
+                        sanitize_path_component(session_id)
+                    ))
+                    .spawn(move || {
+                        let _clear_guard = clear_guard;
+                        if let Err(error) = store.complete_deferred_codex_cli_rebind(
+                            &deferred_session_id,
+                            &record,
+                            &excluded_ids,
+                            launched_at_ns,
+                            expected_provider_resume_id.as_deref(),
+                            CODEX_CLI_DEFERRED_BIND_TIMEOUT,
+                        ) {
+                            eprintln!(
+                                "deferred Codex thread discovery failed for seat {deferred_session_id}: {error:#}"
+                            );
+                        }
+                    });
+                if let Err(error) = spawn_result {
+                    eprintln!("failed to start deferred Codex thread discovery: {error}");
+                }
+            }
         }
         Ok(CoreClearOutcome::Cleared(CoreClearResult {
             status: "cleared".to_owned(),
             session_id: session_id.to_owned(),
         }))
+    }
+
+    fn complete_deferred_codex_cli_rebind(
+        &self,
+        session_id: &str,
+        record: &SessionRecord,
+        excluded_ids: &BTreeSet<String>,
+        launched_at_ns: i128,
+        expected_provider_resume_id: Option<&str>,
+        timeout: Duration,
+    ) -> Result<bool> {
+        let Some(provider_resume_id) = wait_for_codex_cli_provider_resume_id(
+            record,
+            &self.codex_sessions_root,
+            excluded_ids,
+            launched_at_ns,
+            timeout,
+        ) else {
+            eprintln!("deferred Codex thread discovery timed out for seat {session_id}");
+            return Ok(false);
+        };
+        {
+            let _guard = self.write_guard()?;
+            let mut state = self.load_raw_json_value()?;
+            let sessions = ensure_sessions_array_mut(&mut state)?;
+            let Some(session) = session_object_mut(sessions, session_id) else {
+                return Ok(false);
+            };
+            let provider = json_text(session.get("provider")).unwrap_or_else(default_provider);
+            let status = json_text(session.get("status")).unwrap_or_else(|| "running".to_owned());
+            if provider != "codex"
+                || normalized_status(&status) == "stopped"
+                || json_text(session.get("provider_resume_id")).as_deref()
+                    != expected_provider_resume_id
+            {
+                return Ok(false);
+            }
+            session.insert(
+                "provider_resume_id".to_owned(),
+                Value::String(provider_resume_id.clone()),
+            );
+            self.write_raw_json_value(&state)?;
+        }
+        self.append_seat_session(session_id, "codex", &provider_resume_id, None);
+        Ok(true)
     }
 
     fn lock_clear_operation(&self, session_id: &str) -> Result<SessionClearGuard> {
@@ -2480,23 +2556,9 @@ impl SessionStore {
         };
         match result {
             Ok(provider_resume_id) => {
-                if let Some(previous_provider_resume_id) = previous_provider_resume_id.as_deref() {
-                    self.append_seat_session(
-                        session_id,
-                        "codex-fork",
-                        previous_provider_resume_id,
-                        event_stream_path.to_str(),
-                    );
-                }
-                self.append_seat_session(
-                    session_id,
-                    "codex-fork",
-                    &provider_resume_id,
-                    event_stream_path.to_str(),
-                );
                 session.insert(
                     "provider_resume_id".to_owned(),
-                    Value::String(provider_resume_id),
+                    Value::String(provider_resume_id.clone()),
                 );
                 session.insert(
                     "last_handoff_path".to_owned(),
@@ -2515,6 +2577,20 @@ impl SessionStore {
                 clear_codex_fork_handoff_error_raw(session);
                 self.write_raw_json_value(&state)?;
                 drop(_guard);
+                if let Some(previous_provider_resume_id) = previous_provider_resume_id.as_deref() {
+                    self.append_seat_session(
+                        session_id,
+                        "codex-fork",
+                        previous_provider_resume_id,
+                        event_stream_path.to_str(),
+                    );
+                }
+                self.append_seat_session(
+                    session_id,
+                    "codex-fork",
+                    &provider_resume_id,
+                    event_stream_path.to_str(),
+                );
                 let _ = self.cancel_context_monitor_alerts(session_id);
                 Ok(cleared_pending)
             }
@@ -10165,6 +10241,84 @@ mod tests {
             Some("new-id")
         );
 
+        let _ = fs::remove_dir_all(temp_dir);
+    }
+
+    #[test]
+    fn deferred_codex_clear_binding_captures_a_late_replacement_rollout() {
+        let temp_dir = unique_temp_path("codex-deferred-clear-binding");
+        let state_file = temp_dir.join("sessions.json");
+        let working_dir = temp_dir.join("repo");
+        let sessions_root = temp_dir.join("codex-home").join("sessions");
+        let day_dir = sessions_root.join("2026").join("07").join("28");
+        fs::create_dir_all(&working_dir).unwrap();
+        fs::create_dir_all(&day_dir).unwrap();
+        let mut record = session_record("running");
+        record.id = "codex001".to_owned();
+        record.provider = "codex".to_owned();
+        record.working_dir = working_dir.display().to_string();
+        record.provider_resume_id = Some("old-thread".to_owned());
+        record.created_at = "2026-07-28T20:00:00Z".to_owned();
+        record.last_activity = record.created_at.clone();
+        fs::write(
+            &state_file,
+            json!({"sessions": [record.clone()]}).to_string(),
+        )
+        .unwrap();
+        let mut store =
+            SessionStore::new_with_legacy_fallback(state_file.clone(), state_file.clone());
+        store.codex_sessions_root = sessions_root;
+        store.append_seat_session("codex001", "codex", "old-thread", None);
+        let rollout_path = day_dir.join("rollout-new-thread.jsonl");
+        let rollout_working_dir = working_dir.clone();
+        let writer = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(1_200));
+            fs::write(
+                rollout_path,
+                format!(
+                    "{}\n",
+                    json!({
+                        "type": "session_meta",
+                        "payload": {
+                            "id": "new-thread",
+                            "cwd": rollout_working_dir.display().to_string(),
+                            "timestamp": "2026-07-28T20:00:01Z"
+                        }
+                    })
+                ),
+            )
+            .unwrap();
+        });
+
+        assert!(store
+            .complete_deferred_codex_cli_rebind(
+                "codex001",
+                &record,
+                &BTreeSet::from(["old-thread".to_owned()]),
+                parse_timestamp_ns("2026-07-28T20:00:00Z").unwrap(),
+                Some("old-thread"),
+                Duration::from_secs(2),
+            )
+            .unwrap());
+        writer.join().unwrap();
+        assert_eq!(
+            store
+                .get_session("codex001")
+                .unwrap()
+                .unwrap()
+                .provider_resume_id
+                .as_deref(),
+            Some("new-thread")
+        );
+        let count: i64 = rusqlite::Connection::open(state_file.with_extension("usage.db"))
+            .unwrap()
+            .query_row(
+                "SELECT COUNT(*) FROM seat_sessions WHERE seat_id = 'codex001'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 2);
         let _ = fs::remove_dir_all(temp_dir);
     }
 

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1357,11 +1357,16 @@ impl SessionStore {
             let current_socket_name = json_text(session.get("tmux_socket_name"));
             let current_provider =
                 json_text(session.get("provider")).unwrap_or_else(default_provider);
+            let current_status =
+                json_text(session.get("status")).unwrap_or_else(|| "running".to_owned());
             if current_tmux_session.as_deref() != Some(tmux_session.as_str())
                 || current_socket_name != session_socket_name
                 || current_provider != provider
             {
                 anyhow::bail!("session {session_id} changed while clear was in progress");
+            }
+            if normalized_status(&current_status) == "stopped" {
+                anyhow::bail!("session {session_id} stopped while clear was in progress");
             }
             if let Some((provider_resume_id, _)) = replacement_provider_resume_id.as_ref() {
                 session.insert(

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -51,6 +51,7 @@ pub struct SessionStore {
     state_file: PathBuf,
     legacy_state_file: Option<PathBuf>,
     codex_sessions_root: PathBuf,
+    claude_projects_root: PathBuf,
     write_lock: Arc<Mutex<()>>,
     queue_store: Option<RetainedQueueStore>,
     /// Carried on the store rather than read per-request because the codex-fork
@@ -97,6 +98,7 @@ impl SessionStore {
             state_file,
             legacy_state_file,
             codex_sessions_root: expand_home("~/.codex/sessions"),
+            claude_projects_root: expand_home("~/.claude/projects"),
             write_lock: Arc::new(Mutex::new(())),
             queue_store: None,
             context_monitor: ContextMonitorConfig::default(),
@@ -192,21 +194,47 @@ impl SessionStore {
     }
 
     pub fn reconcile_current_seat_sessions(&self) -> Result<()> {
-        let sessions = self
-            .load_snapshot()?
-            .into_sessions()
-            .into_iter()
+        let records = self.load_snapshot()?.into_sessions();
+        let mut claim_attempt = 0;
+        let mut claimed = loop {
+            match self.seat_session_store.claimed_provider_sessions() {
+                Ok(claimed) => break claimed,
+                Err(error)
+                    if usage_ledger_error_is_transient(&error)
+                        && claim_attempt < SEAT_SESSION_RETRY_ATTEMPTS =>
+                {
+                    claim_attempt += 1;
+                    thread::sleep(SEAT_SESSION_RETRY_DELAY);
+                }
+                Err(error) => return Err(error),
+            }
+        };
+        let mut sessions = records
+            .iter()
             .filter_map(|session| {
-                provider_resume_id_for_restore(&session).map(|provider_session_id| {
+                provider_resume_id_for_restore(session).map(|provider_session_id| {
+                    claimed.insert((session.provider.clone(), provider_session_id.clone()));
                     SeatSessionIdentity {
-                        seat_id: session.id,
-                        provider: session.provider,
+                        seat_id: session.id.clone(),
+                        provider: session.provider.clone(),
                         provider_session_id,
-                        artifact_path: session.transcript_path,
+                        artifact_path: session.transcript_path.clone(),
                     }
                 })
             })
             .collect::<Vec<_>>();
+        sessions.extend(historical_claude_seat_sessions(
+            &records,
+            &self.claude_projects_root,
+            &mut claimed,
+        ));
+        if let Some(runtime) = self.delivery_runtime.as_ref() {
+            sessions.extend(historical_codex_fork_seat_sessions(
+                &records,
+                runtime,
+                &mut claimed,
+            ));
+        }
         for attempt in 0..=SEAT_SESSION_RETRY_ATTEMPTS {
             match self.seat_session_store.append_batch(&sessions) {
                 Ok(()) => return Ok(()),
@@ -258,6 +286,7 @@ impl SessionStore {
             state_file,
             legacy_state_file: Some(legacy_state_file),
             codex_sessions_root: expand_home("~/.codex/sessions"),
+            claude_projects_root: expand_home("~/.claude/projects"),
             write_lock: Arc::new(Mutex::new(())),
             queue_store: None,
             context_monitor: ContextMonitorConfig::default(),
@@ -266,6 +295,12 @@ impl SessionStore {
             clear_operation_locks: Arc::new(Mutex::new(BTreeMap::new())),
             seat_session_store,
         }
+    }
+
+    #[cfg(test)]
+    fn with_claude_projects_root(mut self, projects_root: PathBuf) -> Self {
+        self.claude_projects_root = projects_root;
+        self
     }
 
     pub fn list_sessions(&self, include_stopped: bool) -> Result<Vec<SessionRecord>> {
@@ -6660,8 +6695,157 @@ fn read_codex_cli_session_metadata(path: &Path) -> Option<(String, String, Optio
 #[derive(Debug, Default)]
 struct ClaudeTranscriptMetadata {
     mtime_ns: i128,
+    session_id: Option<String>,
     started_at_ns: Option<i128>,
+    ended_at_ns: Option<i128>,
     cwd: Option<String>,
+}
+
+fn historical_claude_seat_sessions(
+    sessions: &[SessionRecord],
+    projects_root: &Path,
+    claimed: &mut BTreeSet<(String, String)>,
+) -> Vec<SeatSessionIdentity> {
+    let mut project_dirs = BTreeMap::<PathBuf, BTreeSet<String>>::new();
+    for session in sessions
+        .iter()
+        .filter(|session| session.provider == "claude")
+        .filter(|session| has_text(Some(&session.working_dir)))
+    {
+        project_dirs
+            .entry(projects_root.join(claude_project_dir_name(&session.working_dir)))
+            .or_default()
+            .insert(resolve_path_lossy(expand_home(&session.working_dir)));
+    }
+
+    let mut identities = Vec::new();
+    for (project_dir, project_working_dirs) in project_dirs {
+        let Ok(entries) = fs::read_dir(project_dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|value| value.to_str()) != Some("jsonl") {
+                continue;
+            }
+            let Ok(metadata) = read_claude_transcript_metadata(&path) else {
+                continue;
+            };
+            let Some(provider_session_id) = metadata.session_id else {
+                continue;
+            };
+            let claim = ("claude".to_owned(), provider_session_id.clone());
+            if claimed.contains(&claim) {
+                continue;
+            }
+            let artifact_start = metadata.started_at_ns.unwrap_or(metadata.mtime_ns);
+            let artifact_end = metadata.ended_at_ns.unwrap_or(metadata.mtime_ns);
+            let matching_seats = sessions
+                .iter()
+                .filter(|session| session.provider == "claude")
+                .filter(|session| {
+                    let working_dir = resolve_path_lossy(expand_home(&session.working_dir));
+                    metadata.cwd.as_deref().map_or_else(
+                        || project_working_dirs.contains(&working_dir),
+                        |cwd| cwd == working_dir,
+                    )
+                })
+                .filter(|session| session_lifetime_overlaps(session, artifact_start, artifact_end))
+                .map(|session| session.id.as_str())
+                .collect::<BTreeSet<_>>();
+            if matching_seats.is_empty() {
+                continue;
+            }
+            let seat_id = if matching_seats.len() == 1 {
+                matching_seats.into_iter().next().unwrap().to_owned()
+            } else {
+                "unassigned".to_owned()
+            };
+            claimed.insert(claim);
+            identities.push(SeatSessionIdentity {
+                seat_id,
+                provider: "claude".to_owned(),
+                provider_session_id,
+                artifact_path: Some(resolve_path_lossy(path)),
+            });
+        }
+    }
+    identities
+}
+
+fn historical_codex_fork_seat_sessions(
+    sessions: &[SessionRecord],
+    runtime: &TmuxRuntime,
+    claimed: &mut BTreeSet<(String, String)>,
+) -> Vec<SeatSessionIdentity> {
+    let mut identities = Vec::new();
+    for session in sessions
+        .iter()
+        .filter(|session| session.provider == "codex-fork")
+    {
+        let Some(log_file) = session.log_file.as_deref().map(expand_home) else {
+            continue;
+        };
+        let spec = TmuxSessionSpec {
+            session_id: session.id.clone(),
+            tmux_session: session.tmux_session.clone(),
+            working_dir: session.working_dir.clone(),
+            log_file,
+            provider: session.provider.clone(),
+            initial_message: None,
+            model: session.model.clone(),
+            reasoning_effort: session.reasoning_effort.clone(),
+        };
+        let Ok(Some(artifacts)) = runtime.codex_fork_runtime_artifacts(&spec) else {
+            continue;
+        };
+        let Ok(file) = fs::File::open(&artifacts.event_stream_path) else {
+            continue;
+        };
+        for line in BufReader::new(file).lines().map_while(|line| line.ok()) {
+            let Some(provider_session_id) =
+                serde_json::from_str::<Value>(&line).ok().and_then(|value| {
+                    value
+                        .as_object()
+                        .and_then(extract_codex_fork_thread_started)
+                })
+            else {
+                continue;
+            };
+            let claim = ("codex-fork".to_owned(), provider_session_id.clone());
+            if !claimed.insert(claim) {
+                continue;
+            }
+            identities.push(SeatSessionIdentity {
+                seat_id: session.id.clone(),
+                provider: "codex-fork".to_owned(),
+                provider_session_id,
+                artifact_path: Some(artifacts.event_stream_path.display().to_string()),
+            });
+        }
+    }
+    identities
+}
+
+fn session_lifetime_overlaps(
+    session: &SessionRecord,
+    artifact_start: i128,
+    artifact_end: i128,
+) -> bool {
+    let Some(seat_start) = parse_timestamp_ns(&session.created_at) else {
+        return false;
+    };
+    let seat_end = if normalized_status(&session.status) == "stopped" {
+        session
+            .stopped_at
+            .as_deref()
+            .and_then(parse_timestamp_ns)
+            .or_else(|| parse_timestamp_ns(&session.last_activity))
+            .unwrap_or(seat_start)
+    } else {
+        i128::MAX
+    };
+    artifact_end >= seat_start && artifact_start <= seat_end
 }
 
 fn discover_claude_transcript_path(
@@ -6751,6 +6935,30 @@ fn read_claude_transcript_metadata(path: &Path) -> Result<ClaudeTranscriptMetada
         let Some(object) = value.as_object() else {
             continue;
         };
+        if metadata.session_id.is_none() {
+            metadata.session_id = object
+                .get("sessionId")
+                .and_then(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned);
+        }
+        if let Some(timestamp) = object
+            .get("timestamp")
+            .and_then(Value::as_str)
+            .and_then(parse_timestamp_ns)
+        {
+            metadata.started_at_ns = Some(
+                metadata
+                    .started_at_ns
+                    .map_or(timestamp, |started| started.min(timestamp)),
+            );
+            metadata.ended_at_ns = Some(
+                metadata
+                    .ended_at_ns
+                    .map_or(timestamp, |ended| ended.max(timestamp)),
+            );
+        }
         if object.get("type").and_then(Value::as_str) == Some("user") && metadata.cwd.is_none() {
             if let Some(cwd) = object
                 .get("cwd")
@@ -6760,10 +6968,6 @@ fn read_claude_transcript_metadata(path: &Path) -> Result<ClaudeTranscriptMetada
             {
                 metadata.cwd = Some(resolve_path_lossy(expand_home(cwd)));
             }
-            metadata.started_at_ns = object
-                .get("timestamp")
-                .and_then(Value::as_str)
-                .and_then(parse_timestamp_ns);
         }
     }
     Ok(metadata)
@@ -8889,6 +9093,167 @@ mod tests {
             )
             .unwrap();
         assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn startup_reconciliation_backfills_historical_claude_identities_conservatively() {
+        let state_file = unique_temp_path("seat-session-claude-backfill");
+        let usage_db_path = state_file.with_extension("usage.db");
+        let projects_root = state_file.with_extension("claude-projects");
+        let working_dir = state_file.with_extension("repo");
+        fs::create_dir_all(&working_dir).unwrap();
+        let project_dir =
+            projects_root.join(claude_project_dir_name(working_dir.to_str().unwrap()));
+        fs::create_dir_all(&project_dir).unwrap();
+        let current_path = project_dir.join("current-thread.jsonl");
+        let historical_path = project_dir.join("historical.jsonl");
+        let ambiguous_path = project_dir.join("ambiguous.jsonl");
+        let transcript = |session_id: &str, timestamp: &str| {
+            json!({
+                "type": "user",
+                "sessionId": session_id,
+                "cwd": working_dir.display().to_string(),
+                "timestamp": timestamp
+            })
+            .to_string()
+        };
+        fs::write(
+            &current_path,
+            transcript("current-thread", "2026-01-06T00:00:00Z"),
+        )
+        .unwrap();
+        fs::write(
+            &historical_path,
+            transcript("historical-thread", "2026-01-02T00:00:00Z"),
+        )
+        .unwrap();
+        fs::write(
+            &ambiguous_path,
+            transcript("ambiguous-thread", "2026-01-04T12:00:00Z"),
+        )
+        .unwrap();
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [
+                    {
+                        "id": "seat-old",
+                        "name": "claude-seat-old",
+                        "provider": "claude",
+                        "working_dir": working_dir.display().to_string(),
+                        "tmux_session": "claude-seat-old",
+                        "status": "stopped",
+                        "created_at": "2026-01-01T00:00:00Z",
+                        "last_activity": "2026-01-05T00:00:00Z",
+                        "stopped_at": "2026-01-05T00:00:00Z"
+                    },
+                    {
+                        "id": "seat-current",
+                        "name": "claude-seat-current",
+                        "provider": "claude",
+                        "working_dir": working_dir.display().to_string(),
+                        "tmux_session": "claude-seat-current",
+                        "status": "running",
+                        "transcript_path": current_path.display().to_string(),
+                        "created_at": "2026-01-04T00:00:00Z",
+                        "last_activity": "2026-01-06T00:00:00Z"
+                    }
+                ]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let store = SessionStore::new_with_legacy_fallback(state_file.clone(), state_file)
+            .with_claude_projects_root(projects_root);
+
+        store.reconcile_current_seat_sessions().unwrap();
+
+        let connection = rusqlite::Connection::open(usage_db_path).unwrap();
+        let mut statement = connection
+            .prepare(
+                "SELECT seat_id, provider_session_id FROM seat_sessions ORDER BY provider_session_id",
+            )
+            .unwrap();
+        let rows = statement
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                ("unassigned".to_owned(), "ambiguous-thread".to_owned()),
+                ("seat-current".to_owned(), "current-thread".to_owned()),
+                ("seat-old".to_owned(), "historical-thread".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn startup_reconciliation_backfills_codex_fork_thread_history() {
+        let state_file = unique_temp_path("seat-session-fork-backfill");
+        let usage_db_path = state_file.with_extension("usage.db");
+        let log_file = state_file.with_extension("log");
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [{
+                    "id": "codex001",
+                    "name": "codex-codex001",
+                    "provider": "codex-fork",
+                    "provider_resume_id": "current-thread",
+                    "working_dir": "/repo",
+                    "tmux_session": "codex-codex001",
+                    "log_file": log_file.display().to_string(),
+                    "status": "running",
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "last_activity": "2026-01-02T00:00:00Z"
+                }]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let runtime = TmuxRuntime::from_config(&crate::config::RustCoreConfig::default());
+        let store = SessionStore::new_with_legacy_fallback(state_file.clone(), state_file)
+            .with_delivery_runtime(Some(runtime.clone()));
+        let snapshot = store.load_snapshot().unwrap();
+        let record = snapshot.sessions.first().unwrap();
+        let spec = TmuxSessionSpec {
+            session_id: record.id.clone(),
+            tmux_session: record.tmux_session.clone(),
+            working_dir: record.working_dir.clone(),
+            log_file,
+            provider: record.provider.clone(),
+            initial_message: None,
+            model: None,
+            reasoning_effort: None,
+        };
+        let artifacts = runtime
+            .codex_fork_runtime_artifacts(&spec)
+            .unwrap()
+            .unwrap();
+        fs::write(
+            &artifacts.event_stream_path,
+            concat!(
+                "{\"event_type\":\"thread/started\",\"payload\":{\"thread\":{\"id\":\"historical-thread\"}}}\n",
+                "{\"event_type\":\"thread/started\",\"payload\":{\"thread\":{\"id\":\"current-thread\"}}}\n"
+            ),
+        )
+        .unwrap();
+
+        store.reconcile_current_seat_sessions().unwrap();
+
+        let count: i64 = rusqlite::Connection::open(usage_db_path)
+            .unwrap()
+            .query_row(
+                "SELECT COUNT(*) FROM seat_sessions WHERE seat_id = 'codex001'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 2);
     }
 
     #[test]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1195,83 +1195,109 @@ impl SessionStore {
         request: ClearSessionRequest,
         runtime: &TmuxRuntime,
     ) -> Result<CoreClearOutcome> {
-        let _guard = self.write_guard()?;
-        let mut state = self.load_raw_json_value()?;
-        let sessions = ensure_sessions_array_mut(&mut state)?;
-        let claimed_provider_resume_ids = sessions
-            .iter()
-            .filter_map(|session| json_text(session.get("provider_resume_id")))
-            .collect::<BTreeSet<_>>();
-        let Some(session) = session_object_mut(sessions, session_id) else {
-            return Ok(CoreClearOutcome::NotFound);
-        };
-        if let Some(message) =
-            clear_authorization_error(session, request.requester_session_id.as_deref())
-        {
-            return Ok(CoreClearOutcome::Unauthorized(message));
-        }
-        let node = json_text(session.get("node")).unwrap_or_else(default_node);
-        ensure_runtime_local_node(&node)?;
-        let tmux_session = json_text(session.get("tmux_session"))
-            .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?;
-        let session_socket_name = json_text(session.get("tmux_socket_name"));
-        let session_runtime = runtime.for_socket_name(session_socket_name.as_deref());
-        let provider = json_text(session.get("provider")).unwrap_or_else(default_provider);
-        let clear_command = if matches!(provider.as_str(), "codex" | "codex-fork") {
-            "/new"
-        } else {
-            "/clear"
-        };
-        let codex_cli_clear_binding = (provider == "codex").then(|| -> Result<_> {
-            let mut record =
-                serde_json::from_value::<SessionRecord>(Value::Object(session.clone()))?;
-            if let Some(previous_provider_resume_id) = record.provider_resume_id.as_deref() {
-                self.append_seat_session(session_id, &provider, previous_provider_resume_id, None);
-            }
-            let launched_at = OffsetDateTime::now_utc();
-            // `/new` writes under today's rollout directory, which may be far
-            // from the seat's original creation date.
-            record.created_at = launched_at
-                .format(&Rfc3339)
-                .context("failed to format Codex clear timestamp")?;
-            let mut excluded_ids = claimed_provider_resume_ids;
-            excluded_ids.extend(codex_cli_existing_session_ids(
-                &record,
-                &self.codex_sessions_root,
-            ));
-            Ok((record, excluded_ids, launched_at.unix_timestamp_nanos()))
-        });
-        let codex_cli_clear_binding = codex_cli_clear_binding.transpose()?;
-        let codex_fork_clear_binding = (provider == "codex-fork")
-            .then(|| -> Result<_> {
-                let spec = codex_fork_spec_for_session_raw(session_id, session)?;
-                let artifacts = session_runtime
-                    .codex_fork_runtime_artifacts(&spec)?
-                    .ok_or_else(|| anyhow::anyhow!("session {session_id} has no fork artifacts"))?;
-                if let Some(previous_provider_resume_id) =
-                    json_text(session.get("provider_resume_id"))
-                {
-                    self.append_seat_session(
-                        session_id,
-                        &provider,
-                        &previous_provider_resume_id,
-                        artifacts.event_stream_path.to_str(),
-                    );
-                }
-                let initial_offset = fs::metadata(&artifacts.event_stream_path)
-                    .map(|metadata| metadata.len())
-                    .unwrap_or(0);
-                Ok((artifacts.event_stream_path, initial_offset))
-            })
-            .transpose()?;
         let prompt = request
             .prompt
             .as_deref()
             .map(str::trim)
             .filter(|value| !value.is_empty())
             .map(ToOwned::to_owned);
-        let wake_completed =
-            json_text(session.get("completion_status")).is_some_and(|value| value == "completed");
+        let (
+            tmux_session,
+            session_socket_name,
+            provider,
+            wake_completed,
+            claimed_provider_resume_ids,
+            codex_cli_record,
+            codex_fork_spec,
+            previous_provider_resume_id,
+        ) = {
+            let _guard = self.write_guard()?;
+            let mut state = self.load_raw_json_value()?;
+            let sessions = ensure_sessions_array_mut(&mut state)?;
+            let claimed_provider_resume_ids = sessions
+                .iter()
+                .filter_map(|session| json_text(session.get("provider_resume_id")))
+                .collect::<BTreeSet<_>>();
+            let Some(session) = session_object_mut(sessions, session_id) else {
+                return Ok(CoreClearOutcome::NotFound);
+            };
+            if let Some(message) =
+                clear_authorization_error(session, request.requester_session_id.as_deref())
+            {
+                return Ok(CoreClearOutcome::Unauthorized(message));
+            }
+            let node = json_text(session.get("node")).unwrap_or_else(default_node);
+            ensure_runtime_local_node(&node)?;
+            let tmux_session = json_text(session.get("tmux_session"))
+                .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?;
+            let session_socket_name = json_text(session.get("tmux_socket_name"));
+            let provider = json_text(session.get("provider")).unwrap_or_else(default_provider);
+            let wake_completed = json_text(session.get("completion_status"))
+                .is_some_and(|value| value == "completed");
+            let previous_provider_resume_id = json_text(session.get("provider_resume_id"));
+            let codex_cli_record = (provider == "codex")
+                .then(|| serde_json::from_value::<SessionRecord>(Value::Object(session.clone())))
+                .transpose()?;
+            let codex_fork_spec = (provider == "codex-fork")
+                .then(|| codex_fork_spec_for_session_raw(session_id, session))
+                .transpose()?;
+            (
+                tmux_session,
+                session_socket_name,
+                provider,
+                wake_completed,
+                claimed_provider_resume_ids,
+                codex_cli_record,
+                codex_fork_spec,
+                previous_provider_resume_id,
+            )
+        };
+
+        let session_runtime = runtime.for_socket_name(session_socket_name.as_deref());
+        let codex_cli_clear_binding = codex_cli_record
+            .map(|mut record| -> Result<_> {
+                let launched_at = OffsetDateTime::now_utc();
+                // `/new` writes under today's rollout directory, which may be far
+                // from the seat's original creation date.
+                record.created_at = launched_at
+                    .format(&Rfc3339)
+                    .context("failed to format Codex clear timestamp")?;
+                let mut excluded_ids = claimed_provider_resume_ids;
+                excluded_ids.extend(codex_cli_existing_session_ids(
+                    &record,
+                    &self.codex_sessions_root,
+                ));
+                Ok((record, excluded_ids, launched_at.unix_timestamp_nanos()))
+            })
+            .transpose()?;
+        let codex_fork_clear_binding = codex_fork_spec
+            .map(|spec| -> Result<_> {
+                let artifacts = session_runtime
+                    .codex_fork_runtime_artifacts(&spec)?
+                    .ok_or_else(|| anyhow::anyhow!("session {session_id} has no fork artifacts"))?;
+                let initial_offset = fs::metadata(&artifacts.event_stream_path)
+                    .map(|metadata| metadata.len())
+                    .unwrap_or(0);
+                Ok((artifacts.event_stream_path, initial_offset))
+            })
+            .transpose()?;
+        if matches!(provider.as_str(), "codex" | "codex-fork") {
+            if let Some(previous_provider_resume_id) = previous_provider_resume_id.as_deref() {
+                self.append_seat_session(
+                    session_id,
+                    &provider,
+                    previous_provider_resume_id,
+                    codex_fork_clear_binding
+                        .as_ref()
+                        .and_then(|(event_stream_path, _)| event_stream_path.to_str()),
+                );
+            }
+        }
+        let clear_command = if matches!(provider.as_str(), "codex" | "codex-fork") {
+            "/new"
+        } else {
+            "/clear"
+        };
         let delivered = session_runtime.clear_session(
             &tmux_session,
             clear_command,
@@ -1281,50 +1307,80 @@ impl SessionStore {
         if !delivered {
             return Err(anyhow::anyhow!("tmux session is not running"));
         }
-        if let Some((record, excluded_ids, launched_at_ns)) = codex_cli_clear_binding {
-            if let Some(provider_resume_id) = wait_for_codex_cli_provider_resume_id(
+        let replacement_provider_resume_id = if let Some((record, excluded_ids, launched_at_ns)) =
+            codex_cli_clear_binding
+        {
+            let provider_resume_id = wait_for_codex_cli_provider_resume_id(
                 &record,
                 &self.codex_sessions_root,
                 &excluded_ids,
                 launched_at_ns,
                 CODEX_CLI_SESSION_BIND_TIMEOUT,
+            );
+            if provider_resume_id.is_none() {
+                eprintln!("failed to discover replacement Codex thread for seat {session_id}");
+            }
+            provider_resume_id.map(|provider_resume_id| (provider_resume_id, None))
+        } else if let Some((event_stream_path, initial_offset)) = codex_fork_clear_binding.as_ref()
+        {
+            match wait_for_codex_fork_provider_resume_id_after_offset(
+                event_stream_path,
+                *initial_offset,
+                CODEX_FORK_THREAD_STARTED_TIMEOUT,
             ) {
+                Ok(provider_resume_id) => Some((
+                    provider_resume_id,
+                    event_stream_path.to_str().map(ToOwned::to_owned),
+                )),
+                Err(error) => {
+                    eprintln!(
+                            "failed to discover replacement codex-fork thread for seat {session_id}: {error:#}"
+                        );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        self.cancel_context_monitor_alerts(session_id)?;
+
+        {
+            let _guard = self.write_guard()?;
+            let mut state = self.load_raw_json_value()?;
+            let sessions = ensure_sessions_array_mut(&mut state)?;
+            let Some(session) = session_object_mut(sessions, session_id) else {
+                return Ok(CoreClearOutcome::NotFound);
+            };
+            let current_node = json_text(session.get("node")).unwrap_or_else(default_node);
+            ensure_runtime_local_node(&current_node)?;
+            let current_tmux_session = json_text(session.get("tmux_session"));
+            let current_socket_name = json_text(session.get("tmux_socket_name"));
+            let current_provider =
+                json_text(session.get("provider")).unwrap_or_else(default_provider);
+            if current_tmux_session.as_deref() != Some(tmux_session.as_str())
+                || current_socket_name != session_socket_name
+                || current_provider != provider
+            {
+                anyhow::bail!("session {session_id} changed while clear was in progress");
+            }
+            if let Some((provider_resume_id, _)) = replacement_provider_resume_id.as_ref() {
                 session.insert(
                     "provider_resume_id".to_owned(),
                     Value::String(provider_resume_id.clone()),
                 );
-                self.append_seat_session(session_id, &provider, &provider_resume_id, None);
-            } else {
-                eprintln!("failed to discover replacement Codex thread for seat {session_id}");
             }
+            let now = now_rfc3339();
+            reset_session_after_clear(session, &now);
+            self.write_raw_json_value(&state)?;
         }
-        if let Some((event_stream_path, initial_offset)) = codex_fork_clear_binding {
-            match wait_for_codex_fork_provider_resume_id_after_offset(
-                &event_stream_path,
-                initial_offset,
-                CODEX_FORK_THREAD_STARTED_TIMEOUT,
-            ) {
-                Ok(provider_resume_id) => {
-                    session.insert(
-                        "provider_resume_id".to_owned(),
-                        Value::String(provider_resume_id.clone()),
-                    );
-                    self.append_seat_session(
-                        session_id,
-                        &provider,
-                        &provider_resume_id,
-                        event_stream_path.to_str(),
-                    );
-                }
-                Err(error) => eprintln!(
-                    "failed to discover replacement codex-fork thread for seat {session_id}: {error:#}"
-                ),
-            }
+        if let Some((provider_resume_id, artifact_path)) = replacement_provider_resume_id {
+            self.append_seat_session(
+                session_id,
+                &provider,
+                &provider_resume_id,
+                artifact_path.as_deref(),
+            );
         }
-        let now = now_rfc3339();
-        reset_session_after_clear(session, &now);
-        self.cancel_context_monitor_alerts(session_id)?;
-        self.write_raw_json_value(&state)?;
         Ok(CoreClearOutcome::Cleared(CoreClearResult {
             status: "cleared".to_owned(),
             session_id: session_id.to_owned(),
@@ -8893,6 +8949,67 @@ mod tests {
     }
 
     #[test]
+    fn codex_fork_clear_wait_does_not_hold_the_session_mutex() {
+        let Some(fixture) = CodexForkHandoffFixture::new("clear-unlocked") else {
+            return;
+        };
+        fixture.kill_tmux();
+        fixture.start_delayed_clear_tmux();
+        let mut state: Value =
+            serde_json::from_slice(&fs::read(&fixture.state_file).unwrap()).unwrap();
+        session_object_mut(ensure_sessions_array_mut(&mut state).unwrap(), "codex001")
+            .unwrap()
+            .insert(
+                "parent_session_id".to_owned(),
+                Value::String("parent01".to_owned()),
+            );
+        fs::write(&fixture.state_file, serde_json::to_vec(&state).unwrap()).unwrap();
+        let store = fixture.store();
+        let clear_store = store.clone();
+        let runtime = TmuxRuntime::from_config(&crate::config::RustCoreConfig::default());
+        let clear = thread::spawn(move || {
+            clear_store.clear_core_session_with_runtime(
+                "codex001",
+                ClearSessionRequest {
+                    prompt: None,
+                    requester_session_id: Some("parent01".to_owned()),
+                },
+                &runtime,
+            )
+        });
+
+        thread::sleep(Duration::from_millis(250));
+        if clear.is_finished() {
+            let pane = fixture.capture_pane();
+            let result = clear.join().unwrap();
+            panic!("clear completed before the delayed identity event: {result:?}; pane={pane:?}");
+        }
+        let started = Instant::now();
+        assert!(store
+            .apply_claude_pre_tool_use_hook("codex001", Some("Read"))
+            .unwrap());
+        let mutation_elapsed = started.elapsed();
+
+        assert!(matches!(
+            clear.join().unwrap().unwrap(),
+            CoreClearOutcome::Cleared(_)
+        ));
+        assert!(
+            mutation_elapsed < Duration::from_secs(1),
+            "the global session lock remained held during fork identity discovery"
+        );
+        assert_eq!(
+            store
+                .get_session("codex001")
+                .unwrap()
+                .unwrap()
+                .provider_resume_id
+                .as_deref(),
+            Some("new-thread")
+        );
+    }
+
+    #[test]
     fn codex_fork_handoff_executes_after_turn_complete() {
         let Some(fixture) = CodexForkHandoffFixture::new("execute") else {
             return;
@@ -9221,6 +9338,14 @@ mod tests {
             );
         }
 
+        fn start_delayed_clear_tmux(&self) {
+            start_codex_fork_delayed_clear_tmux(
+                &self.tmux_socket,
+                &self.tmux_session,
+                &self.event_stream_path,
+            );
+        }
+
         fn wait_for_handoff_error(&self, store: &SessionStore) {
             let deadline = Instant::now() + Duration::from_secs(3);
             loop {
@@ -9255,6 +9380,20 @@ mod tests {
         let script = r#"event_file=$1; pending=; printf '› '; while IFS= read -r line; do if [ "${line%/new}" != "$line" ]; then printf '{"event_type":"thread/started","payload":{"thread":{"id":"new-thread"}}}\n' >> "$event_file"; printf 'received:%s\n› ' "$line"; elif [ -n "$pending" ]; then printf '{"event_type":"op_submitted","payload":{"UserTurn":{"items":[{"type":"text","text":"%s"}]}}}\n' "$pending" >> "$event_file"; pending=; printf '\n› '; elif [ "${line#Read }" != "$line" ]; then pending=$line; printf 'received:%s\n› %s' "$line" "$line"; else printf 'received:%s\n› ' "$line"; fi; done"#;
         let command = format!(
             "/bin/sh -lc {} handoff-shell {}",
+            shell_quote_handoff_fixture(script),
+            shell_quote_handoff_fixture(&event_stream_path.display().to_string())
+        );
+        let status = Command::new("tmux")
+            .args(["-L", socket, "new-session", "-d", "-s", session, &command])
+            .status()
+            .unwrap();
+        assert!(status.success());
+    }
+
+    fn start_codex_fork_delayed_clear_tmux(socket: &str, session: &str, event_stream_path: &Path) {
+        let script = r#"event_file=$1; printf '› '; while IFS= read -r line; do if [ "${line%/new}" != "$line" ]; then sleep 1; printf '{"event_type":"thread/started","payload":{"thread":{"id":"new-thread"}}}\n' >> "$event_file"; printf 'received:%s\n› ' "$line"; else printf 'received:%s\n› ' "$line"; fi; done"#;
+        let command = format!(
+            "/bin/sh -lc {} clear-shell {}",
             shell_quote_handoff_fixture(script),
             shell_quote_handoff_fixture(&event_stream_path.display().to_string())
         );

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -313,6 +313,21 @@ impl SessionStore {
             return Ok(false);
         };
         let provider = json_text(session.get("provider")).unwrap_or_else(|| "claude".to_owned());
+        if provider == "claude" {
+            let previous_transcript_path = json_text(session.get("transcript_path"));
+            let previous_provider_resume_id = previous_transcript_path
+                .as_deref()
+                .and_then(provider_resume_id_from_transcript_path)
+                .or_else(|| json_text(session.get("provider_resume_id")));
+            if let Some(previous_provider_resume_id) = previous_provider_resume_id.as_deref() {
+                self.append_seat_session(
+                    session_id,
+                    &provider,
+                    previous_provider_resume_id,
+                    previous_transcript_path.as_deref(),
+                );
+            }
+        }
         let provider_resume_id = if provider == "claude" {
             transcript_path.and_then(provider_resume_id_from_transcript_path)
         } else {
@@ -1144,6 +1159,28 @@ impl SessionStore {
             Ok((record, excluded_ids, launched_at.unix_timestamp_nanos()))
         });
         let codex_cli_clear_binding = codex_cli_clear_binding.transpose()?;
+        let codex_fork_clear_binding = (provider == "codex-fork")
+            .then(|| -> Result<_> {
+                let spec = codex_fork_spec_for_session_raw(session_id, session)?;
+                let artifacts = session_runtime
+                    .codex_fork_runtime_artifacts(&spec)?
+                    .ok_or_else(|| anyhow::anyhow!("session {session_id} has no fork artifacts"))?;
+                if let Some(previous_provider_resume_id) =
+                    json_text(session.get("provider_resume_id"))
+                {
+                    self.append_seat_session(
+                        session_id,
+                        &provider,
+                        &previous_provider_resume_id,
+                        artifacts.event_stream_path.to_str(),
+                    );
+                }
+                let initial_offset = fs::metadata(&artifacts.event_stream_path)
+                    .map(|metadata| metadata.len())
+                    .unwrap_or(0);
+                Ok((artifacts.event_stream_path, initial_offset))
+            })
+            .transpose()?;
         let prompt = request
             .prompt
             .as_deref()
@@ -1176,6 +1213,29 @@ impl SessionStore {
                 self.append_seat_session(session_id, &provider, &provider_resume_id, None);
             } else {
                 eprintln!("failed to discover replacement Codex thread for seat {session_id}");
+            }
+        }
+        if let Some((event_stream_path, initial_offset)) = codex_fork_clear_binding {
+            match wait_for_codex_fork_provider_resume_id_after_offset(
+                &event_stream_path,
+                initial_offset,
+                CODEX_FORK_THREAD_STARTED_TIMEOUT,
+            ) {
+                Ok(provider_resume_id) => {
+                    session.insert(
+                        "provider_resume_id".to_owned(),
+                        Value::String(provider_resume_id.clone()),
+                    );
+                    self.append_seat_session(
+                        session_id,
+                        &provider,
+                        &provider_resume_id,
+                        event_stream_path.to_str(),
+                    );
+                }
+                Err(error) => eprintln!(
+                    "failed to discover replacement codex-fork thread for seat {session_id}: {error:#}"
+                ),
             }
         }
         let now = now_rfc3339();
@@ -3395,9 +3455,18 @@ fn wait_for_codex_fork_provider_resume_id(
     event_stream_path: &Path,
     timeout: Duration,
 ) -> Result<String> {
+    wait_for_codex_fork_provider_resume_id_after_offset(event_stream_path, 0, timeout)
+}
+
+fn wait_for_codex_fork_provider_resume_id_after_offset(
+    event_stream_path: &Path,
+    initial_offset: u64,
+    timeout: Duration,
+) -> Result<String> {
     let started = Instant::now();
+    let mut offset = initial_offset;
     loop {
-        if let Ok(content) = fs::read_to_string(event_stream_path) {
+        if let Ok(content) = read_file_from_offset(event_stream_path, &mut offset) {
             for line in content.lines() {
                 let Ok(event) = serde_json::from_str::<Value>(line.trim()) else {
                     continue;
@@ -3412,7 +3481,7 @@ fn wait_for_codex_fork_provider_resume_id(
         }
         if started.elapsed() >= timeout {
             anyhow::bail!(
-                "timed out waiting for codex-fork thread_started event in {}",
+                "timed out waiting for a new codex-fork thread_started event in {}",
                 event_stream_path.display()
             );
         }
@@ -8418,6 +8487,38 @@ mod tests {
                 .as_deref(),
             Some("thread-after-handoff")
         );
+    }
+
+    #[test]
+    fn codex_fork_clear_rebind_reads_only_events_after_the_clear_offset() {
+        let event_stream_path = unique_temp_path("codex-clear-rebind-events");
+        fs::write(
+            &event_stream_path,
+            r#"{"event_type":"thread/started","payload":{"thread":{"id":"old-thread"}}}
+"#,
+        )
+        .unwrap();
+        let clear_offset = fs::metadata(&event_stream_path).unwrap().len();
+        fs::OpenOptions::new()
+            .append(true)
+            .open(&event_stream_path)
+            .unwrap()
+            .write_all(
+                br#"{"event_type":"thread/started","payload":{"thread":{"id":"new-thread"}}}
+"#,
+            )
+            .unwrap();
+
+        assert_eq!(
+            wait_for_codex_fork_provider_resume_id_after_offset(
+                &event_stream_path,
+                clear_offset,
+                Duration::ZERO,
+            )
+            .unwrap(),
+            "new-thread"
+        );
+        let _ = fs::remove_file(event_stream_path);
     }
 
     #[test]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -69,6 +69,12 @@ pub struct SessionStore {
 }
 
 #[derive(Debug)]
+pub struct SeatSessionReconciliationSnapshot {
+    records: Vec<SessionRecord>,
+    artifact_cutoff_ns: i128,
+}
+
+#[derive(Debug)]
 struct SessionClearLock {
     held: Mutex<bool>,
     available: Condvar,
@@ -195,7 +201,34 @@ impl SessionStore {
     }
 
     pub fn reconcile_current_seat_sessions(&self) -> Result<()> {
-        let records = self.load_snapshot()?.into_sessions();
+        let snapshot = self.prepare_seat_session_reconciliation(i128::MAX)?;
+        self.reconcile_seat_sessions(snapshot)
+    }
+
+    #[cfg(test)]
+    fn reconcile_current_seat_sessions_through(&self, artifact_cutoff_ns: i128) -> Result<()> {
+        let snapshot = self.prepare_seat_session_reconciliation(artifact_cutoff_ns)?;
+        self.reconcile_seat_sessions(snapshot)
+    }
+
+    pub fn prepare_seat_session_reconciliation(
+        &self,
+        artifact_cutoff_ns: i128,
+    ) -> Result<SeatSessionReconciliationSnapshot> {
+        Ok(SeatSessionReconciliationSnapshot {
+            records: self.load_snapshot()?.into_sessions(),
+            artifact_cutoff_ns,
+        })
+    }
+
+    pub fn reconcile_seat_sessions(
+        &self,
+        snapshot: SeatSessionReconciliationSnapshot,
+    ) -> Result<()> {
+        let SeatSessionReconciliationSnapshot {
+            records,
+            artifact_cutoff_ns,
+        } = snapshot;
         let mut claim_attempt = 0;
         let mut claimed = loop {
             match self.seat_session_store.claimed_provider_sessions() {
@@ -223,19 +256,33 @@ impl SessionStore {
                     .collect::<BTreeMap<_, _>>()
             })
             .unwrap_or_default();
+        let current_codex_ids = records
+            .iter()
+            .filter(|session| session.provider == "codex")
+            .filter_map(provider_resume_id_for_restore)
+            .collect::<BTreeSet<_>>();
+        let codex_artifact_paths =
+            codex_cli_artifact_paths(&self.codex_sessions_root, &current_codex_ids);
         let mut sessions = records
             .iter()
             .filter_map(|session| {
                 provider_resume_id_for_restore(session).map(|provider_session_id| {
                     claimed.insert((session.provider.clone(), provider_session_id.clone()));
+                    let artifact_path = fork_artifact_paths
+                        .get(&session.id)
+                        .map(|path| path.display().to_string())
+                        .or_else(|| {
+                            (session.provider == "codex")
+                                .then(|| codex_artifact_paths.get(&provider_session_id))
+                                .flatten()
+                                .map(|path| resolve_path_lossy(path.clone()))
+                        })
+                        .or_else(|| session.transcript_path.clone());
                     SeatSessionIdentity {
                         seat_id: session.id.clone(),
                         provider: session.provider.clone(),
                         provider_session_id,
-                        artifact_path: fork_artifact_paths
-                            .get(&session.id)
-                            .map(|path| path.display().to_string())
-                            .or_else(|| session.transcript_path.clone()),
+                        artifact_path,
                     }
                 })
             })
@@ -243,11 +290,13 @@ impl SessionStore {
         sessions.extend(historical_claude_seat_sessions(
             &records,
             &self.claude_projects_root,
+            artifact_cutoff_ns,
             &mut claimed,
         ));
         sessions.extend(historical_codex_cli_seat_sessions(
             &records,
             &self.codex_sessions_root,
+            artifact_cutoff_ns,
             &mut claimed,
         ));
         if let Some(runtime) = self.delivery_runtime.as_ref() {
@@ -6801,6 +6850,7 @@ struct ClaudeTranscriptMetadata {
 fn historical_claude_seat_sessions(
     sessions: &[SessionRecord],
     projects_root: &Path,
+    artifact_cutoff_ns: i128,
     claimed: &mut BTreeSet<(String, String)>,
 ) -> Vec<SeatSessionIdentity> {
     let mut project_dirs = BTreeMap::<PathBuf, BTreeSet<String>>::new();
@@ -6837,6 +6887,9 @@ fn historical_claude_seat_sessions(
             }
             let artifact_start = metadata.started_at_ns.unwrap_or(metadata.mtime_ns);
             let artifact_end = metadata.ended_at_ns.unwrap_or(metadata.mtime_ns);
+            if artifact_start > artifact_cutoff_ns {
+                continue;
+            }
             let matching_seats = sessions
                 .iter()
                 .filter(|session| session.provider == "claude")
@@ -6873,6 +6926,7 @@ fn historical_claude_seat_sessions(
 fn historical_codex_cli_seat_sessions(
     sessions: &[SessionRecord],
     sessions_root: &Path,
+    artifact_cutoff_ns: i128,
     claimed: &mut BTreeSet<(String, String)>,
 ) -> Vec<SeatSessionIdentity> {
     let codex_seats = sessions
@@ -6908,6 +6962,9 @@ fn historical_codex_cli_seat_sessions(
         let started_at_ns = started_at_ns
             .or_else(|| file_mtime_ns(&path).ok())
             .unwrap_or(0);
+        if started_at_ns > artifact_cutoff_ns {
+            continue;
+        }
         let ended_at_ns = codex_transcript_end_ns(&path, started_at_ns);
         let matching_seats = matching_cwd_seats
             .into_iter()
@@ -6931,6 +6988,25 @@ fn historical_codex_cli_seat_sessions(
         });
     }
     identities
+}
+
+fn codex_cli_artifact_paths(
+    sessions_root: &Path,
+    provider_session_ids: &BTreeSet<String>,
+) -> BTreeMap<String, PathBuf> {
+    if provider_session_ids.is_empty() {
+        return BTreeMap::new();
+    }
+    let mut paths = BTreeMap::new();
+    for path in jsonl_files_recursive(sessions_root) {
+        let Some((provider_session_id, _, _)) = read_codex_cli_session_metadata(&path) else {
+            continue;
+        };
+        if provider_session_ids.contains(&provider_session_id) {
+            paths.entry(provider_session_id).or_insert(path);
+        }
+    }
+    paths
 }
 
 fn codex_transcript_end_ns(path: &Path, started_at_ns: i128) -> i128 {
@@ -9506,6 +9582,7 @@ mod tests {
         };
         rollout("historical-thread", "2026-01-02T00:00:00Z");
         rollout("current-thread", "2026-01-03T00:00:00Z");
+        rollout("post-snapshot-thread", "2026-01-04T00:00:00Z");
         fs::write(
             &state_file,
             json!({
@@ -9528,7 +9605,11 @@ mod tests {
             SessionStore::new_with_legacy_fallback(state_file.clone(), state_file.clone());
         store.codex_sessions_root = sessions_root;
 
-        store.reconcile_current_seat_sessions().unwrap();
+        store
+            .reconcile_current_seat_sessions_through(
+                parse_timestamp_ns("2026-01-03T12:00:00Z").unwrap(),
+            )
+            .unwrap();
 
         let connection = rusqlite::Connection::open(state_file.with_extension("usage.db")).unwrap();
         let mut statement = connection
@@ -9545,6 +9626,14 @@ mod tests {
             ids,
             vec!["current-thread".to_owned(), "historical-thread".to_owned()]
         );
+        let paths: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM seat_sessions WHERE seat_id = 'codex001' AND artifact_path IS NOT NULL",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(paths, 2);
     }
 
     #[test]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -313,19 +313,15 @@ impl SessionStore {
             return Ok(false);
         };
         let provider = json_text(session.get("provider")).unwrap_or_else(|| "claude".to_owned());
+        let mut seat_session_appends = Vec::new();
         if provider == "claude" {
             let previous_transcript_path = json_text(session.get("transcript_path"));
             let previous_provider_resume_id = previous_transcript_path
                 .as_deref()
                 .and_then(provider_resume_id_from_transcript_path)
                 .or_else(|| json_text(session.get("provider_resume_id")));
-            if let Some(previous_provider_resume_id) = previous_provider_resume_id.as_deref() {
-                self.append_seat_session(
-                    session_id,
-                    &provider,
-                    previous_provider_resume_id,
-                    previous_transcript_path.as_deref(),
-                );
+            if let Some(previous_provider_resume_id) = previous_provider_resume_id {
+                seat_session_appends.push((previous_provider_resume_id, previous_transcript_path));
             }
         }
         let provider_resume_id = if provider == "claude" {
@@ -334,9 +330,21 @@ impl SessionStore {
             None
         };
         if let Some(provider_resume_id) = provider_resume_id.as_deref() {
-            self.append_seat_session(session_id, &provider, provider_resume_id, transcript_path);
+            seat_session_appends.push((
+                provider_resume_id.to_owned(),
+                transcript_path.map(ToOwned::to_owned),
+            ));
         }
         if normalized_status(&json_text(session.get("status")).unwrap_or_default()) == "stopped" {
+            drop(_guard);
+            for (provider_resume_id, artifact_path) in seat_session_appends {
+                self.append_seat_session(
+                    session_id,
+                    &provider,
+                    &provider_resume_id,
+                    artifact_path.as_deref(),
+                );
+            }
             return Ok(false);
         }
 
@@ -417,6 +425,15 @@ impl SessionStore {
             }
         }
         self.write_raw_json_value(&state)?;
+        drop(_guard);
+        for (provider_resume_id, artifact_path) in seat_session_appends {
+            self.append_seat_session(
+                session_id,
+                &provider,
+                &provider_resume_id,
+                artifact_path.as_deref(),
+            );
+        }
         Ok(!superseded)
     }
 
@@ -7968,6 +7985,68 @@ mod tests {
 
         assert_eq!(session.status, "idle");
         assert_eq!(projected_activity_state(&session, &session.status), "idle");
+    }
+
+    #[test]
+    fn claude_stop_hook_releases_session_lock_before_blocked_ledger_write() {
+        let store = store_with_running_claude_session("stopledgerlock");
+        store
+            .seat_session_store
+            .append("seed", "claude", "seed-thread", None)
+            .unwrap();
+        let usage_db_path = store.state_file.with_extension("usage.db");
+        let connection = rusqlite::Connection::open(usage_db_path).unwrap();
+        connection.execute_batch("BEGIN IMMEDIATE").unwrap();
+
+        let stop_store = store.clone();
+        let stop = thread::spawn(move || {
+            stop_store.apply_claude_stop_hook(
+                "stopledgerlock",
+                None,
+                None,
+                None,
+                Some("/tmp/rebound-thread.jsonl"),
+                None,
+                None,
+            )
+        });
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        let persisted_before_unlock = loop {
+            if store
+                .get_session("stopledgerlock")
+                .unwrap()
+                .and_then(|session| session.transcript_path)
+                .as_deref()
+                == Some("/tmp/rebound-thread.jsonl")
+            {
+                break true;
+            }
+            if Instant::now() >= deadline {
+                break false;
+            }
+            thread::sleep(Duration::from_millis(10));
+        };
+        let mutation_elapsed = if persisted_before_unlock {
+            let started = Instant::now();
+            assert!(store
+                .apply_claude_pre_tool_use_hook("stopledgerlock", Some("Read"))
+                .unwrap());
+            Some(started.elapsed())
+        } else {
+            None
+        };
+
+        connection.execute_batch("ROLLBACK").unwrap();
+        assert!(stop.join().unwrap().unwrap());
+        assert!(
+            persisted_before_unlock,
+            "core Stop state remained behind the blocked usage ledger"
+        );
+        assert!(
+            mutation_elapsed.is_some_and(|elapsed| elapsed < Duration::from_secs(1)),
+            "the global session lock remained held during the usage ledger wait"
+        );
     }
 
     #[test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -16278,6 +16278,7 @@ fn runtime_app_with_command(
                     .display()
                     .to_string(),
             ),
+            transcript_root: None,
         },
         ..AppConfig::default()
     }))

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -14144,6 +14144,100 @@ async fn runtime_core_rejects_review_when_session_is_busy() {
 }
 
 #[tokio::test]
+async fn runtime_core_delayed_initial_codex_binding_updates_session_chain() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let working_dir = unique_short_temp_dir("sm-rust-codex-create-bind");
+    fs::create_dir_all(&working_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-test-codex-create-bind-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app_with_codex_composer(&state_file, &log_dir, &tmux_socket);
+    let now = time::OffsetDateTime::now_utc();
+    let sessions_root = state_file.with_extension("codex-home").join("sessions");
+    let day_dir = sessions_root
+        .join(format!("{:04}", now.year()))
+        .join(format!("{:02}", now.month() as u8))
+        .join(format!("{:02}", now.day()));
+    fs::create_dir_all(&day_dir).unwrap();
+    let rollout_path = day_dir.join("rollout-delayed-create-thread.jsonl");
+    let rollout_working_dir = working_dir.clone();
+    let writer = thread::spawn(move || {
+        thread::sleep(Duration::from_millis(1_200));
+        fs::write(
+            rollout_path,
+            format!(
+                "{}\n",
+                json!({
+                    "type": "session_meta",
+                    "payload": {
+                        "id": "delayed-create-thread",
+                        "cwd": rollout_working_dir.display().to_string(),
+                        "timestamp": (time::OffsetDateTime::now_utc()
+                            + time::Duration::seconds(1))
+                            .format(&time::format_description::well_known::Rfc3339)
+                            .unwrap()
+                    }
+                })
+            ),
+        )
+        .unwrap();
+    });
+
+    let (status, payload) = post_json(
+        app,
+        "/sessions",
+        json!({
+            "id": "createcodex",
+            "name": "create-codex",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "codex"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(payload["provider_resume_id"].is_null());
+    writer.join().unwrap();
+
+    let mut bound = false;
+    for _ in 0..30 {
+        let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+        bound = state["sessions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|session| session["id"] == "createcodex")
+            .is_some_and(|session| session["provider_resume_id"] == "delayed-create-thread");
+        if bound {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(
+        bound,
+        "deferred creation binding did not update the session"
+    );
+    let count: i64 = Connection::open(state_file.with_extension("usage.db"))
+        .unwrap()
+        .query_row(
+            "SELECT COUNT(*) FROM seat_sessions WHERE seat_id = 'createcodex' AND provider_session_id = 'delayed-create-thread'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(count, 1);
+}
+
+#[tokio::test]
 async fn runtime_core_clear_rebinds_plain_codex_provider_session_chain() {
     if !tmux_available() {
         return;

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -7963,6 +7963,75 @@ async fn claude_stop_hook_reads_local_transcript_metadata_when_not_inlined() {
 }
 
 #[tokio::test]
+async fn claude_stop_hooks_append_distinct_provider_sessions_without_losing_the_first() {
+    let state_file = write_session_fixture();
+    let usage_db_path = state_file.with_extension("usage.db");
+    let transcript_dir = unique_temp_path();
+    fs::create_dir_all(&transcript_dir).unwrap();
+    let first_transcript = transcript_dir.join("provider-session-first.jsonl");
+    let second_transcript = transcript_dir.join("provider-session-second.jsonl");
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+
+    for transcript_path in [&first_transcript, &second_transcript] {
+        let (status, payload) = post_json(
+            app.clone(),
+            "/hooks/claude",
+            json!({
+                "hook_event_name": "Stop",
+                "session_manager_id": "run12345",
+                "sm_last_message": "turn complete",
+                "sm_native_title": "Session chain fixture",
+                "sm_transcript_mtime_ns": 424242_i64,
+                "transcript_path": transcript_path.display().to_string()
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(payload, json!({ "status": "ok" }));
+    }
+
+    let connection = Connection::open(&usage_db_path).unwrap();
+    let mut statement = connection
+        .prepare(
+            "SELECT provider_session_id, artifact_path FROM seat_sessions WHERE seat_id = 'run12345' ORDER BY provider_session_id",
+        )
+        .unwrap();
+    let rows = statement
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap();
+    assert_eq!(
+        rows,
+        vec![
+            (
+                "provider-session-first".to_owned(),
+                first_transcript.display().to_string(),
+            ),
+            (
+                "provider-session-second".to_owned(),
+                second_transcript.display().to_string(),
+            ),
+        ]
+    );
+
+    let raw_state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let session = raw_state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "run12345")
+        .unwrap();
+    assert_eq!(
+        session["transcript_path"],
+        second_transcript.display().to_string()
+    );
+    assert_eq!(session["provider_resume_id"], "provider-session-second");
+}
+
+#[tokio::test]
 async fn claude_stop_hook_retries_local_transcript_metadata_read() {
     let state_file = write_session_fixture();
     let transcript_path = unique_temp_path().with_extension("jsonl");

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -7970,6 +7970,17 @@ async fn claude_stop_hooks_append_distinct_provider_sessions_without_losing_the_
     fs::create_dir_all(&transcript_dir).unwrap();
     let first_transcript = transcript_dir.join("provider-session-first.jsonl");
     let second_transcript = transcript_dir.join("provider-session-second.jsonl");
+    let legacy_transcript = transcript_dir.join("provider-session-before-deployment.jsonl");
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let session = state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "run12345")
+        .unwrap();
+    session["provider_resume_id"] = json!("provider-session-before-deployment");
+    session["transcript_path"] = json!(legacy_transcript.display().to_string());
+    fs::write(&state_file, serde_json::to_string_pretty(&state).unwrap()).unwrap();
     let app = router(AppState::new(config_with_state_file(&state_file)));
 
     for transcript_path in [&first_transcript, &second_transcript] {
@@ -8006,6 +8017,10 @@ async fn claude_stop_hooks_append_distinct_provider_sessions_without_losing_the_
     assert_eq!(
         rows,
         vec![
+            (
+                "provider-session-before-deployment".to_owned(),
+                legacy_transcript.display().to_string(),
+            ),
             (
                 "provider-session-first".to_owned(),
                 first_transcript.display().to_string(),

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -16,6 +16,7 @@ use sha2::Sha256;
 use sm_server::btw::BtwStore;
 use sm_server::config::RustShadowConfig;
 use sm_server::queue::{QueueAdmissionPolicy, RetainedQueueStore};
+use sm_server::seat_sessions::SeatSessionStore;
 use sm_server::{
     config::{
         AppArtifactsConfig, AppConfig, BugReportsConfig, CodexEventsConfig, CodexForkLaunchConfig,
@@ -14126,6 +14127,144 @@ async fn runtime_core_rejects_review_when_session_is_busy() {
         "runtime:/review review after stale dispatch clear",
     )
     .await;
+}
+
+#[tokio::test]
+async fn runtime_core_clear_rebinds_plain_codex_provider_session_chain() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let working_dir = unique_short_temp_dir("sm-rust-codex-clear-rebind");
+    fs::create_dir_all(&working_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-test-codex-clear-rebind-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app_with_codex_composer(&state_file, &log_dir, &tmux_socket);
+
+    let (status, _) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "clearcodex",
+            "name": "clear-codex",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "codex"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let now = time::OffsetDateTime::now_utc();
+    let sessions_root = state_file.with_extension("codex-home").join("sessions");
+    let day_dir = sessions_root
+        .join(format!("{:04}", now.year()))
+        .join(format!("{:02}", now.month() as u8))
+        .join(format!("{:02}", now.day()));
+    fs::create_dir_all(&day_dir).unwrap();
+    let write_rollout = |path: &PathBuf, id: &str, timestamp: time::OffsetDateTime| {
+        fs::write(
+            path,
+            format!(
+                "{}\n",
+                json!({
+                    "type": "session_meta",
+                    "payload": {
+                        "id": id,
+                        "cwd": working_dir.display().to_string(),
+                        "timestamp": timestamp
+                            .format(&time::format_description::well_known::Rfc3339)
+                            .unwrap()
+                    }
+                })
+            ),
+        )
+        .unwrap();
+    };
+    write_rollout(
+        &day_dir.join("rollout-old-thread.jsonl"),
+        "old-thread",
+        now - time::Duration::seconds(1),
+    );
+
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let session = state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "clearcodex")
+        .unwrap();
+    session["parent_session_id"] = json!("operator-parent");
+    session["provider_resume_id"] = json!("old-thread");
+    fs::write(&state_file, serde_json::to_string_pretty(&state).unwrap()).unwrap();
+    SeatSessionStore::for_state_file(&state_file)
+        .append("clearcodex", "codex", "old-thread", None)
+        .unwrap();
+
+    let new_rollout = day_dir.join("rollout-new-thread.jsonl");
+    let new_working_dir = working_dir.clone();
+    let writer = thread::spawn(move || {
+        thread::sleep(Duration::from_millis(250));
+        fs::write(
+            new_rollout,
+            format!(
+                "{}\n",
+                json!({
+                    "type": "session_meta",
+                    "payload": {
+                        "id": "new-thread",
+                        "cwd": new_working_dir.display().to_string(),
+                        "timestamp": (time::OffsetDateTime::now_utc()
+                            + time::Duration::seconds(1))
+                            .format(&time::format_description::well_known::Rfc3339)
+                            .unwrap()
+                    }
+                })
+            ),
+        )
+        .unwrap();
+    });
+
+    let (status, payload) = post_json(
+        app,
+        "/sessions/clearcodex/clear",
+        json!({ "prompt": "continue in the replacement thread" }),
+    )
+    .await;
+    writer.join().unwrap();
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        payload,
+        json!({ "status": "cleared", "session_id": "clearcodex" })
+    );
+
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let session = state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "clearcodex")
+        .unwrap();
+    assert_eq!(session["provider_resume_id"], "new-thread");
+
+    let connection = Connection::open(state_file.with_extension("usage.db")).unwrap();
+    let provider_session_ids = connection
+        .prepare(
+            "SELECT provider_session_id FROM seat_sessions WHERE seat_id = 'clearcodex' ORDER BY provider_session_id",
+        )
+        .unwrap()
+        .query_map([], |row| row.get::<_, String>(0))
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap();
+    assert_eq!(provider_session_ids, vec!["new-thread", "old-thread"]);
 }
 
 #[tokio::test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -8032,6 +8032,48 @@ async fn claude_stop_hooks_append_distinct_provider_sessions_without_losing_the_
 }
 
 #[tokio::test]
+async fn claude_stop_hook_survives_an_unwritable_usage_database() {
+    let state_file = write_session_fixture();
+    fs::create_dir_all(state_file.with_extension("usage.db")).unwrap();
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+
+    let (status, payload) = post_json(
+        app,
+        "/hooks/claude",
+        json!({
+            "hook_event_name": "Stop",
+            "session_manager_id": "run12345",
+            "sm_last_message": "turn complete despite ledger failure",
+            "transcript_path": "/tmp/provider-session-after-failure.jsonl"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload, json!({ "status": "ok" }));
+
+    let raw_state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let session = raw_state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "run12345")
+        .unwrap();
+    assert_eq!(session["status"], "idle");
+    assert_eq!(
+        session["last_action_summary"],
+        "turn complete despite ledger failure"
+    );
+    assert_eq!(
+        session["transcript_path"],
+        "/tmp/provider-session-after-failure.jsonl"
+    );
+    assert_eq!(
+        session["provider_resume_id"],
+        "provider-session-after-failure"
+    );
+}
+
+#[tokio::test]
 async fn claude_stop_hook_retries_local_transcript_metadata_read() {
     let state_file = write_session_fixture();
     let transcript_path = unique_temp_path().with_extension("jsonl");

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -16,7 +16,6 @@ use sha2::Sha256;
 use sm_server::btw::BtwStore;
 use sm_server::config::RustShadowConfig;
 use sm_server::queue::{QueueAdmissionPolicy, RetainedQueueStore};
-use sm_server::seat_sessions::SeatSessionStore;
 use sm_server::{
     config::{
         AppArtifactsConfig, AppConfig, BugReportsConfig, CodexEventsConfig, CodexForkLaunchConfig,
@@ -14169,31 +14168,6 @@ async fn runtime_core_clear_rebinds_plain_codex_provider_session_chain() {
         .join(format!("{:02}", now.month() as u8))
         .join(format!("{:02}", now.day()));
     fs::create_dir_all(&day_dir).unwrap();
-    let write_rollout = |path: &PathBuf, id: &str, timestamp: time::OffsetDateTime| {
-        fs::write(
-            path,
-            format!(
-                "{}\n",
-                json!({
-                    "type": "session_meta",
-                    "payload": {
-                        "id": id,
-                        "cwd": working_dir.display().to_string(),
-                        "timestamp": timestamp
-                            .format(&time::format_description::well_known::Rfc3339)
-                            .unwrap()
-                    }
-                })
-            ),
-        )
-        .unwrap();
-    };
-    write_rollout(
-        &day_dir.join("rollout-old-thread.jsonl"),
-        "old-thread",
-        now - time::Duration::seconds(1),
-    );
-
     let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
     let session = state["sessions"]
         .as_array_mut()
@@ -14203,10 +14177,8 @@ async fn runtime_core_clear_rebinds_plain_codex_provider_session_chain() {
         .unwrap();
     session["parent_session_id"] = json!("operator-parent");
     session["provider_resume_id"] = json!("old-thread");
+    session["created_at"] = json!("2026-07-01T12:00:00Z");
     fs::write(&state_file, serde_json::to_string_pretty(&state).unwrap()).unwrap();
-    SeatSessionStore::for_state_file(&state_file)
-        .append("clearcodex", "codex", "old-thread", None)
-        .unwrap();
 
     let new_rollout = day_dir.join("rollout-new-thread.jsonl");
     let new_working_dir = working_dir.clone();

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -14499,6 +14499,15 @@ while true; do sleep 1; done
     assert!(output_text.contains("ids:runtimefork:runtimefork:false"));
     let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
     assert_eq!(state["sessions"][0]["reasoning_effort"], "ultra");
+    let connection = Connection::open(state_file.with_extension("usage.db")).unwrap();
+    let provider_session_id: String = connection
+        .query_row(
+            "SELECT provider_session_id FROM seat_sessions WHERE seat_id = 'runtimefork'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(provider_session_id, "provider-thread-123");
     let mut lifecycle_status = String::new();
     for _ in 0..30 {
         let (_, session) = get_json(app.clone(), "/sessions/runtimefork").await;


### PR DESCRIPTION
## Summary

Implements Phase 0 session chaining from `specs/1182_sm_usage_quota_attribution.html`.

- adds the append-only `seat_sessions` schema in the WAL-backed `usage.db`; provisional `unassigned` ownership is atomically replaced by definitive live binding in either race order
- records every Claude Stop transcript identity before lifecycle suppression, retaining prior identities while keeping `transcript_path` and `provider_resume_id` as compatibility pointers
- resolves nested Claude `chat.jsonl` and `subagents/*.jsonl` identities from transcript metadata, recursively scans them, discovers explicit/comma-separated `CLAUDE_CONFIG_DIR`, XDG, and default roots, and excludes every artifact belonging to a provider session already claimed by another seat during restore
- records Codex and Codex-fork provider identities on binding, restore, thread/handoff identity events, and `/new` clears\n- requires an explicit post-offset `thread/started` event for fork clear/handoff rebinding, so stale old-thread lifecycle events cannot be claimed
- retries delayed initial and clear-time classic Codex rollout discovery for 30 seconds, persisting both session state and the seat ledger when the rollout appears
- serializes classic Codex creation and clear discovery by canonical sessions root and working directory from the pre-launch exclusion snapshot through direct or deferred persistence, preventing same-directory seats from claiming one rollout
- captures the seat registry and artifact cutoff before serving, then reconciles in the blocking pool so live creates cannot be mistaken for historical usage\n- collapses duplicate current provider-session pointers to one `unassigned` claim, preventing ambiguous upgrade state from double-attributing usage
- conservatively backfills historical Claude, classic Codex, and codex-fork artifacts by working directory and seat lifetime; ambiguous ownership is recorded as `unassigned`
- repairs missing codex-fork artifact paths and resolves current classic Codex rollout paths without replacing an existing path
- treats usage-ledger writes as best effort so a ledger outage cannot suppress core session lifecycle updates
- keeps the Phase 0 schema isolated from Phase 1 account/timeline work

## Verification

Focused tests passed, including session-chain append behavior, provisional-to-definitive ownership convergence, Claude Stop hooks, nested Claude transcript identity/root discovery and claimed-sibling exclusion, classic Codex initial/clear and codex-fork clear/handoff rebinding, delayed initial and replacement discovery, startup reconciliation and historical backfill, the pre-serve artifact cutoff, per-seat and per-discovery-domain serialization, lock-release behavior, transient ledger retry, and missing artifact-path repair.

On exact head `12ba3cc0f2688aea51a5646c2a2f7223acd9a824`:

- `cargo test -- --skip codex_review_request_watcher_delivers_sequential_wake_to_runtime_session`: 297 library, 57 CLI, 238 HTTP integration, and doc tests passed
- `cargo test -p sm-server --test read_only_http codex_review_request_watcher_delivers_sequential_wake_to_runtime_session -- --exact --nocapture`: 1 passed
- `cargo check`: passed
- `cargo fmt --all -- --check`: passed
- `git diff --check`: passed

Unfiltered `cargo test` was run twice on the prior head. Its only failure is the order-dependent pre-existing review-watcher fixture tracked in #1189: it returns 502 in the suite and passes in isolation. This phase does not touch review watcher or queue-delivery code.

## Carry-forward

- Phase 1 independently adds the account/account_timeline usage store. Phase 1 integration will consolidate configurable `usage.db_path` ownership while preserving alternate-state-file isolation in tests.
- Review P2: overlapping clear requests currently wait on a synchronous per-seat condition variable. Move that wait off Tokio workers or return a conflict response in a later runtime hardening phase; it is outside the Phase 0 chaining contract.\n- Review P2: live classic Codex create/clear bindings persist the provider session ID immediately but leave `artifact_path` null until startup reconciliation resolves the rollout. Preserve the discovered rollout path in the Phase 3 artifact-ingest integration.




