### PR TITLE
feat: expose consent-based reparent workflow

### DIFF
--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -50,6 +50,11 @@ enum Command {
     Children(ChildrenArgs),
     Tail(TailArgs),
     Retire(SessionIdArgs),
+    Reparent(ReparentArgs),
+    #[command(name = "reparent-tree")]
+    ReparentTree(ReparentTreeArgs),
+    Adopt(AdoptArgs),
+    Recredential(RecredentialArgs),
     Restore(RestoreArgs),
     Attach(SessionIdArgs),
     Output(OutputArgs),
@@ -103,6 +108,58 @@ struct EmptyArgs {}
 #[derive(Args)]
 struct StatusArgs {
     text: Vec<String>,
+}
+
+#[derive(Args)]
+struct ReparentArgs {
+    #[command(subcommand)]
+    command: ReparentCommand,
+}
+
+#[derive(Subcommand)]
+enum ReparentCommand {
+    Request {
+        child: String,
+        #[arg(long)]
+        to: String,
+    },
+    Approve {
+        request_id: String,
+    },
+    Reject {
+        request_id: String,
+    },
+    Status {
+        request_id: Option<String>,
+    },
+    Repair {
+        request_id: String,
+        #[arg(long, conflicts_with = "rollback_precommit")]
+        resume: bool,
+        #[arg(long = "rollback-precommit", conflicts_with = "resume")]
+        rollback_precommit: bool,
+    },
+}
+
+#[derive(Args)]
+struct ReparentTreeArgs {
+    source: String,
+    #[arg(long)]
+    to: String,
+    #[arg(long)]
+    dry_run: bool,
+}
+
+#[derive(Args)]
+struct AdoptArgs {
+    child: String,
+}
+
+#[derive(Args)]
+struct RecredentialArgs {
+    session: Option<String>,
+    #[arg(long, conflicts_with = "session")]
+    all_live: bool,
 }
 
 #[derive(Args)]
@@ -796,6 +853,10 @@ fn run() -> Result<()> {
             )?;
             println!("{}", retire_response_status(&payload, &args.session_id)?);
         }
+        Command::Reparent(args) => run_reparent(&client, args)?,
+        Command::ReparentTree(args) => run_reparent_tree(&client, args)?,
+        Command::Adopt(args) => run_adopt(&client, args)?,
+        Command::Recredential(args) => run_recredential(&client, args)?,
         Command::Restore(args) => {
             restore_session(&client, args)?;
         }
@@ -2577,6 +2638,352 @@ fn run_what(client: &ApiClient, args: WhatArgs) -> Result<()> {
     }
 }
 
