### PR TITLE
feat: add consent-based authority transfer

### DIFF
--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -50,6 +50,11 @@ enum Command {
     Children(ChildrenArgs),
     Tail(TailArgs),
     Retire(SessionIdArgs),
+    Reparent(ReparentArgs),
+    #[command(name = "reparent-tree")]
+    ReparentTree(ReparentTreeArgs),
+    Adopt(AdoptArgs),
+    Recredential(RecredentialArgs),
     Restore(RestoreArgs),
     Attach(SessionIdArgs),
     Output(OutputArgs),
@@ -103,6 +108,58 @@ struct EmptyArgs {}
 #[derive(Args)]
 struct StatusArgs {
     text: Vec<String>,
+}
+
+#[derive(Args)]
+struct ReparentArgs {
+    #[command(subcommand)]
+    command: ReparentCommand,
+}
+
+#[derive(Subcommand)]
+enum ReparentCommand {
+    Request {
+        child: String,
+        #[arg(long)]
+        to: String,
+    },
+    Approve {
+        request_id: String,
+    },
+    Reject {
+        request_id: String,
+    },
+    Status {
+        request_id: Option<String>,
+    },
+    Repair {
+        request_id: String,
+        #[arg(long, conflicts_with = "rollback_precommit")]
+        resume: bool,
+        #[arg(long = "rollback-precommit", conflicts_with = "resume")]
+        rollback_precommit: bool,
+    },
+}
+
+#[derive(Args)]
+struct ReparentTreeArgs {
+    source: String,
+    #[arg(long)]
+    to: String,
+    #[arg(long)]
+    dry_run: bool,
+}
+
+#[derive(Args)]
+struct AdoptArgs {
+    child: String,
+}
+
+#[derive(Args)]
+struct RecredentialArgs {
+    session: Option<String>,
+    #[arg(long, conflicts_with = "session")]
+    all_live: bool,
 }
 
 #[derive(Args)]
@@ -796,6 +853,10 @@ fn run() -> Result<()> {
             )?;
             println!("{}", retire_response_status(&payload, &args.session_id)?);
         }
+        Command::Reparent(args) => run_reparent(&client, args)?,
+        Command::ReparentTree(args) => run_reparent_tree(&client, args)?,
+        Command::Adopt(args) => run_adopt(&client, args)?,
+        Command::Recredential(args) => run_recredential(&client, args)?,
         Command::Restore(args) => {
             restore_session(&client, args)?;
         }
@@ -2577,6 +2638,352 @@ fn run_what(client: &ApiClient, args: WhatArgs) -> Result<()> {
     }
 }
 
+fn run_reparent(client: &ApiClient, args: ReparentArgs) -> Result<()> {
+    match args.command {
+        ReparentCommand::Request { child, to } => {
+            let requester = current_session_id()?;
+            let credential = current_session_credential(&requester)?;
+            let child = resolve_required_session(client, &child)?;
+            let target = resolve_required_session(client, &to)?;
+            let record = client.post_json_with_session_credential(
+                &format!("/sessions/{child}/reparent-requests"),
+                json!({
+                    "requester_session_id": requester,
+                    "target_parent_session_id": target,
+                }),
+                &credential,
+            )?;
+            print_reparent_request_created(&record);
+        }
+        ReparentCommand::Approve { request_id } => {
+            decide_reparent_request(client, &request_id, "approve")?;
+        }
+        ReparentCommand::Reject { request_id } => {
+            decide_reparent_request(client, &request_id, "reject")?;
+        }
+        ReparentCommand::Status { request_id } => match request_id {
+            Some(request_id) => {
+                let record = get_reparent_json(
+                    client,
+                    &format!("/reparent-requests/{}", encode_path_segment(&request_id)),
+                )?;
+                print_reparent_request_detail(&record);
+            }
+            None => {
+                let payload = get_reparent_json(client, "/reparent-requests")?;
+                let records = payload["requests"].as_array().cloned().unwrap_or_default();
+                if records.is_empty() {
+                    println!("No reparent requests");
+                } else {
+                    for record in records {
+                        println!("{}", format_reparent_request_row(&record));
+                    }
+                }
+            }
+        },
+        ReparentCommand::Repair {
+            request_id,
+            resume,
+            rollback_precommit,
+        } => {
+            let action = match (resume, rollback_precommit) {
+                (true, false) => "resume",
+                (false, true) => "rollback_precommit",
+                _ => bail!("choose exactly one of --resume or --rollback-precommit"),
+            };
+            let record = client.post_json(
+                &format!(
+                    "/reparent-requests/{}/repair",
+                    encode_path_segment(&request_id)
+                ),
+                json!({ "action": action }),
+            )?;
+            print_reparent_request_detail(&record);
+        }
+    }
+    Ok(())
+}
+
+fn run_reparent_tree(client: &ApiClient, args: ReparentTreeArgs) -> Result<()> {
+    let requester = current_session_id()?;
+    let credential = current_session_credential(&requester)?;
+    let source = resolve_required_session(client, &args.source)?;
+    let target = resolve_required_session(client, &args.to)?;
+    let response = client.post_json_with_session_credential(
+        &format!("/sessions/{source}/reparent-tree-requests"),
+        json!({
+            "requester_session_id": requester,
+            "target_session_id": target,
+            "dry_run": args.dry_run,
+        }),
+        &credential,
+    )?;
+    if args.dry_run {
+        print_reparent_tree_preview(&response);
+    } else {
+        print_reparent_request_created(&response);
+    }
+    Ok(())
+}
+
+fn run_adopt(client: &ApiClient, args: AdoptArgs) -> Result<()> {
+    let requester = current_session_id()?;
+    let credential = current_session_credential(&requester)?;
+    let child = resolve_required_session(client, &args.child)?;
+    let record = client.post_json_with_session_credential(
+        &format!("/sessions/{child}/reparent-requests"),
+        json!({
+            "requester_session_id": requester,
+            "target_parent_session_id": requester,
+        }),
+        &credential,
+    )?;
+    print_reparent_request_created(&record);
+    Ok(())
+}
+
+fn run_recredential(client: &ApiClient, args: RecredentialArgs) -> Result<()> {
+    let targets = if args.all_live {
+        let payload = client.get_json("/sessions")?;
+        payload["sessions"]
+            .as_array()
+            .into_iter()
+            .flatten()
+            .filter(|session| {
+                matches!(
+                    session["status"].as_str().unwrap_or_default(),
+                    "running" | "idle" | "waiting_permission"
+                )
+            })
+            .filter_map(|session| session["id"].as_str().map(ToOwned::to_owned))
+            .collect::<Vec<_>>()
+    } else {
+        let target = args
+            .session
+            .as_deref()
+            .context("session is required unless --all-live is used")?;
+        vec![resolve_required_session(client, target)?]
+    };
+    if targets.is_empty() {
+        println!("No live sessions to recredential");
+        return Ok(());
+    }
+    let mut failed = 0usize;
+    for target in targets {
+        match client.post_json(
+            &format!("/sessions/{target}/credential-rotation"),
+            json!({}),
+        ) {
+            Ok(record) => println!(
+                "{} {}",
+                target,
+                record["status"].as_str().unwrap_or("unknown")
+            ),
+            Err(error) => {
+                failed += 1;
+                eprintln!("{target} failed: {error:#}");
+            }
+        }
+    }
+    if failed > 0 {
+        bail!("{failed} recredential request(s) failed");
+    }
+    Ok(())
+}
+
+fn decide_reparent_request(client: &ApiClient, request_id: &str, action: &str) -> Result<()> {
+    let requester = current_session_id()?;
+    let credential = current_session_credential(&requester)?;
+    let record = client.post_json_with_session_credential(
+        &format!(
+            "/reparent-requests/{}/{}",
+            encode_path_segment(request_id),
+            action
+        ),
+        json!({ "requester_session_id": requester }),
+        &credential,
+    )?;
+    print_reparent_request_detail(&record);
+    Ok(())
+}
+
+fn current_session_credential(session_id: &str) -> Result<String> {
+    env::var("SM_SESSION_CREDENTIAL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .with_context(|| {
+            format!(
+                "this session has no runtime credential; ask the operator to run `sm recredential {session_id}`"
+            )
+        })
+}
+
+fn get_reparent_json(client: &ApiClient, path: &str) -> Result<Value> {
+    let Some(session_id) = optional_current_session_id() else {
+        return client.get_json(path);
+    };
+    let credential = current_session_credential(&session_id)?;
+    client.get_json_with_session_credential(path, &session_id, &credential)
+}
+
+fn resolve_required_session(client: &ApiClient, identifier: &str) -> Result<String> {
+    lookup_identifier_exact(client, identifier)?
+        .with_context(|| format!("No agent named '{identifier}' is reachable"))
+}
+
+fn print_reparent_request_created(record: &Value) {
+    println!(
+        "Reparent request {} created: {}",
+        record["id"].as_str().unwrap_or("unknown"),
+        format_reparent_request_row(record)
+    );
+}
+
+fn format_reparent_request_row(record: &Value) -> String {
+    let id = record["id"].as_str().unwrap_or("unknown");
+    let kind = record["kind"].as_str().unwrap_or("unknown");
+    let source = record["subject_session_id"].as_str().unwrap_or("unknown");
+    let target = record["target_parent_session_id"]
+        .as_str()
+        .unwrap_or("unknown");
+    let status = record["status"].as_str().unwrap_or("unknown");
+    let mut row = format!("{id} {kind} {source} -> {target} {status}");
+    if let Some(reason) = record["failure_reason"].as_str() {
+        row.push_str(&format!(" ({reason})"));
+    }
+    row
+}
+
+fn print_reparent_request_detail(record: &Value) {
+    println!("{}", format_reparent_request_row(record));
+    println!(
+        "initiator: {} · expires: {} · stage: {}",
+        record["initiator_session_id"].as_str().unwrap_or("unknown"),
+        record["expires_at"].as_str().unwrap_or("unknown"),
+        record["apply_stage"].as_str().unwrap_or("-")
+    );
+    let edges = reparent_edges_for_display(record);
+    print_reparent_edges(Some(&edges));
+    let approvals = record["approvals"].as_array().cloned().unwrap_or_default();
+    let required = record["required_agent_approvals"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    for actor in required {
+        let actor = actor.as_str().unwrap_or("unknown");
+        let decision = approvals
+            .iter()
+            .find(|approval| approval["actor_kind"] == "agent" && approval["actor_id"] == actor)
+            .and_then(|approval| approval["decision"].as_str())
+            .unwrap_or("pending");
+        println!("agent approval: {actor} {decision}");
+    }
+    if record["required_human_approval"].as_bool().unwrap_or(false) {
+        let decision = approvals
+            .iter()
+            .find(|approval| approval["actor_kind"] == "human")
+            .and_then(|approval| approval["decision"].as_str())
+            .unwrap_or("pending");
+        println!("human approval: {decision}");
+    }
+}
+
+fn reparent_edges_for_display(record: &Value) -> Vec<Value> {
+    if let Some(edges) = record["apply_plan"]["edge_changes"].as_array() {
+        return edges.clone();
+    }
+    let source = record["subject_session_id"].as_str().unwrap_or("unknown");
+    let target = record["target_parent_session_id"]
+        .as_str()
+        .unwrap_or("unknown");
+    let old_parent = record["expected_parent_session_id"].as_str();
+    if record["kind"] == "tree" {
+        let mut edges = vec![
+            json!({
+                "session_id": target,
+                "expected_parent_session_id": source,
+                "new_parent_session_id": old_parent,
+            }),
+            json!({
+                "session_id": source,
+                "expected_parent_session_id": old_parent,
+                "new_parent_session_id": target,
+            }),
+        ];
+        edges.extend(
+            record["frozen_live_child_ids"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .filter_map(Value::as_str)
+                .filter(|child| *child != target)
+                .map(|child| {
+                    json!({
+                        "session_id": child,
+                        "expected_parent_session_id": source,
+                        "new_parent_session_id": target,
+                    })
+                }),
+        );
+        edges
+    } else {
+        vec![json!({
+            "session_id": source,
+            "expected_parent_session_id": old_parent,
+            "new_parent_session_id": target,
+        })]
+    }
+}
+
+fn print_reparent_tree_preview(preview: &Value) {
+    println!(
+        "Dry run: {} -> {}",
+        preview["source_session_id"].as_str().unwrap_or("unknown"),
+        preview["target_session_id"].as_str().unwrap_or("unknown")
+    );
+    print_reparent_edges(preview["edge_changes"].as_array());
+    for blocker in preview["blockers"].as_array().into_iter().flatten() {
+        println!("blocker: {}", blocker.as_str().unwrap_or("unknown"));
+    }
+    for actor in preview["required_agent_approvals"]
+        .as_array()
+        .into_iter()
+        .flatten()
+    {
+        println!("agent approval: {}", actor.as_str().unwrap_or("unknown"));
+    }
+    if preview["required_human_approval"]
+        .as_bool()
+        .unwrap_or(false)
+    {
+        println!("human approval: required");
+    }
+    println!(
+        "routing changes: JSON {} · queue {}",
+        preview["json_routing_changes"]
+            .as_array()
+            .map_or(0, Vec::len),
+        preview["queue_routing_changes"]
+            .as_array()
+            .map_or(0, Vec::len)
+    );
+}
+
+fn print_reparent_edges(edges: Option<&Vec<Value>>) {
+    if let Some(edges) = edges {
+        for edge in edges {
+            println!(
+                "edge: {} {} -> {}",
+                edge["session_id"].as_str().unwrap_or("unknown"),
+                edge["expected_parent_session_id"]
+                    .as_str()
+                    .unwrap_or("root"),
+                edge["new_parent_session_id"].as_str().unwrap_or("root")
+            );
+        }
+    }
+}
+
 fn run_usage(client: &ApiClient, args: UsageArgs) -> Result<()> {
     if args.account && (args.agent.is_some() || args.include_children) {
         bail!("--account is mutually exclusive with AGENT and --include-children");
@@ -3951,8 +4358,41 @@ impl ApiClient {
         response.into_json()
     }
 
+    fn get_json_with_session_credential(
+        &self,
+        path: &str,
+        session_id: &str,
+        credential: &str,
+    ) -> Result<Value> {
+        self.request_with_headers(
+            "GET",
+            path,
+            None,
+            &[
+                ("X-SM-Session-ID", session_id),
+                ("X-SM-Session-Credential", credential),
+            ],
+        )?
+        .into_json()
+    }
+
     fn post_json(&self, path: &str, body: Value) -> Result<Value> {
         let response = self.request("POST", path, Some(body))?;
+        response.into_json()
+    }
+
+    fn post_json_with_session_credential(
+        &self,
+        path: &str,
+        body: Value,
+        credential: &str,
+    ) -> Result<Value> {
+        let response = self.request_with_headers(
+            "POST",
+            path,
+            Some(body),
+            &[("X-SM-Session-Credential", credential)],
+        )?;
         response.into_json()
     }
 
@@ -3972,8 +4412,18 @@ impl ApiClient {
     }
 
     fn request(&self, method: &str, path: &str, body: Option<Value>) -> Result<ApiResponse> {
+        self.request_with_headers(method, path, body, &[])
+    }
+
+    fn request_with_headers(
+        &self,
+        method: &str,
+        path: &str,
+        body: Option<Value>,
+        headers: &[(&str, &str)],
+    ) -> Result<ApiResponse> {
         if self.scheme == "https" {
-            return self.request_https(method, path, body);
+            return self.request_https(method, path, body, headers);
         }
         let body_bytes = match body {
             Some(value) => serde_json::to_vec(&value)?,
@@ -3982,11 +4432,14 @@ impl ApiClient {
         let full_path = format!("{}{}", self.path_prefix, path);
         let mut stream = TcpStream::connect((self.host.as_str(), self.port))
             .with_context(|| format!("failed to connect to {}", self.authority))?;
-        let request = format!(
-            "{method} {full_path} HTTP/1.1\r\nHost: {}\r\nAccept: application/json\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
-            self.authority,
-            body_bytes.len()
+        let mut request = format!(
+            "{method} {full_path} HTTP/1.1\r\nHost: {}\r\nAccept: application/json\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n",
+            self.authority, body_bytes.len()
         );
+        for (name, value) in headers {
+            request.push_str(&format!("{name}: {value}\r\n"));
+        }
+        request.push_str("\r\n");
         stream.write_all(request.as_bytes())?;
         stream.write_all(&body_bytes)?;
         let mut raw = Vec::new();
@@ -3994,7 +4447,13 @@ impl ApiClient {
         parse_response(&raw)
     }
 
-    fn request_https(&self, method: &str, path: &str, body: Option<Value>) -> Result<ApiResponse> {
+    fn request_https(
+        &self,
+        method: &str,
+        path: &str,
+        body: Option<Value>,
+        headers: &[(&str, &str)],
+    ) -> Result<ApiResponse> {
         let body_bytes = match body {
             Some(value) => serde_json::to_vec(&value)?,
             None => Vec::new(),
@@ -4008,32 +4467,57 @@ impl ApiClient {
             .build()
             .into();
         let mut response = match method {
-            "GET" => agent
-                .get(&url)
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
-                .call(),
-            "POST" => agent
-                .post(&url)
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
-                .send(body_bytes.as_slice()),
-            "PUT" => agent
-                .put(&url)
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
-                .send(body_bytes.as_slice()),
-            "PATCH" => agent
-                .patch(&url)
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
-                .send(body_bytes.as_slice()),
-            "DELETE" => agent
-                .delete(&url)
-                .header("Accept", "application/json")
-                .header("Content-Type", "application/json")
-                .force_send_body()
-                .send(body_bytes.as_slice()),
+            "GET" => {
+                let mut request = agent
+                    .get(&url)
+                    .header("Accept", "application/json")
+                    .header("Content-Type", "application/json");
+                for (name, value) in headers {
+                    request = request.header(*name, *value);
+                }
+                request.call()
+            }
+            "POST" => {
+                let mut request = agent
+                    .post(&url)
+                    .header("Accept", "application/json")
+                    .header("Content-Type", "application/json");
+                for (name, value) in headers {
+                    request = request.header(*name, *value);
+                }
+                request.send(body_bytes.as_slice())
+            }
+            "PUT" => {
+                let mut request = agent
+                    .put(&url)
+                    .header("Accept", "application/json")
+                    .header("Content-Type", "application/json");
+                for (name, value) in headers {
+                    request = request.header(*name, *value);
+                }
+                request.send(body_bytes.as_slice())
+            }
+            "PATCH" => {
+                let mut request = agent
+                    .patch(&url)
+                    .header("Accept", "application/json")
+                    .header("Content-Type", "application/json");
+                for (name, value) in headers {
+                    request = request.header(*name, *value);
+                }
+                request.send(body_bytes.as_slice())
+            }
+            "DELETE" => {
+                let mut request = agent
+                    .delete(&url)
+                    .header("Accept", "application/json")
+                    .header("Content-Type", "application/json")
+                    .force_send_body();
+                for (name, value) in headers {
+                    request = request.header(*name, *value);
+                }
+                request.send(body_bytes.as_slice())
+            }
             _ => bail!("unsupported HTTP method {method}"),
         }
         .with_context(|| format!("failed to request {url}"))?;
@@ -4392,6 +4876,32 @@ mod tests {
                 stream.write_all(response.as_bytes()).unwrap();
             }
             paths
+        });
+        let client = ApiClient::parse(&format!("http://{address}")).unwrap();
+        (client, server)
+    }
+
+    fn single_request_server(
+        status: u16,
+        body: &'static str,
+    ) -> (ApiClient, thread::JoinHandle<Vec<String>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            stream
+                .set_read_timeout(Some(std::time::Duration::from_secs(2)))
+                .unwrap();
+            let mut buffer = [0_u8; 8192];
+            let bytes_read = stream.read(&mut buffer).unwrap();
+            let request = String::from_utf8_lossy(&buffer[..bytes_read]).to_string();
+            let reason = if status == 200 { "OK" } else { "Error" };
+            let response = format!(
+                "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                body.len()
+            );
+            stream.write_all(response.as_bytes()).unwrap();
+            vec![request]
         });
         let client = ApiClient::parse(&format!("http://{address}")).unwrap();
         (client, server)
@@ -4780,6 +5290,91 @@ mod tests {
             assert_eq!(args.prompt.join(" "), "Summarize current work");
         }
         assert_eq!(retired_command_message(&["what", "worker"]), None);
+    }
+
+    #[test]
+    fn reparent_cli_parses_request_tree_decision_repair_and_rollout_forms() {
+        let request =
+            Cli::try_parse_from(["sm", "reparent", "request", "child", "--to", "parent"]).unwrap();
+        let Command::Reparent(request) = request.command else {
+            panic!("expected reparent command");
+        };
+        assert!(matches!(
+            request.command,
+            ReparentCommand::Request { child, to } if child == "child" && to == "parent"
+        ));
+
+        let tree = Cli::try_parse_from([
+            "sm",
+            "reparent-tree",
+            "source",
+            "--to",
+            "target",
+            "--dry-run",
+        ])
+        .unwrap();
+        let Command::ReparentTree(tree) = tree.command else {
+            panic!("expected reparent-tree command");
+        };
+        assert_eq!(tree.source, "source");
+        assert_eq!(tree.to, "target");
+        assert!(tree.dry_run);
+
+        assert!(matches!(
+            Cli::try_parse_from(["sm", "reparent", "approve", "request1"])
+                .unwrap()
+                .command,
+            Command::Reparent(ReparentArgs {
+                command: ReparentCommand::Approve { .. }
+            })
+        ));
+        assert!(matches!(
+            Cli::try_parse_from([
+                "sm",
+                "reparent",
+                "repair",
+                "request1",
+                "--rollback-precommit",
+            ])
+            .unwrap()
+            .command,
+            Command::Reparent(ReparentArgs {
+                command: ReparentCommand::Repair {
+                    rollback_precommit: true,
+                    ..
+                }
+            })
+        ));
+        assert!(matches!(
+            Cli::try_parse_from(["sm", "recredential", "--all-live"])
+                .unwrap()
+                .command,
+            Command::Recredential(RecredentialArgs { all_live: true, .. })
+        ));
+        assert!(matches!(
+            Cli::try_parse_from(["sm", "adopt", "child"])
+                .unwrap()
+                .command,
+            Command::Adopt(AdoptArgs { child }) if child == "child"
+        ));
+    }
+
+    #[test]
+    fn session_credential_header_is_sent_without_entering_the_json_body() {
+        let (client, handle) = single_request_server(200, r#"{"id":"request1"}"#);
+
+        let response = client
+            .post_json_with_session_credential(
+                "/sessions/child/reparent-requests",
+                json!({"requester_session_id": "parent"}),
+                "opaque-secret",
+            )
+            .unwrap();
+
+        assert_eq!(response["id"], "request1");
+        let requests = handle.join().unwrap();
+        assert!(requests[0].contains("X-SM-Session-Credential: opaque-secret\r\n"));
+        assert!(!requests[0].contains("\"opaque-secret\""));
     }
 
     #[test]

--- a/crates/sm-server/src/btw.rs
+++ b/crates/sm-server/src/btw.rs
@@ -158,6 +158,40 @@ impl BtwStore {
         })
     }
 
+    pub fn active_for_target(&self, target_session_id: &str) -> Result<Option<BtwRequestRecord>> {
+        self.with_connection(|conn| {
+            conn.query_row(
+                r#"
+                SELECT
+                    request_id,
+                    requester_session_id,
+                    target_session_id,
+                    target_provider,
+                    delivery_mode,
+                    prompt,
+                    status,
+                    provider_correlation,
+                    created_at,
+                    started_at,
+                    finished_at,
+                    result,
+                    error,
+                    response_delivered_at,
+                    response_undeliverable_at
+                FROM btw_requests
+                WHERE target_session_id = ?1
+                  AND status IN ('pending', 'running')
+                ORDER BY created_at ASC
+                LIMIT 1
+                "#,
+                [target_session_id],
+                record_from_row,
+            )
+            .optional()
+            .map_err(Into::into)
+        })
+    }
+
     pub fn list_recoverable(&self) -> Result<Vec<BtwRequestRecord>> {
         self.with_connection(|conn| {
             let mut statement = conn.prepare(

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -434,6 +434,9 @@ impl AppState {
         session_store
             .reconcile_reparent_requests()
             .context("reparent authority recovery failed")?;
+        if let Err(error) = session_store.reconcile_reparent_notifications() {
+            eprintln!("reparent notification recovery failed: {error:#}");
+        }
         if let Err(error) = session_store.recover_session_credential_rotation_workers() {
             eprintln!("session credential rotation recovery failed: {error:#}");
         }
@@ -2880,8 +2883,31 @@ async fn list_reparent_requests(
     request: Request,
 ) -> Result<Json<Value>, ApiError> {
     ensure_session_read_allowed(&state, &request)?;
+    reconcile_reparent_notifications_best_effort(&state);
+    let requests = if let Some(session_id) = header_text(request.headers(), "x-sm-session-id") {
+        let credential = reparent_session_credential(request.headers())?;
+        state
+            .session_store
+            .list_reparent_requests_for_session(&session_id, &credential)?
+            .ok_or_else(|| ApiError::Status {
+                status: StatusCode::FORBIDDEN,
+                detail: "session credential is missing, stale, or does not match the claimed actor"
+                    .to_owned(),
+            })?
+    } else {
+        if state.config.google_auth.requested()
+            && request_actor_email(&state.config, &request).is_none()
+        {
+            return Err(ApiError::Status {
+                status: StatusCode::UNAUTHORIZED,
+                detail: "Operator authentication or managed session identity is required"
+                    .to_owned(),
+            });
+        }
+        state.session_store.list_reparent_requests()?
+    };
     Ok(Json(json!({
-        "requests": state.session_store.list_reparent_requests()?,
+        "requests": requests,
     })))
 }
 
@@ -2964,10 +2990,37 @@ async fn get_reparent_request(
     request: Request,
 ) -> Result<Json<Value>, ApiError> {
     ensure_session_read_allowed(&state, &request)?;
+    reconcile_reparent_notifications_best_effort(&state);
     let record = state
         .session_store
         .get_reparent_request(&request_id)?
         .ok_or(ApiError::NotFound("Reparent request not found"))?;
+    if let Some(session_id) = header_text(request.headers(), "x-sm-session-id") {
+        let credential = reparent_session_credential(request.headers())?;
+        let visible = state
+            .session_store
+            .list_reparent_requests_for_session(&session_id, &credential)?
+            .ok_or_else(|| ApiError::Status {
+                status: StatusCode::FORBIDDEN,
+                detail: "session credential is missing, stale, or does not match the claimed actor"
+                    .to_owned(),
+            })?
+            .into_iter()
+            .any(|candidate| candidate.id == record.id);
+        if !visible {
+            return Err(ApiError::Status {
+                status: StatusCode::FORBIDDEN,
+                detail: "reparent request does not involve this session".to_owned(),
+            });
+        }
+    } else if state.config.google_auth.requested()
+        && request_actor_email(&state.config, &request).is_none()
+    {
+        return Err(ApiError::Status {
+            status: StatusCode::UNAUTHORIZED,
+            detail: "Operator authentication or managed session identity is required".to_owned(),
+        });
+    }
     Ok(Json(serde_json::to_value(record)?))
 }
 
@@ -2979,11 +3032,12 @@ async fn create_reparent_request(
 ) -> Result<Response, ApiError> {
     ensure_core_writes_enabled(&state)?;
     let credential = reparent_session_credential(&headers)?;
-    reparent_mutation_response(state.session_store.create_reparent_request(
-        &subject_session_id,
-        payload,
-        &credential,
-    )?)
+    let outcome =
+        state
+            .session_store
+            .create_reparent_request(&subject_session_id, payload, &credential)?;
+    reconcile_reparent_notifications_best_effort(&state);
+    reparent_mutation_response(outcome)
 }
 
 async fn create_reparent_tree_request(
@@ -2994,11 +3048,13 @@ async fn create_reparent_tree_request(
 ) -> Result<Response, ApiError> {
     ensure_core_writes_enabled(&state)?;
     let credential = reparent_session_credential(&headers)?;
-    reparent_mutation_response(state.session_store.create_reparent_tree_request(
+    let outcome = state.session_store.create_reparent_tree_request(
         &source_session_id,
         payload,
         &credential,
-    )?)
+    )?;
+    reconcile_reparent_notifications_best_effort(&state);
+    reparent_mutation_response(outcome)
 }
 
 async fn approve_reparent_request(
@@ -3009,12 +3065,14 @@ async fn approve_reparent_request(
 ) -> Result<Response, ApiError> {
     ensure_core_writes_enabled(&state)?;
     let credential = reparent_session_credential(&headers)?;
-    reparent_mutation_response(state.session_store.decide_reparent_request(
+    let outcome = state.session_store.decide_reparent_request(
         &request_id,
         payload,
         ReparentDecision::Approved,
         &credential,
-    )?)
+    )?;
+    reconcile_reparent_notifications_best_effort(&state);
+    reparent_mutation_response(outcome)
 }
 
 async fn reject_reparent_request(
@@ -3025,12 +3083,14 @@ async fn reject_reparent_request(
 ) -> Result<Response, ApiError> {
     ensure_core_writes_enabled(&state)?;
     let credential = reparent_session_credential(&headers)?;
-    reparent_mutation_response(state.session_store.decide_reparent_request(
+    let outcome = state.session_store.decide_reparent_request(
         &request_id,
         payload,
         ReparentDecision::Rejected,
         &credential,
-    )?)
+    )?;
+    reconcile_reparent_notifications_best_effort(&state);
+    reparent_mutation_response(outcome)
 }
 
 async fn human_approve_reparent_request(
@@ -3083,11 +3143,11 @@ async fn repair_reparent_request(
         status: StatusCode::BAD_REQUEST,
         detail: "action must be resume or rollback_precommit".to_owned(),
     })?;
-    reparent_mutation_response(state.session_store.repair_reparent_request(
-        &request_id,
-        &actor_id,
-        action,
-    )?)
+    let outcome = state
+        .session_store
+        .repair_reparent_request(&request_id, &actor_id, action)?;
+    reconcile_reparent_notifications_best_effort(&state);
+    reparent_mutation_response(outcome)
 }
 
 fn human_decide_reparent_request(
@@ -3102,11 +3162,17 @@ fn human_decide_reparent_request(
         status: StatusCode::UNAUTHORIZED,
         detail: "Operator authentication is required".to_owned(),
     })?;
-    reparent_mutation_response(
-        state
-            .session_store
-            .decide_reparent_request_as_human(request_id, &actor_id, decision)?,
-    )
+    let outcome = state
+        .session_store
+        .decide_reparent_request_as_human(request_id, &actor_id, decision)?;
+    reconcile_reparent_notifications_best_effort(state);
+    reparent_mutation_response(outcome)
+}
+
+fn reconcile_reparent_notifications_best_effort(state: &AppState) {
+    if let Err(error) = state.session_store.reconcile_reparent_notifications() {
+        eprintln!("reparent notification reconciliation failed: {error:#}");
+    }
 }
 
 fn reparent_session_credential(headers: &HeaderMap) -> Result<String, ApiError> {

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -422,6 +422,9 @@ impl AppState {
                 );
             session_store = session_store.with_usage_report_store(report_store);
         }
+        if let Err(error) = session_store.recover_session_runtime_launches() {
+            eprintln!("session runtime launch recovery failed: {error:#}");
+        }
         if let Err(error) = session_store.recover_pending_codex_fork_handoffs() {
             eprintln!("codex-fork handoff recovery failed: {error:#}");
         }

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -16,6 +16,7 @@ use std::{
     time::{Duration, Instant, UNIX_EPOCH},
 };
 
+use anyhow::Context as _;
 use axum::{
     body::{to_bytes, Body, Bytes},
     extract::{
@@ -122,11 +123,12 @@ use crate::sessions::{
     CoreRetireOutcome, CoreReviewOutcome, CreateCoreSessionRequest, CreateReparentRequest,
     CredentialRotationOutcome, DecideReparentRequest, HandoffOutcome, HandoffRequest,
     MaintainerMutationOutcome, RegistryMutationOutcome, ReparentDecision, ReparentMutationOutcome,
-    RoleRegistrationRequest, SeatSessionReconciliationSnapshot, SendCoreInputBatchRequest,
-    SendCoreInputRequest, SessionMetadataOutcome, SessionRecord, SessionResponse, SessionStore,
-    SessionsEnvelope, SetMaintainerRequest, SpawnReviewRequest, StartReviewRequest,
-    SubagentStartOutcome, SubagentStartRequest, SubagentStopOutcome, SubagentStopRequest,
-    TaskCompleteOutcome, TaskCompleteRequest, TurnCompleteOutcome, UpdateSessionMetadataRequest,
+    ReparentRepairAction, RoleRegistrationRequest, SeatSessionReconciliationSnapshot,
+    SendCoreInputBatchRequest, SendCoreInputRequest, SessionMetadataOutcome, SessionRecord,
+    SessionResponse, SessionStore, SessionsEnvelope, SetMaintainerRequest, SpawnReviewRequest,
+    StartReviewRequest, SubagentStartOutcome, SubagentStartRequest, SubagentStopOutcome,
+    SubagentStopRequest, TaskCompleteOutcome, TaskCompleteRequest, TurnCompleteOutcome,
+    UpdateSessionMetadataRequest,
 };
 
 use crate::studio_ssh::{self, StudioSshStatus};
@@ -376,6 +378,10 @@ pub struct AppState {
 
 impl AppState {
     pub fn new(config: AppConfig) -> Self {
+        Self::try_new(config).expect("session manager startup recovery failed")
+    }
+
+    pub fn try_new(config: AppConfig) -> anyhow::Result<Self> {
         let state_file = expand_home(&config.paths.state_file);
         let queue_db_path = expand_home(&config.sm_send.db_path);
         let mut session_store = SessionStore::new_with_queue(state_file, queue_db_path)
@@ -422,9 +428,12 @@ impl AppState {
                 );
             session_store = session_store.with_usage_report_store(report_store);
         }
-        if let Err(error) = session_store.recover_session_runtime_launches() {
-            eprintln!("session runtime launch recovery failed: {error:#}");
-        }
+        session_store
+            .recover_session_runtime_launches()
+            .context("session runtime launch recovery failed")?;
+        session_store
+            .reconcile_reparent_requests()
+            .context("reparent authority recovery failed")?;
         if let Err(error) = session_store.recover_session_credential_rotation_workers() {
             eprintln!("session credential rotation recovery failed: {error:#}");
         }
@@ -441,7 +450,7 @@ impl AppState {
         OsRng.fill_bytes(&mut mobile_terminal_secret);
         let (tmux_client_event_tx, _) = broadcast::channel(128);
         let studio_ssh_enabled = studio_ssh::status(&config.external_access.studio_ssh).enabled;
-        Self {
+        Ok(Self {
             config,
             session_store,
             github_review_poster: Arc::new(GhCliReviewPoster),
@@ -459,7 +468,7 @@ impl AppState {
             mobile_terminal_runtime_disabled: Arc::new(AtomicBool::new(false)),
             studio_ssh_enabled: Arc::new(AtomicBool::new(studio_ssh_enabled)),
             mobile_terminal_secret,
-        }
+        })
     }
 
     pub fn with_github_review_poster(mut self, poster: Arc<dyn GitHubReviewPoster>) -> Self {
@@ -1068,6 +1077,10 @@ pub fn router(state: AppState) -> Router {
         .route(
             "/reparent-requests/{request_id}/human-reject",
             post(human_reject_reparent_request),
+        )
+        .route(
+            "/reparent-requests/{request_id}/repair",
+            post(repair_reparent_request),
         )
         .route("/sessions/input-batch", post(send_session_input_batch))
         .route("/sessions/spawn", post(spawn_session))
@@ -2896,6 +2909,17 @@ async fn create_session_credential_rotation(
             status: StatusCode::UNAUTHORIZED,
             detail: "Operator authentication is required".to_owned(),
         })?;
+    if btw_db_path(&state).exists() {
+        if let Some(active) = btw_store(&state)?.active_for_target(&session_id)? {
+            return Err(ApiError::Status {
+                status: StatusCode::CONFLICT,
+                detail: format!(
+                    "session {session_id} has active sm what request {}",
+                    active.request_id
+                ),
+            });
+        }
+    }
     match state
         .session_store
         .create_session_credential_rotation(&session_id, &request_actor)?
@@ -2915,6 +2939,18 @@ async fn create_session_credential_rotation(
             status: StatusCode::CONFLICT,
             detail,
         }),
+    }
+}
+
+fn authority_mutation_error(error: anyhow::Error) -> ApiError {
+    let detail = error.to_string();
+    if detail.starts_with("reparent request ") && detail.contains(" controls session ") {
+        ApiError::Status {
+            status: StatusCode::CONFLICT,
+            detail,
+        }
+    } else {
+        ApiError::Internal(error)
     }
 }
 
@@ -2992,6 +3028,47 @@ async fn human_reject_reparent_request(
     request: Request,
 ) -> Result<Response, ApiError> {
     human_decide_reparent_request(&state, &request_id, &request, ReparentDecision::Rejected)
+}
+
+#[derive(Debug, Deserialize)]
+struct RepairReparentRequest {
+    action: String,
+}
+
+async fn repair_reparent_request(
+    State(state): State<Arc<AppState>>,
+    Path(request_id): Path<String>,
+    request: Request,
+) -> Result<Response, ApiError> {
+    ensure_core_writes_enabled(&state)?;
+    ensure_session_read_allowed(&state, &request)?;
+    let actor_id =
+        request_actor_email(&state.config, &request).ok_or_else(|| ApiError::Status {
+            status: StatusCode::UNAUTHORIZED,
+            detail: "Operator authentication is required".to_owned(),
+        })?;
+    let (parts, body) = request.into_parts();
+    let bytes = to_bytes(body, 64 * 1024)
+        .await
+        .map_err(|error| ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: format!("Invalid repair request body: {error}"),
+        })?;
+    let _ = parts;
+    let payload: RepairReparentRequest =
+        serde_json::from_slice(&bytes).map_err(|error| ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: format!("Invalid repair request: {error}"),
+        })?;
+    let action = ReparentRepairAction::parse(&payload.action).ok_or_else(|| ApiError::Status {
+        status: StatusCode::BAD_REQUEST,
+        detail: "action must be resume or rollback_precommit".to_owned(),
+    })?;
+    reparent_mutation_response(state.session_store.repair_reparent_request(
+        &request_id,
+        &actor_id,
+        action,
+    )?)
 }
 
 fn human_decide_reparent_request(
@@ -11602,7 +11679,7 @@ where
     E: Into<anyhow::Error>,
 {
     fn from(error: E) -> Self {
-        Self::Internal(error.into())
+        authority_mutation_error(error.into())
     }
 }
 

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -119,8 +119,9 @@ use crate::sessions::{
     ClaudeHookGate, ClearSessionRequest, ClientSessionResponse, ContextMonitorOutcome,
     ContextMonitorRequest, ContextSnapshotResponse, ContextUsageEvent, ContextUsageOutcome,
     CoreClearOutcome, CoreInputBatchResponse, CoreInputBatchResult, CoreRestoreOutcome,
-    CoreRetireOutcome, CoreReviewOutcome, CreateCoreSessionRequest, HandoffOutcome, HandoffRequest,
-    MaintainerMutationOutcome, RegistryMutationOutcome, RoleRegistrationRequest,
+    CoreRetireOutcome, CoreReviewOutcome, CreateCoreSessionRequest, CreateReparentRequest,
+    DecideReparentRequest, HandoffOutcome, HandoffRequest, MaintainerMutationOutcome,
+    RegistryMutationOutcome, ReparentDecision, ReparentMutationOutcome, RoleRegistrationRequest,
     SeatSessionReconciliationSnapshot, SendCoreInputBatchRequest, SendCoreInputRequest,
     SessionMetadataOutcome, SessionRecord, SessionResponse, SessionStore, SessionsEnvelope,
     SetMaintainerRequest, SpawnReviewRequest, StartReviewRequest, SubagentStartOutcome,
@@ -1040,6 +1041,16 @@ pub fn router(state: AppState) -> Router {
         .route(DEFAULT_EMAIL_WEBHOOK_PATH, post(inbound_email_webhook))
         .route("/usage/accounts", get(get_account_usage))
         .route("/sessions", get(list_sessions).post(create_session))
+        .route("/reparent-requests", get(list_reparent_requests))
+        .route("/reparent-requests/{request_id}", get(get_reparent_request))
+        .route(
+            "/reparent-requests/{request_id}/approve",
+            post(approve_reparent_request),
+        )
+        .route(
+            "/reparent-requests/{request_id}/reject",
+            post(reject_reparent_request),
+        )
         .route("/sessions/input-batch", post(send_session_input_batch))
         .route("/sessions/spawn", post(spawn_session))
         .route("/sessions/review", post(spawn_review_session))
@@ -1049,6 +1060,10 @@ pub fn router(state: AppState) -> Router {
             get(get_session).patch(update_session_metadata),
         )
         .route("/sessions/{session_id}/context", get(get_session_context))
+        .route(
+            "/sessions/{session_id}/reparent-requests",
+            post(create_reparent_request),
+        )
         .route("/sessions/{session_id}/usage", get(get_session_usage))
         .route("/sessions/{session_id}/review", post(start_session_review))
         .route(
@@ -2819,6 +2834,121 @@ async fn list_sessions(
         .map(|session| session_response_with_live_activity(&state, session))
         .collect::<Vec<_>>();
     Ok(Json(SessionsEnvelope::from(sessions)))
+}
+
+async fn list_reparent_requests(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    Ok(Json(json!({
+        "requests": state.session_store.list_reparent_requests()?,
+    })))
+}
+
+async fn get_reparent_request(
+    State(state): State<Arc<AppState>>,
+    Path(request_id): Path<String>,
+    request: Request,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    let record = state
+        .session_store
+        .get_reparent_request(&request_id)?
+        .ok_or(ApiError::NotFound("Reparent request not found"))?;
+    Ok(Json(serde_json::to_value(record)?))
+}
+
+async fn create_reparent_request(
+    State(state): State<Arc<AppState>>,
+    Path(subject_session_id): Path<String>,
+    headers: HeaderMap,
+    Json(payload): Json<CreateReparentRequest>,
+) -> Result<Response, ApiError> {
+    ensure_core_writes_enabled(&state)?;
+    let credential = reparent_session_credential(&headers)?;
+    reparent_mutation_response(state.session_store.create_reparent_request(
+        &subject_session_id,
+        payload,
+        &credential,
+    )?)
+}
+
+async fn approve_reparent_request(
+    State(state): State<Arc<AppState>>,
+    Path(request_id): Path<String>,
+    headers: HeaderMap,
+    Json(payload): Json<DecideReparentRequest>,
+) -> Result<Response, ApiError> {
+    ensure_core_writes_enabled(&state)?;
+    let credential = reparent_session_credential(&headers)?;
+    reparent_mutation_response(state.session_store.decide_reparent_request(
+        &request_id,
+        payload,
+        ReparentDecision::Approved,
+        &credential,
+    )?)
+}
+
+async fn reject_reparent_request(
+    State(state): State<Arc<AppState>>,
+    Path(request_id): Path<String>,
+    headers: HeaderMap,
+    Json(payload): Json<DecideReparentRequest>,
+) -> Result<Response, ApiError> {
+    ensure_core_writes_enabled(&state)?;
+    let credential = reparent_session_credential(&headers)?;
+    reparent_mutation_response(state.session_store.decide_reparent_request(
+        &request_id,
+        payload,
+        ReparentDecision::Rejected,
+        &credential,
+    )?)
+}
+
+fn reparent_session_credential(headers: &HeaderMap) -> Result<String, ApiError> {
+    let credential = header_text(headers, "x-sm-session-credential").unwrap_or_default();
+    if credential.is_empty() {
+        return Err(ApiError::Status {
+            status: StatusCode::FORBIDDEN,
+            detail: "X-SM-Session-Credential is required".to_owned(),
+        });
+    }
+    Ok(credential)
+}
+
+fn reparent_mutation_response(outcome: ReparentMutationOutcome) -> Result<Response, ApiError> {
+    match outcome {
+        ReparentMutationOutcome::Created(record) => {
+            Ok((StatusCode::CREATED, Json(serde_json::to_value(record)?)).into_response())
+        }
+        ReparentMutationOutcome::Updated(record) => {
+            Ok(Json(serde_json::to_value(record)?).into_response())
+        }
+        ReparentMutationOutcome::SessionNotFound(session_id) => Err(ApiError::Status {
+            status: StatusCode::NOT_FOUND,
+            detail: format!("Session {session_id} not found"),
+        }),
+        ReparentMutationOutcome::RequestNotFound => {
+            Err(ApiError::NotFound("Reparent request not found"))
+        }
+        ReparentMutationOutcome::BadRequest(detail) => Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail,
+        }),
+        ReparentMutationOutcome::Forbidden(detail) => Err(ApiError::Status {
+            status: StatusCode::FORBIDDEN,
+            detail,
+        }),
+        ReparentMutationOutcome::Conflict(detail) => Err(ApiError::Status {
+            status: StatusCode::CONFLICT,
+            detail,
+        }),
+        ReparentMutationOutcome::Expired => Err(ApiError::Status {
+            status: StatusCode::GONE,
+            detail: "Reparent request expired".to_owned(),
+        }),
+    }
 }
 
 async fn list_children_sessions(
@@ -9289,6 +9419,7 @@ fn codex_fork_event_stream_path_for_session(
         .filter(|value| !value.is_empty())?;
     let spec = crate::runtime::TmuxSessionSpec {
         session_id: session.id.clone(),
+        session_credential: None,
         tmux_session: session.tmux_session.clone(),
         working_dir: expand_home(&session.working_dir).display().to_string(),
         log_file: expand_home(log_file),
@@ -12537,6 +12668,7 @@ fn node_restore_candidate_value(session: SessionRecord, node_id: &str) -> Result
             detail: "failed to project node restore candidate".to_owned(),
         });
     };
+    object.remove("session_credential_sha256");
     object.insert("node".to_owned(), Value::String(node_id.to_owned()));
     object.insert("origin_node".to_owned(), Value::String(node_id.to_owned()));
     object.insert(
@@ -13310,6 +13442,7 @@ mod tests {
         .unwrap();
         let spec = crate::runtime::TmuxSessionSpec {
             session_id: session.id.clone(),
+            session_credential: None,
             tmux_session: session.tmux_session.clone(),
             working_dir: session.working_dir.clone(),
             log_file: log_file.clone(),
@@ -13359,6 +13492,7 @@ mod tests {
         .unwrap();
         let spec = crate::runtime::TmuxSessionSpec {
             session_id: session.id.clone(),
+            session_credential: None,
             tmux_session: session.tmux_session.clone(),
             working_dir: session.working_dir.clone(),
             log_file: log_file.clone(),
@@ -13411,6 +13545,7 @@ mod tests {
         .unwrap();
         let spec = crate::runtime::TmuxSessionSpec {
             session_id: session.id.clone(),
+            session_credential: None,
             tmux_session: session.tmux_session.clone(),
             working_dir: session.working_dir.clone(),
             log_file: log_file.clone(),

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -3663,15 +3663,14 @@ fn queue_wait_notification(state: &AppState, watcher_session_id: &str, text: Str
 }
 
 fn spawn_child_wait_monitor(state: Arc<AppState>, child: SessionRecord, wait_seconds: u64) {
-    let Some(parent_session_id) = child
+    if child
         .parent_session_id
         .as_deref()
         .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned)
-    else {
+        .is_none_or(str::is_empty)
+    {
         return;
-    };
+    }
     let child_session_id = child.id.clone();
 
     tokio::spawn(async move {
@@ -3705,39 +3704,24 @@ fn spawn_child_wait_monitor(state: Arc<AppState>, child: SessionRecord, wait_sec
             let Some(completion_message) = completion_message else {
                 continue;
             };
-
             let notification = format!(
                 "Child {} ({}) completed: {}",
                 child_display_name(&child),
                 short_session_id(&child_session_id),
                 completion_message
             );
-            let request = SendCoreInputRequest {
-                text: notification,
-                delivery_mode: "sequential".to_owned(),
-                sender_session_id: None,
-                from_sm_send: false,
-                timeout_seconds: None,
-                notify_on_delivery: false,
-                notify_after_seconds: None,
-                notify_on_stop: false,
-                remind_soft_threshold: None,
-                remind_hard_threshold: None,
-                remind_cancel_on_reply_session_id: None,
-                parent_session_id: None,
-            };
-            let _ = if state.config.rust_core.runtime_enabled {
-                let runtime = TmuxRuntime::from_app_config(&state.config);
-                state.session_store.send_core_input_with_runtime(
-                    &parent_session_id,
-                    request,
-                    &runtime,
-                )
-            } else {
-                state
-                    .session_store
-                    .send_core_input(&parent_session_id, request)
-            };
+            let runtime = state
+                .config
+                .rust_core
+                .runtime_enabled
+                .then(|| TmuxRuntime::from_app_config(&state.config));
+            let _ = state.session_store.send_parent_notification(
+                &child_session_id,
+                &notification,
+                "sequential",
+                "child_wait",
+                runtime.as_ref(),
+            );
             break;
         }
     });

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -121,14 +121,14 @@ use crate::sessions::{
     ContextMonitorRequest, ContextSnapshotResponse, ContextUsageEvent, ContextUsageOutcome,
     CoreClearOutcome, CoreInputBatchResponse, CoreInputBatchResult, CoreRestoreOutcome,
     CoreRetireOutcome, CoreReviewOutcome, CreateCoreSessionRequest, CreateReparentRequest,
-    CredentialRotationOutcome, DecideReparentRequest, HandoffOutcome, HandoffRequest,
-    MaintainerMutationOutcome, RegistryMutationOutcome, ReparentDecision, ReparentMutationOutcome,
-    ReparentRepairAction, RoleRegistrationRequest, SeatSessionReconciliationSnapshot,
-    SendCoreInputBatchRequest, SendCoreInputRequest, SessionMetadataOutcome, SessionRecord,
-    SessionResponse, SessionStore, SessionsEnvelope, SetMaintainerRequest, SpawnReviewRequest,
-    StartReviewRequest, SubagentStartOutcome, SubagentStartRequest, SubagentStopOutcome,
-    SubagentStopRequest, TaskCompleteOutcome, TaskCompleteRequest, TurnCompleteOutcome,
-    UpdateSessionMetadataRequest,
+    CreateReparentTreeRequest, CredentialRotationOutcome, DecideReparentRequest, HandoffOutcome,
+    HandoffRequest, MaintainerMutationOutcome, RegistryMutationOutcome, ReparentDecision,
+    ReparentMutationOutcome, ReparentRepairAction, RoleRegistrationRequest,
+    SeatSessionReconciliationSnapshot, SendCoreInputBatchRequest, SendCoreInputRequest,
+    SessionMetadataOutcome, SessionRecord, SessionResponse, SessionStore, SessionsEnvelope,
+    SetMaintainerRequest, SpawnReviewRequest, StartReviewRequest, SubagentStartOutcome,
+    SubagentStartRequest, SubagentStopOutcome, SubagentStopRequest, TaskCompleteOutcome,
+    TaskCompleteRequest, TurnCompleteOutcome, UpdateSessionMetadataRequest,
 };
 
 use crate::studio_ssh::{self, StudioSshStatus};
@@ -1094,6 +1094,10 @@ pub fn router(state: AppState) -> Router {
         .route(
             "/sessions/{session_id}/reparent-requests",
             post(create_reparent_request),
+        )
+        .route(
+            "/sessions/{session_id}/reparent-tree-requests",
+            post(create_reparent_tree_request),
         )
         .route(
             "/sessions/{session_id}/credential-rotation",
@@ -2982,6 +2986,21 @@ async fn create_reparent_request(
     )?)
 }
 
+async fn create_reparent_tree_request(
+    State(state): State<Arc<AppState>>,
+    Path(source_session_id): Path<String>,
+    headers: HeaderMap,
+    Json(payload): Json<CreateReparentTreeRequest>,
+) -> Result<Response, ApiError> {
+    ensure_core_writes_enabled(&state)?;
+    let credential = reparent_session_credential(&headers)?;
+    reparent_mutation_response(state.session_store.create_reparent_tree_request(
+        &source_session_id,
+        payload,
+        &credential,
+    )?)
+}
+
 async fn approve_reparent_request(
     State(state): State<Arc<AppState>>,
     Path(request_id): Path<String>,
@@ -3108,6 +3127,9 @@ fn reparent_mutation_response(outcome: ReparentMutationOutcome) -> Result<Respon
         }
         ReparentMutationOutcome::Updated(record) => {
             Ok(Json(serde_json::to_value(record)?).into_response())
+        }
+        ReparentMutationOutcome::Preview(preview) => {
+            Ok(Json(serde_json::to_value(preview)?).into_response())
         }
         ReparentMutationOutcome::SessionNotFound(session_id) => Err(ApiError::Status {
             status: StatusCode::NOT_FOUND,

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -120,13 +120,13 @@ use crate::sessions::{
     ContextMonitorRequest, ContextSnapshotResponse, ContextUsageEvent, ContextUsageOutcome,
     CoreClearOutcome, CoreInputBatchResponse, CoreInputBatchResult, CoreRestoreOutcome,
     CoreRetireOutcome, CoreReviewOutcome, CreateCoreSessionRequest, CreateReparentRequest,
-    DecideReparentRequest, HandoffOutcome, HandoffRequest, MaintainerMutationOutcome,
-    RegistryMutationOutcome, ReparentDecision, ReparentMutationOutcome, RoleRegistrationRequest,
-    SeatSessionReconciliationSnapshot, SendCoreInputBatchRequest, SendCoreInputRequest,
-    SessionMetadataOutcome, SessionRecord, SessionResponse, SessionStore, SessionsEnvelope,
-    SetMaintainerRequest, SpawnReviewRequest, StartReviewRequest, SubagentStartOutcome,
-    SubagentStartRequest, SubagentStopOutcome, SubagentStopRequest, TaskCompleteOutcome,
-    TaskCompleteRequest, TurnCompleteOutcome, UpdateSessionMetadataRequest,
+    CredentialRotationOutcome, DecideReparentRequest, HandoffOutcome, HandoffRequest,
+    MaintainerMutationOutcome, RegistryMutationOutcome, ReparentDecision, ReparentMutationOutcome,
+    RoleRegistrationRequest, SeatSessionReconciliationSnapshot, SendCoreInputBatchRequest,
+    SendCoreInputRequest, SessionMetadataOutcome, SessionRecord, SessionResponse, SessionStore,
+    SessionsEnvelope, SetMaintainerRequest, SpawnReviewRequest, StartReviewRequest,
+    SubagentStartOutcome, SubagentStartRequest, SubagentStopOutcome, SubagentStopRequest,
+    TaskCompleteOutcome, TaskCompleteRequest, TurnCompleteOutcome, UpdateSessionMetadataRequest,
 };
 
 use crate::studio_ssh::{self, StudioSshStatus};
@@ -424,6 +424,9 @@ impl AppState {
         }
         if let Err(error) = session_store.recover_session_runtime_launches() {
             eprintln!("session runtime launch recovery failed: {error:#}");
+        }
+        if let Err(error) = session_store.recover_session_credential_rotation_workers() {
+            eprintln!("session credential rotation recovery failed: {error:#}");
         }
         if let Err(error) = session_store.recover_pending_codex_fork_handoffs() {
             eprintln!("codex-fork handoff recovery failed: {error:#}");
@@ -1045,6 +1048,10 @@ pub fn router(state: AppState) -> Router {
         .route("/usage/accounts", get(get_account_usage))
         .route("/sessions", get(list_sessions).post(create_session))
         .route("/reparent-requests", get(list_reparent_requests))
+        .route(
+            "/session-credential-rotations",
+            get(list_session_credential_rotations),
+        )
         .route("/reparent-requests/{request_id}", get(get_reparent_request))
         .route(
             "/reparent-requests/{request_id}/approve",
@@ -1066,6 +1073,10 @@ pub fn router(state: AppState) -> Router {
         .route(
             "/sessions/{session_id}/reparent-requests",
             post(create_reparent_request),
+        )
+        .route(
+            "/sessions/{session_id}/credential-rotation",
+            post(create_session_credential_rotation),
         )
         .route("/sessions/{session_id}/usage", get(get_session_usage))
         .route("/sessions/{session_id}/review", post(start_session_review))
@@ -2847,6 +2858,56 @@ async fn list_reparent_requests(
     Ok(Json(json!({
         "requests": state.session_store.list_reparent_requests()?,
     })))
+}
+
+async fn list_session_credential_rotations(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+) -> Result<Json<Value>, ApiError> {
+    ensure_session_read_allowed(&state, &request)?;
+    if request_actor_email(&state.config, &request).is_none() {
+        return Err(ApiError::Status {
+            status: StatusCode::UNAUTHORIZED,
+            detail: "Operator authentication is required".to_owned(),
+        });
+    }
+    Ok(Json(json!({
+        "rotations": state.session_store.list_session_credential_rotations()?,
+    })))
+}
+
+async fn create_session_credential_rotation(
+    State(state): State<Arc<AppState>>,
+    Path(session_id): Path<String>,
+    request: Request,
+) -> Result<Response, ApiError> {
+    ensure_core_writes_enabled(&state)?;
+    ensure_session_read_allowed(&state, &request)?;
+    let request_actor =
+        request_actor_email(&state.config, &request).ok_or_else(|| ApiError::Status {
+            status: StatusCode::UNAUTHORIZED,
+            detail: "Operator authentication is required".to_owned(),
+        })?;
+    match state
+        .session_store
+        .create_session_credential_rotation(&session_id, &request_actor)?
+    {
+        CredentialRotationOutcome::Created(record) => {
+            Ok((StatusCode::CREATED, Json(serde_json::to_value(record)?)).into_response())
+        }
+        CredentialRotationOutcome::Existing(record) => {
+            Ok(Json(serde_json::to_value(record)?).into_response())
+        }
+        CredentialRotationOutcome::SessionNotFound => Err(ApiError::NotFound("Session not found")),
+        CredentialRotationOutcome::BadRequest(detail) => Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail,
+        }),
+        CredentialRotationOutcome::Conflict(detail) => Err(ApiError::Status {
+            status: StatusCode::CONFLICT,
+            detail,
+        }),
+    }
 }
 
 async fn get_reparent_request(

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -1061,6 +1061,14 @@ pub fn router(state: AppState) -> Router {
             "/reparent-requests/{request_id}/reject",
             post(reject_reparent_request),
         )
+        .route(
+            "/reparent-requests/{request_id}/human-approve",
+            post(human_approve_reparent_request),
+        )
+        .route(
+            "/reparent-requests/{request_id}/human-reject",
+            post(human_reject_reparent_request),
+        )
         .route("/sessions/input-batch", post(send_session_input_batch))
         .route("/sessions/spawn", post(spawn_session))
         .route("/sessions/review", post(spawn_review_session))
@@ -2968,6 +2976,41 @@ async fn reject_reparent_request(
         ReparentDecision::Rejected,
         &credential,
     )?)
+}
+
+async fn human_approve_reparent_request(
+    State(state): State<Arc<AppState>>,
+    Path(request_id): Path<String>,
+    request: Request,
+) -> Result<Response, ApiError> {
+    human_decide_reparent_request(&state, &request_id, &request, ReparentDecision::Approved)
+}
+
+async fn human_reject_reparent_request(
+    State(state): State<Arc<AppState>>,
+    Path(request_id): Path<String>,
+    request: Request,
+) -> Result<Response, ApiError> {
+    human_decide_reparent_request(&state, &request_id, &request, ReparentDecision::Rejected)
+}
+
+fn human_decide_reparent_request(
+    state: &AppState,
+    request_id: &str,
+    request: &Request,
+    decision: ReparentDecision,
+) -> Result<Response, ApiError> {
+    ensure_core_writes_enabled(state)?;
+    ensure_session_read_allowed(state, request)?;
+    let actor_id = request_actor_email(&state.config, request).ok_or_else(|| ApiError::Status {
+        status: StatusCode::UNAUTHORIZED,
+        detail: "Operator authentication is required".to_owned(),
+    })?;
+    reparent_mutation_response(
+        state
+            .session_store
+            .decide_reparent_request_as_human(request_id, &actor_id, decision)?,
+    )
 }
 
 fn reparent_session_credential(headers: &HeaderMap) -> Result<String, ApiError> {

--- a/crates/sm-server/src/main.rs
+++ b/crates/sm-server/src/main.rs
@@ -98,7 +98,7 @@ async fn main() -> Result<()> {
         );
     }
 
-    let state = AppState::new(config);
+    let state = AppState::try_new(config).context("failed to initialize server state")?;
     // Capture the artifact boundary before serving. The background scan may run
     // alongside live creates, but it must not attribute their new artifacts
     // against this startup snapshot of the seat registry.

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -254,6 +254,28 @@ pub struct StopNotifyState {
     pub delay_seconds: i64,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParentRoutingWakeRow {
+    pub id: String,
+    pub child_session_id: String,
+    pub parent_session_id: String,
+    pub period_seconds: i64,
+    pub is_active: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParentRoutingMessageRow {
+    pub id: String,
+    pub child_session_id: String,
+    pub parent_session_id: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ParentRoutingSnapshot {
+    pub wake_rows: Vec<ParentRoutingWakeRow>,
+    pub message_rows: Vec<ParentRoutingMessageRow>,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct QueueMessageMetadata {
     pub sender_session_id: Option<String>,
@@ -1176,6 +1198,107 @@ impl RetainedQueueStore {
         })
     }
 
+    pub fn snapshot_parent_routing(
+        &self,
+        child_session_id: &str,
+        expected_parent_session_id: &str,
+    ) -> Result<ParentRoutingSnapshot> {
+        self.with_connection(|conn| {
+            snapshot_parent_routing_conn(conn, child_session_id, expected_parent_session_id)
+        })
+    }
+
+    pub fn quiesce_parent_routing(&self, snapshot: &ParentRoutingSnapshot) -> Result<()> {
+        self.with_connection(|conn| {
+            with_immediate_transaction(conn, |conn| {
+                for wake in &snapshot.wake_rows {
+                    let current = parent_routing_wake_row_conn(conn, &wake.id)?
+                        .with_context(|| format!("parent wake {} disappeared", wake.id))?;
+                    if current.child_session_id != wake.child_session_id
+                        || current.parent_session_id != wake.parent_session_id
+                        || current.period_seconds != wake.period_seconds
+                        || (current.is_active != wake.is_active && current.is_active)
+                    {
+                        anyhow::bail!("parent wake {} changed after planning", wake.id);
+                    }
+                    conn.execute(
+                        "UPDATE parent_wake_registrations SET is_active = 0 WHERE id = ?1",
+                        params![wake.id],
+                    )?;
+                }
+                for message in &snapshot.message_rows {
+                    let (current_child, current_parent) = parent_routing_message_state_conn(
+                        conn,
+                        &message.id,
+                    )?
+                        .with_context(|| format!("queue message {} disappeared", message.id))?;
+                    if current_child != message.child_session_id
+                        || (current_parent.as_deref()
+                            != Some(message.parent_session_id.as_str())
+                            && current_parent.is_some())
+                    {
+                        anyhow::bail!("queue message {} changed after planning", message.id);
+                    }
+                    conn.execute(
+                        "UPDATE message_queue SET parent_session_id = NULL WHERE id = ?1 AND delivered_at IS NULL",
+                        params![message.id],
+                    )?;
+                }
+                Ok(())
+            })
+        })
+    }
+
+    pub fn retarget_parent_routing(
+        &self,
+        snapshot: &ParentRoutingSnapshot,
+        new_parent_session_id: &str,
+    ) -> Result<()> {
+        self.with_connection(|conn| {
+            with_immediate_transaction(conn, |conn| {
+                for wake in &snapshot.wake_rows {
+                    let current = parent_routing_wake_row_conn(conn, &wake.id)?
+                        .with_context(|| format!("parent wake {} disappeared", wake.id))?;
+                    let valid = current.child_session_id == wake.child_session_id
+                        && current.period_seconds == wake.period_seconds
+                        && ((current.parent_session_id == wake.parent_session_id
+                            && current.is_active == wake.is_active)
+                            || (current.parent_session_id == wake.parent_session_id
+                                && !current.is_active)
+                            || (current.parent_session_id == new_parent_session_id
+                                && current.is_active == wake.is_active));
+                    if !valid {
+                        anyhow::bail!("parent wake {} changed after planning", wake.id);
+                    }
+                    conn.execute(
+                        "UPDATE parent_wake_registrations SET parent_session_id = ?2, is_active = ?3 WHERE id = ?1",
+                        params![wake.id, new_parent_session_id, i64::from(wake.is_active)],
+                    )?;
+                }
+                for message in &snapshot.message_rows {
+                    let (current_child, current_parent) = parent_routing_message_state_conn(
+                        conn,
+                        &message.id,
+                    )?
+                        .with_context(|| format!("queue message {} disappeared", message.id))?;
+                    if current_child != message.child_session_id
+                        || (current_parent.as_deref()
+                            != Some(message.parent_session_id.as_str())
+                        && current_parent.is_some()
+                        && current_parent.as_deref() != Some(new_parent_session_id))
+                    {
+                        anyhow::bail!("queue message {} changed after planning", message.id);
+                    }
+                    conn.execute(
+                        "UPDATE message_queue SET parent_session_id = ?2 WHERE id = ?1 AND delivered_at IS NULL",
+                        params![message.id, new_parent_session_id],
+                    )?;
+                }
+                Ok(())
+            })
+        })
+    }
+
     pub fn pending_messages_for_target(
         &self,
         target_session_id: &str,
@@ -1759,6 +1882,123 @@ fn register_parent_wake_conn(
         ],
     )?;
     Ok(id)
+}
+
+fn snapshot_parent_routing_conn(
+    conn: &Connection,
+    child_session_id: &str,
+    expected_parent_session_id: &str,
+) -> Result<ParentRoutingSnapshot> {
+    let mut wake_statement = conn.prepare(
+        r#"
+        SELECT id, child_session_id, parent_session_id, period_seconds, is_active
+        FROM parent_wake_registrations
+        WHERE child_session_id = ?1
+          AND parent_session_id = ?2
+          AND is_active = 1
+        ORDER BY id
+        "#,
+    )?;
+    let wake_rows = wake_statement
+        .query_map(
+            params![child_session_id, expected_parent_session_id],
+            |row| {
+                Ok(ParentRoutingWakeRow {
+                    id: row.get(0)?,
+                    child_session_id: row.get(1)?,
+                    parent_session_id: row.get(2)?,
+                    period_seconds: row.get(3)?,
+                    is_active: row.get::<_, i64>(4)? != 0,
+                })
+            },
+        )?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+
+    let mut message_statement = conn.prepare(
+        r#"
+        SELECT id, target_session_id, parent_session_id
+        FROM message_queue
+        WHERE target_session_id = ?1
+          AND parent_session_id = ?2
+          AND delivered_at IS NULL
+        ORDER BY id
+        "#,
+    )?;
+    let message_rows = message_statement
+        .query_map(
+            params![child_session_id, expected_parent_session_id],
+            |row| {
+                Ok(ParentRoutingMessageRow {
+                    id: row.get(0)?,
+                    child_session_id: row.get(1)?,
+                    parent_session_id: row.get(2)?,
+                })
+            },
+        )?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    Ok(ParentRoutingSnapshot {
+        wake_rows,
+        message_rows,
+    })
+}
+
+fn parent_routing_wake_row_conn(
+    conn: &Connection,
+    record_id: &str,
+) -> Result<Option<ParentRoutingWakeRow>> {
+    conn.query_row(
+        r#"
+        SELECT id, child_session_id, parent_session_id, period_seconds, is_active
+        FROM parent_wake_registrations
+        WHERE id = ?1
+        "#,
+        params![record_id],
+        |row| {
+            Ok(ParentRoutingWakeRow {
+                id: row.get(0)?,
+                child_session_id: row.get(1)?,
+                parent_session_id: row.get(2)?,
+                period_seconds: row.get(3)?,
+                is_active: row.get::<_, i64>(4)? != 0,
+            })
+        },
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+fn parent_routing_message_state_conn(
+    conn: &Connection,
+    record_id: &str,
+) -> Result<Option<(String, Option<String>)>> {
+    conn.query_row(
+        r#"
+        SELECT target_session_id, parent_session_id
+        FROM message_queue
+        WHERE id = ?1 AND delivered_at IS NULL
+        "#,
+        params![record_id],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+fn with_immediate_transaction<T>(
+    conn: &Connection,
+    action: impl FnOnce(&Connection) -> Result<T>,
+) -> Result<T> {
+    conn.execute_batch("BEGIN IMMEDIATE")?;
+    match action(conn) {
+        Ok(value) => {
+            conn.execute_batch("COMMIT")?;
+            Ok(value)
+        }
+        Err(error) => {
+            let _ = conn.execute_batch("ROLLBACK");
+            Err(error)
+        }
+    }
 }
 
 fn cancel_parent_wake_conn(conn: &Connection, child_session_id: &str) -> Result<()> {
@@ -3927,6 +4167,143 @@ mod tests {
             )
             .unwrap();
         assert_eq!(stop_notify, ("em002".to_owned(), "other-em".to_owned(), 0));
+    }
+
+    #[test]
+    fn parent_routing_coordinator_quiesces_and_retargets_idempotently() {
+        let db_path = unique_temp_path("parent-routing");
+        let store = RetainedQueueStore::new(db_path.clone());
+        store.ensure_schema().unwrap();
+        let wake_id = store
+            .register_parent_wake("child001", "parent-old", 600)
+            .unwrap();
+        let message_id = store
+            .enqueue_message_with_metadata(
+                "child001",
+                "parent-derived wait",
+                "important",
+                QueueMessageMetadata {
+                    parent_session_id: Some("parent-old".to_owned()),
+                    ..QueueMessageMetadata::default()
+                },
+            )
+            .unwrap();
+        store
+            .enqueue_message_with_metadata(
+                "child001",
+                "explicit peer route",
+                "important",
+                QueueMessageMetadata {
+                    parent_session_id: Some("peer-explicit".to_owned()),
+                    ..QueueMessageMetadata::default()
+                },
+            )
+            .unwrap();
+
+        let snapshot = store
+            .snapshot_parent_routing("child001", "parent-old")
+            .unwrap();
+        assert_eq!(snapshot.wake_rows.len(), 1);
+        assert_eq!(snapshot.wake_rows[0].id, wake_id);
+        assert_eq!(snapshot.message_rows.len(), 1);
+        assert_eq!(snapshot.message_rows[0].id, message_id);
+
+        store.quiesce_parent_routing(&snapshot).unwrap();
+        store.quiesce_parent_routing(&snapshot).unwrap();
+        assert_eq!(store.active_parent_wake_parent("child001").unwrap(), None);
+        let conn = Connection::open(&db_path).unwrap();
+        let quiesced_parent: Option<String> = conn
+            .query_row(
+                "SELECT parent_session_id FROM message_queue WHERE id = ?1",
+                params![message_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(quiesced_parent, None);
+
+        store
+            .retarget_parent_routing(&snapshot, "parent-new")
+            .unwrap();
+        store
+            .retarget_parent_routing(&snapshot, "parent-new")
+            .unwrap();
+        assert_eq!(
+            store.active_parent_wake_parent("child001").unwrap(),
+            Some("parent-new".to_owned())
+        );
+        let parents = conn
+            .prepare("SELECT text, parent_session_id FROM message_queue ORDER BY text")
+            .unwrap()
+            .query_map([], |row| {
+                Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+            })
+            .unwrap()
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(
+            parents,
+            vec![
+                ("explicit peer route".to_owned(), "peer-explicit".to_owned()),
+                ("parent-derived wait".to_owned(), "parent-new".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn parent_routing_coordinator_rolls_back_on_snapshot_mismatch() {
+        let db_path = unique_temp_path("parent-routing-mismatch");
+        let store = RetainedQueueStore::new(db_path.clone());
+        store.ensure_schema().unwrap();
+        store
+            .register_parent_wake("child001", "parent-old", 600)
+            .unwrap();
+        let first_id = store
+            .enqueue_message_with_metadata(
+                "child001",
+                "first",
+                "important",
+                QueueMessageMetadata {
+                    parent_session_id: Some("parent-old".to_owned()),
+                    ..QueueMessageMetadata::default()
+                },
+            )
+            .unwrap();
+        let second_id = store
+            .enqueue_message_with_metadata(
+                "child001",
+                "second",
+                "important",
+                QueueMessageMetadata {
+                    parent_session_id: Some("parent-old".to_owned()),
+                    ..QueueMessageMetadata::default()
+                },
+            )
+            .unwrap();
+        let snapshot = store
+            .snapshot_parent_routing("child001", "parent-old")
+            .unwrap();
+        Connection::open(&db_path)
+            .unwrap()
+            .execute(
+                "UPDATE message_queue SET parent_session_id = 'unexpected' WHERE id = ?1",
+                params![second_id],
+            )
+            .unwrap();
+
+        assert!(store.quiesce_parent_routing(&snapshot).is_err());
+        let conn = Connection::open(db_path).unwrap();
+        let first_parent: String = conn
+            .query_row(
+                "SELECT parent_session_id FROM message_queue WHERE id = ?1",
+                params![first_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(first_parent, "parent-old");
+        assert_eq!(
+            store.active_parent_wake_parent("child001").unwrap(),
+            Some("parent-old".to_owned())
+        );
     }
 
     #[test]

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -1261,7 +1261,7 @@ impl RetainedQueueStore {
     pub fn retarget_parent_routing(
         &self,
         snapshot: &ParentRoutingSnapshot,
-        new_parent_session_id: &str,
+        new_parent_session_id: Option<&str>,
     ) -> Result<ParentRoutingRetargetResult> {
         self.with_connection(|conn| {
             with_immediate_transaction(conn, |conn| {
@@ -1275,15 +1275,24 @@ impl RetainedQueueStore {
                             && current.is_active == wake.is_active)
                             || (current.parent_session_id == wake.parent_session_id
                                 && !current.is_active)
-                            || (current.parent_session_id == new_parent_session_id
-                                && current.is_active == wake.is_active));
+                            || new_parent_session_id.is_some_and(|new_parent| {
+                                current.parent_session_id == new_parent
+                                    && current.is_active == wake.is_active
+                            }));
                     if !valid {
                         anyhow::bail!("parent wake {} changed after planning", wake.id);
                     }
-                    conn.execute(
-                        "UPDATE parent_wake_registrations SET parent_session_id = ?2, is_active = ?3 WHERE id = ?1",
-                        params![wake.id, new_parent_session_id, i64::from(wake.is_active)],
-                    )?;
+                    if let Some(new_parent) = new_parent_session_id {
+                        conn.execute(
+                            "UPDATE parent_wake_registrations SET parent_session_id = ?2, is_active = ?3 WHERE id = ?1",
+                            params![wake.id, new_parent, i64::from(wake.is_active)],
+                        )?;
+                    } else {
+                        conn.execute(
+                            "UPDATE parent_wake_registrations SET is_active = 0 WHERE id = ?1",
+                            params![wake.id],
+                        )?;
+                    }
                 }
                 for message in &snapshot.message_rows {
                     let (current_child, current_parent, delivered) =
@@ -1294,7 +1303,7 @@ impl RetainedQueueStore {
                         || (current_parent.as_deref()
                             != Some(message.parent_session_id.as_str())
                         && current_parent.is_some()
-                        && current_parent.as_deref() != Some(new_parent_session_id))
+                        && current_parent.as_deref() != new_parent_session_id)
                     {
                         anyhow::bail!("queue message {} changed after planning", message.id);
                     }
@@ -4237,10 +4246,10 @@ mod tests {
         assert_eq!(quiesced_parent, None);
 
         store
-            .retarget_parent_routing(&snapshot, "parent-new")
+            .retarget_parent_routing(&snapshot, Some("parent-new"))
             .unwrap();
         store
-            .retarget_parent_routing(&snapshot, "parent-new")
+            .retarget_parent_routing(&snapshot, Some("parent-new"))
             .unwrap();
         assert_eq!(
             store.active_parent_wake_parent("child001").unwrap(),
@@ -4262,6 +4271,45 @@ mod tests {
                 ("parent-derived wait".to_owned(), "parent-new".to_owned()),
             ]
         );
+    }
+
+    #[test]
+    fn parent_routing_coordinator_clears_routes_for_a_new_root_idempotently() {
+        let db_path = unique_temp_path("parent-routing-root");
+        let store = RetainedQueueStore::new(db_path.clone());
+        store.ensure_schema().unwrap();
+        store
+            .register_parent_wake("child001", "parent-old", 600)
+            .unwrap();
+        let message_id = store
+            .enqueue_message_with_metadata(
+                "child001",
+                "parent-derived wait",
+                "important",
+                QueueMessageMetadata {
+                    parent_session_id: Some("parent-old".to_owned()),
+                    ..QueueMessageMetadata::default()
+                },
+            )
+            .unwrap();
+        let snapshot = store
+            .snapshot_parent_routing("child001", "parent-old")
+            .unwrap();
+
+        store.quiesce_parent_routing(&snapshot).unwrap();
+        store.retarget_parent_routing(&snapshot, None).unwrap();
+        store.retarget_parent_routing(&snapshot, None).unwrap();
+
+        assert_eq!(store.active_parent_wake_parent("child001").unwrap(), None);
+        let conn = Connection::open(&db_path).unwrap();
+        let parent: Option<String> = conn
+            .query_row(
+                "SELECT parent_session_id FROM message_queue WHERE id = ?1",
+                params![message_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(parent, None);
     }
 
     #[test]
@@ -4359,7 +4407,7 @@ mod tests {
             .unwrap()
             .is_none());
         let result = store
-            .retarget_parent_routing(&snapshot, "parent-new")
+            .retarget_parent_routing(&snapshot, Some("parent-new"))
             .unwrap();
 
         assert_eq!(result.delivered_message_rows, snapshot.message_rows);

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -18,6 +18,7 @@ use rusqlite::{
     types::{Value as SqlValue, ValueRef},
     Connection, OpenFlags, OptionalExtension,
 };
+use serde::Serialize;
 use serde_json::{Number as JsonNumber, Value as JsonValue};
 use time::{
     format_description::well_known::Rfc3339, macros::format_description, Duration, OffsetDateTime,
@@ -254,7 +255,7 @@ pub struct StopNotifyState {
     pub delay_seconds: i64,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ParentRoutingWakeRow {
     pub id: String,
     pub child_session_id: String,
@@ -263,17 +264,23 @@ pub struct ParentRoutingWakeRow {
     pub is_active: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ParentRoutingMessageRow {
     pub id: String,
     pub child_session_id: String,
     pub parent_session_id: String,
+    pub creates_parent_wake: bool,
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 pub struct ParentRoutingSnapshot {
     pub wake_rows: Vec<ParentRoutingWakeRow>,
     pub message_rows: Vec<ParentRoutingMessageRow>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ParentRoutingRetargetResult {
+    pub delivered_message_rows: Vec<ParentRoutingMessageRow>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -1227,17 +1234,19 @@ impl RetainedQueueStore {
                     )?;
                 }
                 for message in &snapshot.message_rows {
-                    let (current_child, current_parent) = parent_routing_message_state_conn(
-                        conn,
-                        &message.id,
-                    )?
-                        .with_context(|| format!("queue message {} disappeared", message.id))?;
+                    let (current_child, current_parent, delivered) =
+                        parent_routing_message_state_conn(conn, &message.id)?.with_context(|| {
+                            format!("queue message {} disappeared", message.id)
+                        })?;
                     if current_child != message.child_session_id
                         || (current_parent.as_deref()
                             != Some(message.parent_session_id.as_str())
                             && current_parent.is_some())
                     {
                         anyhow::bail!("queue message {} changed after planning", message.id);
+                    }
+                    if delivered {
+                        anyhow::bail!("queue message {} delivered before quiesce", message.id);
                     }
                     conn.execute(
                         "UPDATE message_queue SET parent_session_id = NULL WHERE id = ?1 AND delivered_at IS NULL",
@@ -1253,9 +1262,10 @@ impl RetainedQueueStore {
         &self,
         snapshot: &ParentRoutingSnapshot,
         new_parent_session_id: &str,
-    ) -> Result<()> {
+    ) -> Result<ParentRoutingRetargetResult> {
         self.with_connection(|conn| {
             with_immediate_transaction(conn, |conn| {
+                let mut result = ParentRoutingRetargetResult::default();
                 for wake in &snapshot.wake_rows {
                     let current = parent_routing_wake_row_conn(conn, &wake.id)?
                         .with_context(|| format!("parent wake {} disappeared", wake.id))?;
@@ -1276,11 +1286,10 @@ impl RetainedQueueStore {
                     )?;
                 }
                 for message in &snapshot.message_rows {
-                    let (current_child, current_parent) = parent_routing_message_state_conn(
-                        conn,
-                        &message.id,
-                    )?
-                        .with_context(|| format!("queue message {} disappeared", message.id))?;
+                    let (current_child, current_parent, delivered) =
+                        parent_routing_message_state_conn(conn, &message.id)?.with_context(|| {
+                            format!("queue message {} disappeared", message.id)
+                        })?;
                     if current_child != message.child_session_id
                         || (current_parent.as_deref()
                             != Some(message.parent_session_id.as_str())
@@ -1289,12 +1298,16 @@ impl RetainedQueueStore {
                     {
                         anyhow::bail!("queue message {} changed after planning", message.id);
                     }
+                    if delivered {
+                        result.delivered_message_rows.push(message.clone());
+                        continue;
+                    }
                     conn.execute(
                         "UPDATE message_queue SET parent_session_id = ?2 WHERE id = ?1 AND delivered_at IS NULL",
                         params![message.id, new_parent_session_id],
                     )?;
                 }
-                Ok(())
+                Ok(result)
             })
         })
     }
@@ -1916,7 +1929,8 @@ fn snapshot_parent_routing_conn(
 
     let mut message_statement = conn.prepare(
         r#"
-        SELECT id, target_session_id, parent_session_id
+        SELECT id, target_session_id, parent_session_id,
+               remind_soft_threshold IS NOT NULL
         FROM message_queue
         WHERE target_session_id = ?1
           AND parent_session_id = ?2
@@ -1932,6 +1946,7 @@ fn snapshot_parent_routing_conn(
                     id: row.get(0)?,
                     child_session_id: row.get(1)?,
                     parent_session_id: row.get(2)?,
+                    creates_parent_wake: row.get::<_, i64>(3)? != 0,
                 })
             },
         )?
@@ -1970,15 +1985,15 @@ fn parent_routing_wake_row_conn(
 fn parent_routing_message_state_conn(
     conn: &Connection,
     record_id: &str,
-) -> Result<Option<(String, Option<String>)>> {
+) -> Result<Option<(String, Option<String>, bool)>> {
     conn.query_row(
         r#"
-        SELECT target_session_id, parent_session_id
+        SELECT target_session_id, parent_session_id, delivered_at IS NOT NULL
         FROM message_queue
-        WHERE id = ?1 AND delivered_at IS NULL
+        WHERE id = ?1
         "#,
         params![record_id],
-        |row| Ok((row.get(0)?, row.get(1)?)),
+        |row| Ok((row.get(0)?, row.get(1)?, row.get::<_, i64>(2)? != 0)),
     )
     .optional()
     .map_err(Into::into)
@@ -4304,6 +4319,54 @@ mod tests {
             store.active_parent_wake_parent("child001").unwrap(),
             Some("parent-old".to_owned())
         );
+    }
+
+    #[test]
+    fn parent_routing_retarget_preserves_messages_delivered_while_quiesced() {
+        let db_path = unique_temp_path("parent-routing-delivery-race");
+        let store = RetainedQueueStore::new(db_path);
+        store.ensure_schema().unwrap();
+        let message_id = store
+            .enqueue_message_with_metadata(
+                "child001",
+                "delivered during reparent",
+                "important",
+                QueueMessageMetadata {
+                    remind_soft_threshold: Some(600),
+                    parent_session_id: Some("parent-old".to_owned()),
+                    ..QueueMessageMetadata::default()
+                },
+            )
+            .unwrap();
+        let snapshot = store
+            .snapshot_parent_routing("child001", "parent-old")
+            .unwrap();
+        assert!(snapshot.message_rows[0].creates_parent_wake);
+
+        store.quiesce_parent_routing(&snapshot).unwrap();
+        let message = store
+            .pending_messages_for_target("child001", 10)
+            .unwrap()
+            .into_iter()
+            .find(|message| message.id == message_id)
+            .unwrap();
+        assert!(message.parent_session_id.is_none());
+        store
+            .mark_delivered_and_apply_side_effects(&message)
+            .unwrap();
+        assert!(store
+            .active_parent_wake_parent("child001")
+            .unwrap()
+            .is_none());
+        let result = store
+            .retarget_parent_routing(&snapshot, "parent-new")
+            .unwrap();
+
+        assert_eq!(result.delivered_message_rows, snapshot.message_rows);
+        assert!(store
+            .pending_messages_for_target("child001", 10)
+            .unwrap()
+            .is_empty());
     }
 
     #[test]

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -80,9 +80,10 @@ pub(crate) enum ConditionalClearOutcome {
     SessionMissing,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct TmuxSessionSpec {
     pub session_id: String,
+    pub session_credential: Option<String>,
     pub tmux_session: String,
     pub working_dir: String,
     pub log_file: PathBuf,
@@ -265,7 +266,11 @@ impl TmuxRuntime {
                 .is_some_and(|value| !value.is_empty());
 
         let mut command = self.launch_command(spec, &prompt_mode)?;
-        command = managed_session_command(&command, &spec.session_id);
+        command = managed_session_command(
+            &command,
+            &spec.session_id,
+            spec.session_credential.as_deref(),
+        );
 
         let create_result = if self.tmux_history_limit.is_some()
             || (self.socket_name.is_some() && self.tmux_native_scrollback)
@@ -1417,11 +1422,20 @@ fn hex_char(value: u8) -> char {
     }
 }
 
-fn managed_session_command(command: &str, session_id: &str) -> String {
+fn managed_session_command(
+    command: &str,
+    session_id: &str,
+    session_credential: Option<&str>,
+) -> String {
     let session_id = shell_quote(session_id);
+    let credential_export = session_credential
+        .map(shell_quote)
+        .map(|credential| format!("export SM_SESSION_CREDENTIAL={credential}; "))
+        .unwrap_or_default();
     format!(
         "export SESSION_MANAGER_ID={session_id}; \
          export CLAUDE_SESSION_MANAGER_ID={session_id}; \
+         {credential_export}\
          unset CLAUDECODE; \
          export ENABLE_TOOL_SEARCH=false; \
          {command}"
@@ -1492,9 +1506,10 @@ mod tests {
 
     #[test]
     fn managed_session_command_exports_canonical_and_legacy_session_ids() {
-        let command = managed_session_command("claude", "session'42");
+        let command = managed_session_command("claude", "session'42", Some("credential'42"));
         assert!(command.contains("export SESSION_MANAGER_ID='session'\\''42'"));
         assert!(command.contains("export CLAUDE_SESSION_MANAGER_ID='session'\\''42'"));
+        assert!(command.contains("export SM_SESSION_CREDENTIAL='credential'\\''42'"));
         assert!(command.contains("unset CLAUDECODE"));
         assert!(command.contains("export ENABLE_TOOL_SEARCH=false"));
         assert!(command.ends_with("; claude"));
@@ -1533,6 +1548,7 @@ mod tests {
         fs::create_dir_all(&working_dir).unwrap();
         let spec = TmuxSessionSpec {
             session_id: "abc12345".to_owned(),
+            session_credential: None,
             tmux_session: "sm-test".to_owned(),
             working_dir: working_dir.display().to_string(),
             log_file: temp_dir.join("session.log"),
@@ -1602,6 +1618,7 @@ mod tests {
         fs::create_dir_all(&working_dir).unwrap();
         let spec = TmuxSessionSpec {
             session_id: "abc12345".to_owned(),
+            session_credential: None,
             tmux_session: "sm-test".to_owned(),
             working_dir: working_dir.display().to_string(),
             log_file: temp_dir.join("session.log"),
@@ -1640,6 +1657,7 @@ mod tests {
         fs::create_dir_all(&working_dir).unwrap();
         let spec = TmuxSessionSpec {
             session_id: "abc12345".to_owned(),
+            session_credential: None,
             tmux_session: "sm-test".to_owned(),
             working_dir: working_dir.display().to_string(),
             log_file: temp_dir.join("session.log"),
@@ -1673,6 +1691,7 @@ mod tests {
         fs::create_dir_all(&working_dir).unwrap();
         let spec = TmuxSessionSpec {
             session_id: "abc12345".to_owned(),
+            session_credential: None,
             tmux_session: "sm-test".to_owned(),
             working_dir: working_dir.display().to_string(),
             log_file: temp_dir.join("session.log"),

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -884,6 +884,28 @@ impl TmuxRuntime {
         Some(String::from_utf8_lossy(&output.stdout).to_string())
     }
 
+    pub fn session_input_ready(&self, tmux_session: &str, provider: &str) -> bool {
+        match provider {
+            "codex" | "codex-fork" => self.codex_composer_is_ready(tmux_session, None),
+            _ => self
+                .capture_pane_last_line(tmux_session)
+                .is_some_and(|line| matches!(line.trim(), ">" | "❯")),
+        }
+    }
+
+    pub fn session_has_attached_clients(&self, tmux_session: &str) -> Result<bool> {
+        let output = self
+            .tmux_command(["list-clients", "-t", tmux_session, "-F", "#{client_name}"])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .output()
+            .context("failed to list tmux clients")?;
+        if !output.status.success() {
+            return Ok(false);
+        }
+        Ok(!String::from_utf8_lossy(&output.stdout).trim().is_empty())
+    }
+
     pub fn capture_pane_tail(&self, tmux_session: &str, lines: usize) -> Option<String> {
         if lines == 0 {
             return Some(String::new());

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -2638,25 +2638,35 @@ impl SessionStore {
             Vec::new()
         };
         self.persist_delivered_reparent_wake_intents(request_id, &delivered_message_rows)?;
-        let replay_targets = self.replay_deferred_reparent_routes(request_id, false)?;
-        let _guard = self.write_guard()?;
-        let mut state = self.load_raw_json_value()?;
-        let mut records = reparent_request_records(&state)?;
-        let record = leased_reparent_request_mut(&state, &mut records, request_id)?;
-        if record.apply_stage.as_deref() != Some("authority_committed") {
-            anyhow::bail!("reparent request stage changed during queue retarget")
+        let mut replay_targets = BTreeSet::new();
+        loop {
+            replay_targets.extend(self.replay_deferred_reparent_routes(request_id, false)?);
+            let _guard = self.write_guard()?;
+            let mut state = self.load_raw_json_value()?;
+            let mut records = reparent_request_records(&state)?;
+            let record = leased_reparent_request_mut(&state, &mut records, request_id)?;
+            if record.apply_stage.as_deref() != Some("authority_committed") {
+                anyhow::bail!("reparent request stage changed during queue retarget")
+            }
+            if record
+                .deferred_routing_intents
+                .iter()
+                .any(|intent| intent.replayed_at.is_none())
+            {
+                continue;
+            }
+            let now = now_rfc3339();
+            record.status = "applied".to_owned();
+            record.apply_stage = Some("applied".to_owned());
+            record.applied_at = Some(now.clone());
+            record.decided_at = Some(now);
+            record.ready_to_apply = false;
+            record.failure_reason = None;
+            store_reparent_request_records(&mut state, &records)?;
+            store_reparent_apply_lease(&mut state, None)?;
+            self.write_raw_json_value(&state)?;
+            break;
         }
-        let now = now_rfc3339();
-        record.status = "applied".to_owned();
-        record.apply_stage = Some("applied".to_owned());
-        record.applied_at = Some(now.clone());
-        record.decided_at = Some(now);
-        record.ready_to_apply = false;
-        record.failure_reason = None;
-        store_reparent_request_records(&mut state, &records)?;
-        store_reparent_apply_lease(&mut state, None)?;
-        self.write_raw_json_value(&state)?;
-        drop(_guard);
         self.drain_reparent_replay_targets(&replay_targets);
         Ok(())
     }
@@ -2984,20 +2994,33 @@ impl SessionStore {
     }
 
     fn complete_reparent_prequiesce_abort(&self, request_id: &str) -> Result<()> {
-        let replay_targets = self.replay_deferred_reparent_routes(request_id, true)?;
-        let _guard = self.write_guard()?;
-        let mut state = self.load_raw_json_value()?;
-        let mut records = reparent_request_records(&state)?;
-        let record = leased_reparent_request_mut(&state, &mut records, request_id)?;
-        if record.apply_stage.as_deref() != Some("prequiesce_aborting") {
-            anyhow::bail!("reparent request stage changed during pre-quiesce abort")
+        let mut replay_targets = BTreeSet::new();
+        let mut reapply_completed = true;
+        loop {
+            replay_targets
+                .extend(self.replay_deferred_reparent_routes(request_id, reapply_completed)?);
+            reapply_completed = false;
+            let _guard = self.write_guard()?;
+            let mut state = self.load_raw_json_value()?;
+            let mut records = reparent_request_records(&state)?;
+            let record = leased_reparent_request_mut(&state, &mut records, request_id)?;
+            if record.apply_stage.as_deref() != Some("prequiesce_aborting") {
+                anyhow::bail!("reparent request stage changed during pre-quiesce abort")
+            }
+            if record
+                .deferred_routing_intents
+                .iter()
+                .any(|intent| intent.replayed_at.is_none())
+            {
+                continue;
+            }
+            record.status = "stale".to_owned();
+            record.apply_stage = Some("prequiesce_aborted".to_owned());
+            store_reparent_request_records(&mut state, &records)?;
+            store_reparent_apply_lease(&mut state, None)?;
+            self.write_raw_json_value(&state)?;
+            break;
         }
-        record.status = "stale".to_owned();
-        record.apply_stage = Some("prequiesce_aborted".to_owned());
-        store_reparent_request_records(&mut state, &records)?;
-        store_reparent_apply_lease(&mut state, None)?;
-        self.write_raw_json_value(&state)?;
-        drop(_guard);
         self.drain_reparent_replay_targets(&replay_targets);
         Ok(())
     }
@@ -3057,28 +3080,41 @@ impl SessionStore {
             verify_old_reparent_edges(&state, &plan)?;
             self.write_raw_json_value(&state)?;
         }
-        let replay_targets = self.replay_deferred_reparent_routes(request_id, true)?;
-        let _guard = self.write_guard()?;
-        let mut state = self.load_raw_json_value()?;
-        let mut records = reparent_request_records(&state)?;
-        let record = leased_reparent_request_mut(&state, &mut records, request_id)?;
-        record.status = if stale_reason.is_some() {
-            "stale".to_owned()
-        } else {
-            "repaired".to_owned()
-        };
-        record.apply_stage = Some(if stale_reason.is_some() {
-            "prequiesce_aborted".to_owned()
-        } else {
-            "repair_rolled_back".to_owned()
-        });
-        record.failure_reason = stale_reason.map(ToOwned::to_owned);
-        record.ready_to_apply = false;
-        record.decided_at = Some(now_rfc3339());
-        store_reparent_request_records(&mut state, &records)?;
-        store_reparent_apply_lease(&mut state, None)?;
-        self.write_raw_json_value(&state)?;
-        drop(_guard);
+        let mut replay_targets = BTreeSet::new();
+        let mut reapply_completed = true;
+        loop {
+            replay_targets
+                .extend(self.replay_deferred_reparent_routes(request_id, reapply_completed)?);
+            reapply_completed = false;
+            let _guard = self.write_guard()?;
+            let mut state = self.load_raw_json_value()?;
+            let mut records = reparent_request_records(&state)?;
+            let record = leased_reparent_request_mut(&state, &mut records, request_id)?;
+            if record
+                .deferred_routing_intents
+                .iter()
+                .any(|intent| intent.replayed_at.is_none())
+            {
+                continue;
+            }
+            record.status = if stale_reason.is_some() {
+                "stale".to_owned()
+            } else {
+                "repaired".to_owned()
+            };
+            record.apply_stage = Some(if stale_reason.is_some() {
+                "prequiesce_aborted".to_owned()
+            } else {
+                "repair_rolled_back".to_owned()
+            });
+            record.failure_reason = stale_reason.map(ToOwned::to_owned);
+            record.ready_to_apply = false;
+            record.decided_at = Some(now_rfc3339());
+            store_reparent_request_records(&mut state, &records)?;
+            store_reparent_apply_lease(&mut state, None)?;
+            self.write_raw_json_value(&state)?;
+            break;
+        }
         self.drain_reparent_replay_targets(&replay_targets);
         Ok(())
     }

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1262,6 +1262,7 @@ impl SessionStore {
             apply_stage: None,
             apply_plan: None,
             notification_intents: Vec::new(),
+            deferred_routing_intents: Vec::new(),
             repair_history: Vec::new(),
         };
         records.push(record.clone());
@@ -9442,6 +9443,19 @@ pub struct ReparentNotificationIntent {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ReparentDeferredRoutingIntent {
+    pub key: String,
+    pub operation: String,
+    pub child_session_id: String,
+    pub payload: Value,
+    pub created_at: String,
+    #[serde(default)]
+    pub replayed_at: Option<String>,
+    #[serde(default)]
+    pub resolved_parent_session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ReparentRepairRecord {
     pub actor_kind: String,
     pub actor_id: String,
@@ -9490,6 +9504,8 @@ pub struct ReparentRequestRecord {
     pub apply_plan: Option<ReparentApplyPlan>,
     #[serde(default)]
     pub notification_intents: Vec<ReparentNotificationIntent>,
+    #[serde(default)]
+    pub deferred_routing_intents: Vec<ReparentDeferredRoutingIntent>,
     #[serde(default)]
     pub repair_history: Vec<ReparentRepairRecord>,
 }

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1966,29 +1966,61 @@ impl SessionStore {
             required_human_approval,
             blockers: blockers.clone(),
         };
-        if request.dry_run {
-            return Ok(ReparentMutationOutcome::Preview(preview));
-        }
-        if let Some(blocker) = blockers.into_iter().next() {
-            return Ok(ReparentMutationOutcome::BadRequest(blocker));
-        }
         let now = OffsetDateTime::now_utc();
         let mut records = reparent_request_records(&state)?;
-        let _ = refresh_reparent_requests(&mut records, &sessions, now);
+        let refreshed = refresh_reparent_requests(&mut records, &sessions, now);
         let affected_ids = preview
             .edge_changes
             .iter()
             .map(|change| change.session_id.clone())
             .chain(expected_parent_session_id.iter().cloned())
             .collect::<BTreeSet<_>>();
-        if let Some(conflict) = records.iter().find(|record| {
+        let active_conflict = records.iter().find(|record| {
             record.is_active() && !record.affected_session_ids().is_disjoint(&affected_ids)
-        }) {
+        });
+        if request.dry_run {
+            let mut preview = preview;
+            if let Some(conflict) = active_conflict {
+                let overlapping_session = if affected_ids.contains(&conflict.subject_session_id) {
+                    conflict.subject_session_id.clone()
+                } else {
+                    conflict
+                        .affected_session_ids()
+                        .intersection(&affected_ids)
+                        .next()
+                        .cloned()
+                        .unwrap_or_else(|| "unknown".to_owned())
+                };
+                preview.blockers.push(format!(
+                    "request {} already controls session {} in the tree promotion",
+                    conflict.id, overlapping_session
+                ));
+            }
+            if refreshed {
+                store_reparent_request_records(&mut state, &records)?;
+                self.write_raw_json_value(&state)?;
+            }
+            return Ok(ReparentMutationOutcome::Preview(preview));
+        }
+        if let Some(blocker) = blockers.into_iter().next() {
+            return Ok(ReparentMutationOutcome::BadRequest(blocker));
+        }
+        if let Some(conflict) = active_conflict {
+            let overlapping_session = if affected_ids.contains(&conflict.subject_session_id) {
+                conflict.subject_session_id.clone()
+            } else {
+                conflict
+                    .affected_session_ids()
+                    .intersection(&affected_ids)
+                    .next()
+                    .cloned()
+                    .unwrap_or_else(|| "unknown".to_owned())
+            };
             store_reparent_request_records(&mut state, &records)?;
             self.write_raw_json_value(&state)?;
             return Ok(ReparentMutationOutcome::Conflict(format!(
-                "request {} already controls part of the tree promotion",
-                conflict.id
+                "request {} already controls session {} in the tree promotion",
+                conflict.id, overlapping_session
             )));
         }
         let created_at = now.format(&Rfc3339)?;
@@ -2274,6 +2306,30 @@ impl SessionStore {
         Ok(records)
     }
 
+    pub fn list_reparent_requests_for_session(
+        &self,
+        session_id: &str,
+        session_credential: &str,
+    ) -> Result<Option<Vec<ReparentRequestRecord>>> {
+        let session_id = session_id.trim();
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = snapshot_from_raw_value(&state)?.into_sessions();
+        if !session_credential_matches(&sessions, session_id, session_credential) {
+            return Ok(None);
+        }
+        let mut records = reparent_request_records(&state)?;
+        if refresh_reparent_requests(&mut records, &sessions, OffsetDateTime::now_utc()) {
+            store_reparent_request_records(&mut state, &records)?;
+            self.write_raw_json_value(&state)?;
+        }
+        records.retain(|record| record.involves_session(session_id));
+        records.sort_by(|left, right| {
+            (&left.created_at, &left.id).cmp(&(&right.created_at, &right.id))
+        });
+        Ok(Some(records))
+    }
+
     pub fn send_parent_notification(
         &self,
         child_session_id: &str,
@@ -2345,6 +2401,82 @@ impl SessionStore {
                 return Ok(first);
             }
         }
+    }
+
+    pub fn reconcile_reparent_notifications(&self) -> Result<()> {
+        let pending = {
+            let _guard = self.write_guard()?;
+            let mut state = self.load_raw_json_value()?;
+            let sessions = snapshot_from_raw_value(&state)?.into_sessions();
+            let mut records = reparent_request_records(&state)?;
+            let refreshed =
+                refresh_reparent_requests(&mut records, &sessions, OffsetDateTime::now_utc());
+            let mut changed = refreshed;
+            for record in &mut records {
+                for desired in desired_reparent_notifications(record) {
+                    if record
+                        .notification_intents
+                        .iter()
+                        .all(|intent| intent.key != desired.intent.key)
+                    {
+                        record.notification_intents.push(desired.intent);
+                        changed = true;
+                    }
+                }
+            }
+            if changed {
+                store_reparent_request_records(&mut state, &records)?;
+                self.write_raw_json_value(&state)?;
+            }
+            records
+                .iter()
+                .flat_map(|record| {
+                    desired_reparent_notifications(record)
+                        .into_iter()
+                        .filter(|desired| {
+                            record.notification_intents.iter().any(|intent| {
+                                intent.key == desired.intent.key && intent.enqueued_at.is_none()
+                            })
+                        })
+                })
+                .collect::<Vec<_>>()
+        };
+        for desired in pending {
+            let queue = self
+                .queue_store
+                .as_ref()
+                .context("reparent notifications require the retained queue store")?;
+            queue.enqueue_message_once_with_metadata(
+                &desired.intent.key,
+                &desired.intent.recipient_session_id,
+                &desired.text,
+                "important",
+                QueueMessageMetadata {
+                    message_category: Some("reparent".to_owned()),
+                    ..QueueMessageMetadata::default()
+                },
+            )?;
+            let _guard = self.write_guard()?;
+            let mut state = self.load_raw_json_value()?;
+            let mut records = reparent_request_records(&state)?;
+            let record = records
+                .iter_mut()
+                .find(|record| record.id == desired.request_id)
+                .with_context(|| format!("reparent request {} disappeared", desired.request_id))?;
+            let intent = record
+                .notification_intents
+                .iter_mut()
+                .find(|intent| intent.key == desired.intent.key)
+                .with_context(|| {
+                    format!("reparent notification {} disappeared", desired.intent.key)
+                })?;
+            if intent.enqueued_at.is_none() {
+                intent.enqueued_at = Some(now_rfc3339());
+                store_reparent_request_records(&mut state, &records)?;
+                self.write_raw_json_value(&state)?;
+            }
+        }
+        Ok(())
     }
 
     pub fn repair_reparent_request(
@@ -11642,12 +11774,24 @@ fn store_reparent_request_records(
     state: &mut Value,
     records: &[ReparentRequestRecord],
 ) -> Result<()> {
+    let mut records = records.to_vec();
+    for record in &mut records {
+        for desired in desired_reparent_notifications(record) {
+            if record
+                .notification_intents
+                .iter()
+                .all(|intent| intent.key != desired.intent.key)
+            {
+                record.notification_intents.push(desired.intent);
+            }
+        }
+    }
     let object = state
         .as_object_mut()
         .ok_or_else(|| anyhow::anyhow!("session state root must be an object"))?;
     object.insert(
         "reparent_requests".to_owned(),
-        serde_json::to_value(records)?,
+        serde_json::to_value(&records)?,
     );
     Ok(())
 }
@@ -12767,6 +12911,177 @@ pub struct ReparentNotificationIntent {
     pub enqueued_at: Option<String>,
 }
 
+#[derive(Debug, Clone)]
+struct DesiredReparentNotification {
+    request_id: String,
+    intent: ReparentNotificationIntent,
+    text: String,
+}
+
+fn desired_reparent_notifications(
+    record: &ReparentRequestRecord,
+) -> Vec<DesiredReparentNotification> {
+    let mut desired = Vec::new();
+    if record.status == "pending" {
+        let approved = record
+            .approvals
+            .iter()
+            .filter(|approval| approval.actor_kind == "agent" && approval.decision == "approved")
+            .map(|approval| approval.actor_id.as_str())
+            .collect::<BTreeSet<_>>();
+        let missing = record
+            .required_agent_approvals
+            .iter()
+            .filter(|actor| !approved.contains(actor.as_str()))
+            .cloned()
+            .collect::<Vec<_>>();
+        let event = format!("approval:{}", missing.join(","));
+        for recipient in &missing {
+            desired.push(reparent_notification(
+                record,
+                &event,
+                recipient,
+                reparent_approval_notification_text(record),
+            ));
+        }
+        if record.approvals.len() > 1 {
+            for recipient in record
+                .required_agent_approvals
+                .iter()
+                .chain(std::iter::once(&record.initiator_session_id))
+                .filter(|recipient| !missing.contains(recipient))
+                .collect::<BTreeSet<_>>()
+            {
+                desired.push(reparent_notification(
+                    record,
+                    &event,
+                    recipient,
+                    reparent_progress_notification_text(record, &missing),
+                ));
+            }
+        }
+    } else if matches!(
+        record.status.as_str(),
+        "applied" | "rejected" | "expired" | "stale" | "failed" | "repaired"
+    ) {
+        let event = format!("terminal:{}", record.status);
+        for recipient in record
+            .required_agent_approvals
+            .iter()
+            .chain(std::iter::once(&record.initiator_session_id))
+            .collect::<BTreeSet<_>>()
+        {
+            desired.push(reparent_notification(
+                record,
+                &event,
+                recipient,
+                reparent_terminal_notification_text(record),
+            ));
+        }
+    }
+    desired
+}
+
+fn reparent_notification(
+    record: &ReparentRequestRecord,
+    event: &str,
+    recipient: &str,
+    text: String,
+) -> DesiredReparentNotification {
+    DesiredReparentNotification {
+        request_id: record.id.clone(),
+        intent: ReparentNotificationIntent {
+            key: format!("reparent:{}:{event}:{recipient}", record.id),
+            event: event.to_owned(),
+            recipient_session_id: recipient.to_owned(),
+            enqueued_at: None,
+        },
+        text,
+    }
+}
+
+fn reparent_approval_notification_text(record: &ReparentRequestRecord) -> String {
+    format!(
+        "[sm reparent] {} request {} from {} needs your approval. {} Expires {}. Approve: `sm reparent approve {}`. Reject: `sm reparent reject {}`.",
+        record.kind,
+        record.id,
+        record.initiator_session_id,
+        reparent_edge_summary(record),
+        record.expires_at,
+        record.id,
+        record.id,
+    )
+}
+
+fn reparent_progress_notification_text(
+    record: &ReparentRequestRecord,
+    missing: &[String],
+) -> String {
+    format!(
+        "[sm reparent] Request {} remains pending. Missing agent approvals: {}.{}",
+        record.id,
+        if missing.is_empty() {
+            "none".to_owned()
+        } else {
+            missing.join(", ")
+        },
+        if record.required_human_approval {
+            " Human approval is also required in `sm watch`."
+        } else {
+            ""
+        }
+    )
+}
+
+fn reparent_terminal_notification_text(record: &ReparentRequestRecord) -> String {
+    format!(
+        "[sm reparent] Request {} is {}. {}{}",
+        record.id,
+        record.status,
+        reparent_edge_summary(record),
+        record
+            .failure_reason
+            .as_deref()
+            .map(|reason| format!(" Reason: {reason}."))
+            .unwrap_or_default(),
+    )
+}
+
+fn reparent_edge_summary(record: &ReparentRequestRecord) -> String {
+    let edges = record
+        .apply_plan
+        .as_ref()
+        .map(|plan| plan.edge_changes.clone())
+        .unwrap_or_else(|| {
+            if record.kind == "tree" {
+                tree_reparent_edge_changes(
+                    &record.subject_session_id,
+                    &record.target_parent_session_id,
+                    record.expected_parent_session_id.as_deref(),
+                    &record.frozen_live_child_ids,
+                )
+            } else {
+                vec![ReparentEdgeChange {
+                    session_id: record.subject_session_id.clone(),
+                    expected_parent_session_id: record.expected_parent_session_id.clone(),
+                    new_parent_session_id: Some(record.target_parent_session_id.clone()),
+                }]
+            }
+        });
+    edges
+        .iter()
+        .map(|edge| {
+            format!(
+                "{}: {} -> {}",
+                edge.session_id,
+                edge.expected_parent_session_id.as_deref().unwrap_or("root"),
+                edge.new_parent_session_id.as_deref().unwrap_or("root")
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
 pub struct ReparentDeferredRoutingIntent {
     pub key: String,
@@ -12926,6 +13241,15 @@ impl ReparentRequestRecord {
             );
         }
         affected
+    }
+
+    fn involves_session(&self, session_id: &str) -> bool {
+        self.initiator_session_id == session_id
+            || self
+                .required_agent_approvals
+                .iter()
+                .any(|id| id == session_id)
+            || self.affected_session_ids().contains(session_id)
     }
 
     fn is_apply_fenced(&self) -> bool {
@@ -17860,6 +18184,66 @@ mod tests {
             store.retire_core_session("child001", Some("newpar01")),
             Ok(CoreRetireOutcome::Retired(_))
         ));
+
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
+    fn reparent_notifications_are_exact_and_idempotent_across_reconciliation() {
+        let state_file = unique_temp_path("reparent-notifications");
+        let queue_db = state_file.with_extension("db");
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [
+                    reparent_test_session("oldpar01", None, "old-secret"),
+                    reparent_test_session("newpar01", None, "new-secret"),
+                    reparent_test_session("child001", Some("oldpar01"), "child-secret")
+                ]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let queue = RetainedQueueStore::new(queue_db.clone());
+        queue.ensure_schema().unwrap();
+        let store = SessionStore::new_with_queue(state_file.clone(), queue_db.clone());
+        let request = match store
+            .create_reparent_request(
+                "child001",
+                CreateReparentRequest {
+                    requester_session_id: "oldpar01".to_owned(),
+                    target_parent_session_id: "newpar01".to_owned(),
+                },
+                "old-secret",
+            )
+            .unwrap()
+        {
+            ReparentMutationOutcome::Created(record) => record,
+            other => panic!("unexpected create outcome: {other:?}"),
+        };
+
+        store.reconcile_reparent_notifications().unwrap();
+        store.reconcile_reparent_notifications().unwrap();
+        let pending = queue.pending_messages_for_target("newpar01", 10).unwrap();
+        assert_eq!(pending.len(), 1);
+        assert!(pending[0]
+            .text
+            .contains(&format!("Approve: `sm reparent approve {}`", request.id)));
+        assert!(pending[0]
+            .text
+            .contains(&format!("Reject: `sm reparent reject {}`", request.id)));
+        assert!(pending[0].text.contains("child001: oldpar01 -> newpar01"));
+        let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+        let intents = state["reparent_requests"][0]["notification_intents"]
+            .as_array()
+            .unwrap();
+        let target_intents = intents
+            .iter()
+            .filter(|intent| intent["recipient_session_id"] == "newpar01")
+            .collect::<Vec<_>>();
+        assert_eq!(target_intents.len(), 1);
+        assert!(target_intents[0]["enqueued_at"].is_string());
 
         let _ = fs::remove_file(state_file);
         let _ = fs::remove_file(queue_db);

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -674,6 +674,18 @@ impl SessionStore {
     }
 
     fn recover_session_runtime_launch(&self, launch_id: &str) -> Result<()> {
+        let pending_launch = {
+            let _guard = self.write_guard()?;
+            let state = self.load_raw_json_value()?;
+            session_runtime_launch_records(&state)?
+                .into_iter()
+                .find(|record| record.id == launch_id)
+        };
+        let codex_cli_binding_guard = pending_launch
+            .as_ref()
+            .filter(|launch| launch.operation_kind == "create" && launch.provider == "codex")
+            .map(|launch| self.lock_codex_cli_binding_working_dir(&launch.working_dir))
+            .transpose()?;
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
         let Some(mut launch) = session_runtime_launch_records(&state)?
@@ -740,6 +752,34 @@ impl SessionStore {
             model: launch.model.clone(),
             reasoning_effort: launch.reasoning_effort.clone(),
         };
+        let codex_fork_artifacts = session_runtime.codex_fork_runtime_artifacts(&spec)?;
+        let codex_cli_creation_binding =
+            if launch.operation_kind == "create" && launch.provider == "codex" {
+                let snapshot = snapshot_from_raw_value(&state)?;
+                let record = snapshot
+                    .sessions
+                    .iter()
+                    .find(|session| session.id == launch.session_id)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("runtime launch session disappeared before recovery")
+                    })?;
+                let mut excluded_ids = snapshot
+                    .sessions
+                    .iter()
+                    .filter_map(|session| session.provider_resume_id.clone())
+                    .collect::<BTreeSet<_>>();
+                excluded_ids.extend(codex_cli_existing_session_ids(
+                    record,
+                    &self.codex_sessions_root,
+                ));
+                Some((
+                    record.clone(),
+                    excluded_ids,
+                    OffsetDateTime::now_utc().unix_timestamp_nanos(),
+                ))
+            } else {
+                None
+            };
         let result = (|| -> Result<()> {
             if session_runtime.session_exists(&launch.tmux_session)? {
                 session_runtime.kill_session(&launch.tmux_session)?;
@@ -766,6 +806,43 @@ impl SessionStore {
             return Ok(());
         }
 
+        let mut recovered_provider_resume_id = launch.provider_resume_id.clone();
+        if launch.operation_kind == "create" {
+            if let Some((record, excluded_ids, launched_at_ns)) =
+                codex_cli_creation_binding.as_ref()
+            {
+                recovered_provider_resume_id = wait_for_codex_cli_provider_resume_id(
+                    record,
+                    &self.codex_sessions_root,
+                    excluded_ids,
+                    *launched_at_ns,
+                    CODEX_CLI_SESSION_BIND_TIMEOUT,
+                );
+            }
+            if let Some(artifacts) = codex_fork_artifacts.as_ref() {
+                match wait_for_codex_fork_provider_resume_id(
+                    &artifacts.event_stream_path,
+                    CODEX_FORK_THREAD_STARTED_TIMEOUT,
+                ) {
+                    Ok(provider_resume_id) => {
+                        recovered_provider_resume_id = Some(provider_resume_id);
+                    }
+                    Err(error) => {
+                        let _ = session_runtime.kill_session(&launch.tmux_session);
+                        mark_runtime_launch_failed(
+                            &mut state,
+                            launch_id,
+                            &launch.session_id,
+                            true,
+                            &error.to_string(),
+                        )?;
+                        self.write_raw_json_value(&state)?;
+                        return Ok(());
+                    }
+                }
+            }
+        }
+
         let sessions = ensure_sessions_array_mut(&mut state)?;
         let Some(session) = session_object_mut(sessions, &launch.session_id) else {
             let _ = session_runtime.kill_session(&launch.tmux_session);
@@ -781,9 +858,69 @@ impl SessionStore {
         };
         session.insert("status".to_owned(), Value::String("running".to_owned()));
         session.insert("stopped_at".to_owned(), Value::Null);
+        if launch.operation_kind == "restore" {
+            session.insert("completion_status".to_owned(), Value::Null);
+            session.insert("completion_message".to_owned(), Value::Null);
+            session.insert("completed_at".to_owned(), Value::Null);
+            session.insert("agent_task_completed_at".to_owned(), Value::Null);
+        }
+        if let Some(provider_resume_id) = recovered_provider_resume_id.as_deref() {
+            session.insert(
+                "provider_resume_id".to_owned(),
+                Value::String(provider_resume_id.to_owned()),
+            );
+        }
         session.insert("last_activity".to_owned(), Value::String(now_rfc3339()));
-        mark_runtime_launch_applied(&mut state, launch_id, launch.provider_resume_id.as_deref())?;
+        let recovered = serde_json::from_value::<SessionRecord>(Value::Object(session.clone()))?;
+        mark_runtime_launch_applied(
+            &mut state,
+            launch_id,
+            recovered_provider_resume_id.as_deref(),
+        )?;
         self.write_raw_json_value(&state)?;
+        drop(_guard);
+        if let Some(provider_resume_id) = recovered_provider_resume_id.as_deref() {
+            self.append_seat_session(
+                &launch.session_id,
+                &launch.provider,
+                provider_resume_id,
+                codex_fork_artifacts
+                    .as_ref()
+                    .and_then(|artifacts| artifacts.event_stream_path.to_str()),
+            );
+        }
+        if recovered_provider_resume_id.is_none() {
+            if let Some((record, excluded_ids, launched_at_ns)) = codex_cli_creation_binding {
+                let store = self.clone();
+                let session_id = launch.session_id.clone();
+                let spawn_result = thread::Builder::new()
+                    .name(format!(
+                        "sm-codex-recovery-bind-{}",
+                        sanitize_path_component(&session_id)
+                    ))
+                    .spawn(move || {
+                        let _binding_guard = codex_cli_binding_guard;
+                        if let Err(error) = store.complete_deferred_codex_cli_rebind(
+                            &session_id,
+                            &record,
+                            &excluded_ids,
+                            launched_at_ns,
+                            None,
+                            CODEX_CLI_DEFERRED_BIND_TIMEOUT,
+                        ) {
+                            eprintln!(
+                                "deferred recovered Codex thread discovery failed for seat {session_id}: {error:#}"
+                            );
+                        }
+                    });
+                if let Err(error) = spawn_result {
+                    eprintln!("failed to start recovered Codex thread discovery: {error}");
+                }
+            }
+        }
+        if let Some(artifacts) = codex_fork_artifacts {
+            self.start_codex_fork_event_monitor(recovered.id, artifacts.event_stream_path)?;
+        }
         Ok(())
     }
 
@@ -811,9 +948,9 @@ impl SessionStore {
                         Ok(false) => thread::sleep(Duration::from_secs(1)),
                         Err(error) => {
                             eprintln!(
-                                "credential rotation worker failed for {worker_session_id}: {error:#}"
+                                "credential rotation worker retrying for {worker_session_id}: {error:#}"
                             );
-                            break;
+                            thread::sleep(Duration::from_secs(1));
                         }
                     }
                 }
@@ -853,8 +990,14 @@ impl SessionStore {
             return Ok(true);
         };
         let session_runtime = runtime.for_socket_name(rotation.tmux_socket_name.as_deref());
+        if !session_runtime.session_exists(&rotation.tmux_session)? {
+            self.fail_waiting_credential_rotation(
+                &rotation.id,
+                "session runtime disappeared while waiting for idle",
+            )?;
+            return Ok(true);
+        }
         if !credential_rotation_has_fresh_idle_proof(&rotation, &session)
-            || !session_runtime.session_exists(&rotation.tmux_session)?
             || session_runtime.session_has_attached_clients(&rotation.tmux_session)?
             || !session_runtime.session_input_ready(&rotation.tmux_session, &rotation.provider)
             || !self.credential_rotation_queue_is_drained(session_id)?
@@ -872,6 +1015,15 @@ impl SessionStore {
         else {
             return Ok(true);
         };
+        if !session_runtime.session_exists(&rotation.tmux_session)? {
+            rotations[rotation_index].status = "failed".to_owned();
+            rotations[rotation_index].updated_at = now_rfc3339();
+            rotations[rotation_index].failure_reason =
+                Some("session runtime disappeared while waiting for idle".to_owned());
+            store_session_credential_rotation_records(&mut state, &rotations)?;
+            self.write_raw_json_value(&state)?;
+            return Ok(true);
+        }
         let snapshot = snapshot_from_raw_value(&state)?;
         let Some(session) = snapshot
             .sessions
@@ -906,6 +1058,7 @@ impl SessionStore {
         if !credential_rotation_has_fresh_idle_proof(&rotations[rotation_index], &session)
             || json_text(raw_session.get("pending_handoff_path")).is_some()
             || json_text(raw_session.get("claude_handoff_in_progress_at")).is_some()
+            || review_dispatch_in_progress(raw_session)
             || !self.credential_rotation_queue_is_drained(session_id)?
             || session_runtime.session_has_attached_clients(&rotation.tmux_session)?
             || !session_runtime.session_input_ready(&rotation.tmux_session, &rotation.provider)
@@ -1029,6 +1182,27 @@ impl SessionStore {
             self.start_codex_fork_event_monitor(session.id, artifacts.event_stream_path)?;
         }
         Ok(true)
+    }
+
+    fn fail_waiting_credential_rotation(
+        &self,
+        rotation_id: &str,
+        failure_reason: &str,
+    ) -> Result<()> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let mut rotations = session_credential_rotation_records(&state)?;
+        let Some(rotation) = rotations
+            .iter_mut()
+            .find(|record| record.id == rotation_id && record.status == "waiting_idle")
+        else {
+            return Ok(());
+        };
+        rotation.status = "failed".to_owned();
+        rotation.updated_at = now_rfc3339();
+        rotation.failure_reason = Some(failure_reason.to_owned());
+        store_session_credential_rotation_records(&mut state, &rotations)?;
+        self.write_raw_json_value(&state)
     }
 
     fn credential_rotation_queue_is_drained(&self, session_id: &str) -> Result<bool> {
@@ -9689,15 +9863,27 @@ fn credential_rotation_has_fresh_idle_proof(
     rotation: &SessionCredentialRotationRecord,
     session: &SessionRecord,
 ) -> bool {
-    if normalized_status(&session.status) != "idle" {
+    if normalized_status(&session.status) == "stopped" {
         return false;
     }
-    let proof_at = if session.provider == "claude" {
-        session.activity_hook_at.as_deref()
-    } else {
-        Some(session.last_activity.as_str())
-    };
-    proof_at.is_some_and(|proof_at| timestamp_is_after(proof_at, &rotation.requested_at))
+    match session.provider.as_str() {
+        "claude" => {
+            normalized_status(&session.status) == "idle"
+                && session
+                    .activity_hook_at
+                    .as_deref()
+                    .is_some_and(|proof_at| timestamp_is_after(proof_at, &rotation.requested_at))
+        }
+        "codex-fork" => {
+            normalized_status(&session.status) == "idle"
+                && timestamp_is_after(&session.last_activity, &rotation.requested_at)
+        }
+        // Classic Codex has no durable lifecycle event stream. Its paired
+        // session_input_ready check is a fresh composer observation performed
+        // after the request and repeated under the input fence.
+        "codex" => true,
+        _ => false,
+    }
 }
 
 fn session_id_exists(sessions: &[Value], session_id: &str) -> bool {
@@ -11384,6 +11570,59 @@ mod tests {
         assert_eq!(session_id.len(), 8);
         assert!(session_id.chars().all(|ch| ch.is_ascii_hexdigit()));
         assert_eq!(session_id, session_id.to_ascii_lowercase());
+    }
+
+    #[test]
+    fn credential_rotation_idle_proof_matches_provider_lifecycle_sources() {
+        let rotation = SessionCredentialRotationRecord {
+            id: "rotation01".to_owned(),
+            session_id: "abc12345".to_owned(),
+            provider: "claude".to_owned(),
+            provider_resume_id: "provider-thread".to_owned(),
+            tmux_session: "claude-abc12345".to_owned(),
+            tmux_socket_name: None,
+            request_actor: "operator".to_owned(),
+            status: "waiting_idle".to_owned(),
+            requested_at: "2026-06-01T00:00:30Z".to_owned(),
+            idle_proof_at: None,
+            runtime_launch_id: None,
+            updated_at: "2026-06-01T00:00:30Z".to_owned(),
+            applied_at: None,
+            failure_reason: None,
+        };
+
+        let mut claude = session_record("idle");
+        claude.activity_hook_at = Some("2026-06-01T00:00:31Z".to_owned());
+        assert!(credential_rotation_has_fresh_idle_proof(&rotation, &claude));
+        claude.status = "running".to_owned();
+        assert!(!credential_rotation_has_fresh_idle_proof(
+            &rotation, &claude
+        ));
+
+        let mut codex_fork = session_record("idle");
+        codex_fork.provider = "codex-fork".to_owned();
+        codex_fork.last_activity = "2026-06-01T00:00:31Z".to_owned();
+        assert!(credential_rotation_has_fresh_idle_proof(
+            &rotation,
+            &codex_fork
+        ));
+        codex_fork.status = "running".to_owned();
+        assert!(!credential_rotation_has_fresh_idle_proof(
+            &rotation,
+            &codex_fork
+        ));
+
+        let mut stock_codex = session_record("running");
+        stock_codex.provider = "codex".to_owned();
+        assert!(credential_rotation_has_fresh_idle_proof(
+            &rotation,
+            &stock_codex
+        ));
+        stock_codex.status = "stopped".to_owned();
+        assert!(!credential_rotation_has_fresh_idle_proof(
+            &rotation,
+            &stock_codex
+        ));
     }
 
     #[cfg(unix)]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -28,6 +28,7 @@ use crate::queue::{
     StopNotifyState,
 };
 use crate::{
+    btw::BtwStore,
     config::{CodexReviewConfig, ContextMonitorConfig},
     runtime::{ConditionalClearOutcome, TmuxRuntime, TmuxSessionSpec},
     seat_sessions::{SeatSessionIdentity, SeatSessionStore},
@@ -1002,6 +1003,7 @@ impl SessionStore {
             || session_runtime.session_has_attached_clients(&rotation.tmux_session)?
             || !session_runtime.session_input_ready(&rotation.tmux_session, &rotation.provider)
             || !self.credential_rotation_queue_is_drained(session_id)?
+            || self.credential_rotation_has_active_btw(session_id)?
         {
             return Ok(false);
         }
@@ -1064,6 +1066,7 @@ impl SessionStore {
             || json_text(raw_session.get("claude_handoff_in_progress_at")).is_some()
             || review_dispatch_in_progress(raw_session)
             || !self.credential_rotation_queue_is_drained(session_id)?
+            || self.credential_rotation_has_active_btw(session_id)?
             || session_runtime.session_has_attached_clients(&rotation.tmux_session)?
             || !session_runtime.session_input_ready(&rotation.tmux_session, &rotation.provider)
         {
@@ -1218,6 +1221,18 @@ impl SessionStore {
                     .map(|messages| messages.is_empty())
             })
             .unwrap_or(Ok(true))
+    }
+
+    fn credential_rotation_has_active_btw(&self, session_id: &str) -> Result<bool> {
+        let Some(queue) = self.queue_store.as_ref() else {
+            return Ok(false);
+        };
+        if !queue.db_path().exists() {
+            return Ok(false);
+        }
+        Ok(BtwStore::new(queue.db_path().to_path_buf())?
+            .active_for_target(session_id)?
+            .is_some())
     }
 
     #[cfg(test)]
@@ -2077,10 +2092,96 @@ impl SessionStore {
             Some(request_id) => request_id,
             None => return Ok(None),
         };
+        if self
+            .get_reparent_request(&request_id)?
+            .is_some_and(|record| record.status == "failed")
+        {
+            return self.get_reparent_request(&request_id);
+        }
         if let Err(error) = self.apply_reparent_request(&request_id) {
             self.fail_reparent_apply(&request_id, &error.to_string())?;
         }
         self.get_reparent_request(&request_id)
+    }
+
+    pub fn repair_reparent_request(
+        &self,
+        request_id: &str,
+        actor_id: &str,
+        action: ReparentRepairAction,
+    ) -> Result<ReparentMutationOutcome> {
+        let request_id = request_id.trim();
+        let actor_id = actor_id.trim();
+        if request_id.is_empty() || actor_id.is_empty() {
+            return Ok(ReparentMutationOutcome::BadRequest(
+                "request ID and authenticated human actor are required".to_owned(),
+            ));
+        }
+        {
+            let _guard = self.write_guard()?;
+            let mut state = self.load_raw_json_value()?;
+            let mut records = reparent_request_records(&state)?;
+            let Some(record) = records.iter_mut().find(|record| record.id == request_id) else {
+                return Ok(ReparentMutationOutcome::RequestNotFound);
+            };
+            let lease = reparent_apply_lease(&state)?;
+            if record.status != "failed"
+                || lease.as_ref().map(|lease| lease.request_id.as_str()) != Some(request_id)
+            {
+                return Ok(ReparentMutationOutcome::Conflict(format!(
+                    "request {request_id} is not a quarantined apply transaction"
+                )));
+            }
+            let stage = record.apply_stage.as_deref().unwrap_or("applying");
+            let allowed = match action {
+                ReparentRepairAction::Resume => matches!(
+                    stage,
+                    "prequiesce_aborting"
+                        | "json_routing_quiesced"
+                        | "routing_quiesced"
+                        | "authority_committed"
+                ),
+                ReparentRepairAction::RollbackPrecommit => {
+                    matches!(stage, "json_routing_quiesced" | "routing_quiesced")
+                }
+            };
+            if !allowed {
+                return Ok(ReparentMutationOutcome::Conflict(format!(
+                    "repair action {} is not allowed from stage {stage}",
+                    action.as_str()
+                )));
+            }
+            record.repair_history.push(ReparentRepairRecord {
+                actor_kind: "human".to_owned(),
+                actor_id: actor_id.to_owned(),
+                action: action.as_str().to_owned(),
+                prior_failure: record.failure_reason.clone(),
+                attempted_at: now_rfc3339(),
+                verified_state_fingerprint: Some(record.topology_fingerprint.clone()),
+            });
+            if action == ReparentRepairAction::Resume {
+                record.status = "applying".to_owned();
+                record.failure_reason = None;
+            }
+            store_reparent_request_records(&mut state, &records)?;
+            self.write_raw_json_value(&state)?;
+        }
+        match action {
+            ReparentRepairAction::Resume => {
+                if let Err(error) = self.apply_reparent_request(request_id) {
+                    self.fail_reparent_apply(request_id, &error.to_string())?;
+                }
+            }
+            ReparentRepairAction::RollbackPrecommit => {
+                if let Err(error) = self.rollback_reparent_precommit(request_id) {
+                    self.fail_reparent_apply(request_id, &error.to_string())?;
+                }
+            }
+        }
+        Ok(self
+            .get_reparent_request(request_id)?
+            .map(ReparentMutationOutcome::Updated)
+            .unwrap_or(ReparentMutationOutcome::RequestNotFound))
     }
 
     fn acquire_reparent_apply_lease(&self) -> Result<Option<String>> {
@@ -2378,6 +2479,7 @@ impl SessionStore {
         } else if !snapshot.wake_rows.is_empty() || !snapshot.message_rows.is_empty() {
             anyhow::bail!("reparent plan requires the retained queue store")
         }
+        self.replay_deferred_reparent_routes(request_id, &new_parent_session_id)?;
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
         let mut records = reparent_request_records(&state)?;
@@ -2397,16 +2499,135 @@ impl SessionStore {
         self.write_raw_json_value(&state)
     }
 
+    fn replay_deferred_reparent_routes(
+        &self,
+        request_id: &str,
+        resolved_parent_session_id: &str,
+    ) -> Result<()> {
+        loop {
+            let intent = {
+                let _guard = self.write_guard()?;
+                let state = self.load_raw_json_value()?;
+                let records = reparent_request_records(&state)?;
+                leased_reparent_request(&state, &records, request_id)?
+                    .deferred_routing_intents
+                    .iter()
+                    .find(|intent| intent.replayed_at.is_none())
+                    .cloned()
+            };
+            let Some(intent) = intent else {
+                return Ok(());
+            };
+            if intent.operation != "parent_wake" {
+                anyhow::bail!(
+                    "unsupported deferred routing operation {}",
+                    intent.operation
+                )
+            }
+            let period_seconds = intent
+                .payload
+                .get("period_seconds")
+                .and_then(Value::as_i64)
+                .context("deferred parent wake has no period")?;
+            if let Some(queue) = self.queue_store.as_ref() {
+                queue.register_parent_wake(
+                    &intent.child_session_id,
+                    resolved_parent_session_id,
+                    period_seconds,
+                )?;
+            } else {
+                anyhow::bail!("deferred parent wake requires the retained queue store")
+            }
+            let _guard = self.write_guard()?;
+            let mut state = self.load_raw_json_value()?;
+            let mut records = reparent_request_records(&state)?;
+            let record = leased_reparent_request_mut(&state, &mut records, request_id)?;
+            let current = record
+                .deferred_routing_intents
+                .iter_mut()
+                .find(|current| current.key == intent.key)
+                .with_context(|| format!("deferred routing intent {} disappeared", intent.key))?;
+            if current.replayed_at.is_none() {
+                upsert_parent_wake_raw(
+                    &mut state,
+                    &intent.child_session_id,
+                    resolved_parent_session_id,
+                    period_seconds,
+                )?;
+                current.replayed_at = Some(now_rfc3339());
+                current.resolved_parent_session_id = Some(resolved_parent_session_id.to_owned());
+                store_reparent_request_records(&mut state, &records)?;
+                self.write_raw_json_value(&state)?;
+            }
+        }
+    }
+
     fn fail_reparent_apply(&self, request_id: &str, failure_reason: &str) -> Result<()> {
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
         let mut records = reparent_request_records(&state)?;
         let record = leased_reparent_request_mut(&state, &mut records, request_id)?;
-        record.status = "failed".to_owned();
+        let before_quiesce = matches!(record.apply_stage.as_deref(), None | Some("applying"));
+        record.status = if before_quiesce {
+            "stale".to_owned()
+        } else {
+            "failed".to_owned()
+        };
+        if before_quiesce {
+            record.apply_stage = Some("prequiesce_aborted".to_owned());
+        }
         record.failure_reason = Some(failure_reason.to_owned());
         record.ready_to_apply = false;
         record.decided_at = Some(now_rfc3339());
         store_reparent_request_records(&mut state, &records)?;
+        if before_quiesce {
+            store_reparent_apply_lease(&mut state, None)?;
+        }
+        self.write_raw_json_value(&state)
+    }
+
+    fn rollback_reparent_precommit(&self, request_id: &str) -> Result<()> {
+        let (plan, snapshot, old_parent) = {
+            let _guard = self.write_guard()?;
+            let state = self.load_raw_json_value()?;
+            let records = reparent_request_records(&state)?;
+            let record = leased_reparent_request(&state, &records, request_id)?;
+            if !matches!(
+                record.apply_stage.as_deref(),
+                Some("json_routing_quiesced" | "routing_quiesced")
+            ) {
+                anyhow::bail!("request {request_id} is no longer pre-commit")
+            }
+            let plan = record
+                .apply_plan
+                .clone()
+                .context("reparent apply plan is missing")?;
+            let old_parent = plan
+                .edge_changes
+                .first()
+                .and_then(|change| change.expected_parent_session_id.clone())
+                .context("pre-commit rollback requires an old parent")?;
+            (plan.clone(), queue_snapshot_from_plan(&plan)?, old_parent)
+        };
+        if let Some(queue) = self.queue_store.as_ref() {
+            queue.retarget_parent_routing(&snapshot, &old_parent)?;
+        } else if !snapshot.wake_rows.is_empty() || !snapshot.message_rows.is_empty() {
+            anyhow::bail!("reparent plan requires the retained queue store")
+        }
+        self.replay_deferred_reparent_routes(request_id, &old_parent)?;
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let mut records = reparent_request_records(&state)?;
+        let record = leased_reparent_request_mut(&state, &mut records, request_id)?;
+        restore_json_reparent_routes(&mut state, &plan)?;
+        verify_old_reparent_edges(&state, &plan)?;
+        record.status = "repaired".to_owned();
+        record.apply_stage = Some("repair_rolled_back".to_owned());
+        record.failure_reason = None;
+        record.ready_to_apply = false;
+        record.decided_at = Some(now_rfc3339());
+        store_reparent_request_records(&mut state, &records)?;
+        store_reparent_apply_lease(&mut state, None)?;
         self.write_raw_json_value(&state)
     }
 
@@ -2431,6 +2652,11 @@ impl SessionStore {
         let record = {
             let _guard = self.write_guard()?;
             let mut state = self.load_raw_json_value()?;
+            if let Some(request_id) = active_reparent_request_for_session(&state, session_id)? {
+                return Ok(CredentialRotationOutcome::Conflict(format!(
+                    "reparent request {request_id} controls session {session_id}"
+                )));
+            }
             let snapshot = snapshot_from_raw_value(&state)?;
             let Some(session) = snapshot
                 .sessions
@@ -2535,6 +2761,9 @@ impl SessionStore {
     ) -> Result<SessionRecord> {
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
+        if let Some(parent_id) = request.parent_session_id.as_deref() {
+            ensure_session_not_reparent_fenced(&state, parent_id)?;
+        }
         let sessions = ensure_sessions_array_mut(&mut state)?;
         let record =
             self.build_core_session_record(sessions, &request, log_dir.as_deref(), false, None)?;
@@ -2586,6 +2815,9 @@ impl SessionStore {
             .transpose()?;
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
+        if let Some(parent_id) = request.parent_session_id.as_deref() {
+            ensure_session_not_reparent_fenced(&state, parent_id)?;
+        }
         let mut record = {
             let sessions = ensure_sessions_array_mut(&mut state)?;
             self.build_core_session_record(
@@ -3554,6 +3786,7 @@ impl SessionStore {
     pub fn restore_core_session(&self, session_id: &str) -> Result<Option<CoreRestoreOutcome>> {
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
+        ensure_session_not_reparent_fenced(&state, session_id)?;
         let sessions = ensure_sessions_array_mut(&mut state)?;
         let Some(session) = session_object_mut(sessions, session_id) else {
             return Ok(None);
@@ -3588,6 +3821,7 @@ impl SessionStore {
     ) -> Result<Option<CoreRestoreOutcome>> {
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
+        ensure_session_not_reparent_fenced(&state, session_id)?;
         let snapshot = snapshot_from_raw_value(&state)?;
         let Some(mut record) = snapshot
             .sessions
@@ -3730,7 +3964,17 @@ impl SessionStore {
         self.write_raw_json_value(&state)?;
 
         if session_runtime.session_exists(&record.tmux_session)? {
-            let _ = session_runtime.kill_session(&record.tmux_session)?;
+            if let Err(error) = session_runtime.kill_session(&record.tmux_session) {
+                mark_runtime_launch_failed(
+                    &mut state,
+                    &launch_id,
+                    &record.id,
+                    false,
+                    &format!("failed to tear down prior runtime before restore: {error}"),
+                )?;
+                self.write_raw_json_value(&state)?;
+                return Err(error);
+            }
         }
         if let Err(error) =
             session_runtime.restore_session(&spec, &record.provider, provider_resume_id.as_deref())
@@ -3884,6 +4128,7 @@ impl SessionStore {
     ) -> Result<ContextMonitorOutcome> {
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
+        ensure_session_not_reparent_fenced(&state, session_id)?;
         let sessions = ensure_sessions_array_mut(&mut state)?;
         let requester_session_id = request.requester_session_id.trim();
         if requester_session_id.is_empty() {
@@ -3950,7 +4195,10 @@ impl SessionStore {
             reset_context_oneshot_flags(session);
         } else {
             session.insert("context_monitor_notify".to_owned(), Value::Null);
-            session.insert("context_monitor_notify_source".to_owned(), Value::Null);
+            session.insert(
+                "context_monitor_notify_source".to_owned(),
+                Value::String(default_context_monitor_notify_source()),
+            );
             if request.enabled {
                 reset_context_oneshot_flags(session);
             }
@@ -4046,7 +4294,10 @@ impl SessionStore {
             let notify_target = if informational_only {
                 session.insert("context_monitor_enabled".to_owned(), Value::Bool(false));
                 session.insert("context_monitor_notify".to_owned(), Value::Null);
-                session.insert("context_monitor_notify_source".to_owned(), Value::Null);
+                session.insert(
+                    "context_monitor_notify_source".to_owned(),
+                    Value::String(default_context_monitor_notify_source()),
+                );
                 None
             } else {
                 json_text(session.get("context_monitor_notify"))
@@ -4202,7 +4453,10 @@ impl SessionStore {
                 if had_alert_state {
                     session.insert("context_monitor_enabled".to_owned(), Value::Bool(false));
                     session.insert("context_monitor_notify".to_owned(), Value::Null);
-                    session.insert("context_monitor_notify_source".to_owned(), Value::Null);
+                    session.insert(
+                        "context_monitor_notify_source".to_owned(),
+                        Value::String(default_context_monitor_notify_source()),
+                    );
                     reset_context_oneshot_flags(session);
                     self.cancel_context_monitor_alerts(session_id)?;
                     changed = true;
@@ -5525,6 +5779,7 @@ impl SessionStore {
     ) -> Result<CoreRetireOutcome> {
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
+        ensure_session_not_reparent_fenced(&state, session_id)?;
         let recipient_name = {
             let sessions = ensure_sessions_array_mut(&mut state)?;
             let Some(session) = session_object_mut(sessions, session_id) else {
@@ -5566,6 +5821,7 @@ impl SessionStore {
     ) -> Result<CoreRetireOutcome> {
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
+        ensure_session_not_reparent_fenced(&state, session_id)?;
         let (node, tmux_session, session_socket_name, recipient_name) = {
             let sessions = ensure_sessions_array_mut(&mut state)?;
             let Some(session) = session_object_mut(sessions, session_id) else {
@@ -6235,7 +6491,10 @@ impl SessionStore {
                 if had_alert_state {
                     session.insert("context_monitor_enabled".to_owned(), Value::Bool(false));
                     session.insert("context_monitor_notify".to_owned(), Value::Null);
-                    session.insert("context_monitor_notify_source".to_owned(), Value::Null);
+                    session.insert(
+                        "context_monitor_notify_source".to_owned(),
+                        Value::String(default_context_monitor_notify_source()),
+                    );
                     reset_context_oneshot_flags(session);
                     self.cancel_context_monitor_alerts(session_id)?;
                     changed = true;
@@ -6906,6 +7165,29 @@ pub struct DecideReparentRequest {
 pub enum ReparentDecision {
     Approved,
     Rejected,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReparentRepairAction {
+    Resume,
+    RollbackPrecommit,
+}
+
+impl ReparentRepairAction {
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim() {
+            "resume" => Some(Self::Resume),
+            "rollback_precommit" => Some(Self::RollbackPrecommit),
+            _ => None,
+        }
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Resume => "resume",
+            Self::RollbackPrecommit => "rollback_precommit",
+        }
+    }
 }
 
 impl ReparentDecision {
@@ -8624,6 +8906,23 @@ fn complete_runtime_message_delivery_raw(
         message
     };
 
+    let fenced_message;
+    let message = if message.parent_session_id.is_some()
+        && active_reparent_request_for_session(state, &message.target_session_id)?.is_some()
+    {
+        persist_deferred_parent_wake_intent(state, message)?;
+        // The intent must be durable before SQLite marks the source message
+        // delivered, otherwise a crash can lose the parent wake entirely.
+        store.write_raw_json_value(state)?;
+        fenced_message = PendingMessage {
+            parent_session_id: None,
+            ..message.clone()
+        };
+        &fenced_message
+    } else {
+        message
+    };
+
     queue.mark_delivered_and_apply_side_effects(message)?;
 
     if message.notify_on_delivery {
@@ -8687,6 +8986,36 @@ fn complete_runtime_message_delivery_raw(
         queue.clone(),
         message.clone(),
     );
+    Ok(())
+}
+
+fn persist_deferred_parent_wake_intent(state: &mut Value, message: &PendingMessage) -> Result<()> {
+    let request_id = active_reparent_request_for_session(state, &message.target_session_id)?
+        .context("routing fence disappeared while deferring parent wake")?;
+    let mut records = reparent_request_records(state)?;
+    let record = records
+        .iter_mut()
+        .find(|record| record.id == request_id)
+        .with_context(|| format!("reparent request {request_id} disappeared"))?;
+    let key = format!("message-parent-wake:{}", message.id);
+    if !record
+        .deferred_routing_intents
+        .iter()
+        .any(|intent| intent.key == key)
+    {
+        record
+            .deferred_routing_intents
+            .push(ReparentDeferredRoutingIntent {
+                key,
+                operation: "parent_wake".to_owned(),
+                child_session_id: message.target_session_id.clone(),
+                payload: json!({ "period_seconds": 600 }),
+                created_at: now_rfc3339(),
+                replayed_at: None,
+                resolved_parent_session_id: None,
+            });
+        store_reparent_request_records(state, &records)?;
+    }
     Ok(())
 }
 
@@ -10336,6 +10665,22 @@ fn store_reparent_apply_lease(state: &mut Value, lease: Option<&ReparentApplyLea
     Ok(())
 }
 
+fn active_reparent_request_for_session(state: &Value, session_id: &str) -> Result<Option<String>> {
+    Ok(reparent_request_records(state)?
+        .into_iter()
+        .find(|record| {
+            record.is_apply_fenced() && record.affected_session_ids().contains(session_id.trim())
+        })
+        .map(|record| record.id))
+}
+
+fn ensure_session_not_reparent_fenced(state: &Value, session_id: &str) -> Result<()> {
+    if let Some(request_id) = active_reparent_request_for_session(state, session_id)? {
+        anyhow::bail!("reparent request {request_id} controls session {session_id}")
+    }
+    Ok(())
+}
+
 fn leased_reparent_request<'a>(
     state: &Value,
     records: &'a [ReparentRequestRecord],
@@ -10493,6 +10838,64 @@ fn commit_json_reparent_plan(state: &mut Value, plan: &ReparentApplyPlan) -> Res
                 );
             }
             other => anyhow::bail!("unsupported JSON routing record kind {other}"),
+        }
+    }
+    Ok(())
+}
+
+fn restore_json_reparent_routes(state: &mut Value, plan: &ReparentApplyPlan) -> Result<()> {
+    for change in &plan.json_routing_changes {
+        let old_parent = change
+            .expected_target_session_id
+            .clone()
+            .with_context(|| format!("routing change {} has no old parent", change.record_id))?;
+        match change.record_kind.as_str() {
+            "parent_wake" => {
+                let registrations =
+                    ensure_array_field_mut(state, "retained_parent_wake_registrations")?;
+                let entry = registrations
+                    .iter_mut()
+                    .find(|entry| json_text(entry.get("id")).as_deref() == Some(&change.record_id))
+                    .with_context(|| format!("parent wake {} disappeared", change.record_id))?;
+                let object = entry
+                    .as_object_mut()
+                    .context("parent wake record must be an object")?;
+                validate_json_parent_route(object, change, false)?;
+                object.insert("parent_session_id".to_owned(), Value::String(old_parent));
+                object.insert(
+                    "is_active".to_owned(),
+                    Value::Bool(change.prior_active.unwrap_or(false)),
+                );
+            }
+            "context_monitor" => {
+                let sessions = ensure_sessions_array_mut(state)?;
+                let session = session_object_mut(sessions, &change.child_session_id)
+                    .with_context(|| format!("session {} disappeared", change.child_session_id))?;
+                validate_json_parent_route(session, change, false)?;
+                session.insert(
+                    "context_monitor_notify".to_owned(),
+                    Value::String(old_parent),
+                );
+                session.insert(
+                    "context_monitor_enabled".to_owned(),
+                    Value::Bool(change.prior_active.unwrap_or(false)),
+                );
+            }
+            other => anyhow::bail!("unsupported JSON routing record kind {other}"),
+        }
+    }
+    Ok(())
+}
+
+fn verify_old_reparent_edges(state: &Value, plan: &ReparentApplyPlan) -> Result<()> {
+    for change in &plan.edge_changes {
+        let session = raw_session_object(state, &change.session_id)
+            .with_context(|| format!("session {} disappeared", change.session_id))?;
+        if json_text(session.get("parent_session_id")) != change.expected_parent_session_id {
+            anyhow::bail!(
+                "session {} authority changed before rollback",
+                change.session_id
+            );
         }
     }
     Ok(())
@@ -11299,6 +11702,10 @@ impl ReparentRequestRecord {
             .cloned()
             .collect::<BTreeSet<_>>();
         affected.insert(self.subject_session_id.clone());
+        affected.insert(self.target_parent_session_id.clone());
+        if let Some(parent_id) = self.expected_parent_session_id.as_ref() {
+            affected.insert(parent_id.clone());
+        }
         if let Some(plan) = self.apply_plan.as_ref() {
             affected.extend(
                 plan.edge_changes
@@ -11317,6 +11724,20 @@ impl ReparentRequestRecord {
             );
         }
         affected
+    }
+
+    fn is_apply_fenced(&self) -> bool {
+        self.status == "applying"
+            || (self.status == "failed"
+                && matches!(
+                    self.apply_stage.as_deref(),
+                    Some(
+                        "prequiesce_aborting"
+                            | "json_routing_quiesced"
+                            | "routing_quiesced"
+                            | "authority_committed"
+                    )
+                ))
     }
 }
 
@@ -16229,6 +16650,14 @@ mod tests {
             state["retained_parent_wake_registrations"][0]["is_active"],
             true
         );
+        assert!(matches!(
+            store.retire_core_session("child001", Some("oldpar01")),
+            Ok(CoreRetireOutcome::NotChild)
+        ));
+        assert!(matches!(
+            store.retire_core_session("child001", Some("newpar01")),
+            Ok(CoreRetireOutcome::Retired(_))
+        ));
 
         let _ = fs::remove_file(state_file);
         let _ = fs::remove_file(queue_db);
@@ -16239,6 +16668,167 @@ mod tests {
         let value = reparent_test_session("legacy01", None, "legacy-secret");
         let record: SessionRecord = serde_json::from_value(value).unwrap();
         assert_eq!(record.context_monitor_notify_source, "explicit");
+    }
+
+    #[test]
+    fn failed_precommit_reparent_rolls_back_exact_routes_and_releases_lease() {
+        let (store, queue, state_file, queue_db, request_id) =
+            prepared_reparent_transaction("reparent-rollback");
+        assert_eq!(
+            store.acquire_reparent_apply_lease().unwrap().as_deref(),
+            Some(request_id.as_str())
+        );
+        store.quiesce_reparent_json_routing(&request_id).unwrap();
+        store.quiesce_reparent_queue_routing(&request_id).unwrap();
+        store
+            .fail_reparent_apply(&request_id, "injected precommit failure")
+            .unwrap();
+
+        let failed = store.get_reparent_request(&request_id).unwrap().unwrap();
+        assert_eq!(failed.status, "failed");
+        assert_eq!(failed.apply_stage.as_deref(), Some("routing_quiesced"));
+        assert_eq!(queue.active_parent_wake_parent("child001").unwrap(), None);
+
+        let repaired = match store
+            .repair_reparent_request(
+                &request_id,
+                "owner@example.com",
+                ReparentRepairAction::RollbackPrecommit,
+            )
+            .unwrap()
+        {
+            ReparentMutationOutcome::Updated(record) => record,
+            other => panic!("unexpected repair outcome: {other:?}"),
+        };
+        assert_eq!(repaired.status, "repaired");
+        assert_eq!(repaired.apply_stage.as_deref(), Some("repair_rolled_back"));
+        assert_eq!(repaired.repair_history.len(), 1);
+        assert_eq!(
+            queue
+                .active_parent_wake_parent("child001")
+                .unwrap()
+                .as_deref(),
+            Some("oldpar01")
+        );
+        let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+        assert!(state["reparent_apply_lease"].is_null());
+        assert_eq!(
+            state["retained_parent_wake_registrations"][0]["parent_session_id"],
+            "oldpar01"
+        );
+        assert_eq!(
+            state["retained_parent_wake_registrations"][0]["is_active"],
+            true
+        );
+        assert_eq!(
+            json_text(
+                raw_session_object(&state, "child001")
+                    .unwrap()
+                    .get("parent_session_id")
+            )
+            .as_deref(),
+            Some("oldpar01")
+        );
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
+    fn authority_committed_reparent_resumes_forward_from_immutable_plan() {
+        let (store, queue, state_file, queue_db, request_id) =
+            prepared_reparent_transaction("reparent-forward-recovery");
+        store.acquire_reparent_apply_lease().unwrap();
+        store.quiesce_reparent_json_routing(&request_id).unwrap();
+        store.quiesce_reparent_queue_routing(&request_id).unwrap();
+        store.commit_reparent_authority(&request_id).unwrap();
+
+        let recovered = store.reconcile_reparent_requests().unwrap().unwrap();
+        assert_eq!(recovered.status, "applied");
+        assert_eq!(
+            store
+                .get_session("child001")
+                .unwrap()
+                .unwrap()
+                .parent_session_id
+                .as_deref(),
+            Some("newpar01")
+        );
+        assert_eq!(
+            queue
+                .active_parent_wake_parent("child001")
+                .unwrap()
+                .as_deref(),
+            Some("newpar01")
+        );
+        let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+        assert!(state["reparent_apply_lease"].is_null());
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    fn prepared_reparent_transaction(
+        label: &str,
+    ) -> (SessionStore, RetainedQueueStore, PathBuf, PathBuf, String) {
+        let state_file = unique_temp_path(label);
+        let queue_db = state_file.with_extension("db");
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [
+                    reparent_test_session("oldpar01", None, "old-parent-secret"),
+                    reparent_test_session("newpar01", None, "new-parent-secret"),
+                    reparent_test_session("child001", Some("oldpar01"), "child-secret")
+                ],
+                "retained_parent_wake_registrations": [{
+                    "id": "json-wake-child001",
+                    "child_session_id": "child001",
+                    "parent_session_id": "oldpar01",
+                    "period_seconds": 600,
+                    "is_active": true
+                }]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let queue = RetainedQueueStore::new(queue_db.clone());
+        queue.ensure_schema().unwrap();
+        queue
+            .register_parent_wake("child001", "oldpar01", 600)
+            .unwrap();
+        let store = SessionStore::new_with_queue(state_file.clone(), queue_db.clone());
+        let request = match store
+            .create_reparent_request(
+                "child001",
+                CreateReparentRequest {
+                    requester_session_id: "oldpar01".to_owned(),
+                    target_parent_session_id: "newpar01".to_owned(),
+                },
+                "old-parent-secret",
+            )
+            .unwrap()
+        {
+            ReparentMutationOutcome::Created(record) => record,
+            other => panic!("unexpected create outcome: {other:?}"),
+        };
+        {
+            let _guard = store.write_guard().unwrap();
+            let mut state = store.load_raw_json_value().unwrap();
+            let mut records = reparent_request_records(&state).unwrap();
+            let record = records
+                .iter_mut()
+                .find(|record| record.id == request.id)
+                .unwrap();
+            record.approvals.push(ReparentApprovalRecord {
+                actor_kind: "agent".to_owned(),
+                actor_id: "newpar01".to_owned(),
+                decision: "approved".to_owned(),
+                decided_at: now_rfc3339(),
+            });
+            record.ready_to_apply = true;
+            store_reparent_request_records(&mut state, &records).unwrap();
+            store.write_raw_json_value(&state).unwrap();
+        }
+        (store, queue, state_file, queue_db, request.id)
     }
 
     fn reparent_test_session(id: &str, parent: Option<&str>, credential: &str) -> Value {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1764,6 +1764,91 @@ impl SessionStore {
         Ok(ReparentMutationOutcome::Updated(updated))
     }
 
+    pub fn decide_reparent_request_as_human(
+        &self,
+        request_id: &str,
+        actor_id: &str,
+        decision: ReparentDecision,
+    ) -> Result<ReparentMutationOutcome> {
+        let request_id = request_id.trim();
+        let actor_id = actor_id.trim();
+        if request_id.is_empty() || actor_id.is_empty() {
+            return Ok(ReparentMutationOutcome::BadRequest(
+                "request ID and authenticated human actor are required".to_owned(),
+            ));
+        }
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = snapshot_from_raw_value(&state)?.into_sessions();
+        let mut records = reparent_request_records(&state)?;
+        let now = OffsetDateTime::now_utc();
+        let refreshed = refresh_reparent_requests(&mut records, &sessions, now);
+        let Some(index) = records.iter().position(|record| record.id == request_id) else {
+            if refreshed {
+                store_reparent_request_records(&mut state, &records)?;
+                self.write_raw_json_value(&state)?;
+            }
+            return Ok(ReparentMutationOutcome::RequestNotFound);
+        };
+        let record = &mut records[index];
+        if !record.required_human_approval {
+            return Ok(ReparentMutationOutcome::Forbidden(format!(
+                "request {request_id} does not require human approval"
+            )));
+        }
+        if let Some(existing) = record
+            .approvals
+            .iter()
+            .find(|approval| approval.actor_kind == "human")
+        {
+            if existing.actor_id == actor_id && existing.decision == decision.as_str() {
+                let updated = record.clone();
+                if refreshed {
+                    store_reparent_request_records(&mut state, &records)?;
+                    self.write_raw_json_value(&state)?;
+                }
+                return Ok(ReparentMutationOutcome::Updated(updated));
+            }
+            return Ok(ReparentMutationOutcome::Conflict(format!(
+                "human actor {} already {} request {request_id}",
+                existing.actor_id, existing.decision
+            )));
+        }
+        if record.status == "expired" {
+            store_reparent_request_records(&mut state, &records)?;
+            self.write_raw_json_value(&state)?;
+            return Ok(ReparentMutationOutcome::Expired);
+        }
+        if record.status != "pending" {
+            return Ok(ReparentMutationOutcome::Conflict(format!(
+                "request {} is already {}",
+                record.id, record.status
+            )));
+        }
+        let decided_at = now.format(&Rfc3339)?;
+        record.approvals.push(ReparentApprovalRecord {
+            actor_kind: "human".to_owned(),
+            actor_id: actor_id.to_owned(),
+            decision: decision.as_str().to_owned(),
+            decided_at: decided_at.clone(),
+        });
+        if decision == ReparentDecision::Rejected {
+            record.status = "rejected".to_owned();
+            record.decided_at = Some(decided_at);
+            record.ready_to_apply = false;
+        } else {
+            record.ready_to_apply = approvals_satisfied(
+                &record.required_agent_approvals,
+                record.required_human_approval,
+                &record.approvals,
+            );
+        }
+        let updated = record.clone();
+        store_reparent_request_records(&mut state, &records)?;
+        self.write_raw_json_value(&state)?;
+        Ok(ReparentMutationOutcome::Updated(updated))
+    }
+
     pub fn get_reparent_request(&self, request_id: &str) -> Result<Option<ReparentRequestRecord>> {
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1005,8 +1005,8 @@ impl SessionStore {
             return Ok(false);
         }
 
-        let _guard = self.write_guard()?;
-        let _input_guard = session_runtime.lock_session_input(&rotation.tmux_session)?;
+        let (_input_guard, _guard) =
+            self.lock_session_input_then_state(&session_runtime, &rotation.tmux_session)?;
         let mut state = self.load_raw_json_value()?;
         let mut rotations = session_credential_rotation_records(&state)?;
         let Some(rotation_index) = rotations
@@ -5639,6 +5639,21 @@ impl SessionStore {
         self.write_lock
             .lock()
             .map_err(|_| anyhow::anyhow!("session state write lock poisoned"))
+    }
+
+    fn lock_session_input_then_state<'a>(
+        &'a self,
+        runtime: &TmuxRuntime,
+        tmux_session: &str,
+    ) -> Result<(
+        crate::runtime::SessionInputGuard,
+        std::sync::MutexGuard<'a, ()>,
+    )> {
+        // Claude handoff already holds this input fence before consulting durable
+        // state. Keep the same lock order for every operation that takes both.
+        let input_guard = runtime.lock_session_input(tmux_session)?;
+        let state_guard = self.write_guard()?;
+        Ok((input_guard, state_guard))
     }
 
     fn start_codex_fork_event_monitor(
@@ -11623,6 +11638,46 @@ mod tests {
             &rotation,
             &stock_codex
         ));
+    }
+
+    #[test]
+    fn credential_rotation_waiting_for_input_does_not_hold_state_lock() {
+        let state_file = unique_temp_path("credential-rotation-lock-order");
+        let store = SessionStore::new(state_file.clone());
+        let runtime = TmuxRuntime::from_config(&crate::config::RustCoreConfig::default());
+        let tmux_session = format!("lock-order-{}", generate_session_id());
+        let held_input = runtime.lock_session_input(&tmux_session).unwrap();
+        let contender_store = store.clone();
+        let contender_runtime = runtime.clone();
+        let contender_session = tmux_session.clone();
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (acquired_tx, acquired_rx) = std::sync::mpsc::channel();
+        let contender = thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            let _guards = contender_store
+                .lock_session_input_then_state(&contender_runtime, &contender_session)
+                .unwrap();
+            acquired_tx.send(()).unwrap();
+        });
+        started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        thread::sleep(Duration::from_millis(50));
+
+        let state_store = store.clone();
+        let (state_tx, state_rx) = std::sync::mpsc::channel();
+        let state_writer = thread::spawn(move || {
+            let _guard = state_store.write_guard().unwrap();
+            state_tx.send(()).unwrap();
+        });
+        state_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("input waiter held the global state lock");
+        assert!(acquired_rx.try_recv().is_err());
+
+        drop(held_input);
+        acquired_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        contender.join().unwrap();
+        state_writer.join().unwrap();
+        let _ = fs::remove_file(state_file);
     }
 
     #[cfg(unix)]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1956,10 +1956,9 @@ impl SessionStore {
         self.write_raw_json_value(&state)?;
         drop(_guard);
         if decision == ReparentDecision::Approved && updated.ready_to_apply {
-            if let Some(applied) = self.reconcile_reparent_requests()? {
-                if applied.id == updated.id {
-                    return Ok(ReparentMutationOutcome::Updated(applied));
-                }
+            self.reconcile_reparent_requests()?;
+            if let Some(applied) = self.get_reparent_request(&updated.id)? {
+                return Ok(ReparentMutationOutcome::Updated(applied));
             }
         }
         Ok(ReparentMutationOutcome::Updated(updated))
@@ -2049,10 +2048,9 @@ impl SessionStore {
         self.write_raw_json_value(&state)?;
         drop(_guard);
         if decision == ReparentDecision::Approved && updated.ready_to_apply {
-            if let Some(applied) = self.reconcile_reparent_requests()? {
-                if applied.id == updated.id {
-                    return Ok(ReparentMutationOutcome::Updated(applied));
-                }
+            self.reconcile_reparent_requests()?;
+            if let Some(applied) = self.get_reparent_request(&updated.id)? {
+                return Ok(ReparentMutationOutcome::Updated(applied));
             }
         }
         Ok(ReparentMutationOutcome::Updated(updated))
@@ -2088,20 +2086,32 @@ impl SessionStore {
     }
 
     pub fn reconcile_reparent_requests(&self) -> Result<Option<ReparentRequestRecord>> {
-        let request_id = match self.acquire_reparent_apply_lease()? {
-            Some(request_id) => request_id,
-            None => return Ok(None),
-        };
-        if self
-            .get_reparent_request(&request_id)?
-            .is_some_and(|record| record.status == "failed")
-        {
-            return self.get_reparent_request(&request_id);
+        let mut first = None;
+        loop {
+            let request_id = match self.acquire_reparent_apply_lease()? {
+                Some(request_id) => request_id,
+                None => return Ok(first),
+            };
+            if self
+                .get_reparent_request(&request_id)?
+                .is_some_and(|record| record.status == "failed")
+            {
+                return Ok(first.or(self.get_reparent_request(&request_id)?));
+            }
+            if let Err(error) = self.apply_reparent_request(&request_id) {
+                self.fail_reparent_apply(&request_id, &error.to_string())?;
+            }
+            let current = self.get_reparent_request(&request_id)?;
+            if first.is_none() {
+                first = current.clone();
+            }
+            if current
+                .as_ref()
+                .is_some_and(|record| record.status == "failed")
+            {
+                return Ok(first);
+            }
         }
-        if let Err(error) = self.apply_reparent_request(&request_id) {
-            self.fail_reparent_apply(&request_id, &error.to_string())?;
-        }
-        self.get_reparent_request(&request_id)
     }
 
     pub fn repair_reparent_request(
@@ -2117,6 +2127,7 @@ impl SessionStore {
                 "request ID and authenticated human actor are required".to_owned(),
             ));
         }
+        let attempted_at = now_rfc3339();
         {
             let _guard = self.write_guard()?;
             let mut state = self.load_raw_json_value()?;
@@ -2156,8 +2167,8 @@ impl SessionStore {
                 actor_id: actor_id.to_owned(),
                 action: action.as_str().to_owned(),
                 prior_failure: record.failure_reason.clone(),
-                attempted_at: now_rfc3339(),
-                verified_state_fingerprint: Some(record.topology_fingerprint.clone()),
+                attempted_at: attempted_at.clone(),
+                verified_state_fingerprint: None,
             });
             if action == ReparentRepairAction::Resume {
                 record.status = "applying".to_owned();
@@ -2178,10 +2189,95 @@ impl SessionStore {
                 }
             }
         }
+        if self
+            .get_reparent_request(request_id)?
+            .is_some_and(|record| matches!(record.status.as_str(), "applied" | "repaired"))
+        {
+            self.verify_reparent_repair(request_id, &attempted_at)?;
+        }
         Ok(self
             .get_reparent_request(request_id)?
             .map(ReparentMutationOutcome::Updated)
             .unwrap_or(ReparentMutationOutcome::RequestNotFound))
+    }
+
+    fn verify_reparent_repair(&self, request_id: &str, attempted_at: &str) -> Result<()> {
+        let (record, state_projection) = {
+            let _guard = self.write_guard()?;
+            let state = self.load_raw_json_value()?;
+            let record = reparent_request_records(&state)?
+                .into_iter()
+                .find(|record| record.id == request_id)
+                .with_context(|| format!("reparent request {request_id} disappeared"))?;
+            let sessions = record
+                .affected_session_ids()
+                .into_iter()
+                .map(|session_id| {
+                    let session = raw_session_object(&state, &session_id);
+                    json!({
+                        "id": session_id,
+                        "parent_session_id": session.and_then(|value| value.get("parent_session_id")).cloned(),
+                        "context_monitor_enabled": session.and_then(|value| value.get("context_monitor_enabled")).cloned(),
+                        "context_monitor_notify": session.and_then(|value| value.get("context_monitor_notify")).cloned(),
+                        "context_monitor_notify_source": session.and_then(|value| value.get("context_monitor_notify_source")).cloned(),
+                    })
+                })
+                .collect::<Vec<_>>();
+            let projection = json!({
+                "sessions": sessions,
+                "retained_parent_wake_registrations": state.get("retained_parent_wake_registrations"),
+                "retained_pending_messages": state.get("retained_pending_messages"),
+                "request_status": record.status,
+                "apply_stage": record.apply_stage,
+            });
+            (record, projection)
+        };
+        let queue_projection = if let (Some(queue), Some(plan)) =
+            (self.queue_store.as_ref(), record.apply_plan.as_ref())
+        {
+            let parent = plan
+                .edge_changes
+                .first()
+                .and_then(|change| {
+                    if record.status == "repaired" {
+                        change.expected_parent_session_id.as_deref()
+                    } else {
+                        change.new_parent_session_id.as_deref()
+                    }
+                })
+                .context("verified reparent plan has no resolved parent")?;
+            let child = plan
+                .edge_changes
+                .first()
+                .map(|change| change.session_id.as_str())
+                .context("verified reparent plan has no subject")?;
+            serde_json::to_value(queue.snapshot_parent_routing(child, parent)?)?
+        } else {
+            Value::Null
+        };
+        let fingerprint = {
+            let canonical = json!({
+                "state": state_projection,
+                "queue": queue_projection,
+            });
+            let digest = Sha256::digest(serde_json::to_vec(&canonical)?);
+            digest.iter().map(|byte| format!("{byte:02x}")).collect()
+        };
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let mut records = reparent_request_records(&state)?;
+        let record = records
+            .iter_mut()
+            .find(|record| record.id == request_id)
+            .with_context(|| format!("reparent request {request_id} disappeared"))?;
+        let repair = record
+            .repair_history
+            .iter_mut()
+            .find(|repair| repair.attempted_at == attempted_at)
+            .with_context(|| format!("repair attempt {attempted_at} disappeared"))?;
+        repair.verified_state_fingerprint = Some(fingerprint);
+        store_reparent_request_records(&mut state, &records)?;
+        self.write_raw_json_value(&state)
     }
 
     fn acquire_reparent_apply_lease(&self) -> Result<Option<String>> {
@@ -2279,6 +2375,7 @@ impl SessionStore {
                     new_target_session_id: Some(record.target_parent_session_id.clone()),
                     prior_active: Some(true),
                     period_seconds: Some(period_seconds),
+                    creates_parent_wake: false,
                 });
             }
             if let Some(session) =
@@ -2302,6 +2399,7 @@ impl SessionStore {
                             .unwrap_or(false),
                     ),
                     period_seconds: None,
+                    creates_parent_wake: false,
                 });
             }
         }
@@ -2326,6 +2424,7 @@ impl SessionStore {
                 new_target_session_id: Some(record.target_parent_session_id.clone()),
                 prior_active: Some(row.is_active),
                 period_seconds: Some(row.period_seconds),
+                creates_parent_wake: false,
             })
             .collect::<Vec<_>>();
         queue_routing_changes.extend(queue_snapshot.message_rows.into_iter().map(|row| {
@@ -2338,6 +2437,7 @@ impl SessionStore {
                 new_target_session_id: Some(record.target_parent_session_id.clone()),
                 prior_active: None,
                 period_seconds: None,
+                creates_parent_wake: row.creates_parent_wake,
             }
         }));
         Ok(ReparentApplyPlan {
@@ -2474,11 +2574,16 @@ impl SessionStore {
                 .context("reparent apply plan has no target parent")?;
             (queue_snapshot_from_plan(plan)?, new_parent)
         };
-        if let Some(queue) = self.queue_store.as_ref() {
-            queue.retarget_parent_routing(&snapshot, &new_parent_session_id)?;
+        let delivered_message_rows = if let Some(queue) = self.queue_store.as_ref() {
+            queue
+                .retarget_parent_routing(&snapshot, &new_parent_session_id)?
+                .delivered_message_rows
         } else if !snapshot.wake_rows.is_empty() || !snapshot.message_rows.is_empty() {
             anyhow::bail!("reparent plan requires the retained queue store")
-        }
+        } else {
+            Vec::new()
+        };
+        self.persist_delivered_reparent_wake_intents(request_id, &delivered_message_rows)?;
         self.replay_deferred_reparent_routes(request_id, &new_parent_session_id)?;
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
@@ -2518,25 +2623,47 @@ impl SessionStore {
             let Some(intent) = intent else {
                 return Ok(());
             };
-            if intent.operation != "parent_wake" {
-                anyhow::bail!(
-                    "unsupported deferred routing operation {}",
-                    intent.operation
-                )
-            }
-            let period_seconds = intent
-                .payload
-                .get("period_seconds")
-                .and_then(Value::as_i64)
-                .context("deferred parent wake has no period")?;
-            if let Some(queue) = self.queue_store.as_ref() {
-                queue.register_parent_wake(
-                    &intent.child_session_id,
-                    resolved_parent_session_id,
-                    period_seconds,
-                )?;
-            } else {
-                anyhow::bail!("deferred parent wake requires the retained queue store")
+            match intent.operation.as_str() {
+                "parent_wake" => {
+                    let period_seconds = intent
+                        .payload
+                        .get("period_seconds")
+                        .and_then(Value::as_i64)
+                        .context("deferred parent wake has no period")?;
+                    if let Some(queue) = self.queue_store.as_ref() {
+                        queue.register_parent_wake(
+                            &intent.child_session_id,
+                            resolved_parent_session_id,
+                            period_seconds,
+                        )?;
+                    } else {
+                        anyhow::bail!("deferred parent wake requires the retained queue store")
+                    }
+                }
+                "task_complete" => {
+                    let text = intent
+                        .payload
+                        .get("text")
+                        .and_then(Value::as_str)
+                        .context("deferred task-complete has no text")?;
+                    let message_id = deferred_task_complete_message_id(request_id, &intent.key);
+                    if let Some(queue) = self.queue_store.as_ref() {
+                        queue.enqueue_message_once_with_metadata(
+                            &message_id,
+                            resolved_parent_session_id,
+                            text,
+                            "important",
+                            QueueMessageMetadata {
+                                message_category: Some("task_complete".to_owned()),
+                                ..QueueMessageMetadata::default()
+                            },
+                        )?;
+                        queue.cancel_parent_wake(&intent.child_session_id)?;
+                    } else {
+                        anyhow::bail!("deferred task-complete requires the retained queue store")
+                    }
+                }
+                other => anyhow::bail!("unsupported deferred routing operation {other}"),
             }
             let _guard = self.write_guard()?;
             let mut state = self.load_raw_json_value()?;
@@ -2548,18 +2675,87 @@ impl SessionStore {
                 .find(|current| current.key == intent.key)
                 .with_context(|| format!("deferred routing intent {} disappeared", intent.key))?;
             if current.replayed_at.is_none() {
-                upsert_parent_wake_raw(
-                    &mut state,
-                    &intent.child_session_id,
-                    resolved_parent_session_id,
-                    period_seconds,
-                )?;
+                match intent.operation.as_str() {
+                    "parent_wake" => {
+                        let period_seconds = intent
+                            .payload
+                            .get("period_seconds")
+                            .and_then(Value::as_i64)
+                            .context("deferred parent wake has no period")?;
+                        upsert_parent_wake_raw(
+                            &mut state,
+                            &intent.child_session_id,
+                            resolved_parent_session_id,
+                            period_seconds,
+                        )?;
+                    }
+                    "task_complete" => {
+                        let text = intent
+                            .payload
+                            .get("text")
+                            .and_then(Value::as_str)
+                            .context("deferred task-complete has no text")?;
+                        let message_id = deferred_task_complete_message_id(request_id, &intent.key);
+                        push_retained_message_once_raw(
+                            &mut state,
+                            &message_id,
+                            resolved_parent_session_id,
+                            text,
+                            "important",
+                            Some("task_complete"),
+                        )?;
+                        deactivate_parent_wake_raw(&mut state, &intent.child_session_id)?;
+                    }
+                    other => anyhow::bail!("unsupported deferred routing operation {other}"),
+                }
                 current.replayed_at = Some(now_rfc3339());
                 current.resolved_parent_session_id = Some(resolved_parent_session_id.to_owned());
                 store_reparent_request_records(&mut state, &records)?;
                 self.write_raw_json_value(&state)?;
             }
         }
+    }
+
+    fn persist_delivered_reparent_wake_intents(
+        &self,
+        request_id: &str,
+        delivered_message_rows: &[ParentRoutingMessageRow],
+    ) -> Result<()> {
+        if !delivered_message_rows
+            .iter()
+            .any(|message| message.creates_parent_wake)
+        {
+            return Ok(());
+        }
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let mut records = reparent_request_records(&state)?;
+        let record = leased_reparent_request_mut(&state, &mut records, request_id)?;
+        for message in delivered_message_rows
+            .iter()
+            .filter(|message| message.creates_parent_wake)
+        {
+            let key = format!("delivered-planned-parent-wake:{}", message.id);
+            if !record
+                .deferred_routing_intents
+                .iter()
+                .any(|intent| intent.key == key)
+            {
+                record
+                    .deferred_routing_intents
+                    .push(ReparentDeferredRoutingIntent {
+                        key,
+                        operation: "parent_wake".to_owned(),
+                        child_session_id: message.child_session_id.clone(),
+                        payload: json!({ "period_seconds": 600 }),
+                        created_at: now_rfc3339(),
+                        replayed_at: None,
+                        resolved_parent_session_id: None,
+                    });
+            }
+        }
+        store_reparent_request_records(&mut state, &records)?;
+        self.write_raw_json_value(&state)
     }
 
     fn fail_reparent_apply(&self, request_id: &str, failure_reason: &str) -> Result<()> {
@@ -2609,11 +2805,16 @@ impl SessionStore {
                 .context("pre-commit rollback requires an old parent")?;
             (plan.clone(), queue_snapshot_from_plan(&plan)?, old_parent)
         };
-        if let Some(queue) = self.queue_store.as_ref() {
-            queue.retarget_parent_routing(&snapshot, &old_parent)?;
+        let delivered_message_rows = if let Some(queue) = self.queue_store.as_ref() {
+            queue
+                .retarget_parent_routing(&snapshot, &old_parent)?
+                .delivered_message_rows
         } else if !snapshot.wake_rows.is_empty() || !snapshot.message_rows.is_empty() {
             anyhow::bail!("reparent plan requires the retained queue store")
-        }
+        } else {
+            Vec::new()
+        };
+        self.persist_delivered_reparent_wake_intents(request_id, &delivered_message_rows)?;
         self.replay_deferred_reparent_routes(request_id, &old_parent)?;
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
@@ -5930,6 +6131,63 @@ impl SessionStore {
             )));
         };
 
+        let completed_at = now_rfc3339();
+        let friendly = session
+            .cached_display_name()
+            .unwrap_or_else(|| non_empty_or(session.name.clone(), &session.id));
+        let completion_text =
+            format!("[sm task-complete] agent {session_id}({friendly}) completed its task.");
+        if let Some(request_id) = active_reparent_request_for_session(&state, session_id)? {
+            if let Some(queue) = &self.queue_store {
+                queue.cancel_remind(session_id)?;
+            }
+            deactivate_remind_raw(&mut state, session_id)?;
+            let sessions = ensure_sessions_array_mut(&mut state)?;
+            let session_object = session_object_mut(sessions, session_id)
+                .ok_or_else(|| anyhow::anyhow!("session disappeared during task-complete"))?;
+            session_object.insert(
+                "agent_task_completed_at".to_owned(),
+                Value::String(completed_at.clone()),
+            );
+            session_object.insert("agent_status_text".to_owned(), Value::Null);
+            session_object.insert("agent_status_at".to_owned(), Value::Null);
+
+            let mut records = reparent_request_records(&state)?;
+            let record = records
+                .iter_mut()
+                .find(|record| record.id == request_id)
+                .with_context(|| format!("reparent request {request_id} disappeared"))?;
+            let key = format!("task-complete:{session_id}:{completed_at}");
+            if !record
+                .deferred_routing_intents
+                .iter()
+                .any(|intent| intent.key == key)
+            {
+                record
+                    .deferred_routing_intents
+                    .push(ReparentDeferredRoutingIntent {
+                        key,
+                        operation: "task_complete".to_owned(),
+                        child_session_id: session_id.to_owned(),
+                        payload: json!({
+                            "text": completion_text,
+                            "completed_at": completed_at,
+                        }),
+                        created_at: now_rfc3339(),
+                        replayed_at: None,
+                        resolved_parent_session_id: None,
+                    });
+            }
+            store_reparent_request_records(&mut state, &records)?;
+            self.write_raw_json_value(&state)?;
+            return Ok(TaskCompleteOutcome::Completed(TaskCompleteResult {
+                status: "completed".to_owned(),
+                session_id: session_id.to_owned(),
+                em_notified: false,
+                agent_task_completed_at: completed_at,
+            }));
+        }
+
         let queue_parent = match &self.queue_store {
             Some(queue) => queue.active_parent_wake_parent(session_id)?,
             None => None,
@@ -5944,7 +6202,6 @@ impl SessionStore {
         deactivate_remind_raw(&mut state, session_id)?;
         deactivate_parent_wake_raw(&mut state, session_id)?;
 
-        let completed_at = now_rfc3339();
         let sessions = ensure_sessions_array_mut(&mut state)?;
         let session_object = session_object_mut(sessions, session_id)
             .ok_or_else(|| anyhow::anyhow!("session disappeared during task-complete"))?;
@@ -5957,11 +6214,7 @@ impl SessionStore {
 
         let mut em_notified = false;
         if let Some(em_session_id) = em_session_id {
-            let friendly = session
-                .cached_display_name()
-                .unwrap_or_else(|| non_empty_or(session.name.clone(), &session.id));
-            let text =
-                format!("[sm task-complete] agent {session_id}({friendly}) completed its task.");
+            let text = completion_text;
             if let Some(queue) = &self.queue_store {
                 let message_id = queue.enqueue_message(
                     &em_session_id,
@@ -7879,6 +8132,48 @@ fn push_retained_message_raw(
         "created_at": now_rfc3339(),
     }));
     Ok(())
+}
+
+fn push_retained_message_once_raw(
+    state: &mut Value,
+    id: &str,
+    target_session_id: &str,
+    text: &str,
+    delivery_mode: &str,
+    message_category: Option<&str>,
+) -> Result<()> {
+    let messages = ensure_array_field_mut(state, "retained_pending_messages")?;
+    if let Some(existing) = messages
+        .iter()
+        .find(|message| json_text(message.get("id")).as_deref() == Some(id))
+    {
+        let matches = json_text(existing.get("target_session_id")).as_deref()
+            == Some(target_session_id)
+            && existing.get("text").and_then(Value::as_str) == Some(text)
+            && existing.get("delivery_mode").and_then(Value::as_str) == Some(delivery_mode)
+            && json_text(existing.get("message_category")).as_deref() == message_category;
+        if !matches {
+            anyhow::bail!("retained message id {id} already exists with different content");
+        }
+        return Ok(());
+    }
+    messages.push(json!({
+        "id": id,
+        "target_session_id": target_session_id,
+        "text": text,
+        "delivery_mode": delivery_mode,
+        "message_category": message_category,
+        "created_at": now_rfc3339(),
+    }));
+    Ok(())
+}
+
+fn deferred_task_complete_message_id(request_id: &str, intent_key: &str) -> String {
+    let mut digest = Sha256::new();
+    digest.update(request_id.as_bytes());
+    digest.update(b"\0");
+    digest.update(intent_key.as_bytes());
+    format!("reparent-task-complete-{:x}", digest.finalize())
 }
 
 fn upsert_remind_raw(
@@ -10743,6 +11038,7 @@ fn queue_snapshot_from_plan(plan: &ReparentApplyPlan) -> Result<ParentRoutingSna
                 id: change.record_id.clone(),
                 child_session_id: change.child_session_id.clone(),
                 parent_session_id: old_parent,
+                creates_parent_wake: change.creates_parent_wake,
             }),
             other => anyhow::bail!("unsupported queue routing record kind {other}"),
         }
@@ -11537,6 +11833,8 @@ pub struct ReparentRoutingChange {
     pub prior_active: Option<bool>,
     #[serde(default)]
     pub period_seconds: Option<i64>,
+    #[serde(default)]
+    pub creates_parent_wake: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -16703,6 +17001,15 @@ mod tests {
         assert_eq!(repaired.status, "repaired");
         assert_eq!(repaired.apply_stage.as_deref(), Some("repair_rolled_back"));
         assert_eq!(repaired.repair_history.len(), 1);
+        assert!(repaired.repair_history[0]
+            .verified_state_fingerprint
+            .is_some());
+        assert_ne!(
+            repaired.repair_history[0]
+                .verified_state_fingerprint
+                .as_deref(),
+            Some(repaired.topology_fingerprint.as_str())
+        );
         assert_eq!(
             queue
                 .active_parent_wake_parent("child001")
@@ -16762,6 +17069,118 @@ mod tests {
         );
         let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
         assert!(state["reparent_apply_lease"].is_null());
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
+    fn task_complete_during_reparent_notifies_only_the_committed_parent() {
+        let (store, queue, state_file, queue_db, request_id) =
+            prepared_reparent_transaction("reparent-task-complete");
+        store.acquire_reparent_apply_lease().unwrap();
+        store.quiesce_reparent_json_routing(&request_id).unwrap();
+        store.quiesce_reparent_queue_routing(&request_id).unwrap();
+
+        let completed = store
+            .task_complete(
+                "child001",
+                TaskCompleteRequest {
+                    requester_session_id: "child001".to_owned(),
+                },
+                None,
+            )
+            .unwrap();
+        assert!(matches!(
+            completed,
+            TaskCompleteOutcome::Completed(TaskCompleteResult {
+                em_notified: false,
+                ..
+            })
+        ));
+        assert!(queue
+            .pending_messages_for_target("oldpar01", 10)
+            .unwrap()
+            .is_empty());
+
+        store.commit_reparent_authority(&request_id).unwrap();
+        store.finish_reparent_routing(&request_id).unwrap();
+
+        let messages = queue.pending_messages_for_target("newpar01", 10).unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].message_category.as_deref(),
+            Some("task_complete")
+        );
+        assert!(queue
+            .active_parent_wake_parent("child001")
+            .unwrap()
+            .is_none());
+        let record = store.get_reparent_request(&request_id).unwrap().unwrap();
+        assert_eq!(record.status, "applied");
+        assert_eq!(record.deferred_routing_intents.len(), 1);
+        assert!(record.deferred_routing_intents[0].replayed_at.is_some());
+        assert_eq!(
+            record.deferred_routing_intents[0]
+                .resolved_parent_session_id
+                .as_deref(),
+            Some("newpar01")
+        );
+
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
+    fn delivered_planned_message_recreates_its_parent_wake_after_commit() {
+        let (store, queue, state_file, queue_db, request_id) =
+            prepared_reparent_transaction("reparent-delivered-message");
+        let message_id = queue
+            .enqueue_message_with_metadata(
+                "child001",
+                "delivery races reparent",
+                "important",
+                QueueMessageMetadata {
+                    remind_soft_threshold: Some(600),
+                    parent_session_id: Some("oldpar01".to_owned()),
+                    ..QueueMessageMetadata::default()
+                },
+            )
+            .unwrap();
+        store.acquire_reparent_apply_lease().unwrap();
+        store.quiesce_reparent_json_routing(&request_id).unwrap();
+        store.quiesce_reparent_queue_routing(&request_id).unwrap();
+        let message = queue
+            .pending_messages_for_target("child001", 10)
+            .unwrap()
+            .into_iter()
+            .find(|message| message.id == message_id)
+            .unwrap();
+        assert!(message.parent_session_id.is_none());
+        queue
+            .mark_delivered_and_apply_side_effects(&message)
+            .unwrap();
+        store.commit_reparent_authority(&request_id).unwrap();
+        store.finish_reparent_routing(&request_id).unwrap();
+
+        let record = store.get_reparent_request(&request_id).unwrap().unwrap();
+        let intent = record
+            .deferred_routing_intents
+            .iter()
+            .find(|intent| intent.key == format!("delivered-planned-parent-wake:{message_id}"))
+            .unwrap();
+        assert!(intent.replayed_at.is_some());
+        assert_eq!(
+            intent.resolved_parent_session_id.as_deref(),
+            Some("newpar01")
+        );
+        assert_eq!(
+            queue
+                .active_parent_wake_parent("child001")
+                .unwrap()
+                .as_deref(),
+            Some("newpar01")
+        );
+
         let _ = fs::remove_file(state_file);
         let _ = fs::remove_file(queue_db);
     }

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1854,6 +1854,194 @@ impl SessionStore {
         Ok(ReparentMutationOutcome::Created(record))
     }
 
+    pub fn create_reparent_tree_request(
+        &self,
+        source_session_id: &str,
+        request: CreateReparentTreeRequest,
+        session_credential: &str,
+    ) -> Result<ReparentMutationOutcome> {
+        let source_session_id = source_session_id.trim();
+        let target_session_id = request.target_session_id.trim();
+        let requester_session_id = request.requester_session_id.trim();
+        if source_session_id.is_empty()
+            || target_session_id.is_empty()
+            || requester_session_id.is_empty()
+        {
+            return Ok(ReparentMutationOutcome::BadRequest(
+                "source, target, and requester session IDs are required".to_owned(),
+            ));
+        }
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = snapshot_from_raw_value(&state)?.into_sessions();
+        if !session_credential_matches(&sessions, requester_session_id, session_credential) {
+            return Ok(ReparentMutationOutcome::Forbidden(
+                "session credential is missing, stale, or does not match the claimed actor"
+                    .to_owned(),
+            ));
+        }
+        let Some(source) = sessions
+            .iter()
+            .find(|session| session.id == source_session_id)
+        else {
+            return Ok(ReparentMutationOutcome::SessionNotFound(
+                source_session_id.to_owned(),
+            ));
+        };
+        let Some(target) = sessions
+            .iter()
+            .find(|session| session.id == target_session_id)
+        else {
+            return Ok(ReparentMutationOutcome::SessionNotFound(
+                target_session_id.to_owned(),
+            ));
+        };
+        let mut blockers = Vec::new();
+        if !source.is_live_for_registry() {
+            blockers.push(format!("source session {source_session_id} is stopped"));
+        }
+        if !target.is_live_for_registry() {
+            blockers.push(format!("target session {target_session_id} is stopped"));
+        }
+        if target.parent_session_id.as_deref() != Some(source_session_id) {
+            blockers.push(format!(
+                "target session {target_session_id} is not a live direct child of {source_session_id}"
+            ));
+        }
+        let expected_parent_session_id = source.parent_session_id.clone();
+        let expected_parent_is_live = expected_parent_session_id.as_deref().is_some_and(|id| {
+            sessions
+                .iter()
+                .find(|session| session.id == id)
+                .is_some_and(SessionRecord::is_live_for_registry)
+        });
+        let initiator_allowed = requester_session_id == source_session_id
+            || requester_session_id == target_session_id
+            || (expected_parent_is_live
+                && expected_parent_session_id.as_deref() == Some(requester_session_id));
+        if !initiator_allowed {
+            return Ok(ReparentMutationOutcome::Forbidden(
+                "only the source, target, or live source parent may request tree promotion"
+                    .to_owned(),
+            ));
+        }
+        let frozen_live_child_ids = sessions
+            .iter()
+            .filter(|session| {
+                session.is_live_for_registry()
+                    && session.parent_session_id.as_deref() == Some(source_session_id)
+            })
+            .map(|session| session.id.clone())
+            .collect::<Vec<_>>();
+        let edge_changes = tree_reparent_edge_changes(
+            source_session_id,
+            target_session_id,
+            expected_parent_session_id.as_deref(),
+            &frozen_live_child_ids,
+        );
+        if reparent_plan_would_create_cycle(&sessions, &edge_changes) {
+            blockers.push("tree promotion would create a session hierarchy cycle".to_owned());
+        }
+        let (json_routing_changes, queue_routing_changes) =
+            self.build_reparent_routing_changes(&state, &edge_changes)?;
+        let mut required_agent_approvals =
+            BTreeSet::from([source_session_id.to_owned(), target_session_id.to_owned()]);
+        if expected_parent_is_live {
+            if let Some(parent) = expected_parent_session_id.as_ref() {
+                required_agent_approvals.insert(parent.clone());
+            }
+        }
+        let required_agent_approvals = required_agent_approvals.into_iter().collect::<Vec<_>>();
+        let required_human_approval =
+            expected_parent_session_id.is_some() && !expected_parent_is_live;
+        let preview = ReparentTreePreview {
+            kind: "tree".to_owned(),
+            source_session_id: source_session_id.to_owned(),
+            target_session_id: target_session_id.to_owned(),
+            frozen_live_child_ids: frozen_live_child_ids.clone(),
+            edge_changes,
+            json_routing_changes,
+            queue_routing_changes,
+            required_agent_approvals: required_agent_approvals.clone(),
+            required_human_approval,
+            blockers: blockers.clone(),
+        };
+        if request.dry_run {
+            return Ok(ReparentMutationOutcome::Preview(preview));
+        }
+        if let Some(blocker) = blockers.into_iter().next() {
+            return Ok(ReparentMutationOutcome::BadRequest(blocker));
+        }
+        let now = OffsetDateTime::now_utc();
+        let mut records = reparent_request_records(&state)?;
+        let _ = refresh_reparent_requests(&mut records, &sessions, now);
+        let affected_ids = preview
+            .edge_changes
+            .iter()
+            .map(|change| change.session_id.clone())
+            .chain(expected_parent_session_id.iter().cloned())
+            .collect::<BTreeSet<_>>();
+        if let Some(conflict) = records.iter().find(|record| {
+            record.is_active() && !record.affected_session_ids().is_disjoint(&affected_ids)
+        }) {
+            store_reparent_request_records(&mut state, &records)?;
+            self.write_raw_json_value(&state)?;
+            return Ok(ReparentMutationOutcome::Conflict(format!(
+                "request {} already controls part of the tree promotion",
+                conflict.id
+            )));
+        }
+        let created_at = now.format(&Rfc3339)?;
+        let expires_at =
+            (now + TimeDuration::hours(REPARENT_REQUEST_TTL_HOURS)).format(&Rfc3339)?;
+        let approvals = vec![ReparentApprovalRecord {
+            actor_kind: "agent".to_owned(),
+            actor_id: requester_session_id.to_owned(),
+            decision: "approved".to_owned(),
+            decided_at: created_at.clone(),
+        }];
+        let record = ReparentRequestRecord {
+            id: generate_unique_reparent_request_id(&records)?,
+            kind: "tree".to_owned(),
+            subject_session_id: source_session_id.to_owned(),
+            target_parent_session_id: target_session_id.to_owned(),
+            expected_parent_session_id,
+            expected_parent_is_live,
+            frozen_live_child_ids,
+            initiator_session_id: requester_session_id.to_owned(),
+            required_agent_approvals: required_agent_approvals.clone(),
+            required_human_approval,
+            ready_to_apply: approvals_satisfied(
+                &required_agent_approvals,
+                required_human_approval,
+                &approvals,
+            ),
+            approvals,
+            status: "pending".to_owned(),
+            created_at,
+            expires_at,
+            decided_at: None,
+            applied_at: None,
+            failure_reason: None,
+            topology_fingerprint: reparent_topology_fingerprint(
+                "tree",
+                source_session_id,
+                target_session_id,
+                source.parent_session_id.as_deref(),
+                &preview.frozen_live_child_ids,
+            ),
+            apply_stage: None,
+            apply_plan: None,
+            notification_intents: Vec::new(),
+            deferred_routing_intents: Vec::new(),
+            repair_history: Vec::new(),
+        };
+        records.push(record.clone());
+        store_reparent_request_records(&mut state, &records)?;
+        self.write_raw_json_value(&state)?;
+        Ok(ReparentMutationOutcome::Created(record))
+    }
+
     pub fn decide_reparent_request(
         &self,
         request_id: &str,
@@ -2281,21 +2469,23 @@ impl SessionStore {
         let queue_projection = if let (Some(queue), Some(plan)) =
             (self.queue_store.as_ref(), record.apply_plan.as_ref())
         {
-            let change = plan
-                .edge_changes
-                .first()
-                .context("verified reparent plan has no subject")?;
-            let parent = if record.status == "repaired" {
-                change.expected_parent_session_id.as_deref()
-            } else {
-                change.new_parent_session_id.as_deref()
-            };
-            match parent {
-                Some(parent) => serde_json::to_value(
-                    queue.snapshot_parent_routing(&change.session_id, parent)?,
-                )?,
-                None => serde_json::to_value(ParentRoutingSnapshot::default())?,
+            let mut projections = Vec::new();
+            for change in &plan.edge_changes {
+                let parent = if record.status == "repaired" {
+                    change.expected_parent_session_id.as_deref()
+                } else {
+                    change.new_parent_session_id.as_deref()
+                };
+                projections.push(json!({
+                    "session_id": change.session_id,
+                    "parent_session_id": parent,
+                    "routing": match parent {
+                        Some(parent) => queue.snapshot_parent_routing(&change.session_id, parent)?,
+                        None => ParentRoutingSnapshot::default(),
+                    },
+                }));
             }
+            Value::Array(projections)
         } else {
             Value::Null
         };
@@ -2337,7 +2527,9 @@ impl SessionStore {
             .iter()
             .enumerate()
             .filter(|(_, record)| {
-                record.kind == "single" && record.status == "pending" && record.ready_to_apply
+                matches!(record.kind.as_str(), "single" | "tree")
+                    && record.status == "pending"
+                    && record.ready_to_apply
             })
             .min_by(|(_, left), (_, right)| {
                 (&left.created_at, &left.id).cmp(&(&right.created_at, &right.id))
@@ -2357,7 +2549,7 @@ impl SessionStore {
             self.write_raw_json_value(&state)?;
             return Ok(None);
         }
-        let plan = self.build_single_reparent_apply_plan(&state, &records[index])?;
+        let plan = self.build_reparent_apply_plan(&state, &records[index])?;
         let request_id = records[index].id.clone();
         let acquired_at = now_rfc3339();
         records[index].status = "applying".to_owned();
@@ -2376,13 +2568,46 @@ impl SessionStore {
         Ok(Some(request_id))
     }
 
-    fn build_single_reparent_apply_plan(
+    fn build_reparent_apply_plan(
         &self,
         state: &Value,
         record: &ReparentRequestRecord,
     ) -> Result<ReparentApplyPlan> {
+        let edge_changes = if record.kind == "tree" {
+            tree_reparent_edge_changes(
+                &record.subject_session_id,
+                &record.target_parent_session_id,
+                record.expected_parent_session_id.as_deref(),
+                &record.frozen_live_child_ids,
+            )
+        } else {
+            vec![ReparentEdgeChange {
+                session_id: record.subject_session_id.clone(),
+                expected_parent_session_id: record.expected_parent_session_id.clone(),
+                new_parent_session_id: Some(record.target_parent_session_id.clone()),
+            }]
+        };
+        let (json_routing_changes, queue_routing_changes) =
+            self.build_reparent_routing_changes(state, &edge_changes)?;
+        Ok(ReparentApplyPlan {
+            version: 1,
+            edge_changes,
+            json_routing_changes,
+            queue_routing_changes,
+        })
+    }
+
+    fn build_reparent_routing_changes(
+        &self,
+        state: &Value,
+        edge_changes: &[ReparentEdgeChange],
+    ) -> Result<(Vec<ReparentRoutingChange>, Vec<ReparentRoutingChange>)> {
         let mut json_routing_changes = Vec::new();
-        if let Some(old_parent) = record.expected_parent_session_id.as_deref() {
+        let mut queue_routing_changes = Vec::new();
+        for edge in edge_changes {
+            let Some(old_parent) = edge.expected_parent_session_id.as_deref() else {
+                continue;
+            };
             for entry in state
                 .get("retained_parent_wake_registrations")
                 .and_then(Value::as_array)
@@ -2390,7 +2615,7 @@ impl SessionStore {
                 .flatten()
                 .filter(|entry| {
                     entry.get("child_session_id").and_then(Value::as_str)
-                        == Some(record.subject_session_id.as_str())
+                        == Some(edge.session_id.as_str())
                         && json_text(entry.get("parent_session_id")).as_deref() == Some(old_parent)
                         && entry
                             .get("is_active")
@@ -2401,7 +2626,7 @@ impl SessionStore {
                 let record_id = json_text(entry.get("id")).ok_or_else(|| {
                     anyhow::anyhow!(
                         "parent wake for {} is missing its durable ID",
-                        record.subject_session_id
+                        edge.session_id
                     )
                 })?;
                 let period_seconds = entry
@@ -2414,28 +2639,26 @@ impl SessionStore {
                     store: "json".to_owned(),
                     record_kind: "parent_wake".to_owned(),
                     record_id,
-                    child_session_id: record.subject_session_id.clone(),
+                    child_session_id: edge.session_id.clone(),
                     expected_target_session_id: Some(old_parent.to_owned()),
-                    new_target_session_id: Some(record.target_parent_session_id.clone()),
+                    new_target_session_id: edge.new_parent_session_id.clone(),
                     prior_active: Some(true),
                     period_seconds: Some(period_seconds),
                     creates_parent_wake: false,
                 });
             }
-            if let Some(session) =
-                raw_session_object(state, &record.subject_session_id).filter(|session| {
-                    json_text(session.get("context_monitor_notify")).as_deref() == Some(old_parent)
-                        && json_text(session.get("context_monitor_notify_source")).as_deref()
-                            == Some("parent_derived")
-                })
-            {
+            if let Some(session) = raw_session_object(state, &edge.session_id).filter(|session| {
+                json_text(session.get("context_monitor_notify")).as_deref() == Some(old_parent)
+                    && json_text(session.get("context_monitor_notify_source")).as_deref()
+                        == Some("parent_derived")
+            }) {
                 json_routing_changes.push(ReparentRoutingChange {
                     store: "json".to_owned(),
                     record_kind: "context_monitor".to_owned(),
-                    record_id: record.subject_session_id.clone(),
-                    child_session_id: record.subject_session_id.clone(),
+                    record_id: edge.session_id.clone(),
+                    child_session_id: edge.session_id.clone(),
                     expected_target_session_id: Some(old_parent.to_owned()),
-                    new_target_session_id: Some(record.target_parent_session_id.clone()),
+                    new_target_session_id: edge.new_parent_session_id.clone(),
                     prior_active: Some(
                         session
                             .get("context_monitor_enabled")
@@ -2446,54 +2669,38 @@ impl SessionStore {
                     creates_parent_wake: false,
                 });
             }
+            let queue_snapshot = match self.queue_store.as_ref() {
+                Some(queue) => queue.snapshot_parent_routing(&edge.session_id, old_parent)?,
+                None => ParentRoutingSnapshot::default(),
+            };
+            queue_routing_changes.extend(queue_snapshot.wake_rows.into_iter().map(|row| {
+                ReparentRoutingChange {
+                    store: "queue".to_owned(),
+                    record_kind: "parent_wake".to_owned(),
+                    record_id: row.id,
+                    child_session_id: row.child_session_id,
+                    expected_target_session_id: Some(row.parent_session_id),
+                    new_target_session_id: edge.new_parent_session_id.clone(),
+                    prior_active: Some(row.is_active),
+                    period_seconds: Some(row.period_seconds),
+                    creates_parent_wake: false,
+                }
+            }));
+            queue_routing_changes.extend(queue_snapshot.message_rows.into_iter().map(|row| {
+                ReparentRoutingChange {
+                    store: "queue".to_owned(),
+                    record_kind: "message".to_owned(),
+                    record_id: row.id,
+                    child_session_id: row.child_session_id,
+                    expected_target_session_id: Some(row.parent_session_id),
+                    new_target_session_id: edge.new_parent_session_id.clone(),
+                    prior_active: None,
+                    period_seconds: None,
+                    creates_parent_wake: row.creates_parent_wake,
+                }
+            }));
         }
-        let queue_snapshot = match (
-            self.queue_store.as_ref(),
-            record.expected_parent_session_id.as_deref(),
-        ) {
-            (Some(queue), Some(old_parent)) => {
-                queue.snapshot_parent_routing(&record.subject_session_id, old_parent)?
-            }
-            _ => ParentRoutingSnapshot::default(),
-        };
-        let mut queue_routing_changes = queue_snapshot
-            .wake_rows
-            .into_iter()
-            .map(|row| ReparentRoutingChange {
-                store: "queue".to_owned(),
-                record_kind: "parent_wake".to_owned(),
-                record_id: row.id,
-                child_session_id: row.child_session_id,
-                expected_target_session_id: Some(row.parent_session_id),
-                new_target_session_id: Some(record.target_parent_session_id.clone()),
-                prior_active: Some(row.is_active),
-                period_seconds: Some(row.period_seconds),
-                creates_parent_wake: false,
-            })
-            .collect::<Vec<_>>();
-        queue_routing_changes.extend(queue_snapshot.message_rows.into_iter().map(|row| {
-            ReparentRoutingChange {
-                store: "queue".to_owned(),
-                record_kind: "message".to_owned(),
-                record_id: row.id,
-                child_session_id: row.child_session_id,
-                expected_target_session_id: Some(row.parent_session_id),
-                new_target_session_id: Some(record.target_parent_session_id.clone()),
-                prior_active: None,
-                period_seconds: None,
-                creates_parent_wake: row.creates_parent_wake,
-            }
-        }));
-        Ok(ReparentApplyPlan {
-            version: 1,
-            edge_changes: vec![ReparentEdgeChange {
-                session_id: record.subject_session_id.clone(),
-                expected_parent_session_id: record.expected_parent_session_id.clone(),
-                new_parent_session_id: Some(record.target_parent_session_id.clone()),
-            }],
-            json_routing_changes,
-            queue_routing_changes,
-        })
+        Ok((json_routing_changes, queue_routing_changes))
     }
 
     fn apply_reparent_request(&self, request_id: &str) -> Result<()> {
@@ -2612,7 +2819,7 @@ impl SessionStore {
     }
 
     fn finish_reparent_routing(&self, request_id: &str) -> Result<()> {
-        let (snapshot, new_parent_session_id) = {
+        let route_groups = {
             let _guard = self.write_guard()?;
             let state = self.load_raw_json_value()?;
             let records = reparent_request_records(&state)?;
@@ -2621,22 +2828,20 @@ impl SessionStore {
                 .apply_plan
                 .as_ref()
                 .context("reparent apply plan is missing")?;
-            let new_parent = plan
-                .edge_changes
-                .first()
-                .and_then(|change| change.new_parent_session_id.clone())
-                .context("reparent apply plan has no target parent")?;
-            (queue_snapshot_from_plan(plan)?, new_parent)
+            queue_route_groups_from_plan(plan, false)?
         };
-        let delivered_message_rows = if let Some(queue) = self.queue_store.as_ref() {
-            queue
-                .retarget_parent_routing(&snapshot, &new_parent_session_id)?
-                .delivered_message_rows
-        } else if !snapshot.wake_rows.is_empty() || !snapshot.message_rows.is_empty() {
-            anyhow::bail!("reparent plan requires the retained queue store")
-        } else {
-            Vec::new()
-        };
+        let mut delivered_message_rows = Vec::new();
+        for (snapshot, parent) in route_groups {
+            if let Some(queue) = self.queue_store.as_ref() {
+                delivered_message_rows.extend(
+                    queue
+                        .retarget_parent_routing(&snapshot, parent.as_deref())?
+                        .delivered_message_rows,
+                );
+            } else if !snapshot.wake_rows.is_empty() || !snapshot.message_rows.is_empty() {
+                anyhow::bail!("reparent plan requires the retained queue store")
+            }
+        }
         self.persist_delivered_reparent_wake_intents(request_id, &delivered_message_rows)?;
         let mut replay_targets = BTreeSet::new();
         loop {
@@ -3030,7 +3235,7 @@ impl SessionStore {
         request_id: &str,
         stale_reason: Option<&str>,
     ) -> Result<()> {
-        let (plan, snapshot, old_parent) = {
+        let (plan, route_groups) = {
             let _guard = self.write_guard()?;
             let state = self.load_raw_json_value()?;
             let records = reparent_request_records(&state)?;
@@ -3045,31 +3250,20 @@ impl SessionStore {
                 .apply_plan
                 .clone()
                 .context("reparent apply plan is missing")?;
-            let old_parent = plan
-                .edge_changes
-                .first()
-                .context("reparent apply plan has no edge changes")?
-                .expected_parent_session_id
-                .clone();
-            (plan.clone(), queue_snapshot_from_plan(&plan)?, old_parent)
+            (plan.clone(), queue_route_groups_from_plan(&plan, true)?)
         };
-        let delivered_message_rows = match (self.queue_store.as_ref(), old_parent.as_deref()) {
-            (Some(queue), Some(old_parent)) => {
-                queue
-                    .retarget_parent_routing(&snapshot, old_parent)?
-                    .delivered_message_rows
-            }
-            (_, None) if snapshot.wake_rows.is_empty() && snapshot.message_rows.is_empty() => {
-                Vec::new()
-            }
-            (_, None) => anyhow::bail!("parentless reparent plan contains old-parent routes"),
-            (None, Some(_))
-                if !snapshot.wake_rows.is_empty() || !snapshot.message_rows.is_empty() =>
-            {
+        let mut delivered_message_rows = Vec::new();
+        for (snapshot, parent) in route_groups {
+            if let Some(queue) = self.queue_store.as_ref() {
+                delivered_message_rows.extend(
+                    queue
+                        .retarget_parent_routing(&snapshot, parent.as_deref())?
+                        .delivered_message_rows,
+                );
+            } else if !snapshot.wake_rows.is_empty() || !snapshot.message_rows.is_empty() {
                 anyhow::bail!("reparent plan requires the retained queue store")
             }
-            (None, Some(_)) => Vec::new(),
-        };
+        }
         self.persist_delivered_reparent_wake_intents(request_id, &delivered_message_rows)?;
         {
             let _guard = self.write_guard()?;
@@ -7772,6 +7966,14 @@ pub struct CreateReparentRequest {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct CreateReparentTreeRequest {
+    pub requester_session_id: String,
+    pub target_session_id: String,
+    #[serde(default)]
+    pub dry_run: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
 pub struct DecideReparentRequest {
     pub requester_session_id: String,
 }
@@ -8154,6 +8356,7 @@ pub enum ContextMonitorOutcome {
 pub enum ReparentMutationOutcome {
     Created(ReparentRequestRecord),
     Updated(ReparentRequestRecord),
+    Preview(ReparentTreePreview),
     SessionNotFound(String),
     RequestNotFound,
     BadRequest(String),
@@ -11575,6 +11778,52 @@ fn queue_snapshot_from_plan(plan: &ReparentApplyPlan) -> Result<ParentRoutingSna
     Ok(snapshot)
 }
 
+fn queue_route_groups_from_plan(
+    plan: &ReparentApplyPlan,
+    restore_old_targets: bool,
+) -> Result<Vec<(ParentRoutingSnapshot, Option<String>)>> {
+    let mut groups = BTreeMap::<Option<String>, ParentRoutingSnapshot>::new();
+    for change in &plan.queue_routing_changes {
+        if change.store != "queue" {
+            anyhow::bail!("queue routing plan contains store {}", change.store);
+        }
+        let old_parent = change
+            .expected_target_session_id
+            .clone()
+            .with_context(|| format!("routing change {} has no old parent", change.record_id))?;
+        let target = if restore_old_targets {
+            Some(old_parent.clone())
+        } else {
+            change.new_target_session_id.clone()
+        };
+        let snapshot = groups.entry(target).or_default();
+        match change.record_kind.as_str() {
+            "parent_wake" => snapshot.wake_rows.push(ParentRoutingWakeRow {
+                id: change.record_id.clone(),
+                child_session_id: change.child_session_id.clone(),
+                parent_session_id: old_parent,
+                period_seconds: change
+                    .period_seconds
+                    .with_context(|| format!("parent wake {} has no period", change.record_id))?,
+                is_active: change.prior_active.with_context(|| {
+                    format!("parent wake {} has no active state", change.record_id)
+                })?,
+            }),
+            "message" => snapshot.message_rows.push(ParentRoutingMessageRow {
+                id: change.record_id.clone(),
+                child_session_id: change.child_session_id.clone(),
+                parent_session_id: old_parent,
+                creates_parent_wake: change.creates_parent_wake,
+            }),
+            other => anyhow::bail!("unsupported queue routing record kind {other}"),
+        }
+    }
+    Ok(groups
+        .into_iter()
+        .map(|(target, snapshot)| (snapshot, target))
+        .collect())
+}
+
 fn quiesce_json_reparent_routes(state: &mut Value, plan: &ReparentApplyPlan) -> Result<()> {
     for change in &plan.json_routing_changes {
         match change.record_kind.as_str() {
@@ -11626,10 +11875,6 @@ fn commit_json_reparent_plan(state: &mut Value, plan: &ReparentApplyPlan) -> Res
         );
     }
     for change in &plan.json_routing_changes {
-        let new_parent = change
-            .new_target_session_id
-            .clone()
-            .with_context(|| format!("routing change {} has no new parent", change.record_id))?;
         match change.record_kind.as_str() {
             "parent_wake" => {
                 let registrations =
@@ -11642,10 +11887,18 @@ fn commit_json_reparent_plan(state: &mut Value, plan: &ReparentApplyPlan) -> Res
                     .as_object_mut()
                     .context("parent wake record must be an object")?;
                 validate_json_parent_route(object, change, false)?;
-                object.insert("parent_session_id".to_owned(), Value::String(new_parent));
+                if let Some(new_parent) = change.new_target_session_id.as_ref() {
+                    object.insert(
+                        "parent_session_id".to_owned(),
+                        Value::String(new_parent.clone()),
+                    );
+                }
                 object.insert(
                     "is_active".to_owned(),
-                    Value::Bool(change.prior_active.unwrap_or(false)),
+                    Value::Bool(
+                        change.new_target_session_id.is_some()
+                            && change.prior_active.unwrap_or(false),
+                    ),
                 );
             }
             "context_monitor" => {
@@ -11655,11 +11908,18 @@ fn commit_json_reparent_plan(state: &mut Value, plan: &ReparentApplyPlan) -> Res
                 validate_json_parent_route(session, change, false)?;
                 session.insert(
                     "context_monitor_notify".to_owned(),
-                    Value::String(new_parent),
+                    change
+                        .new_target_session_id
+                        .clone()
+                        .map(Value::String)
+                        .unwrap_or(Value::Null),
                 );
                 session.insert(
                     "context_monitor_enabled".to_owned(),
-                    Value::Bool(change.prior_active.unwrap_or(false)),
+                    Value::Bool(
+                        change.new_target_session_id.is_some()
+                            && change.prior_active.unwrap_or(false),
+                    ),
                 );
             }
             other => anyhow::bail!("unsupported JSON routing record kind {other}"),
@@ -12053,7 +12313,32 @@ fn reparent_stale_reason(
     if !target.is_live_for_registry() {
         return Some("target parent session is no longer live".to_owned());
     }
-    if reparent_would_create_cycle(
+    if record.kind == "tree" {
+        if target.parent_session_id.as_deref() != Some(&record.subject_session_id) {
+            return Some("tree target is no longer a direct child of the source".to_owned());
+        }
+        let current_live_children = sessions
+            .iter()
+            .filter(|session| {
+                session.is_live_for_registry()
+                    && session.parent_session_id.as_deref()
+                        == Some(record.subject_session_id.as_str())
+            })
+            .map(|session| session.id.clone())
+            .collect::<Vec<_>>();
+        if current_live_children != record.frozen_live_child_ids {
+            return Some("source live-child set changed after request creation".to_owned());
+        }
+        let changes = tree_reparent_edge_changes(
+            &record.subject_session_id,
+            &record.target_parent_session_id,
+            record.expected_parent_session_id.as_deref(),
+            &record.frozen_live_child_ids,
+        );
+        if reparent_plan_would_create_cycle(sessions, &changes) {
+            return Some("current tree plan would create a hierarchy cycle".to_owned());
+        }
+    } else if reparent_would_create_cycle(
         sessions,
         &record.subject_session_id,
         &record.target_parent_session_id,
@@ -12061,6 +12346,64 @@ fn reparent_stale_reason(
         return Some("current topology would create a hierarchy cycle".to_owned());
     }
     None
+}
+
+fn tree_reparent_edge_changes(
+    source_session_id: &str,
+    target_session_id: &str,
+    source_parent_session_id: Option<&str>,
+    frozen_live_child_ids: &[String],
+) -> Vec<ReparentEdgeChange> {
+    let mut changes = vec![
+        ReparentEdgeChange {
+            session_id: target_session_id.to_owned(),
+            expected_parent_session_id: Some(source_session_id.to_owned()),
+            new_parent_session_id: source_parent_session_id.map(ToOwned::to_owned),
+        },
+        ReparentEdgeChange {
+            session_id: source_session_id.to_owned(),
+            expected_parent_session_id: source_parent_session_id.map(ToOwned::to_owned),
+            new_parent_session_id: Some(target_session_id.to_owned()),
+        },
+    ];
+    changes.extend(
+        frozen_live_child_ids
+            .iter()
+            .filter(|child| child.as_str() != target_session_id)
+            .map(|child| ReparentEdgeChange {
+                session_id: child.clone(),
+                expected_parent_session_id: Some(source_session_id.to_owned()),
+                new_parent_session_id: Some(target_session_id.to_owned()),
+            }),
+    );
+    changes
+}
+
+fn reparent_plan_would_create_cycle(
+    sessions: &[SessionRecord],
+    changes: &[ReparentEdgeChange],
+) -> bool {
+    let mut parents = sessions
+        .iter()
+        .map(|session| (session.id.clone(), session.parent_session_id.clone()))
+        .collect::<BTreeMap<_, _>>();
+    for change in changes {
+        parents.insert(
+            change.session_id.clone(),
+            change.new_parent_session_id.clone(),
+        );
+    }
+    for start in parents.keys() {
+        let mut current = Some(start.as_str());
+        let mut visited = BTreeSet::new();
+        while let Some(id) = current {
+            if !visited.insert(id.to_owned()) {
+                return true;
+            }
+            current = parents.get(id).and_then(|parent| parent.as_deref());
+        }
+    }
+    false
 }
 
 fn reparent_would_create_cycle(
@@ -12393,6 +12736,20 @@ pub struct ReparentApplyPlan {
     pub json_routing_changes: Vec<ReparentRoutingChange>,
     #[serde(default)]
     pub queue_routing_changes: Vec<ReparentRoutingChange>,
+}
+
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct ReparentTreePreview {
+    pub kind: String,
+    pub source_session_id: String,
+    pub target_session_id: String,
+    pub frozen_live_child_ids: Vec<String>,
+    pub edge_changes: Vec<ReparentEdgeChange>,
+    pub json_routing_changes: Vec<ReparentRoutingChange>,
+    pub queue_routing_changes: Vec<ReparentRoutingChange>,
+    pub required_agent_approvals: Vec<String>,
+    pub required_human_approval: bool,
+    pub blockers: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -17503,6 +17860,253 @@ mod tests {
             store.retire_core_session("child001", Some("newpar01")),
             Ok(CoreRetireOutcome::Retired(_))
         ));
+
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
+    fn approved_tree_reparent_splits_queue_routes_across_each_new_parent() {
+        let state_file = unique_temp_path("reparent-tree-routing");
+        let queue_db = state_file.with_extension("db");
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [
+                    reparent_test_session("grand001", None, "grand-secret"),
+                    reparent_test_session("source01", Some("grand001"), "source-secret"),
+                    reparent_test_session("target01", Some("source01"), "target-secret"),
+                    reparent_test_session("sibling1", Some("source01"), "sibling-secret")
+                ]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let queue = RetainedQueueStore::new(queue_db.clone());
+        queue.ensure_schema().unwrap();
+        let mut message_ids = BTreeMap::new();
+        for (child, parent) in [
+            ("source01", "grand001"),
+            ("target01", "source01"),
+            ("sibling1", "source01"),
+        ] {
+            queue.register_parent_wake(child, parent, 600).unwrap();
+            let message_id = queue
+                .enqueue_message_with_metadata(
+                    child,
+                    &format!("pending for {child}"),
+                    "important",
+                    QueueMessageMetadata {
+                        parent_session_id: Some(parent.to_owned()),
+                        ..QueueMessageMetadata::default()
+                    },
+                )
+                .unwrap();
+            message_ids.insert(child, message_id);
+        }
+        let store = SessionStore::new_with_queue(state_file.clone(), queue_db.clone());
+        let request = match store
+            .create_reparent_tree_request(
+                "source01",
+                CreateReparentTreeRequest {
+                    requester_session_id: "source01".to_owned(),
+                    target_session_id: "target01".to_owned(),
+                    dry_run: false,
+                },
+                "source-secret",
+            )
+            .unwrap()
+        {
+            ReparentMutationOutcome::Created(record) => record,
+            other => panic!("unexpected create outcome: {other:?}"),
+        };
+        let pending = match store
+            .decide_reparent_request(
+                &request.id,
+                DecideReparentRequest {
+                    requester_session_id: "target01".to_owned(),
+                },
+                ReparentDecision::Approved,
+                "target-secret",
+            )
+            .unwrap()
+        {
+            ReparentMutationOutcome::Updated(record) => record,
+            other => panic!("unexpected target approval outcome: {other:?}"),
+        };
+        assert_eq!(pending.status, "pending");
+        let applied = match store
+            .decide_reparent_request(
+                &request.id,
+                DecideReparentRequest {
+                    requester_session_id: "grand001".to_owned(),
+                },
+                ReparentDecision::Approved,
+                "grand-secret",
+            )
+            .unwrap()
+        {
+            ReparentMutationOutcome::Updated(record) => record,
+            other => panic!("unexpected grandparent approval outcome: {other:?}"),
+        };
+        assert_eq!(applied.status, "applied");
+
+        for (child, parent) in [
+            ("source01", "target01"),
+            ("target01", "grand001"),
+            ("sibling1", "target01"),
+        ] {
+            assert_eq!(
+                store
+                    .get_session(child)
+                    .unwrap()
+                    .unwrap()
+                    .parent_session_id
+                    .as_deref(),
+                Some(parent)
+            );
+            assert_eq!(
+                queue.active_parent_wake_parent(child).unwrap().as_deref(),
+                Some(parent)
+            );
+            let pending = queue.pending_messages_for_target(child, 10).unwrap();
+            assert_eq!(
+                pending
+                    .iter()
+                    .find(|message| message.id == message_ids[child])
+                    .and_then(|message| message.parent_session_id.as_deref()),
+                Some(parent)
+            );
+        }
+
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
+    fn failed_tree_reparent_restores_every_queue_route_before_releasing_lease() {
+        let state_file = unique_temp_path("reparent-tree-rollback");
+        let queue_db = state_file.with_extension("db");
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [
+                    reparent_test_session("grand001", None, "grand-secret"),
+                    reparent_test_session("source01", Some("grand001"), "source-secret"),
+                    reparent_test_session("target01", Some("source01"), "target-secret"),
+                    reparent_test_session("sibling1", Some("source01"), "sibling-secret")
+                ]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let queue = RetainedQueueStore::new(queue_db.clone());
+        queue.ensure_schema().unwrap();
+        for (child, parent) in [
+            ("source01", "grand001"),
+            ("target01", "source01"),
+            ("sibling1", "source01"),
+        ] {
+            queue.register_parent_wake(child, parent, 600).unwrap();
+            queue
+                .enqueue_message_with_metadata(
+                    child,
+                    &format!("pending for {child}"),
+                    "important",
+                    QueueMessageMetadata {
+                        parent_session_id: Some(parent.to_owned()),
+                        ..QueueMessageMetadata::default()
+                    },
+                )
+                .unwrap();
+        }
+        let store = SessionStore::new_with_queue(state_file.clone(), queue_db.clone());
+        let request = match store
+            .create_reparent_tree_request(
+                "source01",
+                CreateReparentTreeRequest {
+                    requester_session_id: "source01".to_owned(),
+                    target_session_id: "target01".to_owned(),
+                    dry_run: false,
+                },
+                "source-secret",
+            )
+            .unwrap()
+        {
+            ReparentMutationOutcome::Created(record) => record,
+            other => panic!("unexpected create outcome: {other:?}"),
+        };
+        {
+            let _guard = store.write_guard().unwrap();
+            let mut state = store.load_raw_json_value().unwrap();
+            let mut records = reparent_request_records(&state).unwrap();
+            let record = records
+                .iter_mut()
+                .find(|record| record.id == request.id)
+                .unwrap();
+            for actor_id in ["target01", "grand001"] {
+                record.approvals.push(ReparentApprovalRecord {
+                    actor_kind: "agent".to_owned(),
+                    actor_id: actor_id.to_owned(),
+                    decision: "approved".to_owned(),
+                    decided_at: now_rfc3339(),
+                });
+            }
+            record.ready_to_apply = true;
+            store_reparent_request_records(&mut state, &records).unwrap();
+            store.write_raw_json_value(&state).unwrap();
+        }
+        assert_eq!(
+            store.acquire_reparent_apply_lease().unwrap().as_deref(),
+            Some(request.id.as_str())
+        );
+        store.quiesce_reparent_json_routing(&request.id).unwrap();
+        store.quiesce_reparent_queue_routing(&request.id).unwrap();
+        store
+            .fail_reparent_apply(&request.id, "injected tree precommit failure")
+            .unwrap();
+        let repaired = match store
+            .repair_reparent_request(
+                &request.id,
+                "owner@example.com",
+                ReparentRepairAction::RollbackPrecommit,
+            )
+            .unwrap()
+        {
+            ReparentMutationOutcome::Updated(record) => record,
+            other => panic!("unexpected repair outcome: {other:?}"),
+        };
+        assert_eq!(repaired.status, "repaired");
+        assert!(repaired.repair_history[0]
+            .verified_state_fingerprint
+            .is_some());
+        for (child, parent) in [
+            ("source01", "grand001"),
+            ("target01", "source01"),
+            ("sibling1", "source01"),
+        ] {
+            assert_eq!(
+                store
+                    .get_session(child)
+                    .unwrap()
+                    .unwrap()
+                    .parent_session_id
+                    .as_deref(),
+                Some(parent)
+            );
+            assert_eq!(
+                queue.active_parent_wake_parent(child).unwrap().as_deref(),
+                Some(parent)
+            );
+            assert_eq!(
+                queue.pending_messages_for_target(child, 10).unwrap()[0]
+                    .parent_session_id
+                    .as_deref(),
+                Some(parent)
+            );
+        }
+        let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+        assert!(state["reparent_apply_lease"].is_null());
 
         let _ = fs::remove_file(state_file);
         let _ = fs::remove_file(queue_db);

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -2234,11 +2234,12 @@ impl SessionStore {
                 }
             }
         }
-        if self
+        let repaired = self
             .get_reparent_request(request_id)?
-            .is_some_and(|record| matches!(record.status.as_str(), "applied" | "repaired"))
-        {
+            .filter(|record| matches!(record.status.as_str(), "applied" | "repaired"));
+        if repaired.is_some() {
             self.verify_reparent_repair(request_id, &attempted_at)?;
+            self.reconcile_reparent_requests()?;
         }
         Ok(self
             .get_reparent_request(request_id)?
@@ -2280,23 +2281,21 @@ impl SessionStore {
         let queue_projection = if let (Some(queue), Some(plan)) =
             (self.queue_store.as_ref(), record.apply_plan.as_ref())
         {
-            let parent = plan
+            let change = plan
                 .edge_changes
                 .first()
-                .and_then(|change| {
-                    if record.status == "repaired" {
-                        change.expected_parent_session_id.as_deref()
-                    } else {
-                        change.new_parent_session_id.as_deref()
-                    }
-                })
-                .context("verified reparent plan has no resolved parent")?;
-            let child = plan
-                .edge_changes
-                .first()
-                .map(|change| change.session_id.as_str())
                 .context("verified reparent plan has no subject")?;
-            serde_json::to_value(queue.snapshot_parent_routing(child, parent)?)?
+            let parent = if record.status == "repaired" {
+                change.expected_parent_session_id.as_deref()
+            } else {
+                change.new_parent_session_id.as_deref()
+            };
+            match parent {
+                Some(parent) => serde_json::to_value(
+                    queue.snapshot_parent_routing(&change.session_id, parent)?,
+                )?,
+                None => serde_json::to_value(ParentRoutingSnapshot::default())?,
+            }
         } else {
             Value::Null
         };
@@ -3015,18 +3014,27 @@ impl SessionStore {
             let old_parent = plan
                 .edge_changes
                 .first()
-                .and_then(|change| change.expected_parent_session_id.clone())
-                .context("pre-commit rollback requires an old parent")?;
+                .context("reparent apply plan has no edge changes")?
+                .expected_parent_session_id
+                .clone();
             (plan.clone(), queue_snapshot_from_plan(&plan)?, old_parent)
         };
-        let delivered_message_rows = if let Some(queue) = self.queue_store.as_ref() {
-            queue
-                .retarget_parent_routing(&snapshot, &old_parent)?
-                .delivered_message_rows
-        } else if !snapshot.wake_rows.is_empty() || !snapshot.message_rows.is_empty() {
-            anyhow::bail!("reparent plan requires the retained queue store")
-        } else {
-            Vec::new()
+        let delivered_message_rows = match (self.queue_store.as_ref(), old_parent.as_deref()) {
+            (Some(queue), Some(old_parent)) => {
+                queue
+                    .retarget_parent_routing(&snapshot, old_parent)?
+                    .delivered_message_rows
+            }
+            (_, None) if snapshot.wake_rows.is_empty() && snapshot.message_rows.is_empty() => {
+                Vec::new()
+            }
+            (_, None) => anyhow::bail!("parentless reparent plan contains old-parent routes"),
+            (None, Some(_))
+                if !snapshot.wake_rows.is_empty() || !snapshot.message_rows.is_empty() =>
+            {
+                anyhow::bail!("reparent plan requires the retained queue store")
+            }
+            (None, Some(_)) => Vec::new(),
         };
         self.persist_delivered_reparent_wake_intents(request_id, &delivered_message_rows)?;
         {
@@ -3510,6 +3518,8 @@ impl SessionStore {
             if let Some(request_id) = active_reparent_route_request_for_session(&state, session_id)?
             {
                 let key = format!("parent-input:{}", generate_session_id());
+                let metadata =
+                    queue_metadata_for_send_request(&state, session_id, &request, sender_name);
                 persist_deferred_parent_input_intent(
                     &mut state,
                     &request_id,
@@ -3517,8 +3527,7 @@ impl SessionStore {
                     session_id,
                     &queued_text,
                     &delivery_mode,
-                    &request,
-                    sender_name.as_deref(),
+                    &metadata,
                 )?;
                 self.write_raw_json_value(&state)?;
                 return Ok(Some(CoreInputResult {
@@ -8520,8 +8529,7 @@ fn persist_deferred_parent_input_intent(
     target_session_id: &str,
     text: &str,
     delivery_mode: &str,
-    request: &SendCoreInputRequest,
-    sender_name: Option<&str>,
+    metadata: &QueueMessageMetadata,
 ) -> Result<()> {
     let mut records = reparent_request_records(state)?;
     let record = records
@@ -8542,16 +8550,16 @@ fn persist_deferred_parent_input_intent(
                 payload: json!({
                     "text": text,
                     "delivery_mode": delivery_mode,
-                    "sender_session_id": request.sender_session_id,
-                    "sender_name": sender_name,
-                    "from_sm_send": request.from_sm_send,
-                    "timeout_seconds": request.timeout_seconds,
-                    "notify_on_delivery": request.notify_on_delivery,
-                    "notify_after_seconds": request.notify_after_seconds,
-                    "notify_on_stop": request.notify_on_stop,
-                    "remind_soft_threshold": request.remind_soft_threshold,
-                    "remind_hard_threshold": request.remind_hard_threshold,
-                    "remind_cancel_on_reply_session_id": request.remind_cancel_on_reply_session_id,
+                    "sender_session_id": metadata.sender_session_id,
+                    "sender_name": metadata.sender_name,
+                    "from_sm_send": metadata.from_sm_send,
+                    "timeout_seconds": metadata.timeout_seconds,
+                    "notify_on_delivery": metadata.notify_on_delivery,
+                    "notify_after_seconds": metadata.notify_after_seconds,
+                    "notify_on_stop": metadata.notify_on_stop,
+                    "remind_soft_threshold": metadata.remind_soft_threshold,
+                    "remind_hard_threshold": metadata.remind_hard_threshold,
+                    "remind_cancel_on_reply_session_id": metadata.remind_cancel_on_reply_session_id,
                 }),
                 created_at: now_rfc3339(),
                 replayed_at: None,
@@ -17517,6 +17525,86 @@ mod tests {
     }
 
     #[test]
+    fn parentless_precommit_reparent_rolls_back_without_stranding_the_lease() {
+        let state_file = unique_temp_path("reparent-parentless-rollback");
+        let queue_db = state_file.with_extension("db");
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [
+                    reparent_test_session("newpar01", None, "new-parent-secret"),
+                    reparent_test_session("child001", None, "child-secret")
+                ]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let queue = RetainedQueueStore::new(queue_db.clone());
+        queue.ensure_schema().unwrap();
+        let store = SessionStore::new_with_queue(state_file.clone(), queue_db.clone());
+        let request = match store
+            .create_reparent_request(
+                "child001",
+                CreateReparentRequest {
+                    requester_session_id: "newpar01".to_owned(),
+                    target_parent_session_id: "newpar01".to_owned(),
+                },
+                "new-parent-secret",
+            )
+            .unwrap()
+        {
+            ReparentMutationOutcome::Created(record) => record,
+            other => panic!("unexpected create outcome: {other:?}"),
+        };
+        {
+            let _guard = store.write_guard().unwrap();
+            let mut state = store.load_raw_json_value().unwrap();
+            let mut records = reparent_request_records(&state).unwrap();
+            let record = records
+                .iter_mut()
+                .find(|record| record.id == request.id)
+                .unwrap();
+            record.approvals.push(ReparentApprovalRecord {
+                actor_kind: "human".to_owned(),
+                actor_id: "owner@example.com".to_owned(),
+                decision: "approved".to_owned(),
+                decided_at: now_rfc3339(),
+            });
+            record.ready_to_apply = true;
+            store_reparent_request_records(&mut state, &records).unwrap();
+            store.write_raw_json_value(&state).unwrap();
+        }
+
+        store.acquire_reparent_apply_lease().unwrap();
+        store.quiesce_reparent_json_routing(&request.id).unwrap();
+        store.quiesce_reparent_queue_routing(&request.id).unwrap();
+        store
+            .fail_reparent_apply(&request.id, "injected parentless failure")
+            .unwrap();
+        let repaired = store
+            .repair_reparent_request(
+                &request.id,
+                "owner@example.com",
+                ReparentRepairAction::RollbackPrecommit,
+            )
+            .unwrap();
+        assert!(matches!(repaired, ReparentMutationOutcome::Updated(_)));
+
+        let state = store.load_raw_json_value().unwrap();
+        assert!(state["reparent_apply_lease"].is_null());
+        assert!(raw_session_object(&state, "child001")
+            .unwrap()
+            .get("parent_session_id")
+            .is_none_or(Value::is_null));
+        let record = store.get_reparent_request(&request.id).unwrap().unwrap();
+        assert_eq!(record.status, "repaired");
+        assert_eq!(record.apply_stage.as_deref(), Some("repair_rolled_back"));
+
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
     fn authority_committed_reparent_resumes_forward_from_immutable_plan() {
         let (store, queue, state_file, queue_db, request_id) =
             prepared_reparent_transaction("reparent-forward-recovery");
@@ -17647,9 +17735,9 @@ mod tests {
                     sender_session_id: None,
                     from_sm_send: false,
                     timeout_seconds: None,
-                    notify_on_delivery: false,
-                    notify_after_seconds: None,
-                    notify_on_stop: false,
+                    notify_on_delivery: true,
+                    notify_after_seconds: Some(15),
+                    notify_on_stop: true,
                     remind_soft_threshold: Some(600),
                     remind_hard_threshold: None,
                     remind_cancel_on_reply_session_id: None,
@@ -17671,6 +17759,9 @@ mod tests {
         let messages = queue.pending_messages_for_target("child001", 10).unwrap();
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].parent_session_id.as_deref(), Some("newpar01"));
+        assert!(!messages[0].notify_on_delivery);
+        assert_eq!(messages[0].notify_after_seconds, None);
+        assert!(!messages[0].notify_on_stop);
         let _ = fs::remove_file(state_file);
         let _ = fs::remove_file(queue_db);
     }

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -2404,7 +2404,7 @@ impl SessionStore {
     }
 
     pub fn reconcile_reparent_notifications(&self) -> Result<()> {
-        let pending = {
+        let (pending, recipients) = {
             let _guard = self.write_guard()?;
             let mut state = self.load_raw_json_value()?;
             let sessions = snapshot_from_raw_value(&state)?.into_sessions();
@@ -2428,7 +2428,7 @@ impl SessionStore {
                 store_reparent_request_records(&mut state, &records)?;
                 self.write_raw_json_value(&state)?;
             }
-            records
+            let pending = records
                 .iter()
                 .flat_map(|record| {
                     desired_reparent_notifications(record)
@@ -2439,7 +2439,17 @@ impl SessionStore {
                             })
                         })
                 })
-                .collect::<Vec<_>>()
+                .collect::<Vec<_>>();
+            let recipients = records
+                .iter()
+                .flat_map(|record| {
+                    record
+                        .notification_intents
+                        .iter()
+                        .map(|intent| intent.recipient_session_id.clone())
+                })
+                .collect::<BTreeSet<_>>();
+            (pending, recipients)
         };
         for desired in pending {
             let queue = self
@@ -2474,6 +2484,25 @@ impl SessionStore {
                 intent.enqueued_at = Some(now_rfc3339());
                 store_reparent_request_records(&mut state, &records)?;
                 self.write_raw_json_value(&state)?;
+            }
+        }
+        if let Some(runtime) = self.delivery_runtime.as_ref() {
+            let mut first_error = None;
+            for recipient in recipients {
+                if let Err(error) = self.drain_runtime_pending_messages_for_session_category(
+                    &recipient,
+                    runtime,
+                    Some("reparent"),
+                ) {
+                    if first_error.is_none() {
+                        first_error = Some(error.context(format!(
+                            "failed to deliver reparent notifications to {recipient}"
+                        )));
+                    }
+                }
+            }
+            if let Some(error) = first_error {
+                return Err(error);
             }
         }
         Ok(())

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -70,6 +70,7 @@ pub struct SessionStore {
     delivery_runtime: Option<TmuxRuntime>,
     codex_fork_handoff_monitors: Arc<Mutex<BTreeSet<String>>>,
     claude_handoff_workers: Arc<Mutex<BTreeSet<String>>>,
+    credential_rotation_workers: Arc<Mutex<BTreeSet<String>>>,
     seat_session_appends: Arc<Mutex<BTreeSet<(String, String, String)>>>,
     clear_operation_locks: Arc<Mutex<BTreeMap<String, Weak<SessionClearLock>>>>,
     seat_session_store: SeatSessionStore,
@@ -124,6 +125,7 @@ impl SessionStore {
             delivery_runtime: None,
             codex_fork_handoff_monitors: Arc::new(Mutex::new(BTreeSet::new())),
             claude_handoff_workers: Arc::new(Mutex::new(BTreeSet::new())),
+            credential_rotation_workers: Arc::new(Mutex::new(BTreeSet::new())),
             seat_session_appends: Arc::new(Mutex::new(BTreeSet::new())),
             clear_operation_locks: Arc::new(Mutex::new(BTreeMap::new())),
             seat_session_store,
@@ -654,6 +656,137 @@ impl SessionStore {
         self
     }
 
+    pub fn recover_session_runtime_launches(&self) -> Result<()> {
+        loop {
+            let launch_id = {
+                let _guard = self.write_guard()?;
+                let state = self.load_raw_json_value()?;
+                session_runtime_launch_records(&state)?
+                    .into_iter()
+                    .find(|record| matches!(record.status.as_str(), "prepared" | "launching"))
+                    .map(|record| record.id)
+            };
+            let Some(launch_id) = launch_id else {
+                return Ok(());
+            };
+            self.recover_session_runtime_launch(&launch_id)?;
+        }
+    }
+
+    fn recover_session_runtime_launch(&self, launch_id: &str) -> Result<()> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let Some(mut launch) = session_runtime_launch_records(&state)?
+            .into_iter()
+            .find(|record| record.id == launch_id)
+        else {
+            return Ok(());
+        };
+        if !matches!(launch.status.as_str(), "prepared" | "launching") {
+            return Ok(());
+        }
+        let Some(runtime) = self.delivery_runtime.as_ref() else {
+            mark_runtime_launch_failed(
+                &mut state,
+                launch_id,
+                &launch.session_id,
+                launch.operation_kind == "create",
+                "runtime launch recovery is disabled",
+            )?;
+            self.write_raw_json_value(&state)?;
+            return Ok(());
+        };
+        let session_runtime = runtime.for_socket_name(launch.tmux_socket_name.as_deref());
+        let credential = generate_session_credential();
+        let credential_sha256 = sha256_text(&credential);
+        launch.credential_sha256 = credential_sha256.clone();
+        launch.status = "launching".to_owned();
+        launch.updated_at = now_rfc3339();
+        launch.failure_reason = None;
+        let mut records = session_runtime_launch_records(&state)?;
+        let Some(stored_launch) = records.iter_mut().find(|record| record.id == launch_id) else {
+            return Ok(());
+        };
+        *stored_launch = launch.clone();
+        store_session_runtime_launch_records(&mut state, &records)?;
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let Some(session) = session_object_mut(sessions, &launch.session_id) else {
+            mark_runtime_launch_failed(
+                &mut state,
+                launch_id,
+                &launch.session_id,
+                false,
+                "runtime launch session is missing",
+            )?;
+            self.write_raw_json_value(&state)?;
+            return Ok(());
+        };
+        session.insert(
+            "session_credential_sha256".to_owned(),
+            Value::String(credential_sha256),
+        );
+        session.insert("status".to_owned(), Value::String("stopped".to_owned()));
+        session.insert("stopped_at".to_owned(), Value::String(now_rfc3339()));
+        self.write_raw_json_value(&state)?;
+
+        let spec = TmuxSessionSpec {
+            session_id: launch.session_id.clone(),
+            session_credential: Some(credential),
+            tmux_session: launch.tmux_session.clone(),
+            working_dir: launch.working_dir.clone(),
+            log_file: PathBuf::from(&launch.log_file),
+            provider: launch.provider.clone(),
+            initial_message: launch.initial_message.clone(),
+            model: launch.model.clone(),
+            reasoning_effort: launch.reasoning_effort.clone(),
+        };
+        let result = (|| -> Result<()> {
+            if session_runtime.session_exists(&launch.tmux_session)? {
+                session_runtime.kill_session(&launch.tmux_session)?;
+            }
+            if launch.operation_kind == "create" {
+                session_runtime.create_session(&spec)
+            } else {
+                session_runtime.restore_session(
+                    &spec,
+                    &launch.provider,
+                    launch.provider_resume_id.as_deref(),
+                )
+            }
+        })();
+        if let Err(error) = result {
+            mark_runtime_launch_failed(
+                &mut state,
+                launch_id,
+                &launch.session_id,
+                launch.operation_kind == "create",
+                &error.to_string(),
+            )?;
+            self.write_raw_json_value(&state)?;
+            return Ok(());
+        }
+
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let Some(session) = session_object_mut(sessions, &launch.session_id) else {
+            let _ = session_runtime.kill_session(&launch.tmux_session);
+            mark_runtime_launch_failed(
+                &mut state,
+                launch_id,
+                &launch.session_id,
+                false,
+                "runtime launch session disappeared after recovery",
+            )?;
+            self.write_raw_json_value(&state)?;
+            return Ok(());
+        };
+        session.insert("status".to_owned(), Value::String("running".to_owned()));
+        session.insert("stopped_at".to_owned(), Value::Null);
+        session.insert("last_activity".to_owned(), Value::String(now_rfc3339()));
+        mark_runtime_launch_applied(&mut state, launch_id, launch.provider_resume_id.as_deref())?;
+        self.write_raw_json_value(&state)?;
+        Ok(())
+    }
+
     #[cfg(test)]
     fn new_with_legacy_fallback(state_file: PathBuf, legacy_state_file: PathBuf) -> Self {
         let seat_session_store = SeatSessionStore::for_state_file(&state_file);
@@ -668,6 +801,7 @@ impl SessionStore {
             delivery_runtime: None,
             codex_fork_handoff_monitors: Arc::new(Mutex::new(BTreeSet::new())),
             claude_handoff_workers: Arc::new(Mutex::new(BTreeSet::new())),
+            credential_rotation_workers: Arc::new(Mutex::new(BTreeSet::new())),
             seat_session_appends: Arc::new(Mutex::new(BTreeSet::new())),
             clear_operation_locks: Arc::new(Mutex::new(BTreeMap::new())),
             seat_session_store,
@@ -1462,16 +1596,19 @@ impl SessionStore {
             .transpose()?;
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
-        let sessions = ensure_sessions_array_mut(&mut state)?;
-        let mut record = self.build_core_session_record(
-            sessions,
-            &request,
-            log_dir.as_deref(),
-            true,
-            runtime.socket_name(),
-        )?;
+        let mut record = {
+            let sessions = ensure_sessions_array_mut(&mut state)?;
+            self.build_core_session_record(
+                sessions,
+                &request,
+                log_dir.as_deref(),
+                true,
+                runtime.socket_name(),
+            )?
+        };
         let session_credential = generate_session_credential();
-        record.session_credential_sha256 = Some(sha256_text(&session_credential));
+        let credential_sha256 = sha256_text(&session_credential);
+        record.session_credential_sha256 = Some(credential_sha256.clone());
         if record.provider == "codex"
             && codex_cli_working_dir.as_deref() != Some(record.working_dir.as_str())
         {
@@ -1496,8 +1633,11 @@ impl SessionStore {
         };
         let codex_fork_artifacts = runtime.codex_fork_runtime_artifacts(&spec)?;
         let codex_cli_creation_binding = (record.provider == "codex").then(|| {
-            let mut excluded_ids = sessions
-                .iter()
+            let mut excluded_ids = state
+                .get("sessions")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
                 .filter_map(|session| json_text(session.get("provider_resume_id")))
                 .collect::<BTreeSet<_>>();
             excluded_ids.extend(codex_cli_existing_session_ids(
@@ -1509,7 +1649,46 @@ impl SessionStore {
                 OffsetDateTime::now_utc().unix_timestamp_nanos(),
             )
         });
-        runtime.create_session(&spec)?;
+        let mut launch_records = session_runtime_launch_records(&state)?;
+        let launch_id = generate_unique_runtime_launch_id(&launch_records)?;
+        let launch_time = now_rfc3339();
+        launch_records.push(SessionRuntimeLaunchRecord {
+            id: launch_id.clone(),
+            operation_kind: "create".to_owned(),
+            session_id: record.id.clone(),
+            tmux_session: record.tmux_session.clone(),
+            tmux_socket_name: runtime.socket_name().map(ToOwned::to_owned),
+            working_dir: spec.working_dir.clone(),
+            log_file: spec.log_file.display().to_string(),
+            provider: record.provider.clone(),
+            provider_resume_id: None,
+            credential_rotation_id: None,
+            initial_message: request.initial_message.clone(),
+            model: request.model.clone(),
+            reasoning_effort: request.reasoning_effort.clone(),
+            credential_sha256,
+            status: "launching".to_owned(),
+            created_at: launch_time.clone(),
+            updated_at: launch_time,
+            failure_reason: None,
+        });
+        record.status = "stopped".to_owned();
+        record.stopped_at = Some(now_rfc3339());
+        ensure_sessions_array_mut(&mut state)?.push(serde_json::to_value(&record)?);
+        store_session_runtime_launch_records(&mut state, &launch_records)?;
+        self.write_raw_json_value(&state)?;
+
+        if let Err(error) = runtime.create_session(&spec) {
+            mark_runtime_launch_failed(
+                &mut state,
+                &launch_id,
+                &record.id,
+                true,
+                &error.to_string(),
+            )?;
+            self.write_raw_json_value(&state)?;
+            return Err(error);
+        }
         if let Some((excluded_ids, launched_at_ns)) = codex_cli_creation_binding.as_ref() {
             record.provider_resume_id = wait_for_codex_cli_provider_resume_id(
                 &record,
@@ -1529,6 +1708,14 @@ impl SessionStore {
                 }
                 Err(error) => {
                     let _ = runtime.kill_session(&record.tmux_session);
+                    mark_runtime_launch_failed(
+                        &mut state,
+                        &launch_id,
+                        &record.id,
+                        true,
+                        &error.to_string(),
+                    )?;
+                    self.write_raw_json_value(&state)?;
                     return Err(error).with_context(|| {
                         format!(
                             "codex-fork session {} did not publish a provider resume id",
@@ -1538,7 +1725,18 @@ impl SessionStore {
                 }
             }
         }
-        sessions.push(serde_json::to_value(&record)?);
+        record.status = "running".to_owned();
+        record.stopped_at = None;
+        record.last_activity = now_rfc3339();
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let Some(session) = sessions
+            .iter_mut()
+            .find(|session| session.get("id").and_then(Value::as_str) == Some(record.id.as_str()))
+        else {
+            anyhow::bail!("provisional runtime session {} disappeared", record.id);
+        };
+        *session = serde_json::to_value(&record)?;
+        mark_runtime_launch_applied(&mut state, &launch_id, record.provider_resume_id.as_deref())?;
         if let Err(error) = self.write_raw_json_value(&state) {
             let _ = runtime.kill_session(&record.tmux_session);
             return Err(error);
@@ -2451,12 +2649,11 @@ impl SessionStore {
         else {
             return Err(anyhow::anyhow!("session {session_id} missing log_file"));
         };
-        if session_runtime.session_exists(&record.tmux_session)? {
-            let _ = session_runtime.kill_session(&record.tmux_session)?;
-        }
+        let session_credential = generate_session_credential();
+        let credential_sha256 = sha256_text(&session_credential);
         let spec = TmuxSessionSpec {
             session_id: record.id.clone(),
-            session_credential: Some(generate_session_credential()),
+            session_credential: Some(session_credential),
             tmux_session: record.tmux_session.clone(),
             working_dir: expand_home(&record.working_dir).display().to_string(),
             log_file,
@@ -2466,7 +2663,82 @@ impl SessionStore {
             reasoning_effort: record.reasoning_effort.clone(),
         };
         let codex_fork_artifacts = session_runtime.codex_fork_runtime_artifacts(&spec)?;
-        session_runtime.restore_session(&spec, &record.provider, provider_resume_id.as_deref())?;
+        let mut launch_records = session_runtime_launch_records(&state)?;
+        let launch_id = generate_unique_runtime_launch_id(&launch_records)?;
+        let launch_time = now_rfc3339();
+        launch_records.push(SessionRuntimeLaunchRecord {
+            id: launch_id.clone(),
+            operation_kind: "restore".to_owned(),
+            session_id: record.id.clone(),
+            tmux_session: record.tmux_session.clone(),
+            tmux_socket_name: session_runtime.socket_name().map(ToOwned::to_owned),
+            working_dir: spec.working_dir.clone(),
+            log_file: spec.log_file.display().to_string(),
+            provider: record.provider.clone(),
+            provider_resume_id: provider_resume_id.clone(),
+            credential_rotation_id: None,
+            initial_message: None,
+            model: record.model.clone(),
+            reasoning_effort: record.reasoning_effort.clone(),
+            credential_sha256: credential_sha256.clone(),
+            status: "launching".to_owned(),
+            created_at: launch_time.clone(),
+            updated_at: launch_time,
+            failure_reason: None,
+        });
+        {
+            let sessions = ensure_sessions_array_mut(&mut state)?;
+            let Some(session) = session_object_mut(sessions, session_id) else {
+                return Ok(None);
+            };
+            session.insert(
+                "session_credential_sha256".to_owned(),
+                Value::String(credential_sha256),
+            );
+            if stored_provider_resume_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                != provider_resume_id.as_deref()
+            {
+                if let Some(provider_resume_id) = provider_resume_id.as_deref() {
+                    session.insert(
+                        "provider_resume_id".to_owned(),
+                        Value::String(provider_resume_id.to_owned()),
+                    );
+                }
+            }
+            if let Some(transcript_path) = record
+                .transcript_path
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                session.insert(
+                    "transcript_path".to_owned(),
+                    Value::String(transcript_path.to_owned()),
+                );
+            }
+        }
+        store_session_runtime_launch_records(&mut state, &launch_records)?;
+        self.write_raw_json_value(&state)?;
+
+        if session_runtime.session_exists(&record.tmux_session)? {
+            let _ = session_runtime.kill_session(&record.tmux_session)?;
+        }
+        if let Err(error) =
+            session_runtime.restore_session(&spec, &record.provider, provider_resume_id.as_deref())
+        {
+            mark_runtime_launch_failed(
+                &mut state,
+                &launch_id,
+                &record.id,
+                false,
+                &error.to_string(),
+            )?;
+            self.write_raw_json_value(&state)?;
+            return Err(error);
+        }
 
         let sessions = ensure_sessions_array_mut(&mut state)?;
         let Some(session) = session_object_mut(sessions, session_id) else {
@@ -2480,12 +2752,6 @@ impl SessionStore {
         session.insert("completed_at".to_owned(), Value::Null);
         session.insert("agent_task_completed_at".to_owned(), Value::Null);
         session.insert("last_activity".to_owned(), Value::String(now));
-        session.insert(
-            "session_credential_sha256".to_owned(),
-            Value::String(sha256_text(
-                spec.session_credential.as_deref().unwrap_or_default(),
-            )),
-        );
         if let Some(socket_name) = session_runtime.socket_name() {
             session.insert(
                 "tmux_socket_name".to_owned(),
@@ -2498,10 +2764,10 @@ impl SessionStore {
             .filter(|value| !value.is_empty())
             != provider_resume_id.as_deref()
         {
-            if let Some(provider_resume_id) = provider_resume_id {
+            if let Some(provider_resume_id) = provider_resume_id.as_deref() {
                 session.insert(
                     "provider_resume_id".to_owned(),
-                    Value::String(provider_resume_id),
+                    Value::String(provider_resume_id.to_owned()),
                 );
             }
         }
@@ -2517,6 +2783,7 @@ impl SessionStore {
             );
         }
         let restored = serde_json::from_value::<SessionRecord>(Value::Object(session.clone()))?;
+        mark_runtime_launch_applied(&mut state, &launch_id, provider_resume_id.as_deref())?;
         self.write_raw_json_value(&state)?;
         if let Some(provider_resume_id) = provider_resume_id_for_restore(&restored) {
             self.append_seat_session(
@@ -5975,6 +6242,15 @@ pub enum ReparentMutationOutcome {
     Expired,
 }
 
+#[derive(Debug, Clone)]
+pub enum CredentialRotationOutcome {
+    Created(SessionCredentialRotationRecord),
+    Existing(SessionCredentialRotationRecord),
+    SessionNotFound,
+    BadRequest(String),
+    Conflict(String),
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct HandoffResult {
     pub status: String,
@@ -8880,6 +9156,28 @@ fn generate_unique_reparent_request_id(records: &[ReparentRequestRecord]) -> Res
     anyhow::bail!("failed to generate unique reparent request id after 64 attempts")
 }
 
+fn generate_unique_runtime_launch_id(records: &[SessionRuntimeLaunchRecord]) -> Result<String> {
+    for _ in 0..64 {
+        let id = generate_session_id();
+        if !records.iter().any(|record| record.id == id) {
+            return Ok(id);
+        }
+    }
+    anyhow::bail!("failed to generate unique runtime launch id after 64 attempts")
+}
+
+fn generate_unique_credential_rotation_id(
+    records: &[SessionCredentialRotationRecord],
+) -> Result<String> {
+    for _ in 0..64 {
+        let id = generate_session_id();
+        if !records.iter().any(|record| record.id == id) {
+            return Ok(id);
+        }
+    }
+    anyhow::bail!("failed to generate unique credential rotation id after 64 attempts")
+}
+
 fn generate_session_credential() -> String {
     let mut bytes = [0u8; 32];
     OsRng.fill_bytes(&mut bytes);
@@ -8962,6 +9260,113 @@ fn store_reparent_request_records(
         "reparent_requests".to_owned(),
         serde_json::to_value(records)?,
     );
+    Ok(())
+}
+
+fn session_runtime_launch_records(state: &Value) -> Result<Vec<SessionRuntimeLaunchRecord>> {
+    state
+        .get("session_runtime_launches")
+        .and_then(Value::as_array)
+        .map(|records| {
+            records
+                .iter()
+                .map(|record| {
+                    serde_json::from_value(record.clone())
+                        .context("failed to parse session runtime launch record")
+                })
+                .collect()
+        })
+        .unwrap_or_else(|| Ok(Vec::new()))
+}
+
+fn store_session_runtime_launch_records(
+    state: &mut Value,
+    records: &[SessionRuntimeLaunchRecord],
+) -> Result<()> {
+    let object = state
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("session state root must be an object"))?;
+    object.insert(
+        "session_runtime_launches".to_owned(),
+        serde_json::to_value(records)?,
+    );
+    Ok(())
+}
+
+fn session_credential_rotation_records(
+    state: &Value,
+) -> Result<Vec<SessionCredentialRotationRecord>> {
+    state
+        .get("session_credential_rotations")
+        .and_then(Value::as_array)
+        .map(|records| {
+            records
+                .iter()
+                .map(|record| {
+                    serde_json::from_value(record.clone())
+                        .context("failed to parse session credential rotation record")
+                })
+                .collect()
+        })
+        .unwrap_or_else(|| Ok(Vec::new()))
+}
+
+fn store_session_credential_rotation_records(
+    state: &mut Value,
+    records: &[SessionCredentialRotationRecord],
+) -> Result<()> {
+    let object = state
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("session state root must be an object"))?;
+    object.insert(
+        "session_credential_rotations".to_owned(),
+        serde_json::to_value(records)?,
+    );
+    Ok(())
+}
+
+fn mark_runtime_launch_applied(
+    state: &mut Value,
+    launch_id: &str,
+    provider_resume_id: Option<&str>,
+) -> Result<()> {
+    let mut records = session_runtime_launch_records(state)?;
+    let record = records
+        .iter_mut()
+        .find(|record| record.id == launch_id)
+        .ok_or_else(|| anyhow::anyhow!("runtime launch {launch_id} disappeared"))?;
+    record.status = "applied".to_owned();
+    record.updated_at = now_rfc3339();
+    record.failure_reason = None;
+    if let Some(provider_resume_id) = provider_resume_id {
+        record.provider_resume_id = Some(provider_resume_id.to_owned());
+    }
+    store_session_runtime_launch_records(state, &records)
+}
+
+fn mark_runtime_launch_failed(
+    state: &mut Value,
+    launch_id: &str,
+    session_id: &str,
+    remove_provisional_session: bool,
+    failure_reason: &str,
+) -> Result<()> {
+    let mut records = session_runtime_launch_records(state)?;
+    let record = records
+        .iter_mut()
+        .find(|record| record.id == launch_id)
+        .ok_or_else(|| anyhow::anyhow!("runtime launch {launch_id} disappeared"))?;
+    record.status = "failed".to_owned();
+    record.updated_at = now_rfc3339();
+    record.failure_reason = Some(failure_reason.to_owned());
+    store_session_runtime_launch_records(state, &records)?;
+    let sessions = ensure_sessions_array_mut(state)?;
+    if remove_provisional_session {
+        sessions.retain(|session| session.get("id").and_then(Value::as_str) != Some(session_id));
+    } else if let Some(session) = session_object_mut(sessions, session_id) {
+        session.insert("status".to_owned(), Value::String("stopped".to_owned()));
+        session.insert("stopped_at".to_owned(), Value::String(now_rfc3339()));
+    }
     Ok(())
 }
 
@@ -9508,6 +9913,58 @@ pub struct ReparentRequestRecord {
     pub deferred_routing_intents: Vec<ReparentDeferredRoutingIntent>,
     #[serde(default)]
     pub repair_history: Vec<ReparentRepairRecord>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct SessionRuntimeLaunchRecord {
+    pub id: String,
+    pub operation_kind: String,
+    pub session_id: String,
+    pub tmux_session: String,
+    #[serde(default)]
+    pub tmux_socket_name: Option<String>,
+    pub working_dir: String,
+    pub log_file: String,
+    pub provider: String,
+    #[serde(default)]
+    pub provider_resume_id: Option<String>,
+    #[serde(default)]
+    pub credential_rotation_id: Option<String>,
+    #[serde(default)]
+    pub initial_message: Option<String>,
+    #[serde(default)]
+    pub model: Option<String>,
+    #[serde(default)]
+    pub reasoning_effort: Option<String>,
+    pub credential_sha256: String,
+    pub status: String,
+    pub created_at: String,
+    pub updated_at: String,
+    #[serde(default)]
+    pub failure_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct SessionCredentialRotationRecord {
+    pub id: String,
+    pub session_id: String,
+    pub provider: String,
+    pub provider_resume_id: String,
+    pub tmux_session: String,
+    #[serde(default)]
+    pub tmux_socket_name: Option<String>,
+    pub request_actor: String,
+    pub status: String,
+    pub requested_at: String,
+    #[serde(default)]
+    pub idle_proof_at: Option<String>,
+    #[serde(default)]
+    pub runtime_launch_id: Option<String>,
+    pub updated_at: String,
+    #[serde(default)]
+    pub applied_at: Option<String>,
+    #[serde(default)]
+    pub failure_reason: Option<String>,
 }
 
 impl ReparentRequestRecord {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -9500,7 +9500,7 @@ impl ReparentRequestRecord {
             || (self.status == "failed"
                 && matches!(
                     self.apply_stage.as_deref(),
-                    Some("routing_quiesced" | "authority_committed")
+                    Some("json_routing_quiesced" | "routing_quiesced" | "authority_committed")
                 ))
     }
 

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -23,7 +23,8 @@ use time::{
 };
 
 use crate::queue::{
-    followup_notification_text, PendingMessage, QueueMessageMetadata, RetainedQueueStore,
+    followup_notification_text, ParentRoutingMessageRow, ParentRoutingSnapshot,
+    ParentRoutingWakeRow, PendingMessage, QueueMessageMetadata, RetainedQueueStore,
     StopNotifyState,
 };
 use crate::{
@@ -1938,6 +1939,14 @@ impl SessionStore {
         let updated = record.clone();
         store_reparent_request_records(&mut state, &records)?;
         self.write_raw_json_value(&state)?;
+        drop(_guard);
+        if decision == ReparentDecision::Approved && updated.ready_to_apply {
+            if let Some(applied) = self.reconcile_reparent_requests()? {
+                if applied.id == updated.id {
+                    return Ok(ReparentMutationOutcome::Updated(applied));
+                }
+            }
+        }
         Ok(ReparentMutationOutcome::Updated(updated))
     }
 
@@ -2023,6 +2032,14 @@ impl SessionStore {
         let updated = record.clone();
         store_reparent_request_records(&mut state, &records)?;
         self.write_raw_json_value(&state)?;
+        drop(_guard);
+        if decision == ReparentDecision::Approved && updated.ready_to_apply {
+            if let Some(applied) = self.reconcile_reparent_requests()? {
+                if applied.id == updated.id {
+                    return Ok(ReparentMutationOutcome::Updated(applied));
+                }
+            }
+        }
         Ok(ReparentMutationOutcome::Updated(updated))
     }
 
@@ -2053,6 +2070,344 @@ impl SessionStore {
             (&left.created_at, &left.id).cmp(&(&right.created_at, &right.id))
         });
         Ok(records)
+    }
+
+    pub fn reconcile_reparent_requests(&self) -> Result<Option<ReparentRequestRecord>> {
+        let request_id = match self.acquire_reparent_apply_lease()? {
+            Some(request_id) => request_id,
+            None => return Ok(None),
+        };
+        if let Err(error) = self.apply_reparent_request(&request_id) {
+            self.fail_reparent_apply(&request_id, &error.to_string())?;
+        }
+        self.get_reparent_request(&request_id)
+    }
+
+    fn acquire_reparent_apply_lease(&self) -> Result<Option<String>> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        if let Some(lease) = reparent_apply_lease(&state)? {
+            return Ok(Some(lease.request_id));
+        }
+        let sessions = snapshot_from_raw_value(&state)?.into_sessions();
+        let mut records = reparent_request_records(&state)?;
+        let _ = refresh_reparent_requests(&mut records, &sessions, OffsetDateTime::now_utc());
+        let Some(index) = records
+            .iter()
+            .enumerate()
+            .filter(|(_, record)| {
+                record.kind == "single" && record.status == "pending" && record.ready_to_apply
+            })
+            .min_by(|(_, left), (_, right)| {
+                (&left.created_at, &left.id).cmp(&(&right.created_at, &right.id))
+            })
+            .map(|(index, _)| index)
+        else {
+            store_reparent_request_records(&mut state, &records)?;
+            self.write_raw_json_value(&state)?;
+            return Ok(None);
+        };
+        if let Some(reason) = reparent_stale_reason(&records[index], &sessions) {
+            records[index].status = "stale".to_owned();
+            records[index].ready_to_apply = false;
+            records[index].failure_reason = Some(reason);
+            records[index].decided_at = Some(now_rfc3339());
+            store_reparent_request_records(&mut state, &records)?;
+            self.write_raw_json_value(&state)?;
+            return Ok(None);
+        }
+        let plan = self.build_single_reparent_apply_plan(&state, &records[index])?;
+        let request_id = records[index].id.clone();
+        let acquired_at = now_rfc3339();
+        records[index].status = "applying".to_owned();
+        records[index].apply_stage = Some("applying".to_owned());
+        records[index].apply_plan = Some(plan);
+        records[index].failure_reason = None;
+        store_reparent_request_records(&mut state, &records)?;
+        store_reparent_apply_lease(
+            &mut state,
+            Some(&ReparentApplyLease {
+                request_id: request_id.clone(),
+                acquired_at,
+            }),
+        )?;
+        self.write_raw_json_value(&state)?;
+        Ok(Some(request_id))
+    }
+
+    fn build_single_reparent_apply_plan(
+        &self,
+        state: &Value,
+        record: &ReparentRequestRecord,
+    ) -> Result<ReparentApplyPlan> {
+        let mut json_routing_changes = Vec::new();
+        if let Some(old_parent) = record.expected_parent_session_id.as_deref() {
+            for entry in state
+                .get("retained_parent_wake_registrations")
+                .and_then(Value::as_array)
+                .into_iter()
+                .flatten()
+                .filter(|entry| {
+                    entry.get("child_session_id").and_then(Value::as_str)
+                        == Some(record.subject_session_id.as_str())
+                        && json_text(entry.get("parent_session_id")).as_deref() == Some(old_parent)
+                        && entry
+                            .get("is_active")
+                            .and_then(Value::as_bool)
+                            .unwrap_or(true)
+                })
+            {
+                let record_id = json_text(entry.get("id")).ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "parent wake for {} is missing its durable ID",
+                        record.subject_session_id
+                    )
+                })?;
+                let period_seconds = entry
+                    .get("period_seconds")
+                    .and_then(Value::as_i64)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("parent wake {record_id} is missing its period")
+                    })?;
+                json_routing_changes.push(ReparentRoutingChange {
+                    store: "json".to_owned(),
+                    record_kind: "parent_wake".to_owned(),
+                    record_id,
+                    child_session_id: record.subject_session_id.clone(),
+                    expected_target_session_id: Some(old_parent.to_owned()),
+                    new_target_session_id: Some(record.target_parent_session_id.clone()),
+                    prior_active: Some(true),
+                    period_seconds: Some(period_seconds),
+                });
+            }
+            if let Some(session) =
+                raw_session_object(state, &record.subject_session_id).filter(|session| {
+                    json_text(session.get("context_monitor_notify")).as_deref() == Some(old_parent)
+                        && json_text(session.get("context_monitor_notify_source")).as_deref()
+                            == Some("parent_derived")
+                })
+            {
+                json_routing_changes.push(ReparentRoutingChange {
+                    store: "json".to_owned(),
+                    record_kind: "context_monitor".to_owned(),
+                    record_id: record.subject_session_id.clone(),
+                    child_session_id: record.subject_session_id.clone(),
+                    expected_target_session_id: Some(old_parent.to_owned()),
+                    new_target_session_id: Some(record.target_parent_session_id.clone()),
+                    prior_active: Some(
+                        session
+                            .get("context_monitor_enabled")
+                            .and_then(Value::as_bool)
+                            .unwrap_or(false),
+                    ),
+                    period_seconds: None,
+                });
+            }
+        }
+        let queue_snapshot = match (
+            self.queue_store.as_ref(),
+            record.expected_parent_session_id.as_deref(),
+        ) {
+            (Some(queue), Some(old_parent)) => {
+                queue.snapshot_parent_routing(&record.subject_session_id, old_parent)?
+            }
+            _ => ParentRoutingSnapshot::default(),
+        };
+        let mut queue_routing_changes = queue_snapshot
+            .wake_rows
+            .into_iter()
+            .map(|row| ReparentRoutingChange {
+                store: "queue".to_owned(),
+                record_kind: "parent_wake".to_owned(),
+                record_id: row.id,
+                child_session_id: row.child_session_id,
+                expected_target_session_id: Some(row.parent_session_id),
+                new_target_session_id: Some(record.target_parent_session_id.clone()),
+                prior_active: Some(row.is_active),
+                period_seconds: Some(row.period_seconds),
+            })
+            .collect::<Vec<_>>();
+        queue_routing_changes.extend(queue_snapshot.message_rows.into_iter().map(|row| {
+            ReparentRoutingChange {
+                store: "queue".to_owned(),
+                record_kind: "message".to_owned(),
+                record_id: row.id,
+                child_session_id: row.child_session_id,
+                expected_target_session_id: Some(row.parent_session_id),
+                new_target_session_id: Some(record.target_parent_session_id.clone()),
+                prior_active: None,
+                period_seconds: None,
+            }
+        }));
+        Ok(ReparentApplyPlan {
+            version: 1,
+            edge_changes: vec![ReparentEdgeChange {
+                session_id: record.subject_session_id.clone(),
+                expected_parent_session_id: record.expected_parent_session_id.clone(),
+                new_parent_session_id: Some(record.target_parent_session_id.clone()),
+            }],
+            json_routing_changes,
+            queue_routing_changes,
+        })
+    }
+
+    fn apply_reparent_request(&self, request_id: &str) -> Result<()> {
+        for _ in 0..8 {
+            let stage = {
+                let _guard = self.write_guard()?;
+                let state = self.load_raw_json_value()?;
+                let lease =
+                    reparent_apply_lease(&state)?.context("reparent apply lease disappeared")?;
+                if lease.request_id != request_id {
+                    anyhow::bail!(
+                        "reparent apply lease belongs to {}, not {request_id}",
+                        lease.request_id
+                    );
+                }
+                reparent_request_records(&state)?
+                    .into_iter()
+                    .find(|record| record.id == request_id)
+                    .with_context(|| format!("reparent request {request_id} disappeared"))?
+                    .apply_stage
+                    .unwrap_or_else(|| "applying".to_owned())
+            };
+            match stage.as_str() {
+                "applying" => self.quiesce_reparent_json_routing(request_id)?,
+                "json_routing_quiesced" => self.quiesce_reparent_queue_routing(request_id)?,
+                "routing_quiesced" => self.commit_reparent_authority(request_id)?,
+                "authority_committed" => {
+                    self.finish_reparent_routing(request_id)?;
+                    return Ok(());
+                }
+                "applied" => return Ok(()),
+                other => {
+                    anyhow::bail!("reparent request {request_id} cannot resume from stage {other}")
+                }
+            }
+        }
+        anyhow::bail!("reparent request {request_id} exceeded the apply stage limit")
+    }
+
+    fn quiesce_reparent_json_routing(&self, request_id: &str) -> Result<()> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let mut records = reparent_request_records(&state)?;
+        let record = leased_reparent_request_mut(&state, &mut records, request_id)?;
+        let plan = record
+            .apply_plan
+            .clone()
+            .context("reparent apply plan is missing")?;
+        let sessions = snapshot_from_raw_value(&state)?.into_sessions();
+        if let Some(reason) = reparent_stale_reason(record, &sessions) {
+            anyhow::bail!("reparent request became stale before quiesce: {reason}");
+        }
+        quiesce_json_reparent_routes(&mut state, &plan)?;
+        record.apply_stage = Some("json_routing_quiesced".to_owned());
+        store_reparent_request_records(&mut state, &records)?;
+        self.write_raw_json_value(&state)
+    }
+
+    fn quiesce_reparent_queue_routing(&self, request_id: &str) -> Result<()> {
+        let snapshot = {
+            let _guard = self.write_guard()?;
+            let state = self.load_raw_json_value()?;
+            let records = reparent_request_records(&state)?;
+            let record = leased_reparent_request(&state, &records, request_id)?;
+            queue_snapshot_from_plan(
+                record
+                    .apply_plan
+                    .as_ref()
+                    .context("reparent apply plan is missing")?,
+            )?
+        };
+        if let Some(queue) = self.queue_store.as_ref() {
+            queue.quiesce_parent_routing(&snapshot)?;
+        } else if !snapshot.wake_rows.is_empty() || !snapshot.message_rows.is_empty() {
+            anyhow::bail!("reparent plan requires the retained queue store")
+        }
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let mut records = reparent_request_records(&state)?;
+        let record = leased_reparent_request_mut(&state, &mut records, request_id)?;
+        if record.apply_stage.as_deref() != Some("json_routing_quiesced") {
+            anyhow::bail!("reparent request stage changed during queue quiesce")
+        }
+        record.apply_stage = Some("routing_quiesced".to_owned());
+        store_reparent_request_records(&mut state, &records)?;
+        self.write_raw_json_value(&state)
+    }
+
+    fn commit_reparent_authority(&self, request_id: &str) -> Result<()> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let mut records = reparent_request_records(&state)?;
+        let record = leased_reparent_request_mut(&state, &mut records, request_id)?;
+        let plan = record
+            .apply_plan
+            .clone()
+            .context("reparent apply plan is missing")?;
+        let sessions = snapshot_from_raw_value(&state)?.into_sessions();
+        if let Some(reason) = reparent_stale_reason(record, &sessions) {
+            anyhow::bail!("reparent request became stale before authority commit: {reason}");
+        }
+        commit_json_reparent_plan(&mut state, &plan)?;
+        record.apply_stage = Some("authority_committed".to_owned());
+        store_reparent_request_records(&mut state, &records)?;
+        self.write_raw_json_value(&state)
+    }
+
+    fn finish_reparent_routing(&self, request_id: &str) -> Result<()> {
+        let (snapshot, new_parent_session_id) = {
+            let _guard = self.write_guard()?;
+            let state = self.load_raw_json_value()?;
+            let records = reparent_request_records(&state)?;
+            let record = leased_reparent_request(&state, &records, request_id)?;
+            let plan = record
+                .apply_plan
+                .as_ref()
+                .context("reparent apply plan is missing")?;
+            let new_parent = plan
+                .edge_changes
+                .first()
+                .and_then(|change| change.new_parent_session_id.clone())
+                .context("reparent apply plan has no target parent")?;
+            (queue_snapshot_from_plan(plan)?, new_parent)
+        };
+        if let Some(queue) = self.queue_store.as_ref() {
+            queue.retarget_parent_routing(&snapshot, &new_parent_session_id)?;
+        } else if !snapshot.wake_rows.is_empty() || !snapshot.message_rows.is_empty() {
+            anyhow::bail!("reparent plan requires the retained queue store")
+        }
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let mut records = reparent_request_records(&state)?;
+        let record = leased_reparent_request_mut(&state, &mut records, request_id)?;
+        if record.apply_stage.as_deref() != Some("authority_committed") {
+            anyhow::bail!("reparent request stage changed during queue retarget")
+        }
+        let now = now_rfc3339();
+        record.status = "applied".to_owned();
+        record.apply_stage = Some("applied".to_owned());
+        record.applied_at = Some(now.clone());
+        record.decided_at = Some(now);
+        record.ready_to_apply = false;
+        record.failure_reason = None;
+        store_reparent_request_records(&mut state, &records)?;
+        store_reparent_apply_lease(&mut state, None)?;
+        self.write_raw_json_value(&state)
+    }
+
+    fn fail_reparent_apply(&self, request_id: &str, failure_reason: &str) -> Result<()> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let mut records = reparent_request_records(&state)?;
+        let record = leased_reparent_request_mut(&state, &mut records, request_id)?;
+        record.status = "failed".to_owned();
+        record.failure_reason = Some(failure_reason.to_owned());
+        record.ready_to_apply = false;
+        record.decided_at = Some(now_rfc3339());
+        store_reparent_request_records(&mut state, &records)?;
+        self.write_raw_json_value(&state)
     }
 
     pub fn create_session_credential_rotation(
@@ -3571,9 +3926,21 @@ impl SessionStore {
             Value::Bool(effective_enabled),
         );
         if effective_enabled {
+            let notify_session_id = notify_session_id.unwrap();
             session.insert(
                 "context_monitor_notify".to_owned(),
-                Value::String(notify_session_id.unwrap()),
+                Value::String(notify_session_id.clone()),
+            );
+            session.insert(
+                "context_monitor_notify_source".to_owned(),
+                Value::String(
+                    if is_parent && notify_session_id == requester_session_id {
+                        "parent_derived"
+                    } else {
+                        "explicit"
+                    }
+                    .to_owned(),
+                ),
             );
             // Enabling starts a fresh notification cycle. Without this, latches
             // left set by an earlier cycle suppress the first warning until a
@@ -3583,6 +3950,7 @@ impl SessionStore {
             reset_context_oneshot_flags(session);
         } else {
             session.insert("context_monitor_notify".to_owned(), Value::Null);
+            session.insert("context_monitor_notify_source".to_owned(), Value::Null);
             if request.enabled {
                 reset_context_oneshot_flags(session);
             }
@@ -3678,6 +4046,7 @@ impl SessionStore {
             let notify_target = if informational_only {
                 session.insert("context_monitor_enabled".to_owned(), Value::Bool(false));
                 session.insert("context_monitor_notify".to_owned(), Value::Null);
+                session.insert("context_monitor_notify_source".to_owned(), Value::Null);
                 None
             } else {
                 json_text(session.get("context_monitor_notify"))
@@ -3833,6 +4202,7 @@ impl SessionStore {
                 if had_alert_state {
                     session.insert("context_monitor_enabled".to_owned(), Value::Bool(false));
                     session.insert("context_monitor_notify".to_owned(), Value::Null);
+                    session.insert("context_monitor_notify_source".to_owned(), Value::Null);
                     reset_context_oneshot_flags(session);
                     self.cancel_context_monitor_alerts(session_id)?;
                     changed = true;
@@ -5865,6 +6235,7 @@ impl SessionStore {
                 if had_alert_state {
                     session.insert("context_monitor_enabled".to_owned(), Value::Bool(false));
                     session.insert("context_monitor_notify".to_owned(), Value::Null);
+                    session.insert("context_monitor_notify_source".to_owned(), Value::Null);
                     reset_context_oneshot_flags(session);
                     self.cancel_context_monitor_alerts(session_id)?;
                     changed = true;
@@ -6031,6 +6402,7 @@ impl SessionStore {
             context_compaction_active: false,
             context_monitor_enabled: false,
             context_monitor_notify: None,
+            context_monitor_notify_source: default_context_monitor_notify_source(),
             context_warning_sent: false,
             context_critical_sent: false,
             aliases: Vec::new(),
@@ -9941,6 +10313,229 @@ fn store_reparent_request_records(
     Ok(())
 }
 
+fn reparent_apply_lease(state: &Value) -> Result<Option<ReparentApplyLease>> {
+    match state.get("reparent_apply_lease") {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => serde_json::from_value(value.clone())
+            .context("failed to parse reparent apply lease")
+            .map(Some),
+    }
+}
+
+fn store_reparent_apply_lease(state: &mut Value, lease: Option<&ReparentApplyLease>) -> Result<()> {
+    let object = state
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("session state root must be an object"))?;
+    object.insert(
+        "reparent_apply_lease".to_owned(),
+        lease
+            .map(serde_json::to_value)
+            .transpose()?
+            .unwrap_or(Value::Null),
+    );
+    Ok(())
+}
+
+fn leased_reparent_request<'a>(
+    state: &Value,
+    records: &'a [ReparentRequestRecord],
+    request_id: &str,
+) -> Result<&'a ReparentRequestRecord> {
+    let lease = reparent_apply_lease(state)?.context("reparent apply lease disappeared")?;
+    if lease.request_id != request_id {
+        anyhow::bail!(
+            "reparent apply lease belongs to {}, not {request_id}",
+            lease.request_id
+        );
+    }
+    records
+        .iter()
+        .find(|record| record.id == request_id)
+        .with_context(|| format!("reparent request {request_id} disappeared"))
+}
+
+fn leased_reparent_request_mut<'a>(
+    state: &Value,
+    records: &'a mut [ReparentRequestRecord],
+    request_id: &str,
+) -> Result<&'a mut ReparentRequestRecord> {
+    let lease = reparent_apply_lease(state)?.context("reparent apply lease disappeared")?;
+    if lease.request_id != request_id {
+        anyhow::bail!(
+            "reparent apply lease belongs to {}, not {request_id}",
+            lease.request_id
+        );
+    }
+    records
+        .iter_mut()
+        .find(|record| record.id == request_id)
+        .with_context(|| format!("reparent request {request_id} disappeared"))
+}
+
+fn queue_snapshot_from_plan(plan: &ReparentApplyPlan) -> Result<ParentRoutingSnapshot> {
+    let mut snapshot = ParentRoutingSnapshot::default();
+    for change in &plan.queue_routing_changes {
+        if change.store != "queue" {
+            anyhow::bail!("queue routing plan contains store {}", change.store);
+        }
+        let old_parent = change
+            .expected_target_session_id
+            .clone()
+            .with_context(|| format!("routing change {} has no old parent", change.record_id))?;
+        match change.record_kind.as_str() {
+            "parent_wake" => snapshot.wake_rows.push(ParentRoutingWakeRow {
+                id: change.record_id.clone(),
+                child_session_id: change.child_session_id.clone(),
+                parent_session_id: old_parent,
+                period_seconds: change
+                    .period_seconds
+                    .with_context(|| format!("parent wake {} has no period", change.record_id))?,
+                is_active: change.prior_active.with_context(|| {
+                    format!("parent wake {} has no active state", change.record_id)
+                })?,
+            }),
+            "message" => snapshot.message_rows.push(ParentRoutingMessageRow {
+                id: change.record_id.clone(),
+                child_session_id: change.child_session_id.clone(),
+                parent_session_id: old_parent,
+            }),
+            other => anyhow::bail!("unsupported queue routing record kind {other}"),
+        }
+    }
+    Ok(snapshot)
+}
+
+fn quiesce_json_reparent_routes(state: &mut Value, plan: &ReparentApplyPlan) -> Result<()> {
+    for change in &plan.json_routing_changes {
+        match change.record_kind.as_str() {
+            "parent_wake" => {
+                let registrations =
+                    ensure_array_field_mut(state, "retained_parent_wake_registrations")?;
+                let entry = registrations
+                    .iter_mut()
+                    .find(|entry| json_text(entry.get("id")).as_deref() == Some(&change.record_id))
+                    .with_context(|| format!("parent wake {} disappeared", change.record_id))?;
+                let object = entry
+                    .as_object_mut()
+                    .context("parent wake record must be an object")?;
+                validate_json_parent_route(object, change, true)?;
+                object.insert("is_active".to_owned(), Value::Bool(false));
+            }
+            "context_monitor" => {
+                let sessions = ensure_sessions_array_mut(state)?;
+                let session = session_object_mut(sessions, &change.child_session_id)
+                    .with_context(|| format!("session {} disappeared", change.child_session_id))?;
+                validate_json_parent_route(session, change, true)?;
+                session.insert("context_monitor_enabled".to_owned(), Value::Bool(false));
+            }
+            other => anyhow::bail!("unsupported JSON routing record kind {other}"),
+        }
+    }
+    Ok(())
+}
+
+fn commit_json_reparent_plan(state: &mut Value, plan: &ReparentApplyPlan) -> Result<()> {
+    for change in &plan.edge_changes {
+        let sessions = ensure_sessions_array_mut(state)?;
+        let session = session_object_mut(sessions, &change.session_id)
+            .with_context(|| format!("session {} disappeared", change.session_id))?;
+        let current_parent = json_text(session.get("parent_session_id"));
+        if current_parent != change.expected_parent_session_id {
+            anyhow::bail!(
+                "session {} parent changed after planning",
+                change.session_id
+            );
+        }
+        session.insert(
+            "parent_session_id".to_owned(),
+            change
+                .new_parent_session_id
+                .clone()
+                .map(Value::String)
+                .unwrap_or(Value::Null),
+        );
+    }
+    for change in &plan.json_routing_changes {
+        let new_parent = change
+            .new_target_session_id
+            .clone()
+            .with_context(|| format!("routing change {} has no new parent", change.record_id))?;
+        match change.record_kind.as_str() {
+            "parent_wake" => {
+                let registrations =
+                    ensure_array_field_mut(state, "retained_parent_wake_registrations")?;
+                let entry = registrations
+                    .iter_mut()
+                    .find(|entry| json_text(entry.get("id")).as_deref() == Some(&change.record_id))
+                    .with_context(|| format!("parent wake {} disappeared", change.record_id))?;
+                let object = entry
+                    .as_object_mut()
+                    .context("parent wake record must be an object")?;
+                validate_json_parent_route(object, change, false)?;
+                object.insert("parent_session_id".to_owned(), Value::String(new_parent));
+                object.insert(
+                    "is_active".to_owned(),
+                    Value::Bool(change.prior_active.unwrap_or(false)),
+                );
+            }
+            "context_monitor" => {
+                let sessions = ensure_sessions_array_mut(state)?;
+                let session = session_object_mut(sessions, &change.child_session_id)
+                    .with_context(|| format!("session {} disappeared", change.child_session_id))?;
+                validate_json_parent_route(session, change, false)?;
+                session.insert(
+                    "context_monitor_notify".to_owned(),
+                    Value::String(new_parent),
+                );
+                session.insert(
+                    "context_monitor_enabled".to_owned(),
+                    Value::Bool(change.prior_active.unwrap_or(false)),
+                );
+            }
+            other => anyhow::bail!("unsupported JSON routing record kind {other}"),
+        }
+    }
+    Ok(())
+}
+
+fn validate_json_parent_route(
+    object: &Map<String, Value>,
+    change: &ReparentRoutingChange,
+    allow_pre_state: bool,
+) -> Result<()> {
+    let target_field = if change.record_kind == "context_monitor" {
+        "context_monitor_notify"
+    } else {
+        "parent_session_id"
+    };
+    let active_field = if change.record_kind == "context_monitor" {
+        "context_monitor_enabled"
+    } else {
+        "is_active"
+    };
+    let current_target = json_text(object.get(target_field));
+    let current_active = object
+        .get(active_field)
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let old_parent = change.expected_target_session_id.as_deref();
+    let valid = current_target.as_deref() == old_parent
+        && (!current_active || (allow_pre_state && change.prior_active == Some(current_active)));
+    if !valid {
+        anyhow::bail!("JSON route {} changed after planning", change.record_id);
+    }
+    if change.record_kind == "context_monitor"
+        && json_text(object.get("context_monitor_notify_source")).as_deref()
+            != Some("parent_derived")
+    {
+        anyhow::bail!(
+            "context monitor {} lost parent provenance",
+            change.record_id
+        );
+    }
+    Ok(())
+}
+
 fn session_runtime_launch_records(state: &Value) -> Result<Vec<SessionRuntimeLaunchRecord>> {
     state
         .get("session_runtime_launches")
@@ -10537,6 +11132,8 @@ pub struct ReparentRoutingChange {
     pub new_target_session_id: Option<String>,
     #[serde(default)]
     pub prior_active: Option<bool>,
+    #[serde(default)]
+    pub period_seconds: Option<i64>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -10548,6 +11145,12 @@ pub struct ReparentApplyPlan {
     pub json_routing_changes: Vec<ReparentRoutingChange>,
     #[serde(default)]
     pub queue_routing_changes: Vec<ReparentRoutingChange>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ReparentApplyLease {
+    pub request_id: String,
+    pub acquired_at: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
@@ -10839,6 +11442,8 @@ pub struct SessionRecord {
     pub context_monitor_enabled: bool,
     #[serde(default)]
     pub context_monitor_notify: Option<String>,
+    #[serde(default = "default_context_monitor_notify_source")]
+    pub context_monitor_notify_source: String,
     /// One-shot latches for the current accumulation cycle. Persisted rather
     /// than held in memory (as the Python server did) so a server restart does
     /// not re-fire a warning the agent has already been told about; the cycle
@@ -11419,6 +12024,10 @@ fn default_provider() -> String {
     "claude".to_owned()
 }
 
+fn default_context_monitor_notify_source() -> String {
+    "explicit".to_owned()
+}
+
 fn provider_manages_context_inline(provider: &str) -> bool {
     matches!(provider.trim(), "codex" | "codex-fork" | "codex-app")
 }
@@ -11842,6 +12451,7 @@ mod tests {
             context_compaction_active: false,
             context_monitor_enabled: false,
             context_monitor_notify: None,
+            context_monitor_notify_source: default_context_monitor_notify_source(),
             context_warning_sent: false,
             context_critical_sent: false,
             aliases: Vec::new(),
@@ -15501,6 +16111,148 @@ mod tests {
         assert!(provider_manages_context_inline("codex-fork"));
         assert!(provider_manages_context_inline("codex-app"));
         assert!(!provider_manages_context_inline("claude"));
+    }
+
+    #[test]
+    fn approved_single_reparent_retargets_parent_derived_routing_across_stores() {
+        let state_file = unique_temp_path("reparent-apply");
+        let queue_db = state_file.with_extension("db");
+        let old_credential = "old-parent-secret";
+        let new_credential = "new-parent-secret";
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [
+                    reparent_test_session("oldpar01", None, old_credential),
+                    reparent_test_session("newpar01", None, new_credential),
+                    {
+                        "id": "child001",
+                        "name": "claude-child001",
+                        "working_dir": "/repo",
+                        "tmux_session": "claude-child001",
+                        "status": "running",
+                        "created_at": "2026-06-01T00:00:00Z",
+                        "last_activity": "2026-06-01T00:01:00Z",
+                        "parent_session_id": "oldpar01",
+                        "context_monitor_enabled": true,
+                        "context_monitor_notify": "oldpar01",
+                        "context_monitor_notify_source": "parent_derived"
+                    }
+                ],
+                "retained_parent_wake_registrations": [{
+                    "id": "json-wake-child001",
+                    "child_session_id": "child001",
+                    "parent_session_id": "oldpar01",
+                    "period_seconds": 600,
+                    "is_active": true
+                }]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let queue = RetainedQueueStore::new(queue_db.clone());
+        queue.ensure_schema().unwrap();
+        queue
+            .register_parent_wake("child001", "oldpar01", 600)
+            .unwrap();
+        let message_id = queue
+            .enqueue_message_with_metadata(
+                "child001",
+                "wait for parent",
+                "important",
+                QueueMessageMetadata {
+                    parent_session_id: Some("oldpar01".to_owned()),
+                    ..QueueMessageMetadata::default()
+                },
+            )
+            .unwrap();
+        let store = SessionStore::new_with_queue(state_file.clone(), queue_db.clone());
+
+        let request = match store
+            .create_reparent_request(
+                "child001",
+                CreateReparentRequest {
+                    requester_session_id: "oldpar01".to_owned(),
+                    target_parent_session_id: "newpar01".to_owned(),
+                },
+                old_credential,
+            )
+            .unwrap()
+        {
+            ReparentMutationOutcome::Created(record) => record,
+            other => panic!("unexpected create outcome: {other:?}"),
+        };
+        let applied = match store
+            .decide_reparent_request(
+                &request.id,
+                DecideReparentRequest {
+                    requester_session_id: "newpar01".to_owned(),
+                },
+                ReparentDecision::Approved,
+                new_credential,
+            )
+            .unwrap()
+        {
+            ReparentMutationOutcome::Updated(record) => record,
+            other => panic!("unexpected approval outcome: {other:?}"),
+        };
+
+        assert_eq!(applied.status, "applied");
+        assert_eq!(applied.apply_stage.as_deref(), Some("applied"));
+        let child = store.get_session("child001").unwrap().unwrap();
+        assert_eq!(child.parent_session_id.as_deref(), Some("newpar01"));
+        assert_eq!(child.context_monitor_notify.as_deref(), Some("newpar01"));
+        assert!(child.context_monitor_enabled);
+        assert_eq!(child.context_monitor_notify_source, "parent_derived");
+        assert_eq!(
+            queue
+                .active_parent_wake_parent("child001")
+                .unwrap()
+                .as_deref(),
+            Some("newpar01")
+        );
+        let pending = queue.pending_messages_for_target("child001", 10).unwrap();
+        assert_eq!(
+            pending
+                .iter()
+                .find(|message| message.id == message_id)
+                .and_then(|message| message.parent_session_id.as_deref()),
+            Some("newpar01")
+        );
+        let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+        assert!(state["reparent_apply_lease"].is_null());
+        assert_eq!(
+            state["retained_parent_wake_registrations"][0]["parent_session_id"],
+            "newpar01"
+        );
+        assert_eq!(
+            state["retained_parent_wake_registrations"][0]["is_active"],
+            true
+        );
+
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
+    fn legacy_context_monitor_provenance_defaults_to_explicit() {
+        let value = reparent_test_session("legacy01", None, "legacy-secret");
+        let record: SessionRecord = serde_json::from_value(value).unwrap();
+        assert_eq!(record.context_monitor_notify_source, "explicit");
+    }
+
+    fn reparent_test_session(id: &str, parent: Option<&str>, credential: &str) -> Value {
+        json!({
+            "id": id,
+            "name": format!("claude-{id}"),
+            "working_dir": "/repo",
+            "tmux_session": format!("claude-{id}"),
+            "status": "running",
+            "created_at": "2026-06-01T00:00:00Z",
+            "last_activity": "2026-06-01T00:01:00Z",
+            "parent_session_id": parent,
+            "session_credential_sha256": sha256_text(credential)
+        })
     }
 
     fn unique_temp_path(label: &str) -> PathBuf {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1062,6 +1062,7 @@ impl SessionStore {
         let raw_session = raw_session_object(&state, session_id)
             .ok_or_else(|| anyhow::anyhow!("session {session_id} disappeared"))?;
         if !credential_rotation_has_fresh_idle_proof(&rotations[rotation_index], &session)
+            || active_reparent_request_for_session(&state, session_id)?.is_some()
             || json_text(raw_session.get("pending_handoff_path")).is_some()
             || json_text(raw_session.get("claude_handoff_in_progress_at")).is_some()
             || review_dispatch_in_progress(raw_session)
@@ -2094,7 +2095,10 @@ impl SessionStore {
             };
             if self
                 .get_reparent_request(&request_id)?
-                .is_some_and(|record| record.status == "failed")
+                .is_some_and(|record| {
+                    record.status == "failed"
+                        && record.apply_stage.as_deref() != Some("prequiesce_aborting")
+                })
             {
                 return Ok(first.or(self.get_reparent_request(&request_id)?));
             }
@@ -2184,7 +2188,7 @@ impl SessionStore {
                 }
             }
             ReparentRepairAction::RollbackPrecommit => {
-                if let Err(error) = self.rollback_reparent_precommit(request_id) {
+                if let Err(error) = self.rollback_reparent_precommit(request_id, None) {
                     self.fail_reparent_apply(request_id, &error.to_string())?;
                 }
             }
@@ -2474,8 +2478,17 @@ impl SessionStore {
             };
             match stage.as_str() {
                 "applying" => self.quiesce_reparent_json_routing(request_id)?,
+                "prequiesce_aborting" => {
+                    self.complete_reparent_prequiesce_abort(request_id)?;
+                    return Ok(());
+                }
                 "json_routing_quiesced" => self.quiesce_reparent_queue_routing(request_id)?,
-                "routing_quiesced" => self.commit_reparent_authority(request_id)?,
+                "routing_quiesced" => {
+                    if let Some(reason) = self.commit_reparent_authority(request_id)? {
+                        self.rollback_reparent_precommit(request_id, Some(&reason))?;
+                        return Ok(());
+                    }
+                }
                 "authority_committed" => {
                     self.finish_reparent_routing(request_id)?;
                     return Ok(());
@@ -2538,7 +2551,7 @@ impl SessionStore {
         self.write_raw_json_value(&state)
     }
 
-    fn commit_reparent_authority(&self, request_id: &str) -> Result<()> {
+    fn commit_reparent_authority(&self, request_id: &str) -> Result<Option<String>> {
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
         let mut records = reparent_request_records(&state)?;
@@ -2549,12 +2562,13 @@ impl SessionStore {
             .context("reparent apply plan is missing")?;
         let sessions = snapshot_from_raw_value(&state)?.into_sessions();
         if let Some(reason) = reparent_stale_reason(record, &sessions) {
-            anyhow::bail!("reparent request became stale before authority commit: {reason}");
+            return Ok(Some(reason));
         }
         commit_json_reparent_plan(&mut state, &plan)?;
         record.apply_stage = Some("authority_committed".to_owned());
         store_reparent_request_records(&mut state, &records)?;
-        self.write_raw_json_value(&state)
+        self.write_raw_json_value(&state)?;
+        Ok(None)
     }
 
     fn finish_reparent_routing(&self, request_id: &str) -> Result<()> {
@@ -2584,7 +2598,7 @@ impl SessionStore {
             Vec::new()
         };
         self.persist_delivered_reparent_wake_intents(request_id, &delivered_message_rows)?;
-        self.replay_deferred_reparent_routes(request_id, &new_parent_session_id)?;
+        self.replay_deferred_reparent_routes(request_id, false)?;
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
         let mut records = reparent_request_records(&state)?;
@@ -2607,8 +2621,9 @@ impl SessionStore {
     fn replay_deferred_reparent_routes(
         &self,
         request_id: &str,
-        resolved_parent_session_id: &str,
+        reapply_completed: bool,
     ) -> Result<()> {
+        let mut reapplied = BTreeSet::new();
         loop {
             let intent = {
                 let _guard = self.write_guard()?;
@@ -2617,11 +2632,26 @@ impl SessionStore {
                 leased_reparent_request(&state, &records, request_id)?
                     .deferred_routing_intents
                     .iter()
-                    .find(|intent| intent.replayed_at.is_none())
+                    .find(|intent| {
+                        intent.replayed_at.is_none()
+                            || (reapply_completed && !reapplied.contains(&intent.key))
+                    })
                     .cloned()
             };
             let Some(intent) = intent else {
                 return Ok(());
+            };
+            let resolved_parent_session_id = {
+                let _guard = self.write_guard()?;
+                let state = self.load_raw_json_value()?;
+                raw_session_object(&state, &intent.child_session_id)
+                    .and_then(|session| json_text(session.get("parent_session_id")))
+                    .with_context(|| {
+                        format!(
+                            "deferred route for {} has no canonical parent",
+                            intent.child_session_id
+                        )
+                    })?
             };
             match intent.operation.as_str() {
                 "parent_wake" => {
@@ -2633,7 +2663,7 @@ impl SessionStore {
                     if let Some(queue) = self.queue_store.as_ref() {
                         queue.register_parent_wake(
                             &intent.child_session_id,
-                            resolved_parent_session_id,
+                            &resolved_parent_session_id,
                             period_seconds,
                         )?;
                     } else {
@@ -2650,7 +2680,7 @@ impl SessionStore {
                     if let Some(queue) = self.queue_store.as_ref() {
                         queue.enqueue_message_once_with_metadata(
                             &message_id,
-                            resolved_parent_session_id,
+                            &resolved_parent_session_id,
                             text,
                             "important",
                             QueueMessageMetadata {
@@ -2674,45 +2704,46 @@ impl SessionStore {
                 .iter_mut()
                 .find(|current| current.key == intent.key)
                 .with_context(|| format!("deferred routing intent {} disappeared", intent.key))?;
-            if current.replayed_at.is_none() {
-                match intent.operation.as_str() {
-                    "parent_wake" => {
-                        let period_seconds = intent
-                            .payload
-                            .get("period_seconds")
-                            .and_then(Value::as_i64)
-                            .context("deferred parent wake has no period")?;
-                        upsert_parent_wake_raw(
-                            &mut state,
-                            &intent.child_session_id,
-                            resolved_parent_session_id,
-                            period_seconds,
-                        )?;
-                    }
-                    "task_complete" => {
-                        let text = intent
-                            .payload
-                            .get("text")
-                            .and_then(Value::as_str)
-                            .context("deferred task-complete has no text")?;
-                        let message_id = deferred_task_complete_message_id(request_id, &intent.key);
-                        push_retained_message_once_raw(
-                            &mut state,
-                            &message_id,
-                            resolved_parent_session_id,
-                            text,
-                            "important",
-                            Some("task_complete"),
-                        )?;
-                        deactivate_parent_wake_raw(&mut state, &intent.child_session_id)?;
-                    }
-                    other => anyhow::bail!("unsupported deferred routing operation {other}"),
+            match intent.operation.as_str() {
+                "parent_wake" => {
+                    let period_seconds = intent
+                        .payload
+                        .get("period_seconds")
+                        .and_then(Value::as_i64)
+                        .context("deferred parent wake has no period")?;
+                    upsert_parent_wake_raw(
+                        &mut state,
+                        &intent.child_session_id,
+                        &resolved_parent_session_id,
+                        period_seconds,
+                    )?;
                 }
-                current.replayed_at = Some(now_rfc3339());
-                current.resolved_parent_session_id = Some(resolved_parent_session_id.to_owned());
-                store_reparent_request_records(&mut state, &records)?;
-                self.write_raw_json_value(&state)?;
+                "task_complete" => {
+                    let text = intent
+                        .payload
+                        .get("text")
+                        .and_then(Value::as_str)
+                        .context("deferred task-complete has no text")?;
+                    let message_id = deferred_task_complete_message_id(request_id, &intent.key);
+                    push_retained_message_once_raw(
+                        &mut state,
+                        &message_id,
+                        &resolved_parent_session_id,
+                        text,
+                        "important",
+                        Some("task_complete"),
+                    )?;
+                    deactivate_parent_wake_raw(&mut state, &intent.child_session_id)?;
+                }
+                other => anyhow::bail!("unsupported deferred routing operation {other}"),
             }
+            if current.replayed_at.is_none() {
+                current.replayed_at = Some(now_rfc3339());
+                current.resolved_parent_session_id = Some(resolved_parent_session_id);
+            }
+            store_reparent_request_records(&mut state, &records)?;
+            self.write_raw_json_value(&state)?;
+            reapplied.insert(intent.key);
         }
     }
 
@@ -2759,30 +2790,50 @@ impl SessionStore {
     }
 
     fn fail_reparent_apply(&self, request_id: &str, failure_reason: &str) -> Result<()> {
+        let before_quiesce = {
+            let _guard = self.write_guard()?;
+            let mut state = self.load_raw_json_value()?;
+            let mut records = reparent_request_records(&state)?;
+            let record = leased_reparent_request_mut(&state, &mut records, request_id)?;
+            let before_quiesce = matches!(record.apply_stage.as_deref(), None | Some("applying"));
+            record.status = "failed".to_owned();
+            if before_quiesce {
+                record.apply_stage = Some("prequiesce_aborting".to_owned());
+            }
+            record.failure_reason = Some(failure_reason.to_owned());
+            record.ready_to_apply = false;
+            record.decided_at = Some(now_rfc3339());
+            store_reparent_request_records(&mut state, &records)?;
+            self.write_raw_json_value(&state)?;
+            before_quiesce
+        };
+        if !before_quiesce {
+            return Ok(());
+        }
+        self.complete_reparent_prequiesce_abort(request_id)
+    }
+
+    fn complete_reparent_prequiesce_abort(&self, request_id: &str) -> Result<()> {
+        self.replay_deferred_reparent_routes(request_id, true)?;
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
         let mut records = reparent_request_records(&state)?;
         let record = leased_reparent_request_mut(&state, &mut records, request_id)?;
-        let before_quiesce = matches!(record.apply_stage.as_deref(), None | Some("applying"));
-        record.status = if before_quiesce {
-            "stale".to_owned()
-        } else {
-            "failed".to_owned()
-        };
-        if before_quiesce {
-            record.apply_stage = Some("prequiesce_aborted".to_owned());
+        if record.apply_stage.as_deref() != Some("prequiesce_aborting") {
+            anyhow::bail!("reparent request stage changed during pre-quiesce abort")
         }
-        record.failure_reason = Some(failure_reason.to_owned());
-        record.ready_to_apply = false;
-        record.decided_at = Some(now_rfc3339());
+        record.status = "stale".to_owned();
+        record.apply_stage = Some("prequiesce_aborted".to_owned());
         store_reparent_request_records(&mut state, &records)?;
-        if before_quiesce {
-            store_reparent_apply_lease(&mut state, None)?;
-        }
+        store_reparent_apply_lease(&mut state, None)?;
         self.write_raw_json_value(&state)
     }
 
-    fn rollback_reparent_precommit(&self, request_id: &str) -> Result<()> {
+    fn rollback_reparent_precommit(
+        &self,
+        request_id: &str,
+        stale_reason: Option<&str>,
+    ) -> Result<()> {
         let (plan, snapshot, old_parent) = {
             let _guard = self.write_guard()?;
             let state = self.load_raw_json_value()?;
@@ -2815,16 +2866,31 @@ impl SessionStore {
             Vec::new()
         };
         self.persist_delivered_reparent_wake_intents(request_id, &delivered_message_rows)?;
-        self.replay_deferred_reparent_routes(request_id, &old_parent)?;
+        {
+            let _guard = self.write_guard()?;
+            let mut state = self.load_raw_json_value()?;
+            let records = reparent_request_records(&state)?;
+            let _ = leased_reparent_request(&state, &records, request_id)?;
+            restore_json_reparent_routes(&mut state, &plan)?;
+            verify_old_reparent_edges(&state, &plan)?;
+            self.write_raw_json_value(&state)?;
+        }
+        self.replay_deferred_reparent_routes(request_id, true)?;
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
         let mut records = reparent_request_records(&state)?;
         let record = leased_reparent_request_mut(&state, &mut records, request_id)?;
-        restore_json_reparent_routes(&mut state, &plan)?;
-        verify_old_reparent_edges(&state, &plan)?;
-        record.status = "repaired".to_owned();
-        record.apply_stage = Some("repair_rolled_back".to_owned());
-        record.failure_reason = None;
+        record.status = if stale_reason.is_some() {
+            "stale".to_owned()
+        } else {
+            "repaired".to_owned()
+        };
+        record.apply_stage = Some(if stale_reason.is_some() {
+            "prequiesce_aborted".to_owned()
+        } else {
+            "repair_rolled_back".to_owned()
+        });
+        record.failure_reason = stale_reason.map(ToOwned::to_owned);
         record.ready_to_apply = false;
         record.decided_at = Some(now_rfc3339());
         store_reparent_request_records(&mut state, &records)?;
@@ -6137,7 +6203,7 @@ impl SessionStore {
             .unwrap_or_else(|| non_empty_or(session.name.clone(), &session.id));
         let completion_text =
             format!("[sm task-complete] agent {session_id}({friendly}) completed its task.");
-        if let Some(request_id) = active_reparent_request_for_session(&state, session_id)? {
+        if let Some(request_id) = active_reparent_route_request_for_session(&state, session_id)? {
             if let Some(queue) = &self.queue_store {
                 queue.cancel_remind(session_id)?;
             }
@@ -10969,6 +11035,23 @@ fn active_reparent_request_for_session(state: &Value, session_id: &str) -> Resul
         .map(|record| record.id))
 }
 
+fn active_reparent_route_request_for_session(
+    state: &Value,
+    session_id: &str,
+) -> Result<Option<String>> {
+    Ok(reparent_request_records(state)?
+        .into_iter()
+        .find(|record| {
+            record.is_apply_fenced()
+                && record.apply_plan.as_ref().is_some_and(|plan| {
+                    plan.edge_changes
+                        .iter()
+                        .any(|change| change.session_id == session_id.trim())
+                })
+        })
+        .map(|record| record.id))
+}
+
 fn ensure_session_not_reparent_fenced(state: &Value, session_id: &str) -> Result<()> {
     if let Some(request_id) = active_reparent_request_for_session(state, session_id)? {
         anyhow::bail!("reparent request {request_id} controls session {session_id}")
@@ -11156,7 +11239,16 @@ fn restore_json_reparent_routes(state: &mut Value, plan: &ReparentApplyPlan) -> 
                 let object = entry
                     .as_object_mut()
                     .context("parent wake record must be an object")?;
-                validate_json_parent_route(object, change, false)?;
+                let already_restored = json_text(object.get("parent_session_id")).as_deref()
+                    == Some(old_parent.as_str())
+                    && object
+                        .get("is_active")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false)
+                        == change.prior_active.unwrap_or(false);
+                if !already_restored {
+                    validate_json_parent_route(object, change, false)?;
+                }
                 object.insert("parent_session_id".to_owned(), Value::String(old_parent));
                 object.insert(
                     "is_active".to_owned(),
@@ -11167,7 +11259,16 @@ fn restore_json_reparent_routes(state: &mut Value, plan: &ReparentApplyPlan) -> 
                 let sessions = ensure_sessions_array_mut(state)?;
                 let session = session_object_mut(sessions, &change.child_session_id)
                     .with_context(|| format!("session {} disappeared", change.child_session_id))?;
-                validate_json_parent_route(session, change, false)?;
+                let already_restored = json_text(session.get("context_monitor_notify")).as_deref()
+                    == Some(old_parent.as_str())
+                    && session
+                        .get("context_monitor_enabled")
+                        .and_then(Value::as_bool)
+                        .unwrap_or(false)
+                        == change.prior_active.unwrap_or(false);
+                if !already_restored {
+                    validate_json_parent_route(session, change, false)?;
+                }
                 session.insert(
                     "context_monitor_notify".to_owned(),
                     Value::String(old_parent),
@@ -17126,6 +17227,125 @@ mod tests {
             Some("newpar01")
         );
 
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
+    fn task_complete_for_an_affected_parent_is_not_deferred_as_a_changed_edge() {
+        let (store, _queue, state_file, queue_db, request_id) =
+            prepared_reparent_transaction("reparent-parent-task-complete");
+        store.acquire_reparent_apply_lease().unwrap();
+        store.quiesce_reparent_json_routing(&request_id).unwrap();
+        store.quiesce_reparent_queue_routing(&request_id).unwrap();
+
+        store
+            .task_complete(
+                "newpar01",
+                TaskCompleteRequest {
+                    requester_session_id: "newpar01".to_owned(),
+                },
+                None,
+            )
+            .unwrap();
+
+        let record = store.get_reparent_request(&request_id).unwrap().unwrap();
+        assert!(record.deferred_routing_intents.is_empty());
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
+    fn stale_after_routing_quiesce_rolls_back_without_human_repair() {
+        let (store, queue, state_file, queue_db, request_id) =
+            prepared_reparent_transaction("reparent-stale-rollback");
+        store.acquire_reparent_apply_lease().unwrap();
+        store.quiesce_reparent_json_routing(&request_id).unwrap();
+        store.quiesce_reparent_queue_routing(&request_id).unwrap();
+        {
+            let _guard = store.write_guard().unwrap();
+            let mut state = store.load_raw_json_value().unwrap();
+            let sessions = ensure_sessions_array_mut(&mut state).unwrap();
+            session_object_mut(sessions, "newpar01")
+                .unwrap()
+                .insert("status".to_owned(), Value::String("stopped".to_owned()));
+            store.write_raw_json_value(&state).unwrap();
+        }
+
+        store.apply_reparent_request(&request_id).unwrap();
+
+        let record = store.get_reparent_request(&request_id).unwrap().unwrap();
+        assert_eq!(record.status, "stale");
+        assert_eq!(record.apply_stage.as_deref(), Some("prequiesce_aborted"));
+        assert!(record.failure_reason.is_some());
+        assert_eq!(
+            store
+                .get_session("child001")
+                .unwrap()
+                .unwrap()
+                .parent_session_id
+                .as_deref(),
+            Some("oldpar01")
+        );
+        assert_eq!(
+            queue
+                .active_parent_wake_parent("child001")
+                .unwrap()
+                .as_deref(),
+            Some("oldpar01")
+        );
+        let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+        assert!(state["reparent_apply_lease"].is_null());
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
+    fn prequiesce_abort_replays_deferred_completion_before_releasing_lease() {
+        let (store, queue, state_file, queue_db, request_id) =
+            prepared_reparent_transaction("reparent-prequiesce-abort");
+        store.acquire_reparent_apply_lease().unwrap();
+        store
+            .task_complete(
+                "child001",
+                TaskCompleteRequest {
+                    requester_session_id: "child001".to_owned(),
+                },
+                None,
+            )
+            .unwrap();
+        {
+            let _guard = store.write_guard().unwrap();
+            let mut state = store.load_raw_json_value().unwrap();
+            let sessions = ensure_sessions_array_mut(&mut state).unwrap();
+            session_object_mut(sessions, "newpar01")
+                .unwrap()
+                .insert("status".to_owned(), Value::String("stopped".to_owned()));
+            store.write_raw_json_value(&state).unwrap();
+        }
+
+        let error = store.apply_reparent_request(&request_id).unwrap_err();
+        store
+            .fail_reparent_apply(&request_id, &error.to_string())
+            .unwrap();
+
+        let record = store.get_reparent_request(&request_id).unwrap().unwrap();
+        assert_eq!(record.status, "stale");
+        assert!(record.deferred_routing_intents[0].replayed_at.is_some());
+        assert_eq!(
+            record.deferred_routing_intents[0]
+                .resolved_parent_session_id
+                .as_deref(),
+            Some("oldpar01")
+        );
+        let messages = queue.pending_messages_for_target("oldpar01", 10).unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].message_category.as_deref(),
+            Some("task_complete")
+        );
+        let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+        assert!(state["reparent_apply_lease"].is_null());
         let _ = fs::remove_file(state_file);
         let _ = fs::remove_file(queue_db);
     }

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1005,8 +1005,11 @@ impl SessionStore {
             return Ok(false);
         }
 
-        let (_input_guard, _guard) =
-            self.lock_session_input_then_state(&session_runtime, &rotation.tmux_session)?;
+        let (_clear_guard, _guard, _input_guard) = self.lock_credential_rotation_fences(
+            session_id,
+            &session_runtime,
+            &rotation.tmux_session,
+        )?;
         let mut state = self.load_raw_json_value()?;
         let mut rotations = session_credential_rotation_records(&state)?;
         let Some(rotation_index) = rotations
@@ -3127,6 +3130,22 @@ impl SessionStore {
 
     fn lock_clear_operation(&self, session_id: &str) -> Result<SessionClearGuard> {
         self.lock_named_clear_operation(session_id)
+    }
+
+    fn lock_credential_rotation_fences<'a>(
+        &'a self,
+        session_id: &str,
+        runtime: &TmuxRuntime,
+        tmux_session: &str,
+    ) -> Result<(
+        SessionClearGuard,
+        std::sync::MutexGuard<'a, ()>,
+        crate::runtime::SessionInputGuard,
+    )> {
+        let clear_guard = self.lock_clear_operation(session_id)?;
+        let state_guard = self.write_guard()?;
+        let input_guard = runtime.lock_session_input(tmux_session)?;
+        Ok((clear_guard, state_guard, input_guard))
     }
 
     fn lock_codex_cli_binding_operation(
@@ -5639,21 +5658,6 @@ impl SessionStore {
         self.write_lock
             .lock()
             .map_err(|_| anyhow::anyhow!("session state write lock poisoned"))
-    }
-
-    fn lock_session_input_then_state<'a>(
-        &'a self,
-        runtime: &TmuxRuntime,
-        tmux_session: &str,
-    ) -> Result<(
-        crate::runtime::SessionInputGuard,
-        std::sync::MutexGuard<'a, ()>,
-    )> {
-        // Claude handoff already holds this input fence before consulting durable
-        // state. Keep the same lock order for every operation that takes both.
-        let input_guard = runtime.lock_session_input(tmux_session)?;
-        let state_guard = self.write_guard()?;
-        Ok((input_guard, state_guard))
     }
 
     fn start_codex_fork_event_monitor(
@@ -11641,42 +11645,73 @@ mod tests {
     }
 
     #[test]
-    fn credential_rotation_waiting_for_input_does_not_hold_state_lock() {
-        let state_file = unique_temp_path("credential-rotation-lock-order");
+    fn credential_rotation_and_clear_share_one_seat_operation_fence() {
+        let state_file = unique_temp_path("credential-rotation-clear-fence");
         let store = SessionStore::new(state_file.clone());
+        let clear_guard = store.lock_clear_operation("codex001").unwrap();
         let runtime = TmuxRuntime::from_config(&crate::config::RustCoreConfig::default());
-        let tmux_session = format!("lock-order-{}", generate_session_id());
-        let held_input = runtime.lock_session_input(&tmux_session).unwrap();
         let contender_store = store.clone();
         let contender_runtime = runtime.clone();
-        let contender_session = tmux_session.clone();
         let (started_tx, started_rx) = std::sync::mpsc::channel();
         let (acquired_tx, acquired_rx) = std::sync::mpsc::channel();
         let contender = thread::spawn(move || {
             started_tx.send(()).unwrap();
             let _guards = contender_store
-                .lock_session_input_then_state(&contender_runtime, &contender_session)
+                .lock_credential_rotation_fences("codex001", &contender_runtime, "tmux-codex001")
                 .unwrap();
             acquired_tx.send(()).unwrap();
         });
         started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
-        thread::sleep(Duration::from_millis(50));
-
-        let state_store = store.clone();
-        let (state_tx, state_rx) = std::sync::mpsc::channel();
-        let state_writer = thread::spawn(move || {
-            let _guard = state_store.write_guard().unwrap();
-            state_tx.send(()).unwrap();
-        });
-        state_rx
-            .recv_timeout(Duration::from_secs(1))
-            .expect("input waiter held the global state lock");
-        assert!(acquired_rx.try_recv().is_err());
-
-        drop(held_input);
+        assert!(acquired_rx
+            .recv_timeout(Duration::from_millis(100))
+            .is_err());
+        drop(clear_guard);
         acquired_rx.recv_timeout(Duration::from_secs(1)).unwrap();
         contender.join().unwrap();
-        state_writer.join().unwrap();
+        let _ = fs::remove_file(state_file);
+    }
+
+    #[test]
+    fn credential_rotation_uses_the_send_state_then_input_lock_order() {
+        let state_file = unique_temp_path("credential-rotation-send-lock-order");
+        let store = SessionStore::new(state_file.clone());
+        let runtime = TmuxRuntime::from_config(&crate::config::RustCoreConfig::default());
+        let tmux_session = format!("lock-order-{}", generate_session_id());
+        let held_input = runtime.lock_session_input(&tmux_session).unwrap();
+        let send_store = store.clone();
+        let send_runtime = runtime.clone();
+        let send_session = tmux_session.clone();
+        let (send_state_tx, send_state_rx) = std::sync::mpsc::channel();
+        let (send_done_tx, send_done_rx) = std::sync::mpsc::channel();
+        let send = thread::spawn(move || {
+            let _state_guard = send_store.write_guard().unwrap();
+            send_state_tx.send(()).unwrap();
+            let _input_guard = send_runtime.lock_session_input(&send_session).unwrap();
+            send_done_tx.send(()).unwrap();
+        });
+        send_state_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+
+        let rotation_store = store.clone();
+        let rotation_runtime = runtime.clone();
+        let rotation_session = tmux_session.clone();
+        let (rotation_done_tx, rotation_done_rx) = std::sync::mpsc::channel();
+        let rotation = thread::spawn(move || {
+            let _guards = rotation_store
+                .lock_credential_rotation_fences("codex001", &rotation_runtime, &rotation_session)
+                .unwrap();
+            rotation_done_tx.send(()).unwrap();
+        });
+        assert!(rotation_done_rx
+            .recv_timeout(Duration::from_millis(100))
+            .is_err());
+
+        drop(held_input);
+        send_done_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        rotation_done_rx
+            .recv_timeout(Duration::from_secs(1))
+            .unwrap();
+        send.join().unwrap();
+        rotation.join().unwrap();
         let _ = fs::remove_file(state_file);
     }
 

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -2690,12 +2690,6 @@ impl SessionStore {
                 let state = self.load_raw_json_value()?;
                 raw_session_object(&state, &intent.child_session_id)
                     .and_then(|session| json_text(session.get("parent_session_id")))
-                    .with_context(|| {
-                        format!(
-                            "deferred route for {} has no canonical parent",
-                            intent.child_session_id
-                        )
-                    })?
             };
             match intent.operation.as_str() {
                 "parent_wake" => {
@@ -2704,13 +2698,16 @@ impl SessionStore {
                         .get("period_seconds")
                         .and_then(Value::as_i64)
                         .context("deferred parent wake has no period")?;
-                    if let Some(queue) = self.queue_store.as_ref() {
+                    if let (Some(queue), Some(parent_session_id)) = (
+                        self.queue_store.as_ref(),
+                        resolved_parent_session_id.as_deref(),
+                    ) {
                         queue.register_parent_wake(
                             &intent.child_session_id,
-                            &resolved_parent_session_id,
+                            parent_session_id,
                             period_seconds,
                         )?;
-                    } else {
+                    } else if resolved_parent_session_id.is_some() {
                         anyhow::bail!("deferred parent wake requires the retained queue store")
                     }
                 }
@@ -2721,10 +2718,13 @@ impl SessionStore {
                         .and_then(Value::as_str)
                         .context("deferred task-complete has no text")?;
                     let message_id = deferred_task_complete_message_id(request_id, &intent.key);
-                    if let Some(queue) = self.queue_store.as_ref() {
+                    if let (Some(queue), Some(parent_session_id)) = (
+                        self.queue_store.as_ref(),
+                        resolved_parent_session_id.as_deref(),
+                    ) {
                         queue.enqueue_message_once_with_metadata(
                             &message_id,
-                            &resolved_parent_session_id,
+                            parent_session_id,
                             text,
                             "important",
                             QueueMessageMetadata {
@@ -2733,8 +2733,8 @@ impl SessionStore {
                             },
                         )?;
                         queue.cancel_parent_wake(&intent.child_session_id)?;
-                        replay_targets.insert(resolved_parent_session_id.clone());
-                    } else {
+                        replay_targets.insert(parent_session_id.to_owned());
+                    } else if resolved_parent_session_id.is_some() {
                         anyhow::bail!("deferred task-complete requires the retained queue store")
                     }
                 }
@@ -2755,10 +2755,13 @@ impl SessionStore {
                         .and_then(Value::as_str)
                         .context("deferred parent message has no category")?;
                     let message_id = deferred_parent_message_id(request_id, &intent.key);
-                    if let Some(queue) = self.queue_store.as_ref() {
+                    if let (Some(queue), Some(parent_session_id)) = (
+                        self.queue_store.as_ref(),
+                        resolved_parent_session_id.as_deref(),
+                    ) {
                         queue.enqueue_message_once_with_metadata(
                             &message_id,
-                            &resolved_parent_session_id,
+                            parent_session_id,
                             text,
                             delivery_mode,
                             QueueMessageMetadata {
@@ -2767,8 +2770,8 @@ impl SessionStore {
                                 ..QueueMessageMetadata::default()
                             },
                         )?;
-                        replay_targets.insert(resolved_parent_session_id.clone());
-                    } else {
+                        replay_targets.insert(parent_session_id.to_owned());
+                    } else if resolved_parent_session_id.is_some() {
                         anyhow::bail!("deferred parent message requires the retained queue store")
                     }
                 }
@@ -2784,8 +2787,10 @@ impl SessionStore {
                         .and_then(Value::as_str)
                         .context("deferred parent input has no delivery mode")?;
                     let message_id = deferred_parent_message_id(request_id, &intent.key);
-                    let metadata =
-                        deferred_parent_input_metadata(&intent, &resolved_parent_session_id)?;
+                    let metadata = deferred_parent_input_metadata(
+                        &intent,
+                        resolved_parent_session_id.as_deref(),
+                    )?;
                     if let Some(queue) = self.queue_store.as_ref() {
                         queue.enqueue_message_once_with_metadata(
                             &message_id,
@@ -2817,12 +2822,14 @@ impl SessionStore {
                         .get("period_seconds")
                         .and_then(Value::as_i64)
                         .context("deferred parent wake has no period")?;
-                    upsert_parent_wake_raw(
-                        &mut state,
-                        &intent.child_session_id,
-                        &resolved_parent_session_id,
-                        period_seconds,
-                    )?;
+                    if let Some(parent_session_id) = resolved_parent_session_id.as_deref() {
+                        upsert_parent_wake_raw(
+                            &mut state,
+                            &intent.child_session_id,
+                            parent_session_id,
+                            period_seconds,
+                        )?;
+                    }
                 }
                 "task_complete" => {
                     let text = intent
@@ -2831,15 +2838,17 @@ impl SessionStore {
                         .and_then(Value::as_str)
                         .context("deferred task-complete has no text")?;
                     let message_id = deferred_task_complete_message_id(request_id, &intent.key);
-                    push_retained_message_once_raw(
-                        &mut state,
-                        &message_id,
-                        &resolved_parent_session_id,
-                        text,
-                        "important",
-                        Some("task_complete"),
-                    )?;
-                    deactivate_parent_wake_raw(&mut state, &intent.child_session_id)?;
+                    if let Some(parent_session_id) = resolved_parent_session_id.as_deref() {
+                        push_retained_message_once_raw(
+                            &mut state,
+                            &message_id,
+                            parent_session_id,
+                            text,
+                            "important",
+                            Some("task_complete"),
+                        )?;
+                        deactivate_parent_wake_raw(&mut state, &intent.child_session_id)?;
+                    }
                 }
                 "parent_message" => {
                     let text = intent
@@ -2858,21 +2867,23 @@ impl SessionStore {
                         .and_then(Value::as_str)
                         .context("deferred parent message has no category")?;
                     let message_id = deferred_parent_message_id(request_id, &intent.key);
-                    push_retained_message_once_raw(
-                        &mut state,
-                        &message_id,
-                        &resolved_parent_session_id,
-                        text,
-                        delivery_mode,
-                        Some(category),
-                    )?;
+                    if let Some(parent_session_id) = resolved_parent_session_id.as_deref() {
+                        push_retained_message_once_raw(
+                            &mut state,
+                            &message_id,
+                            parent_session_id,
+                            text,
+                            delivery_mode,
+                            Some(category),
+                        )?;
+                    }
                 }
                 "parent_input" => {}
                 other => anyhow::bail!("unsupported deferred routing operation {other}"),
             }
             if current.replayed_at.is_none() {
                 current.replayed_at = Some(now_rfc3339());
-                current.resolved_parent_session_id = Some(resolved_parent_session_id);
+                current.resolved_parent_session_id = resolved_parent_session_id;
             }
             store_reparent_request_records(&mut state, &records)?;
             self.write_raw_json_value(&state)?;
@@ -4741,7 +4752,7 @@ impl SessionStore {
         emitted_at: Option<&str>,
         runtime: Option<&TmuxRuntime>,
     ) -> Result<ContextUsageOutcome> {
-        let (notify_target, label, informational_only) = {
+        let (notify_target, notify_source, label, informational_only) = {
             let sessions = ensure_sessions_array_mut(state)?;
             let Some(session) = session_object_mut(sessions, session_id) else {
                 return Ok(ContextUsageOutcome::UnknownSession);
@@ -4758,22 +4769,33 @@ impl SessionStore {
                     .as_deref()
                     .unwrap_or("claude"),
             );
-            let notify_target = if informational_only {
+            let (notify_target, notify_source) = if informational_only {
                 session.insert("context_monitor_enabled".to_owned(), Value::Bool(false));
                 session.insert("context_monitor_notify".to_owned(), Value::Null);
                 session.insert(
                     "context_monitor_notify_source".to_owned(),
                     Value::String(default_context_monitor_notify_source()),
                 );
-                None
+                (None, default_context_monitor_notify_source())
             } else {
-                json_text(session.get("context_monitor_notify"))
-                    // Fall back to the parent so an unregistered child still reports
-                    // its own context loss upward (#210).
-                    .or_else(|| json_text(session.get("parent_session_id")))
+                let configured_target = json_text(session.get("context_monitor_notify"));
+                let notify_source = if configured_target.is_some() {
+                    json_text(session.get("context_monitor_notify_source"))
+                        .unwrap_or_else(default_context_monitor_notify_source)
+                } else {
+                    "parent_derived".to_owned()
+                };
+                (
+                    configured_target
+                        // Fall back to the parent so an unregistered child still reports
+                        // its own context loss upward (#210).
+                        .or_else(|| json_text(session.get("parent_session_id"))),
+                    notify_source,
+                )
             };
             (
                 notify_target,
+                notify_source,
                 raw_session_label(session, session_id),
                 informational_only,
             )
@@ -4784,8 +4806,12 @@ impl SessionStore {
                 "[sm context] Compaction fired for {label} ({session_id}). \
                  Context was compacted — agent is still running."
             );
-            if let Some(request_id) = active_reparent_route_request_for_session(state, session_id)?
-            {
+            let deferred_request_id = if notify_source == "parent_derived" {
+                active_reparent_route_request_for_session(state, session_id)?
+            } else {
+                None
+            };
+            if let Some(request_id) = deferred_request_id {
                 persist_deferred_parent_message_intent(
                     state,
                     &request_id,
@@ -8571,7 +8597,7 @@ fn persist_deferred_parent_input_intent(
 
 fn deferred_parent_input_metadata(
     intent: &ReparentDeferredRoutingIntent,
-    parent_session_id: &str,
+    parent_session_id: Option<&str>,
 ) -> Result<QueueMessageMetadata> {
     Ok(QueueMessageMetadata {
         sender_session_id: intent
@@ -8620,7 +8646,7 @@ fn deferred_parent_input_metadata(
             .get("remind_cancel_on_reply_session_id")
             .and_then(Value::as_str)
             .map(ToOwned::to_owned),
-        parent_session_id: Some(parent_session_id.to_owned()),
+        parent_session_id: parent_session_id.map(ToOwned::to_owned),
         ..QueueMessageMetadata::default()
     })
 }
@@ -17579,6 +17605,15 @@ mod tests {
         store.quiesce_reparent_json_routing(&request.id).unwrap();
         store.quiesce_reparent_queue_routing(&request.id).unwrap();
         store
+            .send_parent_notification(
+                "child001",
+                "Child child001 completed: Session exited",
+                "sequential",
+                "child_wait",
+                None,
+            )
+            .unwrap();
+        store
             .fail_reparent_apply(&request.id, "injected parentless failure")
             .unwrap();
         let repaired = store
@@ -17599,6 +17634,15 @@ mod tests {
         let record = store.get_reparent_request(&request.id).unwrap().unwrap();
         assert_eq!(record.status, "repaired");
         assert_eq!(record.apply_stage.as_deref(), Some("repair_rolled_back"));
+        assert_eq!(record.deferred_routing_intents.len(), 1);
+        assert!(record.deferred_routing_intents[0].replayed_at.is_some());
+        assert!(record.deferred_routing_intents[0]
+            .resolved_parent_session_id
+            .is_none());
+        assert!(queue
+            .pending_messages_for_target("newpar01", 10)
+            .unwrap()
+            .is_empty());
 
         let _ = fs::remove_file(state_file);
         let _ = fs::remove_file(queue_db);
@@ -17800,6 +17844,51 @@ mod tests {
             messages[0].message_category.as_deref(),
             Some("context_monitor")
         );
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
+    fn explicit_compaction_target_is_not_retargeted_during_reparent() {
+        let (store, queue, state_file, queue_db, request_id) =
+            prepared_reparent_transaction("reparent-explicit-compaction");
+        {
+            let _guard = store.write_guard().unwrap();
+            let mut state = store.load_raw_json_value().unwrap();
+            let child =
+                session_object_mut(ensure_sessions_array_mut(&mut state).unwrap(), "child001")
+                    .unwrap();
+            child.insert(
+                "context_monitor_notify".to_owned(),
+                Value::String("oldpar01".to_owned()),
+            );
+            child.insert(
+                "context_monitor_notify_source".to_owned(),
+                Value::String("explicit".to_owned()),
+            );
+            store.write_raw_json_value(&state).unwrap();
+        }
+        store.acquire_reparent_apply_lease().unwrap();
+        store.quiesce_reparent_json_routing(&request_id).unwrap();
+        store.quiesce_reparent_queue_routing(&request_id).unwrap();
+
+        store
+            .apply_context_usage_event(&lifecycle_event("child001", "compaction"), None)
+            .unwrap();
+
+        let record = store.get_reparent_request(&request_id).unwrap().unwrap();
+        assert!(record.deferred_routing_intents.is_empty());
+        let messages = queue.pending_messages_for_target("oldpar01", 10).unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].message_category.as_deref(),
+            Some("context_monitor")
+        );
+        assert!(queue
+            .pending_messages_for_target("newpar01", 10)
+            .unwrap()
+            .is_empty());
+
         let _ = fs::remove_file(state_file);
         let _ = fs::remove_file(queue_db);
     }

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -787,6 +787,261 @@ impl SessionStore {
         Ok(())
     }
 
+    fn start_credential_rotation_worker(&self, session_id: String) -> Result<()> {
+        {
+            let mut workers = self
+                .credential_rotation_workers
+                .lock()
+                .map_err(|_| anyhow::anyhow!("credential rotation worker registry poisoned"))?;
+            if !workers.insert(session_id.clone()) {
+                return Ok(());
+            }
+        }
+        let store = self.clone();
+        let worker_session_id = session_id.clone();
+        let spawn_result = thread::Builder::new()
+            .name(format!(
+                "sm-recredential-{}",
+                sanitize_path_component(&session_id)
+            ))
+            .spawn(move || {
+                loop {
+                    match store.try_apply_waiting_credential_rotation(&worker_session_id) {
+                        Ok(true) => break,
+                        Ok(false) => thread::sleep(Duration::from_secs(1)),
+                        Err(error) => {
+                            eprintln!(
+                                "credential rotation worker failed for {worker_session_id}: {error:#}"
+                            );
+                            break;
+                        }
+                    }
+                }
+                if let Ok(mut workers) = store.credential_rotation_workers.lock() {
+                    workers.remove(&worker_session_id);
+                }
+            });
+        if let Err(error) = spawn_result {
+            if let Ok(mut workers) = self.credential_rotation_workers.lock() {
+                workers.remove(&session_id);
+            }
+            return Err(error).context("failed to start credential rotation worker");
+        }
+        Ok(())
+    }
+
+    fn try_apply_waiting_credential_rotation(&self, session_id: &str) -> Result<bool> {
+        let (rotation, session) = {
+            let _guard = self.write_guard()?;
+            let state = self.load_raw_json_value()?;
+            let Some(rotation) = session_credential_rotation_records(&state)?
+                .into_iter()
+                .find(|record| record.session_id == session_id && record.status == "waiting_idle")
+            else {
+                return Ok(true);
+            };
+            let Some(session) = snapshot_from_raw_value(&state)?
+                .sessions
+                .into_iter()
+                .find(|session| session.id == session_id)
+            else {
+                return Ok(true);
+            };
+            (rotation, session)
+        };
+        let Some(runtime) = self.delivery_runtime.as_ref() else {
+            return Ok(true);
+        };
+        let session_runtime = runtime.for_socket_name(rotation.tmux_socket_name.as_deref());
+        if !credential_rotation_has_fresh_idle_proof(&rotation, &session)
+            || !session_runtime.session_exists(&rotation.tmux_session)?
+            || session_runtime.session_has_attached_clients(&rotation.tmux_session)?
+            || !session_runtime.session_input_ready(&rotation.tmux_session, &rotation.provider)
+            || !self.credential_rotation_queue_is_drained(session_id)?
+        {
+            return Ok(false);
+        }
+
+        let _guard = self.write_guard()?;
+        let _input_guard = session_runtime.lock_session_input(&rotation.tmux_session)?;
+        let mut state = self.load_raw_json_value()?;
+        let mut rotations = session_credential_rotation_records(&state)?;
+        let Some(rotation_index) = rotations
+            .iter()
+            .position(|record| record.id == rotation.id && record.status == "waiting_idle")
+        else {
+            return Ok(true);
+        };
+        let snapshot = snapshot_from_raw_value(&state)?;
+        let Some(session) = snapshot
+            .sessions
+            .iter()
+            .find(|session| session.id == session_id)
+            .cloned()
+        else {
+            rotations[rotation_index].status = "failed".to_owned();
+            rotations[rotation_index].updated_at = now_rfc3339();
+            rotations[rotation_index].failure_reason = Some("session disappeared".to_owned());
+            store_session_credential_rotation_records(&mut state, &rotations)?;
+            self.write_raw_json_value(&state)?;
+            return Ok(true);
+        };
+        if !session.is_live_for_registry()
+            || session.provider != rotation.provider
+            || session.tmux_session != rotation.tmux_session
+            || session.tmux_socket_name != rotation.tmux_socket_name
+            || provider_resume_id_for_restore(&session).as_deref()
+                != Some(rotation.provider_resume_id.as_str())
+        {
+            rotations[rotation_index].status = "failed".to_owned();
+            rotations[rotation_index].updated_at = now_rfc3339();
+            rotations[rotation_index].failure_reason =
+                Some("session runtime identity changed while waiting for idle".to_owned());
+            store_session_credential_rotation_records(&mut state, &rotations)?;
+            self.write_raw_json_value(&state)?;
+            return Ok(true);
+        }
+        let raw_session = raw_session_object(&state, session_id)
+            .ok_or_else(|| anyhow::anyhow!("session {session_id} disappeared"))?;
+        if !credential_rotation_has_fresh_idle_proof(&rotations[rotation_index], &session)
+            || json_text(raw_session.get("pending_handoff_path")).is_some()
+            || json_text(raw_session.get("claude_handoff_in_progress_at")).is_some()
+            || !self.credential_rotation_queue_is_drained(session_id)?
+            || session_runtime.session_has_attached_clients(&rotation.tmux_session)?
+            || !session_runtime.session_input_ready(&rotation.tmux_session, &rotation.provider)
+        {
+            return Ok(false);
+        }
+
+        let Some(log_file) = session
+            .log_file
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(expand_home)
+        else {
+            rotations[rotation_index].status = "failed".to_owned();
+            rotations[rotation_index].updated_at = now_rfc3339();
+            rotations[rotation_index].failure_reason =
+                Some("session log file is missing".to_owned());
+            store_session_credential_rotation_records(&mut state, &rotations)?;
+            self.write_raw_json_value(&state)?;
+            return Ok(true);
+        };
+        let credential = generate_session_credential();
+        let credential_sha256 = sha256_text(&credential);
+        let spec = TmuxSessionSpec {
+            session_id: session.id.clone(),
+            session_credential: Some(credential),
+            tmux_session: session.tmux_session.clone(),
+            working_dir: expand_home(&session.working_dir).display().to_string(),
+            log_file,
+            provider: session.provider.clone(),
+            initial_message: None,
+            model: session.model.clone(),
+            reasoning_effort: session.reasoning_effort.clone(),
+        };
+        let codex_fork_artifacts = session_runtime.codex_fork_runtime_artifacts(&spec)?;
+        let mut launches = session_runtime_launch_records(&state)?;
+        let launch_id = generate_unique_runtime_launch_id(&launches)?;
+        let now = now_rfc3339();
+        launches.push(SessionRuntimeLaunchRecord {
+            id: launch_id.clone(),
+            operation_kind: "recredential".to_owned(),
+            session_id: session.id.clone(),
+            tmux_session: session.tmux_session.clone(),
+            tmux_socket_name: session_runtime.socket_name().map(ToOwned::to_owned),
+            working_dir: spec.working_dir.clone(),
+            log_file: spec.log_file.display().to_string(),
+            provider: session.provider.clone(),
+            provider_resume_id: Some(rotation.provider_resume_id.clone()),
+            credential_rotation_id: Some(rotation.id.clone()),
+            initial_message: None,
+            model: session.model.clone(),
+            reasoning_effort: session.reasoning_effort.clone(),
+            credential_sha256: credential_sha256.clone(),
+            status: "launching".to_owned(),
+            created_at: now.clone(),
+            updated_at: now.clone(),
+            failure_reason: None,
+        });
+        rotations[rotation_index].status = "relaunching".to_owned();
+        rotations[rotation_index].idle_proof_at = Some(now.clone());
+        rotations[rotation_index].runtime_launch_id = Some(launch_id.clone());
+        rotations[rotation_index].updated_at = now;
+        {
+            let sessions = ensure_sessions_array_mut(&mut state)?;
+            let raw_session = session_object_mut(sessions, session_id)
+                .ok_or_else(|| anyhow::anyhow!("session {session_id} disappeared"))?;
+            raw_session.insert(
+                "session_credential_sha256".to_owned(),
+                Value::String(credential_sha256),
+            );
+            raw_session.insert("status".to_owned(), Value::String("stopped".to_owned()));
+            raw_session.insert("stopped_at".to_owned(), Value::String(now_rfc3339()));
+        }
+        store_session_runtime_launch_records(&mut state, &launches)?;
+        store_session_credential_rotation_records(&mut state, &rotations)?;
+        self.write_raw_json_value(&state)?;
+
+        let relaunch_result = (|| -> Result<()> {
+            if session_runtime.session_exists(&session.tmux_session)? {
+                session_runtime.kill_session(&session.tmux_session)?;
+            }
+            session_runtime.restore_session(
+                &spec,
+                &session.provider,
+                Some(&rotation.provider_resume_id),
+            )
+        })();
+        if let Err(error) = relaunch_result {
+            mark_runtime_launch_failed(
+                &mut state,
+                &launch_id,
+                session_id,
+                false,
+                &error.to_string(),
+            )?;
+            self.write_raw_json_value(&state)?;
+            return Ok(true);
+        }
+
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let Some(raw_session) = session_object_mut(sessions, session_id) else {
+            let _ = session_runtime.kill_session(&session.tmux_session);
+            mark_runtime_launch_failed(
+                &mut state,
+                &launch_id,
+                session_id,
+                false,
+                "session disappeared after credential relaunch",
+            )?;
+            self.write_raw_json_value(&state)?;
+            return Ok(true);
+        };
+        raw_session.insert("status".to_owned(), Value::String("running".to_owned()));
+        raw_session.insert("stopped_at".to_owned(), Value::Null);
+        raw_session.insert("last_activity".to_owned(), Value::String(now_rfc3339()));
+        mark_runtime_launch_applied(&mut state, &launch_id, Some(&rotation.provider_resume_id))?;
+        self.write_raw_json_value(&state)?;
+        drop(_guard);
+        if let Some(artifacts) = codex_fork_artifacts {
+            self.start_codex_fork_event_monitor(session.id, artifacts.event_stream_path)?;
+        }
+        Ok(true)
+    }
+
+    fn credential_rotation_queue_is_drained(&self, session_id: &str) -> Result<bool> {
+        self.queue_store
+            .as_ref()
+            .map(|queue| {
+                queue
+                    .pending_messages_for_target(session_id, 1)
+                    .map(|messages| messages.is_empty())
+            })
+            .unwrap_or(Ok(true))
+    }
+
     #[cfg(test)]
     fn new_with_legacy_fallback(state_file: PathBuf, legacy_state_file: PathBuf) -> Self {
         let seat_session_store = SeatSessionStore::for_state_file(&state_file);
@@ -1536,6 +1791,124 @@ impl SessionStore {
             (&left.created_at, &left.id).cmp(&(&right.created_at, &right.id))
         });
         Ok(records)
+    }
+
+    pub fn create_session_credential_rotation(
+        &self,
+        session_id: &str,
+        request_actor: &str,
+    ) -> Result<CredentialRotationOutcome> {
+        let session_id = session_id.trim();
+        let request_actor = request_actor.trim();
+        if session_id.is_empty() || request_actor.is_empty() {
+            return Ok(CredentialRotationOutcome::BadRequest(
+                "session ID and authenticated request actor are required".to_owned(),
+            ));
+        }
+        if self.delivery_runtime.is_none() {
+            return Ok(CredentialRotationOutcome::BadRequest(
+                "runtime-backed sessions are disabled".to_owned(),
+            ));
+        }
+
+        let record = {
+            let _guard = self.write_guard()?;
+            let mut state = self.load_raw_json_value()?;
+            let snapshot = snapshot_from_raw_value(&state)?;
+            let Some(session) = snapshot
+                .sessions
+                .iter()
+                .find(|session| session.id == session_id)
+            else {
+                return Ok(CredentialRotationOutcome::SessionNotFound);
+            };
+            if !session.is_live_for_registry() {
+                return Ok(CredentialRotationOutcome::BadRequest(format!(
+                    "session {session_id} is stopped"
+                )));
+            }
+            if !is_primary_node(&session.node) {
+                return Ok(CredentialRotationOutcome::BadRequest(format!(
+                    "session {session_id} belongs to remote node {}",
+                    session.node
+                )));
+            }
+            if !matches!(session.provider.as_str(), "claude" | "codex" | "codex-fork") {
+                return Ok(CredentialRotationOutcome::BadRequest(format!(
+                    "provider {} does not support credential rotation",
+                    session.provider
+                )));
+            }
+            let Some(provider_resume_id) = provider_resume_id_for_restore(session) else {
+                return Ok(CredentialRotationOutcome::BadRequest(format!(
+                    "session {session_id} has no resumable provider identity"
+                )));
+            };
+            let mut rotations = session_credential_rotation_records(&state)?;
+            rotations.sort_by(|left, right| {
+                (&left.requested_at, &left.id).cmp(&(&right.requested_at, &right.id))
+            });
+            if let Some(existing) = rotations.iter().rev().find(|rotation| {
+                rotation.session_id == session_id
+                    && matches!(
+                        rotation.status.as_str(),
+                        "waiting_idle" | "relaunching" | "applied"
+                    )
+            }) {
+                return Ok(CredentialRotationOutcome::Existing(existing.clone()));
+            }
+            let now = now_rfc3339();
+            let rotation = SessionCredentialRotationRecord {
+                id: generate_unique_credential_rotation_id(&rotations)?,
+                session_id: session.id.clone(),
+                provider: session.provider.clone(),
+                provider_resume_id,
+                tmux_session: session.tmux_session.clone(),
+                tmux_socket_name: session.tmux_socket_name.clone(),
+                request_actor: request_actor.to_owned(),
+                status: "waiting_idle".to_owned(),
+                requested_at: now.clone(),
+                idle_proof_at: None,
+                runtime_launch_id: None,
+                updated_at: now,
+                applied_at: None,
+                failure_reason: None,
+            };
+            rotations.push(rotation.clone());
+            store_session_credential_rotation_records(&mut state, &rotations)?;
+            self.write_raw_json_value(&state)?;
+            rotation
+        };
+        self.start_credential_rotation_worker(record.session_id.clone())?;
+        Ok(CredentialRotationOutcome::Created(record))
+    }
+
+    pub fn list_session_credential_rotations(
+        &self,
+    ) -> Result<Vec<SessionCredentialRotationRecord>> {
+        let _guard = self.write_guard()?;
+        let state = self.load_raw_json_value()?;
+        let mut records = session_credential_rotation_records(&state)?;
+        records.sort_by(|left, right| {
+            (&left.requested_at, &left.id).cmp(&(&right.requested_at, &right.id))
+        });
+        Ok(records)
+    }
+
+    pub fn recover_session_credential_rotation_workers(&self) -> Result<usize> {
+        let session_ids = {
+            let _guard = self.write_guard()?;
+            let state = self.load_raw_json_value()?;
+            session_credential_rotation_records(&state)?
+                .into_iter()
+                .filter(|record| record.status == "waiting_idle")
+                .map(|record| record.session_id)
+                .collect::<BTreeSet<_>>()
+        };
+        for session_id in &session_ids {
+            self.start_credential_rotation_worker(session_id.clone())?;
+        }
+        Ok(session_ids.len())
     }
 
     pub fn create_core_session(
@@ -9227,6 +9600,21 @@ fn session_credential_matches(
     constant_time_text_eq(expected, &sha256_text(credential))
 }
 
+fn credential_rotation_has_fresh_idle_proof(
+    rotation: &SessionCredentialRotationRecord,
+    session: &SessionRecord,
+) -> bool {
+    if normalized_status(&session.status) != "idle" {
+        return false;
+    }
+    let proof_at = if session.provider == "claude" {
+        session.activity_hook_at.as_deref()
+    } else {
+        Some(session.last_activity.as_str())
+    };
+    proof_at.is_some_and(|proof_at| timestamp_is_after(proof_at, &rotation.requested_at))
+}
+
 fn session_id_exists(sessions: &[Value], session_id: &str) -> bool {
     sessions
         .iter()
@@ -9341,7 +9729,27 @@ fn mark_runtime_launch_applied(
     if let Some(provider_resume_id) = provider_resume_id {
         record.provider_resume_id = Some(provider_resume_id.to_owned());
     }
-    store_session_runtime_launch_records(state, &records)
+    let credential_rotation_id = record.credential_rotation_id.clone();
+    store_session_runtime_launch_records(state, &records)?;
+    if let Some(credential_rotation_id) = credential_rotation_id {
+        let mut rotations = session_credential_rotation_records(state)?;
+        let rotation = rotations
+            .iter_mut()
+            .find(|rotation| rotation.id == credential_rotation_id)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "credential rotation {credential_rotation_id} disappeared during launch"
+                )
+            })?;
+        let now = now_rfc3339();
+        rotation.status = "applied".to_owned();
+        rotation.updated_at = now.clone();
+        rotation.applied_at = Some(now);
+        rotation.failure_reason = None;
+        rotation.runtime_launch_id = Some(launch_id.to_owned());
+        store_session_credential_rotation_records(state, &rotations)?;
+    }
+    Ok(())
 }
 
 fn mark_runtime_launch_failed(
@@ -9359,7 +9767,21 @@ fn mark_runtime_launch_failed(
     record.status = "failed".to_owned();
     record.updated_at = now_rfc3339();
     record.failure_reason = Some(failure_reason.to_owned());
+    let credential_rotation_id = record.credential_rotation_id.clone();
     store_session_runtime_launch_records(state, &records)?;
+    if let Some(credential_rotation_id) = credential_rotation_id {
+        let mut rotations = session_credential_rotation_records(state)?;
+        if let Some(rotation) = rotations
+            .iter_mut()
+            .find(|rotation| rotation.id == credential_rotation_id)
+        {
+            rotation.status = "failed".to_owned();
+            rotation.updated_at = now_rfc3339();
+            rotation.failure_reason = Some(failure_reason.to_owned());
+            rotation.runtime_launch_id = Some(launch_id.to_owned());
+            store_session_credential_rotation_records(state, &rotations)?;
+        }
+    }
     let sessions = ensure_sessions_array_mut(state)?;
     if remove_provisional_session {
         sessions.retain(|session| session.get("id").and_then(Value::as_str) != Some(session_id));

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -49,6 +49,7 @@ const CODEX_FORK_EVENT_MONITOR_POLL: Duration = Duration::from_millis(250);
 const CODEX_FORK_CONTROL_TIMEOUT: Duration = Duration::from_secs(3);
 const SEAT_SESSION_RETRY_ATTEMPTS: usize = 20;
 const SEAT_SESSION_RETRY_DELAY: Duration = Duration::from_millis(100);
+const REPARENT_REQUEST_TTL_HOURS: i64 = 24;
 static STATE_WRITE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone)]
@@ -1107,6 +1108,301 @@ impl SessionStore {
             .collect())
     }
 
+    pub fn create_reparent_request(
+        &self,
+        subject_session_id: &str,
+        request: CreateReparentRequest,
+        session_credential: &str,
+    ) -> Result<ReparentMutationOutcome> {
+        let subject_session_id = subject_session_id.trim();
+        let target_parent_session_id = request.target_parent_session_id.trim();
+        let requester_session_id = request.requester_session_id.trim();
+        if subject_session_id.is_empty()
+            || target_parent_session_id.is_empty()
+            || requester_session_id.is_empty()
+        {
+            return Ok(ReparentMutationOutcome::BadRequest(
+                "subject, target parent, and requester session IDs are required".to_owned(),
+            ));
+        }
+        if subject_session_id == target_parent_session_id {
+            return Ok(ReparentMutationOutcome::BadRequest(
+                "a session cannot be its own parent".to_owned(),
+            ));
+        }
+
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = snapshot_from_raw_value(&state)?.into_sessions();
+        if !session_credential_matches(&sessions, requester_session_id, session_credential) {
+            return Ok(ReparentMutationOutcome::Forbidden(
+                "session credential is missing, stale, or does not match the claimed actor"
+                    .to_owned(),
+            ));
+        }
+        let Some(subject) = sessions
+            .iter()
+            .find(|session| session.id == subject_session_id)
+        else {
+            return Ok(ReparentMutationOutcome::SessionNotFound(
+                subject_session_id.to_owned(),
+            ));
+        };
+        if !subject.is_live_for_registry() {
+            return Ok(ReparentMutationOutcome::BadRequest(format!(
+                "subject session {subject_session_id} is stopped"
+            )));
+        }
+        let Some(target_parent) = sessions
+            .iter()
+            .find(|session| session.id == target_parent_session_id)
+        else {
+            return Ok(ReparentMutationOutcome::SessionNotFound(
+                target_parent_session_id.to_owned(),
+            ));
+        };
+        if !target_parent.is_live_for_registry() {
+            return Ok(ReparentMutationOutcome::BadRequest(format!(
+                "target parent session {target_parent_session_id} is stopped"
+            )));
+        }
+        if subject.parent_session_id.as_deref() == Some(target_parent_session_id) {
+            return Ok(ReparentMutationOutcome::BadRequest(format!(
+                "session {subject_session_id} is already a child of {target_parent_session_id}"
+            )));
+        }
+
+        let expected_parent_session_id = subject.parent_session_id.clone();
+        let expected_parent_is_live = expected_parent_session_id.as_deref().is_some_and(|id| {
+            sessions
+                .iter()
+                .find(|session| session.id == id)
+                .is_some_and(SessionRecord::is_live_for_registry)
+        });
+        let requester_is_current_parent = expected_parent_is_live
+            && expected_parent_session_id.as_deref() == Some(requester_session_id);
+        let requester_is_target_parent = requester_session_id == target_parent_session_id;
+        if !requester_is_current_parent && !requester_is_target_parent {
+            return Ok(ReparentMutationOutcome::Forbidden(
+                "only the live current parent or proposed new parent may request reparenting"
+                    .to_owned(),
+            ));
+        }
+        if reparent_would_create_cycle(&sessions, subject_session_id, target_parent_session_id) {
+            return Ok(ReparentMutationOutcome::Conflict(
+                "reparenting would create a session hierarchy cycle".to_owned(),
+            ));
+        }
+
+        let now = OffsetDateTime::now_utc();
+        let mut records = reparent_request_records(&state)?;
+        let _ = refresh_reparent_requests(&mut records, &sessions, now);
+        let affected_ids = BTreeSet::from([subject_session_id.to_owned()]);
+        if let Some(conflict) = records.iter().find(|record| {
+            record.is_active() && !record.affected_session_ids().is_disjoint(&affected_ids)
+        }) {
+            store_reparent_request_records(&mut state, &records)?;
+            self.write_raw_json_value(&state)?;
+            return Ok(ReparentMutationOutcome::Conflict(format!(
+                "request {} already controls session {}",
+                conflict.id, subject_session_id
+            )));
+        }
+
+        let mut required_agent_approvals = BTreeSet::from([target_parent_session_id.to_owned()]);
+        if expected_parent_is_live {
+            if let Some(parent_id) = expected_parent_session_id.as_ref() {
+                required_agent_approvals.insert(parent_id.clone());
+            }
+        }
+        let required_agent_approvals = required_agent_approvals.into_iter().collect::<Vec<_>>();
+        let required_human_approval = !expected_parent_is_live;
+        let created_at = now.format(&Rfc3339)?;
+        let expires_at =
+            (now + TimeDuration::hours(REPARENT_REQUEST_TTL_HOURS)).format(&Rfc3339)?;
+        let id = generate_unique_reparent_request_id(&records)?;
+        let topology_fingerprint = reparent_topology_fingerprint(
+            "single",
+            subject_session_id,
+            target_parent_session_id,
+            expected_parent_session_id.as_deref(),
+            &[],
+        );
+        let approvals = vec![ReparentApprovalRecord {
+            actor_kind: "agent".to_owned(),
+            actor_id: requester_session_id.to_owned(),
+            decision: "approved".to_owned(),
+            decided_at: created_at.clone(),
+        }];
+        let ready_to_apply = approvals_satisfied(
+            &required_agent_approvals,
+            required_human_approval,
+            &approvals,
+        );
+        let record = ReparentRequestRecord {
+            id,
+            kind: "single".to_owned(),
+            subject_session_id: subject_session_id.to_owned(),
+            target_parent_session_id: target_parent_session_id.to_owned(),
+            expected_parent_session_id,
+            expected_parent_is_live,
+            frozen_live_child_ids: Vec::new(),
+            initiator_session_id: requester_session_id.to_owned(),
+            required_agent_approvals,
+            required_human_approval,
+            approvals,
+            status: "pending".to_owned(),
+            ready_to_apply,
+            created_at,
+            expires_at,
+            decided_at: None,
+            applied_at: None,
+            failure_reason: None,
+            topology_fingerprint,
+            apply_stage: None,
+            apply_plan: None,
+            notification_intents: Vec::new(),
+            repair_history: Vec::new(),
+        };
+        records.push(record.clone());
+        store_reparent_request_records(&mut state, &records)?;
+        self.write_raw_json_value(&state)?;
+        Ok(ReparentMutationOutcome::Created(record))
+    }
+
+    pub fn decide_reparent_request(
+        &self,
+        request_id: &str,
+        request: DecideReparentRequest,
+        decision: ReparentDecision,
+        session_credential: &str,
+    ) -> Result<ReparentMutationOutcome> {
+        let request_id = request_id.trim();
+        let requester_session_id = request.requester_session_id.trim();
+        if request_id.is_empty() || requester_session_id.is_empty() {
+            return Ok(ReparentMutationOutcome::BadRequest(
+                "request ID and requester session ID are required".to_owned(),
+            ));
+        }
+
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = snapshot_from_raw_value(&state)?.into_sessions();
+        if !session_credential_matches(&sessions, requester_session_id, session_credential) {
+            return Ok(ReparentMutationOutcome::Forbidden(
+                "session credential is missing, stale, or does not match the claimed actor"
+                    .to_owned(),
+            ));
+        }
+        let mut records = reparent_request_records(&state)?;
+        let now = OffsetDateTime::now_utc();
+        let refreshed = refresh_reparent_requests(&mut records, &sessions, now);
+        let Some(index) = records.iter().position(|record| record.id == request_id) else {
+            if refreshed {
+                store_reparent_request_records(&mut state, &records)?;
+                self.write_raw_json_value(&state)?;
+            }
+            return Ok(ReparentMutationOutcome::RequestNotFound);
+        };
+        let record = &mut records[index];
+        if !record
+            .required_agent_approvals
+            .iter()
+            .any(|actor| actor == requester_session_id)
+        {
+            return Ok(ReparentMutationOutcome::Forbidden(format!(
+                "session {requester_session_id} is not a required approver for request {request_id}"
+            )));
+        }
+        if let Some(existing) = record.approvals.iter().find(|approval| {
+            approval.actor_kind == "agent" && approval.actor_id == requester_session_id
+        }) {
+            if existing.decision == decision.as_str() {
+                let updated = record.clone();
+                if refreshed {
+                    store_reparent_request_records(&mut state, &records)?;
+                    self.write_raw_json_value(&state)?;
+                }
+                return Ok(ReparentMutationOutcome::Updated(updated));
+            }
+            return Ok(ReparentMutationOutcome::Conflict(format!(
+                "session {requester_session_id} already {} request {request_id}",
+                existing.decision
+            )));
+        }
+        if record.status == "expired" {
+            store_reparent_request_records(&mut state, &records)?;
+            self.write_raw_json_value(&state)?;
+            return Ok(ReparentMutationOutcome::Expired);
+        }
+        if record.status != "pending" {
+            let detail = format!(
+                "request {} is already {}{}",
+                record.id,
+                record.status,
+                record
+                    .failure_reason
+                    .as_deref()
+                    .map(|reason| format!(": {reason}"))
+                    .unwrap_or_default()
+            );
+            store_reparent_request_records(&mut state, &records)?;
+            self.write_raw_json_value(&state)?;
+            return Ok(ReparentMutationOutcome::Conflict(detail));
+        }
+        let decided_at = now.format(&Rfc3339)?;
+        record.approvals.push(ReparentApprovalRecord {
+            actor_kind: "agent".to_owned(),
+            actor_id: requester_session_id.to_owned(),
+            decision: decision.as_str().to_owned(),
+            decided_at: decided_at.clone(),
+        });
+        if decision == ReparentDecision::Rejected {
+            record.status = "rejected".to_owned();
+            record.decided_at = Some(decided_at);
+            record.ready_to_apply = false;
+        } else {
+            record.ready_to_apply = approvals_satisfied(
+                &record.required_agent_approvals,
+                record.required_human_approval,
+                &record.approvals,
+            );
+        }
+        let updated = record.clone();
+        store_reparent_request_records(&mut state, &records)?;
+        self.write_raw_json_value(&state)?;
+        Ok(ReparentMutationOutcome::Updated(updated))
+    }
+
+    pub fn get_reparent_request(&self, request_id: &str) -> Result<Option<ReparentRequestRecord>> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = snapshot_from_raw_value(&state)?.into_sessions();
+        let mut records = reparent_request_records(&state)?;
+        if refresh_reparent_requests(&mut records, &sessions, OffsetDateTime::now_utc()) {
+            store_reparent_request_records(&mut state, &records)?;
+            self.write_raw_json_value(&state)?;
+        }
+        Ok(records
+            .into_iter()
+            .find(|record| record.id == request_id.trim()))
+    }
+
+    pub fn list_reparent_requests(&self) -> Result<Vec<ReparentRequestRecord>> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let sessions = snapshot_from_raw_value(&state)?.into_sessions();
+        let mut records = reparent_request_records(&state)?;
+        if refresh_reparent_requests(&mut records, &sessions, OffsetDateTime::now_utc()) {
+            store_reparent_request_records(&mut state, &records)?;
+            self.write_raw_json_value(&state)?;
+        }
+        records.sort_by(|left, right| {
+            (&left.created_at, &left.id).cmp(&(&right.created_at, &right.id))
+        });
+        Ok(records)
+    }
+
     pub fn create_core_session(
         &self,
         request: CreateCoreSessionRequest,
@@ -1173,6 +1469,8 @@ impl SessionStore {
             true,
             runtime.socket_name(),
         )?;
+        let session_credential = generate_session_credential();
+        record.session_credential_sha256 = Some(sha256_text(&session_credential));
         if record.provider == "codex"
             && codex_cli_working_dir.as_deref() != Some(record.working_dir.as_str())
         {
@@ -1186,6 +1484,7 @@ impl SessionStore {
             .ok_or_else(|| anyhow::anyhow!("runtime session missing log file"))?;
         let spec = TmuxSessionSpec {
             session_id: record.id.clone(),
+            session_credential: Some(session_credential),
             tmux_session: record.tmux_session.clone(),
             working_dir: expand_home(&record.working_dir).display().to_string(),
             log_file,
@@ -2156,6 +2455,7 @@ impl SessionStore {
         }
         let spec = TmuxSessionSpec {
             session_id: record.id.clone(),
+            session_credential: Some(generate_session_credential()),
             tmux_session: record.tmux_session.clone(),
             working_dir: expand_home(&record.working_dir).display().to_string(),
             log_file,
@@ -2179,6 +2479,12 @@ impl SessionStore {
         session.insert("completed_at".to_owned(), Value::Null);
         session.insert("agent_task_completed_at".to_owned(), Value::Null);
         session.insert("last_activity".to_owned(), Value::String(now));
+        session.insert(
+            "session_credential_sha256".to_owned(),
+            Value::String(sha256_text(
+                spec.session_credential.as_deref().unwrap_or_default(),
+            )),
+        );
         if let Some(socket_name) = session_runtime.socket_name() {
             session.insert(
                 "tmux_socket_name".to_owned(),
@@ -4780,6 +5086,7 @@ impl SessionStore {
             git_remote_url: None,
             review_config: None,
             parent_session_id: request.parent_session_id.clone(),
+            session_credential_sha256: None,
             last_handoff_path: None,
             agent_status_text: None,
             agent_status_at: None,
@@ -5293,6 +5600,32 @@ pub struct ContextMonitorRequest {
     pub notify_session_id: Option<String>,
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct CreateReparentRequest {
+    pub requester_session_id: String,
+    pub target_parent_session_id: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct DecideReparentRequest {
+    pub requester_session_id: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReparentDecision {
+    Approved,
+    Rejected,
+}
+
+impl ReparentDecision {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Approved => "approved",
+            Self::Rejected => "rejected",
+        }
+    }
+}
+
 /// One post from a context-monitor producer hook. `event` distinguishes the
 /// lifecycle hooks (`compaction`, `compaction_complete`, `context_reset`) from a
 /// plain status-line usage sample, which carries no `event` at all.
@@ -5627,6 +5960,18 @@ pub enum ContextMonitorOutcome {
     MissingNotifyTarget,
     NotifyTargetNotFound(String),
     Unauthorized,
+}
+
+#[derive(Debug, Clone)]
+pub enum ReparentMutationOutcome {
+    Created(ReparentRequestRecord),
+    Updated(ReparentRequestRecord),
+    SessionNotFound(String),
+    RequestNotFound,
+    BadRequest(String),
+    Forbidden(String),
+    Conflict(String),
+    Expired,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -6513,6 +6858,7 @@ fn codex_fork_spec_for_session_raw(
         .ok_or_else(|| anyhow::anyhow!("session {session_id} missing log_file"))?;
     Ok(TmuxSessionSpec {
         session_id: session_id.to_owned(),
+        session_credential: None,
         tmux_session,
         working_dir: expand_home(&working_dir).display().to_string(),
         log_file: expand_home(&log_file),
@@ -6555,6 +6901,7 @@ pub fn submit_codex_fork_btw(
     }
     let spec = TmuxSessionSpec {
         session_id: session.id.clone(),
+        session_credential: None,
         tmux_session: session.tmux_session.clone(),
         working_dir: session.working_dir.clone(),
         log_file: session
@@ -8156,6 +8503,7 @@ fn codex_fork_event_stream_path(session: &SessionRecord, runtime: &TmuxRuntime) 
     let log_file = session.log_file.as_deref().map(expand_home)?;
     let spec = TmuxSessionSpec {
         session_id: session.id.clone(),
+        session_credential: None,
         tmux_session: session.tmux_session.clone(),
         working_dir: session.working_dir.clone(),
         log_file: log_file.clone(),
@@ -8515,10 +8863,273 @@ fn generate_unique_session_id(sessions: &[Value]) -> Result<String> {
     anyhow::bail!("failed to generate unique session id after 64 attempts")
 }
 
+fn generate_unique_reparent_request_id(records: &[ReparentRequestRecord]) -> Result<String> {
+    for _ in 0..64 {
+        let mut bytes = [0u8; 6];
+        OsRng.fill_bytes(&mut bytes);
+        let mut id = String::with_capacity(12);
+        for byte in bytes {
+            id.push(hex_char(byte >> 4));
+            id.push(hex_char(byte & 0x0f));
+        }
+        if !records.iter().any(|record| record.id == id) {
+            return Ok(id);
+        }
+    }
+    anyhow::bail!("failed to generate unique reparent request id after 64 attempts")
+}
+
+fn generate_session_credential() -> String {
+    let mut bytes = [0u8; 32];
+    OsRng.fill_bytes(&mut bytes);
+    let mut credential = String::with_capacity(64);
+    for byte in bytes {
+        credential.push(hex_char(byte >> 4));
+        credential.push(hex_char(byte & 0x0f));
+    }
+    credential
+}
+
+fn sha256_text(value: &str) -> String {
+    let digest = Sha256::digest(value.as_bytes());
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn constant_time_text_eq(left: &str, right: &str) -> bool {
+    if left.len() != right.len() {
+        return false;
+    }
+    left.as_bytes()
+        .iter()
+        .zip(right.as_bytes())
+        .fold(0u8, |difference, (left, right)| difference | (left ^ right))
+        == 0
+}
+
+fn session_credential_matches(
+    sessions: &[SessionRecord],
+    session_id: &str,
+    credential: &str,
+) -> bool {
+    let session_id = session_id.trim();
+    let credential = credential.trim();
+    if session_id.is_empty() || credential.is_empty() {
+        return false;
+    }
+    let Some(expected) = sessions
+        .iter()
+        .find(|session| session.id == session_id)
+        .and_then(|session| session.session_credential_sha256.as_deref())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return false;
+    };
+    constant_time_text_eq(expected, &sha256_text(credential))
+}
+
 fn session_id_exists(sessions: &[Value], session_id: &str) -> bool {
     sessions
         .iter()
         .any(|value| value.get("id").and_then(Value::as_str) == Some(session_id))
+}
+
+fn reparent_request_records(state: &Value) -> Result<Vec<ReparentRequestRecord>> {
+    state
+        .get("reparent_requests")
+        .and_then(Value::as_array)
+        .map(|records| {
+            records
+                .iter()
+                .map(|record| {
+                    serde_json::from_value(record.clone())
+                        .context("failed to parse reparent request record")
+                })
+                .collect()
+        })
+        .unwrap_or_else(|| Ok(Vec::new()))
+}
+
+fn store_reparent_request_records(
+    state: &mut Value,
+    records: &[ReparentRequestRecord],
+) -> Result<()> {
+    let object = state
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("session state root must be an object"))?;
+    object.insert(
+        "reparent_requests".to_owned(),
+        serde_json::to_value(records)?,
+    );
+    Ok(())
+}
+
+fn reparent_topology_fingerprint(
+    kind: &str,
+    subject_session_id: &str,
+    target_parent_session_id: &str,
+    expected_parent_session_id: Option<&str>,
+    frozen_live_child_ids: &[String],
+) -> String {
+    let mut children = frozen_live_child_ids.to_vec();
+    children.sort();
+    let canonical = json!({
+        "kind": kind,
+        "subject_session_id": subject_session_id,
+        "target_parent_session_id": target_parent_session_id,
+        "expected_parent_session_id": expected_parent_session_id,
+        "frozen_live_child_ids": children,
+    });
+    let digest = Sha256::digest(serde_json::to_vec(&canonical).unwrap_or_default());
+    digest.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn approvals_satisfied(
+    required_agent_approvals: &[String],
+    required_human_approval: bool,
+    approvals: &[ReparentApprovalRecord],
+) -> bool {
+    let agents_satisfied = required_agent_approvals.iter().all(|required| {
+        approvals.iter().any(|approval| {
+            approval.actor_kind == "agent"
+                && approval.actor_id == *required
+                && approval.decision == "approved"
+        })
+    });
+    let human_satisfied = !required_human_approval
+        || approvals
+            .iter()
+            .any(|approval| approval.actor_kind == "human" && approval.decision == "approved");
+    agents_satisfied && human_satisfied
+}
+
+fn refresh_reparent_requests(
+    records: &mut [ReparentRequestRecord],
+    sessions: &[SessionRecord],
+    now: OffsetDateTime,
+) -> bool {
+    let mut changed = false;
+    let decided_at = now
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned());
+    for record in records {
+        if record.status != "pending" {
+            continue;
+        }
+        match parse_timestamp(&record.expires_at) {
+            Some(expires_at) if expires_at <= now => {
+                record.status = "expired".to_owned();
+                record.decided_at = Some(decided_at.clone());
+                record.failure_reason = Some("request expired before all approvals".to_owned());
+                record.ready_to_apply = false;
+                changed = true;
+                continue;
+            }
+            None => {
+                record.status = "stale".to_owned();
+                record.decided_at = Some(decided_at.clone());
+                record.failure_reason = Some("request expiry timestamp is invalid".to_owned());
+                record.ready_to_apply = false;
+                changed = true;
+                continue;
+            }
+            _ => {}
+        }
+        if let Some(reason) = reparent_stale_reason(record, sessions) {
+            record.status = "stale".to_owned();
+            record.decided_at = Some(decided_at.clone());
+            record.failure_reason = Some(reason);
+            record.ready_to_apply = false;
+            changed = true;
+        }
+    }
+    changed
+}
+
+fn reparent_stale_reason(
+    record: &ReparentRequestRecord,
+    sessions: &[SessionRecord],
+) -> Option<String> {
+    let expected_fingerprint = reparent_topology_fingerprint(
+        &record.kind,
+        &record.subject_session_id,
+        &record.target_parent_session_id,
+        record.expected_parent_session_id.as_deref(),
+        &record.frozen_live_child_ids,
+    );
+    if record.topology_fingerprint != expected_fingerprint {
+        return Some("stored topology fingerprint does not match the request plan".to_owned());
+    }
+    let Some(subject) = sessions
+        .iter()
+        .find(|session| session.id == record.subject_session_id)
+    else {
+        return Some("subject session no longer exists".to_owned());
+    };
+    if !subject.is_live_for_registry() {
+        return Some("subject session is no longer live".to_owned());
+    }
+    if subject.parent_session_id != record.expected_parent_session_id {
+        return Some("subject parent changed after request creation".to_owned());
+    }
+    let expected_parent_is_live_now =
+        record
+            .expected_parent_session_id
+            .as_deref()
+            .is_some_and(|parent_id| {
+                sessions
+                    .iter()
+                    .find(|session| session.id == parent_id)
+                    .is_some_and(SessionRecord::is_live_for_registry)
+            });
+    if expected_parent_is_live_now != record.expected_parent_is_live {
+        return Some("current parent liveness changed after request creation".to_owned());
+    }
+    let Some(target) = sessions
+        .iter()
+        .find(|session| session.id == record.target_parent_session_id)
+    else {
+        return Some("target parent session no longer exists".to_owned());
+    };
+    if !target.is_live_for_registry() {
+        return Some("target parent session is no longer live".to_owned());
+    }
+    if reparent_would_create_cycle(
+        sessions,
+        &record.subject_session_id,
+        &record.target_parent_session_id,
+    ) {
+        return Some("current topology would create a hierarchy cycle".to_owned());
+    }
+    None
+}
+
+fn reparent_would_create_cycle(
+    sessions: &[SessionRecord],
+    subject_session_id: &str,
+    target_parent_session_id: &str,
+) -> bool {
+    if subject_session_id == target_parent_session_id {
+        return true;
+    }
+    let by_id = sessions
+        .iter()
+        .map(|session| (session.id.as_str(), session))
+        .collect::<BTreeMap<_, _>>();
+    let mut current_id = Some(target_parent_session_id);
+    let mut visited = BTreeSet::new();
+    while let Some(session_id) = current_id {
+        if session_id == subject_session_id {
+            return true;
+        }
+        if !visited.insert(session_id) {
+            return true;
+        }
+        current_id = by_id
+            .get(session_id)
+            .and_then(|session| session.parent_session_id.as_deref());
+    }
+    false
 }
 
 fn now_rfc3339() -> String {
@@ -8721,8 +9332,12 @@ impl StateSnapshot {
                     proposer_name: proposer_names.get(&proposal.proposer_session_id).cloned(),
                     target_session_id: proposal.target_session_id.clone(),
                     created_at: proposal.created_at.clone(),
-                    status: proposal.status.clone(),
+                    status: "stale".to_owned(),
                     decided_at: proposal.decided_at.clone(),
+                    actionable: false,
+                    failure_reason: Some(
+                        "legacy adoption proposal requires a new consent request".to_owned(),
+                    ),
                 });
         }
         for proposals in proposal_map.values_mut() {
@@ -8773,6 +9388,148 @@ struct AdoptionProposalRecord {
     status: String,
     #[serde(default)]
     decided_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ReparentApprovalRecord {
+    pub actor_kind: String,
+    pub actor_id: String,
+    pub decision: String,
+    pub decided_at: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ReparentEdgeChange {
+    pub session_id: String,
+    #[serde(default)]
+    pub expected_parent_session_id: Option<String>,
+    #[serde(default)]
+    pub new_parent_session_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ReparentRoutingChange {
+    pub store: String,
+    pub record_kind: String,
+    pub record_id: String,
+    pub child_session_id: String,
+    #[serde(default)]
+    pub expected_target_session_id: Option<String>,
+    #[serde(default)]
+    pub new_target_session_id: Option<String>,
+    #[serde(default)]
+    pub prior_active: Option<bool>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ReparentApplyPlan {
+    pub version: u32,
+    #[serde(default)]
+    pub edge_changes: Vec<ReparentEdgeChange>,
+    #[serde(default)]
+    pub json_routing_changes: Vec<ReparentRoutingChange>,
+    #[serde(default)]
+    pub queue_routing_changes: Vec<ReparentRoutingChange>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ReparentNotificationIntent {
+    pub key: String,
+    pub event: String,
+    pub recipient_session_id: String,
+    #[serde(default)]
+    pub enqueued_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ReparentRepairRecord {
+    pub actor_kind: String,
+    pub actor_id: String,
+    pub action: String,
+    #[serde(default)]
+    pub prior_failure: Option<String>,
+    pub attempted_at: String,
+    #[serde(default)]
+    pub verified_state_fingerprint: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct ReparentRequestRecord {
+    pub id: String,
+    pub kind: String,
+    pub subject_session_id: String,
+    pub target_parent_session_id: String,
+    #[serde(default)]
+    pub expected_parent_session_id: Option<String>,
+    #[serde(default)]
+    pub expected_parent_is_live: bool,
+    #[serde(default)]
+    pub frozen_live_child_ids: Vec<String>,
+    pub initiator_session_id: String,
+    #[serde(default)]
+    pub required_agent_approvals: Vec<String>,
+    #[serde(default)]
+    pub required_human_approval: bool,
+    #[serde(default)]
+    pub approvals: Vec<ReparentApprovalRecord>,
+    pub status: String,
+    #[serde(default)]
+    pub ready_to_apply: bool,
+    pub created_at: String,
+    pub expires_at: String,
+    #[serde(default)]
+    pub decided_at: Option<String>,
+    #[serde(default)]
+    pub applied_at: Option<String>,
+    #[serde(default)]
+    pub failure_reason: Option<String>,
+    pub topology_fingerprint: String,
+    #[serde(default)]
+    pub apply_stage: Option<String>,
+    #[serde(default)]
+    pub apply_plan: Option<ReparentApplyPlan>,
+    #[serde(default)]
+    pub notification_intents: Vec<ReparentNotificationIntent>,
+    #[serde(default)]
+    pub repair_history: Vec<ReparentRepairRecord>,
+}
+
+impl ReparentRequestRecord {
+    fn is_active(&self) -> bool {
+        matches!(self.status.as_str(), "pending" | "applying")
+            || (self.status == "failed"
+                && matches!(
+                    self.apply_stage.as_deref(),
+                    Some("routing_quiesced" | "authority_committed")
+                ))
+    }
+
+    fn affected_session_ids(&self) -> BTreeSet<String> {
+        let mut affected = self
+            .frozen_live_child_ids
+            .iter()
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        affected.insert(self.subject_session_id.clone());
+        if let Some(plan) = self.apply_plan.as_ref() {
+            affected.extend(
+                plan.edge_changes
+                    .iter()
+                    .map(|change| change.session_id.clone()),
+            );
+            affected.extend(
+                plan.json_routing_changes
+                    .iter()
+                    .map(|change| change.child_session_id.clone()),
+            );
+            affected.extend(
+                plan.queue_routing_changes
+                    .iter()
+                    .map(|change| change.child_session_id.clone()),
+            );
+        }
+        affected
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -8841,6 +9598,8 @@ pub struct SessionRecord {
     pub review_config: Option<Value>,
     #[serde(default)]
     pub parent_session_id: Option<String>,
+    #[serde(default)]
+    pub session_credential_sha256: Option<String>,
     #[serde(default)]
     pub last_handoff_path: Option<String>,
     #[serde(default)]
@@ -9007,6 +9766,8 @@ pub struct AdoptionProposalResponse {
     created_at: String,
     status: String,
     decided_at: Option<String>,
+    actionable: bool,
+    failure_reason: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -9746,6 +10507,7 @@ mod tests {
             git_remote_url: None,
             review_config: None,
             parent_session_id: None,
+            session_credential_sha256: None,
             last_handoff_path: None,
             agent_status_text: None,
             agent_status_at: None,
@@ -11019,6 +11781,7 @@ mod tests {
         let record = snapshot.sessions.first().unwrap();
         let spec = TmuxSessionSpec {
             session_id: record.id.clone(),
+            session_credential: None,
             tmux_session: record.tmux_session.clone(),
             working_dir: record.working_dir.clone(),
             log_file,
@@ -12072,6 +12835,14 @@ mod tests {
         assert_eq!(
             child.pending_adoption_proposals[0].proposer_name.as_deref(),
             Some("maintainer")
+        );
+        assert_eq!(child.pending_adoption_proposals[0].status, "stale");
+        assert!(!child.pending_adoption_proposals[0].actionable);
+        assert_eq!(
+            child.pending_adoption_proposals[0]
+                .failure_reason
+                .as_deref(),
+            Some("legacy adoption proposal requires a new consent request")
         );
     }
 

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -9714,6 +9714,7 @@ fn complete_runtime_message_delivery_raw(
 
     let fenced_message;
     let message = if message.parent_session_id.is_some()
+        && message.remind_soft_threshold.is_some()
         && active_reparent_request_for_session(state, &message.target_session_id)?.is_some()
     {
         persist_deferred_parent_wake_intent(state, message)?;
@@ -18106,6 +18107,46 @@ mod tests {
                 .as_deref(),
             Some("newpar01")
         );
+
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
+    fn delivered_parent_metadata_without_reminder_creates_no_deferred_wake() {
+        let (store, queue, state_file, queue_db, request_id) =
+            prepared_reparent_transaction("reparent-no-reminder-wake");
+        let message_id = queue
+            .enqueue_message_with_metadata(
+                "child001",
+                "delivery has parent metadata only",
+                "important",
+                QueueMessageMetadata {
+                    parent_session_id: Some("oldpar01".to_owned()),
+                    ..QueueMessageMetadata::default()
+                },
+            )
+            .unwrap();
+        queue.cancel_parent_wake("child001").unwrap();
+        store.acquire_reparent_apply_lease().unwrap();
+        let message = queue
+            .pending_messages_for_target("child001", 10)
+            .unwrap()
+            .into_iter()
+            .find(|message| message.id == message_id)
+            .unwrap();
+        let runtime = TmuxRuntime::from_config(&crate::config::RustCoreConfig::default());
+        {
+            let _guard = store.write_guard().unwrap();
+            let mut state = store.load_raw_json_value().unwrap();
+            complete_runtime_message_delivery_raw(&store, &mut state, &runtime, &queue, &message)
+                .unwrap();
+            store.write_raw_json_value(&state).unwrap();
+        }
+
+        let record = store.get_reparent_request(&request_id).unwrap().unwrap();
+        assert!(record.deferred_routing_intents.is_empty());
+        assert_eq!(queue.active_parent_wake_parent("child001").unwrap(), None);
 
         let _ = fs::remove_file(state_file);
         let _ = fs::remove_file(queue_db);

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -970,24 +970,46 @@ impl SessionStore {
     }
 
     fn try_apply_waiting_credential_rotation(&self, session_id: &str) -> Result<bool> {
-        let (rotation, session) = {
+        let (rotation, session, recovering_launch_id) = {
             let _guard = self.write_guard()?;
             let state = self.load_raw_json_value()?;
-            let Some(rotation) = session_credential_rotation_records(&state)?
-                .into_iter()
-                .find(|record| record.session_id == session_id && record.status == "waiting_idle")
-            else {
-                return Ok(true);
-            };
-            let Some(session) = snapshot_from_raw_value(&state)?
-                .sessions
-                .into_iter()
-                .find(|session| session.id == session_id)
-            else {
-                return Ok(true);
-            };
-            (rotation, session)
+            let rotations = session_credential_rotation_records(&state)?;
+            let recovering_launch_id = rotations
+                .iter()
+                .find(|record| record.session_id == session_id && record.status == "relaunching")
+                .map(|rotation| {
+                    rotation.runtime_launch_id.clone().with_context(|| {
+                        format!(
+                            "relaunching credential rotation {} has no runtime launch",
+                            rotation.id
+                        )
+                    })
+                })
+                .transpose()?;
+            if recovering_launch_id.is_some() {
+                (None, None, recovering_launch_id)
+            } else {
+                let Some(rotation) = rotations.into_iter().find(|record| {
+                    record.session_id == session_id && record.status == "waiting_idle"
+                }) else {
+                    return Ok(true);
+                };
+                let Some(session) = snapshot_from_raw_value(&state)?
+                    .sessions
+                    .into_iter()
+                    .find(|session| session.id == session_id)
+                else {
+                    return Ok(true);
+                };
+                (Some(rotation), Some(session), None)
+            }
         };
+        if let Some(launch_id) = recovering_launch_id {
+            self.recover_session_runtime_launch(&launch_id)?;
+            return Ok(true);
+        }
+        let rotation = rotation.expect("waiting rotation checked above");
+        let session = session.expect("waiting rotation session checked above");
         let Some(runtime) = self.delivery_runtime.as_ref() else {
             return Ok(true);
         };
@@ -1749,6 +1771,11 @@ impl SessionStore {
                 "target parent session {target_parent_session_id} is stopped"
             )));
         }
+        if !session_supports_reparent_consent(target_parent) {
+            return Ok(ReparentMutationOutcome::BadRequest(format!(
+                "target parent session {target_parent_session_id} cannot participate in credential-bound consent"
+            )));
+        }
         if subject.parent_session_id.as_deref() == Some(target_parent_session_id) {
             return Ok(ReparentMutationOutcome::BadRequest(format!(
                 "session {subject_session_id} is already a child of {target_parent_session_id}"
@@ -1770,6 +1797,18 @@ impl SessionStore {
                 "only the live current parent or proposed new parent may request reparenting"
                     .to_owned(),
             ));
+        }
+        if expected_parent_is_live {
+            let expected_parent = sessions
+                .iter()
+                .find(|session| Some(session.id.as_str()) == expected_parent_session_id.as_deref())
+                .expect("live expected parent checked above");
+            if !session_supports_reparent_consent(expected_parent) {
+                return Ok(ReparentMutationOutcome::BadRequest(format!(
+                    "current parent session {} cannot participate in credential-bound consent",
+                    expected_parent.id
+                )));
+            }
         }
         if reparent_would_create_cycle(&sessions, subject_session_id, target_parent_session_id) {
             return Ok(ReparentMutationOutcome::Conflict(
@@ -1903,6 +1942,16 @@ impl SessionStore {
         if !target.is_live_for_registry() {
             blockers.push(format!("target session {target_session_id} is stopped"));
         }
+        if !session_supports_reparent_consent(source) {
+            blockers.push(format!(
+                "source session {source_session_id} cannot participate in credential-bound consent"
+            ));
+        }
+        if !session_supports_reparent_consent(target) {
+            blockers.push(format!(
+                "target session {target_session_id} cannot participate in credential-bound consent"
+            ));
+        }
         if target.parent_session_id.as_deref() != Some(source_session_id) {
             blockers.push(format!(
                 "target session {target_session_id} is not a live direct child of {source_session_id}"
@@ -1915,6 +1964,18 @@ impl SessionStore {
                 .find(|session| session.id == id)
                 .is_some_and(SessionRecord::is_live_for_registry)
         });
+        if expected_parent_is_live {
+            let expected_parent = sessions
+                .iter()
+                .find(|session| Some(session.id.as_str()) == expected_parent_session_id.as_deref())
+                .expect("live expected parent checked above");
+            if !session_supports_reparent_consent(expected_parent) {
+                blockers.push(format!(
+                    "current parent session {} cannot participate in credential-bound consent",
+                    expected_parent.id
+                ));
+            }
+        }
         let initiator_allowed = requester_session_id == source_session_id
             || requester_session_id == target_session_id
             || (expected_parent_is_live
@@ -13237,7 +13298,12 @@ impl ReparentRequestRecord {
             || (self.status == "failed"
                 && matches!(
                     self.apply_stage.as_deref(),
-                    Some("json_routing_quiesced" | "routing_quiesced" | "authority_committed")
+                    Some(
+                        "prequiesce_aborting"
+                            | "json_routing_quiesced"
+                            | "routing_quiesced"
+                            | "authority_committed"
+                    )
                 ))
     }
 
@@ -14008,6 +14074,13 @@ fn provider_manages_context_inline(provider: &str) -> bool {
     matches!(provider.trim(), "codex" | "codex-fork" | "codex-app")
 }
 
+fn session_supports_reparent_consent(session: &SessionRecord) -> bool {
+    is_primary_node(&session.node)
+        && matches!(session.provider.as_str(), "claude" | "codex" | "codex-fork")
+        && (session.session_credential_sha256.is_some()
+            || provider_resume_id_for_restore(session).is_some())
+}
+
 fn default_delivery_mode() -> String {
     "sequential".to_owned()
 }
@@ -14227,6 +14300,60 @@ mod tests {
             &rotation,
             &stock_codex
         ));
+    }
+
+    #[test]
+    fn credential_rotation_worker_recovers_a_relaunching_runtime_transaction() {
+        let state_file = unique_temp_path("credential-rotation-relaunch-recovery");
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [reparent_test_session("rotate01", None, "old-secret")],
+                "session_runtime_launches": [{
+                    "id": "launch01",
+                    "operation_kind": "recredential",
+                    "session_id": "rotate01",
+                    "tmux_session": "claude-rotate01",
+                    "working_dir": "/repo",
+                    "log_file": "/tmp/rotate01.log",
+                    "provider": "claude",
+                    "provider_resume_id": "provider-thread",
+                    "credential_rotation_id": "rotation01",
+                    "credential_sha256": sha256_text("new-secret"),
+                    "status": "launching",
+                    "created_at": "2026-06-01T00:00:00Z",
+                    "updated_at": "2026-06-01T00:00:01Z"
+                }],
+                "session_credential_rotations": [{
+                    "id": "rotation01",
+                    "session_id": "rotate01",
+                    "provider": "claude",
+                    "provider_resume_id": "provider-thread",
+                    "tmux_session": "claude-rotate01",
+                    "request_actor": "operator",
+                    "status": "relaunching",
+                    "requested_at": "2026-06-01T00:00:00Z",
+                    "runtime_launch_id": "launch01",
+                    "updated_at": "2026-06-01T00:00:01Z"
+                }]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let store = SessionStore::new(state_file.clone());
+
+        assert!(store
+            .try_apply_waiting_credential_rotation("rotate01")
+            .unwrap());
+
+        let state = store.load_raw_json_value().unwrap();
+        assert_eq!(state["session_runtime_launches"][0]["status"], "failed");
+        assert_eq!(state["session_credential_rotations"][0]["status"], "failed");
+        assert_ne!(
+            state["session_credential_rotations"][0]["status"],
+            "relaunching"
+        );
+        let _ = fs::remove_file(state_file);
     }
 
     #[test]
@@ -18214,6 +18341,122 @@ mod tests {
             Ok(CoreRetireOutcome::Retired(_))
         ));
 
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
+    fn reparent_request_rejects_a_remote_required_approver() {
+        let state_file = unique_temp_path("reparent-remote-approver");
+        let mut target = reparent_test_session("newpar01", None, "new-secret");
+        target["node"] = json!("remote-builder");
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [
+                    reparent_test_session("oldpar01", None, "old-secret"),
+                    target,
+                    reparent_test_session("child001", Some("oldpar01"), "child-secret")
+                ]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let store = SessionStore::new(state_file.clone());
+
+        let outcome = store
+            .create_reparent_request(
+                "child001",
+                CreateReparentRequest {
+                    requester_session_id: "oldpar01".to_owned(),
+                    target_parent_session_id: "newpar01".to_owned(),
+                },
+                "old-secret",
+            )
+            .unwrap();
+
+        assert!(matches!(
+            outcome,
+            ReparentMutationOutcome::BadRequest(message)
+                if message.contains("cannot participate in credential-bound consent")
+        ));
+        let _ = fs::remove_file(state_file);
+    }
+
+    #[test]
+    fn reparent_tree_preview_reports_unsupported_approver_provider() {
+        let state_file = unique_temp_path("reparent-tree-unsupported-approver");
+        let mut target = reparent_test_session("target01", Some("source01"), "target-secret");
+        target["provider"] = json!("codex-app");
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [
+                    reparent_test_session("source01", None, "source-secret"),
+                    target
+                ]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let store = SessionStore::new(state_file.clone());
+
+        let outcome = store
+            .create_reparent_tree_request(
+                "source01",
+                CreateReparentTreeRequest {
+                    requester_session_id: "source01".to_owned(),
+                    target_session_id: "target01".to_owned(),
+                    dry_run: true,
+                },
+                "source-secret",
+            )
+            .unwrap();
+
+        let ReparentMutationOutcome::Preview(preview) = outcome else {
+            panic!("unexpected tree preview outcome: {outcome:?}");
+        };
+        assert!(preview.blockers.iter().any(|blocker| {
+            blocker.contains("target session target01")
+                && blocker.contains("cannot participate in credential-bound consent")
+        }));
+        let _ = fs::remove_file(state_file);
+    }
+
+    #[test]
+    fn prequiesce_abort_failure_keeps_reparent_exclusivity() {
+        let (store, _queue, state_file, queue_db, request_id) =
+            prepared_reparent_transaction("reparent-prequiesce-exclusivity");
+        {
+            let _guard = store.write_guard().unwrap();
+            let mut state = store.load_raw_json_value().unwrap();
+            let mut records = reparent_request_records(&state).unwrap();
+            let record = records
+                .iter_mut()
+                .find(|record| record.id == request_id)
+                .unwrap();
+            record.status = "failed".to_owned();
+            record.apply_stage = Some("prequiesce_aborting".to_owned());
+            record.failure_reason = Some("injected abort failure".to_owned());
+            store_reparent_request_records(&mut state, &records).unwrap();
+            store.write_raw_json_value(&state).unwrap();
+        }
+
+        let outcome = store
+            .create_reparent_request(
+                "child001",
+                CreateReparentRequest {
+                    requester_session_id: "oldpar01".to_owned(),
+                    target_parent_session_id: "newpar01".to_owned(),
+                },
+                "old-parent-secret",
+            )
+            .unwrap();
+
+        assert!(matches!(
+            outcome,
+            ReparentMutationOutcome::Conflict(message) if message.contains(&request_id)
+        ));
         let _ = fs::remove_file(state_file);
         let _ = fs::remove_file(queue_db);
     }

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -2086,6 +2086,47 @@ impl SessionStore {
         Ok(records)
     }
 
+    pub fn send_parent_notification(
+        &self,
+        child_session_id: &str,
+        text: &str,
+        delivery_mode: &str,
+        message_category: &str,
+        runtime: Option<&TmuxRuntime>,
+    ) -> Result<()> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        if let Some(request_id) =
+            active_reparent_route_request_for_session(&state, child_session_id)?
+        {
+            persist_deferred_parent_message_intent(
+                &mut state,
+                &request_id,
+                &format!("{message_category}:{child_session_id}:{}", now_rfc3339()),
+                child_session_id,
+                text,
+                delivery_mode,
+                message_category,
+            )?;
+            return self.write_raw_json_value(&state);
+        }
+        let Some(parent_session_id) = raw_session_object(&state, child_session_id)
+            .and_then(|session| json_text(session.get("parent_session_id")))
+        else {
+            return Ok(());
+        };
+        self.queue_parent_message(
+            &mut state,
+            child_session_id,
+            &parent_session_id,
+            text,
+            delivery_mode,
+            message_category,
+            runtime,
+        )?;
+        self.write_raw_json_value(&state)
+    }
+
     pub fn reconcile_reparent_requests(&self) -> Result<Option<ReparentRequestRecord>> {
         let mut first = None;
         loop {
@@ -2598,7 +2639,7 @@ impl SessionStore {
             Vec::new()
         };
         self.persist_delivered_reparent_wake_intents(request_id, &delivered_message_rows)?;
-        self.replay_deferred_reparent_routes(request_id, false)?;
+        let replay_targets = self.replay_deferred_reparent_routes(request_id, false)?;
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
         let mut records = reparent_request_records(&state)?;
@@ -2615,15 +2656,19 @@ impl SessionStore {
         record.failure_reason = None;
         store_reparent_request_records(&mut state, &records)?;
         store_reparent_apply_lease(&mut state, None)?;
-        self.write_raw_json_value(&state)
+        self.write_raw_json_value(&state)?;
+        drop(_guard);
+        self.drain_reparent_replay_targets(&replay_targets);
+        Ok(())
     }
 
     fn replay_deferred_reparent_routes(
         &self,
         request_id: &str,
         reapply_completed: bool,
-    ) -> Result<()> {
+    ) -> Result<BTreeSet<String>> {
         let mut reapplied = BTreeSet::new();
+        let mut replay_targets = BTreeSet::new();
         loop {
             let intent = {
                 let _guard = self.write_guard()?;
@@ -2639,7 +2684,7 @@ impl SessionStore {
                     .cloned()
             };
             let Some(intent) = intent else {
-                return Ok(());
+                return Ok(replay_targets);
             };
             let resolved_parent_session_id = {
                 let _guard = self.write_guard()?;
@@ -2689,8 +2734,70 @@ impl SessionStore {
                             },
                         )?;
                         queue.cancel_parent_wake(&intent.child_session_id)?;
+                        replay_targets.insert(resolved_parent_session_id.clone());
                     } else {
                         anyhow::bail!("deferred task-complete requires the retained queue store")
+                    }
+                }
+                "parent_message" => {
+                    let text = intent
+                        .payload
+                        .get("text")
+                        .and_then(Value::as_str)
+                        .context("deferred parent message has no text")?;
+                    let delivery_mode = intent
+                        .payload
+                        .get("delivery_mode")
+                        .and_then(Value::as_str)
+                        .context("deferred parent message has no delivery mode")?;
+                    let category = intent
+                        .payload
+                        .get("message_category")
+                        .and_then(Value::as_str)
+                        .context("deferred parent message has no category")?;
+                    let message_id = deferred_parent_message_id(request_id, &intent.key);
+                    if let Some(queue) = self.queue_store.as_ref() {
+                        queue.enqueue_message_once_with_metadata(
+                            &message_id,
+                            &resolved_parent_session_id,
+                            text,
+                            delivery_mode,
+                            QueueMessageMetadata {
+                                sender_session_id: Some(intent.child_session_id.clone()),
+                                message_category: Some(category.to_owned()),
+                                ..QueueMessageMetadata::default()
+                            },
+                        )?;
+                        replay_targets.insert(resolved_parent_session_id.clone());
+                    } else {
+                        anyhow::bail!("deferred parent message requires the retained queue store")
+                    }
+                }
+                "parent_input" => {
+                    let text = intent
+                        .payload
+                        .get("text")
+                        .and_then(Value::as_str)
+                        .context("deferred parent input has no text")?;
+                    let delivery_mode = intent
+                        .payload
+                        .get("delivery_mode")
+                        .and_then(Value::as_str)
+                        .context("deferred parent input has no delivery mode")?;
+                    let message_id = deferred_parent_message_id(request_id, &intent.key);
+                    let metadata =
+                        deferred_parent_input_metadata(&intent, &resolved_parent_session_id)?;
+                    if let Some(queue) = self.queue_store.as_ref() {
+                        queue.enqueue_message_once_with_metadata(
+                            &message_id,
+                            &intent.child_session_id,
+                            text,
+                            delivery_mode,
+                            metadata,
+                        )?;
+                        replay_targets.insert(intent.child_session_id.clone());
+                    } else {
+                        anyhow::bail!("deferred parent input requires the retained queue store")
                     }
                 }
                 other => anyhow::bail!("unsupported deferred routing operation {other}"),
@@ -2735,6 +2842,33 @@ impl SessionStore {
                     )?;
                     deactivate_parent_wake_raw(&mut state, &intent.child_session_id)?;
                 }
+                "parent_message" => {
+                    let text = intent
+                        .payload
+                        .get("text")
+                        .and_then(Value::as_str)
+                        .context("deferred parent message has no text")?;
+                    let delivery_mode = intent
+                        .payload
+                        .get("delivery_mode")
+                        .and_then(Value::as_str)
+                        .context("deferred parent message has no delivery mode")?;
+                    let category = intent
+                        .payload
+                        .get("message_category")
+                        .and_then(Value::as_str)
+                        .context("deferred parent message has no category")?;
+                    let message_id = deferred_parent_message_id(request_id, &intent.key);
+                    push_retained_message_once_raw(
+                        &mut state,
+                        &message_id,
+                        &resolved_parent_session_id,
+                        text,
+                        delivery_mode,
+                        Some(category),
+                    )?;
+                }
+                "parent_input" => {}
                 other => anyhow::bail!("unsupported deferred routing operation {other}"),
             }
             if current.replayed_at.is_none() {
@@ -2744,6 +2878,32 @@ impl SessionStore {
             store_reparent_request_records(&mut state, &records)?;
             self.write_raw_json_value(&state)?;
             reapplied.insert(intent.key);
+        }
+    }
+
+    fn drain_reparent_replay_targets(&self, targets: &BTreeSet<String>) {
+        let (Some(runtime), Some(queue)) =
+            (self.delivery_runtime.as_ref(), self.queue_store.as_ref())
+        else {
+            return;
+        };
+        let result = (|| -> Result<()> {
+            let _guard = self.write_guard()?;
+            let mut state = self.load_raw_json_value()?;
+            for target in targets {
+                let node = raw_session_object(&state, target)
+                    .and_then(|session| json_text(session.get("node")))
+                    .unwrap_or_else(default_node);
+                if is_primary_node(&node) {
+                    drain_pending_runtime_messages_raw(
+                        self, &mut state, target, runtime, queue, None, None, None,
+                    )?;
+                }
+            }
+            self.write_raw_json_value(&state)
+        })();
+        if let Err(error) = result {
+            eprintln!("deferred reparent message drain will retry on later traffic: {error:#}");
         }
     }
 
@@ -2814,7 +2974,7 @@ impl SessionStore {
     }
 
     fn complete_reparent_prequiesce_abort(&self, request_id: &str) -> Result<()> {
-        self.replay_deferred_reparent_routes(request_id, true)?;
+        let replay_targets = self.replay_deferred_reparent_routes(request_id, true)?;
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
         let mut records = reparent_request_records(&state)?;
@@ -2826,7 +2986,10 @@ impl SessionStore {
         record.apply_stage = Some("prequiesce_aborted".to_owned());
         store_reparent_request_records(&mut state, &records)?;
         store_reparent_apply_lease(&mut state, None)?;
-        self.write_raw_json_value(&state)
+        self.write_raw_json_value(&state)?;
+        drop(_guard);
+        self.drain_reparent_replay_targets(&replay_targets);
+        Ok(())
     }
 
     fn rollback_reparent_precommit(
@@ -2875,7 +3038,7 @@ impl SessionStore {
             verify_old_reparent_edges(&state, &plan)?;
             self.write_raw_json_value(&state)?;
         }
-        self.replay_deferred_reparent_routes(request_id, true)?;
+        let replay_targets = self.replay_deferred_reparent_routes(request_id, true)?;
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
         let mut records = reparent_request_records(&state)?;
@@ -2895,7 +3058,10 @@ impl SessionStore {
         record.decided_at = Some(now_rfc3339());
         store_reparent_request_records(&mut state, &records)?;
         store_reparent_apply_lease(&mut state, None)?;
-        self.write_raw_json_value(&state)
+        self.write_raw_json_value(&state)?;
+        drop(_guard);
+        self.drain_reparent_replay_targets(&replay_targets);
+        Ok(())
     }
 
     pub fn create_session_credential_rotation(
@@ -3340,6 +3506,31 @@ impl SessionStore {
 
         let delivery_mode = normalized_delivery_mode(&request.delivery_mode);
         let (queued_text, sender_name) = format_send_input_text_raw(&state, &request);
+        if request.parent_session_id.is_some() {
+            if let Some(request_id) = active_reparent_route_request_for_session(&state, session_id)?
+            {
+                let key = format!("parent-input:{}", generate_session_id());
+                persist_deferred_parent_input_intent(
+                    &mut state,
+                    &request_id,
+                    &key,
+                    session_id,
+                    &queued_text,
+                    &delivery_mode,
+                    &request,
+                    sender_name.as_deref(),
+                )?;
+                self.write_raw_json_value(&state)?;
+                return Ok(Some(CoreInputResult {
+                    ok: true,
+                    session_id: session_id.to_owned(),
+                    delivered: false,
+                    delivery_mode: request.delivery_mode,
+                    notify_after_seconds: request.notify_after_seconds,
+                    status: initial_status,
+                }));
+            }
+        }
         if should_persist_runtime_send(&delivery_mode) {
             if let Some(queue) = &self.queue_store {
                 let metadata =
@@ -4584,14 +4775,27 @@ impl SessionStore {
                 "[sm context] Compaction fired for {label} ({session_id}). \
                  Context was compacted — agent is still running."
             );
-            self.queue_context_monitor_message(
-                state,
-                session_id,
-                &notify_target,
-                &text,
-                "sequential",
-                runtime,
-            )?;
+            if let Some(request_id) = active_reparent_route_request_for_session(state, session_id)?
+            {
+                persist_deferred_parent_message_intent(
+                    state,
+                    &request_id,
+                    &format!("context-compaction:{session_id}:{}", now_rfc3339()),
+                    session_id,
+                    &text,
+                    "sequential",
+                    "context_monitor",
+                )?;
+            } else {
+                self.queue_context_monitor_message(
+                    state,
+                    session_id,
+                    &notify_target,
+                    &text,
+                    "sequential",
+                    runtime,
+                )?;
+            }
         }
 
         if informational_only {
@@ -4836,6 +5040,27 @@ impl SessionStore {
         delivery_mode: &str,
         runtime: Option<&TmuxRuntime>,
     ) -> Result<()> {
+        self.queue_parent_message(
+            state,
+            sender_session_id,
+            notify_target,
+            text,
+            delivery_mode,
+            "context_monitor",
+            runtime,
+        )
+    }
+
+    fn queue_parent_message(
+        &self,
+        state: &mut Value,
+        sender_session_id: &str,
+        notify_target: &str,
+        text: &str,
+        delivery_mode: &str,
+        message_category: &str,
+        runtime: Option<&TmuxRuntime>,
+    ) -> Result<()> {
         if raw_session_object(state, notify_target).is_none() {
             return Ok(());
         }
@@ -4846,7 +5071,7 @@ impl SessionStore {
                 delivery_mode,
                 QueueMessageMetadata {
                     sender_session_id: Some(sender_session_id.to_owned()),
-                    message_category: Some("context_monitor".to_owned()),
+                    message_category: Some(message_category.to_owned()),
                     ..QueueMessageMetadata::default()
                 },
             )?;
@@ -4873,7 +5098,7 @@ impl SessionStore {
             notify_target,
             text,
             delivery_mode,
-            Some("context_monitor"),
+            Some(message_category),
         )?;
         Ok(())
     }
@@ -8240,6 +8465,156 @@ fn deferred_task_complete_message_id(request_id: &str, intent_key: &str) -> Stri
     digest.update(b"\0");
     digest.update(intent_key.as_bytes());
     format!("reparent-task-complete-{:x}", digest.finalize())
+}
+
+fn deferred_parent_message_id(request_id: &str, intent_key: &str) -> String {
+    let mut digest = Sha256::new();
+    digest.update(request_id.as_bytes());
+    digest.update(b"\0parent-message\0");
+    digest.update(intent_key.as_bytes());
+    format!("reparent-parent-message-{:x}", digest.finalize())
+}
+
+fn persist_deferred_parent_message_intent(
+    state: &mut Value,
+    request_id: &str,
+    key: &str,
+    child_session_id: &str,
+    text: &str,
+    delivery_mode: &str,
+    message_category: &str,
+) -> Result<()> {
+    let mut records = reparent_request_records(state)?;
+    let record = records
+        .iter_mut()
+        .find(|record| record.id == request_id)
+        .with_context(|| format!("reparent request {request_id} disappeared"))?;
+    if !record
+        .deferred_routing_intents
+        .iter()
+        .any(|intent| intent.key == key)
+    {
+        record
+            .deferred_routing_intents
+            .push(ReparentDeferredRoutingIntent {
+                key: key.to_owned(),
+                operation: "parent_message".to_owned(),
+                child_session_id: child_session_id.to_owned(),
+                payload: json!({
+                    "text": text,
+                    "delivery_mode": delivery_mode,
+                    "message_category": message_category,
+                }),
+                created_at: now_rfc3339(),
+                replayed_at: None,
+                resolved_parent_session_id: None,
+            });
+    }
+    store_reparent_request_records(state, &records)
+}
+
+fn persist_deferred_parent_input_intent(
+    state: &mut Value,
+    request_id: &str,
+    key: &str,
+    target_session_id: &str,
+    text: &str,
+    delivery_mode: &str,
+    request: &SendCoreInputRequest,
+    sender_name: Option<&str>,
+) -> Result<()> {
+    let mut records = reparent_request_records(state)?;
+    let record = records
+        .iter_mut()
+        .find(|record| record.id == request_id)
+        .with_context(|| format!("reparent request {request_id} disappeared"))?;
+    if !record
+        .deferred_routing_intents
+        .iter()
+        .any(|intent| intent.key == key)
+    {
+        record
+            .deferred_routing_intents
+            .push(ReparentDeferredRoutingIntent {
+                key: key.to_owned(),
+                operation: "parent_input".to_owned(),
+                child_session_id: target_session_id.to_owned(),
+                payload: json!({
+                    "text": text,
+                    "delivery_mode": delivery_mode,
+                    "sender_session_id": request.sender_session_id,
+                    "sender_name": sender_name,
+                    "from_sm_send": request.from_sm_send,
+                    "timeout_seconds": request.timeout_seconds,
+                    "notify_on_delivery": request.notify_on_delivery,
+                    "notify_after_seconds": request.notify_after_seconds,
+                    "notify_on_stop": request.notify_on_stop,
+                    "remind_soft_threshold": request.remind_soft_threshold,
+                    "remind_hard_threshold": request.remind_hard_threshold,
+                    "remind_cancel_on_reply_session_id": request.remind_cancel_on_reply_session_id,
+                }),
+                created_at: now_rfc3339(),
+                replayed_at: None,
+                resolved_parent_session_id: None,
+            });
+    }
+    store_reparent_request_records(state, &records)
+}
+
+fn deferred_parent_input_metadata(
+    intent: &ReparentDeferredRoutingIntent,
+    parent_session_id: &str,
+) -> Result<QueueMessageMetadata> {
+    Ok(QueueMessageMetadata {
+        sender_session_id: intent
+            .payload
+            .get("sender_session_id")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        sender_name: intent
+            .payload
+            .get("sender_name")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        from_sm_send: intent
+            .payload
+            .get("from_sm_send")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        timeout_seconds: intent
+            .payload
+            .get("timeout_seconds")
+            .and_then(Value::as_u64),
+        notify_on_delivery: intent
+            .payload
+            .get("notify_on_delivery")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        notify_after_seconds: intent
+            .payload
+            .get("notify_after_seconds")
+            .and_then(Value::as_u64),
+        notify_on_stop: intent
+            .payload
+            .get("notify_on_stop")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        remind_soft_threshold: intent
+            .payload
+            .get("remind_soft_threshold")
+            .and_then(Value::as_u64),
+        remind_hard_threshold: intent
+            .payload
+            .get("remind_hard_threshold")
+            .and_then(Value::as_u64),
+        remind_cancel_on_reply_session_id: intent
+            .payload
+            .get("remind_cancel_on_reply_session_id")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned),
+        parent_session_id: Some(parent_session_id.to_owned()),
+        ..QueueMessageMetadata::default()
+    })
 }
 
 fn upsert_remind_raw(
@@ -17251,6 +17626,121 @@ mod tests {
 
         let record = store.get_reparent_request(&request_id).unwrap().unwrap();
         assert!(record.deferred_routing_intents.is_empty());
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
+    fn parent_derived_input_created_during_reparent_replays_with_new_parent() {
+        let (store, queue, state_file, queue_db, request_id) =
+            prepared_reparent_transaction("reparent-parent-input");
+        store.acquire_reparent_apply_lease().unwrap();
+        store.quiesce_reparent_json_routing(&request_id).unwrap();
+        store.quiesce_reparent_queue_routing(&request_id).unwrap();
+
+        let outcome = store
+            .send_core_input_with_runtime(
+                "child001",
+                SendCoreInputRequest {
+                    text: "queued during reparent".to_owned(),
+                    delivery_mode: "important".to_owned(),
+                    sender_session_id: None,
+                    from_sm_send: false,
+                    timeout_seconds: None,
+                    notify_on_delivery: false,
+                    notify_after_seconds: None,
+                    notify_on_stop: false,
+                    remind_soft_threshold: Some(600),
+                    remind_hard_threshold: None,
+                    remind_cancel_on_reply_session_id: None,
+                    parent_session_id: Some("oldpar01".to_owned()),
+                },
+                &TmuxRuntime::from_config(&crate::config::RustCoreConfig::default()),
+            )
+            .unwrap()
+            .unwrap();
+        assert!(!outcome.delivered);
+        assert!(queue
+            .pending_messages_for_target("child001", 10)
+            .unwrap()
+            .is_empty());
+
+        store.commit_reparent_authority(&request_id).unwrap();
+        store.finish_reparent_routing(&request_id).unwrap();
+
+        let messages = queue.pending_messages_for_target("child001", 10).unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].parent_session_id.as_deref(), Some("newpar01"));
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
+    fn compaction_during_reparent_notifies_only_the_committed_parent() {
+        let (store, queue, state_file, queue_db, request_id) =
+            prepared_reparent_transaction("reparent-compaction");
+        store.acquire_reparent_apply_lease().unwrap();
+        store.quiesce_reparent_json_routing(&request_id).unwrap();
+        store.quiesce_reparent_queue_routing(&request_id).unwrap();
+
+        assert_eq!(
+            store
+                .apply_context_usage_event(&lifecycle_event("child001", "compaction"), None)
+                .unwrap(),
+            ContextUsageOutcome::CompactionLogged
+        );
+        assert!(queue
+            .pending_messages_for_target("oldpar01", 10)
+            .unwrap()
+            .is_empty());
+        let record = store.get_reparent_request(&request_id).unwrap().unwrap();
+        assert_eq!(record.deferred_routing_intents.len(), 1);
+        assert_eq!(
+            record.deferred_routing_intents[0].operation,
+            "parent_message"
+        );
+
+        store.commit_reparent_authority(&request_id).unwrap();
+        store.finish_reparent_routing(&request_id).unwrap();
+
+        let messages = queue.pending_messages_for_target("newpar01", 10).unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(
+            messages[0].message_category.as_deref(),
+            Some("context_monitor")
+        );
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
+    fn child_wait_notification_resolves_parent_after_reparent_commit() {
+        let (store, queue, state_file, queue_db, request_id) =
+            prepared_reparent_transaction("reparent-child-wait");
+        store.acquire_reparent_apply_lease().unwrap();
+        store.quiesce_reparent_json_routing(&request_id).unwrap();
+        store.quiesce_reparent_queue_routing(&request_id).unwrap();
+
+        store
+            .send_parent_notification(
+                "child001",
+                "Child child001 completed: Session exited",
+                "sequential",
+                "child_wait",
+                None,
+            )
+            .unwrap();
+        assert!(queue
+            .pending_messages_for_target("oldpar01", 10)
+            .unwrap()
+            .is_empty());
+
+        store.commit_reparent_authority(&request_id).unwrap();
+        store.finish_reparent_routing(&request_id).unwrap();
+
+        let messages = queue.pending_messages_for_target("newpar01", 10).unwrap();
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].message_category.as_deref(), Some("child_wait"));
         let _ = fs::remove_file(state_file);
         let _ = fs::remove_file(queue_db);
     }

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -12298,6 +12298,10 @@ async fn runtime_core_lifecycle_uses_tmux_backend_when_enabled() {
     launches[1]["status"] = json!("launching");
     launches[1]["updated_at"] = json!("2026-08-11T00:00:00Z");
     interrupted_state["sessions"][0]["provider_resume_id"] = json!("runtime-thread-1");
+    interrupted_state["sessions"][0]["completion_status"] = json!("completed");
+    interrupted_state["sessions"][0]["completion_message"] = json!("stale completion");
+    interrupted_state["sessions"][0]["completed_at"] = json!("2026-08-11T00:00:00Z");
+    interrupted_state["sessions"][0]["agent_task_completed_at"] = json!("2026-08-11T00:00:00Z");
     fs::write(
         &state_file,
         serde_json::to_vec_pretty(&interrupted_state).unwrap(),
@@ -12319,6 +12323,19 @@ async fn runtime_core_lifecycle_uses_tmux_backend_when_enabled() {
     assert_eq!(
         recovered_state["session_runtime_launches"][1]["credential_sha256"],
         recovered_hash
+    );
+    assert_eq!(
+        recovered_state["sessions"][0]["completion_status"],
+        Value::Null
+    );
+    assert_eq!(
+        recovered_state["sessions"][0]["completion_message"],
+        Value::Null
+    );
+    assert_eq!(recovered_state["sessions"][0]["completed_at"], Value::Null);
+    assert_eq!(
+        recovered_state["sessions"][0]["agent_task_completed_at"],
+        Value::Null
     );
     assert!(tmux_session_exists(&tmux_socket, &tmux_session));
     let (status, payload) = post_json(
@@ -15787,6 +15804,159 @@ while true; do sleep 1; done
     assert!(restored_text.contains("--event-schema-version 7"));
     assert!(restored_text.contains("--model gpt-default"));
     assert!(restored_text.contains("-c model_reasoning_effort=ultra"));
+}
+
+#[tokio::test]
+async fn runtime_launch_recovery_finalizes_codex_fork_identity_and_attribution() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let queue_db_path = queue_db_path_for_state_file(&state_file);
+    let log_dir = unique_short_temp_dir("smrfr");
+    let working_dir = unique_temp_path();
+    fs::create_dir_all(&log_dir).unwrap();
+    fs::create_dir_all(&working_dir).unwrap();
+    let codex_binary = working_dir.join("fake-recovery-codex-fork");
+    fs::write(
+        &codex_binary,
+        r#"#!/bin/sh
+event_stream=""
+previous=""
+for arg in "$@"; do
+  if [ "$previous" = "--event-stream" ]; then
+    event_stream="$arg"
+  fi
+  previous="$arg"
+done
+printf '{"event_type":"thread/started","payload":{"thread":{"id":"recovered-provider-thread"}}}\n' >> "$event_stream"
+printf '{"event_type":"turn_complete","payload":{}}\n' >> "$event_stream"
+while true; do sleep 1; done
+"#,
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&codex_binary).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&codex_binary, permissions).unwrap();
+    }
+    let tmux_socket = format!(
+        "sm-rust-test-codex-fork-recovery-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let session_id = "recoverfork";
+    let tmux_session = "sm-rust-codex-fork-recoverfork-0123456789ab";
+    let log_file = core_log_file_path(&log_dir, session_id);
+    fs::write(
+        &state_file,
+        serde_json::to_vec_pretty(&json!({
+            "sessions": [{
+                "id": session_id,
+                "name": "codex-fork-recoverfork",
+                "working_dir": working_dir.display().to_string(),
+                "tmux_session": tmux_session,
+                "tmux_socket_name": tmux_socket,
+                "node": "primary",
+                "provider": "codex-fork",
+                "log_file": log_file.display().to_string(),
+                "provider_resume_id": null,
+                "session_credential_sha256": "old-credential",
+                "status": "stopped",
+                "stopped_at": "2026-08-11T00:00:00Z",
+                "created_at": "2026-08-11T00:00:00Z",
+                "last_activity": "2026-08-11T00:00:00Z"
+            }],
+            "session_runtime_launches": [{
+                "id": "launchrecover1",
+                "operation_kind": "create",
+                "session_id": session_id,
+                "tmux_session": tmux_session,
+                "tmux_socket_name": tmux_socket,
+                "working_dir": working_dir.display().to_string(),
+                "log_file": log_file.display().to_string(),
+                "provider": "codex-fork",
+                "provider_resume_id": null,
+                "credential_rotation_id": null,
+                "initial_message": null,
+                "model": null,
+                "reasoning_effort": null,
+                "credential_sha256": "old-credential",
+                "status": "launching",
+                "created_at": "2026-08-11T00:00:00Z",
+                "updated_at": "2026-08-11T00:00:00Z",
+                "failure_reason": null
+            }]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    let config = AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        sm_send: SmSendConfig {
+            db_path: queue_db_path.display().to_string(),
+        },
+        codex_fork: CodexForkLaunchConfig {
+            command: codex_binary.display().to_string(),
+            args: vec![],
+            default_model: None,
+            event_schema_version: 2,
+            control_tmux_fallback_enabled: true,
+        },
+        rust_core: RustCoreConfig {
+            runtime_enabled: true,
+            log_dir: Some(log_dir.display().to_string()),
+            tmux_socket_name: Some(tmux_socket.clone()),
+            runtime_prompt_mode: Some("argv".to_owned()),
+            runtime_start_settle_ms: Some(50),
+            ..RustCoreConfig::default()
+        },
+        ..AppConfig::default()
+    };
+
+    let app = router(AppState::new(config));
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    assert_eq!(state["session_runtime_launches"][0]["status"], "applied");
+    assert_eq!(
+        state["session_runtime_launches"][0]["provider_resume_id"],
+        "recovered-provider-thread"
+    );
+    assert!(matches!(
+        state["sessions"][0]["status"].as_str(),
+        Some("running" | "idle")
+    ));
+    assert_eq!(
+        state["sessions"][0]["provider_resume_id"],
+        "recovered-provider-thread"
+    );
+    let connection = Connection::open(state_file.with_extension("usage.db")).unwrap();
+    let attributed_provider_session: String = connection
+        .query_row(
+            "SELECT provider_session_id FROM seat_sessions WHERE seat_id = 'recoverfork'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(attributed_provider_session, "recovered-provider-thread");
+    let deadline = Instant::now() + Duration::from_secs(3);
+    loop {
+        let (_, session) = get_json(app.clone(), "/sessions/recoverfork").await;
+        if session["status"] == "idle" {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "recovered event monitor stayed stale"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
 }
 
 #[tokio::test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -16942,6 +16942,314 @@ async fn reparent_request_read_marks_changed_topology_stale() {
         .contains("parent changed"));
 }
 
+#[tokio::test]
+async fn reparent_tree_dry_run_reports_exact_plan_without_persisting_a_request() {
+    let state_file = write_reparent_tree_fixture();
+    let mut config = config_with_state_file(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, preview) = post_json_with_headers_and_peer(
+        app,
+        "/sessions/source01/reparent-tree-requests",
+        json!({
+            "requester_session_id": "source01",
+            "target_session_id": "target01",
+            "dry_run": true
+        }),
+        &[("x-sm-session-credential", "source-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(preview["kind"], "tree");
+    assert_eq!(
+        preview["frozen_live_child_ids"],
+        json!(["target01", "sibling01"])
+    );
+    assert_eq!(
+        preview["edge_changes"],
+        json!([
+            {
+                "session_id": "target01",
+                "expected_parent_session_id": "source01",
+                "new_parent_session_id": "grand001"
+            },
+            {
+                "session_id": "source01",
+                "expected_parent_session_id": "grand001",
+                "new_parent_session_id": "target01"
+            },
+            {
+                "session_id": "sibling01",
+                "expected_parent_session_id": "source01",
+                "new_parent_session_id": "target01"
+            }
+        ])
+    );
+    assert_eq!(
+        preview["required_agent_approvals"],
+        json!(["grand001", "source01", "target01"])
+    );
+    assert_eq!(preview["required_human_approval"], false);
+    assert!(preview["blockers"].as_array().unwrap().is_empty());
+    assert_eq!(preview["json_routing_changes"].as_array().unwrap().len(), 6);
+    assert!(preview["queue_routing_changes"]
+        .as_array()
+        .unwrap()
+        .is_empty());
+
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    assert!(state["reparent_requests"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn reparent_tree_dry_run_rejects_an_unrelated_authenticated_session() {
+    let state_file = write_reparent_tree_fixture();
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    state["sessions"].as_array_mut().unwrap().push(json!({
+        "id": "outsider",
+        "name": "claude-outsider",
+        "working_dir": "/repo",
+        "tmux_session": "claude-outsider",
+        "provider": "claude",
+        "status": "running",
+        "created_at": "2026-06-01T00:00:00Z",
+        "last_activity": "2026-06-01T00:01:00Z",
+        "session_credential_sha256": session_credential_hash("outsider-token")
+    }));
+    fs::write(&state_file, serde_json::to_vec_pretty(&state).unwrap()).unwrap();
+    let mut config = config_with_state_file(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app,
+        "/sessions/source01/reparent-tree-requests",
+        json!({
+            "requester_session_id": "outsider",
+            "target_session_id": "target01",
+            "dry_run": true
+        }),
+        &[("x-sm-session-credential", "outsider-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert!(payload["detail"]
+        .as_str()
+        .unwrap()
+        .contains("source, target, or live source parent"));
+}
+
+#[tokio::test]
+async fn reparent_tree_requires_all_agents_and_moves_only_frozen_live_children() {
+    let state_file = write_reparent_tree_fixture();
+    let mut config = config_with_state_file(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, created) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/sessions/source01/reparent-tree-requests",
+        json!({
+            "requester_session_id": "source01",
+            "target_session_id": "target01"
+        }),
+        &[("x-sm-session-credential", "source-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(created["ready_to_apply"], false);
+    let request_id = created["id"].as_str().unwrap();
+
+    let (status, target_approved) = post_json_with_headers_and_peer(
+        app.clone(),
+        &format!("/reparent-requests/{request_id}/approve"),
+        json!({ "requester_session_id": "target01" }),
+        &[("x-sm-session-credential", "target-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(target_approved["status"], "pending");
+
+    let (status, applied) = post_json_with_headers_and_peer(
+        app,
+        &format!("/reparent-requests/{request_id}/approve"),
+        json!({ "requester_session_id": "grand001" }),
+        &[("x-sm-session-credential", "grand-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(applied["status"], "applied");
+
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let parent = |id: &str| {
+        state["sessions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|session| session["id"] == id)
+            .and_then(|session| session["parent_session_id"].as_str())
+    };
+    assert_eq!(parent("target01"), Some("grand001"));
+    assert_eq!(parent("source01"), Some("target01"));
+    assert_eq!(parent("sibling01"), Some("target01"));
+    assert_eq!(parent("stopped01"), Some("source01"));
+    for (child, expected) in [
+        ("target01", "grand001"),
+        ("source01", "target01"),
+        ("sibling01", "target01"),
+    ] {
+        let session = state["sessions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|session| session["id"] == child)
+            .unwrap();
+        assert_eq!(session["context_monitor_notify"], expected);
+        assert_eq!(session["context_monitor_enabled"], true);
+        let wake = state["retained_parent_wake_registrations"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|wake| wake["child_session_id"] == child)
+            .unwrap();
+        assert_eq!(wake["parent_session_id"], expected);
+        assert_eq!(wake["is_active"], true);
+    }
+}
+
+#[tokio::test]
+async fn reparent_tree_stales_when_the_frozen_live_child_set_changes() {
+    let state_file = write_reparent_tree_fixture();
+    let mut config = config_with_state_file(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, created) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/sessions/source01/reparent-tree-requests",
+        json!({
+            "requester_session_id": "source01",
+            "target_session_id": "target01"
+        }),
+        &[("x-sm-session-credential", "source-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    state["sessions"].as_array_mut().unwrap().push(json!({
+        "id": "latechild",
+        "name": "claude-latechild",
+        "working_dir": "/repo",
+        "tmux_session": "claude-latechild",
+        "provider": "claude",
+        "status": "running",
+        "created_at": "2026-06-01T00:00:00Z",
+        "last_activity": "2026-06-01T00:01:00Z",
+        "parent_session_id": "source01"
+    }));
+    fs::write(&state_file, serde_json::to_vec_pretty(&state).unwrap()).unwrap();
+
+    let (status, record) = get_json(
+        app,
+        &format!("/reparent-requests/{}", created["id"].as_str().unwrap()),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(record["status"], "stale");
+    assert!(record["failure_reason"]
+        .as_str()
+        .unwrap()
+        .contains("live-child set changed"));
+}
+
+#[tokio::test]
+async fn reparent_tree_promotes_a_root_child_without_stranding_parent_routes() {
+    let state_file = write_reparent_tree_fixture();
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let source = state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "source01")
+        .unwrap();
+    source["parent_session_id"] = Value::Null;
+    source["context_monitor_enabled"] = json!(false);
+    source["context_monitor_notify"] = Value::Null;
+    state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .retain(|session| session["id"] != "grand001");
+    state["retained_parent_wake_registrations"]
+        .as_array_mut()
+        .unwrap()
+        .retain(|wake| wake["child_session_id"] != "source01");
+    fs::write(&state_file, serde_json::to_vec_pretty(&state).unwrap()).unwrap();
+
+    let mut config = config_with_state_file(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+    let (status, created) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/sessions/source01/reparent-tree-requests",
+        json!({
+            "requester_session_id": "source01",
+            "target_session_id": "target01"
+        }),
+        &[("x-sm-session-credential", "source-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(
+        created["required_agent_approvals"],
+        json!(["source01", "target01"])
+    );
+    assert_eq!(created["required_human_approval"], false);
+
+    let (status, applied) = post_json_with_headers_and_peer(
+        app,
+        &format!(
+            "/reparent-requests/{}/approve",
+            created["id"].as_str().unwrap()
+        ),
+        json!({ "requester_session_id": "target01" }),
+        &[("x-sm-session-credential", "target-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(applied["status"], "applied");
+
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let target = state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "target01")
+        .unwrap();
+    assert!(target["parent_session_id"].is_null());
+    assert!(target["context_monitor_notify"].is_null());
+    assert_eq!(target["context_monitor_enabled"], false);
+    let target_wake = state["retained_parent_wake_registrations"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|wake| wake["child_session_id"] == "target01")
+        .unwrap();
+    assert_eq!(target_wake["parent_session_id"], "source01");
+    assert_eq!(target_wake["is_active"], false);
+}
+
 fn config_with_state_file(state_file: &PathBuf) -> AppConfig {
     AppConfig {
         paths: PathsConfig {
@@ -17749,6 +18057,71 @@ fn write_reparent_fixture() -> PathBuf {
                     "created_at": "2026-06-01T00:02:00Z",
                     "status": "pending",
                     "decided_at": null
+                }
+            ]
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    path
+}
+
+fn write_reparent_tree_fixture() -> PathBuf {
+    let path = unique_temp_path();
+    let session = |id: &str, status: &str, parent_session_id: Option<&str>, credential: &str| {
+        let mut value = json!({
+            "id": id,
+            "name": format!("claude-{id}"),
+            "working_dir": "/repo",
+            "tmux_session": format!("claude-{id}"),
+            "log_file": format!("/tmp/{id}.log"),
+            "provider": "claude",
+            "status": status,
+            "created_at": "2026-06-01T00:00:00Z",
+            "last_activity": "2026-06-01T00:01:00Z",
+            "session_credential_sha256": session_credential_hash(credential)
+        });
+        if let Some(parent_session_id) = parent_session_id {
+            value["parent_session_id"] = json!(parent_session_id);
+            if status == "running" {
+                value["context_monitor_enabled"] = json!(true);
+                value["context_monitor_notify"] = json!(parent_session_id);
+                value["context_monitor_notify_source"] = json!("parent_derived");
+            }
+        }
+        value
+    };
+    fs::write(
+        &path,
+        serde_json::to_vec_pretty(&json!({
+            "sessions": [
+                session("grand001", "running", None, "grand-token"),
+                session("source01", "running", Some("grand001"), "source-token"),
+                session("target01", "running", Some("source01"), "target-token"),
+                session("sibling01", "running", Some("source01"), "sibling-token"),
+                session("stopped01", "stopped", Some("source01"), "stopped-token")
+            ],
+            "retained_parent_wake_registrations": [
+                {
+                    "id": "wake-source01",
+                    "child_session_id": "source01",
+                    "parent_session_id": "grand001",
+                    "period_seconds": 600,
+                    "is_active": true
+                },
+                {
+                    "id": "wake-target01",
+                    "child_session_id": "target01",
+                    "parent_session_id": "source01",
+                    "period_seconds": 600,
+                    "is_active": true
+                },
+                {
+                    "id": "wake-sibling01",
+                    "child_session_id": "sibling01",
+                    "parent_session_id": "source01",
+                    "period_seconds": 600,
+                    "is_active": true
                 }
             ]
         }))

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -16995,6 +16995,105 @@ async fn reparent_request_creation_persists_and_queues_exact_actionable_notifica
 }
 
 #[tokio::test]
+async fn reparent_request_immediately_delivers_approval_prompt_to_an_idle_runtime() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let queue_db = queue_db_path_for_state_file(&state_file);
+    let log_dir = unique_temp_path();
+    let working_dir = unique_temp_path();
+    fs::create_dir_all(&working_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-test-reparent-notify-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app(&state_file, &log_dir, &tmux_socket);
+
+    for (id, parent) in [
+        ("notifyold", None),
+        ("notifynew", None),
+        ("notifychild", Some("notifyold")),
+    ] {
+        let mut payload = json!({
+            "id": id,
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude",
+            "initial_message": format!("initial {id}")
+        });
+        if let Some(parent) = parent {
+            payload["parent_session_id"] = json!(parent);
+        }
+        let (status, _) = post_json(app.clone(), "/sessions", payload).await;
+        assert_eq!(status, StatusCode::OK);
+        wait_for_output_contains(app.clone(), id, &format!("runtime:initial {id}")).await;
+    }
+
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    for session in state["sessions"].as_array_mut().unwrap() {
+        let credential = match session["id"].as_str().unwrap() {
+            "notifyold" => "notify-old-token",
+            "notifynew" => "notify-new-token",
+            "notifychild" => "notify-child-token",
+            other => panic!("unexpected session {other}"),
+        };
+        session["session_credential_sha256"] = json!(session_credential_hash(credential));
+    }
+    fs::write(&state_file, serde_json::to_vec_pretty(&state).unwrap()).unwrap();
+
+    let (status, _) = post_json(
+        app.clone(),
+        "/hooks/claude",
+        json!({
+            "hook_event_name": "Stop",
+            "session_manager_id": "notifynew"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, created) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/sessions/notifychild/reparent-requests",
+        json!({
+            "requester_session_id": "notifyold",
+            "target_parent_session_id": "notifynew"
+        }),
+        &[("x-sm-session-credential", "notify-old-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let request_id = created["id"].as_str().unwrap();
+    wait_for_output_contains(
+        app,
+        "notifynew",
+        &format!("sm reparent approve {request_id}"),
+    )
+    .await;
+
+    let delivered: (i64, String) = Connection::open(queue_db)
+        .unwrap()
+        .query_row(
+            r#"
+            SELECT delivered_at IS NOT NULL, message_category
+            FROM message_queue
+            WHERE target_session_id = 'notifynew'
+              AND message_category = 'reparent'
+            "#,
+            [],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(delivered, (1, "reparent".to_owned()));
+}
+
+#[tokio::test]
 async fn reparent_tree_dry_run_reports_exact_plan_without_persisting_a_request() {
     let state_file = write_reparent_tree_fixture();
     let mut config = config_with_state_file(&state_file);

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -49,7 +49,7 @@ use std::{
         mpsc, Arc, Mutex,
     },
     thread,
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 use tower::ServiceExt;
 
@@ -12117,7 +12117,7 @@ async fn runtime_core_lifecycle_uses_tmux_backend_when_enabled() {
             log_dir: Some(log_dir.display().to_string()),
             tmux_socket_name: Some(tmux_socket.clone()),
             runtime_command: Some(
-                r#"/bin/sh -lc 'while IFS= read -r line; do printf "argv:%s\nids:%s:%s:%s\nruntime:%s\n" "$*" "$SESSION_MANAGER_ID" "$CLAUDE_SESSION_MANAGER_ID" "$ENABLE_TOOL_SEARCH" "$line"; done' runtime-sh"#
+                r#"/bin/sh -lc 'while IFS= read -r line; do printf "argv:%s\nids:%s:%s:%s\nruntime:%s\n>\n" "$*" "$SESSION_MANAGER_ID" "$CLAUDE_SESSION_MANAGER_ID" "$ENABLE_TOOL_SEARCH" "$line"; done' runtime-sh"#
                     .to_owned(),
             ),
             runtime_prompt_mode: Some("stdin".to_owned()),
@@ -12297,6 +12297,7 @@ async fn runtime_core_lifecycle_uses_tmux_backend_when_enabled() {
     assert_eq!(launches.len(), 2);
     launches[1]["status"] = json!("launching");
     launches[1]["updated_at"] = json!("2026-08-11T00:00:00Z");
+    interrupted_state["sessions"][0]["provider_resume_id"] = json!("runtime-thread-1");
     fs::write(
         &state_file,
         serde_json::to_vec_pretty(&interrupted_state).unwrap(),
@@ -12304,7 +12305,7 @@ async fn runtime_core_lifecycle_uses_tmux_backend_when_enabled() {
     .unwrap();
     drop(app);
 
-    let recovered_app = router(AppState::new(config));
+    let recovered_app = router(AppState::new(config.clone()));
     let recovered_state: Value =
         serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
     let recovered_hash = recovered_state["sessions"][0]["session_credential_sha256"]
@@ -12332,11 +12333,133 @@ async fn runtime_core_lifecycle_uses_tmux_backend_when_enabled() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["delivered"], true);
     wait_for_output_contains(
-        recovered_app,
+        recovered_app.clone(),
         "runtimecore",
         "runtime:recovered launch message",
     )
     .await;
+
+    let hash_before_rotation = recovered_hash.to_owned();
+    let (status, rotation) = post_json_with_headers_and_peer(
+        recovered_app.clone(),
+        "/sessions/runtimecore/credential-rotation",
+        json!({}),
+        &[("host", "127.0.0.1")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(rotation["status"], "waiting_idle");
+    let waiting_state: Value =
+        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    assert_eq!(
+        waiting_state["sessions"][0]["session_credential_sha256"],
+        hash_before_rotation
+    );
+
+    let (status, payload) = post_json(
+        recovered_app.clone(),
+        "/hooks/claude",
+        json!({
+            "hook_event_name": "Stop",
+            "session_manager_id": "runtimecore"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload, json!({ "status": "ok" }));
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let rotated_state = loop {
+        let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+        if state["session_credential_rotations"][0]["status"] == "applied" {
+            break state;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "credential rotation did not apply"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    };
+    let rotated_hash = rotated_state["sessions"][0]["session_credential_sha256"]
+        .as_str()
+        .unwrap();
+    assert_ne!(rotated_hash, hash_before_rotation);
+    assert_eq!(
+        rotated_state["session_runtime_launches"][2]["operation_kind"],
+        "recredential"
+    );
+    assert_eq!(
+        rotated_state["session_runtime_launches"][2]["status"],
+        "applied"
+    );
+    assert_eq!(
+        rotated_state["session_runtime_launches"][2]["credential_rotation_id"],
+        rotation["id"]
+    );
+    assert_eq!(
+        rotated_state["session_credential_rotations"][0]["runtime_launch_id"],
+        rotated_state["session_runtime_launches"][2]["id"]
+    );
+    let (status, repeated_rotation) = post_json_with_headers_and_peer(
+        recovered_app.clone(),
+        "/sessions/runtimecore/credential-rotation",
+        json!({}),
+        &[("host", "127.0.0.1")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(repeated_rotation["id"], rotation["id"]);
+    let (status, rotations) = json_request_with_headers_and_peer(
+        recovered_app.clone(),
+        "GET",
+        "/session-credential-rotations",
+        Value::Null,
+        &[("host", "127.0.0.1")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(rotations["rotations"][0]["id"], rotation["id"]);
+    let (status, _) = json_request_with_headers_and_peer(
+        recovered_app.clone(),
+        "GET",
+        "/session-credential-rotations",
+        Value::Null,
+        &[("host", "sm.example.com")],
+        Some(SocketAddr::from(([203, 0, 113, 10], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+
+    let hash_after_rotation = rotated_hash.to_owned();
+    let mut interrupted_rotation = rotated_state;
+    interrupted_rotation["session_runtime_launches"][2]["status"] = json!("launching");
+    interrupted_rotation["session_credential_rotations"][0]["status"] = json!("relaunching");
+    interrupted_rotation["session_credential_rotations"][0]["applied_at"] = Value::Null;
+    fs::write(
+        &state_file,
+        serde_json::to_vec_pretty(&interrupted_rotation).unwrap(),
+    )
+    .unwrap();
+    drop(recovered_app);
+
+    let _recovered_rotation_app = router(AppState::new(config));
+    let recovered_rotation: Value =
+        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    assert_eq!(
+        recovered_rotation["session_runtime_launches"][2]["status"],
+        "applied"
+    );
+    assert_eq!(
+        recovered_rotation["session_credential_rotations"][0]["status"],
+        "applied"
+    );
+    assert!(recovered_rotation["session_credential_rotations"][0]["applied_at"].is_string());
+    assert_ne!(
+        recovered_rotation["sessions"][0]["session_credential_sha256"],
+        hash_after_rotation
+    );
 }
 
 #[tokio::test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -16530,8 +16530,46 @@ async fn reparent_request_uses_human_gate_when_the_recorded_parent_is_not_live()
     assert_eq!(repeated["status"], "pending");
     assert_eq!(repeated["ready_to_apply"], false);
 
+    let (status, unauthorized) = post_json_with_headers_and_peer(
+        app.clone(),
+        &format!("/reparent-requests/{request_id}/human-approve"),
+        json!({}),
+        &[("host", "sm.example.com")],
+        Some(SocketAddr::from(([203, 0, 113, 10], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        unauthorized["detail"],
+        "Operator authentication is required"
+    );
+
+    let (status, human_approved) = post_json_with_headers_and_peer(
+        app.clone(),
+        &format!("/reparent-requests/{request_id}/human-approve"),
+        json!({}),
+        &[("host", "127.0.0.1")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(human_approved["ready_to_apply"], true);
+    assert_eq!(human_approved["approvals"][1]["actor_kind"], "human");
+    assert_eq!(human_approved["approvals"][1]["actor_id"], "local_bypass");
+
+    let (status, repeated_human) = post_json_with_headers_and_peer(
+        app.clone(),
+        &format!("/reparent-requests/{request_id}/human-approve"),
+        json!({}),
+        &[("host", "127.0.0.1")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(repeated_human["approvals"].as_array().unwrap().len(), 2);
+
     let (status, conflicting) = post_json_with_headers_and_peer(
-        app,
+        app.clone(),
         &format!("/reparent-requests/{request_id}/reject"),
         json!({ "requester_session_id": "newparent" }),
         &[("x-sm-session-credential", "new-token")],
@@ -16540,6 +16578,20 @@ async fn reparent_request_uses_human_gate_when_the_recorded_parent_is_not_live()
     .await;
     assert_eq!(status, StatusCode::CONFLICT);
     assert!(conflicting["detail"]
+        .as_str()
+        .unwrap()
+        .contains("already approved"));
+
+    let (status, conflicting_human) = post_json_with_headers_and_peer(
+        app,
+        &format!("/reparent-requests/{request_id}/human-reject"),
+        json!({}),
+        &[("host", "127.0.0.1")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert!(conflicting_human["detail"]
         .as_str()
         .unwrap()
         .contains("already approved"));

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -16281,7 +16281,7 @@ async fn reparent_request_reserves_failed_post_quiesce_edges() {
     let mut raw_state: Value =
         serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
     raw_state["reparent_requests"][0]["status"] = json!("failed");
-    raw_state["reparent_requests"][0]["apply_stage"] = json!("routing_quiesced");
+    raw_state["reparent_requests"][0]["apply_stage"] = json!("json_routing_quiesced");
     raw_state["reparent_requests"][0]["failure_reason"] = json!("fixture route failure");
     fs::write(&state_file, serde_json::to_vec_pretty(&raw_state).unwrap()).unwrap();
 

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -171,6 +171,13 @@ fn queued_message_texts(db_path: &PathBuf, target_session_id: &str) -> Vec<Strin
     last_texts
 }
 
+fn session_credential_hash(credential: &str) -> String {
+    Sha256::digest(credential.as_bytes())
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
 fn queue_job_completion_notified_at(queue_state_dir: &PathBuf, job_id: &str) -> Option<String> {
     for attempt in 0..50 {
         let conn = Connection::open(queue_state_dir.join("queue_runner.db")).unwrap();
@@ -880,6 +887,7 @@ async fn node_restore_candidates_project_primary_stopped_sessions() {
     assert_eq!(candidate["restore_source"], "server_state");
     assert_eq!(candidate["activity_state"], "stopped");
     assert_eq!(candidate["provider"], "claude");
+    assert!(candidate.get("session_credential_sha256").is_none());
 }
 
 #[tokio::test]
@@ -11566,7 +11574,8 @@ async fn fixture_registry_prunes_stale_roles_and_updates_maintainer_alias() {
                     "provider": "claude",
                     "created_at": "2026-06-01T00:00:00",
                     "last_activity": "2026-06-01T00:01:00",
-                    "stopped_at": "2026-06-01T00:02:00"
+                    "stopped_at": "2026-06-01T00:02:00",
+                    "session_credential_sha256": "must-not-leave-server-state"
                 }
             ],
             "maintainer_session_id": "staleagent",
@@ -12137,6 +12146,14 @@ async fn runtime_core_lifecycle_uses_tmux_backend_when_enabled() {
     assert_eq!(payload["id"], "runtimecore");
     assert_eq!(payload["status"], "running");
     assert_eq!(payload["tmux_socket_name"], tmux_socket);
+    assert!(payload.get("session_credential_sha256").is_none());
+    let created_state: Value =
+        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let created_credential_hash = created_state["sessions"][0]["session_credential_sha256"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    assert_eq!(created_credential_hash.len(), 64);
     let tmux_session = payload["tmux_session"].as_str().unwrap().to_owned();
 
     let payload =
@@ -12232,6 +12249,14 @@ async fn runtime_core_lifecycle_uses_tmux_backend_when_enabled() {
     assert_eq!(payload["id"], "runtimecore");
     assert_eq!(payload["status"], "running");
     assert_eq!(payload["completion_status"], Value::Null);
+    assert!(payload.get("session_credential_sha256").is_none());
+    let restored_state: Value =
+        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let restored_credential_hash = restored_state["sessions"][0]["session_credential_sha256"]
+        .as_str()
+        .unwrap();
+    assert_eq!(restored_credential_hash.len(), 64);
+    assert_ne!(restored_credential_hash, created_credential_hash);
     assert!(tmux_session_exists(&tmux_socket, &tmux_session));
 
     let (status, payload) = post_json(
@@ -16056,8 +16081,10 @@ async fn sessions_project_top_level_registry_and_adoption_state() {
                 "proposer_name": "maintainer",
                 "target_session_id": "child001",
                 "created_at": "2026-06-01T00:03:00",
-                "status": "pending",
-                "decided_at": null
+                "status": "stale",
+                "decided_at": null,
+                "actionable": false,
+                "failure_reason": "legacy adoption proposal requires a new consent request"
             }
         ])
     );
@@ -16077,6 +16104,427 @@ async fn sessions_project_top_level_registry_and_adoption_state() {
         .unwrap()
         .iter()
         .any(|entry| entry["role"] == "maintainer" && entry["session_id"] == "em123456"));
+}
+
+#[tokio::test]
+async fn reparent_request_requires_bound_credentials_and_dual_agent_consent() {
+    let state_file = write_reparent_fixture();
+    let mut config = config_with_state_file(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/child/reparent-requests",
+        json!({
+            "requester_session_id": "oldparent",
+            "target_parent_session_id": "newparent"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert!(payload["detail"].as_str().unwrap().contains("Credential"));
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/sessions/child/reparent-requests",
+        json!({
+            "requester_session_id": "oldparent",
+            "target_parent_session_id": "newparent"
+        }),
+        &[("x-sm-session-credential", "new-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert!(payload["detail"]
+        .as_str()
+        .unwrap()
+        .contains("does not match"));
+
+    let (status, created) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/sessions/child/reparent-requests",
+        json!({
+            "requester_session_id": "oldparent",
+            "target_parent_session_id": "newparent"
+        }),
+        &[("x-sm-session-credential", "old-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(created["kind"], "single");
+    assert_eq!(created["expected_parent_session_id"], "oldparent");
+    assert_eq!(
+        created["required_agent_approvals"],
+        json!(["newparent", "oldparent"])
+    );
+    assert_eq!(created["required_human_approval"], false);
+    assert_eq!(created["ready_to_apply"], false);
+    let request_id = created["id"].as_str().unwrap();
+
+    let (status, approved) = post_json_with_headers_and_peer(
+        app.clone(),
+        &format!("/reparent-requests/{request_id}/approve"),
+        json!({ "requester_session_id": "newparent" }),
+        &[("x-sm-session-credential", "new-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(approved["status"], "pending");
+    assert_eq!(approved["ready_to_apply"], true);
+    assert_eq!(approved["approvals"].as_array().unwrap().len(), 2);
+
+    let raw_state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let child = raw_state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "child")
+        .unwrap();
+    assert_eq!(child["parent_session_id"], "oldparent");
+    assert_eq!(raw_state["reparent_requests"][0]["ready_to_apply"], true);
+}
+
+#[tokio::test]
+async fn reparent_request_rejects_unauthorized_cycles_and_overlapping_edges() {
+    let state_file = write_reparent_fixture();
+    let mut config = config_with_state_file(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/sessions/child/reparent-requests",
+        json!({
+            "requester_session_id": "unrelated",
+            "target_parent_session_id": "newparent"
+        }),
+        &[("x-sm-session-credential", "unrelated-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert!(payload["detail"]
+        .as_str()
+        .unwrap()
+        .contains("current parent"));
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/sessions/child/reparent-requests",
+        json!({
+            "requester_session_id": "oldparent",
+            "target_parent_session_id": "grandchild"
+        }),
+        &[("x-sm-session-credential", "old-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert!(payload["detail"].as_str().unwrap().contains("cycle"));
+
+    let (status, created) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/sessions/child/reparent-requests",
+        json!({
+            "requester_session_id": "newparent",
+            "target_parent_session_id": "newparent"
+        }),
+        &[("x-sm-session-credential", "new-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert!(!created["id"].as_str().unwrap().is_empty());
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app,
+        "/sessions/child/reparent-requests",
+        json!({
+            "requester_session_id": "oldparent",
+            "target_parent_session_id": "unrelated"
+        }),
+        &[("x-sm-session-credential", "old-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert!(payload["detail"]
+        .as_str()
+        .unwrap()
+        .contains("already controls"));
+}
+
+#[tokio::test]
+async fn reparent_request_reserves_failed_post_quiesce_edges() {
+    let state_file = write_reparent_fixture();
+    let mut config = config_with_state_file(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, created) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/sessions/child/reparent-requests",
+        json!({
+            "requester_session_id": "oldparent",
+            "target_parent_session_id": "newparent"
+        }),
+        &[("x-sm-session-credential", "old-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let mut raw_state: Value =
+        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    raw_state["reparent_requests"][0]["status"] = json!("failed");
+    raw_state["reparent_requests"][0]["apply_stage"] = json!("routing_quiesced");
+    raw_state["reparent_requests"][0]["failure_reason"] = json!("fixture route failure");
+    fs::write(&state_file, serde_json::to_vec_pretty(&raw_state).unwrap()).unwrap();
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app,
+        "/sessions/child/reparent-requests",
+        json!({
+            "requester_session_id": "oldparent",
+            "target_parent_session_id": "newparent"
+        }),
+        &[("x-sm-session-credential", "old-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert!(payload["detail"]
+        .as_str()
+        .unwrap()
+        .contains(created["id"].as_str().unwrap()));
+}
+
+#[tokio::test]
+async fn reparent_request_uses_human_gate_when_the_recorded_parent_is_not_live() {
+    let state_file = write_reparent_fixture();
+    let mut config = config_with_state_file(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, created) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/sessions/orphan/reparent-requests",
+        json!({
+            "requester_session_id": "newparent",
+            "target_parent_session_id": "newparent"
+        }),
+        &[("x-sm-session-credential", "new-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(created["expected_parent_session_id"], "stoppedparent");
+    assert_eq!(created["expected_parent_is_live"], false);
+    assert_eq!(created["required_agent_approvals"], json!(["newparent"]));
+    assert_eq!(created["required_human_approval"], true);
+    assert_eq!(created["ready_to_apply"], false);
+
+    let request_id = created["id"].as_str().unwrap();
+    let (status, repeated) = post_json_with_headers_and_peer(
+        app.clone(),
+        &format!("/reparent-requests/{request_id}/approve"),
+        json!({ "requester_session_id": "newparent" }),
+        &[("x-sm-session-credential", "new-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(repeated["status"], "pending");
+    assert_eq!(repeated["ready_to_apply"], false);
+
+    let (status, conflicting) = post_json_with_headers_and_peer(
+        app,
+        &format!("/reparent-requests/{request_id}/reject"),
+        json!({ "requester_session_id": "newparent" }),
+        &[("x-sm-session-credential", "new-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert!(conflicting["detail"]
+        .as_str()
+        .unwrap()
+        .contains("already approved"));
+}
+
+#[tokio::test]
+async fn reparent_request_rejection_is_terminal_and_same_decision_is_idempotent() {
+    let state_file = write_reparent_fixture();
+    let mut config = config_with_state_file(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, created) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/sessions/child/reparent-requests",
+        json!({
+            "requester_session_id": "oldparent",
+            "target_parent_session_id": "newparent"
+        }),
+        &[("x-sm-session-credential", "old-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let request_id = created["id"].as_str().unwrap();
+
+    for _ in 0..2 {
+        let (status, rejected) = post_json_with_headers_and_peer(
+            app.clone(),
+            &format!("/reparent-requests/{request_id}/reject"),
+            json!({ "requester_session_id": "newparent" }),
+            &[("x-sm-session-credential", "new-token")],
+            Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(rejected["status"], "rejected");
+        assert_eq!(rejected["ready_to_apply"], false);
+    }
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app,
+        &format!("/reparent-requests/{request_id}/approve"),
+        json!({ "requester_session_id": "newparent" }),
+        &[("x-sm-session-credential", "new-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert!(payload["detail"]
+        .as_str()
+        .unwrap()
+        .contains("already rejected"));
+}
+
+#[tokio::test]
+async fn reparent_request_expiration_is_persisted_and_blocks_missing_approval() {
+    let state_file = write_reparent_fixture();
+    let mut config = config_with_state_file(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, created) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/sessions/child/reparent-requests",
+        json!({
+            "requester_session_id": "oldparent",
+            "target_parent_session_id": "newparent"
+        }),
+        &[("x-sm-session-credential", "old-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let request_id = created["id"].as_str().unwrap().to_owned();
+
+    let mut raw_state: Value =
+        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    raw_state["reparent_requests"][0]["expires_at"] = json!("2020-01-01T00:00:00Z");
+    fs::write(&state_file, serde_json::to_vec_pretty(&raw_state).unwrap()).unwrap();
+
+    let (status, record) = get_json(app.clone(), &format!("/reparent-requests/{request_id}")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(record["status"], "expired");
+    assert_eq!(record["ready_to_apply"], false);
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app,
+        &format!("/reparent-requests/{request_id}/approve"),
+        json!({ "requester_session_id": "newparent" }),
+        &[("x-sm-session-credential", "new-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::GONE);
+    assert_eq!(payload["detail"], "Reparent request expired");
+}
+
+#[tokio::test]
+async fn reparent_request_with_invalid_expiration_fails_closed() {
+    let state_file = write_reparent_fixture();
+    let mut config = config_with_state_file(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, created) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/sessions/child/reparent-requests",
+        json!({
+            "requester_session_id": "oldparent",
+            "target_parent_session_id": "newparent"
+        }),
+        &[("x-sm-session-credential", "old-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let request_id = created["id"].as_str().unwrap().to_owned();
+
+    let mut raw_state: Value =
+        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    raw_state["reparent_requests"][0]["expires_at"] = json!("not-a-timestamp");
+    fs::write(&state_file, serde_json::to_vec_pretty(&raw_state).unwrap()).unwrap();
+
+    let (status, record) = get_json(app, &format!("/reparent-requests/{request_id}")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(record["status"], "stale");
+    assert_eq!(record["ready_to_apply"], false);
+    assert_eq!(
+        record["failure_reason"],
+        "request expiry timestamp is invalid"
+    );
+}
+
+#[tokio::test]
+async fn reparent_request_read_marks_changed_topology_stale() {
+    let state_file = write_reparent_fixture();
+    let mut config = config_with_state_file(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, created) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/sessions/child/reparent-requests",
+        json!({
+            "requester_session_id": "oldparent",
+            "target_parent_session_id": "newparent"
+        }),
+        &[("x-sm-session-credential", "old-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let request_id = created["id"].as_str().unwrap().to_owned();
+
+    let mut raw_state: Value =
+        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let child = raw_state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "child")
+        .unwrap();
+    child["parent_session_id"] = json!("unrelated");
+    fs::write(&state_file, serde_json::to_vec_pretty(&raw_state).unwrap()).unwrap();
+
+    let (status, record) = get_json(app, &format!("/reparent-requests/{request_id}")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(record["status"], "stale");
+    assert_eq!(record["ready_to_apply"], false);
+    assert!(record["failure_reason"]
+        .as_str()
+        .unwrap()
+        .contains("parent changed"));
 }
 
 fn config_with_state_file(state_file: &PathBuf) -> AppConfig {
@@ -16841,6 +17289,55 @@ fn write_registry_fixture() -> PathBuf {
             ]
         })
         .to_string(),
+    )
+    .unwrap();
+    path
+}
+
+fn write_reparent_fixture() -> PathBuf {
+    let path = unique_temp_path();
+    let session = |id: &str, status: &str, parent_session_id: Option<&str>, credential: &str| {
+        let mut value = json!({
+            "id": id,
+            "name": format!("claude-{id}"),
+            "working_dir": "/repo",
+            "tmux_session": format!("claude-{id}"),
+            "log_file": format!("/tmp/{id}.log"),
+            "provider": "claude",
+            "status": status,
+            "created_at": "2026-06-01T00:00:00Z",
+            "last_activity": "2026-06-01T00:01:00Z",
+            "session_credential_sha256": session_credential_hash(credential)
+        });
+        if let Some(parent_session_id) = parent_session_id {
+            value["parent_session_id"] = json!(parent_session_id);
+        }
+        value
+    };
+    fs::write(
+        &path,
+        serde_json::to_vec_pretty(&json!({
+            "sessions": [
+                session("oldparent", "running", None, "old-token"),
+                session("newparent", "running", None, "new-token"),
+                session("unrelated", "running", None, "unrelated-token"),
+                session("child", "running", Some("oldparent"), "child-token"),
+                session("grandchild", "running", Some("child"), "grandchild-token"),
+                session("stoppedparent", "stopped", None, "stopped-token"),
+                session("orphan", "running", Some("stoppedparent"), "orphan-token")
+            ],
+            "adoption_proposals": [
+                {
+                    "id": "legacy-proposal",
+                    "proposer_session_id": "newparent",
+                    "target_session_id": "child",
+                    "created_at": "2026-06-01T00:02:00Z",
+                    "status": "pending",
+                    "decided_at": null
+                }
+            ]
+        }))
+        .unwrap(),
     )
     .unwrap();
     path

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -12103,7 +12103,7 @@ async fn runtime_core_lifecycle_uses_tmux_backend_when_enabled() {
             .as_nanos()
     );
     let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
-    let app = router(AppState::new(AppConfig {
+    let config = AppConfig {
         paths: PathsConfig {
             state_file: state_file.display().to_string(),
         },
@@ -12128,7 +12128,8 @@ async fn runtime_core_lifecycle_uses_tmux_backend_when_enabled() {
             ..RustCoreConfig::default()
         },
         ..AppConfig::default()
-    }));
+    };
+    let app = router(AppState::new(config.clone()));
 
     let (status, payload) = post_json(
         app.clone(),
@@ -12154,6 +12155,17 @@ async fn runtime_core_lifecycle_uses_tmux_backend_when_enabled() {
         .unwrap()
         .to_owned();
     assert_eq!(created_credential_hash.len(), 64);
+    assert_eq!(
+        created_state["session_runtime_launches"][0]["status"],
+        "applied"
+    );
+    assert_eq!(
+        created_state["session_runtime_launches"][0]["credential_sha256"],
+        created_credential_hash
+    );
+    assert!(!fs::read_to_string(&state_file)
+        .unwrap()
+        .contains("SM_SESSION_CREDENTIAL"));
     let tmux_session = payload["tmux_session"].as_str().unwrap().to_owned();
 
     let payload =
@@ -12270,7 +12282,61 @@ async fn runtime_core_lifecycle_uses_tmux_backend_when_enabled() {
     .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["delivered"], true);
-    wait_for_output_contains(app, "runtimecore", "runtime:restored runtime message").await;
+    wait_for_output_contains(
+        app.clone(),
+        "runtimecore",
+        "runtime:restored runtime message",
+    )
+    .await;
+
+    let mut interrupted_state: Value =
+        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let launches = interrupted_state["session_runtime_launches"]
+        .as_array_mut()
+        .unwrap();
+    assert_eq!(launches.len(), 2);
+    launches[1]["status"] = json!("launching");
+    launches[1]["updated_at"] = json!("2026-08-11T00:00:00Z");
+    fs::write(
+        &state_file,
+        serde_json::to_vec_pretty(&interrupted_state).unwrap(),
+    )
+    .unwrap();
+    drop(app);
+
+    let recovered_app = router(AppState::new(config));
+    let recovered_state: Value =
+        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let recovered_hash = recovered_state["sessions"][0]["session_credential_sha256"]
+        .as_str()
+        .unwrap();
+    assert_ne!(recovered_hash, restored_credential_hash);
+    assert_eq!(
+        recovered_state["session_runtime_launches"][1]["status"],
+        "applied"
+    );
+    assert_eq!(
+        recovered_state["session_runtime_launches"][1]["credential_sha256"],
+        recovered_hash
+    );
+    assert!(tmux_session_exists(&tmux_socket, &tmux_session));
+    let (status, payload) = post_json(
+        recovered_app.clone(),
+        "/sessions/runtimecore/input",
+        json!({
+            "text": "recovered launch message",
+            "delivery_mode": "sequential"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["delivered"], true);
+    wait_for_output_contains(
+        recovered_app,
+        "runtimecore",
+        "runtime:recovered launch message",
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -16532,8 +16532,9 @@ async fn reparent_request_requires_bound_credentials_and_dual_agent_consent() {
     )
     .await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(approved["status"], "pending");
-    assert_eq!(approved["ready_to_apply"], true);
+    assert_eq!(approved["status"], "applied");
+    assert_eq!(approved["apply_stage"], "applied");
+    assert_eq!(approved["ready_to_apply"], false);
     assert_eq!(approved["approvals"].as_array().unwrap().len(), 2);
 
     let raw_state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
@@ -16543,8 +16544,9 @@ async fn reparent_request_requires_bound_credentials_and_dual_agent_consent() {
         .iter()
         .find(|session| session["id"] == "child")
         .unwrap();
-    assert_eq!(child["parent_session_id"], "oldparent");
-    assert_eq!(raw_state["reparent_requests"][0]["ready_to_apply"], true);
+    assert_eq!(child["parent_session_id"], "newparent");
+    assert_eq!(raw_state["reparent_requests"][0]["status"], "applied");
+    assert_eq!(raw_state["reparent_requests"][0]["ready_to_apply"], false);
 }
 
 #[tokio::test]
@@ -16723,7 +16725,9 @@ async fn reparent_request_uses_human_gate_when_the_recorded_parent_is_not_live()
     )
     .await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(human_approved["ready_to_apply"], true);
+    assert_eq!(human_approved["status"], "applied");
+    assert_eq!(human_approved["apply_stage"], "applied");
+    assert_eq!(human_approved["ready_to_apply"], false);
     assert_eq!(human_approved["approvals"][1]["actor_kind"], "human");
     assert_eq!(human_approved["approvals"][1]["actor_id"], "local_bypass");
 

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -16943,6 +16943,58 @@ async fn reparent_request_read_marks_changed_topology_stale() {
 }
 
 #[tokio::test]
+async fn reparent_request_creation_persists_and_queues_exact_actionable_notification() {
+    let state_file = write_reparent_fixture();
+    let queue_db = queue_db_path_for_state_file(&state_file);
+    let mut config = config_with_state_file_and_queue(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, created) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/sessions/child/reparent-requests",
+        json!({
+            "requester_session_id": "oldparent",
+            "target_parent_session_id": "newparent"
+        }),
+        &[("x-sm-session-credential", "old-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let request_id = created["id"].as_str().unwrap();
+
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let intents = state["reparent_requests"][0]["notification_intents"]
+        .as_array()
+        .unwrap();
+    assert_eq!(intents.len(), 1);
+    assert_eq!(intents[0]["recipient_session_id"], "newparent");
+    assert!(intents[0]["enqueued_at"].as_str().is_some());
+
+    let messages = queued_message_texts(&queue_db, "newparent");
+    assert_eq!(messages.len(), 1);
+    let message = &messages[0];
+    assert!(message.contains(&format!("single request {request_id} from oldparent")));
+    assert!(message.contains("child: oldparent -> newparent"));
+    assert!(message.contains(&format!("sm reparent approve {request_id}")));
+    assert!(message.contains(&format!("sm reparent reject {request_id}")));
+
+    let (status, scoped) = get_json_with_host_and_headers(
+        app,
+        "/reparent-requests",
+        "localhost",
+        &[
+            ("x-sm-session-id", "unrelated".to_owned()),
+            ("x-sm-session-credential", "unrelated-token".to_owned()),
+        ],
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(scoped["requests"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
 async fn reparent_tree_dry_run_reports_exact_plan_without_persisting_a_request() {
     let state_file = write_reparent_tree_fixture();
     let mut config = config_with_state_file(&state_file);
@@ -17002,6 +17054,50 @@ async fn reparent_tree_dry_run_reports_exact_plan_without_persisting_a_request()
 
     let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
     assert!(state["reparent_requests"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn reparent_tree_dry_run_reports_an_overlapping_active_request_as_a_blocker() {
+    let state_file = write_reparent_tree_fixture();
+    let mut config = config_with_state_file(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, active) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/sessions/sibling01/reparent-requests",
+        json!({
+            "requester_session_id": "source01",
+            "target_parent_session_id": "grand001"
+        }),
+        &[("x-sm-session-credential", "source-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let active_id = active["id"].as_str().unwrap();
+
+    let (status, preview) = post_json_with_headers_and_peer(
+        app,
+        "/sessions/source01/reparent-tree-requests",
+        json!({
+            "requester_session_id": "source01",
+            "target_session_id": "target01",
+            "dry_run": true
+        }),
+        &[("x-sm-session-credential", "source-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    let blockers = preview["blockers"].as_array().unwrap();
+    assert_eq!(blockers.len(), 1);
+    assert!(blockers[0].as_str().unwrap().contains(active_id));
+    assert!(blockers[0].as_str().unwrap().contains("sibling01"));
+
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    assert_eq!(state["reparent_requests"].as_array().unwrap().len(), 1);
 }
 
 #[tokio::test]

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -35,6 +35,8 @@ sm reparent reject <request-id>
 sm reparent status [request-id]
 sm reparent repair <request-id> --resume
 sm reparent repair <request-id> --rollback-precommit
+sm recredential <session>
+sm recredential --all-live
 sm adopt <child>
 ```
 
@@ -106,9 +108,31 @@ impersonate an agent approval.
 The same per-session credential gate applies to request creation. Credential
 material is never returned by session/list APIs, written to logs, included in
 notifications, or persisted in plaintext. Existing live sessions without a
-verifier cannot approve after deployment until Session Manager rotates a
-credential into that runtime; rollout must provide an explicit credential
-rotation path and must not fall back to trusting an ID-only payload.
+verifier cannot approve after deployment until Session Manager relaunches that
+runtime with a credential. The operator-authenticated `sm recredential` command
+provides that path; it never falls back to trusting an ID-only payload.
+
+Recredentialing is a durable, idle-only relaunch of the same seat and provider
+thread, not an attempt to mutate a running process environment. Before stopping
+anything, the server must prove the provider has resumable identity, persist a
+rotation record, acquire the session input fence, and verify that the provider
+turn is idle and its input queue is drained. Idle proof must be observed after
+the rotation was requested (a fresh Claude prompt/Stop boundary or Codex
+lifecycle event), not inferred from a stale projected status. Busy or unproven
+seats remain `waiting_idle` and are retried by the provider Stop/event path.
+The relaunch preserves the Session Manager ID, parent graph, task metadata, and
+provider resume ID; it rotates the runtime credential and verifier. A crash
+after the old runtime is
+stopped resumes the recorded relaunch on startup. If resumability or readiness
+cannot be established, the old runtime remains untouched and the rotation
+fails closed. There is no force-active mode in this epic.
+
+Deployment does not silently relaunch the fleet. After the merged server is
+healthy, the maintainer runs `sm recredential --all-live`; the command reports
+which seats were rotated, waiting for idle, already credentialed, or failed.
+Until a legacy seat completes this bootstrap, reparent commands fail with the
+exact `sm recredential <session>` remediation. Newly created and normally
+restored seats already receive credentials and need no bootstrap.
 
 Session Manager agents share one operating-system account and filesystem. A
 hostile same-UID process with arbitrary process-inspection capability is outside
@@ -131,8 +155,8 @@ conflicting or unauthorized decisions fail.
 Requests expire after 24 hours by default. Expiration and staleness are evaluated
 under the session-state write lock before every read that claims actionability
 and before every decision or pre-quiesce apply attempt. An `applying` request at
-or beyond `routing_quiesced` never expires; recovery must finish its immutable
-transaction.
+or beyond `json_routing_quiesced` never expires; recovery must finish its
+immutable transaction.
 
 ## Durable model
 
@@ -157,8 +181,9 @@ decided_at
 applied_at
 failure_reason
 topology_fingerprint
-apply_stage                nullable | routing_quiesced |
-                           authority_committed | repair_rolled_back
+apply_stage                nullable | json_routing_quiesced |
+                           routing_quiesced | authority_committed |
+                           repair_rolled_back
 apply_plan                 nullable while pending; immutable once applying
 notification_intents[]     deterministic event/recipient delivery records
 repair_history[]           actor, action, prior failure, timestamp,
@@ -184,6 +209,8 @@ of parent-derived wake/message metadata for that child is deferred behind the
 transaction. After `authority_committed`, deferred creation derives the new
 canonical parent. Every parent-derived route creation path must use this fence;
 direct queue-table writes are not permitted.
+Parent-derived route reads and mutations, including task-complete fallback and
+deactivation, use the same fence; it is not limited to creation.
 
 The topology fingerprint is a canonical hash over operation kind, subject,
 target, expected parent, and sorted frozen live children. Revalidation compares
@@ -196,6 +223,14 @@ requests with reason `legacy proposal requires a new consent request`, or are
 left read-only while the new projection exposes the same reason. Either shape
 must preserve the old data and prevent old one-party approvals from becoming
 new authority.
+
+Credential bootstrap uses a separate top-level
+`session_credential_rotations` collection. Each record freezes the session ID,
+provider, provider resume ID, original tmux/runtime identity, request actor,
+status (`waiting_idle | relaunching | applied | failed`), requested event
+cursor/timestamp, later idle proof, timestamps, and failure reason. It never
+contains the plaintext credential. Only one active rotation may cover a seat,
+and successful records are idempotent audit history.
 
 ## Validation
 
@@ -212,7 +247,7 @@ Request creation and apply both reject:
 - tree promotion where target is not source's live direct child;
 - duplicate active requests whose affected edge sets overlap;
 - any request whose affected edge set overlaps a `failed` transaction that
-  reached `routing_quiesced` or later and has not been explicitly repaired;
+  reached `json_routing_quiesced` or later and has not been explicitly repaired;
 - a topology that changed after request creation.
 
 Apply revalidates all identities, liveness, topology, consent, and cycle
@@ -256,21 +291,25 @@ therefore a recoverable, fail-closed staged operation:
 1. Under the session write lock, revalidate and persist `status=applying` with
    the complete immutable plan. Parent edges remain unchanged.
 2. Through the queue coordinator's routing fence, stop and remove each affected
-   in-memory parent-wake task/registration, then in one SQLite transaction
-   idempotently quiesce affected parent-derived wake registrations and pending
-   wake metadata. Persist
-   `apply_stage=routing_quiesced` in JSON. A replay accepts either each plan
-   entry's recorded pre-state or its exact already-quiesced state; any third
-   state fails closed. On process restart, inactive SQLite rows cannot recreate
-   the stopped runtime tasks.
+   in-memory parent-wake task/registration. Under the session-state lock,
+   atomically mark every affected retained JSON parent-wake registration
+   inactive and persist `apply_stage=json_routing_quiesced`. Task-complete and
+   all other fallback reads treat that record as inactive, so they cannot route
+   to the old parent. Then, in one SQLite transaction, idempotently quiesce
+   affected parent-derived wake registrations and pending wake metadata and
+   persist `apply_stage=routing_quiesced` in JSON. A replay accepts either each
+   plan entry's recorded pre-state or its exact already-quiesced state; any
+   third state fails closed. On process restart, inactive JSON and SQLite rows
+   cannot recreate the stopped runtime tasks.
 3. In one atomic JSON replacement, update all parent edges and JSON-backed
    routing, and persist `apply_stage=authority_committed`. Dynamic
    task-complete and wait-monitor delivery now resolves this canonical edge.
 4. In one idempotent SQLite transaction, retarget and reactivate affected
-   parent-derived routes, then recreate their in-memory registrations/tasks
-   with the new target under the routing fence and mark the JSON request
-   `applied`. Replay accepts an already-correct runtime registration and never
-   starts a duplicate task.
+   parent-derived routes. Under the state lock, retarget and reactivate the
+   retained JSON registrations, then recreate their in-memory tasks with the
+   new target under the routing fence and mark the JSON request `applied`.
+   Replay accepts an already-correct runtime registration and never starts a
+   duplicate task.
 
 An interruption before step 3 exposes no new destructive authority and leaves
 old-parent routing paused rather than misdirected. An interruption after step 3
@@ -283,10 +322,10 @@ recorded transaction or reports a durable `failed` state requiring operator
 repair; it never silently rolls authority back to a topology that may already
 have been observed.
 
-A `failed` request at or beyond `routing_quiesced` remains a durable quarantine,
-not a released terminal edge. Its complete affected edge set stays reserved by
-the overlap fence, parent-derived route creation remains deferred for those
-children, and no later request may include any reserved edge. Only an
+A `failed` request at or beyond `json_routing_quiesced` remains a durable
+quarantine, not a released terminal edge. Its complete affected edge set stays
+reserved by the overlap fence, parent-derived route creation remains deferred
+for those children, and no later request may include any reserved edge. Only an
 authenticated operator repair action may either resume the immutable plan or
 restore and verify its exact pre-commit state before clearing the quarantine.
 Merely rejecting, expiring, deleting, or recreating the request cannot release
@@ -296,9 +335,10 @@ The authenticated human repair route supports exactly two audited actions:
 
 1. `resume` records a repair attempt, changes `failed` back to `applying`, and
    retries the same immutable plan from its persisted stage. It never replans.
-2. `rollback_precommit` is accepted only from `routing_quiesced`, before
-   `authority_committed`. Under the routing fence, the server restores every
-   route to the apply plan's exact recorded pre-state, verifies all parent edges
+2. `rollback_precommit` is accepted only from `json_routing_quiesced` or
+   `routing_quiesced`, before `authority_committed`. Under the routing fence,
+   the server restores every route to the apply plan's exact recorded
+   pre-state, verifies all parent edges
    still match the old topology and all runtime/JSON/SQLite routes match that
    pre-state, then atomically records `status=repaired` and
    `apply_stage=repair_rolled_back`. Any mismatch leaves the request failed and
@@ -346,6 +386,8 @@ POST /reparent-requests/{request_id}/reject
 POST /reparent-requests/{request_id}/human-approve
 POST /reparent-requests/{request_id}/human-reject
 POST /reparent-requests/{request_id}/repair
+POST /sessions/{session_id}/credential-rotation
+GET  /session-credential-rotations
 ```
 
 Creation payloads carry `requester_session_id`; decision payloads carry the same
@@ -355,6 +397,9 @@ Operator watch can list all pending human-gated requests.
 The repair route is operator-authenticated only and accepts
 `action=resume|rollback_precommit`; an agent session credential cannot invoke
 it. `sm watch` exposes the same actions with the stage-specific safety text.
+Credential-rotation routes are also operator-authenticated only. The create
+route returns the durable rotation state; repeated calls return the existing
+active or already-applied record rather than scheduling a second relaunch.
 
 HTTP status conventions:
 
@@ -396,7 +441,9 @@ events retain the parent/seat metadata recorded when they occurred.
 
 Add the durable request schema, legacy migration/projection, topology planning,
 consent state machine, expiry/staleness handling, read/decision HTTP API, and
-focused tests. No request may apply yet.
+focused tests. Add runtime credential issue/verification plus the durable
+idle-only credential-rotation API and recovery path. No reparent request may
+apply yet.
 
 ### Phase 1 - #1208
 
@@ -432,6 +479,9 @@ PR targets `main`. Partial phases are not deployed.
   durable stage.
 - Post-quiesce failures retain their overlap/routing fence; only a successful
   immutable-plan retry or verified pre-commit rollback releases it.
+- A pre-deployment live seat is recredentialed only after it becomes idle, keeps
+  its seat and provider-thread identity, and recovers a crash after stop without
+  accepting input under two runtimes.
 - Legacy pending adoption records cannot auto-apply.
 - Rust CLI parser/dispatch and Python watch interaction tests pass.
 - Full Rust and retained Python test suites pass, or any demonstrably preexisting

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -158,6 +158,7 @@ topology_fingerprint
 apply_stage                nullable | routing_quiesced |
                            authority_committed
 apply_plan                 nullable while pending; immutable once applying
+notification_intents[]     deterministic event/recipient delivery records
 ```
 
 `apply_plan` is versioned and contains the complete retry input rather than a
@@ -174,8 +175,11 @@ queue_routing_changes[]    table/record ID, child ID, expected old target,
 The transition from `pending` to `applying` discovers these exact records once
 under the state lock and persists the plan before quiescing anything. Recovery
 uses only this plan plus expected-value checks. A route created after planning
-must derive its parent from the canonical graph and is not retroactively folded
-into the in-flight plan.
+must not escape the plan: while an `applying` request covers a child, creation
+of parent-derived wake/message metadata for that child is deferred behind the
+transaction. After `authority_committed`, deferred creation derives the new
+canonical parent. Every parent-derived route creation path must use this fence;
+direct queue-table writes are not permitted.
 
 The topology fingerprint is a canonical hash over operation kind, subject,
 target, expected parent, and sorted frozen live children. Revalidation compares
@@ -236,8 +240,11 @@ therefore a recoverable, fail-closed staged operation:
 
 1. Under the session write lock, revalidate and persist `status=applying` with
    the complete immutable plan. Parent edges remain unchanged.
-2. In one SQLite transaction, quiesce affected parent-derived wake registrations
-   and pending wake metadata. Persist `apply_stage=routing_quiesced` in JSON.
+2. In one SQLite transaction, idempotently quiesce affected parent-derived wake
+   registrations and pending wake metadata. Persist
+   `apply_stage=routing_quiesced` in JSON. A replay accepts either each plan
+   entry's recorded pre-state or its exact already-quiesced state; any third
+   state fails closed.
 3. In one atomic JSON replacement, update all parent edges and JSON-backed
    routing, and persist `apply_stage=authority_committed`. Dynamic
    task-complete and wait-monitor delivery now resolves this canonical edge.
@@ -256,7 +263,8 @@ repair; it never silently rolls authority back to a topology that may already
 have been observed.
 
 No network delivery occurs while holding the write lock. Approval and outcome
-notifications are queued after the durable state transition.
+notification intents are persisted in the same JSON transition that creates
+them, then reconciled to the queue after releasing the lock.
 
 ## Notification contract
 
@@ -270,8 +278,12 @@ Creation sends each missing agent approver an `important` message containing:
 
 Each decision notifies the initiator and remaining approvers. Rejection,
 expiration, staleness, failure, and completion send one terminal notification.
-Notification delivery failure does not undo durable request state and can be
-retried through the existing queue.
+Every intent has a deterministic key formed from request ID, event, and
+recipient. Queue insertion uses that key as its idempotency identity and marks
+the intent enqueued only after the SQLite row exists. Startup and ordinary
+request reconciliation retry unqueued intents. Notification delivery failure
+does not undo durable request state, omit the prompt, or duplicate a terminal
+event.
 
 ## HTTP API
 

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -169,7 +169,7 @@ version
 edge_changes[]             session ID, expected old parent, new parent
 json_routing_changes[]     record kind/ID, expected old target, new target
 queue_routing_changes[]    table/record ID, child ID, expected old target,
-                           new target, prior active state
+                           new target, prior active state, runtime task key
 ```
 
 The transition from `pending` to `applying` discovers these exact records once
@@ -240,16 +240,22 @@ therefore a recoverable, fail-closed staged operation:
 
 1. Under the session write lock, revalidate and persist `status=applying` with
    the complete immutable plan. Parent edges remain unchanged.
-2. In one SQLite transaction, idempotently quiesce affected parent-derived wake
-   registrations and pending wake metadata. Persist
+2. Through the queue coordinator's routing fence, stop and remove each affected
+   in-memory parent-wake task/registration, then in one SQLite transaction
+   idempotently quiesce affected parent-derived wake registrations and pending
+   wake metadata. Persist
    `apply_stage=routing_quiesced` in JSON. A replay accepts either each plan
    entry's recorded pre-state or its exact already-quiesced state; any third
-   state fails closed.
+   state fails closed. On process restart, inactive SQLite rows cannot recreate
+   the stopped runtime tasks.
 3. In one atomic JSON replacement, update all parent edges and JSON-backed
    routing, and persist `apply_stage=authority_committed`. Dynamic
    task-complete and wait-monitor delivery now resolves this canonical edge.
 4. In one idempotent SQLite transaction, retarget and reactivate affected
-   parent-derived routes, then mark the JSON request `applied`.
+   parent-derived routes, then recreate their in-memory registrations/tasks
+   with the new target under the routing fence and mark the JSON request
+   `applied`. Replay accepts an already-correct runtime registration and never
+   starts a duplicate task.
 
 An interruption before step 3 exposes no new destructive authority and leaves
 old-parent routing paused rather than misdirected. An interruption after step 3

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -1,0 +1,335 @@
+# 1207 - Consent-based reparent and authority transfer
+
+Status: implementation contract
+
+Epic: #1207  
+Incident and diagnosis: #1204  
+Phases: #1209, #1208, #1211, #1210
+
+## Summary
+
+Session Manager derives destructive and supervisory authority from the durable
+`parent_session_id` graph. A handoff can transfer responsibility to a successor,
+but the Rust service has no working mutation surface that transfers that graph.
+The Python `sm adopt` implementation remains in the repository, while the Rust
+service only projects its legacy `adoption_proposals` records. The live Rust CLI
+and API cannot create or decide them.
+
+This epic adds two consent-based operations:
+
+1. `reparent` moves one live session under a different live parent.
+2. `reparent-tree` promotes one direct child to replace its parent as the
+   orchestrator of the parent's live tree.
+
+There is no generic inversion flag. Tree promotion is a named operation with a
+fixed topology, consent set, and audit trail.
+
+## User contract
+
+### One-edge transfer
+
+```text
+sm reparent request <child> --to <new-parent>
+sm reparent approve <request-id>
+sm reparent reject <request-id>
+sm reparent status [request-id]
+sm adopt <child>
+```
+
+`sm adopt <child>` is exactly shorthand for requesting that `<child>` move to
+the calling managed session. It does not bypass consent.
+
+Only the current parent or proposed new parent may initiate. Creating the
+request records the initiator's approval. The other party must explicitly run
+`sm reparent approve`. If the child has no live current parent, a signed-in user
+must supply the missing approval through `sm watch`.
+
+A stopped or missing parent is treated as no live parent. It is recorded in the
+expected topology for audit, but cannot approve.
+
+### Tree promotion
+
+```text
+sm reparent-tree <source> --to <target>
+sm reparent-tree <source> --to <target> --dry-run
+```
+
+`target` must be a live direct child of `source`. Given:
+
+```text
+grandparent -> source
+source -> target
+source -> child-a
+source -> child-b
+source -> stopped-child
+```
+
+the accepted transaction produces:
+
+```text
+grandparent -> target
+target -> source
+target -> child-a
+target -> child-b
+source -> stopped-child
+```
+
+The operation freezes the ordered set of live direct children at request
+creation. Any change to the source parent, target edge, or frozen live-child set
+makes the request stale. Stopped children preserve historical lineage.
+
+The source and target must approve. When source has a live parent, that
+grandparent must approve because its own direct-child edge changes. A root
+source needs no extra human approval: source explicitly approves its own
+demotion. If source has a recorded but non-live parent, user approval replaces
+the unavailable grandparent approval.
+
+`--dry-run` creates no durable request. It prints the exact edge changes,
+routing changes, required approvers, and any condition that would prevent a
+request from being created.
+
+## Authentication and consent
+
+Agent decisions use the managed caller identity from `SESSION_MANAGER_ID`, sent
+as `requester_session_id`. A managed request cannot claim another caller. An
+operator shell without that identity cannot impersonate an agent approval.
+
+Human decisions are accepted only on an authenticated operator route used by
+`sm watch`. Local-bypass watch is the supported operator-shell equivalent. A
+human decision records the authenticated actor where available and the access
+mode otherwise.
+
+Required approvals are identities, not roles or aliases. Role reassignment or
+friendly-name changes do not change an outstanding request's consent set.
+
+Every required approver can reject. A rejection is terminal. Approvals and
+rejections are idempotent only when the same actor repeats the same decision;
+conflicting or unauthorized decisions fail.
+
+Requests expire after 24 hours by default. Expiration and staleness are evaluated
+under the session-state write lock before every read that claims actionability
+and before every decision or apply attempt.
+
+## Durable model
+
+The session state gains a top-level `reparent_requests` array. Each record has:
+
+```text
+id
+kind                       single | tree
+subject_session_id         child for single, source for tree
+target_parent_session_id   new parent for single, target for tree
+expected_parent_session_id nullable
+frozen_live_child_ids      [] for single
+initiator_session_id
+required_agent_approvals
+required_human_approval    boolean
+approvals[]                actor kind/id, decision, timestamp
+status                     pending | applying | applied | rejected |
+                           stale | expired | failed
+created_at
+expires_at
+decided_at
+applied_at
+failure_reason
+topology_fingerprint
+apply_stage                nullable | routing_staged
+```
+
+The topology fingerprint is a canonical hash over operation kind, subject,
+target, expected parent, and sorted frozen live children. Revalidation compares
+both the fields and the hash; the hash is not a substitute for readable audit
+data.
+
+Legacy `adoption_proposals` are never auto-applied. On first mutation-aware
+load, pending legacy records are projected as terminal `stale` reparent
+requests with reason `legacy proposal requires a new consent request`, or are
+left read-only while the new projection exposes the same reason. Either shape
+must preserve the old data and prevent old one-party approvals from becoming
+new authority.
+
+## Validation
+
+Request creation and apply both reject:
+
+- empty, missing, stopped, or unsupported source/target sessions;
+- self-parenting;
+- a target already equal to the current parent;
+- cycles, including a new parent inside the subject's descendant set;
+- single-edge initiation by anyone except current or proposed parent;
+- tree promotion where target is not source's live direct child;
+- duplicate active requests whose affected edge sets overlap;
+- a topology that changed after request creation.
+
+Apply revalidates all identities, liveness, topology, consent, and cycle
+conditions while holding the session-state write lock.
+
+## Routing and authority transaction
+
+Changing only `parent_session_id` is incorrect. The following parent-derived
+state must follow the new graph:
+
+- `context_monitor_notify` when it points at the old parent;
+- active parent-wake registrations in retained JSON and queue SQLite;
+- pending parent-wake metadata attached to undelivered queue messages;
+- child wait/completion monitors that captured a parent at spawn time;
+- task-complete fallback routing;
+- any additional old-parent-keyed state found by the phase audit.
+
+Explicit notification recipients that happen to equal the old parent are not
+retargeted unless their schema marks them as parent-derived. Reparenting must
+not rewrite deliberate peer-to-peer messages.
+
+Existing stop-notify `sender_session_id` values and provider
+`subagents[].parent_session_id` values are explicit recipients or historical
+provider lineage. They are preserved. Tool-usage parent fields are also
+historical provenance and are never rewritten.
+
+Parent-dependent runtime behavior should resolve the current parent at delivery
+time where practical. Durable registrations that intentionally pin a parent are
+retargeted during apply.
+
+The JSON state file and queue SQLite cannot share an ACID transaction. Apply is
+therefore a recoverable, fail-closed staged operation:
+
+1. Under the session write lock, revalidate and persist `status=applying` with
+   the complete immutable plan. Parent edges remain unchanged.
+2. In one SQLite transaction, quiesce affected parent-derived wake registrations
+   and pending wake metadata. Persist `apply_stage=routing_quiesced` in JSON.
+3. In one atomic JSON replacement, update all parent edges and JSON-backed
+   routing, and persist `apply_stage=authority_committed`. Dynamic
+   task-complete and wait-monitor delivery now resolves this canonical edge.
+4. In one idempotent SQLite transaction, retarget and reactivate affected
+   parent-derived routes, then mark the JSON request `applied`.
+
+An interruption before step 3 exposes no new destructive authority and leaves
+old-parent routing paused rather than misdirected. An interruption after step 3
+has new authority with parent-derived routing still paused; dynamic delivery
+uses the canonical new edge. Startup and the next request-store mutation resume
+`applying` records from their immutable plan. A retry never recomputes a
+different topology. If the frozen topology no longer matches before routing is
+quiesced, the request becomes stale. After quiescing, recovery completes the
+recorded transaction or reports a durable `failed` state requiring operator
+repair; it never silently rolls authority back to a topology that may already
+have been observed.
+
+No network delivery occurs while holding the write lock. Approval and outcome
+notifications are queued after the durable state transition.
+
+## Notification contract
+
+Creation sends each missing agent approver an `important` message containing:
+
+- request kind and ID;
+- initiator;
+- every edge that will change;
+- expiry;
+- exact approve and reject commands.
+
+Each decision notifies the initiator and remaining approvers. Rejection,
+expiration, staleness, failure, and completion send one terminal notification.
+Notification delivery failure does not undo durable request state and can be
+retried through the existing queue.
+
+## HTTP API
+
+```text
+POST /sessions/{subject}/reparent-requests
+POST /sessions/{source}/reparent-tree-requests
+GET  /reparent-requests
+GET  /reparent-requests/{request_id}
+POST /reparent-requests/{request_id}/approve
+POST /reparent-requests/{request_id}/reject
+POST /reparent-requests/{request_id}/human-approve
+POST /reparent-requests/{request_id}/human-reject
+```
+
+Creation payloads carry `requester_session_id`; decision payloads carry the same
+for agent routes. Human routes ignore agent IDs and use request authentication.
+List defaults to requests involving the caller or requiring human action.
+Operator watch can list all pending human-gated requests.
+
+HTTP status conventions:
+
+- `200`: idempotent read/decision or dry-run;
+- `201`: request created;
+- `400`: malformed or structurally invalid operation;
+- `403`: caller is not an authorized initiator/approver;
+- `404`: session or request not found;
+- `409`: stale topology, conflicting request, terminal decision, or cycle;
+- `410`: expired request;
+- `503`: durable state or routing store unavailable.
+
+## CLI and watch UX
+
+The Rust CLI owns all non-watch commands. It resolves aliases through the
+existing API and always forwards the managed caller identity.
+
+`sm reparent status` prints compact request rows by default and a complete edge
+and approval plan for one ID. Terminal states include their reason.
+
+The retained Python `sm watch` TUI replaces its legacy adoption projection with
+pending reparent requests. `A` and `X` remain approve/reject, but only operate on
+human-gated requests. The detail line shows source, target, operation, age,
+expiry, and missing approvals. Multiple requests are selectable; watch never
+approves an arbitrary first item without showing which request is selected.
+
+## Role and history boundaries
+
+Reparenting does not transfer service roles, aliases, provider sessions,
+transcripts, account identity, working directory, task text, or stopped-child
+history. Those are properties of seats, not parent authority.
+
+Usage ancestry follows the new live graph for future reports. Historical usage
+events retain the parent/seat metadata recorded when they occurred.
+
+## Phases
+
+### Phase 0 - #1209
+
+Add the durable request schema, legacy migration/projection, topology planning,
+consent state machine, expiry/staleness handling, read/decision HTTP API, and
+focused tests. No request may apply yet.
+
+### Phase 1 - #1208
+
+Add single-edge apply, routing reconciliation, fail-closed recovery, and tests
+that direct-child retire/kill authority and supervision follow the new edge.
+
+### Phase 2 - #1211
+
+Add tree-promotion planning/apply, dry-run, frozen child-set validation,
+grandparent consent, stopped-child preservation, and recovery tests.
+
+### Phase 3 - #1210
+
+Add Rust CLI commands, actionable notifications, retained `sm watch` human UX,
+and end-to-end tests.
+
+Every phase PR targets `epic/1207-reparent-authority` and follows
+`docs/working/pr_review_process.md`. After all phases merge, one reviewed epic
+PR targets `main`. Partial phases are not deployed.
+
+## Acceptance gates
+
+- All consent combinations, unauthorized actors, repeated decisions, expiry,
+  staleness, self-parenting, and cycles have deterministic tests.
+- A regular reparent changes exactly one edge.
+- A tree promotion produces exactly the documented live graph and preserves
+  stopped lineage.
+- Parent-derived routing and direct-child destructive authority follow the new
+  graph immediately after apply.
+- Pending and `applying` requests recover correctly after restart at every
+  durable stage.
+- Legacy pending adoption records cannot auto-apply.
+- Rust CLI parser/dispatch and Python watch interaction tests pass.
+- Full Rust and retained Python test suites pass, or any demonstrably preexisting
+  failure is filed and referenced under the maintainer workflow.
+- The final epic PR passes Codex review under the P1 exit criterion, merges to
+  `main`, and is deployed only with `scripts/restart-rust-server.sh`.
+
+## Classification
+
+Epic. The work is split across four dependent tickets because the durable state
+machine, cross-store authority mutation, tree transaction, and operator UX each
+require separate reviewable proofs.

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -2,8 +2,8 @@
 
 Status: implementation contract
 
-Epic: #1207  
-Incident and diagnosis: #1204  
+Epic: #1207
+Incident and diagnosis: #1204
 Phases: #1209, #1208, #1211, #1210
 
 ## Summary

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -78,6 +78,7 @@ The operation freezes the ordered set of live direct children at request
 creation. Any change to the source parent, target edge, or frozen live-child set
 makes the request stale. Stopped children preserve historical lineage.
 
+Only the source, target, or source's live parent may initiate a tree request.
 The source and target must approve. When source has a live parent, that
 grandparent must approve because its own direct-child edge changes. A root
 source needs no extra human approval: source explicitly approves its own
@@ -156,7 +157,25 @@ failure_reason
 topology_fingerprint
 apply_stage                nullable | routing_quiesced |
                            authority_committed
+apply_plan                 nullable while pending; immutable once applying
 ```
+
+`apply_plan` is versioned and contains the complete retry input rather than a
+query that recovery would rerun:
+
+```text
+version
+edge_changes[]             session ID, expected old parent, new parent
+json_routing_changes[]     record kind/ID, expected old target, new target
+queue_routing_changes[]    table/record ID, child ID, expected old target,
+                           new target, prior active state
+```
+
+The transition from `pending` to `applying` discovers these exact records once
+under the state lock and persists the plan before quiescing anything. Recovery
+uses only this plan plus expected-value checks. A route created after planning
+must derive its parent from the canonical graph and is not retroactively folded
+into the in-flight plan.
 
 The topology fingerprint is a canonical hash over operation kind, subject,
 target, expected parent, and sorted frozen live children. Revalidation compares
@@ -179,6 +198,7 @@ Request creation and apply both reject:
 - a target already equal to the current parent;
 - cycles, including a new parent inside the subject's descendant set;
 - single-edge initiation by anyone except current or proposed parent;
+- tree initiation by anyone except source, target, or source's live parent;
 - tree promotion where target is not source's live direct child;
 - duplicate active requests whose affected edge sets overlap;
 - a topology that changed after request creation.

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -127,6 +127,12 @@ stopped resumes the recorded relaunch on startup. If resumability or readiness
 cannot be established, the old runtime remains untouched and the rotation
 fails closed. There is no force-active mode in this epic.
 
+Startup completes every `relaunching` credential rotation synchronously before
+HTTP/input delivery becomes ready. If the named tmux runtime exists, recovery
+kills it and relaunches once from the frozen provider identity; this safely
+handles a crash after launch but before the new verifier was persisted. Waiting
+rotations start background idle-proof workers only after startup recovery.
+
 Deployment does not silently relaunch the fleet. After the merged server is
 healthy, the maintainer runs `sm recredential --all-live`; the command reports
 which seats were rotated, waiting for idle, already credentialed, or failed.
@@ -321,6 +327,12 @@ quiesced, the request becomes stale. After quiescing, recovery completes the
 recorded transaction or reports a durable `failed` state requiring operator
 repair; it never silently rolls authority back to a topology that may already
 have been observed.
+
+On startup, all `applying` reparent records are recovered through their durable
+stage before retained parent-wake tasks are recreated and before HTTP/input
+readiness. In particular, a crash after an in-memory task was stopped but before
+`json_routing_quiesced` cannot briefly recreate an old-parent task from the
+still-active retained record.
 
 A `failed` request at or beyond `json_routing_quiesced` remains a durable
 quarantine, not a released terminal edge. Its complete affected edge set stays

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -133,13 +133,15 @@ epic.
 Every runtime-backed create, normal restore, and recredential relaunch uses one
 durable launch coordinator. Before touching tmux, it persists a
 `session_runtime_launches` record with operation kind, session ID, frozen launch
-parameters and provider resume identity, status (`prepared | launching |
-applied | failed`), timestamps, and failure reason. It never stores the
-plaintext credential. Under the input fence, the coordinator stops any prior
-named runtime when required, generates a credential, and atomically persists
-its verifier plus `status=launching` before starting tmux. Only after the launch
-succeeds does one JSON replacement mark the session running and the launch
-applied.
+parameters and provider resume identity, an optional owning credential-rotation
+ID, status (`prepared | launching | applied | failed`), timestamps, and failure
+reason. It never stores the plaintext credential. Under the input fence, the
+coordinator stops any prior named runtime when required, generates a credential,
+and atomically persists its verifier plus `status=launching` before starting
+tmux. Only after the launch succeeds does one JSON replacement mark the session
+running and the launch applied. For `recredential`, that same replacement also
+marks the referenced `session_credential_rotations` record applied; no durable
+state may expose an applied launch with its owning rotation still relaunching.
 
 Startup completes every `prepared` or `launching` record synchronously before
 HTTP/input delivery becomes ready. Recovery kills any runtime with the frozen
@@ -298,9 +300,10 @@ Runtime creation and relaunch use a separate top-level
 `session_runtime_launches` collection. Each record stores an operation ID,
 operation kind (`create | restore | recredential`), session ID, frozen tmux and
 provider launch parameters, provider resume identity, credential verifier,
-status (`prepared | launching | applied | failed`), timestamps, and failure
-reason. The active record is the source of truth for startup recovery; neither
-it nor any other durable record contains the plaintext credential.
+optional owning credential-rotation ID, status (`prepared | launching | applied
+| failed`), timestamps, and failure reason. The active record is the source of
+truth for startup recovery; neither it nor any other durable record contains
+the plaintext credential.
 
 ## Validation
 
@@ -444,10 +447,13 @@ it.
 
 The authenticated human repair route supports exactly two audited actions:
 
-1. `resume` records a repair attempt, changes `failed` back to `applying`, and
-   continues the persisted stage. At `prequiesce_aborting` it can only finish
-   the abort; at later stages it retries the same immutable plan. It never
-   replans.
+1. `resume` is accepted only for a failed stage that still holds the global
+   lease: `prequiesce_aborting`, `json_routing_quiesced`, `routing_quiesced`, or
+   `authority_committed`. It records a repair attempt, changes `failed` back to
+   `applying`, and continues the persisted stage. At
+   `prequiesce_aborting` it can only finish the abort; at later stages it retries
+   the same immutable plan. It never replans. A completed
+   `prequiesce_aborted` request is terminal and cannot be resumed.
 2. `rollback_precommit` is accepted only from `json_routing_quiesced` or
    `routing_quiesced`, before `authority_committed`. Under the routing fence,
    the server restores every route to the apply plan's exact recorded
@@ -610,6 +616,9 @@ PR targets `main`. Partial phases are not deployed.
 - Create, normal restore, and recredential each recover a crash after tmux
   launch but before final persistence by replacing the unknowable runtime
   credential through the same durable launch coordinator.
+- A successful recredential launch marks its owning rotation applied in the
+  same JSON replacement as the session and launch; restart cannot strand a
+  relaunching rotation behind an already-applied launch.
 - Legacy pending adoption records cannot auto-apply.
 - Rust CLI parser/dispatch and Python watch interaction tests pass.
 - Full Rust and retained Python test suites pass, or any demonstrably preexisting

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -198,6 +198,14 @@ repair_history[]           actor, action, prior failure, timestamp,
                            verified post-state fingerprint
 ```
 
+The state root also has one `reparent_apply_lease` containing request ID and
+acquisition timestamp. Pending consent requests may coexist, but only the lease
+holder may enter `applying`, quiesce routes, or commit authority. A failed
+transaction retains the lease until a retry applies it or a verified rollback
+repairs it. Authority transactions are intentionally serialized globally;
+reparenting is rare, and avoiding cross-plan cycle races is more important than
+parallel apply throughput.
+
 `apply_plan` is versioned and contains the complete retry input rather than a
 query that recovery would rerun:
 
@@ -210,9 +218,11 @@ queue_routing_changes[]    table/record ID, child ID, expected old target,
 ```
 
 The transition from `pending` to `applying` discovers these exact records once
-under the state lock and atomically persists both the plan and a durable
-topology/routing fence before quiescing anything. Recovery uses only this plan
-plus expected-value checks.
+under the state lock and atomically acquires the empty global apply lease while
+persisting both the plan and a durable topology/routing fence. If another
+request holds the lease, an approved request remains pending and ready rather
+than partially applying. Recovery uses only the persisted plan plus
+expected-value checks.
 
 While the fence covers a session, create/spawn with that session as parent,
 restore of a stopped child, explicit retire/stop, and any parent-edge mutation
@@ -317,10 +327,11 @@ retargeted during apply.
 The JSON state file and queue SQLite cannot share an ACID transaction. Apply is
 therefore a recoverable, fail-closed staged operation:
 
-1. Under the session write lock, revalidate and atomically persist
-   `status=applying`, the complete immutable plan, and its topology/routing
-   fence. Parent edges remain unchanged. Every conflicting topology mutation
-   checks this fence under the same lock.
+1. Under the session write lock, require an empty global apply lease,
+   revalidate, and atomically persist the lease, `status=applying`, the complete
+   immutable plan, and its topology/routing fence. Parent edges remain
+   unchanged. Every conflicting topology mutation checks this fence under the
+   same lock.
 2. Through the queue coordinator's routing fence, stop and remove each affected
    in-memory parent-wake task/registration. Under the session-state lock,
    atomically mark every affected retained JSON parent-wake registration
@@ -332,9 +343,13 @@ therefore a recoverable, fail-closed staged operation:
    plan entry's recorded pre-state or its exact already-quiesced state; any
    third state fails closed. On process restart, inactive JSON and SQLite rows
    cannot recreate the stopped runtime tasks.
-3. In one atomic JSON replacement, update all parent edges and JSON-backed
-   routing, and persist `apply_stage=authority_committed`. Dynamic
-   task-complete and wait-monitor delivery now resolves this canonical edge.
+3. Under the session write lock and while still holding the global lease,
+   revalidate the complete current graph and planned post-transaction graph a
+   second time. If either differs from the frozen plan or contains a cycle,
+   take the pre-commit stale/rollback path. Otherwise, in the same atomic JSON
+   replacement, update all parent edges and JSON-backed routing and persist
+   `apply_stage=authority_committed`. Dynamic task-complete and wait-monitor
+   delivery now resolves this canonical edge.
    Deferred routing intents are now eligible to resolve against the new graph;
    topology mutations remain fenced until their replay is durable.
 4. In one idempotent SQLite transaction, retarget and reactivate affected
@@ -342,8 +357,8 @@ therefore a recoverable, fail-closed staged operation:
    retained JSON registrations, then recreate their in-memory tasks with the
    new target under the routing fence, replay deferred routing intents against
    the new canonical parents, mark the JSON request `applied`, and release both
-   fences. Replay accepts an already-correct runtime registration and never
-   starts a duplicate task.
+   fences and the global apply lease. Replay accepts an already-correct runtime
+   registration and never starts a duplicate task.
 
 An interruption before step 3 exposes no new destructive authority and leaves
 old-parent routing paused rather than misdirected. An interruption after step 3
@@ -358,6 +373,11 @@ restoration fails, the request remains failed and quarantined. After authority
 commit, recovery completes the recorded transaction; it never silently rolls
 authority back to a topology that may already have been observed.
 
+The applied and stale/rollback paths clear the global lease only in the same
+final JSON replacement that records every deferred routing intent replayed.
+Failure at any stage retains the lease. Startup recovers the recorded lease
+holder before another ready request may acquire it.
+
 On startup, all `applying` reparent records are recovered through their durable
 stage before retained parent-wake tasks are recreated and before HTTP/input
 readiness. In particular, a crash after an in-memory task was stopped but before
@@ -367,7 +387,8 @@ still-active retained record.
 A `failed` request at or beyond `json_routing_quiesced` remains a durable
 quarantine, not a released terminal edge. Its complete affected edge set stays
 reserved by the overlap fence, parent-derived route creation remains deferred
-for those children, and no later request may include any reserved edge. Only an
+for those children, and its global apply lease prevents any later authority
+transaction from starting. Only an
 authenticated operator repair action may either resume the immutable plan or
 restore and verify its exact pre-commit state before clearing the quarantine.
 Merely rejecting, expiring, deleting, or recreating the request cannot release
@@ -513,6 +534,9 @@ PR targets `main`. Partial phases are not deployed.
 
 - All consent combinations, unauthorized actors, repeated decisions, expiry,
   staleness, self-parenting, and cycles have deterministic tests.
+- Ready requests apply under one durable global lease and revalidate the whole
+  planned graph immediately before commit; concurrent plans cannot jointly
+  create a cycle.
 - A regular reparent changes exactly one edge.
 - A tree promotion produces exactly the documented live graph and preserves
   stopped lineage.

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -205,6 +205,8 @@ Request creation and apply both reject:
 - tree initiation by anyone except source, target, or source's live parent;
 - tree promotion where target is not source's live direct child;
 - duplicate active requests whose affected edge sets overlap;
+- any request whose affected edge set overlaps a `failed` transaction that
+  reached `routing_quiesced` or later and has not been explicitly repaired;
 - a topology that changed after request creation.
 
 Apply revalidates all identities, liveness, topology, consent, and cycle
@@ -215,16 +217,20 @@ conditions while holding the session-state write lock.
 Changing only `parent_session_id` is incorrect. The following parent-derived
 state must follow the new graph:
 
-- `context_monitor_notify` when it points at the old parent;
+- `context_monitor_notify` only when its companion provenance marks the target
+  as parent-derived;
 - active parent-wake registrations in retained JSON and queue SQLite;
 - pending parent-wake metadata attached to undelivered queue messages;
 - child wait/completion monitors that captured a parent at spawn time;
 - task-complete fallback routing;
 - any additional old-parent-keyed state found by the phase audit.
 
-Explicit notification recipients that happen to equal the old parent are not
-retargeted unless their schema marks them as parent-derived. Reparenting must
-not rewrite deliberate peer-to-peer messages.
+Context-monitor state gains a companion provenance value,
+`context_monitor_notify_source = explicit | parent_derived`. New monitor writes
+must set it from the operation that chose the target. Existing records that
+lack provenance are conservatively migrated as `explicit`, even when the target
+happens to equal the old parent. Explicit notification recipients are never
+retargeted; reparenting must not rewrite deliberate peer-to-peer messages.
 
 Existing stop-notify `sender_session_id` values and provider
 `subagents[].parent_session_id` values are explicit recipients or historical
@@ -267,6 +273,15 @@ quiesced, the request becomes stale. After quiescing, recovery completes the
 recorded transaction or reports a durable `failed` state requiring operator
 repair; it never silently rolls authority back to a topology that may already
 have been observed.
+
+A `failed` request at or beyond `routing_quiesced` remains a durable quarantine,
+not a released terminal edge. Its complete affected edge set stays reserved by
+the overlap fence, parent-derived route creation remains deferred for those
+children, and no later request may include any reserved edge. Only an
+authenticated operator repair action may either resume the immutable plan or
+verify and record a consistent replacement topology before clearing the
+quarantine. Merely rejecting, expiring, deleting, or recreating the request
+cannot release it.
 
 No network delivery occurs while holding the write lock. Approval and outcome
 notification intents are persisted in the same JSON transition that creates

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -90,9 +90,28 @@ request from being created.
 
 ## Authentication and consent
 
-Agent decisions use the managed caller identity from `SESSION_MANAGER_ID`, sent
-as `requester_session_id`. A managed request cannot claim another caller. An
-operator shell without that identity cannot impersonate an agent approval.
+Agent decisions require both the managed caller ID and a server-issued,
+per-runtime 256-bit credential. Session Manager injects the opaque credential as
+`SM_SESSION_CREDENTIAL` when it launches or restores a seat, stores only its
+SHA-256 verifier in session state, and rotates it on every restore. The Rust CLI
+sends the credential in `X-SM-Session-Credential`; the server derives the actor
+from the matching credential and rejects a payload whose
+`requester_session_id` disagrees. `SESSION_MANAGER_ID` alone is not
+authentication. An operator shell that merely sets another session ID cannot
+impersonate an agent approval.
+
+The same per-session credential gate applies to request creation. Credential
+material is never returned by session/list APIs, written to logs, included in
+notifications, or persisted in plaintext. Existing live sessions without a
+verifier cannot approve after deployment until Session Manager rotates a
+credential into that runtime; rollout must provide an explicit credential
+rotation path and must not fall back to trusting an ID-only payload.
+
+Session Manager agents share one operating-system account and filesystem. A
+hostile same-UID process with arbitrary process-inspection capability is outside
+this control's isolation boundary; protecting against that requires OS-level
+per-seat identities. This credential still provides server-verifiable request
+binding and prevents operator-shell and accidental cross-seat payload spoofing.
 
 Human decisions are accepted only on an authenticated operator route used by
 `sm watch`. Local-bypass watch is the supported operator-shell equivalent. A
@@ -108,7 +127,9 @@ conflicting or unauthorized decisions fail.
 
 Requests expire after 24 hours by default. Expiration and staleness are evaluated
 under the session-state write lock before every read that claims actionability
-and before every decision or apply attempt.
+and before every decision or pre-quiesce apply attempt. An `applying` request at
+or beyond `routing_quiesced` never expires; recovery must finish its immutable
+transaction.
 
 ## Durable model
 
@@ -133,7 +154,8 @@ decided_at
 applied_at
 failure_reason
 topology_fingerprint
-apply_stage                nullable | routing_staged
+apply_stage                nullable | routing_quiesced |
+                           authority_committed
 ```
 
 The topology fingerprint is a canonical hash over operation kind, subject,

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -122,8 +122,8 @@ lifecycle event), not inferred from a stale projected status. Busy or unproven
 seats remain `waiting_idle` and are retried by the provider Stop/event path.
 The relaunch preserves the Session Manager ID, parent graph, task metadata, and
 provider resume ID; it rotates the runtime credential and verifier. A crash
-after the old runtime is
-stopped resumes the recorded relaunch on startup. If resumability or readiness
+after the old runtime is stopped resumes the recorded relaunch on startup. If
+resumability or readiness
 cannot be established, the old runtime remains untouched and the rotation
 fails closed. There is no force-active mode in this epic.
 
@@ -218,9 +218,11 @@ While the fence covers a session, create/spawn with that session as parent,
 restore of a stopped child, explicit retire/stop, and any parent-edge mutation
 that could change the planned graph return `409` with the controlling request
 ID. Observed provider/runtime death may still persist liveness truth; before
-authority commit it forces the transaction to restore its exact pre-state and
-end stale. If that restoration fails, the request enters the same durable
-quarantine as any other post-quiesce failure. These checks apply to every
+authority commit it forces the transaction to restore its exact old parent
+edges and routing while preserving the observed stopped status, then end stale.
+A frozen child that stopped therefore remains stopped under the old source. If
+that restoration fails, the request enters the same durable quarantine as any
+other post-quiesce failure. These checks apply to every
 session in a tree plan's source/target/grandparent/frozen-child set, not only to
 the edge rows being rewritten.
 
@@ -349,12 +351,12 @@ has new authority with parent-derived routing still paused; dynamic delivery
 uses the canonical new edge. Startup and the next request-store mutation resume
 `applying` records from their immutable plan. A retry never recomputes a
 different topology. If the frozen topology no longer matches before authority
-commit, the server restores the exact pre-state, replays deferred routing
-against the unchanged old parent, marks the request stale, and only then
-releases the fences. If that restoration fails, the request remains failed and
-quarantined. After authority commit, recovery completes the recorded
-transaction; it never silently rolls authority back to a topology that may
-already have been observed.
+commit, the server restores the exact old authority/routing state without
+rewriting observed liveness, replays deferred routing against the unchanged old
+parent, marks the request stale, and only then releases the fences. If that
+restoration fails, the request remains failed and quarantined. After authority
+commit, recovery completes the recorded transaction; it never silently rolls
+authority back to a topology that may already have been observed.
 
 On startup, all `applying` reparent records are recovered through their durable
 stage before retained parent-wake tasks are recreated and before HTTP/input
@@ -378,8 +380,8 @@ The authenticated human repair route supports exactly two audited actions:
 2. `rollback_precommit` is accepted only from `json_routing_quiesced` or
    `routing_quiesced`, before `authority_committed`. Under the routing fence,
    the server restores every route to the apply plan's exact recorded
-   pre-state, verifies all parent edges
-   still match the old topology and all runtime/JSON/SQLite routes match that
+   pre-state, verifies all parent edges still match the old topology and all
+   runtime/JSON/SQLite routes match that
    pre-state, replays deferred routing intents against the unchanged old parent,
    then atomically records `status=repaired` and
    `apply_stage=repair_rolled_back`. Any mismatch leaves the request failed and

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -33,6 +33,8 @@ sm reparent request <child> --to <new-parent>
 sm reparent approve <request-id>
 sm reparent reject <request-id>
 sm reparent status [request-id]
+sm reparent repair <request-id> --resume
+sm reparent repair <request-id> --rollback-precommit
 sm adopt <child>
 ```
 
@@ -148,7 +150,7 @@ required_agent_approvals
 required_human_approval    boolean
 approvals[]                actor kind/id, decision, timestamp
 status                     pending | applying | applied | rejected |
-                           stale | expired | failed
+                           stale | expired | failed | repaired
 created_at
 expires_at
 decided_at
@@ -156,9 +158,11 @@ applied_at
 failure_reason
 topology_fingerprint
 apply_stage                nullable | routing_quiesced |
-                           authority_committed
+                           authority_committed | repair_rolled_back
 apply_plan                 nullable while pending; immutable once applying
 notification_intents[]     deterministic event/recipient delivery records
+repair_history[]           actor, action, prior failure, timestamp,
+                           verified post-state fingerprint
 ```
 
 `apply_plan` is versioned and contains the complete retry input rather than a
@@ -200,7 +204,9 @@ Request creation and apply both reject:
 - empty, missing, stopped, or unsupported source/target sessions;
 - self-parenting;
 - a target already equal to the current parent;
-- cycles, including a new parent inside the subject's descendant set;
+- for single-edge requests, a new parent inside the subject's current
+  descendant set;
+- for tree requests, any cycle in the complete planned post-transaction graph;
 - single-edge initiation by anyone except current or proposed parent;
 - tree initiation by anyone except source, target, or source's live parent;
 - tree promotion where target is not source's live direct child;
@@ -210,7 +216,10 @@ Request creation and apply both reject:
 - a topology that changed after request creation.
 
 Apply revalidates all identities, liveness, topology, consent, and cycle
-conditions while holding the session-state write lock.
+conditions while holding the session-state write lock. Tree cycle validation
+first applies every planned edge replacement to an in-memory graph and then
+checks the resulting graph; it must not reject merely because the target is a
+current direct child of the source.
 
 ## Routing and authority transaction
 
@@ -279,9 +288,28 @@ not a released terminal edge. Its complete affected edge set stays reserved by
 the overlap fence, parent-derived route creation remains deferred for those
 children, and no later request may include any reserved edge. Only an
 authenticated operator repair action may either resume the immutable plan or
-verify and record a consistent replacement topology before clearing the
-quarantine. Merely rejecting, expiring, deleting, or recreating the request
-cannot release it.
+restore and verify its exact pre-commit state before clearing the quarantine.
+Merely rejecting, expiring, deleting, or recreating the request cannot release
+it.
+
+The authenticated human repair route supports exactly two audited actions:
+
+1. `resume` records a repair attempt, changes `failed` back to `applying`, and
+   retries the same immutable plan from its persisted stage. It never replans.
+2. `rollback_precommit` is accepted only from `routing_quiesced`, before
+   `authority_committed`. Under the routing fence, the server restores every
+   route to the apply plan's exact recorded pre-state, verifies all parent edges
+   still match the old topology and all runtime/JSON/SQLite routes match that
+   pre-state, then atomically records `status=repaired` and
+   `apply_stage=repair_rolled_back`. Any mismatch leaves the request failed and
+   quarantined.
+
+At or after `authority_committed`, only forward `resume` is available because
+new authority may already have been observed. A successful retry ends
+`applied`; a verified pre-commit rollback ends `repaired`. Those are the only
+transitions that release the quarantine. Each attempt appends `repair_history`
+with the authenticated human actor, action, prior failure, timestamp, and hash
+of the verified resulting graph and routing state.
 
 No network delivery occurs while holding the write lock. Approval and outcome
 notification intents are persisted in the same JSON transition that creates
@@ -317,12 +345,16 @@ POST /reparent-requests/{request_id}/approve
 POST /reparent-requests/{request_id}/reject
 POST /reparent-requests/{request_id}/human-approve
 POST /reparent-requests/{request_id}/human-reject
+POST /reparent-requests/{request_id}/repair
 ```
 
 Creation payloads carry `requester_session_id`; decision payloads carry the same
 for agent routes. Human routes ignore agent IDs and use request authentication.
 List defaults to requests involving the caller or requiring human action.
 Operator watch can list all pending human-gated requests.
+The repair route is operator-authenticated only and accepts
+`action=resume|rollback_precommit`; an agent session credential cannot invoke
+it. `sm watch` exposes the same actions with the stage-specific safety text.
 
 HTTP status conventions:
 
@@ -370,6 +402,8 @@ focused tests. No request may apply yet.
 
 Add single-edge apply, routing reconciliation, fail-closed recovery, and tests
 that direct-child retire/kill authority and supervision follow the new edge.
+This phase also implements durable repair transitions and their authenticated
+HTTP route; Phase 3 adds their CLI/watch UX.
 
 ### Phase 2 - #1211
 
@@ -396,6 +430,8 @@ PR targets `main`. Partial phases are not deployed.
   graph immediately after apply.
 - Pending and `applying` requests recover correctly after restart at every
   durable stage.
+- Post-quiesce failures retain their overlap/routing fence; only a successful
+  immutable-plan retry or verified pre-commit rollback releases it.
 - Legacy pending adoption records cannot auto-apply.
 - Rust CLI parser/dispatch and Python watch interaction tests pass.
 - Full Rust and retained Python test suites pass, or any demonstrably preexisting

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -192,6 +192,8 @@ apply_stage                nullable | json_routing_quiesced |
                            repair_rolled_back
 apply_plan                 nullable while pending; immutable once applying
 notification_intents[]     deterministic event/recipient delivery records
+deferred_routing_intents[] idempotency key, operation payload, created_at,
+                           replayed_at and resolved parent
 repair_history[]           actor, action, prior failure, timestamp,
                            verified post-state fingerprint
 ```
@@ -208,13 +210,32 @@ queue_routing_changes[]    table/record ID, child ID, expected old target,
 ```
 
 The transition from `pending` to `applying` discovers these exact records once
-under the state lock and persists the plan before quiescing anything. Recovery
-uses only this plan plus expected-value checks. A route created after planning
-must not escape the plan: while an `applying` request covers a child, creation
-of parent-derived wake/message metadata for that child is deferred behind the
-transaction. After `authority_committed`, deferred creation derives the new
-canonical parent. Every parent-derived route creation path must use this fence;
-direct queue-table writes are not permitted.
+under the state lock and atomically persists both the plan and a durable
+topology/routing fence before quiescing anything. Recovery uses only this plan
+plus expected-value checks.
+
+While the fence covers a session, create/spawn with that session as parent,
+restore of a stopped child, explicit retire/stop, and any parent-edge mutation
+that could change the planned graph return `409` with the controlling request
+ID. Observed provider/runtime death may still persist liveness truth; before
+authority commit it forces the transaction to restore its exact pre-state and
+end stale. If that restoration fails, the request enters the same durable
+quarantine as any other post-quiesce failure. These checks apply to every
+session in a tree plan's source/target/grandparent/frozen-child set, not only to
+the edge rows being rewritten.
+
+A route requested after planning must not escape the routing fence. The server
+persists a `deferred_routing_intent` with an idempotency key and complete
+operation payload instead of writing the live JSON/SQLite route. Direct
+queue-table writes are not permitted. On `authority_committed`, each intent is
+replayed once against the new canonical parent. If the transaction becomes
+stale before commit or completes a pre-commit rollback, each intent is replayed
+once against the unchanged old canonical parent before the fence is released.
+Replay first idempotently upserts the target JSON/SQLite record under the
+intent's key. After that record is confirmed, JSON records `replayed_at` and the
+resolved parent. The final JSON replacement releases the fence only when every
+intent is marked replayed. A crash between stores repeats the same keyed upsert,
+so recovery cannot lose or duplicate the operation.
 Parent-derived route reads and mutations, including task-complete fallback and
 deactivation, use the same fence; it is not limited to creation.
 
@@ -294,8 +315,10 @@ retargeted during apply.
 The JSON state file and queue SQLite cannot share an ACID transaction. Apply is
 therefore a recoverable, fail-closed staged operation:
 
-1. Under the session write lock, revalidate and persist `status=applying` with
-   the complete immutable plan. Parent edges remain unchanged.
+1. Under the session write lock, revalidate and atomically persist
+   `status=applying`, the complete immutable plan, and its topology/routing
+   fence. Parent edges remain unchanged. Every conflicting topology mutation
+   checks this fence under the same lock.
 2. Through the queue coordinator's routing fence, stop and remove each affected
    in-memory parent-wake task/registration. Under the session-state lock,
    atomically mark every affected retained JSON parent-wake registration
@@ -310,23 +333,28 @@ therefore a recoverable, fail-closed staged operation:
 3. In one atomic JSON replacement, update all parent edges and JSON-backed
    routing, and persist `apply_stage=authority_committed`. Dynamic
    task-complete and wait-monitor delivery now resolves this canonical edge.
+   Deferred routing intents are now eligible to resolve against the new graph;
+   topology mutations remain fenced until their replay is durable.
 4. In one idempotent SQLite transaction, retarget and reactivate affected
    parent-derived routes. Under the state lock, retarget and reactivate the
    retained JSON registrations, then recreate their in-memory tasks with the
-   new target under the routing fence and mark the JSON request `applied`.
-   Replay accepts an already-correct runtime registration and never starts a
-   duplicate task.
+   new target under the routing fence, replay deferred routing intents against
+   the new canonical parents, mark the JSON request `applied`, and release both
+   fences. Replay accepts an already-correct runtime registration and never
+   starts a duplicate task.
 
 An interruption before step 3 exposes no new destructive authority and leaves
 old-parent routing paused rather than misdirected. An interruption after step 3
 has new authority with parent-derived routing still paused; dynamic delivery
 uses the canonical new edge. Startup and the next request-store mutation resume
 `applying` records from their immutable plan. A retry never recomputes a
-different topology. If the frozen topology no longer matches before routing is
-quiesced, the request becomes stale. After quiescing, recovery completes the
-recorded transaction or reports a durable `failed` state requiring operator
-repair; it never silently rolls authority back to a topology that may already
-have been observed.
+different topology. If the frozen topology no longer matches before authority
+commit, the server restores the exact pre-state, replays deferred routing
+against the unchanged old parent, marks the request stale, and only then
+releases the fences. If that restoration fails, the request remains failed and
+quarantined. After authority commit, recovery completes the recorded
+transaction; it never silently rolls authority back to a topology that may
+already have been observed.
 
 On startup, all `applying` reparent records are recovered through their durable
 stage before retained parent-wake tasks are recreated and before HTTP/input
@@ -352,7 +380,8 @@ The authenticated human repair route supports exactly two audited actions:
    the server restores every route to the apply plan's exact recorded
    pre-state, verifies all parent edges
    still match the old topology and all runtime/JSON/SQLite routes match that
-   pre-state, then atomically records `status=repaired` and
+   pre-state, replays deferred routing intents against the unchanged old parent,
+   then atomically records `status=repaired` and
    `apply_stage=repair_rolled_back`. Any mismatch leaves the request failed and
    quarantined.
 
@@ -485,12 +514,17 @@ PR targets `main`. Partial phases are not deployed.
 - A regular reparent changes exactly one edge.
 - A tree promotion produces exactly the documented live graph and preserves
   stopped lineage.
+- Conflicting spawn/restore/retire/topology mutations are fenced until commit;
+  an observed pre-commit liveness change restores the old graph instead of
+  applying a stale frozen child set.
 - Parent-derived routing and direct-child destructive authority follow the new
   graph immediately after apply.
 - Pending and `applying` requests recover correctly after restart at every
   durable stage.
 - Post-quiesce failures retain their overlap/routing fence; only a successful
   immutable-plan retry or verified pre-commit rollback releases it.
+- Deferred parent-derived route requests replay exactly once against the new
+  parent after commit or the old parent after stale/rollback release.
 - A pre-deployment live seat is recredentialed only after it becomes idle, keeps
   its seat and provider-thread identity, and recovers a crash after stop without
   accepting input under two runtimes.

--- a/specs/1207_reparent_authority_transfer.md
+++ b/specs/1207_reparent_authority_transfer.md
@@ -119,19 +119,37 @@ rotation record, acquire the session input fence, and verify that the provider
 turn is idle and its input queue is drained. Idle proof must be observed after
 the rotation was requested (a fresh Claude prompt/Stop boundary or Codex
 lifecycle event), not inferred from a stale projected status. Busy or unproven
-seats remain `waiting_idle` and are retried by the provider Stop/event path.
+seats remain `waiting_idle` and are retried by the provider Stop/event path. A
+rotation also requires no attached interactive tmux client, no pending typed
+input, and no pending handoff, clear, review, or `what` operation; those checks
+are repeated under the input fence immediately before stopping the runtime.
 The relaunch preserves the Session Manager ID, parent graph, task metadata, and
 provider resume ID; it rotates the runtime credential and verifier. A crash
 after the old runtime is stopped resumes the recorded relaunch on startup. If
-resumability or readiness
-cannot be established, the old runtime remains untouched and the rotation
-fails closed. There is no force-active mode in this epic.
+resumability or readiness cannot be established, the old runtime remains
+untouched and the rotation fails closed. There is no force-active mode in this
+epic.
 
-Startup completes every `relaunching` credential rotation synchronously before
-HTTP/input delivery becomes ready. If the named tmux runtime exists, recovery
-kills it and relaunches once from the frozen provider identity; this safely
-handles a crash after launch but before the new verifier was persisted. Waiting
-rotations start background idle-proof workers only after startup recovery.
+Every runtime-backed create, normal restore, and recredential relaunch uses one
+durable launch coordinator. Before touching tmux, it persists a
+`session_runtime_launches` record with operation kind, session ID, frozen launch
+parameters and provider resume identity, status (`prepared | launching |
+applied | failed`), timestamps, and failure reason. It never stores the
+plaintext credential. Under the input fence, the coordinator stops any prior
+named runtime when required, generates a credential, and atomically persists
+its verifier plus `status=launching` before starting tmux. Only after the launch
+succeeds does one JSON replacement mark the session running and the launch
+applied.
+
+Startup completes every `prepared` or `launching` record synchronously before
+HTTP/input delivery becomes ready. Recovery kills any runtime with the frozen
+tmux identity, generates a new credential/verifier, persists that new attempt,
+and launches once from the frozen provider identity. Thus a crash after launch
+but before final persistence discards the unknowable process-only credential
+and converges on a verifiable runtime. Create failure removes or terminally
+stops its provisional session; restore/recredential failure leaves the session
+stopped with an audited failed launch. Waiting recredential rotations start
+background idle-proof workers only after startup launch recovery.
 
 Deployment does not silently relaunch the fleet. After the merged server is
 healthy, the maintainer runs `sm recredential --all-live`; the command reports
@@ -158,11 +176,11 @@ Every required approver can reject. A rejection is terminal. Approvals and
 rejections are idempotent only when the same actor repeats the same decision;
 conflicting or unauthorized decisions fail.
 
-Requests expire after 24 hours by default. Expiration and staleness are evaluated
-under the session-state write lock before every read that claims actionability
-and before every decision or pre-quiesce apply attempt. An `applying` request at
-or beyond `json_routing_quiesced` never expires; recovery must finish its
-immutable transaction.
+Requests expire after 24 hours by default while `pending`. Expiration and
+staleness are evaluated under the session-state write lock before every read
+that claims actionability and before every decision or apply attempt. Once a
+request enters `applying`, it no longer expires; recovery must finish or abort
+its durable transaction.
 
 ## Durable model
 
@@ -187,7 +205,8 @@ decided_at
 applied_at
 failure_reason
 topology_fingerprint
-apply_stage                nullable | json_routing_quiesced |
+apply_stage                nullable | prequiesce_aborting |
+                           prequiesce_aborted | json_routing_quiesced |
                            routing_quiesced | authority_committed |
                            repair_rolled_back
 apply_plan                 nullable while pending; immutable once applying
@@ -201,8 +220,11 @@ repair_history[]           actor, action, prior failure, timestamp,
 The state root also has one `reparent_apply_lease` containing request ID and
 acquisition timestamp. Pending consent requests may coexist, but only the lease
 holder may enter `applying`, quiesce routes, or commit authority. A failed
-transaction retains the lease until a retry applies it or a verified rollback
-repairs it. Authority transactions are intentionally serialized globally;
+transaction retains the lease until a retry applies it, a verified rollback
+repairs it, or a verified pre-quiesce abort releases it. When the lease is
+empty, reconciliation selects the oldest ready request by `(created_at, id)`;
+this runs on startup, after every lease release, and after a mutation makes a
+request ready. Authority transactions are intentionally serialized globally;
 reparenting is rare, and avoiding cross-plan cycle races is more important than
 parallel apply throughput.
 
@@ -225,11 +247,12 @@ than partially applying. Recovery uses only the persisted plan plus
 expected-value checks.
 
 While the fence covers a session, create/spawn with that session as parent,
-restore of a stopped child, explicit retire/stop, and any parent-edge mutation
-that could change the planned graph return `409` with the controlling request
-ID. Observed provider/runtime death may still persist liveness truth; before
-authority commit it forces the transaction to restore its exact old parent
-edges and routing while preserving the observed stopped status, then end stale.
+restore or recredential of a covered seat, explicit retire/stop, and any
+parent-edge mutation that could change the planned graph return `409` with the
+controlling request ID. Observed provider/runtime death may still persist
+liveness truth; before authority commit it forces the transaction to restore
+its exact old parent edges and routing while preserving the observed stopped
+status, then end stale.
 A frozen child that stopped therefore remains stopped under the old source. If
 that restoration fails, the request enters the same durable quarantine as any
 other post-quiesce failure. These checks apply to every
@@ -271,6 +294,14 @@ cursor/timestamp, later idle proof, timestamps, and failure reason. It never
 contains the plaintext credential. Only one active rotation may cover a seat,
 and successful records are idempotent audit history.
 
+Runtime creation and relaunch use a separate top-level
+`session_runtime_launches` collection. Each record stores an operation ID,
+operation kind (`create | restore | recredential`), session ID, frozen tmux and
+provider launch parameters, provider resume identity, credential verifier,
+status (`prepared | launching | applied | failed`), timestamps, and failure
+reason. The active record is the source of truth for startup recovery; neither
+it nor any other durable record contains the plaintext credential.
+
 ## Validation
 
 Request creation and apply both reject:
@@ -285,8 +316,8 @@ Request creation and apply both reject:
 - tree initiation by anyone except source, target, or source's live parent;
 - tree promotion where target is not source's live direct child;
 - duplicate active requests whose affected edge sets overlap;
-- any request whose affected edge set overlaps a `failed` transaction that
-  reached `json_routing_quiesced` or later and has not been explicitly repaired;
+- any request whose affected edge set overlaps a failed transaction whose
+  durable topology/routing fence is still held;
 - a topology that changed after request creation.
 
 Apply revalidates all identities, liveness, topology, consent, and cycle
@@ -360,6 +391,20 @@ therefore a recoverable, fail-closed staged operation:
    fences and the global apply lease. Replay accepts an already-correct runtime
    registration and never starts a duplicate task.
 
+A deterministic failure or invalidated topology after step 1 but before
+`json_routing_quiesced` enters the durable pre-quiesce abort path. Under the
+state lock it first persists `apply_stage=prequiesce_aborting`; parent edges and
+existing routes are still unchanged. It then replays every deferred routing
+intent idempotently against the old canonical parent and verifies the replay.
+It also recreates and verifies any in-memory tasks stopped before the retained
+JSON records were quiesced. One final JSON replacement marks the request
+`stale` for invalid topology or `failed` for another deterministic apply error,
+records `apply_stage=prequiesce_aborted`, and releases both fences and the
+global lease.
+If replay or verification fails, the request remains `failed` at
+`prequiesce_aborting` and retains its fences and lease. Recovery or an operator
+`resume` continues that abort; it never replans or proceeds to quiescing.
+
 An interruption before step 3 exposes no new destructive authority and leaves
 old-parent routing paused rather than misdirected. An interruption after step 3
 has new authority with parent-derived routing still paused; dynamic delivery
@@ -373,14 +418,17 @@ restoration fails, the request remains failed and quarantined. After authority
 commit, recovery completes the recorded transaction; it never silently rolls
 authority back to a topology that may already have been observed.
 
-The applied and stale/rollback paths clear the global lease only in the same
-final JSON replacement that records every deferred routing intent replayed.
-Failure at any stage retains the lease. Startup recovers the recorded lease
+The applied, stale/rollback, and completed pre-quiesce abort paths clear the
+global lease only in the same final JSON replacement that records every
+deferred routing intent replayed. A failure during pre-quiesce abort or after
+`json_routing_quiesced` retains the lease. Startup recovers the recorded lease
 holder before another ready request may acquire it.
 
 On startup, all `applying` reparent records are recovered through their durable
 stage before retained parent-wake tasks are recreated and before HTTP/input
-readiness. In particular, a crash after an in-memory task was stopped but before
+readiness. `prequiesce_aborting` resumes only the abort path;
+`prequiesce_aborted` is already terminal and holds no lease. In particular, a
+crash after an in-memory task was stopped but before
 `json_routing_quiesced` cannot briefly recreate an old-parent task from the
 still-active retained record.
 
@@ -397,7 +445,9 @@ it.
 The authenticated human repair route supports exactly two audited actions:
 
 1. `resume` records a repair attempt, changes `failed` back to `applying`, and
-   retries the same immutable plan from its persisted stage. It never replans.
+   continues the persisted stage. At `prequiesce_aborting` it can only finish
+   the abort; at later stages it retries the same immutable plan. It never
+   replans.
 2. `rollback_precommit` is accepted only from `json_routing_quiesced` or
    `routing_quiesced`, before `authority_committed`. Under the routing fence,
    the server restores every route to the apply plan's exact recorded
@@ -547,6 +597,9 @@ PR targets `main`. Partial phases are not deployed.
   graph immediately after apply.
 - Pending and `applying` requests recover correctly after restart at every
   durable stage.
+- A failure before JSON quiesce durably aborts, restores any stopped in-memory
+  tasks, replays deferred routes to the old parent, and releases the global
+  lease; a crash during that abort resumes only the abort path.
 - Post-quiesce failures retain their overlap/routing fence; only a successful
   immutable-plan retry or verified pre-commit rollback releases it.
 - Deferred parent-derived route requests replay exactly once against the new
@@ -554,6 +607,9 @@ PR targets `main`. Partial phases are not deployed.
 - A pre-deployment live seat is recredentialed only after it becomes idle, keeps
   its seat and provider-thread identity, and recovers a crash after stop without
   accepting input under two runtimes.
+- Create, normal restore, and recredential each recover a crash after tmux
+  launch but before final persistence by replacing the unknowable runtime
+  credential through the same durable launch coordinator.
 - Legacy pending adoption records cannot auto-apply.
 - Rust CLI parser/dispatch and Python watch interaction tests pass.
 - Full Rust and retained Python test suites pass, or any demonstrably preexisting

--- a/src/cli/client.py
+++ b/src/cli/client.py
@@ -528,6 +528,59 @@ class SessionManagerClient:
         detail = data.get("detail") if isinstance(data, dict) else None
         return {"ok": ok, "unavailable": False, "status_code": status_code, "data": data, "detail": detail}
 
+    def list_reparent_requests(self) -> dict:
+        """List consent-based authority transfer requests for operator watch."""
+        data, status_code, unavailable = self._request_with_status("GET", "/reparent-requests")
+        if unavailable:
+            return {"ok": False, "unavailable": True, "requests": [], "detail": None}
+        requests = data.get("requests", []) if isinstance(data, dict) else []
+        return {
+            "ok": status_code == 200,
+            "unavailable": False,
+            "status_code": status_code,
+            "requests": requests if isinstance(requests, list) else [],
+            "detail": data.get("detail") if isinstance(data, dict) else None,
+        }
+
+    def decide_reparent_request_as_human(self, request_id: str, approve: bool) -> dict:
+        """Approve or reject one human-gated reparent request."""
+        action = "human-approve" if approve else "human-reject"
+        request_path = urllib.parse.quote(request_id, safe="")
+        data, status_code, unavailable = self._request_with_status(
+            "POST",
+            f"/reparent-requests/{request_path}/{action}",
+            {},
+            timeout=MUTATION_API_TIMEOUT,
+        )
+        if unavailable:
+            return {"ok": False, "unavailable": True, "detail": None}
+        return {
+            "ok": status_code == 200,
+            "unavailable": False,
+            "status_code": status_code,
+            "data": data,
+            "detail": data.get("detail") if isinstance(data, dict) else None,
+        }
+
+    def repair_reparent_request(self, request_id: str, action: str) -> dict:
+        """Run one authenticated operator repair action."""
+        request_path = urllib.parse.quote(request_id, safe="")
+        data, status_code, unavailable = self._request_with_status(
+            "POST",
+            f"/reparent-requests/{request_path}/repair",
+            {"action": action},
+            timeout=MUTATION_API_TIMEOUT,
+        )
+        if unavailable:
+            return {"ok": False, "unavailable": True, "detail": None}
+        return {
+            "ok": status_code == 200,
+            "unavailable": False,
+            "status_code": status_code,
+            "data": data,
+            "detail": data.get("detail") if isinstance(data, dict) else None,
+        }
+
     def update_friendly_name(self, session_id: str, friendly_name: str) -> tuple[bool, bool]:
         """
         Update session friendly name.

--- a/src/cli/watch_tui.py
+++ b/src/cli/watch_tui.py
@@ -105,6 +105,7 @@ class WatchRow:
     text: str = ""
     session_id: Optional[str] = None
     repo_key: Optional[str] = None
+    request_id: Optional[str] = None
     activity_state: str = "idle"
     columns: dict[str, str] = field(default_factory=dict)
 
@@ -391,21 +392,35 @@ def _task_completion_line(session: dict) -> Optional[str]:
     return f"task: completed ({_age_from_iso(completed_at)})"
 
 
-def _pending_adoption_lines(session: dict) -> list[str]:
-    proposals = session.get("pending_adoption_proposals") or []
-    lines: list[str] = []
-    for proposal in proposals:
-        if proposal.get("status") != "pending":
-            continue
-        proposer_name = proposal.get("proposer_name") or proposal.get("proposer_session_id") or "unknown"
-        proposer_id = proposal.get("proposer_session_id") or "unknown"
-        created_at = proposal.get("created_at")
-        age = _age_from_iso(created_at)
-        age_suffix = f" ({age})" if age != "-" else ""
-        lines.append(
-            f"adopt: pending from {proposer_name} [{proposer_id}]{age_suffix}  [A accept / X reject]"
-        )
-    return lines
+def _reparent_request_line(request: dict) -> str:
+    request_id = request.get("id") or "unknown"
+    kind = request.get("kind") or "unknown"
+    source = request.get("subject_session_id") or "unknown"
+    target = request.get("target_parent_session_id") or "unknown"
+    status = request.get("status") or "unknown"
+    age = _age_from_iso(request.get("created_at"))
+    expiry = request.get("expires_at") or "unknown"
+    approvals = request.get("approvals") or []
+    approved = {
+        approval.get("actor_id")
+        for approval in approvals
+        if approval.get("actor_kind") == "agent" and approval.get("decision") == "approved"
+    }
+    missing = [
+        actor for actor in (request.get("required_agent_approvals") or []) if actor not in approved
+    ]
+    missing_text = ",".join(missing) if missing else "none"
+    action = "A approve / X reject" if request.get("required_human_approval") and status == "pending" else ""
+    if status == "failed":
+        stage = request.get("apply_stage") or "unknown"
+        action = "R resume"
+        if stage in {"json_routing_quiesced", "routing_quiesced"}:
+            action += " / B rollback"
+    suffix = f"  [{action}]" if action else ""
+    return (
+        f"reparent {request_id}: {kind} {source} -> {target} {status} age={age} "
+        f"expires={expiry} missing={missing_text}{suffix}"
+    )
 
 
 def _format_age(last_activity: Optional[str], activity_state: str) -> str:
@@ -623,6 +638,7 @@ def build_watch_rows(
     expanded_session_ids: Optional[set[str]] = None,
     detail_cache: Optional[dict[str, DetailSnapshot]] = None,
     codex_projection_enabled: bool = True,
+    reparent_requests: Optional[list[dict]] = None,
 ) -> tuple[list[WatchRow], list[str], int]:
     """Build grouped rows and selectable session IDs."""
     rows: list[WatchRow] = []
@@ -633,6 +649,14 @@ def build_watch_rows(
     roots_by_repo: dict[str, list[dict]] = {}
     same_repo_children: dict[str, list[dict]] = {}
     cross_repo_children: dict[str, dict[str, list[dict]]] = {}
+    requests_by_source: dict[str, list[dict]] = {}
+    for request in reparent_requests or []:
+        if request.get("status") == "pending" and request.get("required_human_approval"):
+            requests_by_source.setdefault(request.get("subject_session_id") or "", []).append(request)
+        elif request.get("status") == "failed":
+            requests_by_source.setdefault(request.get("subject_session_id") or "", []).append(request)
+    for requests in requests_by_source.values():
+        requests.sort(key=lambda request: (request.get("created_at") or "", request.get("id") or ""))
 
     for session in sessions:
         key = _repo_key(session.get("working_dir", ""))
@@ -730,12 +754,13 @@ def build_watch_rows(
                 )
             )
 
-        for adoption_line in _pending_adoption_lines(session):
+        for request in requests_by_source.get(session_id or "", []):
             rows.append(
                 WatchRow(
-                    kind="status",
-                    text=f"{status_prefix}{adoption_line}",
+                    kind="reparent",
+                    text=f"{status_prefix}{_reparent_request_line(request)}",
                     session_id=session_id,
+                    request_id=request.get("id"),
                 )
             )
 
@@ -1390,6 +1415,7 @@ def _render(
     rows: list[WatchRow],
     selected_session_id: Optional[str],
     selected_repo_key: Optional[str],
+    selected_request_id: Optional[str],
     scroll_offset: int,
     total_sessions: int,
     repo_count: int,
@@ -1442,6 +1468,11 @@ def _render(
             stdscr.addnstr(y, 0, f"{marker} {row.text}", _render_columns(width, 0), attr)
         elif row.kind == "repo_ref":
             stdscr.addnstr(y, 4, row.text, _render_columns(width, 4), curses.A_BOLD)
+        elif row.kind == "reparent":
+            is_selected = row.request_id == selected_request_id
+            marker = ">" if is_selected else " "
+            attr = curses.A_REVERSE | curses.A_BOLD if is_selected else curses.A_BOLD
+            stdscr.addnstr(y, 2, f"{marker} {row.text}", _render_columns(width, 2), attr)
         elif row.kind == "status":
             stdscr.addnstr(y, 4, row.text, _render_columns(width, 4), curses.A_NORMAL)
         else:
@@ -1461,7 +1492,7 @@ def _render(
     if restore_mode:
         footer = f"j/k: move  Enter: restore/expand  o: sort={restore_sort}  R: hide repo  U: show repos  Tab: expand/collapse  E: expand all  C: collapse all  /: search  r: refresh  q: quit"
     else:
-        footer = "j/k: move  +: create  F: fork  Enter: attach  s: send  K,K: retire  n: rename  A/X: adopt  Tab: details  /: filter  r: refresh  q: quit"
+        footer = "j/k: move  +: create  F: fork  Enter: attach  s: send  K,K: retire  n: rename  A/X: reparent  R/B: repair  Tab: details  /: filter  r: refresh  q: quit"
     stdscr.addnstr(height - 1, 0, footer, _render_columns(width, 0, reserve_last_cell=True))
     stdscr.refresh()
 
@@ -1493,6 +1524,7 @@ def run_watch_tui(
         try:
             selected_session_id: Optional[str] = None
             selected_repo_key: Optional[str] = None
+            selected_request_id: Optional[str] = None
             text_filter: Optional[str] = None
             flash_message: Optional[str] = None
             flash_until = 0.0
@@ -1500,6 +1532,7 @@ def run_watch_tui(
             selectable: list[str] = []
             latest_sessions: list[dict] = []
             latest_by_id: dict[str, dict] = {}
+            latest_reparent_by_id: dict[str, dict] = {}
             expanded_session_ids: set[str] = set()
             collapsed_session_ids: set[str] = set()
             collapsed_repo_keys: set[str] = set()
@@ -1533,6 +1566,18 @@ def run_watch_tui(
                         flash_message = "Session manager unavailable"
                         flash_until = now + 2.5
                     else:
+                        reparent_result = (
+                            client.list_reparent_requests() if not restore_mode else {"ok": True, "requests": []}
+                        )
+                        if reparent_result.get("unavailable"):
+                            flash_message = "Reparent requests unavailable"
+                            flash_until = now + 2.5
+                        reparent_requests = reparent_result.get("requests") or []
+                        latest_reparent_by_id = {
+                            request.get("id", ""): request
+                            for request in reparent_requests
+                            if request.get("id")
+                        }
                         filtered = filter_sessions(
                             listed,
                             repo_filter=repo_filter,
@@ -1572,6 +1617,7 @@ def run_watch_tui(
                                 expanded_session_ids=expanded_session_ids,
                                 detail_cache=detail_cache,
                                 codex_projection_enabled=codex_projection_enabled,
+                                reparent_requests=reparent_requests,
                             )
                             spinner_index += 1
                             # Prune stale expanded IDs and enqueue refresh for active details.
@@ -1582,6 +1628,11 @@ def run_watch_tui(
                                     detail_worker.request(session)
                         if not restore_mode and selected_session_id not in selectable:
                             selected_session_id = selectable[0] if selectable else None
+                        visible_request_ids = {
+                            row.request_id for row in rows if row.kind == "reparent" and row.request_id
+                        }
+                        if selected_request_id not in visible_request_ids:
+                            selected_request_id = None
 
                     next_refresh = now + max(0.2, interval)
 
@@ -1592,7 +1643,12 @@ def run_watch_tui(
 
                 max_rows = max(0, stdscr.getmaxyx()[0] - _RESERVED_SCREEN_ROWS)
                 selected_row_idx = None
-                if selected_session_id:
+                if selected_request_id:
+                    for idx, row in enumerate(rows):
+                        if row.kind == "reparent" and row.request_id == selected_request_id:
+                            selected_row_idx = idx
+                            break
+                elif selected_session_id:
                     for idx, row in enumerate(rows):
                         if row.kind == "session" and row.session_id == selected_session_id:
                             selected_row_idx = idx
@@ -1617,6 +1673,7 @@ def run_watch_tui(
                     rows=rows,
                     selected_session_id=selected_session_id,
                     selected_repo_key=selected_repo_key,
+                    selected_request_id=selected_request_id,
                     scroll_offset=scroll_offset,
                     total_sessions=total_sessions,
                     repo_count=repo_count,
@@ -1648,9 +1705,18 @@ def run_watch_tui(
                             selected_session_id, selected_repo_key = restore_selection_from_key(
                                 restore_keys[min(current_idx + 1, len(restore_keys) - 1)]
                             )
-                    elif selectable:
-                        current_idx = selectable.index(selected_session_id) if selected_session_id in selectable else 0
-                        selected_session_id = selectable[min(current_idx + 1, len(selectable) - 1)]
+                    else:
+                        navigation = [
+                            (row.kind, row.session_id, row.request_id)
+                            for row in rows
+                            if row.kind in {"session", "reparent"}
+                        ]
+                        current = ("reparent", selected_session_id, selected_request_id) if selected_request_id else ("session", selected_session_id, None)
+                        if navigation:
+                            current_idx = navigation.index(current) if current in navigation else 0
+                            kind, selected_session_id, selected_request_id = navigation[min(current_idx + 1, len(navigation) - 1)]
+                            if kind == "session":
+                                selected_request_id = None
                     continue
 
                 if key in (ord("k"), curses.KEY_UP):
@@ -1662,9 +1728,18 @@ def run_watch_tui(
                             selected_session_id, selected_repo_key = restore_selection_from_key(
                                 restore_keys[max(current_idx - 1, 0)]
                             )
-                    elif selectable:
-                        current_idx = selectable.index(selected_session_id) if selected_session_id in selectable else 0
-                        selected_session_id = selectable[max(current_idx - 1, 0)]
+                    else:
+                        navigation = [
+                            (row.kind, row.session_id, row.request_id)
+                            for row in rows
+                            if row.kind in {"session", "reparent"}
+                        ]
+                        current = ("reparent", selected_session_id, selected_request_id) if selected_request_id else ("session", selected_session_id, None)
+                        if navigation:
+                            current_idx = navigation.index(current) if current in navigation else 0
+                            kind, selected_session_id, selected_request_id = navigation[max(current_idx - 1, 0)]
+                            if kind == "session":
+                                selected_request_id = None
                     continue
 
                 if key in (ord("r"),):
@@ -1679,6 +1754,7 @@ def run_watch_tui(
                 selected = None
                 if selected_session_id:
                     selected = latest_by_id.get(selected_session_id)
+                selected_request = latest_reparent_by_id.get(selected_request_id or "")
 
                 if key in (ord("/"),):
                     entered = _prompt_input(stdscr, "filter (blank=clear): ")
@@ -1911,41 +1987,54 @@ def run_watch_tui(
                     continue
 
                 if key in (ord("A"), ord("X")):
-                    if not selected:
-                        flash_message = "No session selected"
+                    if not selected_request:
+                        flash_message = "Select a human-gated reparent request"
                         flash_until = time.monotonic() + 2.0
                         continue
-
-                    proposals = [
-                        proposal
-                        for proposal in (selected.get("pending_adoption_proposals") or [])
-                        if proposal.get("status") == "pending"
-                    ]
-                    if not proposals:
-                        flash_message = "No pending adoption proposal"
+                    if (
+                        selected_request.get("status") != "pending"
+                        or not selected_request.get("required_human_approval")
+                    ):
+                        flash_message = "Selected request does not need a human decision"
                         flash_until = time.monotonic() + 2.0
                         continue
-
-                    proposal = proposals[0]
-                    proposal_id = proposal.get("id")
-                    if not proposal_id:
-                        flash_message = "Pending adoption proposal is missing an id"
-                        flash_until = time.monotonic() + 2.0
-                        continue
-
-                    if key == ord("A"):
-                        result = client.accept_adoption_proposal(proposal_id)
-                        action = "accepted"
-                    else:
-                        result = client.reject_adoption_proposal(proposal_id)
-                        action = "rejected"
+                    result = client.decide_reparent_request_as_human(
+                        selected_request_id,
+                        approve=key == ord("A"),
+                    )
+                    action = "approved" if key == ord("A") else "rejected"
 
                     if result.get("unavailable"):
                         flash_message = "Session manager unavailable"
                     elif result.get("ok"):
-                        flash_message = f"Adoption {action} for {selected_session_id}"
+                        flash_message = f"Reparent request {selected_request_id} {action}"
                     else:
-                        flash_message = str(result.get("detail") or f"Failed to {action} adoption proposal")
+                        flash_message = str(result.get("detail") or f"Failed to {action} reparent request")
+                    flash_until = time.monotonic() + 2.5
+                    next_refresh = 0.0
+                    continue
+
+                if key in (ord("R"), ord("B")):
+                    if not selected_request or selected_request.get("status") != "failed":
+                        flash_message = "Select a failed reparent request"
+                        flash_until = time.monotonic() + 2.0
+                        continue
+                    stage = selected_request.get("apply_stage") or "unknown"
+                    action = "resume" if key == ord("R") else "rollback_precommit"
+                    if action == "rollback_precommit" and stage not in {
+                        "json_routing_quiesced",
+                        "routing_quiesced",
+                    }:
+                        flash_message = f"Rollback is unsafe from stage {stage}; resume only"
+                        flash_until = time.monotonic() + 3.0
+                        continue
+                    result = client.repair_reparent_request(selected_request_id, action)
+                    if result.get("unavailable"):
+                        flash_message = "Session manager unavailable"
+                    elif result.get("ok"):
+                        flash_message = f"Reparent request {selected_request_id}: {action}"
+                    else:
+                        flash_message = str(result.get("detail") or f"Failed to {action}")
                     flash_until = time.monotonic() + 2.5
                     next_refresh = 0.0
                     continue

--- a/tests/unit/test_client_reparent.py
+++ b/tests/unit/test_client_reparent.py
@@ -1,0 +1,59 @@
+"""Unit tests for consent-based reparent operator endpoints."""
+
+from unittest.mock import patch
+
+from src.cli.client import MUTATION_API_TIMEOUT, SessionManagerClient
+
+
+def _client() -> SessionManagerClient:
+    return SessionManagerClient(api_url="http://127.0.0.1:8420")
+
+
+def test_list_reparent_requests_preserves_rows():
+    client = _client()
+    with patch.object(
+        client,
+        "_request_with_status",
+        return_value=({"requests": [{"id": "request1"}]}, 200, False),
+    ) as request:
+        result = client.list_reparent_requests()
+
+    assert result["ok"] is True
+    assert result["requests"] == [{"id": "request1"}]
+    request.assert_called_once_with("GET", "/reparent-requests")
+
+
+def test_human_reparent_decision_targets_exact_request():
+    client = _client()
+    with patch.object(
+        client,
+        "_request_with_status",
+        return_value=({"id": "request/1", "status": "applied"}, 200, False),
+    ) as request:
+        result = client.decide_reparent_request_as_human("request/1", approve=True)
+
+    assert result["ok"] is True
+    request.assert_called_once_with(
+        "POST",
+        "/reparent-requests/request%2F1/human-approve",
+        {},
+        timeout=MUTATION_API_TIMEOUT,
+    )
+
+
+def test_reparent_repair_preserves_stage_action():
+    client = _client()
+    with patch.object(
+        client,
+        "_request_with_status",
+        return_value=({"id": "request1", "status": "repaired"}, 200, False),
+    ) as request:
+        result = client.repair_reparent_request("request1", "rollback_precommit")
+
+    assert result["ok"] is True
+    request.assert_called_once_with(
+        "POST",
+        "/reparent-requests/request1/repair",
+        {"action": "rollback_precommit"},
+        timeout=MUTATION_API_TIMEOUT,
+    )

--- a/tests/unit/test_watch_tui.py
+++ b/tests/unit/test_watch_tui.py
@@ -365,31 +365,38 @@ def test_task_completed_row_shows_age():
     assert any("task: completed (" in row.text for row in status_rows)
 
 
-def test_pending_adoption_row_shows_proposer_and_actions():
+def test_human_gated_reparent_row_shows_exact_request_and_actions():
     rows, _, _ = build_watch_rows(
-        [
-            _session(
-                "s1",
-                "agent",
-                "/tmp/repo",
-                pending_adoption_proposals=[
+        [_session("s1", "agent", "/tmp/repo")],
+        reparent_requests=[
+            {
+                "id": "reparent123",
+                "kind": "single",
+                "subject_session_id": "s1",
+                "target_parent_session_id": "newparent",
+                "initiator_session_id": "newparent",
+                "created_at": "2026-02-21T22:58:00",
+                "expires_at": "2026-02-22T22:58:00Z",
+                "status": "pending",
+                "required_agent_approvals": ["newparent"],
+                "required_human_approval": True,
+                "approvals": [
                     {
-                        "id": "proposal123",
-                        "proposer_session_id": "em123456",
-                        "proposer_name": "em-ops",
-                        "target_session_id": "s1",
-                        "created_at": "2026-02-21T22:58:00",
-                        "status": "pending",
-                        "decided_at": None,
+                        "actor_kind": "agent",
+                        "actor_id": "newparent",
+                        "decision": "approved",
                     }
                 ],
-            )
-        ]
+            }
+        ],
     )
 
-    status_rows = [row for row in rows if row.kind == "status"]
-    assert any("adopt: pending from em-ops [em123456]" in row.text for row in status_rows)
-    assert any("[A accept / X reject]" in row.text for row in status_rows)
+    request_rows = [row for row in rows if row.kind == "reparent"]
+    assert len(request_rows) == 1
+    assert request_rows[0].request_id == "reparent123"
+    assert "single s1 -> newparent pending" in request_rows[0].text
+    assert "missing=none" in request_rows[0].text
+    assert "[A approve / X reject]" in request_rows[0].text
 
 
 def test_status_rows_follow_tree_indentation():


### PR DESCRIPTION
## Summary

- add durable consent requests for single-seat reparenting and atomic tree promotion
- require current-parent and receiver approval, with human approval when the current parent is absent
- move parent-derived supervision, wake, reminder, queue, and destructive authority with the durable graph
- add fail-closed transaction fencing, crash recovery, immutable repair, and idle-only live-seat recredentialing
- expose `sm reparent`, `sm reparent-tree`, `sm adopt`, `sm recredential`, exact actionable notifications, and native `sm watch` approval/repair UX

Closes #1207
Addresses #1204

## Phase PRs

- #1216 - durable consent and credential foundation
- #1217 - single-edge authority transaction and repair
- #1218 - atomic tree promotion and dry-run
- #1220 - CLI, durable notifications, watch UX, and live delivery

Each phase followed `docs/working/pr_review_process.md`. P1 findings were fixed and freshly re-reviewed. P2-only findings exited without review loops and were carried forward where applicable.

## Final verification at `49d9fc4`

- `cargo test` - 397 library + 66 CLI + 260 HTTP passed
- `cargo fmt --all -- --check`
- `/Users/rajesh/projects/session-manager/venv/bin/pytest -q --ignore=tests/unit/test_directional_notify_on_stop.py` - 2445 passed
- unfiltered Python suite - 2447 passed, 8 failed

The eight unfiltered failures are all the base-reproduced missing `em_topic` fixture defect in `tests/unit/test_directional_notify_on_stop.py`, tracked as #1219. Exact run on untouched epic base `f4a306303398a199f2aa43db769b8694f7de5acd`: 8 failed, 2 passed.

One first-pass aggregate HTTP run had the unrelated tmux review-watcher test return 502. It passed immediately in isolation and the full 260-test HTTP suite then passed cleanly; the new live reparent notification test passed in both runs.

## Deployment

After this final review passes and the PR merges, deploy only via `scripts/restart-rust-server.sh`, then smoke the CLI surface, API health, durable request creation, exact notification delivery, consent apply, and authority behavior.
