### PR TITLE
Epic 1182 Phase 2: ingest provider burn samples

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -131,6 +131,7 @@ use crate::tool_usage::{
     list_recent_codex_fork_tool_calls_from_path, list_recent_tool_calls_from_path,
     log_tool_usage_to_path, ToolCallRow, ToolUsageEvent,
 };
+use crate::usage_burn::UsageBurnStore;
 
 const SESSION_COOKIE_NAME: &str = "sm_auth";
 const SESSION_COOKIE_MAX_AGE_SECONDS: i64 = 60 * 60 * 24 * 14;
@@ -383,6 +384,12 @@ impl AppState {
             );
         if should_use_configured_usage_db_path(&config.usage) {
             session_store = session_store.with_usage_db_path(expand_home(&config.usage.db_path));
+        }
+        if config.usage.enabled {
+            match UsageBurnStore::new(expand_home(&config.usage.db_path)) {
+                Ok(store) => session_store = session_store.with_usage_burn_store(store),
+                Err(error) => eprintln!("usage burn store initialization failed: {error:#}"),
+            }
         }
         if let Err(error) = session_store.recover_pending_codex_fork_handoffs() {
             eprintln!("codex-fork handoff recovery failed: {error:#}");
@@ -1455,6 +1462,13 @@ async fn context_usage_hook(
         "/hooks/context-usage",
     )?;
 
+    let rate_limits = payload.get("rate_limits").and_then(Value::as_object);
+    let five_hour = rate_limits
+        .and_then(|limits| limits.get("five_hour"))
+        .and_then(Value::as_object);
+    let seven_day = rate_limits
+        .and_then(|limits| limits.get("seven_day"))
+        .and_then(Value::as_object);
     let event = ContextUsageEvent {
         session_id,
         event: payload
@@ -1465,6 +1479,24 @@ async fn context_usage_hook(
             .map(ToOwned::to_owned),
         used_percentage: payload.get("used_percentage").and_then(Value::as_f64),
         total_input_tokens: payload_i64(payload.get("total_input_tokens")),
+        five_hour_percent: five_hour
+            .and_then(|window| window.get("used_percentage"))
+            .and_then(Value::as_f64)
+            .or_else(|| payload.get("five_hour_percent").and_then(Value::as_f64)),
+        five_hour_resets_at: five_hour
+            .and_then(|window| window.get("resets_at"))
+            .or_else(|| payload.get("five_hour_resets_at"))
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        seven_day_percent: seven_day
+            .and_then(|window| window.get("used_percentage"))
+            .and_then(Value::as_f64)
+            .or_else(|| payload.get("seven_day_percent").and_then(Value::as_f64)),
+        seven_day_resets_at: seven_day
+            .and_then(|window| window.get("resets_at"))
+            .or_else(|| payload.get("seven_day_resets_at"))
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
         emitted_at: hook_emitted_at(&payload).map(ToOwned::to_owned),
     };
 
@@ -1476,6 +1508,11 @@ async fn context_usage_hook(
     let outcome = state
         .session_store
         .apply_context_usage_event(&event, runtime.as_ref())?;
+    if !matches!(outcome, ContextUsageOutcome::UnknownSession) {
+        if let Err(error) = state.session_store.record_claude_statusline_burn(&event) {
+            eprintln!("Claude status-line burn ingest failed: {error:#}");
+        }
+    }
 
     let mut body = json!({ "status": outcome.status() });
     match &outcome {

--- a/crates/sm-server/src/lib.rs
+++ b/crates/sm-server/src/lib.rs
@@ -17,4 +17,5 @@ pub mod seat_sessions;
 pub mod sessions;
 pub mod studio_ssh;
 pub mod tool_usage;
+pub mod usage_burn;
 pub mod usage_identity;

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -30,6 +30,7 @@ use crate::{
     config::{CodexReviewConfig, ContextMonitorConfig},
     runtime::{TmuxRuntime, TmuxSessionSpec},
     seat_sessions::{SeatSessionIdentity, SeatSessionStore},
+    usage_burn::UsageBurnStore,
 };
 
 const DEFAULT_SESSION_STATE_FILE: &str = "~/.local/share/claude-sessions/sessions.json";
@@ -66,6 +67,7 @@ pub struct SessionStore {
     codex_fork_handoff_monitors: Arc<Mutex<BTreeSet<String>>>,
     clear_operation_locks: Arc<Mutex<BTreeMap<String, Weak<SessionClearLock>>>>,
     seat_session_store: SeatSessionStore,
+    usage_burn_store: Option<UsageBurnStore>,
 }
 
 #[derive(Debug)]
@@ -113,6 +115,7 @@ impl SessionStore {
             codex_fork_handoff_monitors: Arc::new(Mutex::new(BTreeSet::new())),
             clear_operation_locks: Arc::new(Mutex::new(BTreeMap::new())),
             seat_session_store,
+            usage_burn_store: None,
         }
     }
 
@@ -126,6 +129,29 @@ impl SessionStore {
     pub fn with_usage_db_path(mut self, db_path: PathBuf) -> Self {
         self.seat_session_store = SeatSessionStore::new(db_path);
         self
+    }
+
+    pub fn with_usage_burn_store(mut self, store: UsageBurnStore) -> Self {
+        self.usage_burn_store = Some(store);
+        self
+    }
+
+    pub fn record_claude_statusline_burn(&self, event: &ContextUsageEvent) -> Result<usize> {
+        let Some(store) = self.usage_burn_store.as_ref() else {
+            return Ok(0);
+        };
+        let observed_at = event
+            .emitted_at
+            .as_deref()
+            .and_then(|value| OffsetDateTime::parse(value, &Rfc3339).ok())
+            .unwrap_or_else(OffsetDateTime::now_utc);
+        store.record_claude_statusline(
+            observed_at,
+            event.five_hour_percent,
+            event.five_hour_resets_at.as_deref(),
+            event.seven_day_percent,
+            event.seven_day_resets_at.as_deref(),
+        )
     }
 
     pub fn with_context_monitor_config(mut self, config: ContextMonitorConfig) -> Self {
@@ -406,6 +432,7 @@ impl SessionStore {
             codex_fork_handoff_monitors: Arc::new(Mutex::new(BTreeSet::new())),
             clear_operation_locks: Arc::new(Mutex::new(BTreeMap::new())),
             seat_session_store,
+            usage_burn_store: None,
         }
     }
 
@@ -3868,6 +3895,11 @@ impl SessionStore {
                 artifact_path.and_then(Path::to_str),
             );
         }
+        if let Some(store) = self.usage_burn_store.as_ref() {
+            if let Err(error) = store.record_codex_event(event, OffsetDateTime::now_utc()) {
+                eprintln!("Codex rate-limit ingest failed for {session_id}: {error:#}");
+            }
+        }
         Ok(())
     }
 
@@ -4478,6 +4510,14 @@ pub struct ContextUsageEvent {
     pub used_percentage: Option<f64>,
     #[serde(default)]
     pub total_input_tokens: Option<i64>,
+    #[serde(default)]
+    pub five_hour_percent: Option<f64>,
+    #[serde(default)]
+    pub five_hour_resets_at: Option<String>,
+    #[serde(default)]
+    pub seven_day_percent: Option<f64>,
+    #[serde(default)]
+    pub seven_day_resets_at: Option<String>,
     /// Stamped by the producer hook before it detached its curl, so it describes
     /// when the sample was taken rather than when it arrived. Absent for hooks
     /// predating that change.
@@ -8555,6 +8595,8 @@ fn extract_provider_native_rename_name(text: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::usage_identity::{AccountIdentity, Provider, UsageIdentityStore};
+    use rusqlite::Connection;
 
     static TEST_ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -11190,10 +11232,9 @@ mod tests {
     fn usage_event(session_id: &str, used_percentage: f64, tokens: i64) -> ContextUsageEvent {
         ContextUsageEvent {
             session_id: session_id.to_owned(),
-            event: None,
             used_percentage: Some(used_percentage),
             total_input_tokens: Some(tokens),
-            emitted_at: None,
+            ..ContextUsageEvent::default()
         }
     }
 
@@ -11213,9 +11254,7 @@ mod tests {
         ContextUsageEvent {
             session_id: session_id.to_owned(),
             event: Some(event.to_owned()),
-            used_percentage: None,
-            total_input_tokens: None,
-            emitted_at: None,
+            ..ContextUsageEvent::default()
         }
     }
 
@@ -11729,10 +11768,8 @@ mod tests {
                 .apply_context_usage_event(
                     &ContextUsageEvent {
                         session_id: "child001".to_owned(),
-                        event: None,
-                        used_percentage: None,
                         total_input_tokens: Some(0),
-                        emitted_at: None,
+                        ..ContextUsageEvent::default()
                     },
                     None
                 )
@@ -11803,6 +11840,87 @@ mod tests {
 
         store.apply_codex_fork_event_line("codex001", line).unwrap();
         assert!(context_monitor_messages(&store).is_empty());
+    }
+
+    #[test]
+    fn codex_rate_limit_event_records_burn_for_the_current_account() {
+        let state_file = unique_temp_path("codexburn");
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [{
+                    "id": "codex001",
+                    "name": "codex-codex001",
+                    "provider": "codex-fork",
+                    "working_dir": "/repo",
+                    "tmux_session": "codex-codex001",
+                    "status": "running",
+                    "created_at": "2026-06-01T00:00:00",
+                    "last_activity": "2026-06-01T00:01:00"
+                }]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let usage_db_path = state_file.with_extension("usage.db");
+        let observed_at = OffsetDateTime::now_utc();
+        UsageIdentityStore::new(&usage_db_path)
+            .unwrap()
+            .record_observation(
+                Provider::Codex,
+                Some(&AccountIdentity {
+                    provider: Provider::Codex,
+                    external_id: "codex-test-account".to_owned(),
+                    label: None,
+                    plan_tier: Some("pro".to_owned()),
+                }),
+                observed_at - TimeDuration::minutes(1),
+                None,
+                None,
+            )
+            .unwrap();
+        let store = SessionStore::new_with_legacy_fallback(state_file.clone(), state_file)
+            .with_usage_burn_store(UsageBurnStore::new(&usage_db_path).unwrap());
+        let event_timestamp = observed_at.format(&Rfc3339).unwrap();
+        let reset_at = (observed_at + TimeDuration::minutes(300)).unix_timestamp();
+
+        store
+            .apply_codex_fork_event_line(
+                "codex001",
+                &json!({
+                    "event_type": "account/rateLimits/updated",
+                    "ts": event_timestamp,
+                    "payload": {"rateLimits": {
+                        "limitId": "codex",
+                        "primary": {
+                            "usedPercent": 27,
+                            "windowDurationMins": 300,
+                            "resetsAt": reset_at
+                        },
+                        "secondary": null
+                    }}
+                })
+                .to_string(),
+            )
+            .unwrap();
+
+        let row: (String, String, f64, String) = Connection::open(usage_db_path)
+            .unwrap()
+            .query_row(
+                "SELECT account_key, window_kind, percent, source FROM burn_samples",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            row,
+            (
+                "codex:codex-test-account".to_owned(),
+                "codex_300".to_owned(),
+                27.0,
+                "codex_event".to_owned(),
+            )
+        );
     }
 
     #[test]

--- a/crates/sm-server/src/usage_burn.rs
+++ b/crates/sm-server/src/usage_burn.rs
@@ -258,25 +258,24 @@ impl UsageBurnStore {
             ) else {
                 continue;
             };
-            let has_update = update.get("usedPercent").is_some()
-                || update.get("used_percent").is_some()
-                || update.get("resetsAt").is_some()
-                || update.get("resets_at").is_some()
-                || update.get("resets_in_seconds").is_some();
-            if !has_update {
-                continue;
-            }
-            let window_kind = format!("codex_{duration_minutes}");
-            let previous =
-                self.latest_window(&attribution.account_key, &window_kind, scope.as_deref())?;
-            let percent = json_f64(
+            let percent_update = json_f64(
                 update
                     .get("usedPercent")
                     .or_else(|| update.get("used_percent")),
-            )
-            .or_else(|| previous.as_ref().map(|window| window.0));
-            let resets_at = codex_reset_at(update, observed_at)
-                .or_else(|| previous.as_ref().map(|window| window.1));
+            );
+            let reset_update = codex_reset_at(update, observed_at);
+            if percent_update.is_none() && reset_update.is_none() {
+                continue;
+            }
+            let window_kind = format!("codex_{duration_minutes}");
+            let previous = self.latest_window(
+                &attribution.account_key,
+                &window_kind,
+                scope.as_deref(),
+                observed_at,
+            )?;
+            let percent = percent_update.or_else(|| previous.as_ref().map(|window| window.0));
+            let resets_at = reset_update.or_else(|| previous.as_ref().map(|window| window.1));
             let (Some(percent), Some(resets_at)) = (percent, resets_at) else {
                 continue;
             };
@@ -303,8 +302,10 @@ impl UsageBurnStore {
         account_key: &str,
         window_kind: &str,
         window_scope: Option<&str>,
+        observed_at: OffsetDateTime,
     ) -> Result<Option<(f64, OffsetDateTime)>> {
         let connection = self.open()?;
+        let observed_at = format_timestamp(observed_at)?;
         let row = connection
             .query_row(
                 r#"
@@ -313,10 +314,11 @@ impl UsageBurnStore {
                 WHERE account_key = ?1
                   AND window_kind = ?2
                   AND window_scope IS ?3
+                  AND observed_at <= ?4
                 ORDER BY observed_at DESC, id DESC
                 LIMIT 1
                 "#,
-                params![account_key, window_kind, window_scope],
+                params![account_key, window_kind, window_scope, observed_at],
                 |row| Ok((row.get::<_, f64>(0)?, row.get::<_, String>(1)?)),
             )
             .optional()?;
@@ -687,7 +689,11 @@ mod tests {
             "ts": "2026-08-10T12:03:00Z",
             "payload": {"rateLimits": {
                 "limitId": "codex",
-                "primary": {"windowDurationMins": 10080}
+                "primary": {
+                    "usedPercent": null,
+                    "windowDurationMins": 10080,
+                    "resetsAt": null
+                }
             }}
         });
         assert_eq!(
@@ -773,5 +779,75 @@ mod tests {
             .unwrap();
         assert_eq!(latest.0, 20.0);
         assert_eq!(latest.1, "2026-08-10T12:01:00.950000000Z");
+    }
+
+    #[test]
+    fn codex_sparse_merge_does_not_inherit_from_future_samples() {
+        let db_path = temp_db("codex-out-of-order");
+        seed_account(
+            &db_path,
+            Provider::Codex,
+            "codex-account",
+            "2026-08-10T12:00:00Z",
+        );
+        let store = UsageBurnStore::new(&db_path).unwrap();
+        for (timestamp, percent, reset) in [
+            ("2026-08-10T12:01:00Z", 10, 1786381200_i64),
+            ("2026-08-10T12:03:00Z", 30, 1786384800_i64),
+        ] {
+            let event = json!({
+                "event_type": "account/rateLimits/updated",
+                "ts": timestamp,
+                "payload": {"rateLimits": {
+                    "limitId": "codex",
+                    "primary": {
+                        "usedPercent": percent,
+                        "windowDurationMins": 300,
+                        "resetsAt": reset
+                    }
+                }}
+            });
+            assert_eq!(
+                store
+                    .record_codex_event(event.as_object().unwrap(), at(timestamp))
+                    .unwrap(),
+                1
+            );
+        }
+        let delayed = json!({
+            "event_type": "account/rateLimits/updated",
+            "ts": "2026-08-10T12:02:00Z",
+            "payload": {"rateLimits": {
+                "limitId": "codex",
+                "primary": {
+                    "windowDurationMins": 300,
+                    "resetsAt": 1786383000_i64
+                }
+            }}
+        });
+        assert_eq!(
+            store
+                .record_codex_event(delayed.as_object().unwrap(), at("2026-08-10T12:04:00Z"))
+                .unwrap(),
+            1
+        );
+
+        let connection = Connection::open(db_path).unwrap();
+        let delayed_percent: f64 = connection
+            .query_row(
+                "SELECT percent FROM burn_samples WHERE observed_at = '2026-08-10T12:02:00.000000000Z'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let latest_percent: f64 = connection
+            .query_row(
+                "SELECT percent FROM burn_samples ORDER BY observed_at DESC LIMIT 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(delayed_percent, 10.0);
+        assert_eq!(latest_percent, 30.0);
     }
 }

--- a/crates/sm-server/src/usage_burn.rs
+++ b/crates/sm-server/src/usage_burn.rs
@@ -1,0 +1,705 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+use anyhow::{bail, Context, Result};
+use rusqlite::{params, Connection, OptionalExtension};
+use serde_json::{Map, Value};
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+use crate::usage_identity::{Provider, UsageIdentityStore};
+
+const USAGE_DB_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
+const SESSION_WINDOW_MINUTES: i64 = 300;
+const WEEKLY_WINDOW_MINUTES: i64 = 10_080;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BurnWindowSample {
+    pub window_kind: String,
+    pub window_scope: Option<String>,
+    pub duration_minutes: i64,
+    pub percent: f64,
+    pub resets_at: OffsetDateTime,
+    pub severity: Option<String>,
+    pub is_active: Option<bool>,
+}
+
+#[derive(Debug, Clone)]
+pub struct UsageBurnStore {
+    db_path: PathBuf,
+    identity_store: UsageIdentityStore,
+}
+
+impl UsageBurnStore {
+    pub fn new(db_path: impl Into<PathBuf>) -> Result<Self> {
+        let db_path = db_path.into();
+        let store = Self {
+            identity_store: UsageIdentityStore::new(&db_path)?,
+            db_path,
+        };
+        store.initialize()?;
+        Ok(store)
+    }
+
+    fn initialize(&self) -> Result<()> {
+        self.open()?
+            .execute_batch(
+                r#"
+                CREATE TABLE IF NOT EXISTS burn_samples (
+                  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+                  account_key  TEXT NOT NULL REFERENCES accounts(account_key),
+                  window_kind  TEXT NOT NULL,
+                  window_scope TEXT,
+                  window_start TEXT NOT NULL,
+                  percent      REAL NOT NULL,
+                  resets_at    TEXT NOT NULL,
+                  severity     TEXT,
+                  is_active    INTEGER,
+                  source       TEXT NOT NULL,
+                  observed_at  TEXT NOT NULL
+                );
+                CREATE INDEX IF NOT EXISTS idx_burn_window
+                  ON burn_samples(account_key, window_kind, observed_at);
+                "#,
+            )
+            .context("failed to initialize usage burn schema")?;
+        Ok(())
+    }
+
+    fn open(&self) -> Result<Connection> {
+        if let Some(parent) = self
+            .db_path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("failed to create usage DB directory {}", parent.display())
+            })?;
+        }
+        let connection = Connection::open(&self.db_path)
+            .with_context(|| format!("failed to open usage DB {}", self.db_path.display()))?;
+        connection.busy_timeout(USAGE_DB_BUSY_TIMEOUT)?;
+        connection.pragma_update(None, "journal_mode", "WAL")?;
+        connection.pragma_update(None, "foreign_keys", true)?;
+        Ok(connection)
+    }
+
+    pub fn record_for_provider(
+        &self,
+        provider: Provider,
+        windows: &[BurnWindowSample],
+        source: &str,
+        observed_at: OffsetDateTime,
+    ) -> Result<usize> {
+        let Some(attribution) = self.identity_store.account_at(provider, observed_at)? else {
+            return Ok(0);
+        };
+        self.record_for_account(&attribution.account_key, windows, source, observed_at)
+    }
+
+    pub fn record_for_account(
+        &self,
+        account_key: &str,
+        windows: &[BurnWindowSample],
+        source: &str,
+        observed_at: OffsetDateTime,
+    ) -> Result<usize> {
+        if account_key.trim().is_empty() || source.trim().is_empty() {
+            bail!("burn sample account and source must not be empty");
+        }
+        for window in windows {
+            validate_window(window)?;
+        }
+        let observed_at = format_timestamp(observed_at)?;
+        let mut connection = self.open()?;
+        let transaction = connection.transaction()?;
+        let mut inserted = 0;
+        for window in windows {
+            let resets_at = format_timestamp(window.resets_at)?;
+            let window_start = format_timestamp(
+                window.resets_at - time::Duration::minutes(window.duration_minutes),
+            )?;
+            inserted += transaction.execute(
+                r#"
+                INSERT INTO burn_samples (
+                  account_key, window_kind, window_scope, window_start, percent,
+                  resets_at, severity, is_active, source, observed_at
+                )
+                SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10
+                WHERE NOT EXISTS (
+                  SELECT 1 FROM burn_samples
+                  WHERE account_key = ?1
+                    AND window_kind = ?2
+                    AND window_scope IS ?3
+                    AND source = ?9
+                    AND observed_at = ?10
+                )
+                "#,
+                params![
+                    account_key,
+                    window.window_kind,
+                    window.window_scope,
+                    window_start,
+                    window.percent,
+                    resets_at,
+                    window.severity,
+                    window.is_active,
+                    source,
+                    observed_at,
+                ],
+            )?;
+        }
+        transaction.commit()?;
+        Ok(inserted)
+    }
+
+    pub fn record_claude_statusline(
+        &self,
+        observed_at: OffsetDateTime,
+        five_hour_percent: Option<f64>,
+        five_hour_resets_at: Option<&str>,
+        seven_day_percent: Option<f64>,
+        seven_day_resets_at: Option<&str>,
+    ) -> Result<usize> {
+        let mut windows = Vec::new();
+        if let Some(window) = paired_claude_window(
+            "session_5h",
+            SESSION_WINDOW_MINUTES,
+            five_hour_percent,
+            five_hour_resets_at,
+        )? {
+            windows.push(window);
+        }
+        if let Some(window) = paired_claude_window(
+            "weekly_all",
+            WEEKLY_WINDOW_MINUTES,
+            seven_day_percent,
+            seven_day_resets_at,
+        )? {
+            windows.push(window);
+        }
+        self.record_for_provider(Provider::Claude, &windows, "statusline", observed_at)
+    }
+
+    pub fn record_claude_json_file(&self, path: &Path) -> Result<usize> {
+        let raw = fs::read_to_string(path)
+            .with_context(|| format!("failed to read Claude usage cache {}", path.display()))?;
+        let value: Value = serde_json::from_str(&raw)
+            .with_context(|| format!("failed to parse Claude usage cache {}", path.display()))?;
+        let Some(snapshot) = parse_claude_cached_usage(&value)? else {
+            return Ok(0);
+        };
+        self.record_for_account(
+            &snapshot.account_key,
+            &snapshot.windows,
+            "claude_json",
+            snapshot.observed_at,
+        )
+    }
+
+    pub fn record_codex_event(
+        &self,
+        event: &Map<String, Value>,
+        received_at: OffsetDateTime,
+    ) -> Result<usize> {
+        if !is_codex_rate_limit_event(event) {
+            return Ok(0);
+        }
+        let observed_at = json_string(event, "ts")
+            .as_deref()
+            .and_then(|value| OffsetDateTime::parse(value, &Rfc3339).ok())
+            .unwrap_or(received_at);
+        let Some(attribution) = self
+            .identity_store
+            .account_at(Provider::Codex, observed_at)?
+        else {
+            return Ok(0);
+        };
+        let rate_limits = event
+            .get("payload")
+            .and_then(Value::as_object)
+            .and_then(|payload| {
+                payload
+                    .get("rateLimits")
+                    .or_else(|| payload.get("rate_limits"))
+            })
+            .and_then(Value::as_object)
+            .or_else(|| event.get("rate_limits").and_then(Value::as_object));
+        let Some(rate_limits) = rate_limits else {
+            return Ok(0);
+        };
+        let limit_id = json_string(rate_limits, "limitId")
+            .or_else(|| json_string(rate_limits, "limit_id"))
+            .unwrap_or_else(|| "codex".to_owned());
+        let limit_name = json_string(rate_limits, "limitName")
+            .or_else(|| json_string(rate_limits, "limit_name"));
+        let scope = if limit_id == "codex" {
+            limit_name
+        } else {
+            limit_name.or(Some(limit_id))
+        };
+        let severity = json_string(rate_limits, "rateLimitReachedType")
+            .or_else(|| json_string(rate_limits, "rate_limit_reached_type"))
+            .map(|_| "critical".to_owned());
+        let mut windows = Vec::new();
+        for slot in ["primary", "secondary"] {
+            let Some(update) = rate_limits.get(slot).and_then(Value::as_object) else {
+                continue;
+            };
+            let Some(duration_minutes) = json_i64(
+                update
+                    .get("windowDurationMins")
+                    .or_else(|| update.get("window_minutes")),
+            ) else {
+                continue;
+            };
+            let has_update = update.get("usedPercent").is_some()
+                || update.get("used_percent").is_some()
+                || update.get("resetsAt").is_some()
+                || update.get("resets_at").is_some()
+                || update.get("resets_in_seconds").is_some();
+            if !has_update {
+                continue;
+            }
+            let window_kind = format!("codex_{duration_minutes}");
+            let previous =
+                self.latest_window(&attribution.account_key, &window_kind, scope.as_deref())?;
+            let percent = json_f64(
+                update
+                    .get("usedPercent")
+                    .or_else(|| update.get("used_percent")),
+            )
+            .or_else(|| previous.as_ref().map(|window| window.0));
+            let resets_at = codex_reset_at(update, observed_at)
+                .or_else(|| previous.as_ref().map(|window| window.1));
+            let (Some(percent), Some(resets_at)) = (percent, resets_at) else {
+                continue;
+            };
+            windows.push(BurnWindowSample {
+                window_kind,
+                window_scope: scope.clone(),
+                duration_minutes,
+                percent,
+                resets_at,
+                severity: severity.clone(),
+                is_active: None,
+            });
+        }
+        self.record_for_account(
+            &attribution.account_key,
+            &windows,
+            "codex_event",
+            observed_at,
+        )
+    }
+
+    fn latest_window(
+        &self,
+        account_key: &str,
+        window_kind: &str,
+        window_scope: Option<&str>,
+    ) -> Result<Option<(f64, OffsetDateTime)>> {
+        let connection = self.open()?;
+        let row = connection
+            .query_row(
+                r#"
+                SELECT percent, resets_at
+                FROM burn_samples
+                WHERE account_key = ?1
+                  AND window_kind = ?2
+                  AND window_scope IS ?3
+                ORDER BY observed_at DESC, id DESC
+                LIMIT 1
+                "#,
+                params![account_key, window_kind, window_scope],
+                |row| Ok((row.get::<_, f64>(0)?, row.get::<_, String>(1)?)),
+            )
+            .optional()?;
+        row.map(|(percent, resets_at)| Ok((percent, OffsetDateTime::parse(&resets_at, &Rfc3339)?)))
+            .transpose()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ClaudeCachedUsage {
+    account_key: String,
+    observed_at: OffsetDateTime,
+    windows: Vec<BurnWindowSample>,
+}
+
+fn parse_claude_cached_usage(value: &Value) -> Result<Option<ClaudeCachedUsage>> {
+    let Some(cached) = value
+        .get("cachedUsageUtilization")
+        .and_then(Value::as_object)
+    else {
+        return Ok(None);
+    };
+    let account_id = json_string(cached, "accountUuid")
+        .or_else(|| {
+            value
+                .get("oauthAccount")
+                .and_then(Value::as_object)
+                .and_then(|account| json_string(account, "accountUuid"))
+        })
+        .context("Claude usage cache is missing accountUuid")?;
+    let fetched_at_ms =
+        json_i64(cached.get("fetchedAtMs")).context("Claude usage cache is missing fetchedAtMs")?;
+    let observed_at =
+        OffsetDateTime::from_unix_timestamp_nanos(i128::from(fetched_at_ms) * 1_000_000)
+            .context("Claude usage fetchedAtMs is out of range")?;
+    let utilization = cached
+        .get("utilization")
+        .and_then(Value::as_object)
+        .context("Claude usage cache is missing utilization")?;
+    let mut windows = Vec::new();
+    if let Some(limits) = utilization.get("limits").and_then(Value::as_array) {
+        for limit in limits.iter().filter_map(Value::as_object) {
+            let Some(kind) = json_string(limit, "kind") else {
+                continue;
+            };
+            let (window_kind, duration_minutes) = match kind.as_str() {
+                "session" => ("session_5h", SESSION_WINDOW_MINUTES),
+                "weekly_all" => ("weekly_all", WEEKLY_WINDOW_MINUTES),
+                "weekly_scoped" => ("weekly_scoped", WEEKLY_WINDOW_MINUTES),
+                _ => continue,
+            };
+            let (Some(percent), Some(resets_at)) = (
+                json_f64(limit.get("percent")),
+                json_string(limit, "resets_at")
+                    .as_deref()
+                    .and_then(|value| OffsetDateTime::parse(value, &Rfc3339).ok()),
+            ) else {
+                continue;
+            };
+            let window_scope = limit
+                .get("scope")
+                .and_then(Value::as_object)
+                .and_then(|scope| scope.get("model"))
+                .and_then(Value::as_object)
+                .and_then(|model| json_string(model, "display_name"));
+            windows.push(BurnWindowSample {
+                window_kind: window_kind.to_owned(),
+                window_scope,
+                duration_minutes,
+                percent,
+                resets_at,
+                severity: json_string(limit, "severity"),
+                is_active: limit.get("is_active").and_then(Value::as_bool),
+            });
+        }
+    }
+    if windows.is_empty() {
+        for (key, kind, duration) in [
+            ("five_hour", "session_5h", SESSION_WINDOW_MINUTES),
+            ("seven_day", "weekly_all", WEEKLY_WINDOW_MINUTES),
+        ] {
+            let Some(window) = utilization.get(key).and_then(Value::as_object) else {
+                continue;
+            };
+            let (Some(percent), Some(resets_at)) = (
+                json_f64(window.get("utilization")),
+                json_string(window, "resets_at")
+                    .as_deref()
+                    .and_then(|value| OffsetDateTime::parse(value, &Rfc3339).ok()),
+            ) else {
+                continue;
+            };
+            windows.push(BurnWindowSample {
+                window_kind: kind.to_owned(),
+                window_scope: None,
+                duration_minutes: duration,
+                percent,
+                resets_at,
+                severity: None,
+                is_active: None,
+            });
+        }
+    }
+    Ok(Some(ClaudeCachedUsage {
+        account_key: format!("claude:{account_id}"),
+        observed_at,
+        windows,
+    }))
+}
+
+fn paired_claude_window(
+    kind: &str,
+    duration_minutes: i64,
+    percent: Option<f64>,
+    resets_at: Option<&str>,
+) -> Result<Option<BurnWindowSample>> {
+    let (Some(percent), Some(resets_at)) = (percent, resets_at) else {
+        return Ok(None);
+    };
+    Ok(Some(BurnWindowSample {
+        window_kind: kind.to_owned(),
+        window_scope: None,
+        duration_minutes,
+        percent,
+        resets_at: OffsetDateTime::parse(resets_at, &Rfc3339)
+            .with_context(|| format!("invalid {kind} reset timestamp"))?,
+        severity: None,
+        is_active: None,
+    }))
+}
+
+fn validate_window(window: &BurnWindowSample) -> Result<()> {
+    if window.window_kind.trim().is_empty() || window.duration_minutes <= 0 {
+        bail!("burn sample window kind and duration must be valid");
+    }
+    if !window.percent.is_finite() || !(0.0..=100.0).contains(&window.percent) {
+        bail!("burn sample percent must be finite and between 0 and 100");
+    }
+    Ok(())
+}
+
+fn is_codex_rate_limit_event(event: &Map<String, Value>) -> bool {
+    let event_type = json_string(event, "event_type")
+        .or_else(|| json_string(event, "type"))
+        .unwrap_or_default();
+    matches!(
+        event_type.as_str(),
+        "account/rateLimits/updated" | "account_rate_limits_updated"
+    )
+}
+
+fn codex_reset_at(
+    update: &Map<String, Value>,
+    observed_at: OffsetDateTime,
+) -> Option<OffsetDateTime> {
+    if let Some(timestamp) = json_i64(update.get("resetsAt").or_else(|| update.get("resets_at"))) {
+        return OffsetDateTime::from_unix_timestamp(timestamp).ok();
+    }
+    json_i64(update.get("resets_in_seconds"))
+        .map(|seconds| observed_at + time::Duration::seconds(seconds))
+}
+
+fn json_string(value: &Map<String, Value>, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn json_i64(value: Option<&Value>) -> Option<i64> {
+    value.and_then(|value| {
+        value
+            .as_i64()
+            .or_else(|| value.as_u64().and_then(|value| i64::try_from(value).ok()))
+    })
+}
+
+fn json_f64(value: Option<&Value>) -> Option<f64> {
+    value.and_then(|value| value.as_f64().or_else(|| value.as_i64().map(|v| v as f64)))
+}
+
+fn format_timestamp(value: OffsetDateTime) -> Result<String> {
+    value.format(&Rfc3339).context("failed to format timestamp")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    use rusqlite::Connection;
+    use serde_json::json;
+
+    use super::*;
+    use crate::usage_identity::AccountIdentity;
+
+    static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(0);
+
+    fn temp_db(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "sm-usage-burn-{label}-{}-{}.db",
+            std::process::id(),
+            NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    fn at(value: &str) -> OffsetDateTime {
+        OffsetDateTime::parse(value, &Rfc3339).unwrap()
+    }
+
+    fn seed_account(db_path: &Path, provider: Provider, external_id: &str, observed_at: &str) {
+        let identity = AccountIdentity {
+            provider,
+            external_id: external_id.to_owned(),
+            label: None,
+            plan_tier: None,
+        };
+        UsageIdentityStore::new(db_path)
+            .unwrap()
+            .record_observation(provider, Some(&identity), at(observed_at), None, None)
+            .unwrap();
+    }
+
+    #[test]
+    fn claude_cache_records_all_windows_at_fetch_time_once() {
+        let db_path = temp_db("claude-cache");
+        seed_account(
+            &db_path,
+            Provider::Claude,
+            "claude-account",
+            "2026-08-10T12:00:00Z",
+        );
+        let cache_path = db_path.with_extension("claude.json");
+        fs::write(
+            &cache_path,
+            json!({
+                "oauthAccount": {"accountUuid": "claude-account"},
+                "cachedUsageUtilization": {
+                    "fetchedAtMs": 1786365000000_i64,
+                    "accountUuid": "claude-account",
+                    "utilization": {
+                        "limits": [
+                            {"kind": "session", "percent": 9, "resets_at": "2026-08-10T20:00:00Z", "severity": "normal", "is_active": true},
+                            {"kind": "weekly_all", "percent": 8, "resets_at": "2026-08-16T16:00:00Z", "severity": "warning", "is_active": false},
+                            {"kind": "weekly_scoped", "percent": 7, "resets_at": "2026-08-16T16:00:00Z", "scope": {"model": {"display_name": "Fable"}}, "is_active": false}
+                        ]
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let store = UsageBurnStore::new(&db_path).unwrap();
+
+        assert_eq!(store.record_claude_json_file(&cache_path).unwrap(), 3);
+        assert_eq!(store.record_claude_json_file(&cache_path).unwrap(), 0);
+
+        let connection = Connection::open(db_path).unwrap();
+        let rows = connection
+            .prepare(
+                "SELECT window_kind, window_scope, percent, source, observed_at FROM burn_samples ORDER BY window_kind",
+            )
+            .unwrap()
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<String>>(1)?,
+                    row.get::<_, f64>(2)?,
+                    row.get::<_, String>(3)?,
+                    row.get::<_, String>(4)?,
+                ))
+            })
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(rows.len(), 3);
+        assert_eq!(rows[0].0, "session_5h");
+        assert_eq!(rows[1].0, "weekly_all");
+        assert_eq!(rows[2].0, "weekly_scoped");
+        assert_eq!(rows[2].1.as_deref(), Some("Fable"));
+        assert!(rows.iter().all(|row| row.3 == "claude_json"));
+        assert!(rows.iter().all(|row| row.4.starts_with("2026-08-10T")));
+    }
+
+    #[test]
+    fn statusline_windows_resolve_the_half_open_claude_account() {
+        let db_path = temp_db("statusline");
+        seed_account(
+            &db_path,
+            Provider::Claude,
+            "claude-account",
+            "2026-08-10T12:00:00Z",
+        );
+        let store = UsageBurnStore::new(&db_path).unwrap();
+
+        assert_eq!(
+            store
+                .record_claude_statusline(
+                    at("2026-08-10T12:01:00Z"),
+                    Some(12.0),
+                    Some("2026-08-10T17:00:00Z"),
+                    Some(34.0),
+                    Some("2026-08-16T16:00:00Z"),
+                )
+                .unwrap(),
+            2
+        );
+        let count: i64 = Connection::open(db_path)
+            .unwrap()
+            .query_row(
+                "SELECT COUNT(*) FROM burn_samples WHERE account_key = 'claude:claude-account' AND source = 'statusline'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn codex_sparse_merge_keys_windows_by_duration_across_slot_swap() {
+        let db_path = temp_db("codex-sparse");
+        seed_account(
+            &db_path,
+            Provider::Codex,
+            "codex-account",
+            "2026-08-10T12:00:00Z",
+        );
+        let store = UsageBurnStore::new(&db_path).unwrap();
+        let first = json!({
+            "event_type": "account/rateLimits/updated",
+            "ts": "2026-08-10T12:01:00Z",
+            "payload": {"rateLimits": {
+                "limitId": "codex",
+                "primary": {"usedPercent": 10, "windowDurationMins": 300, "resetsAt": 1786381200_i64},
+                "secondary": {"usedPercent": 30, "windowDurationMins": 10080, "resetsAt": 1786982400_i64}
+            }}
+        });
+        assert_eq!(
+            store
+                .record_codex_event(first.as_object().unwrap(), at("2026-08-10T12:01:01Z"))
+                .unwrap(),
+            2
+        );
+        let swapped_sparse = json!({
+            "event_type": "account/rateLimits/updated",
+            "ts": "2026-08-10T12:02:00Z",
+            "payload": {"rateLimits": {
+                "limitId": "codex",
+                "primary": {"usedPercent": 40, "windowDurationMins": 10080},
+                "secondary": null
+            }}
+        });
+        assert_eq!(
+            store
+                .record_codex_event(
+                    swapped_sparse.as_object().unwrap(),
+                    at("2026-08-10T12:02:01Z"),
+                )
+                .unwrap(),
+            1
+        );
+        let no_update = json!({
+            "event_type": "account/rateLimits/updated",
+            "ts": "2026-08-10T12:03:00Z",
+            "payload": {"rateLimits": {
+                "limitId": "codex",
+                "primary": {"windowDurationMins": 10080}
+            }}
+        });
+        assert_eq!(
+            store
+                .record_codex_event(no_update.as_object().unwrap(), at("2026-08-10T12:03:01Z"),)
+                .unwrap(),
+            0
+        );
+
+        let connection = Connection::open(db_path).unwrap();
+        let latest: (f64, String) = connection
+            .query_row(
+                "SELECT percent, resets_at FROM burn_samples WHERE window_kind = 'codex_10080' ORDER BY observed_at DESC LIMIT 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(latest.0, 40.0);
+        assert_eq!(latest.1, "2026-08-17T16:00:00Z");
+    }
+}

--- a/crates/sm-server/src/usage_burn.rs
+++ b/crates/sm-server/src/usage_burn.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use anyhow::{bail, Context, Result};
-use rusqlite::{params, Connection, OptionalExtension};
+use rusqlite::{params, Connection, OptionalExtension, Transaction, TransactionBehavior};
 use serde_json::{Map, Value};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
@@ -118,42 +118,7 @@ impl UsageBurnStore {
         let observed_at = format_timestamp(observed_at)?;
         let mut connection = self.open()?;
         let transaction = connection.transaction()?;
-        let mut inserted = 0;
-        for window in windows {
-            let resets_at = format_timestamp(window.resets_at)?;
-            let window_start = format_timestamp(
-                window.resets_at - time::Duration::minutes(window.duration_minutes),
-            )?;
-            inserted += transaction.execute(
-                r#"
-                INSERT INTO burn_samples (
-                  account_key, window_kind, window_scope, window_start, percent,
-                  resets_at, severity, is_active, source, observed_at
-                )
-                SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10
-                WHERE NOT EXISTS (
-                  SELECT 1 FROM burn_samples
-                  WHERE account_key = ?1
-                    AND window_kind = ?2
-                    AND window_scope IS ?3
-                    AND source = ?9
-                    AND observed_at = ?10
-                )
-                "#,
-                params![
-                    account_key,
-                    window.window_kind,
-                    window.window_scope,
-                    window_start,
-                    window.percent,
-                    resets_at,
-                    window.severity,
-                    window.is_active,
-                    source,
-                    observed_at,
-                ],
-            )?;
-        }
+        let inserted = insert_windows(&transaction, account_key, windows, source, &observed_at)?;
         transaction.commit()?;
         Ok(inserted)
     }
@@ -236,16 +201,13 @@ impl UsageBurnStore {
         let limit_id = json_string(rate_limits, "limitId")
             .or_else(|| json_string(rate_limits, "limit_id"))
             .unwrap_or_else(|| "codex".to_owned());
-        let limit_name = json_string(rate_limits, "limitName")
-            .or_else(|| json_string(rate_limits, "limit_name"));
-        let scope = if limit_id == "codex" {
-            limit_name
-        } else {
-            limit_name.or(Some(limit_id))
-        };
+        let scope = (limit_id != "codex").then_some(limit_id);
         let severity = json_string(rate_limits, "rateLimitReachedType")
             .or_else(|| json_string(rate_limits, "rate_limit_reached_type"))
             .map(|_| "critical".to_owned());
+        let observed_at_text = format_timestamp(observed_at)?;
+        let mut connection = self.open()?;
+        let transaction = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let mut windows = Vec::new();
         for slot in ["primary", "secondary"] {
             let Some(update) = rate_limits.get(slot).and_then(Value::as_object) else {
@@ -268,11 +230,12 @@ impl UsageBurnStore {
                 continue;
             }
             let window_kind = format!("codex_{duration_minutes}");
-            let previous = self.latest_window(
+            let previous = latest_window(
+                &transaction,
                 &attribution.account_key,
                 &window_kind,
                 scope.as_deref(),
-                observed_at,
+                &observed_at_text,
             )?;
             let percent = percent_update.or_else(|| previous.as_ref().map(|window| window.0));
             let resets_at = reset_update.or_else(|| previous.as_ref().map(|window| window.1));
@@ -289,42 +252,91 @@ impl UsageBurnStore {
                 is_active: None,
             });
         }
-        self.record_for_account(
+        for window in &windows {
+            validate_window(window)?;
+        }
+        let inserted = insert_windows(
+            &transaction,
             &attribution.account_key,
             &windows,
             "codex_event",
-            observed_at,
-        )
+            &observed_at_text,
+        )?;
+        transaction.commit()?;
+        Ok(inserted)
     }
+}
 
-    fn latest_window(
-        &self,
-        account_key: &str,
-        window_kind: &str,
-        window_scope: Option<&str>,
-        observed_at: OffsetDateTime,
-    ) -> Result<Option<(f64, OffsetDateTime)>> {
-        let connection = self.open()?;
-        let observed_at = format_timestamp(observed_at)?;
-        let row = connection
-            .query_row(
-                r#"
-                SELECT percent, resets_at
-                FROM burn_samples
-                WHERE account_key = ?1
-                  AND window_kind = ?2
-                  AND window_scope IS ?3
-                  AND observed_at <= ?4
-                ORDER BY observed_at DESC, id DESC
-                LIMIT 1
-                "#,
-                params![account_key, window_kind, window_scope, observed_at],
-                |row| Ok((row.get::<_, f64>(0)?, row.get::<_, String>(1)?)),
+fn latest_window(
+    transaction: &Transaction<'_>,
+    account_key: &str,
+    window_kind: &str,
+    window_scope: Option<&str>,
+    observed_at: &str,
+) -> Result<Option<(f64, OffsetDateTime)>> {
+    let row = transaction
+        .query_row(
+            r#"
+            SELECT percent, resets_at
+            FROM burn_samples
+            WHERE account_key = ?1
+              AND window_kind = ?2
+              AND window_scope IS ?3
+              AND observed_at <= ?4
+            ORDER BY observed_at DESC, id DESC
+            LIMIT 1
+            "#,
+            params![account_key, window_kind, window_scope, observed_at],
+            |row| Ok((row.get::<_, f64>(0)?, row.get::<_, String>(1)?)),
+        )
+        .optional()?;
+    row.map(|(percent, resets_at)| Ok((percent, OffsetDateTime::parse(&resets_at, &Rfc3339)?)))
+        .transpose()
+}
+
+fn insert_windows(
+    transaction: &Transaction<'_>,
+    account_key: &str,
+    windows: &[BurnWindowSample],
+    source: &str,
+    observed_at: &str,
+) -> Result<usize> {
+    let mut inserted = 0;
+    for window in windows {
+        let resets_at = format_timestamp(window.resets_at)?;
+        let window_start =
+            format_timestamp(window.resets_at - time::Duration::minutes(window.duration_minutes))?;
+        inserted += transaction.execute(
+            r#"
+            INSERT INTO burn_samples (
+              account_key, window_kind, window_scope, window_start, percent,
+              resets_at, severity, is_active, source, observed_at
             )
-            .optional()?;
-        row.map(|(percent, resets_at)| Ok((percent, OffsetDateTime::parse(&resets_at, &Rfc3339)?)))
-            .transpose()
+            SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10
+            WHERE NOT EXISTS (
+              SELECT 1 FROM burn_samples
+              WHERE account_key = ?1
+                AND window_kind = ?2
+                AND window_scope IS ?3
+                AND source = ?9
+                AND observed_at = ?10
+            )
+            "#,
+            params![
+                account_key,
+                window.window_kind,
+                window.window_scope,
+                window_start,
+                window.percent,
+                resets_at,
+                window.severity,
+                window.is_active,
+                source,
+                observed_at,
+            ],
+        )?;
     }
+    Ok(inserted)
 }
 
 #[derive(Debug, Clone)]
@@ -511,7 +523,14 @@ fn format_timestamp(value: OffsetDateTime) -> Result<String> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::{
+        sync::{
+            atomic::{AtomicU64, Ordering},
+            mpsc,
+        },
+        thread,
+        time::Duration as StdDuration,
+    };
 
     use rusqlite::Connection;
     use serde_json::json;
@@ -849,5 +868,156 @@ mod tests {
             .unwrap();
         assert_eq!(delayed_percent, 10.0);
         assert_eq!(latest_percent, 30.0);
+    }
+
+    #[test]
+    fn codex_sparse_merge_waits_for_a_concurrent_writer_before_reading_history() {
+        let db_path = temp_db("codex-concurrent");
+        seed_account(
+            &db_path,
+            Provider::Codex,
+            "codex-account",
+            "2026-08-10T12:00:00Z",
+        );
+        let store = UsageBurnStore::new(&db_path).unwrap();
+        let baseline = json!({
+            "event_type": "account/rateLimits/updated",
+            "ts": "2026-08-10T12:01:00Z",
+            "payload": {"rateLimits": {
+                "limitId": "codex",
+                "primary": {
+                    "usedPercent": 10,
+                    "windowDurationMins": 300,
+                    "resetsAt": 1786381200_i64
+                }
+            }}
+        });
+        store
+            .record_codex_event(baseline.as_object().unwrap(), at("2026-08-10T12:01:00Z"))
+            .unwrap();
+
+        let mut blocker_connection = store.open().unwrap();
+        let blocker = blocker_connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .unwrap();
+        insert_windows(
+            &blocker,
+            "codex:codex-account",
+            &[BurnWindowSample {
+                window_kind: "codex_300".to_owned(),
+                window_scope: None,
+                duration_minutes: 300,
+                percent: 20.0,
+                resets_at: OffsetDateTime::from_unix_timestamp(1786381200).unwrap(),
+                severity: None,
+                is_active: None,
+            }],
+            "codex_event",
+            "2026-08-10T12:02:00.000000000Z",
+        )
+        .unwrap();
+
+        let reset_only = json!({
+            "event_type": "account/rateLimits/updated",
+            "ts": "2026-08-10T12:03:00Z",
+            "payload": {"rateLimits": {
+                "limitId": "codex",
+                "primary": {
+                    "windowDurationMins": 300,
+                    "resetsAt": 1786384800_i64
+                }
+            }}
+        });
+        let (sent, received) = mpsc::channel();
+        let concurrent_store = store.clone();
+        let writer =
+            thread::spawn(move || {
+                sent.send(concurrent_store.record_codex_event(
+                    reset_only.as_object().unwrap(),
+                    at("2026-08-10T12:03:00Z"),
+                ))
+                .unwrap();
+            });
+        assert!(received.recv_timeout(StdDuration::from_millis(50)).is_err());
+        blocker.commit().unwrap();
+        assert_eq!(
+            received
+                .recv_timeout(StdDuration::from_secs(2))
+                .unwrap()
+                .unwrap(),
+            1
+        );
+        writer.join().unwrap();
+
+        let merged_percent: f64 = Connection::open(db_path)
+            .unwrap()
+            .query_row(
+                "SELECT percent FROM burn_samples WHERE observed_at = '2026-08-10T12:03:00.000000000Z'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(merged_percent, 20.0);
+    }
+
+    #[test]
+    fn codex_non_default_windows_are_keyed_by_limit_id_not_name() {
+        let db_path = temp_db("codex-limit-id");
+        seed_account(
+            &db_path,
+            Provider::Codex,
+            "codex-account",
+            "2026-08-10T12:00:00Z",
+        );
+        let store = UsageBurnStore::new(&db_path).unwrap();
+        for (timestamp, name, percent, reset) in [
+            (
+                "2026-08-10T12:01:00Z",
+                "Fable",
+                Some(10),
+                Some(1786381200_i64),
+            ),
+            ("2026-08-10T12:02:00Z", "Sol", Some(20), None),
+        ] {
+            let event = json!({
+                "event_type": "account/rateLimits/updated",
+                "ts": timestamp,
+                "payload": {"rateLimits": {
+                    "limitId": "premium",
+                    "limitName": name,
+                    "primary": {
+                        "usedPercent": percent,
+                        "windowDurationMins": 300,
+                        "resetsAt": reset
+                    }
+                }}
+            });
+            assert_eq!(
+                store
+                    .record_codex_event(event.as_object().unwrap(), at(timestamp))
+                    .unwrap(),
+                1
+            );
+        }
+
+        let connection = Connection::open(db_path).unwrap();
+        let count: i64 = connection
+            .query_row(
+                "SELECT COUNT(*) FROM burn_samples WHERE window_kind = 'codex_300'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let latest: (String, f64, String) = connection
+            .query_row(
+                "SELECT window_scope, percent, resets_at FROM burn_samples WHERE window_kind = 'codex_300' ORDER BY observed_at DESC LIMIT 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(count, 2);
+        assert_eq!(latest.0, "premium");
+        assert_eq!(latest.1, 20.0);
+        assert_eq!(latest.2, "2026-08-10T17:00:00.000000000Z");
     }
 }

--- a/crates/sm-server/src/usage_burn.rs
+++ b/crates/sm-server/src/usage_burn.rs
@@ -14,6 +14,9 @@ use crate::usage_identity::{Provider, UsageIdentityStore};
 const USAGE_DB_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 const SESSION_WINDOW_MINUTES: i64 = 300;
 const WEEKLY_WINDOW_MINUTES: i64 = 10_080;
+const DB_TIMESTAMP_FORMAT: &[time::format_description::FormatItem<'static>] = time::macros::format_description!(
+    "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:9]Z"
+);
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct BurnWindowSample {
@@ -498,7 +501,10 @@ fn json_f64(value: Option<&Value>) -> Option<f64> {
 }
 
 fn format_timestamp(value: OffsetDateTime) -> Result<String> {
-    value.format(&Rfc3339).context("failed to format timestamp")
+    value
+        .to_offset(time::UtcOffset::UTC)
+        .format(DB_TIMESTAMP_FORMAT)
+        .context("failed to format timestamp")
 }
 
 #[cfg(test)]
@@ -700,6 +706,72 @@ mod tests {
             )
             .unwrap();
         assert_eq!(latest.0, 40.0);
-        assert_eq!(latest.1, "2026-08-17T16:00:00Z");
+        assert_eq!(latest.1, "2026-08-17T16:00:00.000000000Z");
+    }
+
+    #[test]
+    fn codex_sparse_merge_orders_same_second_samples_chronologically() {
+        let db_path = temp_db("codex-same-second");
+        seed_account(
+            &db_path,
+            Provider::Codex,
+            "codex-account",
+            "2026-08-10T12:00:00Z",
+        );
+        let store = UsageBurnStore::new(&db_path).unwrap();
+        for (timestamp, percent) in [
+            ("2026-08-10T12:01:00Z", 10),
+            ("2026-08-10T12:01:00.900Z", 20),
+        ] {
+            let event = json!({
+                "event_type": "account/rateLimits/updated",
+                "ts": timestamp,
+                "payload": {"rateLimits": {
+                    "limitId": "codex",
+                    "primary": {
+                        "usedPercent": percent,
+                        "windowDurationMins": 300,
+                        "resetsAt": 1786381200_i64
+                    }
+                }}
+            });
+            assert_eq!(
+                store
+                    .record_codex_event(event.as_object().unwrap(), at(timestamp))
+                    .unwrap(),
+                1
+            );
+        }
+        let reset_only = json!({
+            "event_type": "account/rateLimits/updated",
+            "ts": "2026-08-10T12:01:00.950Z",
+            "payload": {"rateLimits": {
+                "limitId": "codex",
+                "primary": {
+                    "windowDurationMins": 300,
+                    "resetsAt": 1786384800_i64
+                }
+            }}
+        });
+        assert_eq!(
+            store
+                .record_codex_event(
+                    reset_only.as_object().unwrap(),
+                    at("2026-08-10T12:01:00.950Z"),
+                )
+                .unwrap(),
+            1
+        );
+
+        let latest: (f64, String) = Connection::open(db_path)
+            .unwrap()
+            .query_row(
+                "SELECT percent, observed_at FROM burn_samples ORDER BY observed_at DESC LIMIT 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(latest.0, 20.0);
+        assert_eq!(latest.1, "2026-08-10T12:01:00.950000000Z");
     }
 }

--- a/crates/sm-server/src/usage_burn.rs
+++ b/crates/sm-server/src/usage_burn.rs
@@ -9,7 +9,7 @@ use rusqlite::{params, Connection, OptionalExtension, Transaction, TransactionBe
 use serde_json::{Map, Value};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
-use crate::usage_identity::{Provider, UsageIdentityStore};
+use crate::usage_identity::{AccountIdentity, Provider, UsageIdentityStore};
 
 const USAGE_DB_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 const SESSION_WINDOW_MINUTES: i64 = 300;
@@ -159,8 +159,10 @@ impl UsageBurnStore {
         let Some(snapshot) = parse_claude_cached_usage(&value)? else {
             return Ok(0);
         };
+        self.identity_store
+            .ensure_account(&snapshot.identity, snapshot.observed_at)?;
         self.record_for_account(
-            &snapshot.account_key,
+            &snapshot.identity.account_key(),
             &snapshot.windows,
             "claude_json",
             snapshot.observed_at,
@@ -341,7 +343,7 @@ fn insert_windows(
 
 #[derive(Debug, Clone)]
 struct ClaudeCachedUsage {
-    account_key: String,
+    identity: AccountIdentity,
     observed_at: OffsetDateTime,
     windows: Vec<BurnWindowSample>,
 }
@@ -435,7 +437,12 @@ fn parse_claude_cached_usage(value: &Value) -> Result<Option<ClaudeCachedUsage>>
         }
     }
     Ok(Some(ClaudeCachedUsage {
-        account_key: format!("claude:{account_id}"),
+        identity: AccountIdentity {
+            provider: Provider::Claude,
+            external_id: account_id,
+            label: None,
+            plan_tier: None,
+        },
         observed_at,
         windows,
     }))
@@ -624,6 +631,57 @@ mod tests {
         assert_eq!(rows[2].1.as_deref(), Some("Fable"));
         assert!(rows.iter().all(|row| row.3 == "claude_json"));
         assert!(rows.iter().all(|row| row.4.starts_with("2026-08-10T")));
+    }
+
+    #[test]
+    fn claude_cache_registers_its_stale_account_without_reopening_the_timeline() {
+        let db_path = temp_db("claude-stale-account");
+        seed_account(
+            &db_path,
+            Provider::Claude,
+            "current-account",
+            "2026-08-10T12:00:00Z",
+        );
+        let cache_path = db_path.with_extension("claude.json");
+        fs::write(
+            &cache_path,
+            json!({
+                "oauthAccount": {"accountUuid": "current-account"},
+                "cachedUsageUtilization": {
+                    "fetchedAtMs": 1786361400000_i64,
+                    "accountUuid": "previous-account",
+                    "utilization": {
+                        "five_hour": {
+                            "utilization": 23,
+                            "resets_at": "2026-08-10T17:00:00Z"
+                        }
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let store = UsageBurnStore::new(&db_path).unwrap();
+
+        assert_eq!(store.record_claude_json_file(&cache_path).unwrap(), 1);
+
+        let connection = Connection::open(db_path).unwrap();
+        let burn_account: String = connection
+            .query_row(
+                "SELECT account_key FROM burn_samples WHERE source = 'claude_json'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(burn_account, "claude:previous-account");
+        let timeline_accounts = connection
+            .prepare("SELECT account_key FROM account_timeline ORDER BY from_ts")
+            .unwrap()
+            .query_map([], |row| row.get::<_, String>(0))
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(timeline_accounts, vec!["claude:current-account"]);
     }
 
     #[test]

--- a/crates/sm-server/src/usage_identity.rs
+++ b/crates/sm-server/src/usage_identity.rs
@@ -243,6 +243,43 @@ impl UsageIdentityStore {
         Ok(outcome)
     }
 
+    /// Register account metadata without changing the provider's active timeline.
+    ///
+    /// Cached usage can carry the final sample for an account that was replaced
+    /// before the cache was read. That account must exist for burn-sample foreign
+    /// keys, but it must not become the current account again.
+    pub fn ensure_account(
+        &self,
+        identity: &AccountIdentity,
+        observed_at: OffsetDateTime,
+    ) -> Result<()> {
+        identity.validate()?;
+        let mut conn = self.open()?;
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let observed_ts = format_timestamp(observed_at)?;
+        tx.execute(
+            r#"
+            INSERT INTO accounts (
+              account_key, provider, external_id, label, plan_tier, first_seen, last_seen
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6)
+            ON CONFLICT(account_key) DO UPDATE SET
+              label = COALESCE(excluded.label, accounts.label),
+              plan_tier = COALESCE(excluded.plan_tier, accounts.plan_tier),
+              last_seen = MAX(accounts.last_seen, excluded.last_seen)
+            "#,
+            params![
+                identity.account_key(),
+                identity.provider.as_str(),
+                &identity.external_id,
+                identity.label.as_deref(),
+                identity.plan_tier.as_deref(),
+                observed_ts,
+            ],
+        )?;
+        tx.commit()?;
+        Ok(())
+    }
+
     /// Backfill the assumed interval required when open windows contain messages
     /// older than the first identity poll. This may be called after the scanner
     /// discovers the true earliest timestamp; it always uses the account from the

--- a/crates/sm-server/src/usage_identity.rs
+++ b/crates/sm-server/src/usage_identity.rs
@@ -11,6 +11,8 @@ use rusqlite::{params, Connection, OptionalExtension, Transaction, TransactionBe
 use serde_json::Value;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
+use crate::usage_burn::UsageBurnStore;
+
 const DB_TIMESTAMP_FORMAT: &[time::format_description::FormatItem<'static>] = time::macros::format_description!(
     "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:9]Z"
 );
@@ -577,6 +579,7 @@ fn required_json_string(value: &Value, key: &str, path: &Path) -> Result<String>
 #[derive(Debug)]
 pub struct IdentityPoller {
     store: UsageIdentityStore,
+    burn_store: UsageBurnStore,
     claude_identity_path: PathBuf,
     codex_identity_path: PathBuf,
     last_successful_poll: Mutex<BTreeMap<Provider, OffsetDateTime>>,
@@ -588,8 +591,10 @@ impl IdentityPoller {
         claude_identity_path: impl Into<PathBuf>,
         codex_identity_path: impl Into<PathBuf>,
     ) -> Result<Self> {
+        let db_path = db_path.into();
         Ok(Self {
-            store: UsageIdentityStore::new(db_path)?,
+            store: UsageIdentityStore::new(&db_path)?,
+            burn_store: UsageBurnStore::new(&db_path)?,
             claude_identity_path: claude_identity_path.into(),
             codex_identity_path: codex_identity_path.into(),
             last_successful_poll: Mutex::new(BTreeMap::new()),
@@ -605,7 +610,7 @@ impl IdentityPoller {
     /// the other provider's timeline from advancing.
     pub fn poll_once(&self, observed_at: OffsetDateTime) -> Vec<(Provider, anyhow::Error)> {
         let mut errors = Vec::new();
-        self.poll_provider(
+        let claude_polled = self.poll_provider(
             Provider::Claude,
             observed_at,
             read_claude_identity(&self.claude_identity_path),
@@ -617,6 +622,14 @@ impl IdentityPoller {
             read_codex_identity(&self.codex_identity_path),
             &mut errors,
         );
+        if claude_polled && self.claude_identity_path.exists() {
+            if let Err(error) = self
+                .burn_store
+                .record_claude_json_file(&self.claude_identity_path)
+            {
+                errors.push((Provider::Claude, error));
+            }
+        }
         errors
     }
 
@@ -626,12 +639,12 @@ impl IdentityPoller {
         observed_at: OffsetDateTime,
         identity: Result<Option<AccountIdentity>>,
         errors: &mut Vec<(Provider, anyhow::Error)>,
-    ) {
+    ) -> bool {
         let identity = match identity {
             Ok(identity) => identity,
             Err(error) => {
                 errors.push((provider, error));
-                return;
+                return false;
             }
         };
         let previous = self
@@ -652,8 +665,12 @@ impl IdentityPoller {
                     .lock()
                     .unwrap_or_else(|poisoned| poisoned.into_inner())
                     .insert(provider, observed_at);
+                true
             }
-            Err(error) => errors.push((provider, error)),
+            Err(error) => {
+                errors.push((provider, error));
+                false
+            }
         }
     }
 }

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -27,7 +27,7 @@ use sm_server::{
     http::{router, AppState, GitHubReviewComment, GitHubReviewMatch, GitHubReviewPoster},
     runtime::TmuxRuntime,
     sessions::{SendCoreInputRequest, SessionStore},
-    usage_identity::UsageIdentityStore,
+    usage_identity::{AccountIdentity, Provider, UsageIdentityStore},
 };
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -7612,6 +7612,91 @@ async fn context_usage_hook_is_served_and_records_tokens() {
     let (status, payload) = get_json(app, "/sessions/run12345").await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["tokens_used"], json!(83_000));
+}
+
+#[tokio::test]
+async fn context_usage_hook_records_claude_rate_limits_in_the_configured_usage_database() {
+    let state_file = write_session_fixture();
+    let usage_db_path = unique_temp_path().with_extension("usage.db");
+    let now = time::OffsetDateTime::now_utc();
+    let identity_store = UsageIdentityStore::new(&usage_db_path).unwrap();
+    identity_store
+        .record_observation(
+            Provider::Claude,
+            Some(&AccountIdentity {
+                provider: Provider::Claude,
+                external_id: "claude-test-account".to_owned(),
+                label: None,
+                plan_tier: None,
+            }),
+            now - time::Duration::minutes(1),
+            None,
+            None,
+        )
+        .unwrap();
+    let mut config = config_with_state_file(&state_file);
+    config.usage.enabled = true;
+    config.usage.db_path = usage_db_path.display().to_string();
+    let app = router(AppState::new(config));
+
+    let (status, payload) = post_json(
+        app,
+        "/hooks/context-usage",
+        json!({
+            "session_id": "run12345",
+            "used_percentage": 42.0,
+            "total_input_tokens": 84_000,
+            "rate_limits": {
+                "five_hour": {
+                    "used_percentage": 12.0,
+                    "resets_at": (now + time::Duration::hours(5)).format(&time::format_description::well_known::Rfc3339).unwrap()
+                },
+                "seven_day": {
+                    "used_percentage": 34.0,
+                    "resets_at": (now + time::Duration::days(7)).format(&time::format_description::well_known::Rfc3339).unwrap()
+                }
+            },
+            "sm_hook_emitted_at": now.format(&time::format_description::well_known::Rfc3339).unwrap()
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "ok");
+
+    let connection = Connection::open(usage_db_path).unwrap();
+    let rows = connection
+        .prepare(
+            "SELECT account_key, window_kind, percent, source FROM burn_samples ORDER BY window_kind",
+        )
+        .unwrap()
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, f64>(2)?,
+                row.get::<_, String>(3)?,
+            ))
+        })
+        .unwrap()
+        .collect::<rusqlite::Result<Vec<_>>>()
+        .unwrap();
+    assert_eq!(
+        rows,
+        vec![
+            (
+                "claude:claude-test-account".to_owned(),
+                "session_5h".to_owned(),
+                12.0,
+                "statusline".to_owned(),
+            ),
+            (
+                "claude:claude-test-account".to_owned(),
+                "weekly_all".to_owned(),
+                34.0,
+                "statusline".to_owned(),
+            ),
+        ]
+    );
 }
 
 #[tokio::test]

--- a/hooks/context_monitor.sh
+++ b/hooks/context_monitor.sh
@@ -54,6 +54,10 @@ post_usage() {
        | {session_id: $sid,
           used_percentage: .context_window.used_percentage,
           total_input_tokens: (.context_window.total_input_tokens // 0),
+          rate_limits: {
+            five_hour: (.rate_limits.five_hour // null),
+            seven_day: (.rate_limits.seven_day // null)
+          },
           sm_hook_emitted_at: stamp}' 2>/dev/null
   ) || return 0
   [ -n "$body" ] || return 0

--- a/tests/unit/test_install_notify_server_hook.py
+++ b/tests/unit/test_install_notify_server_hook.py
@@ -8,6 +8,7 @@ duplicates, no widening of the file mode.
 import json
 import os
 import subprocess
+import time
 from pathlib import Path
 
 import pytest
@@ -64,6 +65,58 @@ def test_installs_every_hook_script(tmp_path):
         installed = tmp_path / ".claude" / "hooks" / script
         assert installed.is_file()
         assert os.access(installed, os.X_OK)
+
+
+def test_context_monitor_forwards_rate_limit_windows(tmp_path):
+    capture = tmp_path / "posted.json"
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_curl = fake_bin / "curl"
+    fake_curl.write_text(
+        """#!/bin/bash
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-d" ]; then
+    shift
+    printf '%s' "$1" > "$CAPTURE"
+    exit 0
+  fi
+  shift
+done
+exit 1
+"""
+    )
+    fake_curl.chmod(0o755)
+    payload = {
+        "context_window": {"used_percentage": 41.5, "total_input_tokens": 83000},
+        "rate_limits": {
+            "five_hour": {"used_percentage": 12, "resets_at": "2026-08-10T20:00:00Z"},
+            "seven_day": {"used_percentage": 34, "resets_at": "2026-08-16T16:00:00Z"},
+        },
+    }
+
+    subprocess.run(
+        ["bash", str(REPO_ROOT / "hooks" / "context_monitor.sh")],
+        input=json.dumps(payload),
+        env={
+            **os.environ,
+            "HOME": str(tmp_path),
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+            "CAPTURE": str(capture),
+            "CLAUDE_SESSION_MANAGER_ID": "seat-123",
+        },
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    for _ in range(50):
+        if capture.exists():
+            break
+        time.sleep(0.02)
+
+    posted = json.loads(capture.read_text())
+    assert posted["session_id"] == "seat-123"
+    assert posted["rate_limits"]["five_hour"] == payload["rate_limits"]["five_hour"]
+    assert posted["rate_limits"]["seven_day"] == payload["rate_limits"]["seven_day"]
 
 
 def test_registers_all_events_and_takes_over_status_line(tmp_path):


### PR DESCRIPTION
## Summary
- persist append-only Claude and Codex quota-window samples in the configured `usage.db`
- forward the Claude status-line `rate_limits` block and poll `cachedUsageUtilization` using provider `fetchedAtMs`
- sparsely merge live codex-fork rate-limit events by limit identity and window duration in serialized SQLite transactions

## Tests
- `cargo test -- --skip codex_review_request_watcher_delivers_sequential_wake_to_runtime_session` (317 library, 57 CLI, 240 HTTP passed; #1189 filtered)
- `cargo test -p sm-server usage_burn --lib` (8 passed)
- `cargo test -p sm-server usage_identity --lib` (10 passed)
- `/Users/rajesh/projects/session-manager/venv/bin/pytest -q tests/unit/test_install_notify_server_hook.py` (10 passed)
- `cargo check --workspace`
- `cargo fmt --all -- --check`
- `git diff --check`

## Review fixes
- bound sparse inheritance to samples observed at or before the event timestamp (P1)
- ignore explicit-null sparse fields instead of appending fabricated unchanged rows (P2)
- serialize sparse lookup and insert in one `IMMEDIATE` transaction, with a deterministic concurrent-writer regression (P1)
- key non-default Codex windows by stable `limitId` rather than mutable `limitName` (P2)
- register a cache-owned Claude account without changing the active timeline, preserving final stale-account samples (P2)

## Notes
- Usage collection remains disabled by default.
- The only filtered Rust fixture is the pre-existing #1189 review-wake failure already isolated during Phase 1.
- The final review was P2-only, satisfying `docs/working/pr_review_process.md`; the cheap P2 was folded in without another review loop.
- No spec contradiction or Phase 2 carry-forward finding identified.
