### PR TITLE
Make sm usage actionable for orchestrator seats

### DIFF
--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -126,8 +126,10 @@ struct UsageArgs {
     agent: Option<String>,
     #[arg(long)]
     include_children: bool,
-    #[arg(long)]
+    #[arg(long, conflicts_with = "history")]
     since_reset: bool,
+    #[arg(long, conflicts_with = "since_reset")]
+    history: bool,
     #[arg(long)]
     account: bool,
     #[arg(long)]
@@ -2588,7 +2590,7 @@ fn run_usage(client: &ApiClient, args: UsageArgs) -> Result<()> {
     if args.include_children {
         query.push("include_children=true");
     }
-    if args.since_reset {
+    if args.since_reset || !args.history {
         query.push("since_reset=true");
     }
     if args.by_model {
@@ -2625,19 +2627,50 @@ fn usage_uses_account_view(args: &UsageArgs, current_session_id: Option<&str>) -
     args.account || (args.agent.is_none() && current_session_id.is_none())
 }
 
+fn print_usage_decision(payload: &Value) {
+    let decision = &payload["decision"];
+    match decision["status"].as_str().unwrap_or("non_actionable") {
+        "actionable" => {}
+        "partial" => println!("PARTIAL · some current quota meters are not decision-grade"),
+        _ => println!("NON-ACTIONABLE · no fresh quota meter is available"),
+    }
+    for reason in decision["reasons"].as_array().into_iter().flatten() {
+        if let Some(reason) = reason.as_str() {
+            println!("  {reason}");
+        }
+    }
+    for guidance in decision["refresh_guidance"]
+        .as_array()
+        .into_iter()
+        .flatten()
+    {
+        if let Some(guidance) = guidance.as_str() {
+            println!("  refresh: {guidance}");
+        }
+    }
+}
+
 fn print_usage_report(payload: &Value) {
     if let Some(target) = payload.get("target").filter(|target| !target.is_null()) {
         let id = target["seat_id"].as_str().unwrap_or("unknown");
         let name = target["friendly_name"].as_str().unwrap_or(id);
         let descendants = target["descendant_count"].as_u64().unwrap_or(0);
+        let available_descendants = target["available_descendant_count"]
+            .as_u64()
+            .unwrap_or(descendants);
         if descendants > 0 {
             println!("{name} ({id}) · {descendants} descendants · prior weights");
+        } else if available_descendants > 0 {
+            println!(
+                "{name} ({id}) · {available_descendants} descendants excluded · prior weights"
+            );
         } else {
             println!("{name} ({id}) · prior weights");
         }
     } else {
         println!("account usage · prior weights");
     }
+    print_usage_decision(payload);
     let accounts = payload["accounts"].as_array().cloned().unwrap_or_default();
     if accounts.is_empty() {
         println!("No usage data");
@@ -2653,7 +2686,11 @@ fn print_usage_report(payload: &Value) {
                 || {
                     let last = window["last_known_percent"].as_f64().unwrap_or(0.0);
                     let age_minutes = window["sample_age_seconds"].as_i64().unwrap_or(0) / 60;
-                    format!("unknown (last {last:.1}%, {age_minutes}m ago)")
+                    if window["current"].as_bool().unwrap_or(false) {
+                        format!(">={last:.1}% ({age_minutes}m old sample)")
+                    } else {
+                        format!("unknown (last {last:.1}%, {age_minutes}m ago)")
+                    }
                 },
                 |percent| format!("{percent:.1}%"),
             );
@@ -2663,11 +2700,18 @@ fn print_usage_report(payload: &Value) {
             let child_percent = window["children_percent"]
                 .as_f64()
                 .map_or_else(|| "unknown".to_owned(), |value| format!("{value:.1}%"));
-            let headroom = window["free_headroom_points"]
-                .as_f64()
-                .map_or_else(|| "unknown".to_owned(), |value| format!("{value:.1} pts"));
-            let stale = if window["stale"].as_bool().unwrap_or(true) {
-                " · stale"
+            let headroom = window["free_headroom_points"].as_f64().map_or_else(
+                || {
+                    window["free_headroom_upper_bound_points"]
+                        .as_f64()
+                        .map_or_else(|| "unknown".to_owned(), |value| format!("<={value:.1} pts"))
+                },
+                |value| format!("{value:.1} pts"),
+            );
+            let freshness = if window["freshness"].as_str() == Some("stale") {
+                " · bounds only"
+            } else if window["freshness"].as_str() == Some("expired") {
+                " · closed"
             } else {
                 ""
             };
@@ -2684,26 +2728,28 @@ fn print_usage_report(payload: &Value) {
                 .is_some_and(|target| !target.is_null())
             {
                 println!(
-                    "  {kind:<22} self {self_percent:>7} · children {child_percent:>7} · account {account_usage} · free {headroom}{binding}{stale}"
+                    "  {kind:<22} self {self_percent:>7} · children {child_percent:>7} · account {account_usage} · free {headroom}{binding}{freshness}"
                 );
             } else {
-                println!("  {kind:<22} account {account_usage} · free {headroom}{binding}{stale}");
-                let seats = window["seats"].as_array().cloned().unwrap_or_default();
-                if !seats.is_empty() {
-                    let values = seats
-                        .iter()
-                        .map(|seat| {
-                            let id = seat["seat_id"].as_str().unwrap_or("unknown");
-                            let name = seat["friendly_name"].as_str().unwrap_or(id);
-                            let burn = seat["burn_percent"].as_f64().map_or_else(
-                                || "unknown".to_owned(),
-                                |value| format!("{value:.1}%"),
-                            );
-                            format!("{name} {burn}")
-                        })
-                        .collect::<Vec<_>>();
-                    println!("    seats: {}", values.join(" · "));
-                }
+                println!(
+                    "  {kind:<22} account {account_usage} · free {headroom}{binding}{freshness}"
+                );
+            }
+            let seats = window["seats"].as_array().cloned().unwrap_or_default();
+            for seat in seats {
+                let id = seat["seat_id"].as_str().unwrap_or("unknown");
+                let name = seat["friendly_name"].as_str().unwrap_or(id);
+                let identity = if name == id {
+                    id.to_owned()
+                } else {
+                    format!("{name} ({id})")
+                };
+                let burn = seat["burn_percent"].as_f64().map_or_else(
+                    || "burn unknown".to_owned(),
+                    |value| format!("burn {value:.1}%"),
+                );
+                let tokens = format_usage_tokens(seat["total_tokens"].as_i64().unwrap_or(0));
+                println!("    seat {identity} · {burn} · {tokens} tokens");
             }
             let credit_tokens = window["credit_tokens"].as_i64().unwrap_or(0);
             if credit_tokens > 0 {
@@ -2730,13 +2776,61 @@ fn print_usage_report(payload: &Value) {
                     model["weight_source"].as_str().unwrap_or("prior"),
                 );
             }
+            if let Some(projection) = window.get("projection").filter(|value| !value.is_null()) {
+                let days = projection["horizon_seconds"].as_i64().unwrap_or(0) as f64 / 86_400.0;
+                let rate = projection["burn_rate_points_per_day"]
+                    .as_f64()
+                    .unwrap_or(0.0);
+                let projected = projection["projected_account_percent_at_reset"]
+                    .as_f64()
+                    .unwrap_or(0.0);
+                let projected_free = projection["projected_free_headroom_points"]
+                    .as_f64()
+                    .unwrap_or(0.0);
+                println!(
+                    "    projection (low confidence): {rate:.1} pts/day · {projected:.1}% at reset in {days:.1}d · projected free {projected_free:.1} pts"
+                );
+                let additional_seats = projection["additional_seats"]
+                    .as_array()
+                    .cloned()
+                    .unwrap_or_default();
+                if additional_seats.is_empty() {
+                    println!("      additional seats unavailable · no observed model baseline");
+                }
+                for seat in additional_seats {
+                    let model = seat["model"].as_str().unwrap_or("unknown");
+                    let baseline = seat["baseline_seats"].as_u64().unwrap_or(0);
+                    let equivalents = seat["additional_seat_equivalents"].as_f64().unwrap_or(0.0);
+                    println!(
+                        "      {model}: {equivalents:.1} additional seat equivalents · conservative baseline {baseline}"
+                    );
+                }
+            }
+            let residual_lower = window["residual_lower_bound_percent"]
+                .as_f64()
+                .unwrap_or(0.0);
+            let residual_upper = window["residual_upper_bound_percent"]
+                .as_f64()
+                .unwrap_or(window["last_known_percent"].as_f64().unwrap_or(0.0));
+            println!(
+                "    residual: unknown ({residual_lower:.1}..{residual_upper:.1} pts) · seat burn may be inflated"
+            );
         }
     }
-    println!("\nresidual: unknown · seat figures may include invisible usage");
     for warning in payload["warnings"].as_array().into_iter().flatten() {
         if let Some(warning) = warning.as_str() {
             println!("warning: {warning}");
         }
+    }
+}
+
+fn format_usage_tokens(tokens: i64) -> String {
+    if tokens >= 1_000_000 {
+        format!("{:.1}m", tokens as f64 / 1_000_000.0)
+    } else if tokens >= 1_000 {
+        format!("{:.1}k", tokens as f64 / 1_000.0)
+    } else {
+        tokens.to_string()
     }
 }
 
@@ -4383,6 +4477,7 @@ mod tests {
         assert_eq!(args.agent.as_deref(), Some("worker"));
         assert!(args.include_children);
         assert!(args.since_reset);
+        assert!(!args.history);
         assert!(!args.account);
         assert!(args.by_model);
         assert!(args.json);
@@ -4393,6 +4488,14 @@ mod tests {
         };
         assert!(account.account);
         assert!(account.agent.is_none());
+
+        let history = Cli::try_parse_from(["sm", "usage", "worker", "--history"]).unwrap();
+        let Command::Usage(history) = history.command else {
+            panic!("expected usage command");
+        };
+        assert!(history.history);
+        assert!(!history.since_reset);
+        assert!(Cli::try_parse_from(["sm", "usage", "--history", "--since-reset"]).is_err());
 
         let children = Cli::try_parse_from(["sm", "children", "root", "--usage"]).unwrap();
         let Command::Children(children) = children.command else {
@@ -4408,6 +4511,7 @@ mod tests {
             agent: None,
             include_children: false,
             since_reset: false,
+            history: false,
             account: false,
             by_model: false,
             json: false,
@@ -4429,6 +4533,32 @@ mod tests {
         env::remove_var("SESSION_MANAGER_ID");
         env::remove_var("CLAUDE_SESSION_MANAGER_ID");
         let (client, server) = start_lookup_server([(
+            "/usage/accounts?since_reset=true",
+            200,
+            r#"{"mode":"prior","accounts":[],"warnings":[],"residual":null}"#,
+        )]);
+        let args = UsageArgs {
+            agent: None,
+            include_children: false,
+            since_reset: false,
+            history: false,
+            account: false,
+            by_model: false,
+            json: false,
+        };
+
+        run_usage(&client, args).unwrap();
+
+        assert_eq!(server.join().unwrap(), ["/usage/accounts?since_reset=true"]);
+    }
+
+    #[test]
+    fn usage_history_explicitly_requests_closed_windows() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let _env = EnvRestore::new(&["SESSION_MANAGER_ID", "CLAUDE_SESSION_MANAGER_ID"]);
+        env::remove_var("SESSION_MANAGER_ID");
+        env::remove_var("CLAUDE_SESSION_MANAGER_ID");
+        let (client, server) = start_lookup_server([(
             "/usage/accounts",
             200,
             r#"{"mode":"prior","accounts":[],"warnings":[],"residual":null}"#,
@@ -4437,6 +4567,7 @@ mod tests {
             agent: None,
             include_children: false,
             since_reset: false,
+            history: true,
             account: false,
             by_model: false,
             json: false,
@@ -4445,6 +4576,13 @@ mod tests {
         run_usage(&client, args).unwrap();
 
         assert_eq!(server.join().unwrap(), ["/usage/accounts"]);
+    }
+
+    #[test]
+    fn usage_token_totals_use_compact_readable_units() {
+        assert_eq!(format_usage_tokens(999), "999");
+        assert_eq!(format_usage_tokens(12_345), "12.3k");
+        assert_eq!(format_usage_tokens(2_345_678), "2.3m");
     }
 
     #[test]

--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -2629,10 +2629,8 @@ fn usage_uses_account_view(args: &UsageArgs, current_session_id: Option<&str>) -
 
 fn print_usage_decision(payload: &Value) {
     let decision = &payload["decision"];
-    match decision["status"].as_str().unwrap_or("non_actionable") {
-        "actionable" => {}
-        "partial" => println!("PARTIAL · some current quota meters are not decision-grade"),
-        _ => println!("NON-ACTIONABLE · no fresh quota meter is available"),
+    if let Some(banner) = usage_decision_banner(decision) {
+        println!("{banner}");
     }
     for reason in decision["reasons"].as_array().into_iter().flatten() {
         if let Some(reason) = reason.as_str() {
@@ -2647,6 +2645,14 @@ fn print_usage_decision(payload: &Value) {
         if let Some(guidance) = guidance.as_str() {
             println!("  refresh: {guidance}");
         }
+    }
+}
+
+fn usage_decision_banner(decision: &Value) -> Option<&'static str> {
+    match decision["status"].as_str().unwrap_or("non_actionable") {
+        "actionable" => None,
+        "partial" => Some("PARTIAL · some current quota meters are not decision-grade"),
+        _ => Some("NON-ACTIONABLE · required quota picture is incomplete"),
     }
 }
 
@@ -4583,6 +4589,20 @@ mod tests {
         assert_eq!(format_usage_tokens(999), "999");
         assert_eq!(format_usage_tokens(12_345), "12.3k");
         assert_eq!(format_usage_tokens(2_345_678), "2.3m");
+    }
+
+    #[test]
+    fn non_actionable_banner_does_not_claim_fresh_partial_data_is_absent() {
+        let decision = json!({
+            "status": "non_actionable",
+            "fresh_current_windows": 1,
+            "missing_current_windows": ["codex:a:codex_10080"]
+        });
+
+        assert_eq!(
+            usage_decision_banner(&decision),
+            Some("NON-ACTIONABLE · required quota picture is incomplete")
+        );
     }
 
     #[test]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -177,15 +177,11 @@ impl SessionStore {
             return Ok(None);
         };
         let all_sessions = self.load_snapshot()?.into_sessions();
+        let mut descendants = Vec::new();
+        let mut visited = BTreeSet::new();
+        collect_descendants_preorder(&all_sessions, &session.id, &mut visited, &mut descendants);
+        let available_descendant_count = descendants.len();
         let child_seats = if include_children {
-            let mut descendants = Vec::new();
-            let mut visited = BTreeSet::new();
-            collect_descendants_preorder(
-                &all_sessions,
-                &session.id,
-                &mut visited,
-                &mut descendants,
-            );
             descendants
                 .into_iter()
                 .map(|descendant| descendant.id)
@@ -200,6 +196,7 @@ impl SessionStore {
             usage_cap_fraction: session.usage_cap_fraction,
             self_seats: BTreeSet::from([session.id]),
             child_seats,
+            available_descendant_count,
         };
         Ok(Some(store.report(Some(&target), options)?))
     }

--- a/crates/sm-server/src/usage_ledger.rs
+++ b/crates/sm-server/src/usage_ledger.rs
@@ -2278,7 +2278,7 @@ fn scoped_model_at(
     .map_err(Into::into)
 }
 
-fn plan_excludes_premium(plan_tier: &str) -> bool {
+pub(crate) fn plan_excludes_premium(plan_tier: &str) -> bool {
     let plan = plan_tier.to_ascii_lowercase();
     plan == "pro" || plan.contains("standard_team") || plan.contains("team_standard")
 }

--- a/crates/sm-server/src/usage_report.rs
+++ b/crates/sm-server/src/usage_report.rs
@@ -71,6 +71,7 @@ pub struct UsageAccountReport {
     pub label: Option<String>,
     pub provider: String,
     pub plan_tier: Option<String>,
+    pub active: bool,
     pub windows: Vec<UsageWindowReport>,
 }
 
@@ -206,6 +207,7 @@ impl UsageReportStore {
                         .unwrap_or("unknown")
                         .to_owned(),
                     plan_tier: None,
+                    active: false,
                 });
             let rows = load_window_rows(&connection, &window)?;
             let premium = premium_context(&window, &all_windows, self.premium_cap_ratio);
@@ -228,10 +230,27 @@ impl UsageReportStore {
                     label: self.account_labels.get(&window.account_key).cloned(),
                     provider: metadata.provider.clone(),
                     plan_tier: metadata.plan_tier.clone(),
+                    active: metadata.active,
                     windows: Vec::new(),
                 })
                 .windows
                 .push(report);
+        }
+
+        for (account_key, metadata) in &account_meta {
+            if !metadata.active {
+                continue;
+            }
+            accounts
+                .entry(account_key.clone())
+                .or_insert_with(|| UsageAccountReport {
+                    account_key: account_key.clone(),
+                    label: self.account_labels.get(account_key).cloned(),
+                    provider: metadata.provider.clone(),
+                    plan_tier: metadata.plan_tier.clone(),
+                    active: true,
+                    windows: Vec::new(),
+                });
         }
 
         let mut accounts = accounts.into_values().collect::<Vec<_>>();
@@ -301,6 +320,7 @@ impl UsageReportStore {
 struct AccountMetadata {
     provider: String,
     plan_tier: Option<String>,
+    active: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -353,8 +373,20 @@ struct PremiumContext {
 }
 
 fn load_account_metadata(connection: &Connection) -> Result<BTreeMap<String, AccountMetadata>> {
-    let mut statement = connection
-        .prepare("SELECT account_key, provider, plan_tier FROM accounts ORDER BY account_key")?;
+    let mut statement = connection.prepare(
+        r#"
+        SELECT accounts.account_key, accounts.provider, accounts.plan_tier,
+               EXISTS (
+                 SELECT 1
+                 FROM account_timeline
+                 WHERE account_timeline.account_key = accounts.account_key
+                   AND account_timeline.provider = accounts.provider
+                   AND account_timeline.to_ts IS NULL
+               )
+        FROM accounts
+        ORDER BY accounts.account_key
+        "#,
+    )?;
     let values = statement
         .query_map([], |row| {
             Ok((
@@ -362,6 +394,7 @@ fn load_account_metadata(connection: &Connection) -> Result<BTreeMap<String, Acc
                 AccountMetadata {
                     provider: row.get(1)?,
                     plan_tier: row.get(2)?,
+                    active: row.get(3)?,
                 },
             ))
         })?
@@ -949,18 +982,20 @@ fn mark_binding_limits(windows: &mut [UsageWindowReport]) {
 fn usage_decision_summary(accounts: &[UsageAccountReport]) -> UsageDecisionSummary {
     let fresh_current_windows = accounts
         .iter()
+        .filter(|account| account.active)
         .flat_map(|account| &account.windows)
         .filter(|window| window.current && !window.stale)
         .count();
     let stale_current_windows = accounts
         .iter()
+        .filter(|account| account.active)
         .flat_map(|account| &account.windows)
         .filter(|window| window.current && window.stale)
         .count();
     let mut missing_current_windows = Vec::new();
     let mut accounts_needing_refresh = BTreeSet::new();
     for account in accounts {
-        if !account.windows.iter().any(|window| window.current) {
+        if !account.active {
             continue;
         }
         let mut required = match account.provider.as_str() {
@@ -1709,6 +1744,7 @@ mod tests {
             label: None,
             provider: "codex".to_owned(),
             plan_tier: Some("pro".to_owned()),
+            active: true,
             windows: vec![report],
         }];
 
@@ -1759,6 +1795,7 @@ mod tests {
             label: None,
             provider: "codex".to_owned(),
             plan_tier: Some("pro".to_owned()),
+            active: true,
             windows: vec![report],
         }];
 
@@ -1771,6 +1808,83 @@ mod tests {
             .reasons
             .iter()
             .any(|reason| reason.contains("Missing current limiting meter")));
+    }
+
+    #[test]
+    fn active_account_without_windows_blocks_an_otherwise_complete_report() {
+        let now = OffsetDateTime::parse("2026-08-11T01:00:00Z", &Rfc3339).unwrap();
+        let mut warnings = BTreeSet::new();
+        let build = |kind: &str, start: &str, reset: &str, warnings: &mut BTreeSet<String>| {
+            build_window_report(
+                &BurnWindow {
+                    id: 1,
+                    account_key: "codex:a".to_owned(),
+                    window_kind: kind.to_owned(),
+                    window_scope: None,
+                    window_start: start.to_owned(),
+                    percent: 2.0,
+                    resets_at: reset.to_owned(),
+                    observed_at: "2026-08-11T01:00:00Z".to_owned(),
+                },
+                "codex",
+                &[],
+                None,
+                None,
+                &BTreeMap::new(),
+                false,
+                DEFAULT_PREMIUM_CAP_RATIO,
+                now,
+                warnings,
+            )
+        };
+        let accounts = vec![
+            UsageAccountReport {
+                account_key: "codex:a".to_owned(),
+                label: None,
+                provider: "codex".to_owned(),
+                plan_tier: Some("pro".to_owned()),
+                active: true,
+                windows: vec![
+                    build(
+                        "codex_300",
+                        "2026-08-11T00:00:00Z",
+                        "2026-08-11T05:00:00Z",
+                        &mut warnings,
+                    ),
+                    build(
+                        "codex_10080",
+                        "2026-08-10T00:00:00Z",
+                        "2026-08-17T00:00:00Z",
+                        &mut warnings,
+                    ),
+                ],
+            },
+            UsageAccountReport {
+                account_key: "claude:b".to_owned(),
+                label: None,
+                provider: "claude".to_owned(),
+                plan_tier: Some("max".to_owned()),
+                active: true,
+                windows: Vec::new(),
+            },
+        ];
+
+        let decision = usage_decision_summary(&accounts);
+
+        assert_eq!(decision.status, "non_actionable");
+        assert_eq!(decision.fresh_current_windows, 2);
+        assert_eq!(
+            decision.missing_current_windows,
+            [
+                "claude:b:session_5h",
+                "claude:b:weekly_all",
+                "claude:b:weekly_scoped"
+            ]
+        );
+        assert!(decision
+            .refresh_guidance
+            .iter()
+            .any(|guidance| guidance.starts_with("Claude refreshes")));
     }
 
     #[test]

--- a/crates/sm-server/src/usage_report.rs
+++ b/crates/sm-server/src/usage_report.rs
@@ -998,7 +998,7 @@ fn usage_decision_summary(accounts: &[UsageAccountReport]) -> UsageDecisionSumma
             && (account
                 .plan_tier
                 .as_deref()
-                .is_some_and(|tier| !plan_excludes_premium(tier))
+                .is_none_or(|tier| !plan_excludes_premium(tier))
                 || account
                     .windows
                     .iter()
@@ -1933,6 +1933,64 @@ mod tests {
         assert_eq!(
             decision.missing_current_windows,
             ["claude:team:weekly_scoped"]
+        );
+    }
+
+    #[test]
+    fn unknown_claude_plan_requires_a_scoped_weekly_meter() {
+        let now = OffsetDateTime::parse("2026-08-11T01:00:00Z", &Rfc3339).unwrap();
+        let mut warnings = BTreeSet::new();
+        let build = |kind: &str, start: &str, reset: &str, warnings: &mut BTreeSet<String>| {
+            build_window_report(
+                &BurnWindow {
+                    id: 1,
+                    account_key: "claude:unknown".to_owned(),
+                    window_kind: kind.to_owned(),
+                    window_scope: None,
+                    window_start: start.to_owned(),
+                    percent: 2.0,
+                    resets_at: reset.to_owned(),
+                    observed_at: "2026-08-11T01:00:00Z".to_owned(),
+                },
+                "claude",
+                &[],
+                None,
+                None,
+                &BTreeMap::new(),
+                false,
+                DEFAULT_PREMIUM_CAP_RATIO,
+                now,
+                warnings,
+            )
+        };
+        let accounts = vec![UsageAccountReport {
+            account_key: "claude:unknown".to_owned(),
+            label: None,
+            provider: "claude".to_owned(),
+            plan_tier: None,
+            active: true,
+            windows: vec![
+                build(
+                    "session_5h",
+                    "2026-08-11T00:00:00Z",
+                    "2026-08-11T05:00:00Z",
+                    &mut warnings,
+                ),
+                build(
+                    "weekly_all",
+                    "2026-08-10T00:00:00Z",
+                    "2026-08-17T00:00:00Z",
+                    &mut warnings,
+                ),
+            ],
+        }];
+
+        let decision = usage_decision_summary(&accounts);
+
+        assert_eq!(decision.status, "non_actionable");
+        assert_eq!(
+            decision.missing_current_windows,
+            ["claude:unknown:weekly_scoped"]
         );
     }
 

--- a/crates/sm-server/src/usage_report.rs
+++ b/crates/sm-server/src/usage_report.rs
@@ -60,6 +60,7 @@ pub struct UsageDecisionSummary {
     pub status: &'static str,
     pub fresh_current_windows: usize,
     pub stale_current_windows: usize,
+    pub missing_current_windows: Vec<String>,
     pub reasons: Vec<String>,
     pub refresh_guidance: Vec<String>,
 }
@@ -334,7 +335,15 @@ struct WindowRow {
     seat_id: String,
     model: String,
     credit_metered: bool,
+    first_bucket_ts: Option<String>,
     tokens: TokenCounts,
+}
+
+#[derive(Debug, Clone, Default)]
+struct ModelBurn {
+    burn_percent: f64,
+    weighted_units: f64,
+    first_bucket_ts: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -486,7 +495,7 @@ fn load_window_rows(connection: &Connection, window: &BurnWindow) -> Result<Vec<
     let mut statement = connection.prepare(
         r#"
         SELECT seat_id, model, credit_metered,
-               SUM(input_tokens), SUM(output_tokens), SUM(cache_write_5m),
+               MIN(bucket_ts), SUM(input_tokens), SUM(output_tokens), SUM(cache_write_5m),
                SUM(cache_write_1h), SUM(cache_read_tokens)
         FROM seat_tokens
         WHERE account_key = ?1 AND window_kind = ?2 AND window_start = ?3
@@ -502,12 +511,13 @@ fn load_window_rows(connection: &Connection, window: &BurnWindow) -> Result<Vec<
                     seat_id: row.get(0)?,
                     model: row.get(1)?,
                     credit_metered: row.get(2)?,
+                    first_bucket_ts: row.get(3)?,
                     tokens: TokenCounts {
-                        input: row.get(3)?,
-                        output: row.get(4)?,
-                        cache_write_5m: row.get(5)?,
-                        cache_write_1h: row.get(6)?,
-                        cache_read: row.get(7)?,
+                        input: row.get(4)?,
+                        output: row.get(5)?,
+                        cache_write_5m: row.get(6)?,
+                        cache_write_1h: row.get(7)?,
+                        cache_read: row.get(8)?,
                     },
                 })
             },
@@ -617,7 +627,7 @@ fn build_window_report(
 
     let mut burn_by_seat = BTreeMap::<String, f64>::new();
     let mut units_by_seat = BTreeMap::<String, f64>::new();
-    let mut burn_by_model = BTreeMap::<(String, String), (f64, f64)>::new();
+    let mut burn_by_model = BTreeMap::<(String, String), ModelBurn>::new();
     for (row, units) in weighted {
         let premium_row =
             premium.is_some_and(|premium| model_matches_scope(&row.model, &premium.scope));
@@ -633,8 +643,15 @@ fn build_window_report(
         let model = burn_by_model
             .entry((row.seat_id.clone(), row.model.clone()))
             .or_default();
-        model.0 += burn;
-        model.1 += units;
+        model.burn_percent += burn;
+        model.weighted_units += units;
+        if model.first_bucket_ts.as_ref().is_none_or(|current| {
+            row.first_bucket_ts
+                .as_ref()
+                .is_some_and(|candidate| candidate < current)
+        }) {
+            model.first_bucket_ts = row.first_bucket_ts.clone();
+        }
     }
     let unassigned_points = (premium_units == 0.0)
         .then_some(premium_points)
@@ -645,7 +662,7 @@ fn build_window_report(
         burn_by_model
             .entry(("unassigned".to_owned(), "unassigned".to_owned()))
             .or_default()
-            .0 += unassigned_points;
+            .burn_percent += unassigned_points;
     }
 
     let mut seat_ids = burn_by_seat.keys().cloned().collect::<BTreeSet<_>>();
@@ -683,7 +700,18 @@ fn build_window_report(
             .then_with(|| left.seat_id.cmp(&right.seat_id))
     });
 
-    let projection = build_projection(window, stale, is_scoped, premium_cap_ratio, &burn_by_model);
+    let projection = build_projection(
+        window,
+        stale,
+        is_scoped,
+        premium_cap_ratio,
+        if window.window_kind == "weekly_all" {
+            premium.map(|premium| premium.scope.as_str())
+        } else {
+            None
+        },
+        &burn_by_model,
+    );
     let models = if by_model {
         burn_by_model
             .into_iter()
@@ -692,7 +720,7 @@ fn build_window_report(
                     target.self_seats.contains(seat_id) || target.child_seats.contains(seat_id)
                 })
             })
-            .map(|((seat_id, model), (burn_percent, weighted_units))| {
+            .map(|((seat_id, model), burn)| {
                 let weight_source =
                     if premium.is_some_and(|premium| model_matches_scope(&model, &premium.scope)) {
                         "assumed-ratio"
@@ -702,8 +730,8 @@ fn build_window_report(
                 UsageModelShare {
                     seat_id,
                     model,
-                    burn_percent: (!stale).then_some(burn_percent),
-                    weighted_units,
+                    burn_percent: (!stale).then_some(burn.burn_percent),
+                    weighted_units: burn.weighted_units,
                     weight_source,
                 }
             })
@@ -789,7 +817,8 @@ fn build_projection(
     stale: bool,
     is_scoped: bool,
     premium_cap_ratio: f64,
-    burn_by_model: &BTreeMap<(String, String), (f64, f64)>,
+    excluded_model_scope: Option<&str>,
+    burn_by_model: &BTreeMap<(String, String), ModelBurn>,
 ) -> Option<UsageProjection> {
     let weekly = window.window_kind == "weekly_all"
         || window.window_kind == "weekly_scoped"
@@ -816,25 +845,41 @@ fn build_projection(
         projected_raw_headroom
     };
 
-    let mut model_seats = BTreeMap::<String, BTreeMap<String, f64>>::new();
-    for ((seat_id, model), (burn_percent, _)) in burn_by_model {
-        if seat_id == "unassigned" || *burn_percent <= 0.0 {
+    let mut model_seats = BTreeMap::<String, BTreeMap<String, (f64, String)>>::new();
+    for ((seat_id, model), burn) in burn_by_model {
+        if seat_id == "unassigned"
+            || burn.burn_percent <= 0.0
+            || excluded_model_scope.is_some_and(|scope| model_matches_scope(model, scope))
+        {
             continue;
         }
+        let Some(first_bucket_ts) = burn.first_bucket_ts.clone() else {
+            continue;
+        };
         model_seats
             .entry(model.clone())
             .or_default()
-            .insert(seat_id.clone(), *burn_percent);
+            .insert(seat_id.clone(), (burn.burn_percent, first_bucket_ts));
     }
     let additional_seats = model_seats
         .into_iter()
         .filter_map(|(model, seats)| {
-            let conservative_burn = seats.values().copied().max_by(f64::total_cmp)?;
-            let burn_per_second = conservative_burn / elapsed_seconds as f64;
+            let eligible_rates = seats
+                .values()
+                .filter_map(|(burn_percent, first_bucket_ts)| {
+                    let first_bucket_at = parse_timestamp(first_bucket_ts)?;
+                    let active_started_at = first_bucket_at.max(started_at);
+                    let active_seconds = (observed_at - active_started_at).whole_seconds();
+                    (active_seconds >= MIN_PROJECTION_ELAPSED_SECONDS)
+                        .then_some(*burn_percent / active_seconds as f64)
+                })
+                .collect::<Vec<_>>();
+            let baseline_seats = eligible_rates.len();
+            let burn_per_second = eligible_rates.into_iter().max_by(f64::total_cmp)?;
             let candidate_remaining_burn = burn_per_second * horizon_seconds as f64;
             (candidate_remaining_burn > 0.0).then_some(UsageAdditionalSeatProjection {
                 model,
-                baseline_seats: seats.len(),
+                baseline_seats,
                 burn_points_per_seat_per_day: burn_per_second * 86_400.0,
                 additional_seat_equivalents: projected_raw_headroom / candidate_remaining_burn,
             })
@@ -846,7 +891,7 @@ fn build_projection(
         confidence: "low_conservative",
         assumptions: vec![
             "current-window account burn continues linearly until reset",
-            "candidate capacity uses the highest observed same-model seat burn",
+            "candidate capacity uses the highest same-model seat rate over each seat's active interval after one hour",
             "prior attribution may include invisible usage and biases capacity downward",
         ],
         elapsed_seconds,
@@ -912,10 +957,54 @@ fn usage_decision_summary(accounts: &[UsageAccountReport]) -> UsageDecisionSumma
         .flat_map(|account| &account.windows)
         .filter(|window| window.current && window.stale)
         .count();
-    let status = match (fresh_current_windows, stale_current_windows) {
-        (0, _) => "non_actionable",
-        (_, 0) => "actionable",
-        _ => "partial",
+    let mut missing_current_windows = Vec::new();
+    let mut accounts_needing_refresh = BTreeSet::new();
+    for account in accounts {
+        if !account.windows.iter().any(|window| window.current) {
+            continue;
+        }
+        let mut required = match account.provider.as_str() {
+            "claude" => vec![("session_5h", false), ("weekly_all", false)],
+            "codex" => vec![("codex_300", false), ("codex_10080", false)],
+            _ => Vec::new(),
+        };
+        let scoped_expected = account.provider == "claude"
+            && (account
+                .plan_tier
+                .as_deref()
+                .is_some_and(|tier| tier.to_ascii_lowercase().contains("max"))
+                || account
+                    .windows
+                    .iter()
+                    .any(|window| window.window_kind == "weekly_scoped"));
+        if scoped_expected {
+            required.push(("weekly_scoped", true));
+        }
+        for (kind, scoped) in required {
+            let present = account.windows.iter().any(|window| {
+                window.current
+                    && window.window_kind == kind
+                    && (window.window_scope.is_some() == scoped)
+            });
+            if !present {
+                missing_current_windows.push(format!("{}:{kind}", account.account_key));
+                accounts_needing_refresh.insert(account.account_key.clone());
+            }
+        }
+        if account
+            .windows
+            .iter()
+            .any(|window| window.current && window.stale)
+        {
+            accounts_needing_refresh.insert(account.account_key.clone());
+        }
+    }
+    let status = if !missing_current_windows.is_empty() || fresh_current_windows == 0 {
+        "non_actionable"
+    } else if stale_current_windows == 0 {
+        "actionable"
+    } else {
+        "partial"
     };
     let mut reasons = Vec::new();
     if fresh_current_windows == 0 && stale_current_windows == 0 {
@@ -929,13 +1018,16 @@ fn usage_decision_summary(accounts: &[UsageAccountReport]) -> UsageDecisionSumma
     if fresh_current_windows == 0 && stale_current_windows > 0 {
         reasons.push("No fresh quota meter is available for a spawn decision".to_owned());
     }
+    if !missing_current_windows.is_empty() {
+        reasons.push(format!(
+            "Missing current limiting meter(s): {}",
+            missing_current_windows.join(", ")
+        ));
+    }
 
     let mut refresh_guidance = BTreeSet::new();
     for account in accounts {
-        let needs_refresh = account
-            .windows
-            .iter()
-            .any(|window| window.current && window.stale);
+        let needs_refresh = accounts_needing_refresh.contains(&account.account_key);
         if !needs_refresh {
             continue;
         }
@@ -952,6 +1044,7 @@ fn usage_decision_summary(accounts: &[UsageAccountReport]) -> UsageDecisionSumma
         status,
         fresh_current_windows,
         stale_current_windows,
+        missing_current_windows,
         reasons,
         refresh_guidance: refresh_guidance.into_iter().collect(),
     }
@@ -1055,6 +1148,7 @@ mod tests {
                 seat_id: "seat-a".to_owned(),
                 model: "claude-fable-5".to_owned(),
                 credit_metered: false,
+                first_bucket_ts: None,
                 tokens: TokenCounts {
                     input: 10,
                     ..TokenCounts::default()
@@ -1064,6 +1158,7 @@ mod tests {
                 seat_id: "seat-b".to_owned(),
                 model: "claude-sonnet-5".to_owned(),
                 credit_metered: false,
+                first_bucket_ts: None,
                 tokens: TokenCounts {
                     input: 10,
                     ..TokenCounts::default()
@@ -1130,6 +1225,7 @@ mod tests {
                 seat_id: "quota-seat".to_owned(),
                 model: "claude-sonnet-5".to_owned(),
                 credit_metered: false,
+                first_bucket_ts: None,
                 tokens: TokenCounts {
                     input: 100,
                     ..TokenCounts::default()
@@ -1139,6 +1235,7 @@ mod tests {
                 seat_id: "paid-seat".to_owned(),
                 model: "claude-fable-5".to_owned(),
                 credit_metered: true,
+                first_bucket_ts: None,
                 tokens: TokenCounts {
                     input: 1_000,
                     ..TokenCounts::default()
@@ -1188,6 +1285,7 @@ mod tests {
             seat_id: "seat-a".to_owned(),
             model: "claude-sonnet-5".to_owned(),
             credit_metered: false,
+            first_bucket_ts: None,
             tokens: TokenCounts {
                 input: 10,
                 ..TokenCounts::default()
@@ -1297,6 +1395,7 @@ mod tests {
             seat_id: "seat-a".to_owned(),
             model: "claude-sonnet-5".to_owned(),
             credit_metered: false,
+            first_bucket_ts: None,
             tokens: TokenCounts {
                 input: 10,
                 ..TokenCounts::default()
@@ -1404,6 +1503,7 @@ mod tests {
                 seat_id: seat_id.to_owned(),
                 model: "claude-sonnet-5".to_owned(),
                 credit_metered: false,
+                first_bucket_ts: None,
                 tokens: TokenCounts {
                     input: 10,
                     ..TokenCounts::default()
@@ -1456,6 +1556,7 @@ mod tests {
             seat_id: "luna-seat".to_owned(),
             model: "gpt-5.6-luna".to_owned(),
             credit_metered: false,
+            first_bucket_ts: Some("2026-08-10T00:00:00Z".to_owned()),
             tokens: TokenCounts {
                 input: 100,
                 ..TokenCounts::default()
@@ -1492,6 +1593,89 @@ mod tests {
             projection.additional_seats[0].additional_seat_equivalents,
             0.5
         );
+    }
+
+    #[test]
+    fn premium_models_are_excluded_from_overall_seat_capacity_projection() {
+        let window = BurnWindow {
+            id: 1,
+            account_key: "claude:a".to_owned(),
+            window_kind: "weekly_all".to_owned(),
+            window_scope: None,
+            window_start: "2026-08-10T00:00:00Z".to_owned(),
+            percent: 10.0,
+            resets_at: "2026-08-17T00:00:00Z".to_owned(),
+            observed_at: "2026-08-11T00:00:00Z".to_owned(),
+        };
+        let burn_by_model = BTreeMap::from([
+            (
+                ("premium-seat".to_owned(), "claude-fable-5".to_owned()),
+                ModelBurn {
+                    burn_percent: 5.0,
+                    weighted_units: 10.0,
+                    first_bucket_ts: Some("2026-08-10T00:00:00Z".to_owned()),
+                },
+            ),
+            (
+                ("standard-seat".to_owned(), "claude-sonnet-5".to_owned()),
+                ModelBurn {
+                    burn_percent: 5.0,
+                    weighted_units: 10.0,
+                    first_bucket_ts: Some("2026-08-10T00:00:00Z".to_owned()),
+                },
+            ),
+        ]);
+
+        let projection = build_projection(
+            &window,
+            false,
+            false,
+            DEFAULT_PREMIUM_CAP_RATIO,
+            Some("Fable"),
+            &burn_by_model,
+        )
+        .unwrap();
+
+        assert_eq!(projection.additional_seats.len(), 1);
+        assert_eq!(projection.additional_seats[0].model, "claude-sonnet-5");
+    }
+
+    #[test]
+    fn short_lived_seat_is_not_used_as_a_capacity_baseline() {
+        let window = BurnWindow {
+            id: 1,
+            account_key: "codex:a".to_owned(),
+            window_kind: "codex_10080".to_owned(),
+            window_scope: None,
+            window_start: "2026-08-10T00:00:00Z".to_owned(),
+            percent: 10.0,
+            resets_at: "2026-08-17T00:00:00Z".to_owned(),
+            observed_at: "2026-08-11T00:00:00Z".to_owned(),
+        };
+        let burn_by_model = BTreeMap::from([(
+            ("new-seat".to_owned(), "gpt-5.6-luna".to_owned()),
+            ModelBurn {
+                burn_percent: 10.0,
+                weighted_units: 10.0,
+                first_bucket_ts: Some("2026-08-10T23:30:00Z".to_owned()),
+            },
+        )]);
+
+        let projection = build_projection(
+            &window,
+            false,
+            false,
+            DEFAULT_PREMIUM_CAP_RATIO,
+            None,
+            &burn_by_model,
+        )
+        .unwrap();
+
+        assert_eq!(
+            projection.seat_projection_status,
+            "no_observed_model_baseline"
+        );
+        assert!(projection.additional_seats.is_empty());
     }
 
     #[test]
@@ -1533,6 +1717,7 @@ mod tests {
         assert_eq!(decision.status, "non_actionable");
         assert_eq!(decision.fresh_current_windows, 0);
         assert_eq!(decision.stale_current_windows, 1);
+        assert_eq!(decision.missing_current_windows, ["codex:a:codex_300"]);
         assert!(decision
             .reasons
             .iter()
@@ -1541,6 +1726,51 @@ mod tests {
             .refresh_guidance
             .iter()
             .any(|guidance| guidance.contains("cannot force")));
+    }
+
+    #[test]
+    fn fresh_partial_provider_payload_is_non_actionable_when_weekly_meter_is_missing() {
+        let now = OffsetDateTime::parse("2026-08-11T01:00:00Z", &Rfc3339).unwrap();
+        let window = BurnWindow {
+            id: 1,
+            account_key: "codex:a".to_owned(),
+            window_kind: "codex_300".to_owned(),
+            window_scope: None,
+            window_start: "2026-08-11T00:00:00Z".to_owned(),
+            percent: 2.0,
+            resets_at: "2026-08-11T05:00:00Z".to_owned(),
+            observed_at: "2026-08-11T01:00:00Z".to_owned(),
+        };
+        let mut warnings = BTreeSet::new();
+        let report = build_window_report(
+            &window,
+            "codex",
+            &[],
+            None,
+            None,
+            &BTreeMap::new(),
+            false,
+            DEFAULT_PREMIUM_CAP_RATIO,
+            now,
+            &mut warnings,
+        );
+        let accounts = vec![UsageAccountReport {
+            account_key: "codex:a".to_owned(),
+            label: None,
+            provider: "codex".to_owned(),
+            plan_tier: Some("pro".to_owned()),
+            windows: vec![report],
+        }];
+
+        let decision = usage_decision_summary(&accounts);
+
+        assert_eq!(decision.status, "non_actionable");
+        assert_eq!(decision.fresh_current_windows, 1);
+        assert_eq!(decision.missing_current_windows, ["codex:a:codex_10080"]);
+        assert!(decision
+            .reasons
+            .iter()
+            .any(|reason| reason.contains("Missing current limiting meter")));
     }
 
     #[test]

--- a/crates/sm-server/src/usage_report.rs
+++ b/crates/sm-server/src/usage_report.rs
@@ -12,6 +12,7 @@ use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 const DB_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 const STALE_AFTER_SECONDS: i64 = 600;
+const MIN_PROJECTION_ELAPSED_SECONDS: i64 = 3600;
 const DEFAULT_PREMIUM_CAP_RATIO: f64 = 0.5;
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -28,11 +29,13 @@ pub struct UsageReportTarget {
     pub usage_cap_fraction: Option<f64>,
     pub self_seats: BTreeSet<String>,
     pub child_seats: BTreeSet<String>,
+    pub available_descendant_count: usize,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct UsageReport {
     pub mode: &'static str,
+    pub decision: UsageDecisionSummary,
     pub residual: Option<f64>,
     pub possibly_inflated: bool,
     pub generated_at: String,
@@ -47,8 +50,18 @@ pub struct UsageReportTargetView {
     pub seat_id: String,
     pub friendly_name: Option<String>,
     pub descendant_count: usize,
+    pub available_descendant_count: usize,
     pub account_key: Option<String>,
     pub usage_cap_fraction: Option<f64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UsageDecisionSummary {
+    pub status: &'static str,
+    pub fresh_current_windows: usize,
+    pub stale_current_windows: usize,
+    pub reasons: Vec<String>,
+    pub refresh_guidance: Vec<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -70,6 +83,8 @@ pub struct UsageWindowReport {
     pub account_percent: Option<f64>,
     pub last_known_percent: f64,
     pub sample_age_seconds: Option<i64>,
+    pub current: bool,
+    pub freshness: &'static str,
     pub stale: bool,
     pub weight_source: &'static str,
     pub residual: Option<f64>,
@@ -79,9 +94,15 @@ pub struct UsageWindowReport {
     pub total_percent: Option<f64>,
     pub cap_consumed_percent: Option<f64>,
     pub free_headroom_points: Option<f64>,
+    pub account_lower_bound_percent: Option<f64>,
+    pub free_headroom_upper_bound_points: Option<f64>,
     pub binding_for_scoped_seats: Option<bool>,
     pub binding_for_other_seats: Option<bool>,
     pub credit_tokens: i64,
+    pub residual_lower_bound_percent: f64,
+    pub residual_upper_bound_percent: f64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub projection: Option<UsageProjection>,
     pub seats: Vec<UsageSeatShare>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub models: Vec<UsageModelShare>,
@@ -94,7 +115,30 @@ pub struct UsageSeatShare {
     pub burn_percent: Option<f64>,
     pub share: Option<f64>,
     pub weighted_units: f64,
+    pub total_tokens: i64,
     pub credit_tokens: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UsageProjection {
+    pub method: &'static str,
+    pub confidence: &'static str,
+    pub assumptions: Vec<&'static str>,
+    pub elapsed_seconds: i64,
+    pub horizon_seconds: i64,
+    pub burn_rate_points_per_day: f64,
+    pub projected_account_percent_at_reset: f64,
+    pub projected_free_headroom_points: f64,
+    pub seat_projection_status: &'static str,
+    pub additional_seats: Vec<UsageAdditionalSeatProjection>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct UsageAdditionalSeatProjection {
+    pub model: String,
+    pub baseline_seats: usize,
+    pub burn_points_per_seat_per_day: f64,
+    pub additional_seat_equivalents: f64,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -213,9 +257,11 @@ impl UsageReportStore {
             });
             mark_binding_limits(&mut account.windows);
         }
+        let decision = usage_decision_summary(&accounts);
 
         Ok(UsageReport {
             mode: "prior",
+            decision,
             residual: None,
             possibly_inflated: true,
             generated_at: now.format(&Rfc3339)?,
@@ -223,6 +269,7 @@ impl UsageReportStore {
                 seat_id: target.seat_id.clone(),
                 friendly_name: target.friendly_name.clone(),
                 descendant_count: target.child_seats.len(),
+                available_descendant_count: target.available_descendant_count,
                 account_key: target.account_key.clone(),
                 usage_cap_fraction: target.usage_cap_fraction,
             }),
@@ -525,7 +572,9 @@ fn build_window_report(
             .unwrap_or(true);
     let mut weighted = Vec::new();
     let mut credit_by_seat = BTreeMap::<String, i64>::new();
+    let mut tokens_by_seat = BTreeMap::<String, i64>::new();
     for row in rows {
+        *tokens_by_seat.entry(row.seat_id.clone()).or_default() += row.tokens.total();
         if row.credit_metered {
             *credit_by_seat.entry(row.seat_id.clone()).or_default() += row.tokens.total();
             continue;
@@ -601,6 +650,12 @@ fn build_window_report(
 
     let mut seat_ids = burn_by_seat.keys().cloned().collect::<BTreeSet<_>>();
     seat_ids.extend(credit_by_seat.keys().cloned());
+    seat_ids.extend(tokens_by_seat.keys().cloned());
+    if let Some(target) = target {
+        seat_ids.retain(|seat_id| {
+            target.self_seats.contains(seat_id) || target.child_seats.contains(seat_id)
+        });
+    }
     let mut seats = seat_ids
         .into_iter()
         .map(|seat_id| {
@@ -608,6 +663,7 @@ fn build_window_report(
             UsageSeatShare {
                 friendly_name: names.get(&seat_id).cloned().flatten(),
                 weighted_units: units_by_seat.get(&seat_id).copied().unwrap_or(0.0),
+                total_tokens: tokens_by_seat.get(&seat_id).copied().unwrap_or(0),
                 credit_tokens: credit_by_seat.get(&seat_id).copied().unwrap_or(0),
                 share: (!stale).then_some(if window.percent > 0.0 {
                     burn_percent / window.percent
@@ -627,11 +683,14 @@ fn build_window_report(
             .then_with(|| left.seat_id.cmp(&right.seat_id))
     });
 
+    let projection = build_projection(window, stale, is_scoped, premium_cap_ratio, &burn_by_model);
     let models = if by_model {
         burn_by_model
             .into_iter()
             .filter(|((seat_id, _), _)| {
-                target.is_none_or(|target| target.self_seats.contains(seat_id))
+                target.is_none_or(|target| {
+                    target.self_seats.contains(seat_id) || target.child_seats.contains(seat_id)
+                })
             })
             .map(|((seat_id, model), (burn_percent, weighted_units))| {
                 let weight_source =
@@ -687,6 +746,14 @@ fn build_window_report(
         account_percent: (!stale).then_some(window.percent),
         last_known_percent: window.percent,
         sample_age_seconds,
+        current: !reset_elapsed,
+        freshness: if reset_elapsed {
+            "expired"
+        } else if stale {
+            "stale"
+        } else {
+            "fresh"
+        },
         stale,
         weight_source: "prior",
         residual: None,
@@ -700,12 +767,100 @@ fn build_window_report(
         } else {
             (100.0 - window.percent).max(0.0)
         }),
+        account_lower_bound_percent: (!reset_elapsed).then_some(window.percent),
+        free_headroom_upper_bound_points: (!reset_elapsed).then_some(if is_scoped {
+            premium_cap_ratio * (100.0 - window.percent).max(0.0)
+        } else {
+            (100.0 - window.percent).max(0.0)
+        }),
         binding_for_scoped_seats: (!stale).then_some(false),
         binding_for_other_seats: (!stale).then_some(false),
         credit_tokens: credit_by_seat.values().sum(),
+        residual_lower_bound_percent: 0.0,
+        residual_upper_bound_percent: window.percent.max(0.0),
+        projection,
         seats,
         models,
     }
+}
+
+fn build_projection(
+    window: &BurnWindow,
+    stale: bool,
+    is_scoped: bool,
+    premium_cap_ratio: f64,
+    burn_by_model: &BTreeMap<(String, String), (f64, f64)>,
+) -> Option<UsageProjection> {
+    let weekly = window.window_kind == "weekly_all"
+        || window.window_kind == "weekly_scoped"
+        || window.window_kind.contains("10080");
+    if stale || !weekly {
+        return None;
+    }
+    let started_at = parse_timestamp(&window.window_start)?;
+    let observed_at = parse_timestamp(&window.observed_at)?;
+    let resets_at = parse_timestamp(&window.resets_at)?;
+    let elapsed_seconds = (observed_at - started_at).whole_seconds();
+    let horizon_seconds = (resets_at - observed_at).whole_seconds();
+    if elapsed_seconds < MIN_PROJECTION_ELAPSED_SECONDS || horizon_seconds <= 0 {
+        return None;
+    }
+
+    let burn_rate_per_second = window.percent.max(0.0) / elapsed_seconds as f64;
+    let projected_account_percent_at_reset =
+        window.percent + burn_rate_per_second * horizon_seconds as f64;
+    let projected_raw_headroom = (100.0 - projected_account_percent_at_reset).max(0.0);
+    let projected_free_headroom_points = if is_scoped {
+        premium_cap_ratio * projected_raw_headroom
+    } else {
+        projected_raw_headroom
+    };
+
+    let mut model_seats = BTreeMap::<String, BTreeMap<String, f64>>::new();
+    for ((seat_id, model), (burn_percent, _)) in burn_by_model {
+        if seat_id == "unassigned" || *burn_percent <= 0.0 {
+            continue;
+        }
+        model_seats
+            .entry(model.clone())
+            .or_default()
+            .insert(seat_id.clone(), *burn_percent);
+    }
+    let additional_seats = model_seats
+        .into_iter()
+        .filter_map(|(model, seats)| {
+            let conservative_burn = seats.values().copied().max_by(f64::total_cmp)?;
+            let burn_per_second = conservative_burn / elapsed_seconds as f64;
+            let candidate_remaining_burn = burn_per_second * horizon_seconds as f64;
+            (candidate_remaining_burn > 0.0).then_some(UsageAdditionalSeatProjection {
+                model,
+                baseline_seats: seats.len(),
+                burn_points_per_seat_per_day: burn_per_second * 86_400.0,
+                additional_seat_equivalents: projected_raw_headroom / candidate_remaining_burn,
+            })
+        })
+        .collect::<Vec<UsageAdditionalSeatProjection>>();
+
+    Some(UsageProjection {
+        method: "linear_current_window_conservative_model_max",
+        confidence: "low_conservative",
+        assumptions: vec![
+            "current-window account burn continues linearly until reset",
+            "candidate capacity uses the highest observed same-model seat burn",
+            "prior attribution may include invisible usage and biases capacity downward",
+        ],
+        elapsed_seconds,
+        horizon_seconds,
+        burn_rate_points_per_day: burn_rate_per_second * 86_400.0,
+        projected_account_percent_at_reset,
+        projected_free_headroom_points,
+        seat_projection_status: if additional_seats.is_empty() {
+            "no_observed_model_baseline"
+        } else {
+            "available"
+        },
+        additional_seats,
+    })
 }
 
 fn mark_binding_limits(windows: &mut [UsageWindowReport]) {
@@ -743,6 +898,62 @@ fn mark_binding_limits(windows: &mut [UsageWindowReport]) {
                 windows[index].binding_for_scoped_seats = Some(true);
             }
         }
+    }
+}
+
+fn usage_decision_summary(accounts: &[UsageAccountReport]) -> UsageDecisionSummary {
+    let fresh_current_windows = accounts
+        .iter()
+        .flat_map(|account| &account.windows)
+        .filter(|window| window.current && !window.stale)
+        .count();
+    let stale_current_windows = accounts
+        .iter()
+        .flat_map(|account| &account.windows)
+        .filter(|window| window.current && window.stale)
+        .count();
+    let status = match (fresh_current_windows, stale_current_windows) {
+        (0, _) => "non_actionable",
+        (_, 0) => "actionable",
+        _ => "partial",
+    };
+    let mut reasons = Vec::new();
+    if fresh_current_windows == 0 && stale_current_windows == 0 {
+        reasons.push("No current quota window is available".to_owned());
+    } else if stale_current_windows > 0 {
+        reasons.push(format!(
+            "{stale_current_windows} current quota meter(s) are older than {} minutes; only bounds are safe and projections are suppressed",
+            STALE_AFTER_SECONDS / 60
+        ));
+    }
+    if fresh_current_windows == 0 && stale_current_windows > 0 {
+        reasons.push("No fresh quota meter is available for a spawn decision".to_owned());
+    }
+
+    let mut refresh_guidance = BTreeSet::new();
+    for account in accounts {
+        let needs_refresh = account
+            .windows
+            .iter()
+            .any(|window| window.current && window.stale);
+        if !needs_refresh {
+            continue;
+        }
+        refresh_guidance.insert(match account.provider.as_str() {
+            "claude" => "Claude refreshes when its next status-line payload includes rate limits; sm usage cannot force an account refresh".to_owned(),
+            "codex" => "Codex refreshes when an attached provider emits its next rate-limit event; sm usage cannot force an account refresh".to_owned(),
+            provider => format!(
+                "{provider} has no on-demand usage refresh path in Session Manager"
+            ),
+        });
+    }
+
+    UsageDecisionSummary {
+        status,
+        fresh_current_windows,
+        stale_current_windows,
+        reasons,
+        refresh_guidance: refresh_guidance.into_iter().collect(),
     }
 }
 
@@ -1033,6 +1244,8 @@ mod tests {
             account_percent: Some(0.0),
             last_known_percent: 0.0,
             sample_age_seconds: Some(0),
+            current: true,
+            freshness: "fresh",
             stale: false,
             weight_source: "prior",
             residual: None,
@@ -1042,9 +1255,14 @@ mod tests {
             total_percent: Some(0.0),
             cap_consumed_percent: None,
             free_headroom_points: Some(headroom),
+            account_lower_bound_percent: Some(0.0),
+            free_headroom_upper_bound_points: Some(headroom),
             binding_for_scoped_seats: Some(false),
             binding_for_other_seats: Some(false),
             credit_tokens: 0,
+            residual_lower_bound_percent: 0.0,
+            residual_upper_bound_percent: 0.0,
+            projection: None,
             seats: Vec::new(),
             models: Vec::new(),
         };
@@ -1091,6 +1309,7 @@ mod tests {
             usage_cap_fraction: Some(0.5),
             self_seats: BTreeSet::from(["seat-a".to_owned()]),
             child_seats: BTreeSet::new(),
+            available_descendant_count: 0,
         };
         let report = build_window_report(
             &window,
@@ -1109,6 +1328,13 @@ mod tests {
         assert_eq!(report.account_percent, None);
         assert_eq!(report.last_known_percent, 34.0);
         assert_eq!(report.sample_age_seconds, Some(660));
+        assert!(report.current);
+        assert_eq!(report.freshness, "stale");
+        assert_eq!(report.account_lower_bound_percent, Some(34.0));
+        assert_eq!(report.free_headroom_upper_bound_points, Some(66.0));
+        assert_eq!(report.residual_lower_bound_percent, 0.0);
+        assert_eq!(report.residual_upper_bound_percent, 34.0);
+        assert!(report.projection.is_none());
         assert_eq!(report.self_percent, None);
         assert_eq!(report.children_percent, None);
         assert_eq!(report.total_percent, None);
@@ -1118,6 +1344,7 @@ mod tests {
         assert_eq!(report.binding_for_other_seats, None);
         assert_eq!(report.seats[0].burn_percent, None);
         assert_eq!(report.seats[0].share, None);
+        assert_eq!(report.seats[0].total_tokens, 10);
         assert_eq!(report.models[0].burn_percent, None);
     }
 
@@ -1150,6 +1377,10 @@ mod tests {
         );
 
         assert!(report.stale);
+        assert!(!report.current);
+        assert_eq!(report.freshness, "expired");
+        assert_eq!(report.account_lower_bound_percent, None);
+        assert_eq!(report.free_headroom_upper_bound_points, None);
         assert_eq!(report.account_percent, None);
         assert_eq!(report.last_known_percent, 21.0);
         assert_eq!(report.sample_age_seconds, Some(30));
@@ -1186,6 +1417,7 @@ mod tests {
             usage_cap_fraction: None,
             self_seats: BTreeSet::from(["target".to_owned()]),
             child_seats: BTreeSet::new(),
+            available_descendant_count: 0,
         };
         let mut warnings = BTreeSet::new();
         let report = build_window_report(
@@ -1203,6 +1435,112 @@ mod tests {
 
         assert_eq!(report.models.len(), 1);
         assert_eq!(report.models[0].seat_id, "target");
+        assert_eq!(report.seats.len(), 1);
+        assert_eq!(report.seats[0].seat_id, "target");
+        assert_eq!(report.seats[0].total_tokens, 10);
+    }
+
+    #[test]
+    fn fresh_weekly_window_projects_existing_pace_and_model_seat_equivalents() {
+        let window = BurnWindow {
+            id: 1,
+            account_key: "codex:a".to_owned(),
+            window_kind: "codex_10080".to_owned(),
+            window_scope: None,
+            window_start: "2026-08-10T00:00:00Z".to_owned(),
+            percent: 10.0,
+            resets_at: "2026-08-17T00:00:00Z".to_owned(),
+            observed_at: "2026-08-11T00:00:00Z".to_owned(),
+        };
+        let rows = vec![WindowRow {
+            seat_id: "luna-seat".to_owned(),
+            model: "gpt-5.6-luna".to_owned(),
+            credit_metered: false,
+            tokens: TokenCounts {
+                input: 100,
+                ..TokenCounts::default()
+            },
+        }];
+        let mut warnings = BTreeSet::new();
+
+        let report = build_window_report(
+            &window,
+            "codex",
+            &rows,
+            None,
+            None,
+            &BTreeMap::new(),
+            false,
+            DEFAULT_PREMIUM_CAP_RATIO,
+            OffsetDateTime::parse("2026-08-11T00:00:00Z", &Rfc3339).unwrap(),
+            &mut warnings,
+        );
+
+        let projection = report.projection.unwrap();
+        assert_eq!(projection.confidence, "low_conservative");
+        assert_eq!(projection.assumptions.len(), 3);
+        assert_eq!(projection.seat_projection_status, "available");
+        assert_eq!(projection.elapsed_seconds, 86_400);
+        assert_eq!(projection.horizon_seconds, 6 * 86_400);
+        assert_eq!(projection.burn_rate_points_per_day, 10.0);
+        assert_eq!(projection.projected_account_percent_at_reset, 70.0);
+        assert_eq!(projection.projected_free_headroom_points, 30.0);
+        assert_eq!(projection.additional_seats.len(), 1);
+        assert_eq!(projection.additional_seats[0].model, "gpt-5.6-luna");
+        assert_eq!(projection.additional_seats[0].baseline_seats, 1);
+        assert_eq!(
+            projection.additional_seats[0].additional_seat_equivalents,
+            0.5
+        );
+    }
+
+    #[test]
+    fn stale_current_meter_marks_report_non_actionable_with_refresh_guidance() {
+        let now = OffsetDateTime::parse("2026-08-11T01:00:00Z", &Rfc3339).unwrap();
+        let window = BurnWindow {
+            id: 1,
+            account_key: "codex:a".to_owned(),
+            window_kind: "codex_10080".to_owned(),
+            window_scope: None,
+            window_start: "2026-08-10T00:00:00Z".to_owned(),
+            percent: 12.0,
+            resets_at: "2026-08-17T00:00:00Z".to_owned(),
+            observed_at: "2026-08-11T00:49:00Z".to_owned(),
+        };
+        let mut warnings = BTreeSet::new();
+        let report = build_window_report(
+            &window,
+            "codex",
+            &[],
+            None,
+            None,
+            &BTreeMap::new(),
+            false,
+            DEFAULT_PREMIUM_CAP_RATIO,
+            now,
+            &mut warnings,
+        );
+        let accounts = vec![UsageAccountReport {
+            account_key: "codex:a".to_owned(),
+            label: None,
+            provider: "codex".to_owned(),
+            plan_tier: Some("pro".to_owned()),
+            windows: vec![report],
+        }];
+
+        let decision = usage_decision_summary(&accounts);
+
+        assert_eq!(decision.status, "non_actionable");
+        assert_eq!(decision.fresh_current_windows, 0);
+        assert_eq!(decision.stale_current_windows, 1);
+        assert!(decision
+            .reasons
+            .iter()
+            .any(|reason| reason.contains("older than 10 minutes")));
+        assert!(decision
+            .refresh_guidance
+            .iter()
+            .any(|guidance| guidance.contains("cannot force")));
     }
 
     #[test]

--- a/crates/sm-server/src/usage_report.rs
+++ b/crates/sm-server/src/usage_report.rs
@@ -10,6 +10,8 @@ use rusqlite::{params, Connection};
 use serde::Serialize;
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
+use crate::usage_ledger::plan_excludes_premium;
+
 const DB_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 const STALE_AFTER_SECONDS: i64 = 600;
 const MIN_PROJECTION_ELAPSED_SECONDS: i64 = 3600;
@@ -491,17 +493,6 @@ fn select_windows(
         });
         if let Some(window) = current.into_iter().next() {
             selected.push(window);
-        } else if since_reset {
-            let mut latest = group.clone();
-            latest.sort_by(|left, right| {
-                right
-                    .observed_at
-                    .cmp(&left.observed_at)
-                    .then_with(|| right.id.cmp(&left.id))
-            });
-            if let Some(window) = latest.into_iter().next() {
-                selected.push(window);
-            }
         }
         if !since_reset {
             let mut closed = group
@@ -1007,7 +998,7 @@ fn usage_decision_summary(accounts: &[UsageAccountReport]) -> UsageDecisionSumma
             && (account
                 .plan_tier
                 .as_deref()
-                .is_some_and(|tier| tier.to_ascii_lowercase().contains("max"))
+                .is_some_and(|tier| !plan_excludes_premium(tier))
                 || account
                     .windows
                     .iter()
@@ -1888,6 +1879,64 @@ mod tests {
     }
 
     #[test]
+    fn premium_inclusive_claude_plan_requires_a_scoped_weekly_meter() {
+        let now = OffsetDateTime::parse("2026-08-11T01:00:00Z", &Rfc3339).unwrap();
+        let mut warnings = BTreeSet::new();
+        let build = |kind: &str, start: &str, reset: &str, warnings: &mut BTreeSet<String>| {
+            build_window_report(
+                &BurnWindow {
+                    id: 1,
+                    account_key: "claude:team".to_owned(),
+                    window_kind: kind.to_owned(),
+                    window_scope: None,
+                    window_start: start.to_owned(),
+                    percent: 2.0,
+                    resets_at: reset.to_owned(),
+                    observed_at: "2026-08-11T01:00:00Z".to_owned(),
+                },
+                "claude",
+                &[],
+                None,
+                None,
+                &BTreeMap::new(),
+                false,
+                DEFAULT_PREMIUM_CAP_RATIO,
+                now,
+                warnings,
+            )
+        };
+        let accounts = vec![UsageAccountReport {
+            account_key: "claude:team".to_owned(),
+            label: None,
+            provider: "claude".to_owned(),
+            plan_tier: Some("team_premium".to_owned()),
+            active: true,
+            windows: vec![
+                build(
+                    "session_5h",
+                    "2026-08-11T00:00:00Z",
+                    "2026-08-11T05:00:00Z",
+                    &mut warnings,
+                ),
+                build(
+                    "weekly_all",
+                    "2026-08-10T00:00:00Z",
+                    "2026-08-17T00:00:00Z",
+                    &mut warnings,
+                ),
+            ],
+        }];
+
+        let decision = usage_decision_summary(&accounts);
+
+        assert_eq!(decision.status, "non_actionable");
+        assert_eq!(
+            decision.missing_current_windows,
+            ["claude:team:weekly_scoped"]
+        );
+    }
+
+    #[test]
     fn rolling_resets_select_one_current_snapshot_and_three_closed_windows() {
         let window = |id: i64, start: &str, reset: &str, observed: &str| BurnWindow {
             id,
@@ -1942,6 +1991,9 @@ mod tests {
         let current = select_windows(&windows, true, now);
         assert_eq!(current.len(), 1);
         assert_eq!(current[0].id, 2);
+
+        let expired_only = select_windows(&windows[2..], true, now);
+        assert!(expired_only.is_empty());
 
         let history = select_windows(&windows, false, now);
         assert_eq!(

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -7777,6 +7777,23 @@ async fn usage_routes_preserve_exact_account_burn_and_optionally_include_childre
             None,
         )
         .unwrap();
+    let codex_without_windows = AccountIdentity {
+        provider: Provider::Codex,
+        external_id: "usage-codex-no-windows".to_owned(),
+        label: None,
+        plan_tier: Some("pro".to_owned()),
+        extra_usage_enabled: Some(false),
+    };
+    UsageIdentityStore::new(&usage_db_path)
+        .unwrap()
+        .record_observation(
+            Provider::Codex,
+            Some(&codex_without_windows),
+            now - time::Duration::minutes(1),
+            None,
+            None,
+        )
+        .unwrap();
     UsageBurnStore::new(&usage_db_path)
         .unwrap()
         .record_for_account(
@@ -7852,6 +7869,7 @@ async fn usage_routes_preserve_exact_account_burn_and_optionally_include_childre
     assert_eq!(own["accounts"][0]["windows"][0]["account_percent"], 40.0);
     assert_eq!(own["accounts"][0]["windows"][0]["total_percent"], 20.0);
     assert_eq!(own["accounts"][0]["label"], "primary");
+    assert_eq!(own["accounts"][0]["active"], true);
     assert_eq!(own["target"]["usage_cap_fraction"], 0.5);
     assert_eq!(own["target"]["descendant_count"], 0);
     assert_eq!(own["target"]["available_descendant_count"], 1);
@@ -7902,10 +7920,21 @@ async fn usage_routes_preserve_exact_account_burn_and_optionally_include_childre
 
     let (status, accounts) = get_json(app.clone(), "/usage/accounts?since_reset=true").await;
     assert_eq!(status, StatusCode::OK);
+    assert_eq!(accounts["decision"]["status"], "non_actionable");
+    assert_eq!(accounts["accounts"].as_array().unwrap().len(), 2);
     assert_eq!(
         accounts["accounts"][0]["windows"][0]["account_percent"], 40.0,
         "account view must pass through the exact first-party burn sample"
     );
+    assert_eq!(
+        accounts["accounts"][1]["account_key"],
+        codex_without_windows.account_key()
+    );
+    assert_eq!(accounts["accounts"][1]["active"], true);
+    assert!(accounts["accounts"][1]["windows"]
+        .as_array()
+        .unwrap()
+        .is_empty());
     let (status, idle) = get_json(app.clone(), "/sessions/idle0001/usage?since_reset=true").await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(idle["accounts"][0]["account_key"], account.account_key());

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -7853,6 +7853,23 @@ async fn usage_routes_preserve_exact_account_burn_and_optionally_include_childre
     assert_eq!(own["accounts"][0]["windows"][0]["total_percent"], 20.0);
     assert_eq!(own["accounts"][0]["label"], "primary");
     assert_eq!(own["target"]["usage_cap_fraction"], 0.5);
+    assert_eq!(own["target"]["descendant_count"], 0);
+    assert_eq!(own["target"]["available_descendant_count"], 1);
+    assert_eq!(
+        own["accounts"][0]["windows"][0]["seats"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        own["accounts"][0]["windows"][0]["seats"][0]["seat_id"],
+        "parent01"
+    );
+    assert_eq!(
+        own["accounts"][0]["windows"][0]["seats"][0]["total_tokens"],
+        100
+    );
     assert_eq!(
         own["accounts"][0]["windows"][0]["cap_consumed_percent"],
         40.0
@@ -7865,6 +7882,14 @@ async fn usage_routes_preserve_exact_account_burn_and_optionally_include_childre
     .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(subtree["target"]["descendant_count"], 1);
+    assert_eq!(subtree["target"]["available_descendant_count"], 1);
+    assert_eq!(
+        subtree["accounts"][0]["windows"][0]["seats"]
+            .as_array()
+            .unwrap()
+            .len(),
+        2
+    );
     assert_eq!(
         subtree["accounts"][0]["windows"][0]["account_percent"],
         40.0

--- a/specs/1182_sm_usage_quota_attribution.html
+++ b/specs/1182_sm_usage_quota_attribution.html
@@ -1614,12 +1614,14 @@ dormant.</p>
   <p><strong>Decision safety.</strong> A current sample older than ten minutes is not silently discarded:
   its consumed percentage remains a lower bound and its free headroom remains an upper bound, while the
   report is marked non-actionable and projections are suppressed. Refresh remains provider-event driven;
-  <code>sm usage</code> does not claim to force either provider to poll.</p>
+  <code>sm usage</code> does not claim to force either provider to poll. A partial provider payload is also
+  non-actionable when a required short or weekly limiting meter is absent.</p>
   <p>Fresh weekly windows may show a low-confidence linear projection. Existing account burn continues at
-  its current-window rate; model capacity uses the highest observed same-model seat rate, so prior-mode
-  invisible usage biases capacity downward rather than creating optimistic seats. The JSON response names
-  these assumptions. With prior weights, residual is bounded as zero through measured account burn and is
-  never presented as measured.</p>
+  its current-window rate; model capacity uses the highest observed same-model seat rate over that seat's
+  own active interval after at least one hour of evidence, so prior-mode invisible usage biases capacity
+  downward rather than creating optimistic seats. Premium-model capacity appears only under the scoped
+  meter, never the looser overall meter. The JSON response names these assumptions. With prior weights,
+  residual is bounded as zero through measured account burn and is never presented as measured.</p>
 </blockquote>
 
 <pre><code>$ sm usage 320 --include-children

--- a/specs/1182_sm_usage_quota_attribution.html
+++ b/specs/1182_sm_usage_quota_attribution.html
@@ -1315,9 +1315,9 @@ continuing at a price.</p>
 </blockquote>
 
 <p>The same applies to caps: a <code>usage_cap_fraction</code> is evaluated per account (decision 2), so a
-subtree spanning two accounts is measured against each independently. <code>--since-reset</code> restricts to the current window; without it the report also
-prints the last three closed windows from <code>window_ledger</code>, so historic rate sits beside current
-burn.</p>
+subtree spanning two accounts is measured against each independently. The default and compatibility
+flag <code>--since-reset</code> restrict output to the current window; <code>--history</code> also prints the
+last three closed windows from <code>window_ledger</code>.</p>
 
 <h2>D · Model weights</h2>
 
@@ -1594,7 +1594,7 @@ dormant.</p>
 <p>No denominator field, and no per-model weight field — weights are fitted state, not configuration.</p>
 
 <h3>E.2 CLI</h3>
-<pre><code>sm usage [AGENT] [--include-children] [--since-reset] [--account] [--by-model] [--json]</code></pre>
+<pre><code>sm usage [AGENT] [--include-children] [--history|--since-reset] [--account] [--by-model] [--json]</code></pre>
 
 <div class="tw">
 <table>
@@ -1602,12 +1602,25 @@ dormant.</p>
   <tr><td><em>(none)</em></td><td>Current seat, current windows</td></tr>
   <tr><td><code>AGENT</code></td><td>Named seat or session id</td></tr>
   <tr><td><code>--include-children</code></td><td>Roll up the descendant subtree</td></tr>
-  <tr><td><code>--since-reset</code></td><td>Current window only; otherwise also prints the last three closed windows</td></tr>
+  <tr><td><code>--history</code></td><td>Also print the last three closed windows; normal decision output is current-window only</td></tr>
+  <tr><td><code>--since-reset</code></td><td>Compatibility spelling for the current-window default</td></tr>
   <tr><td><code>--account</code></td><td>Account view: every seat's share, including <code>unassigned</code></td></tr>
   <tr><td><code>--by-model</code></td><td>Break the seat's own burn down by model family, with the weight source</td></tr>
   <tr><td><code>--json</code></td><td>Machine-readable; per-subcommand flag, matching existing convention</td></tr>
 </table>
 </div>
+
+<blockquote>
+  <p><strong>Decision safety.</strong> A current sample older than ten minutes is not silently discarded:
+  its consumed percentage remains a lower bound and its free headroom remains an upper bound, while the
+  report is marked non-actionable and projections are suppressed. Refresh remains provider-event driven;
+  <code>sm usage</code> does not claim to force either provider to poll.</p>
+  <p>Fresh weekly windows may show a low-confidence linear projection. Existing account burn continues at
+  its current-window rate; model capacity uses the highest observed same-model seat rate, so prior-mode
+  invisible usage biases capacity downward rather than creating optimistic seats. The JSON response names
+  these assumptions. With prior weights, residual is bounded as zero through measured account burn and is
+  never presented as measured.</p>
+</blockquote>
 
 <pre><code>$ sm usage 320 --include-children
 seat 320 (a4af4272) · model opus · 4 descendants across 2 accounts

--- a/specs/1182_sm_usage_quota_attribution.html
+++ b/specs/1182_sm_usage_quota_attribution.html
@@ -1615,7 +1615,9 @@ dormant.</p>
   its consumed percentage remains a lower bound and its free headroom remains an upper bound, while the
   report is marked non-actionable and projections are suppressed. Refresh remains provider-event driven;
   <code>sm usage</code> does not claim to force either provider to poll. A partial provider payload is also
-  non-actionable when a required short or weekly limiting meter is absent.</p>
+  non-actionable when a required short or weekly limiting meter is absent. Open
+  <code>account_timeline</code> rows define which accounts require current meters, so an active account with
+  zero windows blocks a decision while a closed historical account does not.</p>
   <p>Fresh weekly windows may show a low-confidence linear projection. Existing account burn continues at
   its current-window rate; model capacity uses the highest observed same-model seat rate over that seat's
   own active interval after at least one hour of evidence, so prior-mode invisible usage biases capacity


### PR DESCRIPTION
Fixes #1201

## Summary

- make current windows the CLI default and add explicit `--history`
- surface stale cumulative meters as safe usage/headroom bounds with non-actionable refresh guidance
- expose targeted seat IDs, exact token totals, conservative weekly model-seat projections, and bounded prior residuals
- require complete limiting meters for open account timelines, including active accounts with zero windows
- exclude premium models from overall capacity and use per-seat active intervals for model baselines
- document the updated CLI and decision-safety contract

## Verification

- `cargo test --workspace --quiet -- --skip codex_review_request_watcher_delivers_sequential_wake_to_runtime_session` (365 lib, 64 CLI, 241 HTTP passed)
- exact `codex_review_request_watcher_delivers_sequential_wake_to_runtime_session` reproduced its tracked intermittent 502/200 failure twice; #1189 documents the unrelated flake
- `cargo fmt --all -- --check`
- `git diff --check`
- focused usage-report, CLI, HTTP subtree, active-account, missing-meter, scoped-capacity, and active-interval tests