+fn run_reparent(client: &ApiClient, args: ReparentArgs) -> Result<()> {
+    match args.command {
+        ReparentCommand::Request { child, to } => {
+            let requester = current_session_id()?;
+            let credential = current_session_credential(&requester)?;
+            let child = resolve_required_session(client, &child)?;
+            let target = resolve_required_session(client, &to)?;
+            let record = client.post_json_with_session_credential(
+                &format!("/sessions/{child}/reparent-requests"),
+                json!({
+                    "requester_session_id": requester,
+                    "target_parent_session_id": target,
+                }),
+                &credential,
+            )?;
+            print_reparent_request_created(&record);
+        }
+        ReparentCommand::Approve { request_id } => {
+            decide_reparent_request(client, &request_id, "approve")?;
+        }
+        ReparentCommand::Reject { request_id } => {
+            decide_reparent_request(client, &request_id, "reject")?;
+        }
+        ReparentCommand::Status { request_id } => match request_id {
+            Some(request_id) => {
+                let record = get_reparent_json(
+                    client,
+                    &format!("/reparent-requests/{}", encode_path_segment(&request_id)),
+                )?;
+                print_reparent_request_detail(&record);
+            }
+            None => {
+                let payload = get_reparent_json(client, "/reparent-requests")?;
+                let records = payload["requests"].as_array().cloned().unwrap_or_default();
+                if records.is_empty() {
+                    println!("No reparent requests");
+                } else {
+                    for record in records {
+                        println!("{}", format_reparent_request_row(&record));
+                    }
+                }
+            }
+        },
+        ReparentCommand::Repair {
+            request_id,
+            resume,
+            rollback_precommit,
+        } => {
+            let action = match (resume, rollback_precommit) {
+                (true, false) => "resume",
+                (false, true) => "rollback_precommit",
+                _ => bail!("choose exactly one of --resume or --rollback-precommit"),
+            };
+            let record = client.post_json(
+                &format!(
+                    "/reparent-requests/{}/repair",
+                    encode_path_segment(&request_id)
+                ),
+                json!({ "action": action }),
+            )?;
+            print_reparent_request_detail(&record);
+        }
+    }
+    Ok(())
+}
+
+fn run_reparent_tree(client: &ApiClient, args: ReparentTreeArgs) -> Result<()> {
+    let requester = current_session_id()?;
+    let credential = current_session_credential(&requester)?;
+    let source = resolve_required_session(client, &args.source)?;
+    let target = resolve_required_session(client, &args.to)?;
+    let response = client.post_json_with_session_credential(
+        &format!("/sessions/{source}/reparent-tree-requests"),
+        json!({
+            "requester_session_id": requester,
+            "target_session_id": target,
+            "dry_run": args.dry_run,
+        }),
+        &credential,
+    )?;
+    if args.dry_run {
+        print_reparent_tree_preview(&response);
+    } else {
+        print_reparent_request_created(&response);
+    }
+    Ok(())
+}
+
+fn run_adopt(client: &ApiClient, args: AdoptArgs) -> Result<()> {
+    let requester = current_session_id()?;
+    let credential = current_session_credential(&requester)?;
+    let child = resolve_required_session(client, &args.child)?;
+    let record = client.post_json_with_session_credential(
+        &format!("/sessions/{child}/reparent-requests"),
+        json!({
+            "requester_session_id": requester,
+            "target_parent_session_id": requester,
+        }),
+        &credential,
+    )?;
+    print_reparent_request_created(&record);
+    Ok(())
+}
+
+fn run_recredential(client: &ApiClient, args: RecredentialArgs) -> Result<()> {
+    let targets = if args.all_live {
+        let payload = client.get_json("/sessions")?;
+        payload["sessions"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter(|session| {
+                matches!(
+                    session["status"].as_str().unwrap_or_default(),
+                    "running" | "idle" | "waiting_permission"
+                )
+            })
+            .filter_map(|session| session["id"].as_str().map(ToOwned::to_owned))
+            .collect::<Vec<_>>()
+    } else {
+        let target = args
+            .session
+            .as_deref()
+            .context("session is required unless --all-live is used")?;
+        vec![resolve_required_session(client, target)?]
+    };
+    if targets.is_empty() {
+        println!("No live sessions to recredential");
+        return Ok(());
+    }
+    let mut failed = 0usize;
+    for target in targets {
+        match client.post_json(
+            &format!("/sessions/{target}/credential-rotation"),
+            json!({}),
+        ) {
+            Ok(record) => println!(
+                "{} {}",
+                target,
+                record["status"].as_str().unwrap_or("unknown")
+            ),
+            Err(error) => {
+                failed += 1;
+                eprintln!("{target} failed: {error:#}");
+            }
+        }
+    }
+    if failed > 0 {
+        bail!("{failed} recredential request(s) failed");
+    }
+    Ok(())
+}
+
+fn decide_reparent_request(client: &ApiClient, request_id: &str, action: &str) -> Result<()> {
+    let requester = current_session_id()?;
+    let credential = current_session_credential(&requester)?;
+    let record = client.post_json_with_session_credential(
+        &format!(
+            "/reparent-requests/{}/{}",
+            encode_path_segment(request_id),
+            action
+        ),
+        json!({ "requester_session_id": requester }),
+        &credential,
+    )?;
+    print_reparent_request_detail(&record);
+    Ok(())
+}
+
+fn current_session_credential(session_id: &str) -> Result<String> {
+    env::var("SM_SESSION_CREDENTIAL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .with_context(|| {
+            format!(
+                "this session has no runtime credential; ask the operator to run `sm recredential {session_id}`"
+            )
+        })
+}
+
+fn get_reparent_json(client: &ApiClient, path: &str) -> Result<Value> {
+    let Some(session_id) = optional_current_session_id() else {
+        return client.get_json(path);
+    };
+    let credential = current_session_credential(&session_id)?;
+    client.get_json_with_session_credential(path, &session_id, &credential)
+}
+
+fn resolve_required_session(client: &ApiClient, identifier: &str) -> Result<String> {
+    lookup_identifier_exact(client, identifier)?
+        .with_context(|| format!("No agent named '{identifier}' is reachable"))
+}
+
+fn print_reparent_request_created(record: &Value) {
+    println!(
+        "Reparent request {} created: {}",
+        record["id"].as_str().unwrap_or("unknown"),
+        format_reparent_request_row(record)
+    );
+}
+
+fn format_reparent_request_row(record: &Value) -> String {
+    let id = record["id"].as_str().unwrap_or("unknown");
+    let kind = record["kind"].as_str().unwrap_or("unknown");
+    let source = record["subject_session_id"].as_str().unwrap_or("unknown");
+    let target = record["target_parent_session_id"]
+        .as_str()
+        .unwrap_or("unknown");
+    let status = record["status"].as_str().unwrap_or("unknown");
+    let mut row = format!("{id} {kind} {source} -> {target} {status}");
+    if let Some(reason) = record["failure_reason"].as_str() {
+        row.push_str(&format!(" ({reason})"));
+    }
+    row
+}
+
+fn print_reparent_request_detail(record: &Value) {
+    println!("{}", format_reparent_request_row(record));
+    println!(
+        "initiator: {} · expires: {} · stage: {}",
+        record["initiator_session_id"].as_str().unwrap_or("unknown"),
+        record["expires_at"].as_str().unwrap_or("unknown"),
+        record["apply_stage"].as_str().unwrap_or("-")
+    );
+    let edges = reparent_edges_for_display(record);
+    print_reparent_edges(Some(&edges));
+    let approvals = record["approvals"].as_array().cloned().unwrap_or_default();
+    let required = record["required_agent_approvals"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    for actor in required {
+        let actor = actor.as_str().unwrap_or("unknown");
+        let decision = approvals
+            .iter()
+            .find(|approval| approval["actor_kind"] == "agent" && approval["actor_id"] == actor)
+            .and_then(|approval| approval["decision"].as_str())
+            .unwrap_or("pending");
+        println!("agent approval: {actor} {decision}");
+    }
+    if record["required_human_approval"].as_bool().unwrap_or(false) {
+        let decision = approvals
+            .iter()
+            .find(|approval| approval["actor_kind"] == "human")
+            .and_then(|approval| approval["decision"].as_str())
+            .unwrap_or("pending");
+        println!("human approval: {decision}");
+    }
+}
+
+fn reparent_edges_for_display(record: &Value) -> Vec<Value> {
+    if let Some(edges) = record["apply_plan"]["edge_changes"].as_array() {
+        return edges.clone();
+    }
+    let source = record["subject_session_id"].as_str().unwrap_or("unknown");
+    let target = record["target_parent_session_id"]
+        .as_str()
+        .unwrap_or("unknown");
+    let old_parent = record["expected_parent_session_id"].as_str();
+    if record["kind"] == "tree" {
+        let mut edges = vec![
+            json!({
+                "session_id": target,
+                "expected_parent_session_id": source,
+                "new_parent_session_id": old_parent,
+            }),
+            json!({
+                "session_id": source,
+                "expected_parent_session_id": old_parent,
+                "new_parent_session_id": target,
+            }),
+        ];
+        edges.extend(
+            record["frozen_live_child_ids"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .filter_map(Value::as_str)
+                .filter(|child| *child != target)
+                .map(|child| {
+                    json!({
+                        "session_id": child,
+                        "expected_parent_session_id": source,
+                        "new_parent_session_id": target,
+                    })
+                }),
+        );
+        edges
+    } else {
+        vec![json!({
+            "session_id": source,
+            "expected_parent_session_id": old_parent,
+            "new_parent_session_id": target,
+        })]
+    }
+}
+
+fn print_reparent_tree_preview(preview: &Value) {
+    println!(
+        "Dry run: {} -> {}",
+        preview["source_session_id"].as_str().unwrap_or("unknown"),
+        preview["target_session_id"].as_str().unwrap_or("unknown")
+    );
+    print_reparent_edges(preview["edge_changes"].as_array());
+    for blocker in preview["blockers"].as_array().into_iter().flatten() {
+        println!("blocker: {}", blocker.as_str().unwrap_or("unknown"));
+    }
+    for actor in preview["required_agent_approvals"]
+        .as_array()
+        .into_iter()
+        .flatten()
+    {
+        println!("agent approval: {}", actor.as_str().unwrap_or("unknown"));
+    }
+    if preview["required_human_approval"]
+        .as_bool()
+        .unwrap_or(false)
+    {
+        println!("human approval: required");
+    }
+    println!(
+        "routing changes: JSON {} · queue {}",
+        preview["json_routing_changes"]
+            .as_array()
+            .map_or(0, Vec::len),
+        preview["queue_routing_changes"]
+            .as_array()
+            .map_or(0, Vec::len)
+    );
+}
+
+fn print_reparent_edges(edges: Option<&Vec<Value>>) {
+    if let Some(edges) = edges {
+        for edge in edges {
+            println!(
+                "edge: {} {} -> {}",
+                edge["session_id"].as_str().unwrap_or("unknown"),
+                edge["expected_parent_session_id"]
+                    .as_str()
+                    .unwrap_or("root"),
+                edge["new_parent_session_id"].as_str().unwrap_or("root")
+            );
+        }
+    }
+}
+
 fn run_usage(client: &ApiClient, args: UsageArgs) -> Result<()> {
     if args.account && (args.agent.is_some() || args.include_children) {
         bail!("--account is mutually exclusive with AGENT and --include-children");
@@ -3951,8 +4358,41 @@ impl ApiClient {
         response.into_json()
     }
 
+    fn get_json_with_session_credential(
+        &self,
+        path: &str,
+        session_id: &str,
+        credential: &str,
+    ) -> Result<Value> {
+        self.request_with_headers(
+            "GET",
+            path,
+            None,
+            &[
+                ("X-SM-Session-ID", session_id),
+                ("X-SM-Session-Credential", credential),
+            ],
+        )?
+        .into_json()
+    }
+
     fn post_json(&self, path: &str, body: Value) -> Result<Value> {
         let response = self.request("POST", path, Some(body))?;
+        response.into_json()
+    }
+
+    fn post_json_with_session_credential(
+        &self,
+        path: &str,
+        body: Value,
+        credential: &str,
+    ) -> Result<Value> {
+        let response = self.request_with_headers(
+            "POST",
+            path,
+            Some(body),
+            &[("X-SM-Session-Credential", credential)],
+        )?;
         response.into_json()
     }
 
@@ -3972,8 +4412,18 @@ impl ApiClient {
     }
 
     fn request(&self, method: &str, path: &str, body: Option<Value>) -> Result<ApiResponse> {
+        self.request_with_headers(method, path, body, &[])
+    }
+
+    fn request_with_headers(
+        &self,
+        method: &str,
+        path: &str,
+        body: Option<Value>,
+        headers: &[(&str, &str)],
+    ) -> Result<ApiResponse> {
         if self.scheme == "https" {
-            return self.request_https(method, path, body);
+            return self.request_https(method, path, body, headers);
         }
         let body_bytes = match body {
             Some(value) => serde_json::to_vec(&value)?,
@@ -3982,11 +4432,14 @@ impl ApiClient {
         let full_path = format!("{}{}", self.path_prefix, path);
         let mut stream = TcpStream::connect((self.host.as_str(), self.port))
             .with_context(|| format!("failed to connect to {}", self.authority))?;
-        let request = format!(
-            "{method} {full_path} HTTP/1.1\r\nHost: {}\r\nAccept: application/json\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-            self.authority,
-            body_bytes.len()
+        let mut request = format!(
+            "{method} {full_path} HTTP/1.1\r\nHost: {}\r\nAccept: application/json\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n",
+            self.authority, body_bytes.len()
         );
+        for (name, value) in headers {
+            request.push_str(&format!("{name}: {value}\r\n"));
+        }
+        request.push_str("\r\n");
         stream.write_all(request.as_bytes())?;
         stream.write_all(&body_bytes)?;
         let mut raw = Vec::new();
@@ -3994,7 +4447,13 @@ impl ApiClient {
         parse_response(&raw)
     }
 
-    fn request_https(&self, method: &str, path: &str, body: Option<Value>) -> Result<ApiResponse> {
+    fn request_https(
+        &self,
+        method: &str,
+        path: &str,
+        body: Option<Value>,
+        headers: &[(&str, &str)],
+    ) -> Result<ApiResponse> {
         let body_bytes = match body {
             Some(value) => serde_json::to_vec(&value)?,
             None => Vec::new(),
@@ -4008,32 +4467,57 @@ impl ApiClient {
             .build()
             .into();
         let mut response = match method {
-            "GET" => agent
-                .get(&url)
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
-                .call(),
-            "POST" => agent
-                .post(&url)
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
-                .send(body_bytes.as_slice()),
-            "PUT" => agent
-                .put(&url)
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
-                .send(body_bytes.as_slice()),
-            "PATCH" => agent
-                .patch(&url)
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
-                .send(body_bytes.as_slice()),
-            "DELETE" => agent
-                .delete(&url)
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
-                .force_send_body()
-                .send(body_bytes.as_slice()),
+            "GET" => {
+                let mut request = agent
+                    .get(&url)
+                    .header("Accept", "application/json")
+                    .header("Content-Type", "application/json");
+                for (name, value) in headers {
+                    request = request.header(*name, *value);
+                }
+                request.call()
+            }
+            "POST" => {
+                let mut request = agent
+                    .post(&url)
+                    .header("Accept", "application/json")
+                    .header("Content-Type", "application/json");
+                for (name, value) in headers {
+                    request = request.header(*name, *value);
+                }
+                request.send(body_bytes.as_slice())
+            }
+            "PUT" => {
+                let mut request = agent
+                    .put(&url)
+                    .header("Accept", "application/json")
+                    .header("Content-Type", "application/json");
+                for (name, value) in headers {
+                    request = request.header(*name, *value);
+                }
+                request.send(body_bytes.as_slice())
+            }
+            "PATCH" => {
+                let mut request = agent
+                    .patch(&url)
+                    .header("Accept", "application/json")
+                    .header("Content-Type", "application/json");
+                for (name, value) in headers {
+                    request = request.header(*name, *value);
+                }
+                request.send(body_bytes.as_slice())
+            }
+            "DELETE" => {
+                let mut request = agent
+                    .delete(&url)
+                    .header("Accept", "application/json")
+                    .header("Content-Type", "application/json")
+                    .force_send_body();
+                for (name, value) in headers {
+                    request = request.header(*name, *value);
+                }
+                request.send(body_bytes.as_slice())
+            }
             _ => bail!("unsupported HTTP method {method}"),
         }
         .with_context(|| format!("failed to request {url}"))?;
@@ -4392,6 +4876,32 @@ mod tests {
                 stream.write_all(response.as_bytes()).unwrap();
             }
             paths
+        });
+        let client = ApiClient::parse(&format!("http://{address}")).unwrap();
+        (client, server)
+    }
+
+    fn single_request_server(
+        status: u16,
+        body: &'static str,
+    ) -> (ApiClient, thread::JoinHandle<Vec<String>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            stream
+                .set_read_timeout(Some(std::time::Duration::from_secs(2)))
+                .unwrap();
+            let mut buffer = [0_u8; 8192];
+            let bytes_read = stream.read(&mut buffer).unwrap();
+            let request = String::from_utf8_lossy(&buffer[..bytes_read]).to_string();
+            let reason = if status == 200 { "OK" } else { "Error" };
+            let response = format!(
+                "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+            vec![request]
         });
         let client = ApiClient::parse(&format!("http://{address}")).unwrap();
         (client, server)
@@ -4780,6 +5290,91 @@ mod tests {
             assert_eq!(args.prompt.join(" "), "Summarize current work");
         }
         assert_eq!(retired_command_message(&["what", "worker"]), None);
+    }
+
+    #[test]
+    fn reparent_cli_parses_request_tree_decision_repair_and_rollout_forms() {
+        let request =
+            Cli::try_parse_from(["sm", "reparent", "request", "child", "--to", "parent"]).unwrap();
+        let Command::Reparent(request) = request.command else {
+            panic!("expected reparent command");
+        };
+        assert!(matches!(
+            request.command,
+            ReparentCommand::Request { child, to } if child == "child" && to == "parent"
+        ));
+
+        let tree = Cli::try_parse_from([
+            "sm",
+            "reparent-tree",
+            "source",
+            "--to",
+            "target",
+            "--dry-run",
+        ])
+        .unwrap();
+        let Command::ReparentTree(tree) = tree.command else {
+            panic!("expected reparent-tree command");
+        };
+        assert_eq!(tree.source, "source");
+        assert_eq!(tree.to, "target");
+        assert!(tree.dry_run);
+
+        assert!(matches!(
+            Cli::try_parse_from(["sm", "reparent", "approve", "request1"])
+                .unwrap()
+                .command,
+            Command::Reparent(ReparentArgs {
+                command: ReparentCommand::Approve { .. }
+            })
+        ));
+        assert!(matches!(
+            Cli::try_parse_from([
+                "sm",
+                "reparent",
+                "repair",
+                "request1",
+                "--rollback-precommit",
+            ])
+            .unwrap()
+            .command,
+            Command::Reparent(ReparentArgs {
+                command: ReparentCommand::Repair {
+                    rollback_precommit: true,
+                    ..
+                }
+            })
+        ));
+        assert!(matches!(
+            Cli::try_parse_from(["sm", "recredential", "--all-live"])
+                .unwrap()
+                .command,
+            Command::Recredential(RecredentialArgs { all_live: true, .. })
+        ));
+        assert!(matches!(
+            Cli::try_parse_from(["sm", "adopt", "child"])
+                .unwrap()
+                .command,
+            Command::Adopt(AdoptArgs { child }) if child == "child"
+        ));
+    }
+
+    #[test]
+    fn session_credential_header_is_sent_without_entering_the_json_body() {
+        let (client, handle) = single_request_server(200, r#"{"id":"request1"}"#);
+
+        let response = client
+            .post_json_with_session_credential(
+                "/sessions/child/reparent-requests",
+                json!({"requester_session_id": "parent"}),
+                "opaque-secret",
+            )
+            .unwrap();
+
+        assert_eq!(response["id"], "request1");
+        let requests = handle.join().unwrap();
+        assert!(requests[0].contains("X-SM-Session-Credential: opaque-secret\r\n"));
+        assert!(!requests[0].contains("\"opaque-secret\""));
     }
 
     #[test]

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -434,6 +434,9 @@ impl AppState {
         session_store
             .reconcile_reparent_requests()
             .context("reparent authority recovery failed")?;
+        if let Err(error) = session_store.reconcile_reparent_notifications() {
+            eprintln!("reparent notification recovery failed: {error:#}");
+        }
         if let Err(error) = session_store.recover_session_credential_rotation_workers() {
             eprintln!("session credential rotation recovery failed: {error:#}");
         }
@@ -2880,8 +2883,31 @@ async fn list_reparent_requests(
     request: Request,
 ) -> Result<Json<Value>, ApiError> {
     ensure_session_read_allowed(&state, &request)?;
+    reconcile_reparent_notifications_best_effort(&state);
+    let requests = if let Some(session_id) = header_text(request.headers(), "x-sm-session-id") {
+        let credential = reparent_session_credential(request.headers())?;
+        state
+            .session_store
+            .list_reparent_requests_for_session(&session_id, &credential)?
+            .ok_or_else(|| ApiError::Status {
+                status: StatusCode::FORBIDDEN,
+                detail: "session credential is missing, stale, or does not match the claimed actor"
+                    .to_owned(),
+            })?
+    } else {
+        if state.config.google_auth.requested()
+            && request_actor_email(&state.config, &request).is_none()
+        {
+            return Err(ApiError::Status {
+                status: StatusCode::UNAUTHORIZED,
+                detail: "Operator authentication or managed session identity is required"
+                    .to_owned(),
+            });
+        }
+        state.session_store.list_reparent_requests()?
+    };
     Ok(Json(json!({
-        "requests": state.session_store.list_reparent_requests()?,
+        "requests": requests,
     })))
 }
 
@@ -2964,10 +2990,37 @@ async fn get_reparent_request(
     request: Request,
 ) -> Result<Json<Value>, ApiError> {
     ensure_session_read_allowed(&state, &request)?;
+    reconcile_reparent_notifications_best_effort(&state);
     let record = state
         .session_store
         .get_reparent_request(&request_id)?
         .ok_or(ApiError::NotFound("Reparent request not found"))?;
+    if let Some(session_id) = header_text(request.headers(), "x-sm-session-id") {
+        let credential = reparent_session_credential(request.headers())?;
+        let visible = state
+            .session_store
+            .list_reparent_requests_for_session(&session_id, &credential)?
+            .ok_or_else(|| ApiError::Status {
+                status: StatusCode::FORBIDDEN,
+                detail: "session credential is missing, stale, or does not match the claimed actor"
+                    .to_owned(),
+            })?
+            .into_iter()
+            .any(|candidate| candidate.id == record.id);
+        if !visible {
+            return Err(ApiError::Status {
+                status: StatusCode::FORBIDDEN,
+                detail: "reparent request does not involve this session".to_owned(),
+            });
+        }
+    } else if state.config.google_auth.requested()
+        && request_actor_email(&state.config, &request).is_none()
+    {
+        return Err(ApiError::Status {
+            status: StatusCode::UNAUTHORIZED,
+            detail: "Operator authentication or managed session identity is required".to_owned(),
+        });
+    }
     Ok(Json(serde_json::to_value(record)?))
 }
 
@@ -2979,11 +3032,12 @@ async fn create_reparent_request(
 ) -> Result<Response, ApiError> {
     ensure_core_writes_enabled(&state)?;
     let credential = reparent_session_credential(&headers)?;
-    reparent_mutation_response(state.session_store.create_reparent_request(
-        &subject_session_id,
-        payload,
-        &credential,
-    )?)
+    let outcome =
+        state
+            .session_store
+            .create_reparent_request(&subject_session_id, payload, &credential)?;
+    reconcile_reparent_notifications_best_effort(&state);
+    reparent_mutation_response(outcome)
 }
 
 async fn create_reparent_tree_request(
@@ -2994,11 +3048,13 @@ async fn create_reparent_tree_request(
 ) -> Result<Response, ApiError> {
     ensure_core_writes_enabled(&state)?;
     let credential = reparent_session_credential(&headers)?;
-    reparent_mutation_response(state.session_store.create_reparent_tree_request(
+    let outcome = state.session_store.create_reparent_tree_request(
         &source_session_id,
         payload,
         &credential,
-    )?)
+    )?;
+    reconcile_reparent_notifications_best_effort(&state);
+    reparent_mutation_response(outcome)
 }
 
 async fn approve_reparent_request(
@@ -3009,12 +3065,14 @@ async fn approve_reparent_request(
 ) -> Result<Response, ApiError> {
     ensure_core_writes_enabled(&state)?;
     let credential = reparent_session_credential(&headers)?;
-    reparent_mutation_response(state.session_store.decide_reparent_request(
+    let outcome = state.session_store.decide_reparent_request(
         &request_id,
         payload,
         ReparentDecision::Approved,
         &credential,
-    )?)
+    )?;
+    reconcile_reparent_notifications_best_effort(&state);
+    reparent_mutation_response(outcome)
 }
 
 async fn reject_reparent_request(
@@ -3025,12 +3083,14 @@ async fn reject_reparent_request(
 ) -> Result<Response, ApiError> {
     ensure_core_writes_enabled(&state)?;
     let credential = reparent_session_credential(&headers)?;
-    reparent_mutation_response(state.session_store.decide_reparent_request(
+    let outcome = state.session_store.decide_reparent_request(
         &request_id,
         payload,
         ReparentDecision::Rejected,
         &credential,
-    )?)
+    )?;
+    reconcile_reparent_notifications_best_effort(&state);
+    reparent_mutation_response(outcome)
 }
 
 async fn human_approve_reparent_request(
@@ -3083,11 +3143,11 @@ async fn repair_reparent_request(
         status: StatusCode::BAD_REQUEST,
         detail: "action must be resume or rollback_precommit".to_owned(),
     })?;
-    reparent_mutation_response(state.session_store.repair_reparent_request(
-        &request_id,
-        &actor_id,
-        action,
-    )?)
+    let outcome = state
+        .session_store
+        .repair_reparent_request(&request_id, &actor_id, action)?;
+    reconcile_reparent_notifications_best_effort(&state);
+    reparent_mutation_response(outcome)
 }
 
 fn human_decide_reparent_request(
@@ -3102,11 +3162,17 @@ fn human_decide_reparent_request(
         status: StatusCode::UNAUTHORIZED,
         detail: "Operator authentication is required".to_owned(),
     })?;
-    reparent_mutation_response(
-        state
-            .session_store
-            .decide_reparent_request_as_human(request_id, &actor_id, decision)?,
-    )
+    let outcome = state
+        .session_store
+        .decide_reparent_request_as_human(request_id, &actor_id, decision)?;
+    reconcile_reparent_notifications_best_effort(state);
+    reparent_mutation_response(outcome)
+}
+
+fn reconcile_reparent_notifications_best_effort(state: &AppState) {
+    if let Err(error) = state.session_store.reconcile_reparent_notifications() {
+        eprintln!("reparent notification reconciliation failed: {error:#}");
+    }
 }
 
 fn reparent_session_credential(headers: &HeaderMap) -> Result<String, ApiError> {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1966,29 +1966,61 @@ impl SessionStore {
             required_human_approval,
             blockers: blockers.clone(),
         };
-        if request.dry_run {
-            return Ok(ReparentMutationOutcome::Preview(preview));
-        }
-        if let Some(blocker) = blockers.into_iter().next() {
-            return Ok(ReparentMutationOutcome::BadRequest(blocker));
-        }
         let now = OffsetDateTime::now_utc();
         let mut records = reparent_request_records(&state)?;
-        let _ = refresh_reparent_requests(&mut records, &sessions, now);
+        let refreshed = refresh_reparent_requests(&mut records, &sessions, now);
         let affected_ids = preview
             .edge_changes
             .iter()
             .map(|change| change.session_id.clone())
             .chain(expected_parent_session_id.iter().cloned())
             .collect::<BTreeSet<_>>();
-        if let Some(conflict) = records.iter().find(|record| {
+        let active_conflict = records.iter().find(|record| {
             record.is_active() && !record.affected_session_ids().is_disjoint(&affected_ids)
-        }) {
+        });
+        if request.dry_run {
+            let mut preview = preview;
+            if let Some(conflict) = active_conflict {
+                let overlapping_session = if affected_ids.contains(&conflict.subject_session_id) {
+                    conflict.subject_session_id.clone()
+                } else {
+                    conflict
+                        .affected_session_ids()
+                        .intersection(&affected_ids)
+                        .next()
+                        .cloned()
+                        .unwrap_or_else(|| "unknown".to_owned())
+                };
+                preview.blockers.push(format!(
+                    "request {} already controls session {} in the tree promotion",
+                    conflict.id, overlapping_session
+                ));
+            }
+            if refreshed {
+                store_reparent_request_records(&mut state, &records)?;
+                self.write_raw_json_value(&state)?;
+            }
+            return Ok(ReparentMutationOutcome::Preview(preview));
+        }
+        if let Some(blocker) = blockers.into_iter().next() {
+            return Ok(ReparentMutationOutcome::BadRequest(blocker));
+        }
+        if let Some(conflict) = active_conflict {
+            let overlapping_session = if affected_ids.contains(&conflict.subject_session_id) {
+                conflict.subject_session_id.clone()
+            } else {
+                conflict
+                    .affected_session_ids()
+                    .intersection(&affected_ids)
+                    .next()
+                    .cloned()
+                    .unwrap_or_else(|| "unknown".to_owned())
+            };
             store_reparent_request_records(&mut state, &records)?;
             self.write_raw_json_value(&state)?;
             return Ok(ReparentMutationOutcome::Conflict(format!(
-                "request {} already controls part of the tree promotion",
-                conflict.id
+                "request {} already controls session {} in the tree promotion",
+                conflict.id, overlapping_session
             )));
         }
         let created_at = now.format(&Rfc3339)?;
@@ -2274,6 +2306,30 @@ impl SessionStore {
         Ok(records)
     }
 
+    pub fn list_reparent_requests_for_session(
+        &self,
+        session_id: &str,
+        session_credential: &str,
+    ) -> Result<Option<Vec<ReparentRequestRecord>>> {
+        let session_id = session_id.trim();
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = snapshot_from_raw_value(&state)?.into_sessions();
+        if !session_credential_matches(&sessions, session_id, session_credential) {
+            return Ok(None);
+        }
+        let mut records = reparent_request_records(&state)?;
+        if refresh_reparent_requests(&mut records, &sessions, OffsetDateTime::now_utc()) {
+            store_reparent_request_records(&mut state, &records)?;
+            self.write_raw_json_value(&state)?;
+        }
+        records.retain(|record| record.involves_session(session_id));
+        records.sort_by(|left, right| {
+            (&left.created_at, &left.id).cmp(&(&right.created_at, &right.id))
+        });
+        Ok(Some(records))
+    }
+
     pub fn send_parent_notification(
         &self,
         child_session_id: &str,
@@ -2345,6 +2401,82 @@ impl SessionStore {
                 return Ok(first);
             }
         }
+    }
+
+    pub fn reconcile_reparent_notifications(&self) -> Result<()> {
+        let pending = {
+            let _guard = self.write_guard()?;
+            let mut state = self.load_raw_json_value()?;
+            let sessions = snapshot_from_raw_value(&state)?.into_sessions();
+            let mut records = reparent_request_records(&state)?;
+            let refreshed =
+                refresh_reparent_requests(&mut records, &sessions, OffsetDateTime::now_utc());
+            let mut changed = refreshed;
+            for record in &mut records {
+                for desired in desired_reparent_notifications(record) {
+                    if record
+                        .notification_intents
+                        .iter()
+                        .all(|intent| intent.key != desired.intent.key)
+                    {
+                        record.notification_intents.push(desired.intent);
+                        changed = true;
+                    }
+                }
+            }
+            if changed {
+                store_reparent_request_records(&mut state, &records)?;
+                self.write_raw_json_value(&state)?;
+            }
+            records
+                .iter()
+                .flat_map(|record| {
+                    desired_reparent_notifications(record)
+                        .into_iter()
+                        .filter(|desired| {
+                            record.notification_intents.iter().any(|intent| {
+                                intent.key == desired.intent.key && intent.enqueued_at.is_none()
+                            })
+                        })
+                })
+                .collect::<Vec<_>>()
+        };
+        for desired in pending {
+            let queue = self
+                .queue_store
+                .as_ref()
+                .context("reparent notifications require the retained queue store")?;
+            queue.enqueue_message_once_with_metadata(
+                &desired.intent.key,
+                &desired.intent.recipient_session_id,
+                &desired.text,
+                "important",
+                QueueMessageMetadata {
+                    message_category: Some("reparent".to_owned()),
+                    ..QueueMessageMetadata::default()
+                },
+            )?;
+            let _guard = self.write_guard()?;
+            let mut state = self.load_raw_json_value()?;
+            let mut records = reparent_request_records(&state)?;
+            let record = records
+                .iter_mut()
+                .find(|record| record.id == desired.request_id)
+                .with_context(|| format!("reparent request {} disappeared", desired.request_id))?;
+            let intent = record
+                .notification_intents
+                .iter_mut()
+                .find(|intent| intent.key == desired.intent.key)
+                .with_context(|| {
+                    format!("reparent notification {} disappeared", desired.intent.key)
+                })?;
+            if intent.enqueued_at.is_none() {
+                intent.enqueued_at = Some(now_rfc3339());
+                store_reparent_request_records(&mut state, &records)?;
+                self.write_raw_json_value(&state)?;
+            }
+        }
+        Ok(())
     }
 
     pub fn repair_reparent_request(
@@ -11642,12 +11774,24 @@ fn store_reparent_request_records(
     state: &mut Value,
     records: &[ReparentRequestRecord],
 ) -> Result<()> {
+    let mut records = records.to_vec();
+    for record in &mut records {
+        for desired in desired_reparent_notifications(record) {
+            if record
+                .notification_intents
+                .iter()
+                .all(|intent| intent.key != desired.intent.key)
+            {
+                record.notification_intents.push(desired.intent);
+            }
+        }
+    }
     let object = state
         .as_object_mut()
         .ok_or_else(|| anyhow::anyhow!("session state root must be an object"))?;
     object.insert(
         "reparent_requests".to_owned(),
-        serde_json::to_value(records)?,
+        serde_json::to_value(&records)?,
     );
     Ok(())
 }
@@ -12767,6 +12911,177 @@ pub struct ReparentNotificationIntent {
     pub enqueued_at: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+struct DesiredReparentNotification {
+    request_id: String,
+    intent: ReparentNotificationIntent,
+    text: String,
+}
+
+fn desired_reparent_notifications(
+    record: &ReparentRequestRecord,
+) -> Vec<DesiredReparentNotification> {
+    let mut desired = Vec::new();
+    if record.status == "pending" {
+        let approved = record
+            .approvals
+            .iter()
+            .filter(|approval| approval.actor_kind == "agent" && approval.decision == "approved")
+            .map(|approval| approval.actor_id.as_str())
+            .collect::<BTreeSet<_>>();
+        let missing = record
+            .required_agent_approvals
+            .iter()
+            .filter(|actor| !approved.contains(actor.as_str()))
+            .cloned()
+            .collect::<Vec<_>>();
+        let event = format!("approval:{}", missing.join(","));
+        for recipient in &missing {
+            desired.push(reparent_notification(
+                record,
+                &event,
+                recipient,
+                reparent_approval_notification_text(record),
+            ));
+        }
+        if record.approvals.len() > 1 {
+            for recipient in record
+                .required_agent_approvals
+                .iter()
+                .chain(std::iter::once(&record.initiator_session_id))
+                .filter(|recipient| !missing.contains(recipient))
+                .collect::<BTreeSet<_>>()
+            {
+                desired.push(reparent_notification(
+                    record,
+                    &event,
+                    recipient,
+                    reparent_progress_notification_text(record, &missing),
+                ));
+            }
+        }
+    } else if matches!(
+        record.status.as_str(),
+        "applied" | "rejected" | "expired" | "stale" | "failed" | "repaired"
+    ) {
+        let event = format!("terminal:{}", record.status);
+        for recipient in record
+            .required_agent_approvals
+            .iter()
+            .chain(std::iter::once(&record.initiator_session_id))
+            .collect::<BTreeSet<_>>()
+        {
+            desired.push(reparent_notification(
+                record,
+                &event,
+                recipient,
+                reparent_terminal_notification_text(record),
+            ));
+        }
+    }
+    desired
+}
+
+fn reparent_notification(
+    record: &ReparentRequestRecord,
+    event: &str,
+    recipient: &str,
+    text: String,
+) -> DesiredReparentNotification {
+    DesiredReparentNotification {
+        request_id: record.id.clone(),
+        intent: ReparentNotificationIntent {
+            key: format!("reparent:{}:{event}:{recipient}", record.id),
+            event: event.to_owned(),
+            recipient_session_id: recipient.to_owned(),
+            enqueued_at: None,
+        },
+        text,
+    }
+}
+
+fn reparent_approval_notification_text(record: &ReparentRequestRecord) -> String {
+    format!(
+        "[sm reparent] {} request {} from {} needs your approval. {} Expires {}. Approve: `sm reparent approve {}`. Reject: `sm reparent reject {}`.",
+        record.kind,
+        record.id,
+        record.initiator_session_id,
+        reparent_edge_summary(record),
+        record.expires_at,
+        record.id,
+        record.id,
+    )
+}
+
+fn reparent_progress_notification_text(
+    record: &ReparentRequestRecord,
+    missing: &[String],
+) -> String {
+    format!(
+        "[sm reparent] Request {} remains pending. Missing agent approvals: {}.{}",
+        record.id,
+        if missing.is_empty() {
+            "none".to_owned()
+        } else {
+            missing.join(", ")
+        },
+        if record.required_human_approval {
+            " Human approval is also required in `sm watch`."
+        } else {
+            ""
+        }
+    )
+}
+
+fn reparent_terminal_notification_text(record: &ReparentRequestRecord) -> String {
+    format!(
+        "[sm reparent] Request {} is {}. {}{}",
+        record.id,
+        record.status,
+        reparent_edge_summary(record),
+        record
+            .failure_reason
+            .as_deref()
+            .map(|reason| format!(" Reason: {reason}."))
+            .unwrap_or_default(),
+    )
+}
+
+fn reparent_edge_summary(record: &ReparentRequestRecord) -> String {
+    let edges = record
+        .apply_plan
+        .as_ref()
+        .map(|plan| plan.edge_changes.clone())
+        .unwrap_or_else(|| {
+            if record.kind == "tree" {
+                tree_reparent_edge_changes(
+                    &record.subject_session_id,
+                    &record.target_parent_session_id,
+                    record.expected_parent_session_id.as_deref(),
+                    &record.frozen_live_child_ids,
+                )
+            } else {
+                vec![ReparentEdgeChange {
+                    session_id: record.subject_session_id.clone(),
+                    expected_parent_session_id: record.expected_parent_session_id.clone(),
+                    new_parent_session_id: Some(record.target_parent_session_id.clone()),
+                }]
+            }
+        });
+    edges
+        .iter()
+        .map(|edge| {
+            format!(
+                "{}: {} -> {}",
+                edge.session_id,
+                edge.expected_parent_session_id.as_deref().unwrap_or("root"),
+                edge.new_parent_session_id.as_deref().unwrap_or("root")
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ReparentDeferredRoutingIntent {
     pub key: String,
@@ -12926,6 +13241,15 @@ impl ReparentRequestRecord {
             );
         }
         affected
+    }
+
+    fn involves_session(&self, session_id: &str) -> bool {
+        self.initiator_session_id == session_id
+            || self
+                .required_agent_approvals
+                .iter()
+                .any(|id| id == session_id)
+            || self.affected_session_ids().contains(session_id)
     }
 
     fn is_apply_fenced(&self) -> bool {
@@ -17860,6 +18184,66 @@ mod tests {
             store.retire_core_session("child001", Some("newpar01")),
             Ok(CoreRetireOutcome::Retired(_))
         ));
+
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
+    fn reparent_notifications_are_exact_and_idempotent_across_reconciliation() {
+        let state_file = unique_temp_path("reparent-notifications");
+        let queue_db = state_file.with_extension("db");
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [
+                    reparent_test_session("oldpar01", None, "old-secret"),
+                    reparent_test_session("newpar01", None, "new-secret"),
+                    reparent_test_session("child001", Some("oldpar01"), "child-secret")
+                ]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let queue = RetainedQueueStore::new(queue_db.clone());
+        queue.ensure_schema().unwrap();
+        let store = SessionStore::new_with_queue(state_file.clone(), queue_db.clone());
+        let request = match store
+            .create_reparent_request(
+                "child001",
+                CreateReparentRequest {
+                    requester_session_id: "oldpar01".to_owned(),
+                    target_parent_session_id: "newpar01".to_owned(),
+                },
+                "old-secret",
+            )
+            .unwrap()
+        {
+            ReparentMutationOutcome::Created(record) => record,
+            other => panic!("unexpected create outcome: {other:?}"),
+        };
+
+        store.reconcile_reparent_notifications().unwrap();
+        store.reconcile_reparent_notifications().unwrap();
+        let pending = queue.pending_messages_for_target("newpar01", 10).unwrap();
+        assert_eq!(pending.len(), 1);
+        assert!(pending[0]
+            .text
+            .contains(&format!("Approve: `sm reparent approve {}`", request.id)));
+        assert!(pending[0]
+            .text
+            .contains(&format!("Reject: `sm reparent reject {}`", request.id)));
+        assert!(pending[0].text.contains("child001: oldpar01 -> newpar01"));
+        let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+        let intents = state["reparent_requests"][0]["notification_intents"]
+            .as_array()
+            .unwrap();
+        let target_intents = intents
+            .iter()
+            .filter(|intent| intent["recipient_session_id"] == "newpar01")
+            .collect::<Vec<_>>();
+        assert_eq!(target_intents.len(), 1);
+        assert!(target_intents[0]["enqueued_at"].is_string());
 
         let _ = fs::remove_file(state_file);
         let _ = fs::remove_file(queue_db);

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -2404,7 +2404,7 @@ impl SessionStore {
     }
 
     pub fn reconcile_reparent_notifications(&self) -> Result<()> {
-        let pending = {
+        let (pending, recipients) = {
             let _guard = self.write_guard()?;
             let mut state = self.load_raw_json_value()?;
             let sessions = snapshot_from_raw_value(&state)?.into_sessions();
@@ -2428,7 +2428,7 @@ impl SessionStore {
                 store_reparent_request_records(&mut state, &records)?;
                 self.write_raw_json_value(&state)?;
             }
-            records
+            let pending = records
                 .iter()
                 .flat_map(|record| {
                     desired_reparent_notifications(record)
@@ -2439,7 +2439,17 @@ impl SessionStore {
                             })
                         })
                 })
-                .collect::<Vec<_>>()
+                .collect::<Vec<_>>();
+            let recipients = records
+                .iter()
+                .flat_map(|record| {
+                    record
+                        .notification_intents
+                        .iter()
+                        .map(|intent| intent.recipient_session_id.clone())
+                })
+                .collect::<BTreeSet<_>>();
+            (pending, recipients)
         };
         for desired in pending {
             let queue = self
@@ -2474,6 +2484,25 @@ impl SessionStore {
                 intent.enqueued_at = Some(now_rfc3339());
                 store_reparent_request_records(&mut state, &records)?;
                 self.write_raw_json_value(&state)?;
+            }
+        }
+        if let Some(runtime) = self.delivery_runtime.as_ref() {
+            let mut first_error = None;
+            for recipient in recipients {
+                if let Err(error) = self.drain_runtime_pending_messages_for_session_category(
+                    &recipient,
+                    runtime,
+                    Some("reparent"),
+                ) {
+                    if first_error.is_none() {
+                        first_error = Some(error.context(format!(
+                            "failed to deliver reparent notifications to {recipient}"
+                        )));
+                    }
+                }
+            }
+            if let Some(error) = first_error {
+                return Err(error);
             }
         }
         Ok(())

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -16995,6 +16995,105 @@ async fn reparent_request_creation_persists_and_queues_exact_actionable_notifica
 }
 
 #[tokio::test]
+async fn reparent_request_immediately_delivers_approval_prompt_to_an_idle_runtime() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let queue_db = queue_db_path_for_state_file(&state_file);
+    let log_dir = unique_temp_path();
+    let working_dir = unique_temp_path();
+    fs::create_dir_all(&working_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-test-reparent-notify-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app(&state_file, &log_dir, &tmux_socket);
+
+    for (id, parent) in [
+        ("notifyold", None),
+        ("notifynew", None),
+        ("notifychild", Some("notifyold")),
+    ] {
+        let mut payload = json!({
+            "id": id,
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude",
+            "initial_message": format!("initial {id}")
+        });
+        if let Some(parent) = parent {
+            payload["parent_session_id"] = json!(parent);
+        }
+        let (status, _) = post_json(app.clone(), "/sessions", payload).await;
+        assert_eq!(status, StatusCode::OK);
+        wait_for_output_contains(app.clone(), id, &format!("runtime:initial {id}")).await;
+    }
+
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    for session in state["sessions"].as_array_mut().unwrap() {
+        let credential = match session["id"].as_str().unwrap() {
+            "notifyold" => "notify-old-token",
+            "notifynew" => "notify-new-token",
+            "notifychild" => "notify-child-token",
+            other => panic!("unexpected session {other}"),
+        };
+        session["session_credential_sha256"] = json!(session_credential_hash(credential));
+    }
+    fs::write(&state_file, serde_json::to_vec_pretty(&state).unwrap()).unwrap();
+
+    let (status, _) = post_json(
+        app.clone(),
+        "/hooks/claude",
+        json!({
+            "hook_event_name": "Stop",
+            "session_manager_id": "notifynew"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, created) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/sessions/notifychild/reparent-requests",
+        json!({
+            "requester_session_id": "notifyold",
+            "target_parent_session_id": "notifynew"
+        }),
+        &[("x-sm-session-credential", "notify-old-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let request_id = created["id"].as_str().unwrap();
+    wait_for_output_contains(
+        app,
+        "notifynew",
+        &format!("sm reparent approve {request_id}"),
+    )
+    .await;
+
+    let delivered: (i64, String) = Connection::open(queue_db)
+        .unwrap()
+        .query_row(
+            r#"
+            SELECT delivered_at IS NOT NULL, message_category
+            FROM message_queue
+            WHERE target_session_id = 'notifynew'
+              AND message_category = 'reparent'
+            "#,
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(delivered, (1, "reparent".to_owned()));
+}
+
+#[tokio::test]
 async fn reparent_tree_dry_run_reports_exact_plan_without_persisting_a_request() {
     let state_file = write_reparent_tree_fixture();
     let mut config = config_with_state_file(&state_file);

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -16943,6 +16943,58 @@ async fn reparent_request_read_marks_changed_topology_stale() {
 }
 
 #[tokio::test]
+async fn reparent_request_creation_persists_and_queues_exact_actionable_notification() {
+    let state_file = write_reparent_fixture();
+    let queue_db = queue_db_path_for_state_file(&state_file);
+    let mut config = config_with_state_file_and_queue(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, created) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/sessions/child/reparent-requests",
+        json!({
+            "requester_session_id": "oldparent",
+            "target_parent_session_id": "newparent"
+        }),
+        &[("x-sm-session-credential", "old-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let request_id = created["id"].as_str().unwrap();
+
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let intents = state["reparent_requests"][0]["notification_intents"]
+        .as_array()
+        .unwrap();
+    assert_eq!(intents.len(), 1);
+    assert_eq!(intents[0]["recipient_session_id"], "newparent");
+    assert!(intents[0]["enqueued_at"].as_str().is_some());
+
+    let messages = queued_message_texts(&queue_db, "newparent");
+    assert_eq!(messages.len(), 1);
+    let message = &messages[0];
+    assert!(message.contains(&format!("single request {request_id} from oldparent")));
+    assert!(message.contains("child: oldparent -> newparent"));
+    assert!(message.contains(&format!("sm reparent approve {request_id}")));
+    assert!(message.contains(&format!("sm reparent reject {request_id}")));
+
+    let (status, scoped) = get_json_with_host_and_headers(
+        app,
+        "/reparent-requests",
+        "localhost",
+        &[
+            ("x-sm-session-id", "unrelated".to_owned()),
+            ("x-sm-session-credential", "unrelated-token".to_owned()),
+        ],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(scoped["requests"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
 async fn reparent_tree_dry_run_reports_exact_plan_without_persisting_a_request() {
     let state_file = write_reparent_tree_fixture();
     let mut config = config_with_state_file(&state_file);
@@ -17002,6 +17054,50 @@ async fn reparent_tree_dry_run_reports_exact_plan_without_persisting_a_request()
 
     let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
     assert!(state["reparent_requests"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn reparent_tree_dry_run_reports_an_overlapping_active_request_as_a_blocker() {
+    let state_file = write_reparent_tree_fixture();
+    let mut config = config_with_state_file(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, active) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/sessions/sibling01/reparent-requests",
+        json!({
+            "requester_session_id": "source01",
+            "target_parent_session_id": "grand001"
+        }),
+        &[("x-sm-session-credential", "source-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let active_id = active["id"].as_str().unwrap();
+
+    let (status, preview) = post_json_with_headers_and_peer(
+        app,
+        "/sessions/source01/reparent-tree-requests",
+        json!({
+            "requester_session_id": "source01",
+            "target_session_id": "target01",
+            "dry_run": true
+        }),
+        &[("x-sm-session-credential", "source-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let blockers = preview["blockers"].as_array().unwrap();
+    assert_eq!(blockers.len(), 1);
+    assert!(blockers[0].as_str().unwrap().contains(active_id));
+    assert!(blockers[0].as_str().unwrap().contains("sibling01"));
+
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    assert_eq!(state["reparent_requests"].as_array().unwrap().len(), 1);
 }
 
 #[tokio::test]

--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -528,6 +528,59 @@ class SessionManagerClient:
         detail = data.get("detail") if isinstance(data, dict) else None
         return {"ok": ok, "unavailable": False, "status_code": status_code, "data": data, "detail": detail}
 
+    def list_reparent_requests(self) -> dict:
+        """List consent-based authority transfer requests for operator watch."""
+        data, status_code, unavailable = self._request_with_status("GET", "/reparent-requests")
+        if unavailable:
+            return {"ok": False, "unavailable": True, "requests": [], "detail": None}
+        requests = data.get("requests", []) if isinstance(data, dict) else []
+        return {
+            "ok": status_code == 200,
+            "unavailable": False,
+            "status_code": status_code,
+            "requests": requests if isinstance(requests, list) else [],
+            "detail": data.get("detail") if isinstance(data, dict) else None,
+        }
+
+    def decide_reparent_request_as_human(self, request_id: str, approve: bool) -> dict:
+        """Approve or reject one human-gated reparent request."""
+        action = "human-approve" if approve else "human-reject"
+        request_path = urllib.parse.quote(request_id, safe="")
+        data, status_code, unavailable = self._request_with_status(
+            "POST",
+            f"/reparent-requests/{request_path}/{action}",
+            {},
+            timeout=MUTATION_API_TIMEOUT,
+        )
+        if unavailable:
+            return {"ok": False, "unavailable": True, "detail": None}
+        return {
+            "ok": status_code == 200,
+            "unavailable": False,
+            "status_code": status_code,
+            "data": data,
+            "detail": data.get("detail") if isinstance(data, dict) else None,
+        }
+
+    def repair_reparent_request(self, request_id: str, action: str) -> dict:
+        """Run one authenticated operator repair action."""
+        request_path = urllib.parse.quote(request_id, safe="")
+        data, status_code, unavailable = self._request_with_status(
+            "POST",
+            f"/reparent-requests/{request_path}/repair",
+            {"action": action},
+            timeout=MUTATION_API_TIMEOUT,
+        )
+        if unavailable:
+            return {"ok": False, "unavailable": True, "detail": None}
+        return {
+            "ok": status_code == 200,
+            "unavailable": False,
+            "status_code": status_code,
+            "data": data,
+            "detail": data.get("detail") if isinstance(data, dict) else None,
+        }
+
     def update_friendly_name(self, session_id: str, friendly_name: str) -> tuple[bool, bool]:
         """
         Update session friendly name.

--- a/src/cli/watch_tui.py
+++ b/src/cli/watch_tui.py
@@ -105,6 +105,7 @@ class WatchRow:
     text: str = ""
     session_id: Optional[str] = None
     repo_key: Optional[str] = None
+    request_id: Optional[str] = None
     activity_state: str = "idle"
     columns: dict[str, str] = field(default_factory=dict)
 
@@ -391,21 +392,35 @@ def _task_completion_line(session: dict) -> Optional[str]:
     return f"task: completed ({_age_from_iso(completed_at)})"
 
 
-def _pending_adoption_lines(session: dict) -> list[str]:
-    proposals = session.get("pending_adoption_proposals") or []
-    lines: list[str] = []
-    for proposal in proposals:
-        if proposal.get("status") != "pending":
-            continue
-        proposer_name = proposal.get("proposer_name") or proposal.get("proposer_session_id") or "unknown"
-        proposer_id = proposal.get("proposer_session_id") or "unknown"
-        created_at = proposal.get("created_at")
-        age = _age_from_iso(created_at)
-        age_suffix = f" ({age})" if age != "-" else ""
-        lines.append(
-            f"adopt: pending from {proposer_name} [{proposer_id}]{age_suffix}  [A accept / X reject]"
-        )
-    return lines
+def _reparent_request_line(request: dict) -> str:
+    request_id = request.get("id") or "unknown"
+    kind = request.get("kind") or "unknown"
+    source = request.get("subject_session_id") or "unknown"
+    target = request.get("target_parent_session_id") or "unknown"
+    status = request.get("status") or "unknown"
+    age = _age_from_iso(request.get("created_at"))
+    expiry = request.get("expires_at") or "unknown"
+    approvals = request.get("approvals") or []
+    approved = {
+        approval.get("actor_id")
+        for approval in approvals
+        if approval.get("actor_kind") == "agent" and approval.get("decision") == "approved"
+    }
+    missing = [
+        actor for actor in (request.get("required_agent_approvals") or []) if actor not in approved
+    ]
+    missing_text = ",".join(missing) if missing else "none"
+    action = "A approve / X reject" if request.get("required_human_approval") and status == "pending" else ""
+    if status == "failed":
+        stage = request.get("apply_stage") or "unknown"
+        action = "R resume"
+        if stage in {"json_routing_quiesced", "routing_quiesced"}:
+            action += " / B rollback"
+    suffix = f"  [{action}]" if action else ""
+    return (
+        f"reparent {request_id}: {kind} {source} -> {target} {status} age={age} "
+        f"expires={expiry} missing={missing_text}{suffix}"
+    )
 
 
 def _format_age(last_activity: Optional[str], activity_state: str) -> str:
@@ -623,6 +638,7 @@ def build_watch_rows(
     expanded_session_ids: Optional[set[str]] = None,
     detail_cache: Optional[dict[str, DetailSnapshot]] = None,
     codex_projection_enabled: bool = True,
+    reparent_requests: Optional[list[dict]] = None,
 ) -> tuple[list[WatchRow], list[str], int]:
     """Build grouped rows and selectable session IDs."""
     rows: list[WatchRow] = []
@@ -633,6 +649,14 @@ def build_watch_rows(
     roots_by_repo: dict[str, list[dict]] = {}
     same_repo_children: dict[str, list[dict]] = {}
     cross_repo_children: dict[str, dict[str, list[dict]]] = {}
+    requests_by_source: dict[str, list[dict]] = {}
+    for request in reparent_requests or []:
+        if request.get("status") == "pending" and request.get("required_human_approval"):
+            requests_by_source.setdefault(request.get("subject_session_id") or "", []).append(request)
+        elif request.get("status") == "failed":
+            requests_by_source.setdefault(request.get("subject_session_id") or "", []).append(request)
+    for requests in requests_by_source.values():
+        requests.sort(key=lambda request: (request.get("created_at") or "", request.get("id") or ""))
 
     for session in sessions:
         key = _repo_key(session.get("working_dir", ""))
@@ -730,12 +754,13 @@ def build_watch_rows(
                 )
             )
 
-        for adoption_line in _pending_adoption_lines(session):
+        for request in requests_by_source.get(session_id or "", []):
             rows.append(
                 WatchRow(
-                    kind="status",
-                    text=f"{status_prefix}{adoption_line}",
+                    kind="reparent",
+                    text=f"{status_prefix}{_reparent_request_line(request)}",
                     session_id=session_id,
+                    request_id=request.get("id"),
                 )
             )
 
@@ -1390,6 +1415,7 @@ def _render(
     rows: list[WatchRow],
     selected_session_id: Optional[str],
     selected_repo_key: Optional[str],
+    selected_request_id: Optional[str],
     scroll_offset: int,
     total_sessions: int,
     repo_count: int,
@@ -1442,6 +1468,11 @@ def _render(
             stdscr.addnstr(y, 0, f"{marker} {row.text}", _render_columns(width, 0), attr)
         elif row.kind == "repo_ref":
             stdscr.addnstr(y, 4, row.text, _render_columns(width, 4), curses.A_BOLD)
+        elif row.kind == "reparent":
+            is_selected = row.request_id == selected_request_id
+            marker = ">" if is_selected else " "
+            attr = curses.A_REVERSE | curses.A_BOLD if is_selected else curses.A_BOLD
+            stdscr.addnstr(y, 2, f"{marker} {row.text}", _render_columns(width, 2), attr)
         elif row.kind == "status":
             stdscr.addnstr(y, 4, row.text, _render_columns(width, 4), curses.A_NORMAL)
         else:
@@ -1461,7 +1492,7 @@ def _render(
     if restore_mode:
         footer = f"j/k: move  Enter: restore/expand  o: sort={restore_sort}  R: hide repo  U: show repos  Tab: expand/collapse  E: expand all  C: collapse all  /: search  r: refresh  q: quit"
     else:
-        footer = "j/k: move  +: create  F: fork  Enter: attach  s: send  K,K: retire  n: rename  A/X: adopt  Tab: details  /: filter  r: refresh  q: quit"
+        footer = "j/k: move  +: create  F: fork  Enter: attach  s: send  K,K: retire  n: rename  A/X: reparent  R/B: repair  Tab: details  /: filter  r: refresh  q: quit"
     stdscr.addnstr(height - 1, 0, footer, _render_columns(width, 0, reserve_last_cell=True))
     stdscr.refresh()
 
@@ -1493,6 +1524,7 @@ def run_watch_tui(
         try:
             selected_session_id: Optional[str] = None
             selected_repo_key: Optional[str] = None
+            selected_request_id: Optional[str] = None
             text_filter: Optional[str] = None
             flash_message: Optional[str] = None
             flash_until = 0.0
@@ -1500,6 +1532,7 @@ def run_watch_tui(
             selectable: list[str] = []
             latest_sessions: list[dict] = []
             latest_by_id: dict[str, dict] = {}
+            latest_reparent_by_id: dict[str, dict] = {}
             expanded_session_ids: set[str] = set()
             collapsed_session_ids: set[str] = set()
             collapsed_repo_keys: set[str] = set()
@@ -1533,6 +1566,18 @@ def run_watch_tui(
                         flash_message = "Session manager unavailable"
                         flash_until = now + 2.5
                     else:
+                        reparent_result = (
+                            client.list_reparent_requests() if not restore_mode else {"ok": True, "requests": []}
+                        )
+                        if reparent_result.get("unavailable"):
+                            flash_message = "Reparent requests unavailable"
+                            flash_until = now + 2.5
+                        reparent_requests = reparent_result.get("requests") or []
+                        latest_reparent_by_id = {
+                            request.get("id", ""): request
+                            for request in reparent_requests
+                            if request.get("id")
+                        }
                         filtered = filter_sessions(
                             listed,
                             repo_filter=repo_filter,
@@ -1572,6 +1617,7 @@ def run_watch_tui(
                                 expanded_session_ids=expanded_session_ids,
                                 detail_cache=detail_cache,
                                 codex_projection_enabled=codex_projection_enabled,
+                                reparent_requests=reparent_requests,
                             )
                             spinner_index += 1
                             # Prune stale expanded IDs and enqueue refresh for active details.
@@ -1582,6 +1628,11 @@ def run_watch_tui(
                                     detail_worker.request(session)
                         if not restore_mode and selected_session_id not in selectable:
                             selected_session_id = selectable[0] if selectable else None
+                        visible_request_ids = {
+                            row.request_id for row in rows if row.kind == "reparent" and row.request_id
+                        }
+                        if selected_request_id not in visible_request_ids:
+                            selected_request_id = None
 
                     next_refresh = now + max(0.2, interval)
 
@@ -1592,7 +1643,12 @@ def run_watch_tui(
 
                 max_rows = max(0, stdscr.getmaxyx()[0] - _RESERVED_SCREEN_ROWS)
                 selected_row_idx = None
-                if selected_session_id:
+                if selected_request_id:
+                    for idx, row in enumerate(rows):
+                        if row.kind == "reparent" and row.request_id == selected_request_id:
+                            selected_row_idx = idx
+                            break
+                elif selected_session_id:
                     for idx, row in enumerate(rows):
                         if row.kind == "session" and row.session_id == selected_session_id:
                             selected_row_idx = idx
@@ -1617,6 +1673,7 @@ def run_watch_tui(
                     rows=rows,
                     selected_session_id=selected_session_id,
                     selected_repo_key=selected_repo_key,
+                    selected_request_id=selected_request_id,
                     scroll_offset=scroll_offset,
                     total_sessions=total_sessions,
                     repo_count=repo_count,
@@ -1648,9 +1705,18 @@ def run_watch_tui(
                             selected_session_id, selected_repo_key = restore_selection_from_key(
                                 restore_keys[min(current_idx + 1, len(restore_keys) - 1)]
                             )
-                    elif selectable:
-                        current_idx = selectable.index(selected_session_id) if selected_session_id in selectable else 0
-                        selected_session_id = selectable[min(current_idx + 1, len(selectable) - 1)]
+                    else:
+                        navigation = [
+                            (row.kind, row.session_id, row.request_id)
+                            for row in rows
+                            if row.kind in {"session", "reparent"}
+                        ]
+                        current = ("reparent", selected_session_id, selected_request_id) if selected_request_id else ("session", selected_session_id, None)
+                        if navigation:
+                            current_idx = navigation.index(current) if current in navigation else 0
+                            kind, selected_session_id, selected_request_id = navigation[min(current_idx + 1, len(navigation) - 1)]
+                            if kind == "session":
+                                selected_request_id = None
                     continue
 
                 if key in (ord("k"), curses.KEY_UP):
@@ -1662,9 +1728,18 @@ def run_watch_tui(
                             selected_session_id, selected_repo_key = restore_selection_from_key(
                                 restore_keys[max(current_idx - 1, 0)]
                             )
-                    elif selectable:
-                        current_idx = selectable.index(selected_session_id) if selected_session_id in selectable else 0
-                        selected_session_id = selectable[max(current_idx - 1, 0)]
+                    else:
+                        navigation = [
+                            (row.kind, row.session_id, row.request_id)
+                            for row in rows
+                            if row.kind in {"session", "reparent"}
+                        ]
+                        current = ("reparent", selected_session_id, selected_request_id) if selected_request_id else ("session", selected_session_id, None)
+                        if navigation:
+                            current_idx = navigation.index(current) if current in navigation else 0
+                            kind, selected_session_id, selected_request_id = navigation[max(current_idx - 1, 0)]
+                            if kind == "session":
+                                selected_request_id = None
                     continue
 
                 if key in (ord("r"),):
@@ -1679,6 +1754,7 @@ def run_watch_tui(
                 selected = None
                 if selected_session_id:
                     selected = latest_by_id.get(selected_session_id)
+                selected_request = latest_reparent_by_id.get(selected_request_id or "")
 
                 if key in (ord("/"),):
                     entered = _prompt_input(stdscr, "filter (blank=clear): ")
@@ -1911,41 +1987,54 @@ def run_watch_tui(
                     continue
 
                 if key in (ord("A"), ord("X")):
-                    if not selected:
-                        flash_message = "No session selected"
+                    if not selected_request:
+                        flash_message = "Select a human-gated reparent request"
                         flash_until = time.monotonic() + 2.0
                         continue
-
-                    proposals = [
-                        proposal
-                        for proposal in (selected.get("pending_adoption_proposals") or [])
-                        if proposal.get("status") == "pending"
-                    ]
-                    if not proposals:
-                        flash_message = "No pending adoption proposal"
+                    if (
+                        selected_request.get("status") != "pending"
+                        or not selected_request.get("required_human_approval")
+                    ):
+                        flash_message = "Selected request does not need a human decision"
                         flash_until = time.monotonic() + 2.0
                         continue
-
-                    proposal = proposals[0]
-                    proposal_id = proposal.get("id")
-                    if not proposal_id:
-                        flash_message = "Pending adoption proposal is missing an id"
-                        flash_until = time.monotonic() + 2.0
-                        continue
-
-                    if key == ord("A"):
-                        result = client.accept_adoption_proposal(proposal_id)
-                        action = "accepted"
-                    else:
-                        result = client.reject_adoption_proposal(proposal_id)
-                        action = "rejected"
+                    result = client.decide_reparent_request_as_human(
+                        selected_request_id,
+                        approve=key == ord("A"),
+                    )
+                    action = "approved" if key == ord("A") else "rejected"
 
                     if result.get("unavailable"):
                         flash_message = "Session manager unavailable"
                     elif result.get("ok"):
-                        flash_message = f"Adoption {action} for {selected_session_id}"
+                        flash_message = f"Reparent request {selected_request_id} {action}"
                     else:
-                        flash_message = str(result.get("detail") or f"Failed to {action} adoption proposal")
+                        flash_message = str(result.get("detail") or f"Failed to {action} reparent request")
+                    flash_until = time.monotonic() + 2.5
+                    next_refresh = 0.0
+                    continue
+
+                if key in (ord("R"), ord("B")):
+                    if not selected_request or selected_request.get("status") != "failed":
+                        flash_message = "Select a failed reparent request"
+                        flash_until = time.monotonic() + 2.0
+                        continue
+                    stage = selected_request.get("apply_stage") or "unknown"
+                    action = "resume" if key == ord("R") else "rollback_precommit"
+                    if action == "rollback_precommit" and stage not in {
+                        "json_routing_quiesced",
+                        "routing_quiesced",
+                    }:
+                        flash_message = f"Rollback is unsafe from stage {stage}; resume only"
+                        flash_until = time.monotonic() + 3.0
+                        continue
+                    result = client.repair_reparent_request(selected_request_id, action)
+                    if result.get("unavailable"):
+                        flash_message = "Session manager unavailable"
+                    elif result.get("ok"):
+                        flash_message = f"Reparent request {selected_request_id}: {action}"
+                    else:
+                        flash_message = str(result.get("detail") or f"Failed to {action}")
                     flash_until = time.monotonic() + 2.5
                     next_refresh = 0.0
                     continue

--- a/tests/unit/test_client_reparent.py
+++ b/tests/unit/test_client_reparent.py
@@ -1,0 +1,59 @@
+"""Unit tests for consent-based reparent operator endpoints."""
+
+from unittest.mock import patch
+
+from src.cli.client import MUTATION_API_TIMEOUT, SessionManagerClient
+
+
+def _client() -> SessionManagerClient:
+    return SessionManagerClient(api_url="http://127.0.0.1:8420")
+
+
+def test_list_reparent_requests_preserves_rows():
+    client = _client()
+    with patch.object(
+        client,
+        "_request_with_status",
+        return_value=({"requests": [{"id": "request1"}]}, 200, False),
+    ) as request:
+        result = client.list_reparent_requests()
+
+    assert result["ok"] is True
+    assert result["requests"] == [{"id": "request1"}]
+    request.assert_called_once_with("GET", "/reparent-requests")
+
+
+def test_human_reparent_decision_targets_exact_request():
+    client = _client()
+    with patch.object(
+        client,
+        "_request_with_status",
+        return_value=({"id": "request/1", "status": "applied"}, 200, False),
+    ) as request:
+        result = client.decide_reparent_request_as_human("request/1", approve=True)
+
+    assert result["ok"] is True
+    request.assert_called_once_with(
+        "POST",
+        "/reparent-requests/request%2F1/human-approve",
+        {},
+        timeout=MUTATION_API_TIMEOUT,
+    )
+
+
+def test_reparent_repair_preserves_stage_action():
+    client = _client()
+    with patch.object(
+        client,
+        "_request_with_status",
+        return_value=({"id": "request1", "status": "repaired"}, 200, False),
+    ) as request:
+        result = client.repair_reparent_request("request1", "rollback_precommit")
+
+    assert result["ok"] is True
+    request.assert_called_once_with(
+        "POST",
+        "/reparent-requests/request1/repair",
+        {"action": "rollback_precommit"},
+        timeout=MUTATION_API_TIMEOUT,
+    )

--- a/tests/unit/test_watch_tui.py
+++ b/tests/unit/test_watch_tui.py
@@ -365,31 +365,38 @@ def test_task_completed_row_shows_age():
     assert any("task: completed (" in row.text for row in status_rows)
 
 
-def test_pending_adoption_row_shows_proposer_and_actions():
+def test_human_gated_reparent_row_shows_exact_request_and_actions():
     rows, _, _ = build_watch_rows(
-        [
-            _session(
-                "s1",
-                "agent",
-                "/tmp/repo",
-                pending_adoption_proposals=[
+        [_session("s1", "agent", "/tmp/repo")],
+        reparent_requests=[
+            {
+                "id": "reparent123",
+                "kind": "single",
+                "subject_session_id": "s1",
+                "target_parent_session_id": "newparent",
+                "initiator_session_id": "newparent",
+                "created_at": "2026-02-21T22:58:00",
+                "expires_at": "2026-02-22T22:58:00Z",
+                "status": "pending",
+                "required_agent_approvals": ["newparent"],
+                "required_human_approval": True,
+                "approvals": [
                     {
-                        "id": "proposal123",
-                        "proposer_session_id": "em123456",
-                        "proposer_name": "em-ops",
-                        "target_session_id": "s1",
-                        "created_at": "2026-02-21T22:58:00",
-                        "status": "pending",
-                        "decided_at": None,
+                        "actor_kind": "agent",
+                        "actor_id": "newparent",
+                        "decision": "approved",
                     }
                 ],
-            )
-        ]
+            }
+        ],
     )
 
-    status_rows = [row for row in rows if row.kind == "status"]
-    assert any("adopt: pending from em-ops [em123456]" in row.text for row in status_rows)
-    assert any("[A accept / X reject]" in row.text for row in status_rows)
+    request_rows = [row for row in rows if row.kind == "reparent"]
+    assert len(request_rows) == 1
+    assert request_rows[0].request_id == "reparent123"
+    assert "single s1 -> newparent pending" in request_rows[0].text
+    assert "missing=none" in request_rows[0].text
+    assert "[A approve / X reject]" in request_rows[0].text
 
 
 def test_status_rows_follow_tree_indentation():


### PR DESCRIPTION
## Summary

- add native Rust `sm reparent`, `sm reparent-tree`, `sm adopt`, and `sm recredential` commands with exact alias resolution and runtime credential forwarding
- persist idempotent actionable notification intents with request transitions, reconcile them through the retained queue, and scope managed-session status reads
- replace legacy adoption rows in `sm watch` with selectable human approval/rejection and stage-safe repair actions
- carry Phase 2 review P2 forward by reporting active overlapping requests in tree dry-run blockers

Closes #1210

## Verification

- `cargo test -p sm-server --lib` - 397 passed
- `cargo test -p sm-server --bin sm` - 66 passed
- `cargo test -p sm-server --test read_only_http` - 259 passed
- `cargo fmt --all -- --check`
- `/Users/rajesh/projects/session-manager/venv/bin/pytest -q tests/unit/test_watch_tui.py tests/unit/test_client_reparent.py` - 58 passed
- full retained Python suite - 2447 passed, 8 failed

The eight failures are all `tests/unit/test_directional_notify_on_stop.py` raising missing fixture field `em_topic`. Exact reproduction on the untouched Phase 3 base `f4a306303398a199f2aa43db769b8694f7de5acd`: 8 failed, 2 passed. Tracked as #1219.

## Review carry-forward

PR #1218 had one P2 and no P1: dry-run omitted active overlapping requests from blockers. This phase fixes it and adds an exact HTTP regression test, without looping Phase 2 review.
