### PR TITLE
spec: consent-based reparent authority transfer

### DIFF
--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -35,6 +35,8 @@ sm reparent reject <request-id>
 sm reparent status [request-id]
 sm reparent repair <request-id> --resume
 sm reparent repair <request-id> --rollback-precommit
+sm recredential <session>
+sm recredential --all-live
 sm adopt <child>
 ```
 
@@ -106,9 +108,31 @@ impersonate an agent approval.
 The same per-session credential gate applies to request creation. Credential
 material is never returned by session/list APIs, written to logs, included in
 notifications, or persisted in plaintext. Existing live sessions without a
-verifier cannot approve after deployment until Session Manager rotates a
-credential into that runtime; rollout must provide an explicit credential
-rotation path and must not fall back to trusting an ID-only payload.
+verifier cannot approve after deployment until Session Manager relaunches that
+runtime with a credential. The operator-authenticated `sm recredential` command
+provides that path; it never falls back to trusting an ID-only payload.
+
+Recredentialing is a durable, idle-only relaunch of the same seat and provider
+thread, not an attempt to mutate a running process environment. Before stopping
+anything, the server must prove the provider has resumable identity, persist a
+rotation record, acquire the session input fence, and verify that the provider
+turn is idle and its input queue is drained. Idle proof must be observed after
+the rotation was requested (a fresh Claude prompt/Stop boundary or Codex
+lifecycle event), not inferred from a stale projected status. Busy or unproven
+seats remain `waiting_idle` and are retried by the provider Stop/event path.
+The relaunch preserves the Session Manager ID, parent graph, task metadata, and
+provider resume ID; it rotates the runtime credential and verifier. A crash
+after the old runtime is
+stopped resumes the recorded relaunch on startup. If resumability or readiness
+cannot be established, the old runtime remains untouched and the rotation
+fails closed. There is no force-active mode in this epic.
+
+Deployment does not silently relaunch the fleet. After the merged server is
+healthy, the maintainer runs `sm recredential --all-live`; the command reports
+which seats were rotated, waiting for idle, already credentialed, or failed.
+Until a legacy seat completes this bootstrap, reparent commands fail with the
+exact `sm recredential <session>` remediation. Newly created and normally
+restored seats already receive credentials and need no bootstrap.
 
 Session Manager agents share one operating-system account and filesystem. A
 hostile same-UID process with arbitrary process-inspection capability is outside
@@ -131,8 +155,8 @@ conflicting or unauthorized decisions fail.
 Requests expire after 24 hours by default. Expiration and staleness are evaluated
 under the session-state write lock before every read that claims actionability
 and before every decision or pre-quiesce apply attempt. An `applying` request at
-or beyond `routing_quiesced` never expires; recovery must finish its immutable
-transaction.
+or beyond `json_routing_quiesced` never expires; recovery must finish its
+immutable transaction.
 
 ## Durable model
 
@@ -157,8 +181,9 @@ decided_at
 applied_at
 failure_reason
 topology_fingerprint
-apply_stage                nullable | routing_quiesced |
-                           authority_committed | repair_rolled_back
+apply_stage                nullable | json_routing_quiesced |
+                           routing_quiesced | authority_committed |
+                           repair_rolled_back
 apply_plan                 nullable while pending; immutable once applying
 notification_intents[]     deterministic event/recipient delivery records
 repair_history[]           actor, action, prior failure, timestamp,
@@ -184,6 +209,8 @@ of parent-derived wake/message metadata for that child is deferred behind the
 transaction. After `authority_committed`, deferred creation derives the new
 canonical parent. Every parent-derived route creation path must use this fence;
 direct queue-table writes are not permitted.
+Parent-derived route reads and mutations, including task-complete fallback and
+deactivation, use the same fence; it is not limited to creation.
 
 The topology fingerprint is a canonical hash over operation kind, subject,
 target, expected parent, and sorted frozen live children. Revalidation compares
@@ -196,6 +223,14 @@ requests with reason `legacy proposal requires a new consent request`, or are
 left read-only while the new projection exposes the same reason. Either shape
 must preserve the old data and prevent old one-party approvals from becoming
 new authority.
+
+Credential bootstrap uses a separate top-level
+`session_credential_rotations` collection. Each record freezes the session ID,
+provider, provider resume ID, original tmux/runtime identity, request actor,
+status (`waiting_idle | relaunching | applied | failed`), requested event
+cursor/timestamp, later idle proof, timestamps, and failure reason. It never
+contains the plaintext credential. Only one active rotation may cover a seat,
+and successful records are idempotent audit history.
 
 ## Validation
 
@@ -212,7 +247,7 @@ Request creation and apply both reject:
 - tree promotion where target is not source's live direct child;
 - duplicate active requests whose affected edge sets overlap;
 - any request whose affected edge set overlaps a `failed` transaction that
-  reached `routing_quiesced` or later and has not been explicitly repaired;
+  reached `json_routing_quiesced` or later and has not been explicitly repaired;
 - a topology that changed after request creation.
 
 Apply revalidates all identities, liveness, topology, consent, and cycle
@@ -256,21 +291,25 @@ therefore a recoverable, fail-closed staged operation:
 1. Under the session write lock, revalidate and persist `status=applying` with
    the complete immutable plan. Parent edges remain unchanged.
 2. Through the queue coordinator's routing fence, stop and remove each affected
-   in-memory parent-wake task/registration, then in one SQLite transaction
-   idempotently quiesce affected parent-derived wake registrations and pending
-   wake metadata. Persist
-   `apply_stage=routing_quiesced` in JSON. A replay accepts either each plan
-   entry's recorded pre-state or its exact already-quiesced state; any third
-   state fails closed. On process restart, inactive SQLite rows cannot recreate
-   the stopped runtime tasks.
+   in-memory parent-wake task/registration. Under the session-state lock,
+   atomically mark every affected retained JSON parent-wake registration
+   inactive and persist `apply_stage=json_routing_quiesced`. Task-complete and
+   all other fallback reads treat that record as inactive, so they cannot route
+   to the old parent. Then, in one SQLite transaction, idempotently quiesce
+   affected parent-derived wake registrations and pending wake metadata and
+   persist `apply_stage=routing_quiesced` in JSON. A replay accepts either each
+   plan entry's recorded pre-state or its exact already-quiesced state; any
+   third state fails closed. On process restart, inactive JSON and SQLite rows
+   cannot recreate the stopped runtime tasks.
 3. In one atomic JSON replacement, update all parent edges and JSON-backed
    routing, and persist `apply_stage=authority_committed`. Dynamic
    task-complete and wait-monitor delivery now resolves this canonical edge.
 4. In one idempotent SQLite transaction, retarget and reactivate affected
-   parent-derived routes, then recreate their in-memory registrations/tasks
-   with the new target under the routing fence and mark the JSON request
-   `applied`. Replay accepts an already-correct runtime registration and never
-   starts a duplicate task.
+   parent-derived routes. Under the state lock, retarget and reactivate the
+   retained JSON registrations, then recreate their in-memory tasks with the
+   new target under the routing fence and mark the JSON request `applied`.
+   Replay accepts an already-correct runtime registration and never starts a
+   duplicate task.
 
 An interruption before step 3 exposes no new destructive authority and leaves
 old-parent routing paused rather than misdirected. An interruption after step 3
@@ -283,10 +322,10 @@ recorded transaction or reports a durable `failed` state requiring operator
 repair; it never silently rolls authority back to a topology that may already
 have been observed.
 
-A `failed` request at or beyond `routing_quiesced` remains a durable quarantine,
-not a released terminal edge. Its complete affected edge set stays reserved by
-the overlap fence, parent-derived route creation remains deferred for those
-children, and no later request may include any reserved edge. Only an
+A `failed` request at or beyond `json_routing_quiesced` remains a durable
+quarantine, not a released terminal edge. Its complete affected edge set stays
+reserved by the overlap fence, parent-derived route creation remains deferred
+for those children, and no later request may include any reserved edge. Only an
 authenticated operator repair action may either resume the immutable plan or
 restore and verify its exact pre-commit state before clearing the quarantine.
 Merely rejecting, expiring, deleting, or recreating the request cannot release
@@ -296,9 +335,10 @@ The authenticated human repair route supports exactly two audited actions:
 
 1. `resume` records a repair attempt, changes `failed` back to `applying`, and
    retries the same immutable plan from its persisted stage. It never replans.
-2. `rollback_precommit` is accepted only from `routing_quiesced`, before
-   `authority_committed`. Under the routing fence, the server restores every
-   route to the apply plan's exact recorded pre-state, verifies all parent edges
+2. `rollback_precommit` is accepted only from `json_routing_quiesced` or
+   `routing_quiesced`, before `authority_committed`. Under the routing fence,
+   the server restores every route to the apply plan's exact recorded
+   pre-state, verifies all parent edges
    still match the old topology and all runtime/JSON/SQLite routes match that
    pre-state, then atomically records `status=repaired` and
    `apply_stage=repair_rolled_back`. Any mismatch leaves the request failed and
@@ -346,6 +386,8 @@ POST /reparent-requests/{request_id}/reject
 POST /reparent-requests/{request_id}/human-approve
 POST /reparent-requests/{request_id}/human-reject
 POST /reparent-requests/{request_id}/repair
+POST /sessions/{session_id}/credential-rotation
+GET  /session-credential-rotations
 ```
 
 Creation payloads carry `requester_session_id`; decision payloads carry the same
