### PR TITLE
Fix Codex restore discovery for configured session paths

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -371,6 +371,7 @@ impl AppState {
         let state_file = expand_home(&config.paths.state_file);
         let queue_db_path = expand_home(&config.sm_send.db_path);
         let session_store = SessionStore::new_with_queue(state_file, queue_db_path)
+            .with_codex_session_index_path(config.codex.session_index_path.as_deref())
             .with_context_monitor_config(config.context_monitor.clone())
             .with_delivery_runtime(
                 config

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -92,6 +92,19 @@ impl SessionStore {
         self
     }
 
+    pub fn with_codex_session_index_path(mut self, session_index_path: Option<&str>) -> Self {
+        if let Some(session_index_path) = session_index_path
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+        {
+            let session_index_path = expand_home(session_index_path);
+            if let Some(parent) = session_index_path.parent() {
+                self.codex_sessions_root = parent.join("sessions");
+            }
+        }
+        self
+    }
+
     /// Drop context alerts this session raised about context it no longer has.
     /// An undelivered warning describes the discarded cycle, so delivering it
     /// after a clear tells the monitor about a problem that no longer exists.


### PR DESCRIPTION
## Summary

- derives the Codex rollout sessions directory from the configured `codex.session_index_path`
- passes that path into `SessionStore` during app construction
- restores custom/test Codex homes without falling back to `~/.codex/sessions`

## Tests

- `cargo test -p sm-server --test read_only_http runtime_core_restores_codex_session -- --exact --nocapture`
- `cargo test -p sm-server sessions::tests::codex_resume_discovery_matches_cwd_time_and_unclaimed_id -- --exact`
- `cargo check --workspace`
- `rustfmt --edition 2021 --check crates/sm-server/src/sessions.rs crates/sm-server/src/http.rs`

Closes #1184