### PR TITLE
fix: yield usage DB write slots during backfill

### DIFF
--- a/crates/sm-server/src/usage_ledger.rs
+++ b/crates/sm-server/src/usage_ledger.rs
@@ -21,7 +21,7 @@ use crate::{
 
 const USAGE_DB_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 const PROJECT_KEY_GIT_TIMEOUT: Duration = Duration::from_secs(1);
-const LEDGER_WRITE_BATCH_SIZE: usize = 256;
+const LEDGER_WRITE_BATCH_SIZE: usize = 16;
 const DB_TIMESTAMP_FORMAT: &[time::format_description::FormatItem<'static>] = time::macros::format_description!(
     "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:9]Z"
 );


### PR DESCRIPTION
## Summary

Reduce the bounded usage-ledger transaction from 256 complete artifact lines to 16. The 256-line boundary still exceeded SQLite's five-second busy timeout on production-scale Codex rollouts, so recovered live event monitors produced repeated lock retries even while usage percentages stayed fresh.

This does not change parsing, attribution, dedupe, checkpoint, or materialization semantics. It trades additional small commits during first-run backfill for predictable live writer access.

## Production evidence

After #1198 restored live monitors, fresh Codex burn values advanced to 27% canonical and 0% scoped. During the same interval, a 256-line scanner transaction generated sustained `database is locked` retries for already-persisted provider session identities and one rate-limit ingest. All queried provider identities were present, but live writers need a tighter scheduling bound.

## Verification

- `cargo test -p sm-server usage_ledger --lib --quiet` (25 passed)
- `cargo check --workspace --quiet`
- `cargo test --workspace --quiet -- --skip codex_review_request_watcher_delivers_sequential_wake_to_runtime_session` (356 library, 61 CLI, 241 HTTP passed; one live watcher filtered)
- `cargo fmt --all -- --check`
- `git diff --check`

The existing committed-prefix failure test derives its input from `LEDGER_WRITE_BATCH_SIZE`, so it verifies checkpointing and fail-closed behavior at the new 16-line boundary.