@@ -355,6 +397,9 @@ Operator watch can list all pending human-gated requests.
 The repair route is operator-authenticated only and accepts
 `action=resume|rollback_precommit`; an agent session credential cannot invoke
 it. `sm watch` exposes the same actions with the stage-specific safety text.
+Credential-rotation routes are also operator-authenticated only. The create
+route returns the durable rotation state; repeated calls return the existing
+active or already-applied record rather than scheduling a second relaunch.
 
 HTTP status conventions:
 
@@ -396,7 +441,9 @@ events retain the parent/seat metadata recorded when they occurred.
 
 Add the durable request schema, legacy migration/projection, topology planning,
 consent state machine, expiry/staleness handling, read/decision HTTP API, and
-focused tests. No request may apply yet.
+focused tests. Add runtime credential issue/verification plus the durable
+idle-only credential-rotation API and recovery path. No reparent request may
+apply yet.
 
 ### Phase 1 - #1208
 
@@ -432,6 +479,9 @@ PR targets `main`. Partial phases are not deployed.
   durable stage.
 - Post-quiesce failures retain their overlap/routing fence; only a successful
   immutable-plan retry or verified pre-commit rollback releases it.
+- A pre-deployment live seat is recredentialed only after it becomes idle, keeps
+  its seat and provider-thread identity, and recovers a crash after stop without
+  accepting input under two runtimes.
 - Legacy pending adoption records cannot auto-apply.
 - Rust CLI parser/dispatch and Python watch interaction tests pass.
 - Full Rust and retained Python test suites pass, or any demonstrably preexisting

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -158,6 +158,7 @@ topology_fingerprint
 apply_stage                nullable | routing_quiesced |
                            authority_committed
 apply_plan                 nullable while pending; immutable once applying
+notification_intents[]     deterministic event/recipient delivery records
 ```
 
 `apply_plan` is versioned and contains the complete retry input rather than a
@@ -174,8 +175,11 @@ queue_routing_changes[]    table/record ID, child ID, expected old target,
 The transition from `pending` to `applying` discovers these exact records once
 under the state lock and persists the plan before quiescing anything. Recovery
 uses only this plan plus expected-value checks. A route created after planning
-must derive its parent from the canonical graph and is not retroactively folded
-into the in-flight plan.
+must not escape the plan: while an `applying` request covers a child, creation
+of parent-derived wake/message metadata for that child is deferred behind the
+transaction. After `authority_committed`, deferred creation derives the new
+canonical parent. Every parent-derived route creation path must use this fence;
+direct queue-table writes are not permitted.
 
 The topology fingerprint is a canonical hash over operation kind, subject,
 target, expected parent, and sorted frozen live children. Revalidation compares
@@ -236,8 +240,11 @@ therefore a recoverable, fail-closed staged operation:
 
 1. Under the session write lock, revalidate and persist `status=applying` with
    the complete immutable plan. Parent edges remain unchanged.
-2. In one SQLite transaction, quiesce affected parent-derived wake registrations
-   and pending wake metadata. Persist `apply_stage=routing_quiesced` in JSON.
+2. In one SQLite transaction, idempotently quiesce affected parent-derived wake
+   registrations and pending wake metadata. Persist
+   `apply_stage=routing_quiesced` in JSON. A replay accepts either each plan
+   entry's recorded pre-state or its exact already-quiesced state; any third
+   state fails closed.
 3. In one atomic JSON replacement, update all parent edges and JSON-backed
    routing, and persist `apply_stage=authority_committed`. Dynamic
    task-complete and wait-monitor delivery now resolves this canonical edge.
@@ -256,7 +263,8 @@ repair; it never silently rolls authority back to a topology that may already
 have been observed.
 
 No network delivery occurs while holding the write lock. Approval and outcome
-notifications are queued after the durable state transition.
+notification intents are persisted in the same JSON transition that creates
+them, then reconciled to the queue after releasing the lock.
 
 ## Notification contract
 
@@ -270,8 +278,12 @@ Creation sends each missing agent approver an `important` message containing:
 
 Each decision notifies the initiator and remaining approvers. Rejection,
 expiration, staleness, failure, and completion send one terminal notification.
-Notification delivery failure does not undo durable request state and can be
-retried through the existing queue.
+Every intent has a deterministic key formed from request ID, event, and
+recipient. Queue insertion uses that key as its idempotency identity and marks
+the intent enqueued only after the SQLite row exists. Startup and ordinary
+request reconciliation retry unqueued intents. Notification delivery failure
+does not undo durable request state, omit the prompt, or duplicate a terminal
+event.
 
 ## HTTP API
 

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -169,7 +169,7 @@ version
 edge_changes[]             session ID, expected old parent, new parent
 json_routing_changes[]     record kind/ID, expected old target, new target
 queue_routing_changes[]    table/record ID, child ID, expected old target,
-                           new target, prior active state
+                           new target, prior active state, runtime task key
 ```
 
 The transition from `pending` to `applying` discovers these exact records once
@@ -240,16 +240,22 @@ therefore a recoverable, fail-closed staged operation:
 
 1. Under the session write lock, revalidate and persist `status=applying` with
    the complete immutable plan. Parent edges remain unchanged.
-2. In one SQLite transaction, idempotently quiesce affected parent-derived wake
-   registrations and pending wake metadata. Persist
+2. Through the queue coordinator's routing fence, stop and remove each affected
+   in-memory parent-wake task/registration, then in one SQLite transaction
+   idempotently quiesce affected parent-derived wake registrations and pending
+   wake metadata. Persist
    `apply_stage=routing_quiesced` in JSON. A replay accepts either each plan
    entry's recorded pre-state or its exact already-quiesced state; any third
-   state fails closed.
+   state fails closed. On process restart, inactive SQLite rows cannot recreate
+   the stopped runtime tasks.
 3. In one atomic JSON replacement, update all parent edges and JSON-backed
    routing, and persist `apply_stage=authority_committed`. Dynamic
    task-complete and wait-monitor delivery now resolves this canonical edge.
 4. In one idempotent SQLite transaction, retarget and reactivate affected
