### PR TITLE
fix: execute Claude handoffs after Stop

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -424,6 +424,9 @@ impl AppState {
         if let Err(error) = session_store.recover_pending_codex_fork_handoffs() {
             eprintln!("codex-fork handoff recovery failed: {error:#}");
         }
+        if let Err(error) = session_store.recover_pending_claude_handoffs() {
+            eprintln!("Claude handoff recovery failed: {error:#}");
+        }
         if let Err(error) = session_store.recover_codex_fork_event_monitors() {
             eprintln!("codex-fork event monitor recovery failed: {error:#}");
         }
@@ -1451,7 +1454,7 @@ async fn claude_hook(
                 native_title_mtime_ns = metadata.mtime_ns;
             }
         }
-        state.session_store.apply_claude_stop_hook(
+        let stop_applied = state.session_store.apply_claude_stop_hook(
             &session_id,
             last_message,
             native_title,
@@ -1460,6 +1463,14 @@ async fn claude_hook(
             Some(&received_at),
             emitted_at,
         )?;
+        if stop_applied {
+            if let Err(error) = state
+                .session_store
+                .start_pending_claude_handoff(&session_id)
+            {
+                eprintln!("failed to start Claude handoff for {session_id}: {error:#}");
+            }
+        }
     }
 
     Ok(Json(json!({ "status": "ok" })).into_response())

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -71,6 +71,15 @@ pub struct TmuxRuntime {
     send_keys_max_chunk_chars: usize,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConditionalClearOutcome {
+    Cleared,
+    IdlePromptNotReady,
+    PostClearPreconditionFailed,
+    PreconditionFailed,
+    SessionMissing,
+}
+
 #[derive(Debug, Clone)]
 pub struct TmuxSessionSpec {
     pub session_id: String,
@@ -479,6 +488,48 @@ impl TmuxRuntime {
         self.clear_session_inner(tmux_session, clear_command, prompt, wake_completed, None)
     }
 
+    pub(crate) fn clear_claude_session_if<P, C, S>(
+        &self,
+        tmux_session: &str,
+        prompt: &str,
+        precondition: P,
+        commit_clear: C,
+        commit_prompt: S,
+    ) -> Result<ConditionalClearOutcome>
+    where
+        P: FnOnce() -> Result<bool>,
+        C: FnOnce(&mut dyn FnMut() -> Result<()>) -> Result<bool>,
+        S: FnOnce(&mut dyn FnMut() -> Result<()>) -> Result<bool>,
+    {
+        let _guard = self.lock_session_input(tmux_session)?;
+        if !self.session_exists(tmux_session)? {
+            return Ok(ConditionalClearOutcome::SessionMissing);
+        }
+        if !precondition()? {
+            return Ok(ConditionalClearOutcome::PreconditionFailed);
+        }
+        if !self.wait_for_prompt(tmux_session, Duration::from_secs_f64(3.0)) {
+            return Ok(ConditionalClearOutcome::IdlePromptNotReady);
+        }
+        let Some(pre_clear_pane) = self.capture_pane_text(tmux_session) else {
+            return Ok(ConditionalClearOutcome::IdlePromptNotReady);
+        };
+        let mut send_clear = || self.send_text_then_enter(tmux_session, "/clear");
+        if !commit_clear(&mut send_clear)? {
+            return Ok(ConditionalClearOutcome::PreconditionFailed);
+        }
+
+        if !self.wait_for_fresh_prompt(tmux_session, &pre_clear_pane, Duration::from_secs_f64(5.0))
+        {
+            bail!("Claude handoff timed out waiting for /clear to finish");
+        }
+        let mut send_prompt = || self.send_text_then_enter(tmux_session, prompt);
+        if !commit_prompt(&mut send_prompt)? {
+            return Ok(ConditionalClearOutcome::PostClearPreconditionFailed);
+        }
+        Ok(ConditionalClearOutcome::Cleared)
+    }
+
     pub fn clear_codex_session_confirming_prompt(
         &self,
         tmux_session: &str,
@@ -757,6 +808,26 @@ impl TmuxRuntime {
         }
     }
 
+    fn wait_for_fresh_prompt(
+        &self,
+        tmux_session: &str,
+        previous_pane: &str,
+        timeout: Duration,
+    ) -> bool {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if self.capture_pane_text(tmux_session).is_some_and(|pane| {
+                pane != previous_pane && pane_last_line(&pane).as_deref() == Some(">")
+            }) {
+                return true;
+            }
+            if Instant::now() >= deadline {
+                return false;
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
+    }
+
     fn wait_for_codex_composer(
         &self,
         tmux_session: &str,
@@ -890,11 +961,7 @@ impl TmuxRuntime {
 
     fn capture_pane_last_line(&self, tmux_session: &str) -> Option<String> {
         let text = self.capture_pane_text(tmux_session)?;
-        text.trim_end_matches('\n')
-            .split('\n')
-            .last()
-            .map(str::trim)
-            .map(ToOwned::to_owned)
+        pane_last_line(&text)
     }
 
     fn run_tmux<'a>(&self, args: impl IntoIterator<Item = &'a str>) -> Result<()> {
@@ -1187,6 +1254,14 @@ fn shell_quote(value: &str) -> String {
         return "''".to_owned();
     }
     format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn pane_last_line(text: &str) -> Option<String> {
+    text.trim_end_matches('\n')
+        .split('\n')
+        .last()
+        .map(str::trim)
+        .map(ToOwned::to_owned)
 }
 
 fn command_parts(command: &str, args: &[String]) -> Vec<String> {
@@ -1667,6 +1742,115 @@ mod tests {
     }
 
     #[test]
+    fn conditional_claude_clear_revalidates_before_touching_the_pane() {
+        let (tmux_binary, log_path, _temp_dir) = fake_tmux_binary();
+        let mut runtime = TmuxRuntime::from_config(&RustCoreConfig {
+            send_keys_settle_ms: Some(0.0),
+            send_keys_settle_max_ms: Some(0.0),
+            ..RustCoreConfig::default()
+        });
+        runtime.tmux_binary = tmux_binary.display().to_string();
+
+        let checks = std::cell::Cell::new(0);
+        let outcome = runtime
+            .clear_claude_session_if(
+                "sm-test",
+                "handoff prompt",
+                || {
+                    checks.set(checks.get() + 1);
+                    Ok(true)
+                },
+                |_send_clear| {
+                    checks.set(checks.get() + 1);
+                    Ok(false)
+                },
+                |_send_prompt| unreachable!("prompt submission must not be reached"),
+            )
+            .unwrap();
+
+        assert_eq!(outcome, ConditionalClearOutcome::PreconditionFailed);
+        assert_eq!(checks.get(), 2);
+        let log = fs::read_to_string(log_path).unwrap();
+        assert!(!log.contains("send-keys -t sm-test -l -- /clear"));
+        assert!(!log.contains("handoff prompt"));
+    }
+
+    #[test]
+    fn conditional_claude_clear_keeps_the_prompt_when_redraw_never_finishes() {
+        let (tmux_binary, log_path, _temp_dir) = fake_tmux_binary_with_stuck_clear();
+        let mut runtime = TmuxRuntime::from_config(&RustCoreConfig {
+            send_keys_settle_ms: Some(0.0),
+            send_keys_settle_max_ms: Some(0.0),
+            ..RustCoreConfig::default()
+        });
+        runtime.tmux_binary = tmux_binary.display().to_string();
+
+        let error = runtime
+            .clear_claude_session_if(
+                "sm-test",
+                "handoff prompt",
+                || Ok(true),
+                |send_clear| {
+                    send_clear()?;
+                    Ok(true)
+                },
+                |send_prompt| {
+                    send_prompt()?;
+                    Ok(true)
+                },
+            )
+            .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("timed out waiting for /clear to finish"));
+        let log = fs::read_to_string(log_path).unwrap();
+        assert!(log.contains("send-keys -t sm-test -l -- /clear"));
+        assert!(!log.contains("handoff prompt"));
+    }
+
+    #[test]
+    fn conditional_claude_clear_revalidates_before_submitting_the_prompt() {
+        let (tmux_binary, log_path, _temp_dir) = fake_tmux_binary_with_fresh_clear();
+        let mut runtime = TmuxRuntime::from_config(&RustCoreConfig {
+            send_keys_settle_ms: Some(0.0),
+            send_keys_settle_max_ms: Some(0.0),
+            ..RustCoreConfig::default()
+        });
+        runtime.tmux_binary = tmux_binary.display().to_string();
+
+        let outcome = runtime
+            .clear_claude_session_if(
+                "sm-test",
+                "handoff prompt",
+                || Ok(true),
+                |send_clear| {
+                    send_clear()?;
+                    Ok(true)
+                },
+                |_send_prompt| Ok(false),
+            )
+            .unwrap();
+
+        assert_eq!(
+            outcome,
+            ConditionalClearOutcome::PostClearPreconditionFailed
+        );
+        let log = fs::read_to_string(log_path).unwrap();
+        assert!(log.contains("send-keys -t sm-test -l -- /clear"));
+        assert!(!log.contains("handoff prompt"));
+    }
+
+    #[test]
+    fn fresh_prompt_wait_rejects_the_unchanged_pre_clear_prompt() {
+        let (tmux_binary, _log_path, _temp_dir) = fake_tmux_binary();
+        let mut runtime = TmuxRuntime::from_config(&RustCoreConfig::default());
+        runtime.tmux_binary = tmux_binary.display().to_string();
+
+        assert!(!runtime.wait_for_fresh_prompt("sm-test", "ready\n>\n", Duration::ZERO,));
+    }
+
+    #[test]
     fn codex_composer_readiness_requires_the_cursor_row() {
         let pane = "› stale transcript prompt\nWorking\n\n› live composer\n\nmodel status\n";
 
@@ -1778,6 +1962,72 @@ esac
 "#,
                 log_path.display(),
                 if has_session { 0 } else { 1 }
+            ),
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&tmux_binary).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&tmux_binary, permissions).unwrap();
+        (tmux_binary, log_path, temp_dir)
+    }
+
+    fn fake_tmux_binary_with_stuck_clear() -> (PathBuf, PathBuf, PathBuf) {
+        let (tmux_binary, log_path, temp_dir) = fake_tmux_binary();
+        fs::write(
+            &tmux_binary,
+            format!(
+                r#"#!/bin/sh
+printf '%s\n' "$*" >> "{}"
+case "$1" in
+  has-session) exit 0 ;;
+  display-message) echo 0; exit 0 ;;
+  capture-pane)
+    if grep -q 'send-keys -t sm-test -l -- /clear' "{}"; then
+      printf 'clearing\n'
+    else
+      printf 'ready\n>\n'
+    fi
+    exit 0
+    ;;
+  show-options) exit 0 ;;
+  *) exit 0 ;;
+esac
+"#,
+                log_path.display(),
+                log_path.display(),
+            ),
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&tmux_binary).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&tmux_binary, permissions).unwrap();
+        (tmux_binary, log_path, temp_dir)
+    }
+
+    fn fake_tmux_binary_with_fresh_clear() -> (PathBuf, PathBuf, PathBuf) {
+        let (tmux_binary, log_path, temp_dir) = fake_tmux_binary();
+        fs::write(
+            &tmux_binary,
+            format!(
+                r#"#!/bin/sh
+printf '%s\n' "$*" >> "{}"
+case "$1" in
+  has-session) exit 0 ;;
+  display-message) echo 0; exit 0 ;;
+  capture-pane)
+    if grep -q 'send-keys -t sm-test -l -- /clear' "{}"; then
+      printf 'cleared\n>\n'
+    else
+      printf 'ready\n>\n'
+    fi
+    exit 0
+    ;;
+  show-options) exit 0 ;;
+  *) exit 0 ;;
+esac
+"#,
+                log_path.display(),
+                log_path.display(),
             ),
         )
         .unwrap();

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -6,7 +6,7 @@ use std::{
     io::{self, BufRead, BufReader, Read, Seek, SeekFrom, Write},
     path::{Path, PathBuf},
     process::Command,
-    sync::atomic::{AtomicU64, Ordering},
+    sync::atomic::{AtomicBool, AtomicU64, Ordering},
     sync::{Arc, Condvar, Mutex, Weak},
     thread,
     time::{Duration, Instant, UNIX_EPOCH},
@@ -28,7 +28,7 @@ use crate::queue::{
 };
 use crate::{
     config::{CodexReviewConfig, ContextMonitorConfig},
-    runtime::{TmuxRuntime, TmuxSessionSpec},
+    runtime::{ConditionalClearOutcome, TmuxRuntime, TmuxSessionSpec},
     seat_sessions::{SeatSessionIdentity, SeatSessionStore},
     usage_burn::UsageBurnStore,
     usage_identity::{Provider as UsageProvider, UsageIdentityStore},
@@ -68,6 +68,7 @@ pub struct SessionStore {
     /// an unrelated request to happen to flush it.
     delivery_runtime: Option<TmuxRuntime>,
     codex_fork_handoff_monitors: Arc<Mutex<BTreeSet<String>>>,
+    claude_handoff_workers: Arc<Mutex<BTreeSet<String>>>,
     seat_session_appends: Arc<Mutex<BTreeSet<(String, String, String)>>>,
     clear_operation_locks: Arc<Mutex<BTreeMap<String, Weak<SessionClearLock>>>>,
     seat_session_store: SeatSessionStore,
@@ -121,6 +122,7 @@ impl SessionStore {
             context_monitor: ContextMonitorConfig::default(),
             delivery_runtime: None,
             codex_fork_handoff_monitors: Arc::new(Mutex::new(BTreeSet::new())),
+            claude_handoff_workers: Arc::new(Mutex::new(BTreeSet::new())),
             seat_session_appends: Arc::new(Mutex::new(BTreeSet::new())),
             clear_operation_locks: Arc::new(Mutex::new(BTreeMap::new())),
             seat_session_store,
@@ -664,6 +666,7 @@ impl SessionStore {
             context_monitor: ContextMonitorConfig::default(),
             delivery_runtime: None,
             codex_fork_handoff_monitors: Arc::new(Mutex::new(BTreeSet::new())),
+            claude_handoff_workers: Arc::new(Mutex::new(BTreeSet::new())),
             seat_session_appends: Arc::new(Mutex::new(BTreeSet::new())),
             clear_operation_locks: Arc::new(Mutex::new(BTreeMap::new())),
             seat_session_store,
@@ -879,7 +882,21 @@ impl SessionStore {
 
         let now = now_rfc3339();
         if !superseded {
-            session.insert("status".to_owned(), Value::String("idle".to_owned()));
+            let reserves_handoff = provider == "claude"
+                && json_text(session.get("pending_handoff_path")).is_some()
+                && json_text(session.get("pending_handoff_recorded_at")).is_some();
+            if reserves_handoff {
+                session.insert(
+                    "claude_handoff_in_progress_at".to_owned(),
+                    Value::String(now.clone()),
+                );
+                // Keep queue delivery from treating the Stop transition as an
+                // ordinary idle prompt before the handoff owns the pane.
+                session.insert("status".to_owned(), Value::String("running".to_owned()));
+            } else {
+                session.insert("claude_handoff_in_progress_at".to_owned(), Value::Null);
+                session.insert("status".to_owned(), Value::String("idle".to_owned()));
+            }
             session.insert("last_activity".to_owned(), Value::String(now.clone()));
             session.insert("activity_hook_at".to_owned(), Value::String(now.clone()));
             session.insert(
@@ -968,6 +985,7 @@ impl SessionStore {
 
         let now = now_rfc3339();
         session.insert("status".to_owned(), Value::String("running".to_owned()));
+        session.insert("claude_handoff_in_progress_at".to_owned(), Value::Null);
         session.insert("last_activity".to_owned(), Value::String(now.clone()));
         session.insert("activity_hook_at".to_owned(), Value::String(now.clone()));
         session.insert("agent_task_completed_at".to_owned(), Value::Null);
@@ -1039,6 +1057,7 @@ impl SessionStore {
                 Value::String(emitted_at.to_owned())
             }),
         );
+        session.insert("claude_handoff_in_progress_at".to_owned(), Value::Null);
         session.insert("agent_task_completed_at".to_owned(), Value::Null);
         self.write_raw_json_value(&state)?;
         Ok(true)
@@ -2790,6 +2809,15 @@ impl SessionStore {
                 "pending_handoff_path".to_owned(),
                 Value::String(request.file_path.clone()),
             );
+            if provider == "claude" {
+                // Also versions the Rust execution contract: older pending paths
+                // must not rotate dormant seats when the fixed server is deployed.
+                session.insert(
+                    "pending_handoff_recorded_at".to_owned(),
+                    Value::String(now_rfc3339()),
+                );
+                session.insert("claude_handoff_in_progress_at".to_owned(), Value::Null);
+            }
             self.write_raw_json_value(&state)?;
             monitor
         };
@@ -2861,6 +2889,496 @@ impl SessionStore {
             )?;
         }
         Ok(monitors.len())
+    }
+
+    pub fn recover_pending_claude_handoffs(&self) -> Result<usize> {
+        if self.delivery_runtime.is_none() {
+            return Ok(0);
+        }
+        let state = self.load_raw_json_value()?;
+        let session_ids = state
+            .get("sessions")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_object)
+            .filter(|session| {
+                json_text(session.get("provider")).as_deref() == Some("claude")
+                    && is_primary_node(&json_text(session.get("node")).unwrap_or_else(default_node))
+                    && normalized_status(&json_text(session.get("status")).unwrap_or_default())
+                        != "stopped"
+                    && json_text(session.get("pending_handoff_path")).is_some()
+                    && json_text(session.get("pending_handoff_recorded_at")).is_some()
+                    && (json_text(session.get("claude_handoff_in_progress_at")).is_some()
+                        || normalized_status(&json_text(session.get("status")).unwrap_or_default())
+                            == "idle")
+            })
+            .filter_map(|session| json_text(session.get("id")))
+            .collect::<Vec<_>>();
+
+        let mut started = 0;
+        for session_id in session_ids {
+            started += usize::from(self.start_pending_claude_handoff(&session_id)?);
+        }
+        Ok(started)
+    }
+
+    pub fn start_pending_claude_handoff(&self, session_id: &str) -> Result<bool> {
+        let reservation = {
+            let _guard = self.write_guard()?;
+            let mut state = self.load_raw_json_value()?;
+            let (reservation, state_changed) = {
+                let sessions = ensure_sessions_array_mut(&mut state)?;
+                let Some(session) = session_object_mut(sessions, session_id) else {
+                    return Ok(false);
+                };
+                let status = json_text(session.get("status")).unwrap_or_default();
+                let file_path = json_text(session.get("pending_handoff_path"));
+                let recorded_at = json_text(session.get("pending_handoff_recorded_at"));
+                let eligible = json_text(session.get("provider")).as_deref() == Some("claude")
+                    && file_path.is_some()
+                    && recorded_at.is_some()
+                    && normalized_status(&status) != "stopped"
+                    && is_primary_node(
+                        &json_text(session.get("node")).unwrap_or_else(default_node),
+                    );
+                if !eligible {
+                    (None, false)
+                } else {
+                    let (reservation_at, state_changed) = if let Some(existing) =
+                        json_text(session.get("claude_handoff_in_progress_at"))
+                    {
+                        (existing, false)
+                    } else if normalized_status(&status) == "idle" {
+                        let now = now_rfc3339();
+                        session.insert(
+                            "claude_handoff_in_progress_at".to_owned(),
+                            Value::String(now.clone()),
+                        );
+                        session.insert("status".to_owned(), Value::String("running".to_owned()));
+                        session.insert("last_activity".to_owned(), Value::String(now.clone()));
+                        (now, true)
+                    } else {
+                        return Ok(false);
+                    };
+                    (
+                        Some((file_path.unwrap(), recorded_at.unwrap(), reservation_at)),
+                        state_changed,
+                    )
+                }
+            };
+            if state_changed {
+                self.write_raw_json_value(&state)?;
+            }
+            reservation
+        };
+        let Some((file_path, recorded_at, reservation_at)) = reservation else {
+            return Ok(false);
+        };
+
+        {
+            let mut workers = self
+                .claude_handoff_workers
+                .lock()
+                .map_err(|_| anyhow::anyhow!("Claude handoff worker lock poisoned"))?;
+            if !workers.insert(session_id.to_owned()) {
+                return Ok(false);
+            }
+        }
+
+        let store = self.clone();
+        let worker_session_id = session_id.to_owned();
+        let worker_file_path = file_path.clone();
+        let worker_recorded_at = recorded_at.clone();
+        let worker_reservation_at = reservation_at.clone();
+        let spawn_result = thread::Builder::new()
+            .name(format!(
+                "sm-claude-handoff-{}",
+                sanitize_path_component(session_id)
+            ))
+            .spawn(move || {
+                if let Err(error) = store.execute_pending_claude_handoff(&worker_session_id) {
+                    eprintln!("Claude handoff execution failed for {worker_session_id}: {error:#}");
+                }
+                if let Ok(mut workers) = store.claude_handoff_workers.lock() {
+                    workers.remove(&worker_session_id);
+                }
+                match store.claude_handoff_reservation_was_replaced(
+                    &worker_session_id,
+                    &worker_file_path,
+                    &worker_recorded_at,
+                    &worker_reservation_at,
+                ) {
+                    Ok(true) => {
+                        if let Err(error) =
+                            store.start_pending_claude_handoff(&worker_session_id)
+                        {
+                            eprintln!(
+                                "Replacement Claude handoff failed to start for {worker_session_id}: {error:#}"
+                            );
+                        }
+                    }
+                    Ok(false) => {}
+                    Err(error) => eprintln!(
+                        "Replacement Claude handoff check failed for {worker_session_id}: {error:#}"
+                    ),
+                }
+            });
+        if let Err(error) = spawn_result {
+            let mut workers = self
+                .claude_handoff_workers
+                .lock()
+                .map_err(|_| anyhow::anyhow!("Claude handoff worker lock poisoned"))?;
+            workers.remove(session_id);
+            let rollback = self.release_failed_claude_handoff_worker_reservation(
+                session_id,
+                &file_path,
+                &recorded_at,
+                &reservation_at,
+            );
+            drop(workers);
+            if let Err(rollback_error) = rollback {
+                return Err(anyhow::anyhow!(error)).context(format!(
+                    "failed to start Claude handoff worker; reservation rollback also failed: {rollback_error:#}"
+                ));
+            }
+            return Err(error).with_context(|| "failed to start Claude handoff worker");
+        }
+        Ok(true)
+    }
+
+    fn claude_handoff_reservation_was_replaced(
+        &self,
+        session_id: &str,
+        file_path: &str,
+        recorded_at: &str,
+        reservation_at: &str,
+    ) -> Result<bool> {
+        let _guard = self.write_guard()?;
+        let state = self.load_raw_json_value()?;
+        let Some(session) = raw_session_object(&state, session_id) else {
+            return Ok(false);
+        };
+        Ok(claude_handoff_reservation_replaced_raw(
+            session,
+            file_path,
+            recorded_at,
+            reservation_at,
+        ))
+    }
+
+    fn release_failed_claude_handoff_worker_reservation(
+        &self,
+        session_id: &str,
+        file_path: &str,
+        recorded_at: &str,
+        reservation_at: &str,
+    ) -> Result<bool> {
+        let released = {
+            let _guard = self.write_guard()?;
+            let mut state = self.load_raw_json_value()?;
+            let sessions = ensure_sessions_array_mut(&mut state)?;
+            let Some(session) = session_object_mut(sessions, session_id) else {
+                return Ok(false);
+            };
+            let matches = json_text(session.get("pending_handoff_path")).as_deref()
+                == Some(file_path)
+                && json_text(session.get("pending_handoff_recorded_at")).as_deref()
+                    == Some(recorded_at)
+                && json_text(session.get("claude_handoff_in_progress_at")).as_deref()
+                    == Some(reservation_at);
+            if matches {
+                session.insert("claude_handoff_in_progress_at".to_owned(), Value::Null);
+                session.insert("status".to_owned(), Value::String("idle".to_owned()));
+                session.insert(
+                    "error_message".to_owned(),
+                    Value::String(
+                        "claude_handoff_failed: failed to start handoff worker".to_owned(),
+                    ),
+                );
+                self.write_raw_json_value(&state)?;
+            }
+            matches
+        };
+        if released {
+            if let Some(runtime) = self.delivery_runtime.as_ref() {
+                let _ = self.drain_runtime_pending_messages_for_session(session_id, runtime);
+            }
+        }
+        Ok(released)
+    }
+
+    fn with_current_claude_handoff_reservation<F>(
+        &self,
+        session_id: &str,
+        file_path: &str,
+        recorded_at: &str,
+        reservation_at: &str,
+        tmux_session: &str,
+        socket_name: &Option<String>,
+        action: F,
+    ) -> Result<bool>
+    where
+        F: FnOnce() -> Result<()>,
+    {
+        let _guard = self.write_guard()?;
+        let state = self.load_raw_json_value()?;
+        let Some(session) = raw_session_object(&state, session_id) else {
+            return Ok(false);
+        };
+        let matches = json_text(session.get("provider")).as_deref() == Some("claude")
+            && normalized_status(&json_text(session.get("status")).unwrap_or_default())
+                != "stopped"
+            && is_primary_node(&json_text(session.get("node")).unwrap_or_else(default_node))
+            && json_text(session.get("tmux_session")).as_deref() == Some(tmux_session)
+            && json_text(session.get("tmux_socket_name")).as_deref() == socket_name.as_deref()
+            && json_text(session.get("pending_handoff_path")).as_deref() == Some(file_path)
+            && json_text(session.get("pending_handoff_recorded_at")).as_deref()
+                == Some(recorded_at)
+            && json_text(session.get("claude_handoff_in_progress_at")).as_deref()
+                == Some(reservation_at);
+        if !matches {
+            return Ok(false);
+        }
+        action()?;
+        Ok(true)
+    }
+
+    fn execute_pending_claude_handoff(&self, session_id: &str) -> Result<bool> {
+        let _clear_guard = self.lock_clear_operation(session_id)?;
+        let (file_path, recorded_at, reservation_at, tmux_session, socket_name) = {
+            let _guard = self.write_guard()?;
+            let state = self.load_raw_json_value()?;
+            let Some(session) = raw_session_object(&state, session_id) else {
+                return Ok(false);
+            };
+            if json_text(session.get("provider")).as_deref() != Some("claude")
+                || normalized_status(&json_text(session.get("status")).unwrap_or_default())
+                    == "stopped"
+            {
+                return Ok(false);
+            }
+            let Some(file_path) = json_text(session.get("pending_handoff_path")) else {
+                return Ok(false);
+            };
+            let Some(recorded_at) = json_text(session.get("pending_handoff_recorded_at")) else {
+                return Ok(false);
+            };
+            let Some(reservation_at) = json_text(session.get("claude_handoff_in_progress_at"))
+            else {
+                return Ok(false);
+            };
+            (
+                file_path,
+                recorded_at,
+                reservation_at,
+                json_text(session.get("tmux_session"))
+                    .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?,
+                json_text(session.get("tmux_socket_name")),
+            )
+        };
+
+        let clear_started = Arc::new(AtomicBool::new(false));
+        let result = (|| {
+            if !Path::new(&file_path).is_file() {
+                anyhow::bail!("handoff file not found: {file_path}");
+            }
+            let runtime = self
+                .delivery_runtime
+                .as_ref()
+                .ok_or_else(|| anyhow::anyhow!("Claude handoff requires the tmux runtime"))?
+                .for_socket_name(socket_name.as_deref());
+            let prompt = format!("Read {file_path} and continue from where you left off.");
+            let precondition_store = self.clone();
+            let precondition_session_id = session_id.to_owned();
+            let precondition_file_path = file_path.clone();
+            let precondition_recorded_at = recorded_at.clone();
+            let precondition_reservation_at = reservation_at.clone();
+            let precondition_tmux_session = tmux_session.clone();
+            let precondition_socket_name = socket_name.clone();
+            let commit_store = self.clone();
+            let commit_session_id = session_id.to_owned();
+            let commit_file_path = file_path.clone();
+            let commit_recorded_at = recorded_at.clone();
+            let commit_reservation_at = reservation_at.clone();
+            let commit_tmux_session = tmux_session.clone();
+            let commit_socket_name = socket_name.clone();
+            let commit_clear_started = clear_started.clone();
+            let prompt_store = self.clone();
+            let prompt_session_id = session_id.to_owned();
+            let prompt_file_path = file_path.clone();
+            let prompt_recorded_at = recorded_at.clone();
+            let prompt_reservation_at = reservation_at.clone();
+            let prompt_tmux_session = tmux_session.clone();
+            let prompt_socket_name = socket_name.clone();
+            runtime.clear_claude_session_if(
+                &tmux_session,
+                &prompt,
+                move || {
+                    precondition_store.with_current_claude_handoff_reservation(
+                        &precondition_session_id,
+                        &precondition_file_path,
+                        &precondition_recorded_at,
+                        &precondition_reservation_at,
+                        &precondition_tmux_session,
+                        &precondition_socket_name,
+                        || Ok(()),
+                    )
+                },
+                move |send_clear| {
+                    commit_store.with_current_claude_handoff_reservation(
+                        &commit_session_id,
+                        &commit_file_path,
+                        &commit_recorded_at,
+                        &commit_reservation_at,
+                        &commit_tmux_session,
+                        &commit_socket_name,
+                        || {
+                            // Conservatively treat an attempted send as
+                            // destructive if tmux reports an error mid-command.
+                            commit_clear_started.store(true, Ordering::Release);
+                            send_clear()
+                        },
+                    )
+                },
+                move |send_prompt| {
+                    prompt_store.with_current_claude_handoff_reservation(
+                        &prompt_session_id,
+                        &prompt_file_path,
+                        &prompt_recorded_at,
+                        &prompt_reservation_at,
+                        &prompt_tmux_session,
+                        &prompt_socket_name,
+                        send_prompt,
+                    )
+                },
+            )
+        })();
+
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let Some(session) = session_object_mut(sessions, session_id) else {
+            return Ok(false);
+        };
+        let current_status = json_text(session.get("status")).unwrap_or_default();
+        let still_same_session = json_text(session.get("provider")).as_deref() == Some("claude")
+            && normalized_status(&current_status) != "stopped"
+            && is_primary_node(&json_text(session.get("node")).unwrap_or_else(default_node))
+            && json_text(session.get("tmux_session")).as_deref() == Some(tmux_session.as_str())
+            && json_text(session.get("tmux_socket_name")) == socket_name;
+        if !still_same_session {
+            return Ok(false);
+        }
+        match result {
+            Ok(ConditionalClearOutcome::Cleared) => {
+                session.insert(
+                    "last_handoff_path".to_owned(),
+                    Value::String(file_path.clone()),
+                );
+                let (cleared_pending, stopped_after_prompt) = consume_completed_claude_handoff_raw(
+                    session,
+                    &file_path,
+                    &recorded_at,
+                    &reservation_at,
+                );
+                let now = now_rfc3339();
+                reset_session_after_clear(session, &now);
+                session.insert(
+                    "status".to_owned(),
+                    Value::String(if stopped_after_prompt {
+                        "idle".to_owned()
+                    } else {
+                        "running".to_owned()
+                    }),
+                );
+                clear_claude_handoff_error_raw(session);
+                self.write_raw_json_value(&state)?;
+                drop(_guard);
+                let _ = self.cancel_context_monitor_alerts(session_id);
+                if let Some(runtime) = self.delivery_runtime.as_ref() {
+                    let _ = self.drain_runtime_pending_messages_for_session(session_id, runtime);
+                }
+                Ok(cleared_pending)
+            }
+            Ok(ConditionalClearOutcome::PostClearPreconditionFailed) => Ok(false),
+            Ok(ConditionalClearOutcome::PreconditionFailed) => {
+                let released = json_text(session.get("claude_handoff_in_progress_at")).as_deref()
+                    == Some(reservation_at.as_str());
+                if released {
+                    session.insert("claude_handoff_in_progress_at".to_owned(), Value::Null);
+                    self.write_raw_json_value(&state)?;
+                }
+                drop(_guard);
+                if let Some(runtime) = self.delivery_runtime.as_ref() {
+                    let _ = self.drain_runtime_pending_messages_for_session(session_id, runtime);
+                }
+                Ok(false)
+            }
+            Ok(
+                outcome @ (ConditionalClearOutcome::IdlePromptNotReady
+                | ConditionalClearOutcome::SessionMissing),
+            ) => {
+                let still_current = json_text(session.get("pending_handoff_path")).as_deref()
+                    == Some(file_path.as_str())
+                    && json_text(session.get("pending_handoff_recorded_at")).as_deref()
+                        == Some(recorded_at.as_str())
+                    && json_text(session.get("claude_handoff_in_progress_at")).as_deref()
+                        == Some(reservation_at.as_str());
+                if still_current {
+                    session.insert("status".to_owned(), Value::String("idle".to_owned()));
+                    session.insert("claude_handoff_in_progress_at".to_owned(), Value::Null);
+                    let reason = match outcome {
+                        ConditionalClearOutcome::IdlePromptNotReady => {
+                            "Claude handoff aborted because the idle prompt was not ready"
+                        }
+                        ConditionalClearOutcome::SessionMissing => "tmux session is not running",
+                        _ => unreachable!(),
+                    };
+                    session.insert(
+                        "error_message".to_owned(),
+                        Value::String(format!("claude_handoff_failed: {reason}")),
+                    );
+                    self.write_raw_json_value(&state)?;
+                }
+                drop(_guard);
+                if still_current {
+                    if let Some(runtime) = self.delivery_runtime.as_ref() {
+                        let _ =
+                            self.drain_runtime_pending_messages_for_session(session_id, runtime);
+                    }
+                }
+                Ok(false)
+            }
+            Err(error) => {
+                let still_current = json_text(session.get("pending_handoff_path")).as_deref()
+                    == Some(file_path.as_str())
+                    && json_text(session.get("pending_handoff_recorded_at")).as_deref()
+                        == Some(recorded_at.as_str())
+                    && json_text(session.get("claude_handoff_in_progress_at")).as_deref()
+                        == Some(reservation_at.as_str());
+                let failed_before_clear = !clear_started.load(Ordering::Acquire);
+                if still_current {
+                    session.insert("status".to_owned(), Value::String("idle".to_owned()));
+                    if failed_before_clear {
+                        session.insert("claude_handoff_in_progress_at".to_owned(), Value::Null);
+                    }
+                    session.insert(
+                        "error_message".to_owned(),
+                        Value::String(format!("claude_handoff_failed: {error}")),
+                    );
+                    self.write_raw_json_value(&state)?;
+                }
+                drop(_guard);
+                if still_current && failed_before_clear {
+                    if let Some(runtime) = self.delivery_runtime.as_ref() {
+                        let _ =
+                            self.drain_runtime_pending_messages_for_session(session_id, runtime);
+                    }
+                }
+                Ok(false)
+            }
+        }
     }
 
     pub fn recover_codex_fork_event_monitors(&self) -> Result<usize> {
@@ -5788,6 +6306,9 @@ fn deliver_runtime_text_to_session_raw(
     let node = json_text(session.get("node")).unwrap_or_else(default_node);
     ensure_runtime_local_node(&node)?;
     let mut status = json_text(session.get("status")).unwrap_or_else(|| "running".to_owned());
+    if claude_handoff_is_reserved_raw(session) {
+        return Ok((status, false));
+    }
     let tmux_session = json_text(session.get("tmux_session"))
         .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?;
     let session_socket_name = json_text(session.get("tmux_socket_name"));
@@ -5835,6 +6356,9 @@ fn deliver_urgent_runtime_text_to_session_raw(
     let node = json_text(session.get("node")).unwrap_or_else(default_node);
     ensure_runtime_local_node(&node)?;
     let mut status = json_text(session.get("status")).unwrap_or_else(|| "running".to_owned());
+    if claude_handoff_is_reserved_raw(session) {
+        return Ok((status, false));
+    }
     let tmux_session = json_text(session.get("tmux_session"))
         .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?;
     let provider = json_text(session.get("provider")).unwrap_or_else(|| "claude".to_owned());
@@ -5892,6 +6416,9 @@ fn deliver_runtime_native_rename_to_session_raw(
     ensure_runtime_local_node(&node)?;
     let status = json_text(session.get("status")).unwrap_or_else(|| "running".to_owned());
     if normalized_status(&status) == "stopped" {
+        return Ok((status, false));
+    }
+    if claude_handoff_is_reserved_raw(session) {
         return Ok((status, false));
     }
     let Some(friendly_name) = extract_provider_native_rename_name(text) else {
@@ -6283,6 +6810,73 @@ fn clear_codex_fork_handoff_error_raw(session: &mut Map<String, Value>) {
     if is_handoff_error {
         session.insert("error_message".to_owned(), Value::Null);
     }
+}
+
+fn clear_claude_handoff_error_raw(session: &mut Map<String, Value>) {
+    let is_handoff_error = json_text(session.get("error_message"))
+        .as_deref()
+        .is_some_and(|message| message.starts_with("claude_handoff_failed:"));
+    if is_handoff_error {
+        session.insert("error_message".to_owned(), Value::Null);
+    }
+}
+
+fn claude_handoff_is_reserved_raw(session: &Map<String, Value>) -> bool {
+    json_text(session.get("provider")).as_deref() == Some("claude")
+        && json_text(session.get("claude_handoff_in_progress_at")).is_some()
+}
+
+fn claude_handoff_reservation_replaced_raw(
+    session: &Map<String, Value>,
+    file_path: &str,
+    recorded_at: &str,
+    reservation_at: &str,
+) -> bool {
+    if json_text(session.get("provider")).as_deref() != Some("claude")
+        || normalized_status(&json_text(session.get("status")).unwrap_or_default()) == "stopped"
+        || !is_primary_node(&json_text(session.get("node")).unwrap_or_else(default_node))
+    {
+        return false;
+    }
+    let Some(current_file_path) = json_text(session.get("pending_handoff_path")) else {
+        return false;
+    };
+    let Some(current_recorded_at) = json_text(session.get("pending_handoff_recorded_at")) else {
+        return false;
+    };
+    let Some(current_reservation_at) = json_text(session.get("claude_handoff_in_progress_at"))
+    else {
+        return false;
+    };
+    current_file_path != file_path
+        || current_recorded_at != recorded_at
+        || current_reservation_at != reservation_at
+}
+
+fn consume_completed_claude_handoff_raw(
+    session: &mut Map<String, Value>,
+    file_path: &str,
+    recorded_at: &str,
+    reservation_at: &str,
+) -> (bool, bool) {
+    let cleared_pending = json_text(session.get("pending_handoff_path")).as_deref()
+        == Some(file_path)
+        && json_text(session.get("pending_handoff_recorded_at")).as_deref() == Some(recorded_at);
+    let stopped_after_prompt = cleared_pending
+        && json_text(session.get("claude_handoff_in_progress_at"))
+            .is_some_and(|current| current != reservation_at);
+    if cleared_pending {
+        session.insert("pending_handoff_path".to_owned(), Value::Null);
+        session.insert("pending_handoff_recorded_at".to_owned(), Value::Null);
+        // The handoff turn's own Stop may refresh this timestamp before the
+        // worker persists success. It still reserves the intent consumed here.
+        session.insert("claude_handoff_in_progress_at".to_owned(), Value::Null);
+    } else if json_text(session.get("claude_handoff_in_progress_at")).as_deref()
+        == Some(reservation_at)
+    {
+        session.insert("claude_handoff_in_progress_at".to_owned(), Value::Null);
+    }
+    (cleared_pending, stopped_after_prompt)
 }
 
 fn drain_pending_runtime_messages_raw(
@@ -9676,11 +10270,123 @@ mod tests {
     }
 
     #[test]
+    fn completed_claude_handoff_clears_refreshed_reservation_for_consumed_intent() {
+        let mut session = json!({
+            "pending_handoff_path": "/tmp/handoff.md",
+            "pending_handoff_recorded_at": "2026-08-11T20:00:00Z",
+            "claude_handoff_in_progress_at": "2026-08-11T20:00:02Z"
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
+        let outcome = consume_completed_claude_handoff_raw(
+            &mut session,
+            "/tmp/handoff.md",
+            "2026-08-11T20:00:00Z",
+            "2026-08-11T20:00:01Z",
+        );
+        assert_eq!(outcome, (true, true));
+        assert!(session["pending_handoff_path"].is_null());
+        assert!(session["pending_handoff_recorded_at"].is_null());
+        assert!(session["claude_handoff_in_progress_at"].is_null());
+    }
+
+    #[test]
+    fn retiring_claude_handoff_worker_detects_a_replacement_reservation() {
+        let session = json!({
+            "provider": "claude",
+            "status": "running",
+            "node": "primary",
+            "pending_handoff_path": "/tmp/replacement.md",
+            "pending_handoff_recorded_at": "2026-08-11T20:00:02Z",
+            "claude_handoff_in_progress_at": "2026-08-11T20:00:03Z"
+        });
+
+        assert!(claude_handoff_reservation_replaced_raw(
+            session.as_object().unwrap(),
+            "/tmp/original.md",
+            "2026-08-11T20:00:00Z",
+            "2026-08-11T20:00:01Z",
+        ));
+        assert!(!claude_handoff_reservation_replaced_raw(
+            session.as_object().unwrap(),
+            "/tmp/replacement.md",
+            "2026-08-11T20:00:02Z",
+            "2026-08-11T20:00:03Z",
+        ));
+    }
+
+    #[test]
+    fn failed_claude_handoff_worker_start_releases_matching_reservation() {
+        let store = store_with_running_claude_session("workerfail");
+        {
+            let mut state = store.load_raw_json_value().unwrap();
+            let sessions = ensure_sessions_array_mut(&mut state).unwrap();
+            let session = session_object_mut(sessions, "workerfail").unwrap();
+            session.insert(
+                "pending_handoff_path".to_owned(),
+                Value::String("/tmp/workerfail-handoff.md".to_owned()),
+            );
+            session.insert(
+                "pending_handoff_recorded_at".to_owned(),
+                Value::String("2026-08-11T20:00:00Z".to_owned()),
+            );
+            session.insert(
+                "claude_handoff_in_progress_at".to_owned(),
+                Value::String("2026-08-11T20:00:01Z".to_owned()),
+            );
+            store.write_raw_json_value(&state).unwrap();
+        }
+
+        assert!(store
+            .release_failed_claude_handoff_worker_reservation(
+                "workerfail",
+                "/tmp/workerfail-handoff.md",
+                "2026-08-11T20:00:00Z",
+                "2026-08-11T20:00:01Z",
+            )
+            .unwrap());
+
+        let state = store.load_raw_json_value().unwrap();
+        let session = raw_session_object(&state, "workerfail").unwrap();
+        assert_eq!(json_text(session.get("status")).as_deref(), Some("idle"));
+        assert!(json_text(session.get("pending_handoff_path")).is_some());
+        assert!(json_text(session.get("pending_handoff_recorded_at")).is_some());
+        assert!(json_text(session.get("claude_handoff_in_progress_at")).is_none());
+        assert_eq!(
+            json_text(session.get("error_message")).as_deref(),
+            Some("claude_handoff_failed: failed to start handoff worker")
+        );
+    }
+
+    #[test]
     fn claude_user_prompt_submit_hook_marks_the_turn_running() {
         let store = store_with_running_claude_session("turnstart");
+        {
+            let mut state = store.load_raw_json_value().unwrap();
+            let sessions = ensure_sessions_array_mut(&mut state).unwrap();
+            let session = session_object_mut(sessions, "turnstart").unwrap();
+            session.insert(
+                "pending_handoff_path".to_owned(),
+                Value::String("/tmp/turnstart-handoff.md".to_owned()),
+            );
+            session.insert(
+                "pending_handoff_recorded_at".to_owned(),
+                Value::String("2026-06-01T00:00:00Z".to_owned()),
+            );
+            store.write_raw_json_value(&state).unwrap();
+        }
         assert!(store
             .apply_claude_stop_hook("turnstart", None, None, None, None, None, None)
             .unwrap());
+        let reserved = store.load_raw_json_value().unwrap();
+        assert!(json_text(
+            raw_session_object(&reserved, "turnstart")
+                .unwrap()
+                .get("claude_handoff_in_progress_at")
+        )
+        .is_some());
         assert!(store
             .apply_claude_user_prompt_submit_hook("turnstart", None)
             .unwrap());
@@ -9690,6 +10396,13 @@ mod tests {
         assert_eq!(session.status, "running");
         assert!(session.agent_task_completed_at.is_none());
         assert_eq!(claude_hook_gate(&session), ClaudeHookGate::TurnRunning);
+        let cancelled = store.load_raw_json_value().unwrap();
+        assert!(json_text(
+            raw_session_object(&cancelled, "turnstart")
+                .unwrap()
+                .get("claude_handoff_in_progress_at")
+        )
+        .is_none());
     }
 
     #[test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -13410,7 +13410,7 @@ async fn runtime_core_replays_retained_urgent_rows_with_interrupt_semantics() {
 }
 
 #[tokio::test]
-async fn runtime_core_handoff_records_without_interrupting_active_turn() {
+async fn runtime_core_claude_handoff_executes_after_stop_without_interrupting_active_turn() {
     if !tmux_available() {
         return;
     }
@@ -13431,7 +13431,7 @@ async fn runtime_core_handoff_records_without_interrupting_active_turn() {
         &state_file,
         &log_dir,
         _tmux_guard.0.as_str(),
-        r#"/bin/sh -lc 'printf ">\n"; while IFS= read -r line; do printf "runtime:%s\n>\n" "$line"; done' runtime-sh"#,
+        r#"/bin/sh -lc 'printf ">\n"; while IFS= read -r line; do if [ "$line" = "/clear" ]; then sleep 1; fi; printf "runtime:%s\n>\n" "$line"; done' runtime-sh"#,
     );
 
     let (status, _payload) = post_json(
@@ -13475,9 +13475,97 @@ async fn runtime_core_handoff_records_without_interrupting_active_turn() {
         .unwrap()
         .contains("continue from where you left off"));
 
-    let (status, payload) = get_json(app, "/sessions/runtimehandoff").await;
+    let (status, payload) = get_json(app.clone(), "/sessions/runtimehandoff").await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["last_handoff_path"], Value::Null);
+    assert_eq!(
+        payload["friendly_name"],
+        Value::String("runtime-handoff".to_owned())
+    );
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/hooks/claude",
+        json!({
+            "hook_event_name": "Stop",
+            "session_manager_id": "runtimehandoff",
+            "sm_hook_emitted_at": "2026-08-11T20:00:00.000000Z"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload, json!({ "status": "ok" }));
+
+    let stopped_state: Value =
+        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let stopped_handoff = stopped_state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "runtimehandoff")
+        .unwrap();
+    assert_eq!(stopped_handoff["status"], "running");
+    assert_eq!(
+        stopped_handoff["pending_handoff_path"],
+        handoff_path.display().to_string()
+    );
+    assert!(stopped_handoff["pending_handoff_recorded_at"].is_string());
+    assert!(stopped_handoff["claude_handoff_in_progress_at"].is_string());
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/runtimehandoff/input",
+        json!({
+            "text": "queued during handoff reservation",
+            "delivery_mode": "sequential"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["delivered"], false);
+
+    let handoff_output = wait_for_output_contains(
+        app.clone(),
+        "runtimehandoff",
+        &format!(
+            "runtime:Read {} and continue from where you left off.",
+            handoff_path.display()
+        ),
+    )
+    .await;
+    assert!(handoff_output["output"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("/clear"));
+    let queued_output = wait_for_output_contains(
+        app.clone(),
+        "runtimehandoff",
+        "runtime:queued during handoff reservation",
+    )
+    .await;
+    let queued_output = queued_output["output"].as_str().unwrap_or_default();
+    let handoff_position = queued_output
+        .find("continue from where you left off")
+        .expect("handoff prompt missing from output");
+    let queued_position = queued_output
+        .find("queued during handoff reservation")
+        .expect("queued message missing from output");
+    assert!(handoff_position < queued_position);
+
+    let mut completed = Value::Null;
+    for _ in 0..30 {
+        let (status, payload) = get_json(app.clone(), "/sessions/runtimehandoff").await;
+        assert_eq!(status, StatusCode::OK);
+        if payload["last_handoff_path"] == handoff_path.display().to_string() {
+            completed = payload;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert_ne!(completed, Value::Null, "handoff metadata was not promoted");
+    assert_eq!(completed["id"], "runtimehandoff");
+    assert_eq!(completed["friendly_name"], "runtime-handoff");
+
     let raw_state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
     let runtime_handoff = raw_state["sessions"]
         .as_array()
@@ -13485,10 +13573,206 @@ async fn runtime_core_handoff_records_without_interrupting_active_turn() {
         .iter()
         .find(|session| session["id"] == "runtimehandoff")
         .unwrap();
+    assert!(runtime_handoff["pending_handoff_path"].is_null());
+    assert!(runtime_handoff["pending_handoff_recorded_at"].is_null());
+    assert!(runtime_handoff["claude_handoff_in_progress_at"].is_null());
     assert_eq!(
-        runtime_handoff["pending_handoff_path"],
+        runtime_handoff["last_handoff_path"],
         handoff_path.display().to_string()
     );
+}
+
+#[tokio::test]
+async fn runtime_core_claude_handoff_failure_retains_pending_and_restart_recovers() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let working_dir = unique_temp_path();
+    fs::create_dir_all(&working_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-test-handoff-recovery-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let runtime_command = r#"/bin/sh -lc 'printf ">\n"; while IFS= read -r line; do printf "runtime:%s\n>\n" "$line"; done' runtime-sh"#;
+    let app = runtime_app_with_command(&state_file, &log_dir, &tmux_socket, runtime_command);
+
+    let (status, _) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "runtimehandoffrecovery",
+            "name": "runtime-handoff-recovery",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude",
+            "initial_message": "initial recovery prompt"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    wait_for_output_contains(
+        app.clone(),
+        "runtimehandoffrecovery",
+        "runtime:initial recovery prompt",
+    )
+    .await;
+
+    let handoff_path = unique_temp_path();
+    fs::write(&handoff_path, "handoff body").unwrap();
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/runtimehandoffrecovery/handoff",
+        json!({
+            "requester_session_id": "runtimehandoffrecovery",
+            "file_path": handoff_path.display().to_string()
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "recorded");
+    fs::remove_file(&handoff_path).unwrap();
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/hooks/claude",
+        json!({
+            "hook_event_name": "Stop",
+            "session_manager_id": "runtimehandoffrecovery",
+            "sm_hook_emitted_at": "2026-08-11T20:00:00.000000Z"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload, json!({ "status": "ok" }));
+
+    let mut failed = Value::Null;
+    for _ in 0..30 {
+        let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+        let session = state["sessions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|session| session["id"] == "runtimehandoffrecovery")
+            .unwrap();
+        if session["error_message"]
+            .as_str()
+            .is_some_and(|message| message.starts_with("claude_handoff_failed:"))
+        {
+            failed = session.clone();
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert_ne!(failed, Value::Null, "handoff failure was not persisted");
+    assert_eq!(
+        failed["pending_handoff_path"],
+        handoff_path.display().to_string()
+    );
+    assert!(failed["last_handoff_path"].is_null());
+    assert_eq!(failed["status"], "idle");
+    assert!(failed["pending_handoff_recorded_at"].is_string());
+    assert!(failed["claude_handoff_in_progress_at"].is_null());
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/runtimehandoffrecovery/input",
+        json!({
+            "text": "delivery after pre-clear handoff failure",
+            "delivery_mode": "sequential"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["delivered"], true);
+    wait_for_output_contains(
+        app,
+        "runtimehandoffrecovery",
+        "runtime:delivery after pre-clear handoff failure",
+    )
+    .await;
+
+    fs::write(&handoff_path, "restored handoff body").unwrap();
+    let mut legacy_state: Value =
+        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    legacy_state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "runtimehandoffrecovery")
+        .unwrap()["pending_handoff_recorded_at"] = Value::Null;
+    fs::write(
+        &state_file,
+        serde_json::to_string_pretty(&legacy_state).unwrap(),
+    )
+    .unwrap();
+    let legacy_restart =
+        runtime_app_with_command(&state_file, &log_dir, &tmux_socket, runtime_command);
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    let (status, legacy_output) = get_json(
+        legacy_restart,
+        "/sessions/runtimehandoffrecovery/output?lines=20",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(!legacy_output["output"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("continue from where you left off"));
+
+    legacy_state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "runtimehandoffrecovery")
+        .unwrap()["pending_handoff_recorded_at"] = Value::String("2026-08-11T20:00:00Z".to_owned());
+    fs::write(
+        &state_file,
+        serde_json::to_string_pretty(&legacy_state).unwrap(),
+    )
+    .unwrap();
+    let restarted = runtime_app_with_command(&state_file, &log_dir, &tmux_socket, runtime_command);
+    tokio::time::sleep(Duration::from_secs(4)).await;
+    wait_for_output_contains(
+        restarted.clone(),
+        "runtimehandoffrecovery",
+        &format!(
+            "runtime:Read {} and continue from where you left off.",
+            handoff_path.display()
+        ),
+    )
+    .await;
+
+    let mut recovered = Value::Null;
+    for _ in 0..30 {
+        let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+        let session = state["sessions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|session| session["id"] == "runtimehandoffrecovery")
+            .unwrap();
+        if session["last_handoff_path"] == handoff_path.display().to_string() {
+            recovered = session.clone();
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert_ne!(
+        recovered,
+        Value::Null,
+        "restart did not recover the handoff"
+    );
+    assert!(recovered["pending_handoff_path"].is_null());
+    assert!(recovered["pending_handoff_recorded_at"].is_null());
+    assert!(recovered["claude_handoff_in_progress_at"].is_null());
+    assert!(recovered["error_message"].is_null());
+    assert_eq!(recovered["status"], "running");
 }
 
 #[tokio::test]

--- a/docs/working/196_sm_handoff.md
+++ b/docs/working/196_sm_handoff.md
@@ -4,6 +4,46 @@
 **Status:** Draft (rev 4 — post-re-review)
 **Author:** Scout
 
+## Rust core parity
+
+The original implementation below describes the Python Stop-hook path. Rust
+initially ported the handoff endpoint without porting that Claude execution
+path; #1178 then added the separate codex-fork turn-complete path. Issue #1203
+closes the remaining Claude parity gap:
+
+- a non-superseded Claude `Stop` atomically reserves the seat before starting
+  a deferred, per-seat handoff worker, so queued delivery cannot enter the
+  soon-to-be-cleared context;
+- the worker serializes with other clears and pane input, revalidates the exact
+  lifecycle reservation, requires an idle prompt before `/clear` and after its
+  redraw, then injects the durable handoff prompt;
+- a newer `UserPromptSubmit` or `PreToolUse` cancels the reservation without
+  consuming the pending handoff; messages held by a successful reservation are
+  delivered only after the new handoff prompt is submitted;
+- success promotes `pending_handoff_path` to `last_handoff_path` and resets the
+  context cycle, including reconciling a reservation refreshed by the handoff
+  turn's own fast Stop and preserving that Stop's idle state; failure keeps
+  pending state and records an actionable error;
+- worker cleanup starts a replacement reservation recorded while the previous
+  handoff worker was still retiring;
+- definite pre-clear failures release the reservation and queued delivery while
+  preserving the pending intent for a later Stop or startup retry; failures
+  after `/clear` starts remain reserved because pane state is uncertain;
+- failure to create the handoff worker rolls its durable reservation back and
+  releases queued delivery;
+- post-`/clear` readiness requires a changed pane at the idle prompt, so the
+  stale pre-clear prompt cannot satisfy completion;
+- the exact lifecycle reservation is revalidated under the state guard again
+  when the handoff prompt is submitted after `/clear`;
+- startup retries post-#1203 Claude handoffs whose Stop reservation was
+  durably recorded before the server exited;
+- pre-#1203 pending records have no `pending_handoff_recorded_at` marker and are
+  deliberately not replayed during deployment. The seat must run `sm handoff`
+  again if that older intent is still wanted.
+
+The phrase "historical Claude Stop-hook workflow" in #1178 referred to this
+Python design. It did not identify an already-working Rust Claude path.
+
 ## Problem
 
 Long-running agents accumulate context until compaction fires. Compaction is expensive, lossy, and unpredictable — the agent doesn't control when it happens or what gets dropped. Agents need a way to proactively rotate their own context by writing a handoff doc and restarting with it.


### PR DESCRIPTION
## Summary
- execute pending Claude handoffs only after a non-superseded Stop hook
- atomically reserve the seat so new lifecycle activity cancels the clear and queued delivery cannot be erased
- require fresh prompt readiness and exact lifecycle ownership after `/clear` before consuming the durable handoff
- preserve failed work for restart recovery and version pending intents against replacement races
- recover only post-fix reserved Claude handoffs on startup so deployment cannot replay legacy dormant intents
- correct the design record: #1178 described the Python-era Claude workflow, not an existing Rust Claude path

## Migration safety
Pre-fix Claude pending records do not contain `pending_handoff_recorded_at` and are deliberately not replayed. A seat must run `sm handoff` again after deployment if that older intent is still desired.

## Review fixes
- P1: revalidate the exact reservation while holding the pane input lock, then hold the lifecycle state guard through `/clear` submission; `UserPromptSubmit` and `PreToolUse` cancel before that commit point
- P1: revalidate and hold the exact lifecycle reservation again while submitting the handoff prompt after `/clear`; an intervening user turn is left untouched
- P1: hold sequential, urgent, and native-rename delivery during the reservation, then drain after the new handoff prompt is submitted
- P1: when success consumes the exact pending intent, reconcile a reservation timestamp refreshed by the handoff turn's own fast Stop so it cannot become orphaned
- P1: after a worker retires, claim a replacement reservation recorded while that worker still occupied the per-seat worker slot
- P2: fail without consuming the handoff prompt when the idle prompt or post-`/clear` redraw is not ready
- P2: require changed rendered pane content at the post-`/clear` prompt so the stale pre-clear `>` cannot satisfy readiness
- P2: preserve idle status when the handoff turn's Stop is recorded before success metadata is persisted
- P2: release the reservation and drain queued input after definite pre-clear failures while retaining the pending handoff for a later Stop or startup retry; keep post-clear failures reserved because pane state is uncertain
- P2: conditionally roll back durable state and queued delivery if the OS cannot create the handoff worker

## Verification
- `cargo check -p sm-server`
- `cargo test -p sm-server conditional_claude_clear --lib -- --nocapture` (3 passed)
- `cargo test -p sm-server fresh_prompt_wait --lib -- --nocapture` (1 passed)
- `cargo test -p sm-server completed_claude_handoff --lib -- --nocapture` (1 passed)
- `cargo test -p sm-server retiring_claude_handoff_worker --lib -- --nocapture` (1 passed)
- `cargo test -p sm-server failed_claude_handoff_worker_start --lib -- --nocapture` (1 passed)
- `cargo test -p sm-server claude_stop_hook --lib -- --nocapture` (4 passed)
- `cargo test -p sm-server --test read_only_http runtime_core_claude_handoff -- --nocapture` (2 passed)
- `cargo test -p sm-server --test read_only_http claude_stop_hook -- --nocapture` (8 passed)
- `cargo test` (372 library, 64 CLI, 243 HTTP/integration passed)
- `cargo fmt --all -- --check`
- `git diff --check`

Fixes #1203
