### PR TITLE
feat(usage): add prior-mode quota reporting surfaces

### DIFF
--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -40,6 +40,7 @@ enum Command {
     Send(SendArgs),
     #[command(alias = "btw")]
     What(WhatArgs),
+    Usage(UsageArgs),
     Remind(RemindArgs),
     Wait(WaitArgs),
     Spawn(SpawnArgs),
@@ -121,6 +122,21 @@ struct WhatArgs {
 }
 
 #[derive(Args)]
+struct UsageArgs {
+    agent: Option<String>,
+    #[arg(long)]
+    include_children: bool,
+    #[arg(long)]
+    since_reset: bool,
+    #[arg(long)]
+    account: bool,
+    #[arg(long)]
+    by_model: bool,
+    #[arg(long)]
+    json: bool,
+}
+
+#[derive(Args)]
 struct RemindArgs {
     #[arg(long)]
     recurring: bool,
@@ -190,6 +206,8 @@ struct ChildrenArgs {
     status: Option<String>,
     #[arg(long)]
     json: bool,
+    #[arg(long)]
+    usage: bool,
 }
 
 #[derive(Args)]
@@ -723,6 +741,7 @@ fn run() -> Result<()> {
             }
         }
         Command::What(args) => run_what(&client, args)?,
+        Command::Usage(args) => run_usage(&client, args)?,
         Command::Remind(args) => run_remind(&client, args)?,
         Command::Output(args) => print_output(&client, &args.session_id, args.lines)?,
         Command::Tail(args) => print_tail(&client, &args.session_id, args.lines, args.raw)?,
@@ -743,6 +762,9 @@ fn run() -> Result<()> {
             }
             if args.terminated {
                 query.push("include_terminated=true".to_owned());
+            }
+            if args.usage {
+                query.push("usage=true".to_owned());
             }
             if let Some(status) = args.status {
                 query.push(format!("status={status}"));
@@ -2553,6 +2575,155 @@ fn run_what(client: &ApiClient, args: WhatArgs) -> Result<()> {
     }
 }
 
+fn run_usage(client: &ApiClient, args: UsageArgs) -> Result<()> {
+    if args.account && (args.agent.is_some() || args.include_children) {
+        bail!("--account is mutually exclusive with AGENT and --include-children");
+    }
+    let mut query = Vec::new();
+    if args.include_children {
+        query.push("include_children=true");
+    }
+    if args.since_reset {
+        query.push("since_reset=true");
+    }
+    if args.by_model {
+        query.push("by_model=true");
+    }
+    let query = if query.is_empty() {
+        String::new()
+    } else {
+        format!("?{}", query.join("&"))
+    };
+    let payload = if args.account {
+        client.get_json(&format!("/usage/accounts{query}"))?
+    } else {
+        let target = match args.agent {
+            Some(identifier) => lookup_identifier_exact(client, &identifier)?
+                .ok_or_else(|| anyhow!("No agent named '{identifier}' is reachable."))?,
+            None => current_session_id()?,
+        };
+        client.get_json(&format!(
+            "/sessions/{}/usage{query}",
+            encode_path_segment(&target)
+        ))?
+    };
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+    } else {
+        print_usage_report(&payload);
+    }
+    Ok(())
+}
+
+fn print_usage_report(payload: &Value) {
+    if let Some(target) = payload.get("target").filter(|target| !target.is_null()) {
+        let id = target["seat_id"].as_str().unwrap_or("unknown");
+        let name = target["friendly_name"].as_str().unwrap_or(id);
+        let descendants = target["descendant_count"].as_u64().unwrap_or(0);
+        println!("{name} ({id}) · {descendants} descendants · prior weights");
+    } else {
+        println!("account usage · prior weights");
+    }
+    let accounts = payload["accounts"].as_array().cloned().unwrap_or_default();
+    if accounts.is_empty() {
+        println!("No usage data");
+        return;
+    }
+    for account in accounts {
+        let key = account["account_key"].as_str().unwrap_or("unknown");
+        let plan = account["plan_tier"].as_str().unwrap_or("unknown tier");
+        println!("\n{key} · {plan}");
+        for window in account["windows"].as_array().into_iter().flatten() {
+            let kind = usage_window_label(window);
+            let account_usage = window["account_percent"].as_f64().map_or_else(
+                || {
+                    let last = window["last_known_percent"].as_f64().unwrap_or(0.0);
+                    let age_minutes = window["sample_age_seconds"].as_i64().unwrap_or(0) / 60;
+                    format!("unknown (last {last:.1}%, {age_minutes}m ago)")
+                },
+                |percent| format!("{percent:.1}%"),
+            );
+            let self_percent = window["self_percent"].as_f64().unwrap_or(0.0);
+            let child_percent = window["children_percent"].as_f64().unwrap_or(0.0);
+            let headroom = window["free_headroom_points"].as_f64().unwrap_or(0.0);
+            let stale = if window["stale"].as_bool().unwrap_or(true) {
+                " · stale"
+            } else {
+                ""
+            };
+            let binding = if window["binding_for_scoped_seats"]
+                .as_bool()
+                .unwrap_or(false)
+            {
+                " · binding for scoped seats"
+            } else {
+                ""
+            };
+            if payload
+                .get("target")
+                .is_some_and(|target| !target.is_null())
+            {
+                println!(
+                    "  {kind:<22} self {self_percent:>6.1}% · children {child_percent:>6.1}% · account {account_usage} · free {headroom:.1} pts{binding}{stale}"
+                );
+            } else {
+                println!(
+                    "  {kind:<22} account {account_usage} · free {headroom:.1} pts{binding}{stale}"
+                );
+                let seats = window["seats"].as_array().cloned().unwrap_or_default();
+                if !seats.is_empty() {
+                    let values = seats
+                        .iter()
+                        .map(|seat| {
+                            let id = seat["seat_id"].as_str().unwrap_or("unknown");
+                            let name = seat["friendly_name"].as_str().unwrap_or(id);
+                            let burn = seat["burn_percent"].as_f64().unwrap_or(0.0);
+                            format!("{name} {burn:.1}%")
+                        })
+                        .collect::<Vec<_>>();
+                    println!("    seats: {}", values.join(" · "));
+                }
+            }
+            let credit_tokens = window["credit_tokens"].as_i64().unwrap_or(0);
+            if credit_tokens > 0 {
+                println!("    paid usage: {credit_tokens} tokens");
+            }
+            if let (Some(cap_fraction), Some(consumed)) = (
+                payload["target"]["usage_cap_fraction"].as_f64(),
+                window["cap_consumed_percent"].as_f64(),
+            ) {
+                println!(
+                    "    cap {:.1}% of week · {:.1}% consumed",
+                    cap_fraction * 100.0,
+                    consumed
+                );
+            }
+            for model in window["models"].as_array().into_iter().flatten() {
+                println!(
+                    "    {} · {} · {:.1}% · prior",
+                    model["seat_id"].as_str().unwrap_or("unknown"),
+                    model["model"].as_str().unwrap_or("unknown"),
+                    model["burn_percent"].as_f64().unwrap_or(0.0)
+                );
+            }
+        }
+    }
+    println!("\nresidual: unknown · seat figures may include invisible usage");
+    for warning in payload["warnings"].as_array().into_iter().flatten() {
+        if let Some(warning) = warning.as_str() {
+            println!("warning: {warning}");
+        }
+    }
+}
+
+fn usage_window_label(window: &Value) -> String {
+    let kind = window["window_kind"].as_str().unwrap_or("unknown");
+    match window["window_scope"].as_str() {
+        Some(scope) => format!("{kind} ({scope})"),
+        None => kind.to_owned(),
+    }
+}
+
 fn run_remind(client: &ApiClient, args: RemindArgs) -> Result<()> {
     if args.delay_or_action == "cancel" {
         if args.recurring || args.message_or_id.len() != 1 {
@@ -3615,7 +3786,13 @@ fn format_child_line(child: &Value) -> String {
         .or_else(|| child["activity_state"].as_str())
         .or_else(|| child["status"].as_str())
         .unwrap_or("unknown");
-    format!("{name} ({id}) | {provider} | {status}")
+    let mut line = format!("{name} ({id}) | {provider} | {status}");
+    if let Some(percent) = child["weekly_usage_percent"].as_f64() {
+        line.push_str(&format!(" | {percent:.1}% wk"));
+    } else if child.get("weekly_usage_percent").is_some() {
+        line.push_str(" | unknown wk");
+    }
+    line
 }
 
 impl ApiClient {
@@ -4162,6 +4339,66 @@ mod tests {
         assert_eq!(cancel.delay_or_action, "cancel");
         assert_eq!(cancel.message_or_id, ["abc123"]);
         assert_eq!(retired_command_message(&["remind"]), None);
+    }
+
+    #[test]
+    fn usage_and_children_usage_flags_parse_the_surface_contract() {
+        let cli = Cli::try_parse_from([
+            "sm",
+            "usage",
+            "worker",
+            "--include-children",
+            "--since-reset",
+            "--by-model",
+            "--json",
+        ])
+        .unwrap();
+        let Command::Usage(args) = cli.command else {
+            panic!("expected usage command");
+        };
+        assert_eq!(args.agent.as_deref(), Some("worker"));
+        assert!(args.include_children);
+        assert!(args.since_reset);
+        assert!(!args.account);
+        assert!(args.by_model);
+        assert!(args.json);
+
+        let account = Cli::try_parse_from(["sm", "usage", "--account"]).unwrap();
+        let Command::Usage(account) = account.command else {
+            panic!("expected account usage command");
+        };
+        assert!(account.account);
+        assert!(account.agent.is_none());
+
+        let children = Cli::try_parse_from(["sm", "children", "root", "--usage"]).unwrap();
+        let Command::Children(children) = children.command else {
+            panic!("expected children command");
+        };
+        assert!(children.usage);
+        assert_eq!(children.session_id.as_deref(), Some("root"));
+    }
+
+    #[test]
+    fn child_usage_column_formats_known_and_unknown_weekly_burn() {
+        let base = json!({
+            "id": "abc12345",
+            "friendly_name": "worker",
+            "provider": "codex-fork",
+            "status": "running"
+        });
+        let mut known = base.clone();
+        known["weekly_usage_percent"] = json!(4.25);
+        assert_eq!(
+            format_child_line(&known),
+            "worker (abc12345) | codex-fork | running | 4.2% wk"
+        );
+
+        let mut unknown = base;
+        unknown["weekly_usage_percent"] = Value::Null;
+        assert_eq!(
+            format_child_line(&unknown),
+            "worker (abc12345) | codex-fork | running | unknown wk"
+        );
     }
 
     #[test]

--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -2643,9 +2643,15 @@ fn print_usage_report(payload: &Value) {
                 },
                 |percent| format!("{percent:.1}%"),
             );
-            let self_percent = window["self_percent"].as_f64().unwrap_or(0.0);
-            let child_percent = window["children_percent"].as_f64().unwrap_or(0.0);
-            let headroom = window["free_headroom_points"].as_f64().unwrap_or(0.0);
+            let self_percent = window["self_percent"]
+                .as_f64()
+                .map_or_else(|| "unknown".to_owned(), |value| format!("{value:.1}%"));
+            let child_percent = window["children_percent"]
+                .as_f64()
+                .map_or_else(|| "unknown".to_owned(), |value| format!("{value:.1}%"));
+            let headroom = window["free_headroom_points"]
+                .as_f64()
+                .map_or_else(|| "unknown".to_owned(), |value| format!("{value:.1} pts"));
             let stale = if window["stale"].as_bool().unwrap_or(true) {
                 " · stale"
             } else {
@@ -2664,12 +2670,10 @@ fn print_usage_report(payload: &Value) {
                 .is_some_and(|target| !target.is_null())
             {
                 println!(
-                    "  {kind:<22} self {self_percent:>6.1}% · children {child_percent:>6.1}% · account {account_usage} · free {headroom:.1} pts{binding}{stale}"
+                    "  {kind:<22} self {self_percent:>7} · children {child_percent:>7} · account {account_usage} · free {headroom}{binding}{stale}"
                 );
             } else {
-                println!(
-                    "  {kind:<22} account {account_usage} · free {headroom:.1} pts{binding}{stale}"
-                );
+                println!("  {kind:<22} account {account_usage} · free {headroom}{binding}{stale}");
                 let seats = window["seats"].as_array().cloned().unwrap_or_default();
                 if !seats.is_empty() {
                     let values = seats
@@ -2677,8 +2681,11 @@ fn print_usage_report(payload: &Value) {
                         .map(|seat| {
                             let id = seat["seat_id"].as_str().unwrap_or("unknown");
                             let name = seat["friendly_name"].as_str().unwrap_or(id);
-                            let burn = seat["burn_percent"].as_f64().unwrap_or(0.0);
-                            format!("{name} {burn:.1}%")
+                            let burn = seat["burn_percent"].as_f64().map_or_else(
+                                || "unknown".to_owned(),
+                                |value| format!("{value:.1}%"),
+                            );
+                            format!("{name} {burn}")
                         })
                         .collect::<Vec<_>>();
                     println!("    seats: {}", values.join(" · "));
@@ -2699,11 +2706,13 @@ fn print_usage_report(payload: &Value) {
                 );
             }
             for model in window["models"].as_array().into_iter().flatten() {
+                let burn = model["burn_percent"]
+                    .as_f64()
+                    .map_or_else(|| "unknown".to_owned(), |value| format!("{value:.1}%"));
                 println!(
-                    "    {} · {} · {:.1}% · prior",
+                    "    {} · {} · {burn} · prior",
                     model["seat_id"].as_str().unwrap_or("unknown"),
                     model["model"].as_str().unwrap_or("unknown"),
-                    model["burn_percent"].as_f64().unwrap_or(0.0)
                 );
             }
         }

--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -2710,9 +2710,10 @@ fn print_usage_report(payload: &Value) {
                     .as_f64()
                     .map_or_else(|| "unknown".to_owned(), |value| format!("{value:.1}%"));
                 println!(
-                    "    {} · {} · {burn} · prior",
+                    "    {} · {} · {burn} · {}",
                     model["seat_id"].as_str().unwrap_or("unknown"),
                     model["model"].as_str().unwrap_or("unknown"),
+                    model["weight_source"].as_str().unwrap_or("prior"),
                 );
             }
         }

--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -845,6 +845,8 @@ pub struct UsageConfig {
     pub poll_interval_secs: u64,
     #[serde(default = "default_usage_scan_interval_secs")]
     pub scan_interval_secs: u64,
+    #[serde(default = "default_usage_premium_cap_ratio")]
+    pub premium_cap_ratio: f64,
     #[serde(default = "default_usage_db_path")]
     pub db_path: String,
     #[serde(default)]
@@ -863,6 +865,7 @@ impl Default for UsageConfig {
             enabled: false,
             poll_interval_secs: default_usage_poll_interval_secs(),
             scan_interval_secs: default_usage_scan_interval_secs(),
+            premium_cap_ratio: default_usage_premium_cap_ratio(),
             db_path: default_usage_db_path(),
             accounts: Vec::new(),
         }
@@ -875,6 +878,10 @@ fn default_usage_poll_interval_secs() -> u64 {
 
 fn default_usage_scan_interval_secs() -> u64 {
     60
+}
+
+fn default_usage_premium_cap_ratio() -> f64 {
+    0.5
 }
 
 fn default_usage_db_path() -> String {
@@ -1924,6 +1931,7 @@ usage:
   enabled: true
   poll_interval_secs: 45
   scan_interval_secs: 75
+  premium_cap_ratio: 0.4
   db_path: /tmp/custom-usage.db
   accounts:
     - key: claude:account-one
@@ -1936,6 +1944,7 @@ usage:
         assert!(config.usage.enabled);
         assert_eq!(config.usage.poll_interval_secs, 45);
         assert_eq!(config.usage.scan_interval_secs, 75);
+        assert_eq!(config.usage.premium_cap_ratio, 0.4);
         assert_eq!(config.usage.db_path, "/tmp/custom-usage.db");
         assert_eq!(
             config.usage.accounts,
@@ -1953,6 +1962,7 @@ usage:
         assert!(!config.usage.enabled);
         assert_eq!(config.usage.poll_interval_secs, 30);
         assert_eq!(config.usage.scan_interval_secs, 60);
+        assert_eq!(config.usage.premium_cap_ratio, 0.5);
         assert!(config.usage.accounts.is_empty());
         assert_eq!(
             config.usage.db_path,

--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -843,8 +843,18 @@ pub struct UsageConfig {
     pub enabled: bool,
     #[serde(default = "default_usage_poll_interval_secs")]
     pub poll_interval_secs: u64,
+    #[serde(default = "default_usage_scan_interval_secs")]
+    pub scan_interval_secs: u64,
     #[serde(default = "default_usage_db_path")]
     pub db_path: String,
+    #[serde(default)]
+    pub accounts: Vec<UsageAccountConfig>,
+}
+
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+pub struct UsageAccountConfig {
+    pub key: String,
+    pub label: String,
 }
 
 impl Default for UsageConfig {
@@ -852,13 +862,19 @@ impl Default for UsageConfig {
         Self {
             enabled: false,
             poll_interval_secs: default_usage_poll_interval_secs(),
+            scan_interval_secs: default_usage_scan_interval_secs(),
             db_path: default_usage_db_path(),
+            accounts: Vec::new(),
         }
     }
 }
 
 fn default_usage_poll_interval_secs() -> u64 {
     30
+}
+
+fn default_usage_scan_interval_secs() -> u64 {
+    60
 }
 
 fn default_usage_db_path() -> String {
@@ -1907,7 +1923,11 @@ tool_logging:
 usage:
   enabled: true
   poll_interval_secs: 45
+  scan_interval_secs: 75
   db_path: /tmp/custom-usage.db
+  accounts:
+    - key: claude:account-one
+      label: primary
 "#,
         )
         .unwrap();
@@ -1915,7 +1935,15 @@ usage:
 
         assert!(config.usage.enabled);
         assert_eq!(config.usage.poll_interval_secs, 45);
+        assert_eq!(config.usage.scan_interval_secs, 75);
         assert_eq!(config.usage.db_path, "/tmp/custom-usage.db");
+        assert_eq!(
+            config.usage.accounts,
+            vec![UsageAccountConfig {
+                key: "claude:account-one".to_owned(),
+                label: "primary".to_owned(),
+            }]
+        );
     }
 
     #[test]
@@ -1924,6 +1952,8 @@ usage:
 
         assert!(!config.usage.enabled);
         assert_eq!(config.usage.poll_interval_secs, 30);
+        assert_eq!(config.usage.scan_interval_secs, 60);
+        assert!(config.usage.accounts.is_empty());
         assert_eq!(
             config.usage.db_path,
             "~/.local/share/claude-sessions/usage.db"

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -409,6 +409,7 @@ impl AppState {
                 Err(error) => eprintln!("usage token ledger initialization failed: {error:#}"),
             }
             let report_store = UsageReportStore::new(expand_home(&config.usage.db_path))
+                .with_premium_cap_ratio(config.usage.premium_cap_ratio)
                 .with_account_labels(
                     config
                         .usage
@@ -2905,9 +2906,11 @@ fn ensure_usage_reporting_enabled(state: &AppState) -> Result<(), ApiError> {
 }
 
 fn current_weekly_usage_percent(report: &crate::usage_report::UsageReport) -> Option<f64> {
+    let current_account = report.target.as_ref()?.account_key.as_deref()?;
     report
         .accounts
         .iter()
+        .filter(|account| account.account_key == current_account)
         .flat_map(|account| &account.windows)
         .filter(|window| {
             !window.stale

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -2915,7 +2915,7 @@ fn current_weekly_usage_percent(report: &crate::usage_report::UsageReport) -> Op
                     || window.window_kind == "codex_10080"
                     || window.window_kind.contains("10080"))
         })
-        .map(|window| window.total_percent)
+        .filter_map(|window| window.total_percent)
         .max_by(f64::total_cmp)
 }
 

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -132,7 +132,9 @@ use crate::tool_usage::{
     log_tool_usage_to_path, ToolCallRow, ToolUsageEvent,
 };
 use crate::usage_burn::UsageBurnStore;
+use crate::usage_identity::UsageIdentityStore;
 use crate::usage_ledger::{ScanSummary, UsageLedgerStore, UsageModelDefaults};
+use crate::usage_report::{UsageReportOptions, UsageReportStore};
 
 const SESSION_COOKIE_NAME: &str = "sm_auth";
 const SESSION_COOKIE_MAX_AGE_SECONDS: i64 = 60 * 60 * 24 * 14;
@@ -387,6 +389,10 @@ impl AppState {
             session_store = session_store.with_usage_db_path(expand_home(&config.usage.db_path));
         }
         if config.usage.enabled {
+            match UsageIdentityStore::new(expand_home(&config.usage.db_path)) {
+                Ok(store) => session_store = session_store.with_usage_identity_store(store),
+                Err(error) => eprintln!("usage identity store initialization failed: {error:#}"),
+            }
             match UsageBurnStore::new(expand_home(&config.usage.db_path)) {
                 Ok(store) => session_store = session_store.with_usage_burn_store(store),
                 Err(error) => eprintln!("usage burn store initialization failed: {error:#}"),
@@ -402,6 +408,15 @@ impl AppState {
                 Ok(store) => session_store = session_store.with_usage_ledger_store(store),
                 Err(error) => eprintln!("usage token ledger initialization failed: {error:#}"),
             }
+            let report_store = UsageReportStore::new(expand_home(&config.usage.db_path))
+                .with_account_labels(
+                    config
+                        .usage
+                        .accounts
+                        .iter()
+                        .map(|account| (account.key.clone(), account.label.clone())),
+                );
+            session_store = session_store.with_usage_report_store(report_store);
         }
         if let Err(error) = session_store.recover_pending_codex_fork_handoffs() {
             eprintln!("codex-fork handoff recovery failed: {error:#}");
@@ -1014,6 +1029,7 @@ pub fn router(state: AppState) -> Router {
         .route("/humans/{identifier}/email", post(send_human_email))
         .route("/email/send", post(send_registered_email))
         .route(DEFAULT_EMAIL_WEBHOOK_PATH, post(inbound_email_webhook))
+        .route("/usage/accounts", get(get_account_usage))
         .route("/sessions", get(list_sessions).post(create_session))
         .route("/sessions/input-batch", post(send_session_input_batch))
         .route("/sessions/spawn", post(spawn_session))
@@ -1024,6 +1040,7 @@ pub fn router(state: AppState) -> Router {
             get(get_session).patch(update_session_metadata),
         )
         .route("/sessions/{session_id}/context", get(get_session_context))
+        .route("/sessions/{session_id}/usage", get(get_session_usage))
         .route("/sessions/{session_id}/review", post(start_session_review))
         .route(
             "/sessions/{parent_session_id}/children",
@@ -2794,21 +2811,112 @@ async fn list_children_sessions(
     request: Request,
 ) -> Result<Json<Value>, ApiError> {
     ensure_session_read_allowed(&state, &request)?;
-    let children = state
-        .session_store
-        .list_child_records(
-            &parent_session_id,
-            query.recursive,
-            query.status.as_deref(),
-            query.include_terminated,
-        )?
-        .into_iter()
-        .map(|session| child_session_response_with_live_activity(&state, session))
-        .collect::<Vec<_>>();
+    let records = state.session_store.list_child_records(
+        &parent_session_id,
+        query.recursive,
+        query.status.as_deref(),
+        query.include_terminated,
+    )?;
+    let mut children = Vec::with_capacity(records.len());
+    for session in records {
+        let session_id = session.id.clone();
+        let response = child_session_response_with_live_activity(&state, session);
+        let mut value = serde_json::to_value(response)?;
+        if query.usage {
+            let percent = state
+                .session_store
+                .usage_report_for_session(
+                    &session_id,
+                    false,
+                    UsageReportOptions {
+                        since_reset: true,
+                        by_model: false,
+                    },
+                )?
+                .as_ref()
+                .and_then(current_weekly_usage_percent);
+            value["weekly_usage_percent"] = json!(percent);
+        }
+        children.push(value);
+    }
     Ok(Json(json!({
         "parent_session_id": parent_session_id,
         "children": children,
     })))
+}
+
+async fn get_session_usage(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+    Query(query): Query<SessionUsageQuery>,
+    request: Request,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    ensure_usage_reporting_enabled(&state)?;
+    if state.session_store.get_session(&session_id)?.is_none() {
+        return Err(ApiError::NotFound("Session not found"));
+    }
+    let report = state
+        .session_store
+        .usage_report_for_session(
+            &session_id,
+            query.include_children,
+            UsageReportOptions {
+                since_reset: query.since_reset,
+                by_model: query.by_model,
+            },
+        )?
+        .ok_or_else(|| ApiError::Status {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            detail: "Usage reporting is unavailable".to_owned(),
+        })?;
+    Ok(Json(serde_json::to_value(report)?))
+}
+
+async fn get_account_usage(
+    State(state): State<Arc<AppState>>,
+    Query(query): Query<AccountUsageQuery>,
+    request: Request,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    ensure_usage_reporting_enabled(&state)?;
+    let report = state
+        .session_store
+        .usage_report_for_accounts(UsageReportOptions {
+            since_reset: query.since_reset,
+            by_model: query.by_model,
+        })?
+        .ok_or_else(|| ApiError::Status {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            detail: "Usage reporting is unavailable".to_owned(),
+        })?;
+    Ok(Json(serde_json::to_value(report)?))
+}
+
+fn ensure_usage_reporting_enabled(state: &AppState) -> Result<(), ApiError> {
+    if state.config.usage.enabled {
+        Ok(())
+    } else {
+        Err(ApiError::Status {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            detail: "Usage reporting is disabled".to_owned(),
+        })
+    }
+}
+
+fn current_weekly_usage_percent(report: &crate::usage_report::UsageReport) -> Option<f64> {
+    report
+        .accounts
+        .iter()
+        .flat_map(|account| &account.windows)
+        .filter(|window| {
+            !window.stale
+                && (window.window_kind == "weekly_all"
+                    || window.window_kind == "codex_10080"
+                    || window.window_kind.contains("10080"))
+        })
+        .map(|window| window.total_percent)
+        .max_by(f64::total_cmp)
 }
 
 async fn create_session(
@@ -11889,6 +11997,26 @@ struct ListChildrenQuery {
     status: Option<String>,
     #[serde(default)]
     include_terminated: bool,
+    #[serde(default)]
+    usage: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct SessionUsageQuery {
+    #[serde(default)]
+    include_children: bool,
+    #[serde(default)]
+    since_reset: bool,
+    #[serde(default)]
+    by_model: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct AccountUsageQuery {
+    #[serde(default)]
+    since_reset: bool,
+    #[serde(default)]
+    by_model: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/sm-server/src/lib.rs
+++ b/crates/sm-server/src/lib.rs
@@ -20,3 +20,4 @@ pub mod tool_usage;
 pub mod usage_burn;
 pub mod usage_identity;
 pub mod usage_ledger;
+pub mod usage_report;

--- a/crates/sm-server/src/main.rs
+++ b/crates/sm-server/src/main.rs
@@ -114,12 +114,13 @@ async fn main() -> Result<()> {
             expand_home("~/.claude.json"),
             expand_home("~/.codex/auth.json"),
         )?);
+        let identity_poller = poller.clone();
         tokio::spawn(async move {
             let mut ticker = tokio::time::interval(Duration::from_secs(poll_interval));
             ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
             loop {
                 ticker.tick().await;
-                let poller = poller.clone();
+                let poller = identity_poller.clone();
                 match tokio::task::spawn_blocking(move || {
                     poller.poll_once(time::OffsetDateTime::now_utc())
                 })
@@ -138,15 +139,32 @@ async fn main() -> Result<()> {
             }
         });
         let usage_state = state.clone();
+        let scan_poller = poller;
         tokio::spawn(async move {
             let mut ticker = tokio::time::interval(Duration::from_secs(scan_interval));
             ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
             loop {
                 ticker.tick().await;
                 let scan_state = usage_state.clone();
-                match tokio::task::spawn_blocking(move || scan_state.scan_usage_ledger()).await {
-                    Ok(Ok(_)) => {}
-                    Ok(Err(error)) => eprintln!("usage token ledger scan failed: {error:#}"),
+                let poller = scan_poller.clone();
+                match tokio::task::spawn_blocking(move || {
+                    let identity_errors = poller.poll_once(time::OffsetDateTime::now_utc());
+                    let scan = scan_state.scan_usage_ledger();
+                    (identity_errors, scan)
+                })
+                .await
+                {
+                    Ok((identity_errors, scan)) => {
+                        for (provider, error) in identity_errors {
+                            eprintln!(
+                                "{} account identity pre-scan poll failed: {error:#}",
+                                provider.as_str()
+                            );
+                        }
+                        if let Err(error) = scan {
+                            eprintln!("usage token ledger scan failed: {error:#}");
+                        }
+                    }
                     Err(error) => eprintln!("usage token ledger task failed: {error}"),
                 }
             }

--- a/crates/sm-server/src/main.rs
+++ b/crates/sm-server/src/main.rs
@@ -53,6 +53,13 @@ async fn main() -> Result<()> {
     if config.usage.enabled && config.usage.db_path.trim().is_empty() {
         anyhow::bail!("usage.db_path must not be empty when usage is enabled");
     }
+    if config.usage.enabled
+        && (!config.usage.premium_cap_ratio.is_finite()
+            || config.usage.premium_cap_ratio <= 0.0
+            || config.usage.premium_cap_ratio > 1.0)
+    {
+        anyhow::bail!("usage.premium_cap_ratio must be greater than 0 and at most 1");
+    }
     // After the address is parsed so a bad --host/--port is caught too, but
     // before binding, so this can run while the old server still holds the port.
     if args.check_config {

--- a/crates/sm-server/src/main.rs
+++ b/crates/sm-server/src/main.rs
@@ -107,8 +107,8 @@ async fn main() -> Result<()> {
     });
 
     if state.config().usage.enabled {
-        let poll_interval = state.config().usage.poll_interval_secs;
-        let usage_state = state.clone();
+        let poll_interval = state.config().usage.poll_interval_secs.max(1);
+        let scan_interval = state.config().usage.scan_interval_secs.max(1);
         let poller = Arc::new(IdentityPoller::new(
             expand_home(&state.config().usage.db_path),
             expand_home("~/.claude.json"),
@@ -132,18 +132,22 @@ async fn main() -> Result<()> {
                                 provider.as_str()
                             );
                         }
-                        let scan_state = usage_state.clone();
-                        match tokio::task::spawn_blocking(move || scan_state.scan_usage_ledger())
-                            .await
-                        {
-                            Ok(Ok(_)) => {}
-                            Ok(Err(error)) => {
-                                eprintln!("usage token ledger scan failed: {error:#}")
-                            }
-                            Err(error) => eprintln!("usage token ledger task failed: {error}"),
-                        }
                     }
                     Err(error) => eprintln!("account identity poll task failed: {error}"),
+                }
+            }
+        });
+        let usage_state = state.clone();
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(Duration::from_secs(scan_interval));
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                let scan_state = usage_state.clone();
+                match tokio::task::spawn_blocking(move || scan_state.scan_usage_ledger()).await {
+                    Ok(Ok(_)) => {}
+                    Ok(Err(error)) => eprintln!("usage token ledger scan failed: {error:#}"),
+                    Err(error) => eprintln!("usage token ledger task failed: {error}"),
                 }
             }
         });

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -31,7 +31,9 @@ use crate::{
     runtime::{TmuxRuntime, TmuxSessionSpec},
     seat_sessions::{SeatSessionIdentity, SeatSessionStore},
     usage_burn::UsageBurnStore,
+    usage_identity::{Provider as UsageProvider, UsageIdentityStore},
     usage_ledger::{ScanSummary, UsageLedgerStore, UsageSeatMetadata},
+    usage_report::{UsageReport, UsageReportOptions, UsageReportStore, UsageReportTarget},
 };
 
 const DEFAULT_SESSION_STATE_FILE: &str = "~/.local/share/claude-sessions/sessions.json";
@@ -68,8 +70,10 @@ pub struct SessionStore {
     codex_fork_handoff_monitors: Arc<Mutex<BTreeSet<String>>>,
     clear_operation_locks: Arc<Mutex<BTreeMap<String, Weak<SessionClearLock>>>>,
     seat_session_store: SeatSessionStore,
+    usage_identity_store: Option<UsageIdentityStore>,
     usage_burn_store: Option<UsageBurnStore>,
     usage_ledger_store: Option<UsageLedgerStore>,
+    usage_report_store: Option<UsageReportStore>,
     usage_project_keys: Arc<Mutex<BTreeMap<String, (String, String)>>>,
 }
 
@@ -118,8 +122,10 @@ impl SessionStore {
             codex_fork_handoff_monitors: Arc::new(Mutex::new(BTreeSet::new())),
             clear_operation_locks: Arc::new(Mutex::new(BTreeMap::new())),
             seat_session_store,
+            usage_identity_store: None,
             usage_burn_store: None,
             usage_ledger_store: None,
+            usage_report_store: None,
             usage_project_keys: Arc::new(Mutex::new(BTreeMap::new())),
         }
     }
@@ -141,9 +147,69 @@ impl SessionStore {
         self
     }
 
+    pub fn with_usage_identity_store(mut self, store: UsageIdentityStore) -> Self {
+        self.usage_identity_store = Some(store);
+        self
+    }
+
     pub fn with_usage_ledger_store(mut self, store: UsageLedgerStore) -> Self {
         self.usage_ledger_store = Some(store);
         self
+    }
+
+    pub fn with_usage_report_store(mut self, store: UsageReportStore) -> Self {
+        self.usage_report_store = Some(store);
+        self
+    }
+
+    pub fn usage_report_for_session(
+        &self,
+        session_id: &str,
+        include_children: bool,
+        options: UsageReportOptions,
+    ) -> Result<Option<UsageReport>> {
+        let Some(store) = self.usage_report_store.as_ref() else {
+            return Ok(None);
+        };
+        let Some(session) = self.get_session(session_id)? else {
+            return Ok(None);
+        };
+        let all_sessions = self.load_snapshot()?.into_sessions();
+        let child_seats = if include_children {
+            let mut descendants = Vec::new();
+            let mut visited = BTreeSet::new();
+            collect_descendants_preorder(
+                &all_sessions,
+                &session.id,
+                &mut visited,
+                &mut descendants,
+            );
+            descendants
+                .into_iter()
+                .map(|descendant| descendant.id)
+                .collect()
+        } else {
+            BTreeSet::new()
+        };
+        let target = UsageReportTarget {
+            seat_id: session.id.clone(),
+            friendly_name: session.cached_display_name(),
+            account_key: session.account_key.clone(),
+            usage_cap_fraction: session.usage_cap_fraction,
+            self_seats: BTreeSet::from([session.id]),
+            child_seats,
+        };
+        Ok(Some(store.report(Some(&target), options)?))
+    }
+
+    pub fn usage_report_for_accounts(
+        &self,
+        options: UsageReportOptions,
+    ) -> Result<Option<UsageReport>> {
+        let Some(store) = self.usage_report_store.as_ref() else {
+            return Ok(None);
+        };
+        Ok(Some(store.report(None, options)?))
     }
 
     pub fn scan_usage_ledger(&self) -> Result<ScanSummary> {
@@ -245,13 +311,45 @@ impl SessionStore {
             .as_deref()
             .and_then(|value| OffsetDateTime::parse(value, &Rfc3339).ok())
             .unwrap_or_else(OffsetDateTime::now_utc);
-        store.record_claude_statusline(
+        let recorded = store.record_claude_statusline(
             observed_at,
             event.five_hour_percent,
             event.five_hour_resets_at.as_deref(),
             event.seven_day_percent,
             event.seven_day_resets_at.as_deref(),
-        )
+        )?;
+        self.record_session_account_key(&event.session_id, UsageProvider::Claude, observed_at)?;
+        Ok(recorded)
+    }
+
+    fn record_session_account_key(
+        &self,
+        session_id: &str,
+        provider: UsageProvider,
+        observed_at: OffsetDateTime,
+    ) -> Result<()> {
+        let Some(identity_store) = self.usage_identity_store.as_ref() else {
+            return Ok(());
+        };
+        let Some(attribution) = identity_store.account_at(provider, observed_at)? else {
+            return Ok(());
+        };
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let Some(session) = session_object_mut(sessions, session_id) else {
+            return Ok(());
+        };
+        if json_text(session.get("account_key")).as_deref()
+            == Some(attribution.account_key.as_str())
+        {
+            return Ok(());
+        }
+        session.insert(
+            "account_key".to_owned(),
+            Value::String(attribution.account_key),
+        );
+        self.write_raw_json_value(&state)
     }
 
     pub fn with_context_monitor_config(mut self, config: ContextMonitorConfig) -> Self {
@@ -532,8 +630,10 @@ impl SessionStore {
             codex_fork_handoff_monitors: Arc::new(Mutex::new(BTreeSet::new())),
             clear_operation_locks: Arc::new(Mutex::new(BTreeMap::new())),
             seat_session_store,
+            usage_identity_store: None,
             usage_burn_store: None,
             usage_ledger_store: None,
+            usage_report_store: None,
             usage_project_keys: Arc::new(Mutex::new(BTreeMap::new())),
         }
     }
@@ -3997,10 +4097,16 @@ impl SessionStore {
                 artifact_path.and_then(Path::to_str),
             );
         }
+        let observed_at = OffsetDateTime::now_utc();
         if let Some(store) = self.usage_burn_store.as_ref() {
-            if let Err(error) = store.record_codex_event(event, OffsetDateTime::now_utc()) {
+            if let Err(error) = store.record_codex_event(event, observed_at) {
                 eprintln!("Codex rate-limit ingest failed for {session_id}: {error:#}");
             }
+        }
+        if let Err(error) =
+            self.record_session_account_key(session_id, UsageProvider::Codex, observed_at)
+        {
+            eprintln!("Codex account attribution update failed for {session_id}: {error:#}");
         }
         Ok(())
     }
@@ -4063,6 +4169,8 @@ impl SessionStore {
             provider,
             model: optional_trimmed(request.model.as_deref()),
             reasoning_effort: optional_trimmed(request.reasoning_effort.as_deref()),
+            account_key: None,
+            usage_cap_fraction: None,
             log_file: Some(log_file.display().to_string()),
             provider_resume_id: None,
             transcript_path: None,
@@ -7983,6 +8091,10 @@ pub struct SessionRecord {
     #[serde(default)]
     pub reasoning_effort: Option<String>,
     #[serde(default)]
+    pub account_key: Option<String>,
+    #[serde(default)]
+    pub usage_cap_fraction: Option<f64>,
+    #[serde(default)]
     pub log_file: Option<String>,
     #[serde(default)]
     pub provider_resume_id: Option<String>,
@@ -8210,6 +8322,8 @@ pub struct SessionResponse {
     tmux_socket_name: Option<String>,
     node: String,
     provider: Option<String>,
+    account_key: Option<String>,
+    usage_cap_fraction: Option<f64>,
     provider_resume_id: Option<String>,
     forked_from_session_id: Option<String>,
     forked_from_provider_resume_id: Option<String>,
@@ -8260,6 +8374,8 @@ impl From<SessionRecord> for SessionResponse {
             tmux_socket_name: session.tmux_socket_name,
             node: non_empty_or(session.node, "primary"),
             provider: Some(non_empty_or(session.provider, "claude")),
+            account_key: session.account_key,
+            usage_cap_fraction: session.usage_cap_fraction,
             provider_resume_id: session.provider_resume_id,
             forked_from_session_id: session.forked_from_session_id,
             forked_from_provider_resume_id: session.forked_from_provider_resume_id,
@@ -8904,6 +9020,8 @@ mod tests {
             provider: "claude".to_owned(),
             model: None,
             reasoning_effort: None,
+            account_key: None,
+            usage_cap_fraction: None,
             log_file: Some("/tmp/abc12345.log".to_owned()),
             provider_resume_id: None,
             transcript_path: None,

--- a/crates/sm-server/src/usage_ledger.rs
+++ b/crates/sm-server/src/usage_ledger.rs
@@ -269,6 +269,7 @@ impl UsageLedgerStore {
             .iter()
             .map(|seat| (seat.seat_id.clone(), seat.clone()))
             .collect::<BTreeMap<_, _>>();
+        self.rebind_provisional_messages(&bindings, &seat_meta)?;
         let artifacts = expand_artifacts(&bindings);
         let mut summary = ScanSummary::default();
         let mut errors = Vec::new();
@@ -365,6 +366,55 @@ impl UsageLedgerStore {
                 seats.push(persisted);
             }
         }
+        Ok(())
+    }
+
+    fn rebind_provisional_messages(
+        &self,
+        bindings: &[ArtifactBinding],
+        seat_meta: &BTreeMap<String, UsageSeatMetadata>,
+    ) -> Result<()> {
+        let mut connection = self.open()?;
+        let tx = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        for binding in bindings
+            .iter()
+            .filter(|binding| binding.seat_id != "unassigned")
+        {
+            let Some(metadata) = seat_meta.get(&binding.seat_id) else {
+                continue;
+            };
+            let account_prefix = match binding.provider.as_str() {
+                "claude" => "claude:%",
+                "codex" | "codex-fork" => "codex:%",
+                _ => continue,
+            };
+            let msg_ids = tx
+                .prepare(
+                    r#"
+                    SELECT msg_id
+                    FROM message_ledger
+                    WHERE seat_id = 'unassigned'
+                      AND source_ref = ?1
+                      AND account_key LIKE ?2
+                    ORDER BY msg_id
+                    "#,
+                )?
+                .query_map(
+                    params![binding.provider_session_id, account_prefix],
+                    |row| row.get::<_, i64>(0),
+                )?
+                .collect::<rusqlite::Result<Vec<_>>>()?;
+            for msg_id in msg_ids {
+                let incumbent = load_contribution(&tx, msg_id)?;
+                reverse_contribution(&tx, msg_id, &incumbent)?;
+                let mut rebound = incumbent;
+                rebound.seat_id = binding.seat_id.clone();
+                rebound.project_key = metadata.project_key.clone();
+                overwrite_contribution(&tx, msg_id, &rebound)?;
+                materialize_contribution(&tx, msg_id, &rebound)?;
+            }
+        }
+        tx.commit()?;
         Ok(())
     }
 
@@ -519,6 +569,9 @@ impl UsageLedgerStore {
         }
 
         self.ensure_bootstrap_for_artifact(artifact, offset)?;
+        let artifact_project_key = matches!(artifact.provider.as_str(), "codex" | "codex-fork")
+            .then(|| codex_artifact_project_key(&artifact.path))
+            .flatten();
 
         let mut connection = self.open()?;
         let tx = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
@@ -569,7 +622,14 @@ impl UsageLedgerStore {
                         .map(String::as_str),
                 )?
                 .map(|event| {
-                    self.process_codex_event(&tx, artifact, event, seat_by_source, seat_meta)
+                    self.process_codex_event(
+                        &tx,
+                        artifact,
+                        event,
+                        seat_by_source,
+                        seat_meta,
+                        artifact_project_key.as_deref(),
+                    )
                 })
                 .transpose()?
                 .flatten(),
@@ -686,6 +746,7 @@ impl UsageLedgerStore {
         event: CodexEvent,
         seat_by_source: &BTreeMap<(String, String), String>,
         seat_meta: &BTreeMap<String, UsageSeatMetadata>,
+        artifact_project_key: Option<&str>,
     ) -> Result<Option<IngestOutcome>> {
         match event {
             CodexEvent::Settings {
@@ -753,6 +814,7 @@ impl UsageLedgerStore {
                 };
                 let project_key = seat
                     .map(|seat| seat.project_key.clone())
+                    .or_else(|| artifact_project_key.map(ToOwned::to_owned))
                     .unwrap_or_else(|| "unassigned".to_owned());
                 let credit_metered = credit_metered(tx, &account_key, &model, timestamp)?;
                 let contribution = Contribution {
@@ -850,6 +912,53 @@ fn expand_artifacts(bindings: &[ArtifactBinding]) -> Vec<Artifact> {
             provider_session_ids,
         })
         .collect()
+}
+
+fn codex_artifact_project_key(path: &Path) -> Option<String> {
+    let reader = BufReader::new(fs::File::open(path).ok()?);
+    for line in reader.lines().take(100).flatten() {
+        let Ok(value) = serde_json::from_str::<Value>(&line) else {
+            continue;
+        };
+        let payload = value.get("payload").and_then(Value::as_object);
+        let settings = payload
+            .and_then(|payload| payload.get("threadSettings"))
+            .and_then(Value::as_object);
+        let cwd = value
+            .get("cwd")
+            .and_then(Value::as_str)
+            .or_else(|| {
+                payload
+                    .and_then(|payload| payload.get("cwd"))
+                    .and_then(Value::as_str)
+            })
+            .or_else(|| {
+                payload
+                    .and_then(|payload| payload.get("workingDirectory"))
+                    .and_then(Value::as_str)
+            })
+            .or_else(|| {
+                payload
+                    .and_then(|payload| payload.get("working_dir"))
+                    .and_then(Value::as_str)
+            })
+            .or_else(|| {
+                settings
+                    .and_then(|settings| settings.get("cwd"))
+                    .and_then(Value::as_str)
+            })
+            .or_else(|| {
+                settings
+                    .and_then(|settings| settings.get("workingDirectory"))
+                    .and_then(Value::as_str)
+            })
+            .map(str::trim)
+            .filter(|cwd| !cwd.is_empty());
+        if let Some(cwd) = cwd {
+            return Some(UsageSeatMetadata::resolve_project_key(cwd));
+        }
+    }
+    None
 }
 
 fn claude_sibling_artifacts(path: &Path, session_id: &str) -> Vec<PathBuf> {
@@ -3195,6 +3304,128 @@ mod tests {
                 "persisted-launch-model".to_owned(),
                 "/retired/repo/.git".to_owned()
             )
+        );
+    }
+
+    #[test]
+    fn definitive_binding_reattributes_checkpointed_provisional_messages() {
+        let dir = TestDir::new("rebind-provisional");
+        let db_path = dir.0.join("usage.db");
+        seed_provider(
+            &db_path,
+            Provider::Codex,
+            "codex-account",
+            "pro",
+            "codex_300",
+            300,
+        );
+        let artifact = dir.0.join("codex.jsonl");
+        fs::write(
+            &artifact,
+            "{\"event_type\":\"thread/tokenUsage/updated\",\"seq\":1,\"ts\":\"2026-08-10T16:00:00Z\",\"payload\":{\"threadId\":\"thread-one\",\"tokenUsage\":{\"total\":{\"inputTokens\":80,\"cachedInputTokens\":60,\"cacheWriteInputTokens\":0,\"outputTokens\":20,\"reasoningOutputTokens\":5,\"totalTokens\":100}}}}\n",
+        )
+        .unwrap();
+        let sessions = SeatSessionStore::new(&db_path);
+        sessions
+            .append("unassigned", "codex-fork", "thread-one", artifact.to_str())
+            .unwrap();
+        let store = UsageLedgerStore::with_model_defaults(
+            &db_path,
+            UsageModelDefaults {
+                codex_fork: Some("gpt-5.6-terra".to_owned()),
+                ..UsageModelDefaults::default()
+            },
+        )
+        .unwrap();
+        store.scan(&[]).unwrap();
+
+        sessions
+            .append("seat-one", "codex-fork", "thread-one", artifact.to_str())
+            .unwrap();
+        let seat = UsageSeatMetadata {
+            seat_id: "seat-one".to_owned(),
+            friendly_name: Some("owner".to_owned()),
+            provider: "codex-fork".to_owned(),
+            model: Some("gpt-5.6-terra".to_owned()),
+            effort: None,
+            working_dir: "/repo".to_owned(),
+            parent_seat_id: None,
+            root_seat_id: Some("seat-one".to_owned()),
+            project_key: "/repo/.git".to_owned(),
+        };
+        assert_eq!(store.scan(&[seat]).unwrap(), ScanSummary::default());
+
+        let connection = Connection::open(db_path).unwrap();
+        let ledger: (String, String) = connection
+            .query_row(
+                "SELECT seat_id, project_key FROM message_ledger",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(ledger, ("seat-one".to_owned(), "/repo/.git".to_owned()));
+        let rollups = connection
+            .prepare(
+                r#"
+                SELECT seat_id,
+                       input_tokens + output_tokens + cache_write_5m
+                         + cache_write_1h + cache_read_tokens
+                FROM seat_tokens
+                ORDER BY seat_id
+                "#,
+            )
+            .unwrap()
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
+            })
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(rollups, vec![("seat-one".to_owned(), 100)]);
+    }
+
+    #[test]
+    fn unassigned_codex_artifact_preserves_project_from_rollout_cwd() {
+        let dir = TestDir::new("unassigned-codex-project");
+        let db_path = dir.0.join("usage.db");
+        seed_provider(
+            &db_path,
+            Provider::Codex,
+            "codex-account",
+            "pro",
+            "codex_300",
+            300,
+        );
+        let project = dir.0.join("project");
+        fs::create_dir_all(&project).unwrap();
+        let artifact = dir.0.join("rollout.jsonl");
+        fs::write(
+            &artifact,
+            format!(
+                "not-json\n{}\n{}\n{}\n",
+                json!({"type": "session_meta", "payload": {"cwd": project}}),
+                json!({"type": "turn_context", "timestamp": "2026-08-10T15:59:59Z", "payload": {"model": "gpt-5.6-terra", "effort": "high"}}),
+                json!({"type": "event_msg", "timestamp": "2026-08-10T16:00:00Z", "payload": {"type": "token_count", "info": {"total_token_usage": {"input_tokens": 80, "cached_input_tokens": 60, "output_tokens": 20, "reasoning_output_tokens": 5, "total_tokens": 100}}}})
+            ),
+        )
+        .unwrap();
+        SeatSessionStore::new(&db_path)
+            .append("unassigned", "codex-fork", "thread-one", artifact.to_str())
+            .unwrap();
+
+        UsageLedgerStore::new(&db_path).unwrap().scan(&[]).unwrap();
+        let connection = Connection::open(db_path).unwrap();
+        let (seat_id, project_key): (String, String) = connection
+            .query_row(
+                "SELECT seat_id, project_key FROM message_ledger",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(seat_id, "unassigned");
+        assert_eq!(
+            project_key,
+            UsageSeatMetadata::resolve_project_key(project.to_str().unwrap())
         );
     }
 

--- a/crates/sm-server/src/usage_report.rs
+++ b/crates/sm-server/src/usage_report.rs
@@ -12,7 +12,7 @@ use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 const DB_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 const STALE_AFTER_SECONDS: i64 = 600;
-const PREMIUM_CAP_RATIO: f64 = 0.5;
+const DEFAULT_PREMIUM_CAP_RATIO: f64 = 0.5;
 
 #[derive(Debug, Clone, Copy, Default)]
 pub struct UsageReportOptions {
@@ -110,6 +110,7 @@ pub struct UsageModelShare {
 pub struct UsageReportStore {
     db_path: PathBuf,
     account_labels: BTreeMap<String, String>,
+    premium_cap_ratio: f64,
 }
 
 impl UsageReportStore {
@@ -117,7 +118,13 @@ impl UsageReportStore {
         Self {
             db_path: db_path.into(),
             account_labels: BTreeMap::new(),
+            premium_cap_ratio: DEFAULT_PREMIUM_CAP_RATIO,
         }
+    }
+
+    pub fn with_premium_cap_ratio(mut self, ratio: f64) -> Self {
+        self.premium_cap_ratio = ratio;
+        self
     }
 
     pub fn with_account_labels(
@@ -156,7 +163,7 @@ impl UsageReportStore {
                     plan_tier: None,
                 });
             let rows = load_window_rows(&connection, &window)?;
-            let premium = premium_context(&window, &all_windows);
+            let premium = premium_context(&window, &all_windows, self.premium_cap_ratio);
             let report = build_window_report(
                 &window,
                 &metadata.provider,
@@ -165,6 +172,7 @@ impl UsageReportStore {
                 target,
                 &names,
                 options.by_model,
+                self.premium_cap_ratio,
                 now,
                 &mut warnings,
             );
@@ -427,7 +435,11 @@ fn load_window_rows(connection: &Connection, window: &BurnWindow) -> Result<Vec<
     Ok(rows)
 }
 
-fn premium_context(window: &BurnWindow, windows: &[BurnWindow]) -> Option<PremiumContext> {
+fn premium_context(
+    window: &BurnWindow,
+    windows: &[BurnWindow],
+    premium_cap_ratio: f64,
+) -> Option<PremiumContext> {
     if window.window_kind == "weekly_scoped" {
         return window.window_scope.clone().map(|scope| PremiumContext {
             scope,
@@ -452,7 +464,7 @@ fn premium_context(window: &BurnWindow, windows: &[BurnWindow]) -> Option<Premiu
         .and_then(|scoped| {
             scoped.window_scope.clone().map(|scope| PremiumContext {
                 scope,
-                points: scoped.percent * PREMIUM_CAP_RATIO,
+                points: scoped.percent * premium_cap_ratio,
             })
         })
 }
@@ -466,6 +478,7 @@ fn build_window_report(
     target: Option<&UsageReportTarget>,
     names: &BTreeMap<String, Option<String>>,
     by_model: bool,
+    premium_cap_ratio: f64,
     now: OffsetDateTime,
     warnings: &mut BTreeSet<String>,
 ) -> UsageWindowReport {
@@ -573,15 +586,21 @@ fn build_window_report(
             .filter(|((seat_id, _), _)| {
                 target.is_none_or(|target| target.self_seats.contains(seat_id))
             })
-            .map(
-                |((seat_id, model), (burn_percent, weighted_units))| UsageModelShare {
+            .map(|((seat_id, model), (burn_percent, weighted_units))| {
+                let weight_source =
+                    if premium.is_some_and(|premium| model_matches_scope(&model, &premium.scope)) {
+                        "assumed-ratio"
+                    } else {
+                        "prior"
+                    };
+                UsageModelShare {
                     seat_id,
                     model,
                     burn_percent: (!stale).then_some(burn_percent),
                     weighted_units,
-                    weight_source: "prior",
-                },
-            )
+                    weight_source,
+                }
+            })
             .collect()
     } else {
         Vec::new()
@@ -630,7 +649,7 @@ fn build_window_report(
         total_percent: (!stale).then_some(total_percent),
         cap_consumed_percent,
         free_headroom_points: (!stale).then_some(if is_scoped {
-            PREMIUM_CAP_RATIO * (100.0 - window.percent).max(0.0)
+            premium_cap_ratio * (100.0 - window.percent).max(0.0)
         } else {
             (100.0 - window.percent).max(0.0)
         }),
@@ -806,6 +825,7 @@ mod tests {
             None,
             &BTreeMap::new(),
             true,
+            DEFAULT_PREMIUM_CAP_RATIO,
             OffsetDateTime::parse("2026-08-10T16:00:00Z", &Rfc3339).unwrap(),
             &mut warnings,
         );
@@ -832,6 +852,7 @@ mod tests {
         );
         assert!(report.residual.is_none());
         assert!(report.possibly_inflated);
+        assert_eq!(report.models[0].weight_source, "assumed-ratio");
     }
 
     #[test]
@@ -875,6 +896,7 @@ mod tests {
             None,
             &BTreeMap::new(),
             false,
+            DEFAULT_PREMIUM_CAP_RATIO,
             OffsetDateTime::parse("2026-08-10T16:00:00Z", &Rfc3339).unwrap(),
             &mut warnings,
         );
@@ -970,6 +992,7 @@ mod tests {
             Some(&target),
             &BTreeMap::new(),
             true,
+            DEFAULT_PREMIUM_CAP_RATIO,
             now,
             &mut warnings,
         );
@@ -1031,6 +1054,7 @@ mod tests {
             Some(&target),
             &BTreeMap::new(),
             true,
+            DEFAULT_PREMIUM_CAP_RATIO,
             OffsetDateTime::parse("2026-08-10T16:00:00Z", &Rfc3339).unwrap(),
             &mut warnings,
         );

--- a/crates/sm-server/src/usage_report.rs
+++ b/crates/sm-server/src/usage_report.rs
@@ -564,6 +564,9 @@ fn build_window_report(
     let models = if by_model {
         burn_by_model
             .into_iter()
+            .filter(|((seat_id, _), _)| {
+                target.is_none_or(|target| target.self_seats.contains(seat_id))
+            })
             .map(
                 |((seat_id, model), (burn_percent, weighted_units))| UsageModelShare {
                     seat_id,
@@ -943,5 +946,54 @@ mod tests {
         assert_eq!(report.account_percent, None);
         assert_eq!(report.last_known_percent, 34.0);
         assert_eq!(report.sample_age_seconds, Some(660));
+    }
+
+    #[test]
+    fn target_model_breakdown_excludes_other_account_seats() {
+        let window = BurnWindow {
+            id: 1,
+            account_key: "claude:a".to_owned(),
+            window_kind: "session_5h".to_owned(),
+            window_scope: None,
+            window_start: "2026-08-10T15:00:00Z".to_owned(),
+            percent: 20.0,
+            resets_at: "2026-08-10T20:00:00Z".to_owned(),
+            observed_at: "2026-08-10T16:00:00Z".to_owned(),
+        };
+        let rows = ["target", "other"]
+            .into_iter()
+            .map(|seat_id| WindowRow {
+                seat_id: seat_id.to_owned(),
+                model: "claude-sonnet-5".to_owned(),
+                credit_metered: false,
+                tokens: TokenCounts {
+                    input: 10,
+                    ..TokenCounts::default()
+                },
+            })
+            .collect::<Vec<_>>();
+        let target = UsageReportTarget {
+            seat_id: "target".to_owned(),
+            friendly_name: None,
+            account_key: None,
+            usage_cap_fraction: None,
+            self_seats: BTreeSet::from(["target".to_owned()]),
+            child_seats: BTreeSet::new(),
+        };
+        let mut warnings = BTreeSet::new();
+        let report = build_window_report(
+            &window,
+            "claude",
+            &rows,
+            None,
+            Some(&target),
+            &BTreeMap::new(),
+            true,
+            OffsetDateTime::UNIX_EPOCH,
+            &mut warnings,
+        );
+
+        assert_eq!(report.models.len(), 1);
+        assert_eq!(report.models[0].seat_id, "target");
     }
 }

--- a/crates/sm-server/src/usage_report.rs
+++ b/crates/sm-server/src/usage_report.rs
@@ -74,13 +74,13 @@ pub struct UsageWindowReport {
     pub weight_source: &'static str,
     pub residual: Option<f64>,
     pub possibly_inflated: bool,
-    pub self_percent: f64,
-    pub children_percent: f64,
-    pub total_percent: f64,
+    pub self_percent: Option<f64>,
+    pub children_percent: Option<f64>,
+    pub total_percent: Option<f64>,
     pub cap_consumed_percent: Option<f64>,
-    pub free_headroom_points: f64,
-    pub binding_for_scoped_seats: bool,
-    pub binding_for_other_seats: bool,
+    pub free_headroom_points: Option<f64>,
+    pub binding_for_scoped_seats: Option<bool>,
+    pub binding_for_other_seats: Option<bool>,
     pub credit_tokens: i64,
     pub seats: Vec<UsageSeatShare>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -91,8 +91,8 @@ pub struct UsageWindowReport {
 pub struct UsageSeatShare {
     pub seat_id: String,
     pub friendly_name: Option<String>,
-    pub burn_percent: f64,
-    pub share: f64,
+    pub burn_percent: Option<f64>,
+    pub share: Option<f64>,
     pub weighted_units: f64,
     pub credit_tokens: i64,
 }
@@ -101,7 +101,7 @@ pub struct UsageSeatShare {
 pub struct UsageModelShare {
     pub seat_id: String,
     pub model: String,
-    pub burn_percent: f64,
+    pub burn_percent: Option<f64>,
     pub weighted_units: f64,
     pub weight_source: &'static str,
 }
@@ -469,6 +469,11 @@ fn build_window_report(
     now: OffsetDateTime,
     warnings: &mut BTreeSet<String>,
 ) -> UsageWindowReport {
+    let sample_age_seconds = parse_timestamp(&window.observed_at)
+        .map(|observed_at| (now - observed_at).whole_seconds().max(0));
+    let stale = sample_age_seconds
+        .map(|age| age > STALE_AFTER_SECONDS)
+        .unwrap_or(true);
     let mut weighted = Vec::new();
     let mut credit_by_seat = BTreeMap::<String, i64>::new();
     for row in rows {
@@ -544,12 +549,12 @@ fn build_window_report(
                 friendly_name: names.get(&seat_id).cloned().flatten(),
                 weighted_units: units_by_seat.get(&seat_id).copied().unwrap_or(0.0),
                 credit_tokens: credit_by_seat.get(&seat_id).copied().unwrap_or(0),
-                share: if window.percent > 0.0 {
+                share: (!stale).then_some(if window.percent > 0.0 {
                     burn_percent / window.percent
                 } else {
                     0.0
-                },
-                burn_percent,
+                }),
+                burn_percent: (!stale).then_some(burn_percent),
                 seat_id,
             }
         })
@@ -557,7 +562,8 @@ fn build_window_report(
     seats.sort_by(|left, right| {
         right
             .burn_percent
-            .total_cmp(&left.burn_percent)
+            .unwrap_or(0.0)
+            .total_cmp(&left.burn_percent.unwrap_or(0.0))
             .then_with(|| left.seat_id.cmp(&right.seat_id))
     });
 
@@ -571,7 +577,7 @@ fn build_window_report(
                 |((seat_id, model), (burn_percent, weighted_units))| UsageModelShare {
                     seat_id,
                     model,
-                    burn_percent,
+                    burn_percent: (!stale).then_some(burn_percent),
                     weighted_units,
                     weight_source: "prior",
                 },
@@ -591,21 +597,20 @@ fn build_window_report(
     } else {
         burn_by_seat.values().sum()
     };
-    let cap_consumed_percent = target
-        .filter(|target| target.account_key.as_deref() == Some(window.account_key.as_str()))
-        .and_then(|target| target.usage_cap_fraction)
-        .filter(|fraction| *fraction > 0.0)
-        .filter(|_| {
-            window.window_kind == "weekly_all"
-                || window.window_kind == "codex_10080"
-                || window.window_kind.contains("10080")
-        })
-        .map(|fraction| total_percent / fraction);
-    let sample_age_seconds = parse_timestamp(&window.observed_at)
-        .map(|observed_at| (now - observed_at).whole_seconds().max(0));
-    let stale = sample_age_seconds
-        .map(|age| age > STALE_AFTER_SECONDS)
-        .unwrap_or(true);
+    let cap_consumed_percent = if stale {
+        None
+    } else {
+        target
+            .filter(|target| target.account_key.as_deref() == Some(window.account_key.as_str()))
+            .and_then(|target| target.usage_cap_fraction)
+            .filter(|fraction| *fraction > 0.0)
+            .filter(|_| {
+                window.window_kind == "weekly_all"
+                    || window.window_kind == "codex_10080"
+                    || window.window_kind.contains("10080")
+            })
+            .map(|fraction| total_percent / fraction)
+    };
 
     UsageWindowReport {
         window_kind: window.window_kind.clone(),
@@ -620,17 +625,17 @@ fn build_window_report(
         weight_source: "prior",
         residual: None,
         possibly_inflated: true,
-        self_percent,
-        children_percent,
-        total_percent,
+        self_percent: (!stale).then_some(self_percent),
+        children_percent: (!stale).then_some(children_percent),
+        total_percent: (!stale).then_some(total_percent),
         cap_consumed_percent,
-        free_headroom_points: if is_scoped {
+        free_headroom_points: (!stale).then_some(if is_scoped {
             PREMIUM_CAP_RATIO * (100.0 - window.percent).max(0.0)
         } else {
             (100.0 - window.percent).max(0.0)
-        },
-        binding_for_scoped_seats: false,
-        binding_for_other_seats: false,
+        }),
+        binding_for_scoped_seats: (!stale).then_some(false),
+        binding_for_other_seats: (!stale).then_some(false),
         credit_tokens: credit_by_seat.values().sum(),
         seats,
         models,
@@ -641,32 +646,35 @@ fn mark_binding_limits(windows: &mut [UsageWindowReport]) {
     let overall = windows
         .iter()
         .enumerate()
-        .filter(|(_, window)| window.window_kind == "weekly_all")
+        .filter(|(_, window)| !window.stale && window.window_kind == "weekly_all")
         .map(|(index, window)| (index, window.window_start.clone()))
         .collect::<Vec<_>>();
     for (overall_index, window_start) in overall {
-        windows[overall_index].binding_for_other_seats = true;
+        windows[overall_index].binding_for_other_seats = Some(true);
         let scoped_index = windows.iter().position(|window| {
-            window.window_kind == "weekly_scoped" && window.window_start == window_start
+            !window.stale
+                && window.window_kind == "weekly_scoped"
+                && window.window_start == window_start
         });
         match scoped_index {
             Some(scoped_index)
                 if windows[scoped_index].free_headroom_points
                     <= windows[overall_index].free_headroom_points =>
             {
-                windows[scoped_index].binding_for_scoped_seats = true;
+                windows[scoped_index].binding_for_scoped_seats = Some(true);
             }
-            _ => windows[overall_index].binding_for_scoped_seats = true,
+            _ => windows[overall_index].binding_for_scoped_seats = Some(true),
         }
     }
     for index in 0..windows.len() {
-        if windows[index].window_kind == "weekly_scoped" {
+        if !windows[index].stale && windows[index].window_kind == "weekly_scoped" {
             let has_overall = windows.iter().any(|window| {
-                window.window_kind == "weekly_all"
+                !window.stale
+                    && window.window_kind == "weekly_all"
                     && window.window_start == windows[index].window_start
             });
             if !has_overall {
-                windows[index].binding_for_scoped_seats = true;
+                windows[index].binding_for_scoped_seats = Some(true);
             }
         }
     }
@@ -694,7 +702,7 @@ fn weighted_units(provider: &str, model: &str, tokens: &TokenCounts) -> (f64, bo
         } else {
             None
         }
-    } else if model.contains("gpt-5.6-sol") || model == "gpt-5.5" {
+    } else if model == "gpt-5.6-sol" || model == "gpt-5.5" {
         Some((5.0, 30.0, 5.0, 5.0, 0.5))
     } else if model.contains("gpt-5.6-terra") {
         Some((2.0, 12.0, 2.0, 2.0, 0.25))
@@ -748,6 +756,9 @@ mod tests {
         let (unknown, present) = weighted_units("claude", "future-model", &tokens);
         assert!(!present);
         assert_eq!(unknown, 24.0);
+        let (sol_wm, present) = weighted_units("codex", "gpt-5.6-sol-wm", &tokens);
+        assert!(!present);
+        assert_eq!(sol_wm, 24.0);
     }
 
     #[test]
@@ -795,7 +806,7 @@ mod tests {
             None,
             &BTreeMap::new(),
             true,
-            OffsetDateTime::UNIX_EPOCH,
+            OffsetDateTime::parse("2026-08-10T16:00:00Z", &Rfc3339).unwrap(),
             &mut warnings,
         );
         assert_eq!(report.seats.len(), 2);
@@ -803,13 +814,22 @@ mod tests {
             (report
                 .seats
                 .iter()
-                .map(|seat| seat.burn_percent)
+                .filter_map(|seat| seat.burn_percent)
                 .sum::<f64>()
                 - 20.0)
                 .abs()
                 < 1e-9
         );
-        assert!((report.seats.iter().map(|seat| seat.share).sum::<f64>() - 1.0).abs() < 1e-9);
+        assert!(
+            (report
+                .seats
+                .iter()
+                .filter_map(|seat| seat.share)
+                .sum::<f64>()
+                - 1.0)
+                .abs()
+                < 1e-9
+        );
         assert!(report.residual.is_none());
         assert!(report.possibly_inflated);
     }
@@ -855,20 +875,20 @@ mod tests {
             None,
             &BTreeMap::new(),
             false,
-            OffsetDateTime::UNIX_EPOCH,
+            OffsetDateTime::parse("2026-08-10T16:00:00Z", &Rfc3339).unwrap(),
             &mut warnings,
         );
 
         assert_eq!(report.credit_tokens, 1_000);
         assert_eq!(report.seats.len(), 2);
         assert_eq!(report.seats[0].seat_id, "quota-seat");
-        assert_eq!(report.seats[0].burn_percent, 25.0);
+        assert_eq!(report.seats[0].burn_percent, Some(25.0));
         let paid = report
             .seats
             .iter()
             .find(|seat| seat.seat_id == "paid-seat")
             .unwrap();
-        assert_eq!(paid.burn_percent, 0.0);
+        assert_eq!(paid.burn_percent, Some(0.0));
         assert_eq!(paid.credit_tokens, 1_000);
     }
 
@@ -887,13 +907,13 @@ mod tests {
             weight_source: "prior",
             residual: None,
             possibly_inflated: true,
-            self_percent: 0.0,
-            children_percent: 0.0,
-            total_percent: 0.0,
+            self_percent: Some(0.0),
+            children_percent: Some(0.0),
+            total_percent: Some(0.0),
             cap_consumed_percent: None,
-            free_headroom_points: headroom,
-            binding_for_scoped_seats: false,
-            binding_for_other_seats: false,
+            free_headroom_points: Some(headroom),
+            binding_for_scoped_seats: Some(false),
+            binding_for_other_seats: Some(false),
             credit_tokens: 0,
             seats: Vec::new(),
             models: Vec::new(),
@@ -905,10 +925,10 @@ mod tests {
 
         mark_binding_limits(&mut windows);
 
-        assert!(windows[0].binding_for_other_seats);
-        assert!(!windows[0].binding_for_scoped_seats);
-        assert!(windows[1].binding_for_scoped_seats);
-        assert!(!windows[1].binding_for_other_seats);
+        assert_eq!(windows[0].binding_for_other_seats, Some(true));
+        assert_eq!(windows[0].binding_for_scoped_seats, Some(false));
+        assert_eq!(windows[1].binding_for_scoped_seats, Some(true));
+        assert_eq!(windows[1].binding_for_other_seats, Some(false));
     }
 
     #[test]
@@ -925,14 +945,31 @@ mod tests {
         };
         let now = OffsetDateTime::parse("2026-08-10T16:11:00Z", &Rfc3339).unwrap();
         let mut warnings = BTreeSet::new();
+        let rows = vec![WindowRow {
+            seat_id: "seat-a".to_owned(),
+            model: "claude-sonnet-5".to_owned(),
+            credit_metered: false,
+            tokens: TokenCounts {
+                input: 10,
+                ..TokenCounts::default()
+            },
+        }];
+        let target = UsageReportTarget {
+            seat_id: "seat-a".to_owned(),
+            friendly_name: None,
+            account_key: Some("claude:a".to_owned()),
+            usage_cap_fraction: Some(0.5),
+            self_seats: BTreeSet::from(["seat-a".to_owned()]),
+            child_seats: BTreeSet::new(),
+        };
         let report = build_window_report(
             &window,
             "claude",
-            &[],
+            &rows,
             None,
-            None,
+            Some(&target),
             &BTreeMap::new(),
-            false,
+            true,
             now,
             &mut warnings,
         );
@@ -941,6 +978,16 @@ mod tests {
         assert_eq!(report.account_percent, None);
         assert_eq!(report.last_known_percent, 34.0);
         assert_eq!(report.sample_age_seconds, Some(660));
+        assert_eq!(report.self_percent, None);
+        assert_eq!(report.children_percent, None);
+        assert_eq!(report.total_percent, None);
+        assert_eq!(report.cap_consumed_percent, None);
+        assert_eq!(report.free_headroom_points, None);
+        assert_eq!(report.binding_for_scoped_seats, None);
+        assert_eq!(report.binding_for_other_seats, None);
+        assert_eq!(report.seats[0].burn_percent, None);
+        assert_eq!(report.seats[0].share, None);
+        assert_eq!(report.models[0].burn_percent, None);
     }
 
     #[test]
@@ -984,7 +1031,7 @@ mod tests {
             Some(&target),
             &BTreeMap::new(),
             true,
-            OffsetDateTime::UNIX_EPOCH,
+            OffsetDateTime::parse("2026-08-10T16:00:00Z", &Rfc3339).unwrap(),
             &mut warnings,
         );
 

--- a/crates/sm-server/src/usage_report.rs
+++ b/crates/sm-server/src/usage_report.rs
@@ -1,0 +1,947 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    path::PathBuf,
+    time::Duration,
+};
+
+use anyhow::{Context, Result};
+use rusqlite::{params, Connection};
+use serde::Serialize;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+const DB_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
+const STALE_AFTER_SECONDS: i64 = 600;
+const PREMIUM_CAP_RATIO: f64 = 0.5;
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct UsageReportOptions {
+    pub since_reset: bool,
+    pub by_model: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct UsageReportTarget {
+    pub seat_id: String,
+    pub friendly_name: Option<String>,
+    pub account_key: Option<String>,
+    pub usage_cap_fraction: Option<f64>,
+    pub self_seats: BTreeSet<String>,
+    pub child_seats: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UsageReport {
+    pub mode: &'static str,
+    pub residual: Option<f64>,
+    pub possibly_inflated: bool,
+    pub generated_at: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target: Option<UsageReportTargetView>,
+    pub accounts: Vec<UsageAccountReport>,
+    pub warnings: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UsageReportTargetView {
+    pub seat_id: String,
+    pub friendly_name: Option<String>,
+    pub descendant_count: usize,
+    pub account_key: Option<String>,
+    pub usage_cap_fraction: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UsageAccountReport {
+    pub account_key: String,
+    pub label: Option<String>,
+    pub provider: String,
+    pub plan_tier: Option<String>,
+    pub windows: Vec<UsageWindowReport>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UsageWindowReport {
+    pub window_kind: String,
+    pub window_scope: Option<String>,
+    pub window_start: String,
+    pub resets_at: String,
+    pub observed_at: String,
+    pub account_percent: Option<f64>,
+    pub last_known_percent: f64,
+    pub sample_age_seconds: Option<i64>,
+    pub stale: bool,
+    pub weight_source: &'static str,
+    pub residual: Option<f64>,
+    pub possibly_inflated: bool,
+    pub self_percent: f64,
+    pub children_percent: f64,
+    pub total_percent: f64,
+    pub cap_consumed_percent: Option<f64>,
+    pub free_headroom_points: f64,
+    pub binding_for_scoped_seats: bool,
+    pub binding_for_other_seats: bool,
+    pub credit_tokens: i64,
+    pub seats: Vec<UsageSeatShare>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub models: Vec<UsageModelShare>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UsageSeatShare {
+    pub seat_id: String,
+    pub friendly_name: Option<String>,
+    pub burn_percent: f64,
+    pub share: f64,
+    pub weighted_units: f64,
+    pub credit_tokens: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UsageModelShare {
+    pub seat_id: String,
+    pub model: String,
+    pub burn_percent: f64,
+    pub weighted_units: f64,
+    pub weight_source: &'static str,
+}
+
+#[derive(Debug, Clone)]
+pub struct UsageReportStore {
+    db_path: PathBuf,
+    account_labels: BTreeMap<String, String>,
+}
+
+impl UsageReportStore {
+    pub fn new(db_path: impl Into<PathBuf>) -> Self {
+        Self {
+            db_path: db_path.into(),
+            account_labels: BTreeMap::new(),
+        }
+    }
+
+    pub fn with_account_labels(
+        mut self,
+        labels: impl IntoIterator<Item = (String, String)>,
+    ) -> Self {
+        self.account_labels = labels.into_iter().collect();
+        self
+    }
+
+    pub fn report(
+        &self,
+        target: Option<&UsageReportTarget>,
+        options: UsageReportOptions,
+    ) -> Result<UsageReport> {
+        let connection = self.open()?;
+        let now = OffsetDateTime::now_utc();
+        let account_meta = load_account_metadata(&connection)?;
+        let names = load_seat_names(&connection)?;
+        let all_windows = load_latest_windows(&connection)?;
+        let selected = select_windows(&all_windows, options.since_reset, now);
+        let mut warnings = BTreeSet::new();
+        let mut accounts = BTreeMap::<String, UsageAccountReport>::new();
+
+        for window in selected {
+            let metadata = account_meta
+                .get(&window.account_key)
+                .cloned()
+                .unwrap_or_else(|| AccountMetadata {
+                    provider: window
+                        .account_key
+                        .split_once(':')
+                        .map(|(provider, _)| provider)
+                        .unwrap_or("unknown")
+                        .to_owned(),
+                    plan_tier: None,
+                });
+            let rows = load_window_rows(&connection, &window)?;
+            let premium = premium_context(&window, &all_windows);
+            let report = build_window_report(
+                &window,
+                &metadata.provider,
+                &rows,
+                premium.as_ref(),
+                target,
+                &names,
+                options.by_model,
+                now,
+                &mut warnings,
+            );
+            accounts
+                .entry(window.account_key.clone())
+                .or_insert_with(|| UsageAccountReport {
+                    account_key: window.account_key.clone(),
+                    label: self.account_labels.get(&window.account_key).cloned(),
+                    provider: metadata.provider.clone(),
+                    plan_tier: metadata.plan_tier.clone(),
+                    windows: Vec::new(),
+                })
+                .windows
+                .push(report);
+        }
+
+        let mut accounts = accounts.into_values().collect::<Vec<_>>();
+        if let Some(target) = target {
+            let target_ids = target
+                .self_seats
+                .union(&target.child_seats)
+                .collect::<BTreeSet<_>>();
+            accounts.retain(|account| {
+                account.windows.iter().any(|window| {
+                    window
+                        .seats
+                        .iter()
+                        .any(|seat| target_ids.contains(&seat.seat_id))
+                })
+            });
+        }
+        for account in &mut accounts {
+            account.windows.sort_by(|left, right| {
+                left.window_kind
+                    .cmp(&right.window_kind)
+                    .then_with(|| right.window_start.cmp(&left.window_start))
+            });
+            mark_binding_limits(&mut account.windows);
+        }
+
+        Ok(UsageReport {
+            mode: "prior",
+            residual: None,
+            possibly_inflated: true,
+            generated_at: now.format(&Rfc3339)?,
+            target: target.map(|target| UsageReportTargetView {
+                seat_id: target.seat_id.clone(),
+                friendly_name: target.friendly_name.clone(),
+                descendant_count: target.child_seats.len(),
+                account_key: target.account_key.clone(),
+                usage_cap_fraction: target.usage_cap_fraction,
+            }),
+            accounts,
+            warnings: warnings.into_iter().collect(),
+        })
+    }
+
+    fn open(&self) -> Result<Connection> {
+        if let Some(parent) = self
+            .db_path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            fs::create_dir_all(parent).with_context(|| {
+                format!("failed to create usage DB directory {}", parent.display())
+            })?;
+        }
+        let connection = Connection::open(&self.db_path)
+            .with_context(|| format!("failed to open usage DB {}", self.db_path.display()))?;
+        connection.busy_timeout(DB_BUSY_TIMEOUT)?;
+        connection.pragma_update(None, "journal_mode", "WAL")?;
+        Ok(connection)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct AccountMetadata {
+    provider: String,
+    plan_tier: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+struct BurnWindow {
+    id: i64,
+    account_key: String,
+    window_kind: String,
+    window_scope: Option<String>,
+    window_start: String,
+    percent: f64,
+    resets_at: String,
+    observed_at: String,
+}
+
+#[derive(Debug, Clone, Default)]
+struct TokenCounts {
+    input: i64,
+    output: i64,
+    cache_write_5m: i64,
+    cache_write_1h: i64,
+    cache_read: i64,
+}
+
+impl TokenCounts {
+    fn total(&self) -> i64 {
+        self.input + self.output + self.cache_write_5m + self.cache_write_1h + self.cache_read
+    }
+}
+
+#[derive(Debug, Clone)]
+struct WindowRow {
+    seat_id: String,
+    model: String,
+    credit_metered: bool,
+    tokens: TokenCounts,
+}
+
+#[derive(Debug, Clone)]
+struct PremiumContext {
+    scope: String,
+    points: f64,
+}
+
+fn load_account_metadata(connection: &Connection) -> Result<BTreeMap<String, AccountMetadata>> {
+    let mut statement = connection
+        .prepare("SELECT account_key, provider, plan_tier FROM accounts ORDER BY account_key")?;
+    let values = statement
+        .query_map([], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                AccountMetadata {
+                    provider: row.get(1)?,
+                    plan_tier: row.get(2)?,
+                },
+            ))
+        })?
+        .collect::<rusqlite::Result<BTreeMap<_, _>>>()?;
+    Ok(values)
+}
+
+fn load_seat_names(connection: &Connection) -> Result<BTreeMap<String, Option<String>>> {
+    let mut statement = connection.prepare(
+        r#"
+        SELECT seat_id, friendly_name
+        FROM seat_meta
+        ORDER BY seat_id, observed_at DESC
+        "#,
+    )?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    let mut names = BTreeMap::new();
+    for (seat_id, friendly_name) in rows {
+        names.entry(seat_id).or_insert(friendly_name);
+    }
+    names.entry("unassigned".to_owned()).or_insert(None);
+    Ok(names)
+}
+
+fn load_latest_windows(connection: &Connection) -> Result<Vec<BurnWindow>> {
+    let mut statement = connection.prepare(
+        r#"
+        SELECT id, account_key, window_kind, window_scope, window_start,
+               percent, resets_at, observed_at
+        FROM burn_samples
+        ORDER BY account_key, window_kind, window_scope, window_start,
+                 observed_at DESC, id DESC
+        "#,
+    )?;
+    let rows = statement
+        .query_map([], |row| {
+            Ok(BurnWindow {
+                id: row.get(0)?,
+                account_key: row.get(1)?,
+                window_kind: row.get(2)?,
+                window_scope: row.get(3)?,
+                window_start: row.get(4)?,
+                percent: row.get(5)?,
+                resets_at: row.get(6)?,
+                observed_at: row.get(7)?,
+            })
+        })?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    let mut latest = BTreeMap::new();
+    for row in rows {
+        let key = (
+            row.account_key.clone(),
+            row.window_kind.clone(),
+            row.window_scope.clone(),
+            row.window_start.clone(),
+        );
+        latest.entry(key).or_insert(row);
+    }
+    Ok(latest.into_values().collect())
+}
+
+fn select_windows(
+    windows: &[BurnWindow],
+    since_reset: bool,
+    now: OffsetDateTime,
+) -> Vec<BurnWindow> {
+    let mut grouped = BTreeMap::<(String, String, Option<String>), Vec<BurnWindow>>::new();
+    for window in windows {
+        grouped
+            .entry((
+                window.account_key.clone(),
+                window.window_kind.clone(),
+                window.window_scope.clone(),
+            ))
+            .or_default()
+            .push(window.clone());
+    }
+    let mut selected = Vec::new();
+    for mut group in grouped.into_values() {
+        group.sort_by(|left, right| right.window_start.cmp(&left.window_start));
+        if since_reset {
+            group.retain(|window| {
+                parse_timestamp(&window.resets_at).is_some_and(|reset| reset > now)
+            });
+        } else {
+            group.truncate(4);
+        }
+        selected.extend(group);
+    }
+    selected
+}
+
+fn load_window_rows(connection: &Connection, window: &BurnWindow) -> Result<Vec<WindowRow>> {
+    let mut statement = connection.prepare(
+        r#"
+        SELECT seat_id, model, credit_metered,
+               SUM(input_tokens), SUM(output_tokens), SUM(cache_write_5m),
+               SUM(cache_write_1h), SUM(cache_read_tokens)
+        FROM seat_tokens
+        WHERE account_key = ?1 AND window_kind = ?2 AND window_start = ?3
+        GROUP BY seat_id, model, credit_metered
+        ORDER BY seat_id, model, credit_metered
+        "#,
+    )?;
+    let rows = statement
+        .query_map(
+            params![window.account_key, window.window_kind, window.window_start],
+            |row| {
+                Ok(WindowRow {
+                    seat_id: row.get(0)?,
+                    model: row.get(1)?,
+                    credit_metered: row.get(2)?,
+                    tokens: TokenCounts {
+                        input: row.get(3)?,
+                        output: row.get(4)?,
+                        cache_write_5m: row.get(5)?,
+                        cache_write_1h: row.get(6)?,
+                        cache_read: row.get(7)?,
+                    },
+                })
+            },
+        )?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(rows)
+}
+
+fn premium_context(window: &BurnWindow, windows: &[BurnWindow]) -> Option<PremiumContext> {
+    if window.window_kind == "weekly_scoped" {
+        return window.window_scope.clone().map(|scope| PremiumContext {
+            scope,
+            points: window.percent,
+        });
+    }
+    if window.window_kind != "weekly_all" {
+        return None;
+    }
+    windows
+        .iter()
+        .filter(|candidate| {
+            candidate.account_key == window.account_key
+                && candidate.window_kind == "weekly_scoped"
+                && candidate.window_start == window.window_start
+        })
+        .max_by(|left, right| {
+            left.observed_at
+                .cmp(&right.observed_at)
+                .then_with(|| left.id.cmp(&right.id))
+        })
+        .and_then(|scoped| {
+            scoped.window_scope.clone().map(|scope| PremiumContext {
+                scope,
+                points: scoped.percent * PREMIUM_CAP_RATIO,
+            })
+        })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_window_report(
+    window: &BurnWindow,
+    provider: &str,
+    rows: &[WindowRow],
+    premium: Option<&PremiumContext>,
+    target: Option<&UsageReportTarget>,
+    names: &BTreeMap<String, Option<String>>,
+    by_model: bool,
+    now: OffsetDateTime,
+    warnings: &mut BTreeSet<String>,
+) -> UsageWindowReport {
+    let mut weighted = Vec::new();
+    let mut credit_by_seat = BTreeMap::<String, i64>::new();
+    for row in rows {
+        if row.credit_metered {
+            *credit_by_seat.entry(row.seat_id.clone()).or_default() += row.tokens.total();
+            continue;
+        }
+        let (units, known) = weighted_units(provider, &row.model, &row.tokens);
+        if !known {
+            warnings.insert(format!(
+                "No price prior for model {}; uniform token weights used",
+                row.model
+            ));
+        }
+        weighted.push((row, units));
+    }
+
+    let is_scoped = window.window_kind == "weekly_scoped";
+    let premium_units = weighted
+        .iter()
+        .filter(|(row, _)| {
+            premium.is_some_and(|premium| model_matches_scope(&row.model, &premium.scope))
+        })
+        .map(|(_, units)| *units)
+        .sum::<f64>();
+    let rest_units = if is_scoped {
+        0.0
+    } else {
+        weighted
+            .iter()
+            .filter(|(row, _)| {
+                !premium.is_some_and(|premium| model_matches_scope(&row.model, &premium.scope))
+            })
+            .map(|(_, units)| *units)
+            .sum::<f64>()
+    };
+    let premium_points = premium.map(|premium| premium.points).unwrap_or(0.0);
+    let rest_points = if is_scoped {
+        0.0
+    } else {
+        (window.percent - premium_points).max(0.0)
+    };
+
+    let mut burn_by_seat = BTreeMap::<String, f64>::new();
+    let mut units_by_seat = BTreeMap::<String, f64>::new();
+    let mut burn_by_model = BTreeMap::<(String, String), (f64, f64)>::new();
+    for (row, units) in weighted {
+        let premium_row =
+            premium.is_some_and(|premium| model_matches_scope(&row.model, &premium.scope));
+        let burn = if premium_row && premium_units > 0.0 {
+            premium_points * units / premium_units
+        } else if !premium_row && rest_units > 0.0 {
+            rest_points * units / rest_units
+        } else {
+            0.0
+        };
+        *burn_by_seat.entry(row.seat_id.clone()).or_default() += burn;
+        *units_by_seat.entry(row.seat_id.clone()).or_default() += units;
+        let model = burn_by_model
+            .entry((row.seat_id.clone(), row.model.clone()))
+            .or_default();
+        model.0 += burn;
+        model.1 += units;
+    }
+
+    let mut seat_ids = burn_by_seat.keys().cloned().collect::<BTreeSet<_>>();
+    seat_ids.extend(credit_by_seat.keys().cloned());
+    let mut seats = seat_ids
+        .into_iter()
+        .map(|seat_id| {
+            let burn_percent = burn_by_seat.get(&seat_id).copied().unwrap_or(0.0);
+            UsageSeatShare {
+                friendly_name: names.get(&seat_id).cloned().flatten(),
+                weighted_units: units_by_seat.get(&seat_id).copied().unwrap_or(0.0),
+                credit_tokens: credit_by_seat.get(&seat_id).copied().unwrap_or(0),
+                share: if window.percent > 0.0 {
+                    burn_percent / window.percent
+                } else {
+                    0.0
+                },
+                burn_percent,
+                seat_id,
+            }
+        })
+        .collect::<Vec<_>>();
+    seats.sort_by(|left, right| {
+        right
+            .burn_percent
+            .total_cmp(&left.burn_percent)
+            .then_with(|| left.seat_id.cmp(&right.seat_id))
+    });
+
+    let models = if by_model {
+        burn_by_model
+            .into_iter()
+            .map(
+                |((seat_id, model), (burn_percent, weighted_units))| UsageModelShare {
+                    seat_id,
+                    model,
+                    burn_percent,
+                    weighted_units,
+                    weight_source: "prior",
+                },
+            )
+            .collect()
+    } else {
+        Vec::new()
+    };
+    let (self_percent, children_percent) = target.map_or((0.0, 0.0), |target| {
+        (
+            burn_for(&burn_by_seat, &target.self_seats),
+            burn_for(&burn_by_seat, &target.child_seats),
+        )
+    });
+    let total_percent = if target.is_some() {
+        self_percent + children_percent
+    } else {
+        burn_by_seat.values().sum()
+    };
+    let cap_consumed_percent = target
+        .filter(|target| {
+            target
+                .account_key
+                .as_deref()
+                .is_none_or(|account_key| account_key == window.account_key)
+        })
+        .and_then(|target| target.usage_cap_fraction)
+        .filter(|fraction| *fraction > 0.0)
+        .filter(|_| {
+            window.window_kind == "weekly_all"
+                || window.window_kind == "codex_10080"
+                || window.window_kind.contains("10080")
+        })
+        .map(|fraction| total_percent / fraction);
+    let sample_age_seconds = parse_timestamp(&window.observed_at)
+        .map(|observed_at| (now - observed_at).whole_seconds().max(0));
+    let stale = sample_age_seconds
+        .map(|age| age > STALE_AFTER_SECONDS)
+        .unwrap_or(true);
+
+    UsageWindowReport {
+        window_kind: window.window_kind.clone(),
+        window_scope: window.window_scope.clone(),
+        window_start: window.window_start.clone(),
+        resets_at: window.resets_at.clone(),
+        observed_at: window.observed_at.clone(),
+        account_percent: (!stale).then_some(window.percent),
+        last_known_percent: window.percent,
+        sample_age_seconds,
+        stale,
+        weight_source: "prior",
+        residual: None,
+        possibly_inflated: true,
+        self_percent,
+        children_percent,
+        total_percent,
+        cap_consumed_percent,
+        free_headroom_points: if is_scoped {
+            PREMIUM_CAP_RATIO * (100.0 - window.percent).max(0.0)
+        } else {
+            (100.0 - window.percent).max(0.0)
+        },
+        binding_for_scoped_seats: false,
+        binding_for_other_seats: false,
+        credit_tokens: credit_by_seat.values().sum(),
+        seats,
+        models,
+    }
+}
+
+fn mark_binding_limits(windows: &mut [UsageWindowReport]) {
+    let overall = windows
+        .iter()
+        .enumerate()
+        .filter(|(_, window)| window.window_kind == "weekly_all")
+        .map(|(index, window)| (index, window.window_start.clone()))
+        .collect::<Vec<_>>();
+    for (overall_index, window_start) in overall {
+        windows[overall_index].binding_for_other_seats = true;
+        let scoped_index = windows.iter().position(|window| {
+            window.window_kind == "weekly_scoped" && window.window_start == window_start
+        });
+        match scoped_index {
+            Some(scoped_index)
+                if windows[scoped_index].free_headroom_points
+                    <= windows[overall_index].free_headroom_points =>
+            {
+                windows[scoped_index].binding_for_scoped_seats = true;
+            }
+            _ => windows[overall_index].binding_for_scoped_seats = true,
+        }
+    }
+    for index in 0..windows.len() {
+        if windows[index].window_kind == "weekly_scoped" {
+            let has_overall = windows.iter().any(|window| {
+                window.window_kind == "weekly_all"
+                    && window.window_start == windows[index].window_start
+            });
+            if !has_overall {
+                windows[index].binding_for_scoped_seats = true;
+            }
+        }
+    }
+}
+
+fn burn_for(values: &BTreeMap<String, f64>, seats: &BTreeSet<String>) -> f64 {
+    seats
+        .iter()
+        .filter_map(|seat| values.get(seat))
+        .copied()
+        .sum()
+}
+
+fn weighted_units(provider: &str, model: &str, tokens: &TokenCounts) -> (f64, bool) {
+    let model = model.to_ascii_lowercase();
+    let rates = if provider == "claude" {
+        if model.contains("fable") {
+            Some((10.0, 50.0, 12.5, 20.0, 1.0))
+        } else if model.contains("opus") {
+            Some((5.0, 25.0, 6.25, 10.0, 0.5))
+        } else if model.contains("sonnet") {
+            Some((3.0, 15.0, 3.75, 6.0, 0.3))
+        } else if model.contains("haiku") {
+            Some((1.0, 5.0, 1.25, 2.0, 0.1))
+        } else {
+            None
+        }
+    } else if model.contains("gpt-5.6-sol") || model == "gpt-5.5" {
+        Some((5.0, 30.0, 5.0, 5.0, 0.5))
+    } else if model.contains("gpt-5.6-terra") {
+        Some((2.0, 12.0, 2.0, 2.0, 0.25))
+    } else if model.contains("gpt-5.6-luna") {
+        Some((0.2, 1.2, 0.2, 0.2, 0.1))
+    } else if model == "gpt-5.4" {
+        Some((2.5, 15.0, 2.5, 2.5, 0.25))
+    } else if model == "gpt-5.4-mini" {
+        Some((0.75, 4.5, 0.75, 0.75, 0.075))
+    } else {
+        None
+    };
+    let known = rates.is_some();
+    let rates = rates.unwrap_or((1.0, 1.0, 1.0, 1.0, 1.0));
+    (
+        tokens.input as f64 * rates.0
+            + tokens.output as f64 * rates.1
+            + tokens.cache_write_5m as f64 * rates.2
+            + tokens.cache_write_1h as f64 * rates.3
+            + tokens.cache_read as f64 * rates.4,
+        known,
+    )
+}
+
+fn model_matches_scope(model: &str, scope: &str) -> bool {
+    let model = model.to_ascii_lowercase();
+    let scope = scope.to_ascii_lowercase();
+    model == scope || model.contains(&scope) || scope.contains(&model)
+}
+
+fn parse_timestamp(value: &str) -> Option<OffsetDateTime> {
+    OffsetDateTime::parse(value, &Rfc3339).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prior_weighting_uses_provider_bucket_prices_and_uniform_unknown_fallback() {
+        let tokens = TokenCounts {
+            input: 10,
+            output: 2,
+            cache_write_5m: 3,
+            cache_write_1h: 4,
+            cache_read: 5,
+        };
+        let (known, present) = weighted_units("claude", "claude-fable-5", &tokens);
+        assert!(present);
+        assert_eq!(known, 322.5);
+        let (unknown, present) = weighted_units("claude", "future-model", &tokens);
+        assert!(!present);
+        assert_eq!(unknown, 24.0);
+    }
+
+    #[test]
+    fn prior_share_arithmetic_sums_to_the_measured_account_burn() {
+        let window = BurnWindow {
+            id: 1,
+            account_key: "claude:a".to_owned(),
+            window_kind: "weekly_all".to_owned(),
+            window_scope: None,
+            window_start: "2026-08-10T00:00:00Z".to_owned(),
+            percent: 20.0,
+            resets_at: "2026-08-17T00:00:00Z".to_owned(),
+            observed_at: "2026-08-10T16:00:00Z".to_owned(),
+        };
+        let rows = vec![
+            WindowRow {
+                seat_id: "seat-a".to_owned(),
+                model: "claude-fable-5".to_owned(),
+                credit_metered: false,
+                tokens: TokenCounts {
+                    input: 10,
+                    ..TokenCounts::default()
+                },
+            },
+            WindowRow {
+                seat_id: "seat-b".to_owned(),
+                model: "claude-sonnet-5".to_owned(),
+                credit_metered: false,
+                tokens: TokenCounts {
+                    input: 10,
+                    ..TokenCounts::default()
+                },
+            },
+        ];
+        let premium = PremiumContext {
+            scope: "Fable".to_owned(),
+            points: 5.0,
+        };
+        let mut warnings = BTreeSet::new();
+        let report = build_window_report(
+            &window,
+            "claude",
+            &rows,
+            Some(&premium),
+            None,
+            &BTreeMap::new(),
+            true,
+            OffsetDateTime::UNIX_EPOCH,
+            &mut warnings,
+        );
+        assert_eq!(report.seats.len(), 2);
+        assert!(
+            (report
+                .seats
+                .iter()
+                .map(|seat| seat.burn_percent)
+                .sum::<f64>()
+                - 20.0)
+                .abs()
+                < 1e-9
+        );
+        assert!((report.seats.iter().map(|seat| seat.share).sum::<f64>() - 1.0).abs() < 1e-9);
+        assert!(report.residual.is_none());
+        assert!(report.possibly_inflated);
+    }
+
+    #[test]
+    fn credit_metered_tokens_are_reported_without_rejoining_quota_shares() {
+        let window = BurnWindow {
+            id: 1,
+            account_key: "claude:a".to_owned(),
+            window_kind: "session_5h".to_owned(),
+            window_scope: None,
+            window_start: "2026-08-10T15:00:00Z".to_owned(),
+            percent: 25.0,
+            resets_at: "2026-08-10T20:00:00Z".to_owned(),
+            observed_at: "2026-08-10T16:00:00Z".to_owned(),
+        };
+        let rows = vec![
+            WindowRow {
+                seat_id: "quota-seat".to_owned(),
+                model: "claude-sonnet-5".to_owned(),
+                credit_metered: false,
+                tokens: TokenCounts {
+                    input: 100,
+                    ..TokenCounts::default()
+                },
+            },
+            WindowRow {
+                seat_id: "paid-seat".to_owned(),
+                model: "claude-fable-5".to_owned(),
+                credit_metered: true,
+                tokens: TokenCounts {
+                    input: 1_000,
+                    ..TokenCounts::default()
+                },
+            },
+        ];
+        let mut warnings = BTreeSet::new();
+        let report = build_window_report(
+            &window,
+            "claude",
+            &rows,
+            None,
+            None,
+            &BTreeMap::new(),
+            false,
+            OffsetDateTime::UNIX_EPOCH,
+            &mut warnings,
+        );
+
+        assert_eq!(report.credit_tokens, 1_000);
+        assert_eq!(report.seats.len(), 2);
+        assert_eq!(report.seats[0].seat_id, "quota-seat");
+        assert_eq!(report.seats[0].burn_percent, 25.0);
+        let paid = report
+            .seats
+            .iter()
+            .find(|seat| seat.seat_id == "paid-seat")
+            .unwrap();
+        assert_eq!(paid.burn_percent, 0.0);
+        assert_eq!(paid.credit_tokens, 1_000);
+    }
+
+    #[test]
+    fn scoped_weekly_headroom_is_compared_in_pool_units_for_binding() {
+        let window = |kind: &str, scope: Option<&str>, headroom: f64| UsageWindowReport {
+            window_kind: kind.to_owned(),
+            window_scope: scope.map(ToOwned::to_owned),
+            window_start: "2026-08-10T00:00:00Z".to_owned(),
+            resets_at: "2026-08-17T00:00:00Z".to_owned(),
+            observed_at: "2026-08-10T16:00:00Z".to_owned(),
+            account_percent: Some(0.0),
+            last_known_percent: 0.0,
+            sample_age_seconds: Some(0),
+            stale: false,
+            weight_source: "prior",
+            residual: None,
+            possibly_inflated: true,
+            self_percent: 0.0,
+            children_percent: 0.0,
+            total_percent: 0.0,
+            cap_consumed_percent: None,
+            free_headroom_points: headroom,
+            binding_for_scoped_seats: false,
+            binding_for_other_seats: false,
+            credit_tokens: 0,
+            seats: Vec::new(),
+            models: Vec::new(),
+        };
+        let mut windows = vec![
+            window("weekly_all", None, 92.0),
+            window("weekly_scoped", Some("Fable"), 46.5),
+        ];
+
+        mark_binding_limits(&mut windows);
+
+        assert!(windows[0].binding_for_other_seats);
+        assert!(!windows[0].binding_for_scoped_seats);
+        assert!(windows[1].binding_for_scoped_seats);
+        assert!(!windows[1].binding_for_other_seats);
+    }
+
+    #[test]
+    fn stale_samples_expose_last_known_value_without_a_current_percentage() {
+        let window = BurnWindow {
+            id: 1,
+            account_key: "claude:a".to_owned(),
+            window_kind: "session_5h".to_owned(),
+            window_scope: None,
+            window_start: "2026-08-10T15:00:00Z".to_owned(),
+            percent: 34.0,
+            resets_at: "2026-08-10T20:00:00Z".to_owned(),
+            observed_at: "2026-08-10T16:00:00Z".to_owned(),
+        };
+        let now = OffsetDateTime::parse("2026-08-10T16:11:00Z", &Rfc3339).unwrap();
+        let mut warnings = BTreeSet::new();
+        let report = build_window_report(
+            &window,
+            "claude",
+            &[],
+            None,
+            None,
+            &BTreeMap::new(),
+            false,
+            now,
+            &mut warnings,
+        );
+
+        assert!(report.stale);
+        assert_eq!(report.account_percent, None);
+        assert_eq!(report.last_known_percent, 34.0);
+        assert_eq!(report.sample_age_seconds, Some(660));
+    }
+}

--- a/crates/sm-server/src/usage_report.rs
+++ b/crates/sm-server/src/usage_report.rs
@@ -592,12 +592,7 @@ fn build_window_report(
         burn_by_seat.values().sum()
     };
     let cap_consumed_percent = target
-        .filter(|target| {
-            target
-                .account_key
-                .as_deref()
-                .is_none_or(|account_key| account_key == window.account_key)
-        })
+        .filter(|target| target.account_key.as_deref() == Some(window.account_key.as_str()))
         .and_then(|target| target.usage_cap_fraction)
         .filter(|fraction| *fraction > 0.0)
         .filter(|_| {

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -23,10 +23,12 @@ use sm_server::{
         ExternalAccessConfig, GoogleAuthConfig, MobileAnalyticsConfig, MobileTerminalConfig,
         MobileTerminalDeviceKeyConfig, MobileTerminalUserConfig, NodeConfig, PathsConfig,
         ProviderLaunchConfig, QueueRunnerConfig, RustCoreConfig, SmSendConfig, ToolLoggingConfig,
+        UsageAccountConfig,
     },
     http::{router, AppState, GitHubReviewComment, GitHubReviewMatch, GitHubReviewPoster},
     runtime::TmuxRuntime,
     sessions::{SendCoreInputRequest, SessionStore},
+    usage_burn::{BurnWindowSample, UsageBurnStore},
     usage_identity::{AccountIdentity, Provider, UsageIdentityStore},
 };
 #[cfg(unix)]
@@ -7698,6 +7700,179 @@ async fn context_usage_hook_records_claude_rate_limits_in_the_configured_usage_d
             ),
         ]
     );
+    let state: Value = serde_json::from_str(&fs::read_to_string(state_file).unwrap()).unwrap();
+    assert_eq!(
+        state["sessions"][0]["account_key"],
+        "claude:claude-test-account"
+    );
+}
+
+#[tokio::test]
+async fn usage_routes_preserve_exact_account_burn_and_optionally_include_children() {
+    let state_file = unique_temp_path();
+    fs::write(
+        &state_file,
+        json!({
+            "sessions": [
+                {
+                    "id": "parent01",
+                    "name": "claude-parent01",
+                    "friendly_name": "parent",
+                    "working_dir": "/repo",
+                    "tmux_session": "claude-parent01",
+                    "provider": "claude",
+                    "account_key": "claude:usage-account",
+                    "usage_cap_fraction": 0.5,
+                    "status": "running",
+                    "created_at": "2026-08-10T00:00:00Z",
+                    "last_activity": "2026-08-10T00:00:00Z"
+                },
+                {
+                    "id": "child001",
+                    "name": "claude-child001",
+                    "friendly_name": "child",
+                    "working_dir": "/repo",
+                    "tmux_session": "claude-child001",
+                    "provider": "claude",
+                    "parent_session_id": "parent01",
+                    "status": "running",
+                    "created_at": "2026-08-10T00:00:00Z",
+                    "last_activity": "2026-08-10T00:00:00Z"
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let usage_db_path = unique_temp_path().with_extension("usage.db");
+    let now = time::OffsetDateTime::now_utc();
+    let reset = now + time::Duration::days(7);
+    let account = AccountIdentity {
+        provider: Provider::Claude,
+        external_id: "usage-account".to_owned(),
+        label: None,
+        plan_tier: Some("max".to_owned()),
+        extra_usage_enabled: Some(true),
+    };
+    UsageIdentityStore::new(&usage_db_path)
+        .unwrap()
+        .record_observation(
+            Provider::Claude,
+            Some(&account),
+            now - time::Duration::minutes(1),
+            None,
+            None,
+        )
+        .unwrap();
+    UsageBurnStore::new(&usage_db_path)
+        .unwrap()
+        .record_for_account(
+            &account.account_key(),
+            &[BurnWindowSample {
+                window_kind: "weekly_all".to_owned(),
+                window_scope: None,
+                duration_minutes: 10_080,
+                percent: 40.0,
+                resets_at: reset,
+                severity: None,
+                is_active: Some(true),
+            }],
+            "test",
+            now,
+        )
+        .unwrap();
+    let mut config = config_with_state_file(&state_file);
+    config.usage.enabled = true;
+    config.usage.db_path = usage_db_path.display().to_string();
+    config.usage.accounts = vec![UsageAccountConfig {
+        key: account.account_key(),
+        label: "primary".to_owned(),
+    }];
+    let app = router(AppState::new(config));
+
+    let connection = Connection::open(&usage_db_path).unwrap();
+    let window_start: String = connection
+        .query_row(
+            "SELECT window_start FROM burn_samples WHERE window_kind = 'weekly_all'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    let observed_at = now
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap();
+    for (seat_id, friendly_name) in [("parent01", "parent"), ("child001", "child")] {
+        connection
+            .execute(
+                r#"
+                INSERT INTO seat_meta (
+                  seat_id, observed_at, friendly_name, provider, model,
+                  project_key, working_dir, parent_seat_id, root_seat_id
+                ) VALUES (?1, ?2, ?3, 'claude', 'claude-sonnet-5',
+                          '/repo/.git', '/repo', ?4, 'parent01')
+                "#,
+                rusqlite::params![
+                    seat_id,
+                    observed_at,
+                    friendly_name,
+                    (seat_id == "child001").then_some("parent01")
+                ],
+            )
+            .unwrap();
+        connection
+            .execute(
+                r#"
+                INSERT INTO seat_tokens (
+                  seat_id, account_key, project_key, window_kind, window_start,
+                  bucket_ts, model, effort, credit_metered, input_tokens,
+                  output_tokens, reasoning_tokens, cache_write_5m,
+                  cache_write_1h, cache_read_tokens, message_count, updated_at
+                ) VALUES (?1, ?2, '/repo/.git', 'weekly_all', ?3, ?4,
+                          'claude-sonnet-5', NULL, 0, 100, 0, 0, 0, 0, 0, 1, ?4)
+                "#,
+                rusqlite::params![seat_id, account.account_key(), window_start, observed_at],
+            )
+            .unwrap();
+    }
+
+    let (status, own) = get_json(app.clone(), "/sessions/parent01/usage?since_reset=true").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(own["accounts"][0]["windows"][0]["account_percent"], 40.0);
+    assert_eq!(own["accounts"][0]["windows"][0]["total_percent"], 20.0);
+    assert_eq!(own["accounts"][0]["label"], "primary");
+    assert_eq!(own["target"]["usage_cap_fraction"], 0.5);
+    assert_eq!(
+        own["accounts"][0]["windows"][0]["cap_consumed_percent"],
+        40.0
+    );
+
+    let (status, subtree) = get_json(
+        app.clone(),
+        "/sessions/parent01/usage?include_children=true&since_reset=true",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(subtree["target"]["descendant_count"], 1);
+    assert_eq!(
+        subtree["accounts"][0]["windows"][0]["account_percent"],
+        40.0
+    );
+    assert_eq!(subtree["accounts"][0]["windows"][0]["total_percent"], 40.0);
+    assert_eq!(
+        subtree["accounts"][0]["windows"][0]["cap_consumed_percent"],
+        80.0
+    );
+
+    let (status, accounts) = get_json(app.clone(), "/usage/accounts?since_reset=true").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        accounts["accounts"][0]["windows"][0]["account_percent"], 40.0,
+        "account view must pass through the exact first-party burn sample"
+    );
+
+    let (status, children) = get_json(app, "/sessions/parent01/children?usage=true").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(children["children"][0]["weekly_usage_percent"], 20.0);
 }
 
 #[tokio::test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -7735,6 +7735,7 @@ async fn usage_routes_preserve_exact_account_burn_and_optionally_include_childre
                     "tmux_session": "claude-child001",
                     "provider": "claude",
                     "parent_session_id": "parent01",
+                    "account_key": "claude:usage-account",
                     "status": "running",
                     "created_at": "2026-08-10T00:00:00Z",
                     "last_activity": "2026-08-10T00:00:00Z"
@@ -7834,7 +7835,6 @@ async fn usage_routes_preserve_exact_account_burn_and_optionally_include_childre
             )
             .unwrap();
     }
-
     let (status, own) = get_json(app.clone(), "/sessions/parent01/usage?since_reset=true").await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(own["accounts"][0]["windows"][0]["account_percent"], 40.0);
@@ -7869,6 +7869,59 @@ async fn usage_routes_preserve_exact_account_burn_and_optionally_include_childre
         accounts["accounts"][0]["windows"][0]["account_percent"], 40.0,
         "account view must pass through the exact first-party burn sample"
     );
+
+    let previous_account_key = "claude:previous-account";
+    UsageIdentityStore::new(&usage_db_path)
+        .unwrap()
+        .ensure_account(
+            &AccountIdentity {
+                provider: Provider::Claude,
+                external_id: "previous-account".to_owned(),
+                label: None,
+                plan_tier: Some("max".to_owned()),
+                extra_usage_enabled: Some(true),
+            },
+            now,
+        )
+        .unwrap();
+    UsageBurnStore::new(&usage_db_path)
+        .unwrap()
+        .record_for_account(
+            previous_account_key,
+            &[BurnWindowSample {
+                window_kind: "weekly_all".to_owned(),
+                window_scope: None,
+                duration_minutes: 10_080,
+                percent: 80.0,
+                resets_at: reset,
+                severity: None,
+                is_active: Some(true),
+            }],
+            "test",
+            now,
+        )
+        .unwrap();
+    let previous_window_start: String = connection
+        .query_row(
+            "SELECT window_start FROM burn_samples WHERE account_key = ?1 AND window_kind = 'weekly_all'",
+            [previous_account_key],
+            |row| row.get(0),
+        )
+        .unwrap();
+    connection
+        .execute(
+            r#"
+            INSERT INTO seat_tokens (
+              seat_id, account_key, project_key, window_kind, window_start,
+              bucket_ts, model, effort, credit_metered, input_tokens,
+              output_tokens, reasoning_tokens, cache_write_5m,
+              cache_write_1h, cache_read_tokens, message_count, updated_at
+            ) VALUES ('child001', ?1, '/repo/.git', 'weekly_all', ?2, ?3,
+                      'claude-sonnet-5', NULL, 0, 100, 0, 0, 0, 0, 0, 1, ?3)
+            "#,
+            rusqlite::params![previous_account_key, previous_window_start, observed_at],
+        )
+        .unwrap();
 
     let (status, children) = get_json(app, "/sessions/parent01/children?usage=true").await;
     assert_eq!(status, StatusCode::OK);


### PR DESCRIPTION
## Summary

- add PRIOR-mode `sm usage` reporting for seats, descendant subtrees, accounts, and optional model breakdowns
- add `GET /sessions/{id}/usage`, `GET /usage/accounts`, and the `sm children --usage` weekly burn column
- preserve exact provider burn totals while applying documented per-model priors, the exact scoped-premium term, separate paid-credit totals, explicit binding limits, and `residual: unknown`
- persist observed account identity and optional owner cap metadata on sessions; support configured account labels and an independent transcript scan interval
- fold in the two Phase 3 P2 carry-forwards by reattributing checkpointed provisional rows and preserving Codex rollout project attribution

## Behavior

- account percentages are direct first-party burn samples; attribution only divides that measured total
- stale samples render as unknown with the last-known percentage and age
- `--since-reset` selects current windows; the default includes the current and three prior windows
- credit-metered tokens remain outside quota shares and are reported separately
- Phase 4 fitting remains intentionally out of scope; reports identify `mode: prior`, `residual: null`, and `possibly_inflated: true`

## Validation

- `cargo test --workspace -- --skip codex_review_request_watcher_delivers_sequential_wake_to_runtime_session` (345 library, 59 CLI, 241 HTTP tests passed; tracked #1189 filter only)
- `cargo check --workspace`
- `cargo fmt --all -- --check`
- `git diff --check`
- real-router integration proves parent-only and descendant attribution and asserts `/usage/accounts` preserves the exact seeded first-party 40% burn sample

The live deployed `claude -p "/usage"` comparison is intentionally not run in this phase PR because the epic contract forbids deployment or enabling `usage` before owner approval. No config was enabled and no service was restarted.

## Carry-forward resolution

- PR #1191 P2: definitive bindings now reverse/rematerialize already-scanned `unassigned` contributions without rereading checkpointed artifacts
- PR #1191 P2: unassigned Codex rollouts resolve project identity from rollout `cwd`, including after malformed non-event lines