-   parent-derived routes, then mark the JSON request `applied`.
+   parent-derived routes, then recreate their in-memory registrations/tasks
+   with the new target under the routing fence and mark the JSON request
+   `applied`. Replay accepts an already-correct runtime registration and never
+   starts a duplicate task.
 
 An interruption before step 3 exposes no new destructive authority and leaves
 old-parent routing paused rather than misdirected. An interruption after step 3

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -1,0 +1,335 @@
+# 1207 - Consent-based reparent and authority transfer
+
+Status: implementation contract
+
+Epic: #1207  
+Incident and diagnosis: #1204  
+Phases: #1209, #1208, #1211, #1210
+
+## Summary
+
+Session Manager derives destructive and supervisory authority from the durable
+`parent_session_id` graph. A handoff can transfer responsibility to a successor,
+but the Rust service has no working mutation surface that transfers that graph.
+The Python `sm adopt` implementation remains in the repository, while the Rust
+service only projects its legacy `adoption_proposals` records. The live Rust CLI
+and API cannot create or decide them.
+
+This epic adds two consent-based operations:
+
+1. `reparent` moves one live session under a different live parent.
+2. `reparent-tree` promotes one direct child to replace its parent as the
+   orchestrator of the parent's live tree.
+
+There is no generic inversion flag. Tree promotion is a named operation with a
+fixed topology, consent set, and audit trail.
+
+## User contract
+
+### One-edge transfer
+
+```text
+sm reparent request <child> --to <new-parent>
+sm reparent approve <request-id>
+sm reparent reject <request-id>
+sm reparent status [request-id]
+sm adopt <child>
+```
+
+`sm adopt <child>` is exactly shorthand for requesting that `<child>` move to
+the calling managed session. It does not bypass consent.
+
+Only the current parent or proposed new parent may initiate. Creating the
+request records the initiator's approval. The other party must explicitly run
+`sm reparent approve`. If the child has no live current parent, a signed-in user
+must supply the missing approval through `sm watch`.
+
+A stopped or missing parent is treated as no live parent. It is recorded in the
+expected topology for audit, but cannot approve.
+
+### Tree promotion
+
+```text
+sm reparent-tree <source> --to <target>
+sm reparent-tree <source> --to <target> --dry-run
+```
+
+`target` must be a live direct child of `source`. Given:
+
+```text
+grandparent -> source
+source -> target
+source -> child-a
+source -> child-b
+source -> stopped-child
+```
+
+the accepted transaction produces:
+
+```text
+grandparent -> target
+target -> source
+target -> child-a
+target -> child-b
+source -> stopped-child
+```
+
+The operation freezes the ordered set of live direct children at request
+creation. Any change to the source parent, target edge, or frozen live-child set
+makes the request stale. Stopped children preserve historical lineage.
+
+The source and target must approve. When source has a live parent, that
+grandparent must approve because its own direct-child edge changes. A root
+source needs no extra human approval: source explicitly approves its own
+demotion. If source has a recorded but non-live parent, user approval replaces
+the unavailable grandparent approval.
+
+`--dry-run` creates no durable request. It prints the exact edge changes,
+routing changes, required approvers, and any condition that would prevent a
+request from being created.
+
+## Authentication and consent
+
+Agent decisions use the managed caller identity from `SESSION_MANAGER_ID`, sent
+as `requester_session_id`. A managed request cannot claim another caller. An
+operator shell without that identity cannot impersonate an agent approval.
+
+Human decisions are accepted only on an authenticated operator route used by
+`sm watch`. Local-bypass watch is the supported operator-shell equivalent. A
+human decision records the authenticated actor where available and the access
+mode otherwise.
+
+Required approvals are identities, not roles or aliases. Role reassignment or
+friendly-name changes do not change an outstanding request's consent set.
+
+Every required approver can reject. A rejection is terminal. Approvals and
+rejections are idempotent only when the same actor repeats the same decision;
+conflicting or unauthorized decisions fail.
+
+Requests expire after 24 hours by default. Expiration and staleness are evaluated
+under the session-state write lock before every read that claims actionability
+and before every decision or apply attempt.
+
+## Durable model
+
+The session state gains a top-level `reparent_requests` array. Each record has:
+
+```text
+id
+kind                       single | tree
+subject_session_id         child for single, source for tree
+target_parent_session_id   new parent for single, target for tree
+expected_parent_session_id nullable
+frozen_live_child_ids      [] for single
+initiator_session_id
+required_agent_approvals
+required_human_approval    boolean
+approvals[]                actor kind/id, decision, timestamp
+status                     pending | applying | applied | rejected |
+                           stale | expired | failed
+created_at
+expires_at
+decided_at
+applied_at
+failure_reason
+topology_fingerprint
+apply_stage                nullable | routing_staged
+```
+
+The topology fingerprint is a canonical hash over operation kind, subject,
+target, expected parent, and sorted frozen live children. Revalidation compares
+both the fields and the hash; the hash is not a substitute for readable audit
+data.
+
+Legacy `adoption_proposals` are never auto-applied. On first mutation-aware
+load, pending legacy records are projected as terminal `stale` reparent
+requests with reason `legacy proposal requires a new consent request`, or are
+left read-only while the new projection exposes the same reason. Either shape
+must preserve the old data and prevent old one-party approvals from becoming
+new authority.
+
+## Validation
+
+Request creation and apply both reject:
+
+- empty, missing, stopped, or unsupported source/target sessions;
+- self-parenting;
+- a target already equal to the current parent;
+- cycles, including a new parent inside the subject's descendant set;
+- single-edge initiation by anyone except current or proposed parent;
+- tree promotion where target is not source's live direct child;
+- duplicate active requests whose affected edge sets overlap;
+- a topology that changed after request creation.
+
+Apply revalidates all identities, liveness, topology, consent, and cycle
+conditions while holding the session-state write lock.
+
+## Routing and authority transaction
+
+Changing only `parent_session_id` is incorrect. The following parent-derived
+state must follow the new graph:
+
+- `context_monitor_notify` when it points at the old parent;
+- active parent-wake registrations in retained JSON and queue SQLite;
+- pending parent-wake metadata attached to undelivered queue messages;
+- child wait/completion monitors that captured a parent at spawn time;
+- task-complete fallback routing;
+- any additional old-parent-keyed state found by the phase audit.
+
+Explicit notification recipients that happen to equal the old parent are not
+retargeted unless their schema marks them as parent-derived. Reparenting must
+not rewrite deliberate peer-to-peer messages.
+
+Existing stop-notify `sender_session_id` values and provider
+`subagents[].parent_session_id` values are explicit recipients or historical
+provider lineage. They are preserved. Tool-usage parent fields are also
+historical provenance and are never rewritten.
+
+Parent-dependent runtime behavior should resolve the current parent at delivery
+time where practical. Durable registrations that intentionally pin a parent are
+retargeted during apply.
+
+The JSON state file and queue SQLite cannot share an ACID transaction. Apply is
+therefore a recoverable, fail-closed staged operation:
+
+1. Under the session write lock, revalidate and persist `status=applying` with
+   the complete immutable plan. Parent edges remain unchanged.
+2. In one SQLite transaction, quiesce affected parent-derived wake registrations
+   and pending wake metadata. Persist `apply_stage=routing_quiesced` in JSON.
+3. In one atomic JSON replacement, update all parent edges and JSON-backed
+   routing, and persist `apply_stage=authority_committed`. Dynamic
+   task-complete and wait-monitor delivery now resolves this canonical edge.
+4. In one idempotent SQLite transaction, retarget and reactivate affected
+   parent-derived routes, then mark the JSON request `applied`.
+
+An interruption before step 3 exposes no new destructive authority and leaves
+old-parent routing paused rather than misdirected. An interruption after step 3
+has new authority with parent-derived routing still paused; dynamic delivery
+uses the canonical new edge. Startup and the next request-store mutation resume
+`applying` records from their immutable plan. A retry never recomputes a
+different topology. If the frozen topology no longer matches before routing is
+quiesced, the request becomes stale. After quiescing, recovery completes the
+recorded transaction or reports a durable `failed` state requiring operator
+repair; it never silently rolls authority back to a topology that may already
+have been observed.
+
+No network delivery occurs while holding the write lock. Approval and outcome
+notifications are queued after the durable state transition.
+
+## Notification contract
+
+Creation sends each missing agent approver an `important` message containing:
+
+- request kind and ID;
+- initiator;
+- every edge that will change;
+- expiry;
+- exact approve and reject commands.
+
+Each decision notifies the initiator and remaining approvers. Rejection,
+expiration, staleness, failure, and completion send one terminal notification.
+Notification delivery failure does not undo durable request state and can be
+retried through the existing queue.
+
+## HTTP API
+
+```text
+POST /sessions/{subject}/reparent-requests
+POST /sessions/{source}/reparent-tree-requests
+GET  /reparent-requests
+GET  /reparent-requests/{request_id}
+POST /reparent-requests/{request_id}/approve
+POST /reparent-requests/{request_id}/reject
+POST /reparent-requests/{request_id}/human-approve
+POST /reparent-requests/{request_id}/human-reject
+```
+
+Creation payloads carry `requester_session_id`; decision payloads carry the same
+for agent routes. Human routes ignore agent IDs and use request authentication.
+List defaults to requests involving the caller or requiring human action.
+Operator watch can list all pending human-gated requests.
+
+HTTP status conventions:
+
+- `200`: idempotent read/decision or dry-run;
+- `201`: request created;
+- `400`: malformed or structurally invalid operation;
+- `403`: caller is not an authorized initiator/approver;
+- `404`: session or request not found;
+- `409`: stale topology, conflicting request, terminal decision, or cycle;
+- `410`: expired request;
+- `503`: durable state or routing store unavailable.
+
+## CLI and watch UX
+
+The Rust CLI owns all non-watch commands. It resolves aliases through the
+existing API and always forwards the managed caller identity.
+
+`sm reparent status` prints compact request rows by default and a complete edge
+and approval plan for one ID. Terminal states include their reason.
+
+The retained Python `sm watch` TUI replaces its legacy adoption projection with
+pending reparent requests. `A` and `X` remain approve/reject, but only operate on
+human-gated requests. The detail line shows source, target, operation, age,
+expiry, and missing approvals. Multiple requests are selectable; watch never
+approves an arbitrary first item without showing which request is selected.
+
+## Role and history boundaries
+
+Reparenting does not transfer service roles, aliases, provider sessions,
+transcripts, account identity, working directory, task text, or stopped-child
+history. Those are properties of seats, not parent authority.
+
+Usage ancestry follows the new live graph for future reports. Historical usage
+events retain the parent/seat metadata recorded when they occurred.
+
+## Phases
+
+### Phase 0 - #1209
+
+Add the durable request schema, legacy migration/projection, topology planning,
+consent state machine, expiry/staleness handling, read/decision HTTP API, and
+focused tests. No request may apply yet.
+
+### Phase 1 - #1208
+
+Add single-edge apply, routing reconciliation, fail-closed recovery, and tests
+that direct-child retire/kill authority and supervision follow the new edge.
+
+### Phase 2 - #1211
+
+Add tree-promotion planning/apply, dry-run, frozen child-set validation,
+grandparent consent, stopped-child preservation, and recovery tests.
+
+### Phase 3 - #1210
+
+Add Rust CLI commands, actionable notifications, retained `sm watch` human UX,
+and end-to-end tests.
+
+Every phase PR targets `epic/1207-reparent-authority` and follows
+`docs/working/pr_review_process.md`. After all phases merge, one reviewed epic
+PR targets `main`. Partial phases are not deployed.
+
+## Acceptance gates
+
+- All consent combinations, unauthorized actors, repeated decisions, expiry,
+  staleness, self-parenting, and cycles have deterministic tests.
+- A regular reparent changes exactly one edge.
+- A tree promotion produces exactly the documented live graph and preserves
+  stopped lineage.
+- Parent-derived routing and direct-child destructive authority follow the new
+  graph immediately after apply.
+- Pending and `applying` requests recover correctly after restart at every
+  durable stage.
+- Legacy pending adoption records cannot auto-apply.
+- Rust CLI parser/dispatch and Python watch interaction tests pass.
+- Full Rust and retained Python test suites pass, or any demonstrably preexisting
+  failure is filed and referenced under the maintainer workflow.
+- The final epic PR passes Codex review under the P1 exit criterion, merges to
+  `main`, and is deployed only with `scripts/restart-rust-server.sh`.
+
+## Classification
+
+Epic. The work is split across four dependent tickets because the durable state
+machine, cross-store authority mutation, tree transaction, and operator UX each
+require separate reviewable proofs.

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -78,6 +78,7 @@ The operation freezes the ordered set of live direct children at request
 creation. Any change to the source parent, target edge, or frozen live-child set
 makes the request stale. Stopped children preserve historical lineage.
 
