### PR TITLE
Fix hanging Codex review-clear integration test

### DIFF
--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -13897,7 +13897,7 @@ async fn runtime_core_rejects_review_when_session_is_busy() {
             .as_nanos()
     );
     let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
-    let app = runtime_app(&state_file, &log_dir, &tmux_socket);
+    let app = runtime_app_with_codex_composer(&state_file, &log_dir, &tmux_socket);
 
     let (status, _payload) = post_json(
         app.clone(),
@@ -15978,6 +15978,19 @@ fn runtime_app(state_file: &PathBuf, log_dir: &PathBuf, tmux_socket: &str) -> ax
         log_dir,
         tmux_socket,
         r#"/bin/sh -lc 'while IFS= read -r line; do printf "argv:%s\nids:%s:%s:%s\nruntime:%s\n" "$*" "$SESSION_MANAGER_ID" "$CLAUDE_SESSION_MANAGER_ID" "$ENABLE_TOOL_SEARCH" "$line"; done' runtime-sh"#,
+    )
+}
+
+fn runtime_app_with_codex_composer(
+    state_file: &PathBuf,
+    log_dir: &PathBuf,
+    tmux_socket: &str,
+) -> axum::Router {
+    runtime_app_with_command(
+        state_file,
+        log_dir,
+        tmux_socket,
+        r#"/bin/sh -lc 'printf "› "; while IFS= read -r line; do printf "\nargv:%s\nids:%s:%s:%s\nruntime:%s\n› " "$*" "$SESSION_MANAGER_ID" "$CLAUDE_SESSION_MANAGER_ID" "$ENABLE_TOOL_SEARCH" "$line"; done' runtime-sh"#,
     )
 }
 


### PR DESCRIPTION
## Summary

- gives the Codex review fixture an actual composer marker at the live cursor row
- lets `/new` readiness observe a changed Codex frame instead of retrying forever against a generic line shell
- preserves the intentionally persistent production handoff readiness behavior

## Tests

- `cargo test -p sm-server --test read_only_http runtime_core_rejects_review_when_session_is_busy -- --exact --nocapture`
- `cargo test --workspace` (275 library, 57 CLI, 235 HTTP passed)
- `rustfmt --edition 2021 --check crates/sm-server/tests/read_only_http.rs`

Closes #1186