+Only the source, target, or source's live parent may initiate a tree request.
 The source and target must approve. When source has a live parent, that
 grandparent must approve because its own direct-child edge changes. A root
 source needs no extra human approval: source explicitly approves its own
@@ -156,7 +157,25 @@ failure_reason
 topology_fingerprint
 apply_stage                nullable | routing_quiesced |
                            authority_committed
+apply_plan                 nullable while pending; immutable once applying
 ```
+
+`apply_plan` is versioned and contains the complete retry input rather than a
+query that recovery would rerun:
+
+```text
+version
+edge_changes[]             session ID, expected old parent, new parent
+json_routing_changes[]     record kind/ID, expected old target, new target
+queue_routing_changes[]    table/record ID, child ID, expected old target,
+                           new target, prior active state
+```
+
+The transition from `pending` to `applying` discovers these exact records once
+under the state lock and persists the plan before quiescing anything. Recovery
+uses only this plan plus expected-value checks. A route created after planning
+must derive its parent from the canonical graph and is not retroactively folded
+into the in-flight plan.
 
 The topology fingerprint is a canonical hash over operation kind, subject,
 target, expected parent, and sorted frozen live children. Revalidation compares
@@ -179,6 +198,7 @@ Request creation and apply both reject:
 - a target already equal to the current parent;
 - cycles, including a new parent inside the subject's descendant set;
 - single-edge initiation by anyone except current or proposed parent;
+- tree initiation by anyone except source, target, or source's live parent;
 - tree promotion where target is not source's live direct child;
 - duplicate active requests whose affected edge sets overlap;
 - a topology that changed after request creation.

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -127,6 +127,12 @@ stopped resumes the recorded relaunch on startup. If resumability or readiness
 cannot be established, the old runtime remains untouched and the rotation
 fails closed. There is no force-active mode in this epic.
 
+Startup completes every `relaunching` credential rotation synchronously before
+HTTP/input delivery becomes ready. If the named tmux runtime exists, recovery
+kills it and relaunches once from the frozen provider identity; this safely
+handles a crash after launch but before the new verifier was persisted. Waiting
+rotations start background idle-proof workers only after startup recovery.
+
 Deployment does not silently relaunch the fleet. After the merged server is
 healthy, the maintainer runs `sm recredential --all-live`; the command reports
 which seats were rotated, waiting for idle, already credentialed, or failed.
@@ -321,6 +327,12 @@ quiesced, the request becomes stale. After quiescing, recovery completes the
 recorded transaction or reports a durable `failed` state requiring operator
 repair; it never silently rolls authority back to a topology that may already
 have been observed.
+
+On startup, all `applying` reparent records are recovered through their durable
+stage before retained parent-wake tasks are recreated and before HTTP/input
+readiness. In particular, a crash after an in-memory task was stopped but before
+`json_routing_quiesced` cannot briefly recreate an old-parent task from the
+still-active retained record.
 
 A `failed` request at or beyond `json_routing_quiesced` remains a durable
 quarantine, not a released terminal edge. Its complete affected edge set stays

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -133,13 +133,15 @@ epic.
 Every runtime-backed create, normal restore, and recredential relaunch uses one
 durable launch coordinator. Before touching tmux, it persists a
 `session_runtime_launches` record with operation kind, session ID, frozen launch
-parameters and provider resume identity, status (`prepared | launching |
-applied | failed`), timestamps, and failure reason. It never stores the
-plaintext credential. Under the input fence, the coordinator stops any prior
-named runtime when required, generates a credential, and atomically persists
-its verifier plus `status=launching` before starting tmux. Only after the launch
-succeeds does one JSON replacement mark the session running and the launch
-applied.
+parameters and provider resume identity, an optional owning credential-rotation
+ID, status (`prepared | launching | applied | failed`), timestamps, and failure
+reason. It never stores the plaintext credential. Under the input fence, the
+coordinator stops any prior named runtime when required, generates a credential,
+and atomically persists its verifier plus `status=launching` before starting
+tmux. Only after the launch succeeds does one JSON replacement mark the session
+running and the launch applied. For `recredential`, that same replacement also
+marks the referenced `session_credential_rotations` record applied; no durable
+state may expose an applied launch with its owning rotation still relaunching.
 
 Startup completes every `prepared` or `launching` record synchronously before
 HTTP/input delivery becomes ready. Recovery kills any runtime with the frozen
@@ -298,9 +300,10 @@ Runtime creation and relaunch use a separate top-level
 `session_runtime_launches` collection. Each record stores an operation ID,
 operation kind (`create | restore | recredential`), session ID, frozen tmux and
 provider launch parameters, provider resume identity, credential verifier,
-status (`prepared | launching | applied | failed`), timestamps, and failure
-reason. The active record is the source of truth for startup recovery; neither
-it nor any other durable record contains the plaintext credential.
+optional owning credential-rotation ID, status (`prepared | launching | applied
+| failed`), timestamps, and failure reason. The active record is the source of
+truth for startup recovery; neither it nor any other durable record contains
+the plaintext credential.
 
 ## Validation
 
@@ -444,10 +447,13 @@ it.
 
 The authenticated human repair route supports exactly two audited actions:
 
-1. `resume` records a repair attempt, changes `failed` back to `applying`, and
-   continues the persisted stage. At `prequiesce_aborting` it can only finish
-   the abort; at later stages it retries the same immutable plan. It never
-   replans.
+1. `resume` is accepted only for a failed stage that still holds the global
+   lease: `prequiesce_aborting`, `json_routing_quiesced`, `routing_quiesced`, or
+   `authority_committed`. It records a repair attempt, changes `failed` back to
+   `applying`, and continues the persisted stage. At
+   `prequiesce_aborting` it can only finish the abort; at later stages it retries
+   the same immutable plan. It never replans. A completed
+   `prequiesce_aborted` request is terminal and cannot be resumed.
 2. `rollback_precommit` is accepted only from `json_routing_quiesced` or
    `routing_quiesced`, before `authority_committed`. Under the routing fence,
    the server restores every route to the apply plan's exact recorded
@@ -610,6 +616,9 @@ PR targets `main`. Partial phases are not deployed.
 - Create, normal restore, and recredential each recover a crash after tmux
   launch but before final persistence by replacing the unknowable runtime
   credential through the same durable launch coordinator.
+- A successful recredential launch marks its owning rotation applied in the
+  same JSON replacement as the session and launch; restart cannot strand a
+  relaunching rotation behind an already-applied launch.
 - Legacy pending adoption records cannot auto-apply.
 - Rust CLI parser/dispatch and Python watch interaction tests pass.
 - Full Rust and retained Python test suites pass, or any demonstrably preexisting

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -198,6 +198,14 @@ repair_history[]           actor, action, prior failure, timestamp,
                            verified post-state fingerprint
 ```
 
+The state root also has one `reparent_apply_lease` containing request ID and
+acquisition timestamp. Pending consent requests may coexist, but only the lease
+holder may enter `applying`, quiesce routes, or commit authority. A failed
+transaction retains the lease until a retry applies it or a verified rollback
+repairs it. Authority transactions are intentionally serialized globally;
+reparenting is rare, and avoiding cross-plan cycle races is more important than
+parallel apply throughput.
+
 `apply_plan` is versioned and contains the complete retry input rather than a
 query that recovery would rerun:
 
@@ -210,9 +218,11 @@ queue_routing_changes[]    table/record ID, child ID, expected old target,
 ```
 
 The transition from `pending` to `applying` discovers these exact records once
-under the state lock and atomically persists both the plan and a durable
-topology/routing fence before quiescing anything. Recovery uses only this plan
-plus expected-value checks.
+under the state lock and atomically acquires the empty global apply lease while
+persisting both the plan and a durable topology/routing fence. If another
+request holds the lease, an approved request remains pending and ready rather
+than partially applying. Recovery uses only the persisted plan plus
+expected-value checks.
 
 While the fence covers a session, create/spawn with that session as parent,
 restore of a stopped child, explicit retire/stop, and any parent-edge mutation
@@ -317,10 +327,11 @@ retargeted during apply.
 The JSON state file and queue SQLite cannot share an ACID transaction. Apply is
 therefore a recoverable, fail-closed staged operation:
 
-1. Under the session write lock, revalidate and atomically persist
-   `status=applying`, the complete immutable plan, and its topology/routing
-   fence. Parent edges remain unchanged. Every conflicting topology mutation
-   checks this fence under the same lock.
+1. Under the session write lock, require an empty global apply lease,
+   revalidate, and atomically persist the lease, `status=applying`, the complete
+   immutable plan, and its topology/routing fence. Parent edges remain
+   unchanged. Every conflicting topology mutation checks this fence under the
+   same lock.
 2. Through the queue coordinator's routing fence, stop and remove each affected
    in-memory parent-wake task/registration. Under the session-state lock,
    atomically mark every affected retained JSON parent-wake registration
@@ -332,9 +343,13 @@ therefore a recoverable, fail-closed staged operation:
    plan entry's recorded pre-state or its exact already-quiesced state; any
    third state fails closed. On process restart, inactive JSON and SQLite rows
    cannot recreate the stopped runtime tasks.
-3. In one atomic JSON replacement, update all parent edges and JSON-backed
-   routing, and persist `apply_stage=authority_committed`. Dynamic
-   task-complete and wait-monitor delivery now resolves this canonical edge.
+3. Under the session write lock and while still holding the global lease,
+   revalidate the complete current graph and planned post-transaction graph a
+   second time. If either differs from the frozen plan or contains a cycle,
+   take the pre-commit stale/rollback path. Otherwise, in the same atomic JSON
+   replacement, update all parent edges and JSON-backed routing and persist
+   `apply_stage=authority_committed`. Dynamic task-complete and wait-monitor
+   delivery now resolves this canonical edge.
    Deferred routing intents are now eligible to resolve against the new graph;
    topology mutations remain fenced until their replay is durable.
 4. In one idempotent SQLite transaction, retarget and reactivate affected
@@ -342,8 +357,8 @@ therefore a recoverable, fail-closed staged operation:
    retained JSON registrations, then recreate their in-memory tasks with the
    new target under the routing fence, replay deferred routing intents against
    the new canonical parents, mark the JSON request `applied`, and release both
-   fences. Replay accepts an already-correct runtime registration and never
-   starts a duplicate task.
+   fences and the global apply lease. Replay accepts an already-correct runtime
+   registration and never starts a duplicate task.
 
 An interruption before step 3 exposes no new destructive authority and leaves
 old-parent routing paused rather than misdirected. An interruption after step 3
@@ -358,6 +373,11 @@ restoration fails, the request remains failed and quarantined. After authority
 commit, recovery completes the recorded transaction; it never silently rolls
 authority back to a topology that may already have been observed.
 
+The applied and stale/rollback paths clear the global lease only in the same
+final JSON replacement that records every deferred routing intent replayed.
+Failure at any stage retains the lease. Startup recovers the recorded lease
+holder before another ready request may acquire it.
+
 On startup, all `applying` reparent records are recovered through their durable
 stage before retained parent-wake tasks are recreated and before HTTP/input
 readiness. In particular, a crash after an in-memory task was stopped but before
@@ -367,7 +387,8 @@ still-active retained record.
 A `failed` request at or beyond `json_routing_quiesced` remains a durable
 quarantine, not a released terminal edge. Its complete affected edge set stays
 reserved by the overlap fence, parent-derived route creation remains deferred
-for those children, and no later request may include any reserved edge. Only an
+for those children, and its global apply lease prevents any later authority
+transaction from starting. Only an
 authenticated operator repair action may either resume the immutable plan or
 restore and verify its exact pre-commit state before clearing the quarantine.
 Merely rejecting, expiring, deleting, or recreating the request cannot release
@@ -513,6 +534,9 @@ PR targets `main`. Partial phases are not deployed.
 
 - All consent combinations, unauthorized actors, repeated decisions, expiry,
   staleness, self-parenting, and cycles have deterministic tests.
+- Ready requests apply under one durable global lease and revalidate the whole
+  planned graph immediately before commit; concurrent plans cannot jointly
+  create a cycle.
 - A regular reparent changes exactly one edge.
 - A tree promotion produces exactly the documented live graph and preserves
   stopped lineage.

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -205,6 +205,8 @@ Request creation and apply both reject:
 - tree initiation by anyone except source, target, or source's live parent;
 - tree promotion where target is not source's live direct child;
 - duplicate active requests whose affected edge sets overlap;
+- any request whose affected edge set overlaps a `failed` transaction that
+  reached `routing_quiesced` or later and has not been explicitly repaired;
 - a topology that changed after request creation.
 
 Apply revalidates all identities, liveness, topology, consent, and cycle
@@ -215,16 +217,20 @@ conditions while holding the session-state write lock.
 Changing only `parent_session_id` is incorrect. The following parent-derived
 state must follow the new graph:
 
-- `context_monitor_notify` when it points at the old parent;
+- `context_monitor_notify` only when its companion provenance marks the target
+  as parent-derived;
 - active parent-wake registrations in retained JSON and queue SQLite;
 - pending parent-wake metadata attached to undelivered queue messages;
 - child wait/completion monitors that captured a parent at spawn time;
 - task-complete fallback routing;
 - any additional old-parent-keyed state found by the phase audit.
 
-Explicit notification recipients that happen to equal the old parent are not
-retargeted unless their schema marks them as parent-derived. Reparenting must
-not rewrite deliberate peer-to-peer messages.
+Context-monitor state gains a companion provenance value,
+`context_monitor_notify_source = explicit | parent_derived`. New monitor writes
+must set it from the operation that chose the target. Existing records that
+lack provenance are conservatively migrated as `explicit`, even when the target
+happens to equal the old parent. Explicit notification recipients are never
+retargeted; reparenting must not rewrite deliberate peer-to-peer messages.
 
 Existing stop-notify `sender_session_id` values and provider
 `subagents[].parent_session_id` values are explicit recipients or historical
@@ -267,6 +273,15 @@ quiesced, the request becomes stale. After quiescing, recovery completes the
 recorded transaction or reports a durable `failed` state requiring operator
 repair; it never silently rolls authority back to a topology that may already
 have been observed.
+
+A `failed` request at or beyond `routing_quiesced` remains a durable quarantine,
+not a released terminal edge. Its complete affected edge set stays reserved by
+the overlap fence, parent-derived route creation remains deferred for those
+children, and no later request may include any reserved edge. Only an
+authenticated operator repair action may either resume the immutable plan or
+verify and record a consistent replacement topology before clearing the
+quarantine. Merely rejecting, expiring, deleting, or recreating the request
+cannot release it.
 
 No network delivery occurs while holding the write lock. Approval and outcome
 notification intents are persisted in the same JSON transition that creates

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -90,9 +90,28 @@ request from being created.
 
 ## Authentication and consent
 
-Agent decisions use the managed caller identity from `SESSION_MANAGER_ID`, sent
-as `requester_session_id`. A managed request cannot claim another caller. An
-operator shell without that identity cannot impersonate an agent approval.
+Agent decisions require both the managed caller ID and a server-issued,
+per-runtime 256-bit credential. Session Manager injects the opaque credential as
+`SM_SESSION_CREDENTIAL` when it launches or restores a seat, stores only its
+SHA-256 verifier in session state, and rotates it on every restore. The Rust CLI
+sends the credential in `X-SM-Session-Credential`; the server derives the actor
+from the matching credential and rejects a payload whose
+`requester_session_id` disagrees. `SESSION_MANAGER_ID` alone is not
+authentication. An operator shell that merely sets another session ID cannot
+impersonate an agent approval.
+
+The same per-session credential gate applies to request creation. Credential
+material is never returned by session/list APIs, written to logs, included in
+notifications, or persisted in plaintext. Existing live sessions without a
+verifier cannot approve after deployment until Session Manager rotates a
+credential into that runtime; rollout must provide an explicit credential
+rotation path and must not fall back to trusting an ID-only payload.
+
+Session Manager agents share one operating-system account and filesystem. A
+hostile same-UID process with arbitrary process-inspection capability is outside
+this control's isolation boundary; protecting against that requires OS-level
+per-seat identities. This credential still provides server-verifiable request
+binding and prevents operator-shell and accidental cross-seat payload spoofing.
 
 Human decisions are accepted only on an authenticated operator route used by
 `sm watch`. Local-bypass watch is the supported operator-shell equivalent. A
@@ -108,7 +127,9 @@ conflicting or unauthorized decisions fail.
 
 Requests expire after 24 hours by default. Expiration and staleness are evaluated
 under the session-state write lock before every read that claims actionability
-and before every decision or apply attempt.
+and before every decision or pre-quiesce apply attempt. An `applying` request at
+or beyond `routing_quiesced` never expires; recovery must finish its immutable
+transaction.
 
 ## Durable model
 
@@ -133,7 +154,8 @@ decided_at
 applied_at
 failure_reason
 topology_fingerprint
-apply_stage                nullable | routing_staged
+apply_stage                nullable | routing_quiesced |
+                           authority_committed
 ```
 
 The topology fingerprint is a canonical hash over operation kind, subject,

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -122,8 +122,8 @@ lifecycle event), not inferred from a stale projected status. Busy or unproven
 seats remain `waiting_idle` and are retried by the provider Stop/event path.
 The relaunch preserves the Session Manager ID, parent graph, task metadata, and
 provider resume ID; it rotates the runtime credential and verifier. A crash
-after the old runtime is
-stopped resumes the recorded relaunch on startup. If resumability or readiness
+after the old runtime is stopped resumes the recorded relaunch on startup. If
+resumability or readiness
 cannot be established, the old runtime remains untouched and the rotation
 fails closed. There is no force-active mode in this epic.
 
@@ -218,9 +218,11 @@ While the fence covers a session, create/spawn with that session as parent,
 restore of a stopped child, explicit retire/stop, and any parent-edge mutation
 that could change the planned graph return `409` with the controlling request
 ID. Observed provider/runtime death may still persist liveness truth; before
-authority commit it forces the transaction to restore its exact pre-state and
-end stale. If that restoration fails, the request enters the same durable
-quarantine as any other post-quiesce failure. These checks apply to every
+authority commit it forces the transaction to restore its exact old parent
+edges and routing while preserving the observed stopped status, then end stale.
+A frozen child that stopped therefore remains stopped under the old source. If
+that restoration fails, the request enters the same durable quarantine as any
+other post-quiesce failure. These checks apply to every
 session in a tree plan's source/target/grandparent/frozen-child set, not only to
 the edge rows being rewritten.
 
@@ -349,12 +351,12 @@ has new authority with parent-derived routing still paused; dynamic delivery
 uses the canonical new edge. Startup and the next request-store mutation resume
 `applying` records from their immutable plan. A retry never recomputes a
 different topology. If the frozen topology no longer matches before authority
-commit, the server restores the exact pre-state, replays deferred routing
-against the unchanged old parent, marks the request stale, and only then
-releases the fences. If that restoration fails, the request remains failed and
-quarantined. After authority commit, recovery completes the recorded
-transaction; it never silently rolls authority back to a topology that may
-already have been observed.
+commit, the server restores the exact old authority/routing state without
+rewriting observed liveness, replays deferred routing against the unchanged old
+parent, marks the request stale, and only then releases the fences. If that
+restoration fails, the request remains failed and quarantined. After authority
+commit, recovery completes the recorded transaction; it never silently rolls
+authority back to a topology that may already have been observed.
 
 On startup, all `applying` reparent records are recovered through their durable
 stage before retained parent-wake tasks are recreated and before HTTP/input
@@ -378,8 +380,8 @@ The authenticated human repair route supports exactly two audited actions:
 2. `rollback_precommit` is accepted only from `json_routing_quiesced` or
    `routing_quiesced`, before `authority_committed`. Under the routing fence,
    the server restores every route to the apply plan's exact recorded
-   pre-state, verifies all parent edges
-   still match the old topology and all runtime/JSON/SQLite routes match that
+   pre-state, verifies all parent edges still match the old topology and all
+   runtime/JSON/SQLite routes match that
    pre-state, replays deferred routing intents against the unchanged old parent,
    then atomically records `status=repaired` and
    `apply_stage=repair_rolled_back`. Any mismatch leaves the request failed and

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -33,6 +33,8 @@ sm reparent request <child> --to <new-parent>
 sm reparent approve <request-id>
 sm reparent reject <request-id>
 sm reparent status [request-id]
+sm reparent repair <request-id> --resume
+sm reparent repair <request-id> --rollback-precommit
 sm adopt <child>
 ```
 
@@ -148,7 +150,7 @@ required_agent_approvals
 required_human_approval    boolean
 approvals[]                actor kind/id, decision, timestamp
 status                     pending | applying | applied | rejected |
-                           stale | expired | failed
+                           stale | expired | failed | repaired
 created_at
 expires_at
 decided_at
@@ -156,9 +158,11 @@ applied_at
 failure_reason
 topology_fingerprint
 apply_stage                nullable | routing_quiesced |
-                           authority_committed
+                           authority_committed | repair_rolled_back
 apply_plan                 nullable while pending; immutable once applying
 notification_intents[]     deterministic event/recipient delivery records
+repair_history[]           actor, action, prior failure, timestamp,
+                           verified post-state fingerprint
 ```
 
 `apply_plan` is versioned and contains the complete retry input rather than a
@@ -200,7 +204,9 @@ Request creation and apply both reject:
 - empty, missing, stopped, or unsupported source/target sessions;
 - self-parenting;
 - a target already equal to the current parent;
-- cycles, including a new parent inside the subject's descendant set;
+- for single-edge requests, a new parent inside the subject's current
+  descendant set;
+- for tree requests, any cycle in the complete planned post-transaction graph;
 - single-edge initiation by anyone except current or proposed parent;
 - tree initiation by anyone except source, target, or source's live parent;
 - tree promotion where target is not source's live direct child;
@@ -210,7 +216,10 @@ Request creation and apply both reject:
 - a topology that changed after request creation.
 
 Apply revalidates all identities, liveness, topology, consent, and cycle
-conditions while holding the session-state write lock.
+conditions while holding the session-state write lock. Tree cycle validation
+first applies every planned edge replacement to an in-memory graph and then
+checks the resulting graph; it must not reject merely because the target is a
+current direct child of the source.
 
 ## Routing and authority transaction
 
@@ -279,9 +288,28 @@ not a released terminal edge. Its complete affected edge set stays reserved by
 the overlap fence, parent-derived route creation remains deferred for those
 children, and no later request may include any reserved edge. Only an
 authenticated operator repair action may either resume the immutable plan or
-verify and record a consistent replacement topology before clearing the
-quarantine. Merely rejecting, expiring, deleting, or recreating the request
-cannot release it.
+restore and verify its exact pre-commit state before clearing the quarantine.
+Merely rejecting, expiring, deleting, or recreating the request cannot release
+it.
+
+The authenticated human repair route supports exactly two audited actions:
+
+1. `resume` records a repair attempt, changes `failed` back to `applying`, and
+   retries the same immutable plan from its persisted stage. It never replans.
+2. `rollback_precommit` is accepted only from `routing_quiesced`, before
+   `authority_committed`. Under the routing fence, the server restores every
+   route to the apply plan's exact recorded pre-state, verifies all parent edges
+   still match the old topology and all runtime/JSON/SQLite routes match that
+   pre-state, then atomically records `status=repaired` and
+   `apply_stage=repair_rolled_back`. Any mismatch leaves the request failed and
+   quarantined.
+
+At or after `authority_committed`, only forward `resume` is available because
+new authority may already have been observed. A successful retry ends
+`applied`; a verified pre-commit rollback ends `repaired`. Those are the only
+transitions that release the quarantine. Each attempt appends `repair_history`
+with the authenticated human actor, action, prior failure, timestamp, and hash
+of the verified resulting graph and routing state.
 
 No network delivery occurs while holding the write lock. Approval and outcome
 notification intents are persisted in the same JSON transition that creates
@@ -317,12 +345,16 @@ POST /reparent-requests/{request_id}/approve
 POST /reparent-requests/{request_id}/reject
 POST /reparent-requests/{request_id}/human-approve
 POST /reparent-requests/{request_id}/human-reject
+POST /reparent-requests/{request_id}/repair
 ```
 
 Creation payloads carry `requester_session_id`; decision payloads carry the same
 for agent routes. Human routes ignore agent IDs and use request authentication.
 List defaults to requests involving the caller or requiring human action.
 Operator watch can list all pending human-gated requests.
+The repair route is operator-authenticated only and accepts
+`action=resume|rollback_precommit`; an agent session credential cannot invoke
+it. `sm watch` exposes the same actions with the stage-specific safety text.
 
 HTTP status conventions:
 
@@ -370,6 +402,8 @@ focused tests. No request may apply yet.
 
 Add single-edge apply, routing reconciliation, fail-closed recovery, and tests
 that direct-child retire/kill authority and supervision follow the new edge.
+This phase also implements durable repair transitions and their authenticated
+HTTP route; Phase 3 adds their CLI/watch UX.
 
 ### Phase 2 - #1211
 
@@ -396,6 +430,8 @@ PR targets `main`. Partial phases are not deployed.
   graph immediately after apply.
 - Pending and `applying` requests recover correctly after restart at every
   durable stage.
+- Post-quiesce failures retain their overlap/routing fence; only a successful
+  immutable-plan retry or verified pre-commit rollback releases it.
 - Legacy pending adoption records cannot auto-apply.
 - Rust CLI parser/dispatch and Python watch interaction tests pass.
 - Full Rust and retained Python test suites pass, or any demonstrably preexisting

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -192,6 +192,8 @@ apply_stage                nullable | json_routing_quiesced |
                            repair_rolled_back
 apply_plan                 nullable while pending; immutable once applying
 notification_intents[]     deterministic event/recipient delivery records
+deferred_routing_intents[] idempotency key, operation payload, created_at,
+                           replayed_at and resolved parent
 repair_history[]           actor, action, prior failure, timestamp,
                            verified post-state fingerprint
 ```
@@ -208,13 +210,32 @@ queue_routing_changes[]    table/record ID, child ID, expected old target,
 ```
 
 The transition from `pending` to `applying` discovers these exact records once
-under the state lock and persists the plan before quiescing anything. Recovery
-uses only this plan plus expected-value checks. A route created after planning
-must not escape the plan: while an `applying` request covers a child, creation
-of parent-derived wake/message metadata for that child is deferred behind the
-transaction. After `authority_committed`, deferred creation derives the new
-canonical parent. Every parent-derived route creation path must use this fence;
-direct queue-table writes are not permitted.
+under the state lock and atomically persists both the plan and a durable
+topology/routing fence before quiescing anything. Recovery uses only this plan
+plus expected-value checks.
+
+While the fence covers a session, create/spawn with that session as parent,
+restore of a stopped child, explicit retire/stop, and any parent-edge mutation
+that could change the planned graph return `409` with the controlling request
+ID. Observed provider/runtime death may still persist liveness truth; before
+authority commit it forces the transaction to restore its exact pre-state and
+end stale. If that restoration fails, the request enters the same durable
+quarantine as any other post-quiesce failure. These checks apply to every
+session in a tree plan's source/target/grandparent/frozen-child set, not only to
+the edge rows being rewritten.
+
+A route requested after planning must not escape the routing fence. The server
+persists a `deferred_routing_intent` with an idempotency key and complete
+operation payload instead of writing the live JSON/SQLite route. Direct
+queue-table writes are not permitted. On `authority_committed`, each intent is
+replayed once against the new canonical parent. If the transaction becomes
+stale before commit or completes a pre-commit rollback, each intent is replayed
+once against the unchanged old canonical parent before the fence is released.
+Replay first idempotently upserts the target JSON/SQLite record under the
+intent's key. After that record is confirmed, JSON records `replayed_at` and the
+resolved parent. The final JSON replacement releases the fence only when every
+intent is marked replayed. A crash between stores repeats the same keyed upsert,
+so recovery cannot lose or duplicate the operation.
 Parent-derived route reads and mutations, including task-complete fallback and
 deactivation, use the same fence; it is not limited to creation.
 
@@ -294,8 +315,10 @@ retargeted during apply.
 The JSON state file and queue SQLite cannot share an ACID transaction. Apply is
 therefore a recoverable, fail-closed staged operation:
 
-1. Under the session write lock, revalidate and persist `status=applying` with
-   the complete immutable plan. Parent edges remain unchanged.
+1. Under the session write lock, revalidate and atomically persist
+   `status=applying`, the complete immutable plan, and its topology/routing
+   fence. Parent edges remain unchanged. Every conflicting topology mutation
+   checks this fence under the same lock.
 2. Through the queue coordinator's routing fence, stop and remove each affected
    in-memory parent-wake task/registration. Under the session-state lock,
    atomically mark every affected retained JSON parent-wake registration
@@ -310,23 +333,28 @@ therefore a recoverable, fail-closed staged operation:
 3. In one atomic JSON replacement, update all parent edges and JSON-backed
    routing, and persist `apply_stage=authority_committed`. Dynamic
    task-complete and wait-monitor delivery now resolves this canonical edge.
+   Deferred routing intents are now eligible to resolve against the new graph;
+   topology mutations remain fenced until their replay is durable.
 4. In one idempotent SQLite transaction, retarget and reactivate affected
    parent-derived routes. Under the state lock, retarget and reactivate the
    retained JSON registrations, then recreate their in-memory tasks with the
-   new target under the routing fence and mark the JSON request `applied`.
-   Replay accepts an already-correct runtime registration and never starts a
-   duplicate task.
+   new target under the routing fence, replay deferred routing intents against
+   the new canonical parents, mark the JSON request `applied`, and release both
+   fences. Replay accepts an already-correct runtime registration and never
+   starts a duplicate task.
 
 An interruption before step 3 exposes no new destructive authority and leaves
 old-parent routing paused rather than misdirected. An interruption after step 3
 has new authority with parent-derived routing still paused; dynamic delivery
 uses the canonical new edge. Startup and the next request-store mutation resume
 `applying` records from their immutable plan. A retry never recomputes a
-different topology. If the frozen topology no longer matches before routing is
-quiesced, the request becomes stale. After quiescing, recovery completes the
-recorded transaction or reports a durable `failed` state requiring operator
-repair; it never silently rolls authority back to a topology that may already
-have been observed.
+different topology. If the frozen topology no longer matches before authority
+commit, the server restores the exact pre-state, replays deferred routing
+against the unchanged old parent, marks the request stale, and only then
+releases the fences. If that restoration fails, the request remains failed and
+quarantined. After authority commit, recovery completes the recorded
+transaction; it never silently rolls authority back to a topology that may
+already have been observed.
 
 On startup, all `applying` reparent records are recovered through their durable
 stage before retained parent-wake tasks are recreated and before HTTP/input
@@ -352,7 +380,8 @@ The authenticated human repair route supports exactly two audited actions:
    the server restores every route to the apply plan's exact recorded
    pre-state, verifies all parent edges
    still match the old topology and all runtime/JSON/SQLite routes match that
-   pre-state, then atomically records `status=repaired` and
+   pre-state, replays deferred routing intents against the unchanged old parent,
+   then atomically records `status=repaired` and
    `apply_stage=repair_rolled_back`. Any mismatch leaves the request failed and
    quarantined.
 
@@ -485,12 +514,17 @@ PR targets `main`. Partial phases are not deployed.
 - A regular reparent changes exactly one edge.
 - A tree promotion produces exactly the documented live graph and preserves
   stopped lineage.
+- Conflicting spawn/restore/retire/topology mutations are fenced until commit;
+  an observed pre-commit liveness change restores the old graph instead of
+  applying a stale frozen child set.
 - Parent-derived routing and direct-child destructive authority follow the new
   graph immediately after apply.
 - Pending and `applying` requests recover correctly after restart at every
   durable stage.
 - Post-quiesce failures retain their overlap/routing fence; only a successful
   immutable-plan retry or verified pre-commit rollback releases it.
+- Deferred parent-derived route requests replay exactly once against the new
+  parent after commit or the old parent after stale/rollback release.
 - A pre-deployment live seat is recredentialed only after it becomes idle, keeps
   its seat and provider-thread identity, and recovers a crash after stop without
   accepting input under two runtimes.

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -119,19 +119,37 @@ rotation record, acquire the session input fence, and verify that the provider
 turn is idle and its input queue is drained. Idle proof must be observed after
 the rotation was requested (a fresh Claude prompt/Stop boundary or Codex
 lifecycle event), not inferred from a stale projected status. Busy or unproven
-seats remain `waiting_idle` and are retried by the provider Stop/event path.
+seats remain `waiting_idle` and are retried by the provider Stop/event path. A
+rotation also requires no attached interactive tmux client, no pending typed
+input, and no pending handoff, clear, review, or `what` operation; those checks
+are repeated under the input fence immediately before stopping the runtime.
 The relaunch preserves the Session Manager ID, parent graph, task metadata, and
 provider resume ID; it rotates the runtime credential and verifier. A crash
 after the old runtime is stopped resumes the recorded relaunch on startup. If
-resumability or readiness
-cannot be established, the old runtime remains untouched and the rotation
-fails closed. There is no force-active mode in this epic.
+resumability or readiness cannot be established, the old runtime remains
+untouched and the rotation fails closed. There is no force-active mode in this
+epic.
 
-Startup completes every `relaunching` credential rotation synchronously before
-HTTP/input delivery becomes ready. If the named tmux runtime exists, recovery
-kills it and relaunches once from the frozen provider identity; this safely
-handles a crash after launch but before the new verifier was persisted. Waiting
-rotations start background idle-proof workers only after startup recovery.
+Every runtime-backed create, normal restore, and recredential relaunch uses one
+durable launch coordinator. Before touching tmux, it persists a
+`session_runtime_launches` record with operation kind, session ID, frozen launch
+parameters and provider resume identity, status (`prepared | launching |
+applied | failed`), timestamps, and failure reason. It never stores the
+plaintext credential. Under the input fence, the coordinator stops any prior
+named runtime when required, generates a credential, and atomically persists
+its verifier plus `status=launching` before starting tmux. Only after the launch
+succeeds does one JSON replacement mark the session running and the launch
+applied.
+
+Startup completes every `prepared` or `launching` record synchronously before
+HTTP/input delivery becomes ready. Recovery kills any runtime with the frozen
+tmux identity, generates a new credential/verifier, persists that new attempt,
+and launches once from the frozen provider identity. Thus a crash after launch
+but before final persistence discards the unknowable process-only credential
+and converges on a verifiable runtime. Create failure removes or terminally
+stops its provisional session; restore/recredential failure leaves the session
+stopped with an audited failed launch. Waiting recredential rotations start
+background idle-proof workers only after startup launch recovery.
 
 Deployment does not silently relaunch the fleet. After the merged server is
 healthy, the maintainer runs `sm recredential --all-live`; the command reports
@@ -158,11 +176,11 @@ Every required approver can reject. A rejection is terminal. Approvals and
 rejections are idempotent only when the same actor repeats the same decision;
 conflicting or unauthorized decisions fail.
 
-Requests expire after 24 hours by default. Expiration and staleness are evaluated
-under the session-state write lock before every read that claims actionability
-and before every decision or pre-quiesce apply attempt. An `applying` request at
-or beyond `json_routing_quiesced` never expires; recovery must finish its
-immutable transaction.
+Requests expire after 24 hours by default while `pending`. Expiration and
+staleness are evaluated under the session-state write lock before every read
+that claims actionability and before every decision or apply attempt. Once a
+request enters `applying`, it no longer expires; recovery must finish or abort
+its durable transaction.
 
 ## Durable model
 
@@ -187,7 +205,8 @@ decided_at
 applied_at
 failure_reason
 topology_fingerprint
-apply_stage                nullable | json_routing_quiesced |
+apply_stage                nullable | prequiesce_aborting |
+                           prequiesce_aborted | json_routing_quiesced |
                            routing_quiesced | authority_committed |
                            repair_rolled_back
 apply_plan                 nullable while pending; immutable once applying
@@ -201,8 +220,11 @@ repair_history[]           actor, action, prior failure, timestamp,
 The state root also has one `reparent_apply_lease` containing request ID and
 acquisition timestamp. Pending consent requests may coexist, but only the lease
 holder may enter `applying`, quiesce routes, or commit authority. A failed
-transaction retains the lease until a retry applies it or a verified rollback
-repairs it. Authority transactions are intentionally serialized globally;
+transaction retains the lease until a retry applies it, a verified rollback
+repairs it, or a verified pre-quiesce abort releases it. When the lease is
+empty, reconciliation selects the oldest ready request by `(created_at, id)`;
+this runs on startup, after every lease release, and after a mutation makes a
+request ready. Authority transactions are intentionally serialized globally;
 reparenting is rare, and avoiding cross-plan cycle races is more important than
 parallel apply throughput.
 
@@ -225,11 +247,12 @@ than partially applying. Recovery uses only the persisted plan plus
 expected-value checks.
 
 While the fence covers a session, create/spawn with that session as parent,
-restore of a stopped child, explicit retire/stop, and any parent-edge mutation
-that could change the planned graph return `409` with the controlling request
-ID. Observed provider/runtime death may still persist liveness truth; before
-authority commit it forces the transaction to restore its exact old parent
-edges and routing while preserving the observed stopped status, then end stale.
+restore or recredential of a covered seat, explicit retire/stop, and any
+parent-edge mutation that could change the planned graph return `409` with the
+controlling request ID. Observed provider/runtime death may still persist
+liveness truth; before authority commit it forces the transaction to restore
+its exact old parent edges and routing while preserving the observed stopped
+status, then end stale.
 A frozen child that stopped therefore remains stopped under the old source. If
 that restoration fails, the request enters the same durable quarantine as any
 other post-quiesce failure. These checks apply to every
@@ -271,6 +294,14 @@ cursor/timestamp, later idle proof, timestamps, and failure reason. It never
 contains the plaintext credential. Only one active rotation may cover a seat,
 and successful records are idempotent audit history.
 
+Runtime creation and relaunch use a separate top-level
+`session_runtime_launches` collection. Each record stores an operation ID,
+operation kind (`create | restore | recredential`), session ID, frozen tmux and
+provider launch parameters, provider resume identity, credential verifier,
+status (`prepared | launching | applied | failed`), timestamps, and failure
+reason. The active record is the source of truth for startup recovery; neither
+it nor any other durable record contains the plaintext credential.
+
 ## Validation
 
 Request creation and apply both reject:
@@ -285,8 +316,8 @@ Request creation and apply both reject:
 - tree initiation by anyone except source, target, or source's live parent;
 - tree promotion where target is not source's live direct child;
 - duplicate active requests whose affected edge sets overlap;
-- any request whose affected edge set overlaps a `failed` transaction that
-  reached `json_routing_quiesced` or later and has not been explicitly repaired;
+- any request whose affected edge set overlaps a failed transaction whose
+  durable topology/routing fence is still held;
 - a topology that changed after request creation.
 
 Apply revalidates all identities, liveness, topology, consent, and cycle
@@ -360,6 +391,20 @@ therefore a recoverable, fail-closed staged operation:
    fences and the global apply lease. Replay accepts an already-correct runtime
    registration and never starts a duplicate task.
 
+A deterministic failure or invalidated topology after step 1 but before
+`json_routing_quiesced` enters the durable pre-quiesce abort path. Under the
+state lock it first persists `apply_stage=prequiesce_aborting`; parent edges and
+existing routes are still unchanged. It then replays every deferred routing
+intent idempotently against the old canonical parent and verifies the replay.
+It also recreates and verifies any in-memory tasks stopped before the retained
+JSON records were quiesced. One final JSON replacement marks the request
+`stale` for invalid topology or `failed` for another deterministic apply error,
+records `apply_stage=prequiesce_aborted`, and releases both fences and the
+global lease.
+If replay or verification fails, the request remains `failed` at
+`prequiesce_aborting` and retains its fences and lease. Recovery or an operator
+`resume` continues that abort; it never replans or proceeds to quiescing.
+
 An interruption before step 3 exposes no new destructive authority and leaves
 old-parent routing paused rather than misdirected. An interruption after step 3
 has new authority with parent-derived routing still paused; dynamic delivery
@@ -373,14 +418,17 @@ restoration fails, the request remains failed and quarantined. After authority
 commit, recovery completes the recorded transaction; it never silently rolls
 authority back to a topology that may already have been observed.
 
-The applied and stale/rollback paths clear the global lease only in the same
-final JSON replacement that records every deferred routing intent replayed.
-Failure at any stage retains the lease. Startup recovers the recorded lease
+The applied, stale/rollback, and completed pre-quiesce abort paths clear the
+global lease only in the same final JSON replacement that records every
+deferred routing intent replayed. A failure during pre-quiesce abort or after
+`json_routing_quiesced` retains the lease. Startup recovers the recorded lease
 holder before another ready request may acquire it.
 
 On startup, all `applying` reparent records are recovered through their durable
 stage before retained parent-wake tasks are recreated and before HTTP/input
-readiness. In particular, a crash after an in-memory task was stopped but before
+readiness. `prequiesce_aborting` resumes only the abort path;
+`prequiesce_aborted` is already terminal and holds no lease. In particular, a
+crash after an in-memory task was stopped but before
 `json_routing_quiesced` cannot briefly recreate an old-parent task from the
 still-active retained record.
 
@@ -397,7 +445,9 @@ it.
 The authenticated human repair route supports exactly two audited actions:
 
 1. `resume` records a repair attempt, changes `failed` back to `applying`, and
-   retries the same immutable plan from its persisted stage. It never replans.
+   continues the persisted stage. At `prequiesce_aborting` it can only finish
+   the abort; at later stages it retries the same immutable plan. It never
+   replans.
 2. `rollback_precommit` is accepted only from `json_routing_quiesced` or
    `routing_quiesced`, before `authority_committed`. Under the routing fence,
    the server restores every route to the apply plan's exact recorded
@@ -547,6 +597,9 @@ PR targets `main`. Partial phases are not deployed.
   graph immediately after apply.
 - Pending and `applying` requests recover correctly after restart at every
   durable stage.
+- A failure before JSON quiesce durably aborts, restores any stopped in-memory
+  tasks, replays deferred routes to the old parent, and releases the global
+  lease; a crash during that abort resumes only the abort path.
 - Post-quiesce failures retain their overlap/routing fence; only a successful
   immutable-plan retry or verified pre-commit rollback releases it.
 - Deferred parent-derived route requests replay exactly once against the new
@@ -554,6 +607,9 @@ PR targets `main`. Partial phases are not deployed.
 - A pre-deployment live seat is recredentialed only after it becomes idle, keeps
   its seat and provider-thread identity, and recovers a crash after stop without
   accepting input under two runtimes.
+- Create, normal restore, and recredential each recover a crash after tmux
+  launch but before final persistence by replacing the unknowable runtime
+  credential through the same durable launch coordinator.
 - Legacy pending adoption records cannot auto-apply.
 - Rust CLI parser/dispatch and Python watch interaction tests pass.
 - Full Rust and retained Python test suites pass, or any demonstrably preexisting


### PR DESCRIPTION
Defines the implementation contract and phased delivery for consent-based single-session reparenting and atomic orchestrator tree promotion.

Tracks #1207.

Phase tickets: #1209, #1208, #1211, #1210.