### PR TITLE
Yield usage artifact scans to live writers

### DIFF
--- a/crates/sm-server/src/usage_ledger.rs
+++ b/crates/sm-server/src/usage_ledger.rs
@@ -22,6 +22,7 @@ use crate::{
 const USAGE_DB_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 const PROJECT_KEY_GIT_TIMEOUT: Duration = Duration::from_secs(1);
 const LEDGER_WRITE_BATCH_SIZE: usize = 16;
+const LEDGER_BATCH_PAUSE: Duration = Duration::from_millis(1);
 const MATERIALIZATION_BATCH_PAUSE: Duration = Duration::from_millis(1);
 const DB_TIMESTAMP_FORMAT: &[time::format_description::FormatItem<'static>] = time::macros::format_description!(
     "[year]-[month]-[day]T[hour]:[minute]:[second].[subsecond digits:9]Z"
@@ -736,6 +737,7 @@ impl UsageLedgerStore {
             if batch_lines >= LEDGER_WRITE_BATCH_SIZE {
                 save_scan_offset(&tx, &artifact.path, line_offset, mtime_ns)?;
                 tx.commit()?;
+                thread::sleep(LEDGER_BATCH_PAUSE);
                 tx = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
                 ensure_codex_cursor_baselines(&tx, artifact)?;
                 batch_lines = 0;
@@ -942,7 +944,7 @@ impl UsageLedgerStore {
                     .map(|(model, _)| model.clone())
                     .or_else(|| seat.and_then(|seat| normalized_model(seat.model.as_deref())))
                     .or_else(|| self.default_model(raw_provider))
-                    .context("Codex token event has no resolvable model")?;
+                    .unwrap_or_else(|| "unknown".to_owned());
                 let effort = settings
                     .and_then(|(_, effort)| effort)
                     .or_else(|| seat.and_then(|seat| seat.effort.clone()));
@@ -2994,6 +2996,88 @@ mod tests {
     }
 
     #[test]
+    fn historical_artifact_scan_yields_to_live_seat_session_writers() {
+        let dir = TestDir::new("artifact-scan-live-writer");
+        let db_path = dir.0.join("usage.db");
+        seed_provider(
+            &db_path,
+            Provider::Claude,
+            "account-one",
+            "max",
+            "session_5h",
+            300,
+        );
+        let transcript = dir.0.join("session-one.jsonl");
+        let mut file = fs::File::create(&transcript).unwrap();
+        for index in 0..4096 {
+            writeln!(
+                file,
+                "{}",
+                json!({
+                    "timestamp": "2026-08-10T16:30:00Z",
+                    "sessionId": "session-one",
+                    "requestId": format!("request-{index}"),
+                    "cwd": "/repo",
+                    "version": "1.0.0",
+                    "message": {
+                        "id": format!("message-{index}"),
+                        "model": "claude-sonnet-5",
+                        "usage": {
+                            "input_tokens": 10,
+                            "output_tokens": 5,
+                            "cache_creation_input_tokens": 0,
+                            "cache_read_input_tokens": 0
+                        }
+                    }
+                })
+            )
+            .unwrap();
+        }
+        drop(file);
+        SeatSessionStore::new(&db_path)
+            .append("seat-one", "claude", "session-one", transcript.to_str())
+            .unwrap();
+        let store = UsageLedgerStore::new(&db_path).unwrap();
+        let scanner = store.clone();
+        let handle = thread::spawn(move || {
+            scanner.scan(&[UsageSeatMetadata {
+                seat_id: "seat-one".to_owned(),
+                friendly_name: None,
+                provider: "claude".to_owned(),
+                model: Some("claude-sonnet-5".to_owned()),
+                effort: None,
+                working_dir: "/repo".to_owned(),
+                parent_seat_id: None,
+                root_seat_id: Some("seat-one".to_owned()),
+                project_key: "/repo".to_owned(),
+            }])
+        });
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let count: i64 = Connection::open(&db_path)
+                .unwrap()
+                .query_row("SELECT COUNT(*) FROM message_ledger", [], |row| row.get(0))
+                .unwrap();
+            if count >= LEDGER_WRITE_BATCH_SIZE as i64 {
+                break;
+            }
+            assert!(Instant::now() < deadline, "artifact scan did not start");
+            thread::sleep(Duration::from_millis(1));
+        }
+        assert!(
+            !handle.is_finished(),
+            "artifact scan finished before the writer probe"
+        );
+        let started_at = Instant::now();
+        SeatSessionStore::new(&db_path)
+            .append("live-seat", "claude", "live-session", None)
+            .unwrap();
+        assert!(started_at.elapsed() < Duration::from_millis(250));
+        handle.join().unwrap().unwrap();
+    }
+
+    #[test]
     fn pending_window_materialization_does_not_expand_into_overlapping_windows() {
         let dir = TestDir::new("materialization-exact-window");
         let db_path = dir.0.join("usage.db");
@@ -4053,6 +4137,47 @@ mod tests {
             .resolve_seat_models(&[seat_preferred])
             .unwrap();
         assert_eq!(resolved[0].model.as_deref(), Some("seat-model"));
+    }
+
+    #[test]
+    fn codex_events_without_model_metadata_are_checkpointed_as_unknown() {
+        let dir = TestDir::new("model-fallback-unknown");
+        let db_path = dir.0.join("usage.db");
+        seed_provider(
+            &db_path,
+            Provider::Codex,
+            "codex-account",
+            "pro",
+            "codex_300",
+            300,
+        );
+        let artifact = dir.0.join("codex.jsonl");
+        fs::write(
+            &artifact,
+            "{\"event_type\":\"thread/tokenUsage/updated\",\"seq\":1,\"ts\":\"2026-08-10T16:00:00Z\",\"payload\":{\"threadId\":\"thread-one\",\"tokenUsage\":{\"total\":{\"inputTokens\":80,\"cachedInputTokens\":60,\"cacheWriteInputTokens\":0,\"outputTokens\":20,\"reasoningOutputTokens\":5,\"totalTokens\":100}}}}\n",
+        )
+        .unwrap();
+        SeatSessionStore::new(&db_path)
+            .append("unassigned", "codex-fork", "thread-one", artifact.to_str())
+            .unwrap();
+
+        let store = UsageLedgerStore::new(&db_path).unwrap();
+        store.scan(&[]).unwrap();
+
+        let connection = Connection::open(&db_path).unwrap();
+        let (model, offset): (String, u64) = connection
+            .query_row(
+                r#"
+                SELECT
+                  (SELECT model FROM message_ledger LIMIT 1),
+                  (SELECT byte_offset FROM scan_offsets WHERE artifact_path = ?1)
+                "#,
+                [artifact.to_string_lossy().as_ref()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(model, "unknown");
+        assert_eq!(offset, fs::metadata(artifact).unwrap().len());
     }
 
     #[test]

--- a/crates/sm-server/src/usage_ledger.rs
+++ b/crates/sm-server/src/usage_ledger.rs
@@ -355,6 +355,7 @@ impl UsageLedgerStore {
             .map(|seat| (seat.seat_id.clone(), seat.clone()))
             .collect::<BTreeMap<_, _>>();
         self.rebind_provisional_messages(&bindings, &seat_meta)?;
+        self.reconcile_unknown_models(&seat_meta)?;
         let artifacts = expand_artifacts(&bindings);
         let mut summary = ScanSummary::default();
         let mut errors = Vec::new();
@@ -495,11 +496,56 @@ impl UsageLedgerStore {
                 let mut rebound = incumbent;
                 rebound.seat_id = binding.seat_id.clone();
                 rebound.project_key = metadata.project_key.clone();
+                if rebound.model == "unknown" {
+                    rebound.model = normalized_model(metadata.model.as_deref())
+                        .or_else(|| self.default_model(&binding.provider))
+                        .unwrap_or(rebound.model);
+                }
                 overwrite_contribution(&tx, msg_id, &rebound)?;
                 materialize_contribution(&tx, msg_id, &rebound)?;
             }
         }
         tx.commit()?;
+        Ok(())
+    }
+
+    fn reconcile_unknown_models(
+        &self,
+        seat_meta: &BTreeMap<String, UsageSeatMetadata>,
+    ) -> Result<()> {
+        let connection = self.open()?;
+        let ids = connection
+            .prepare(
+                "SELECT msg_id FROM message_ledger WHERE model = 'unknown' AND seat_id != 'unassigned' ORDER BY msg_id",
+            )?
+            .query_map([], |row| row.get::<_, i64>(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        drop(connection);
+
+        let mut connection = self.open()?;
+        for (index, batch) in ids.chunks(LEDGER_WRITE_BATCH_SIZE).enumerate() {
+            let tx = connection.transaction_with_behavior(TransactionBehavior::Immediate)?;
+            for msg_id in batch {
+                let incumbent = load_contribution(&tx, *msg_id)?;
+                let Some(metadata) = seat_meta.get(&incumbent.seat_id) else {
+                    continue;
+                };
+                let Some(model) = normalized_model(metadata.model.as_deref())
+                    .or_else(|| self.default_model(&metadata.provider))
+                else {
+                    continue;
+                };
+                reverse_contribution(&tx, *msg_id, &incumbent)?;
+                let mut reconciled = incumbent;
+                reconciled.model = model;
+                overwrite_contribution(&tx, *msg_id, &reconciled)?;
+                materialize_contribution(&tx, *msg_id, &reconciled)?;
+            }
+            tx.commit()?;
+            if index + 1 < ids.len().div_ceil(LEDGER_WRITE_BATCH_SIZE) {
+                thread::sleep(LEDGER_BATCH_PAUSE);
+            }
+        }
         Ok(())
     }
 
@@ -4177,7 +4223,34 @@ mod tests {
             )
             .unwrap();
         assert_eq!(model, "unknown");
-        assert_eq!(offset, fs::metadata(artifact).unwrap().len());
+        assert_eq!(offset, fs::metadata(&artifact).unwrap().len());
+
+        let resolved_seat = UsageSeatMetadata {
+            seat_id: "seat-one".to_owned(),
+            friendly_name: None,
+            provider: "codex-fork".to_owned(),
+            model: Some("gpt-5.6-terra".to_owned()),
+            effort: None,
+            working_dir: "/repo".to_owned(),
+            parent_seat_id: None,
+            root_seat_id: Some("seat-one".to_owned()),
+            project_key: "/repo".to_owned(),
+        };
+        SeatSessionStore::new(&db_path)
+            .append("seat-one", "codex-fork", "thread-one", artifact.to_str())
+            .unwrap();
+        store.scan(&[resolved_seat]).unwrap();
+
+        let connection = Connection::open(&db_path).unwrap();
+        let (seat_id, model): (String, String) = connection
+            .query_row(
+                "SELECT seat_id, model FROM message_ledger LIMIT 1",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(seat_id, "seat-one");
+        assert_eq!(model, "gpt-5.6-terra");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- pause after each committed 16-line artifact batch so queued live SQLite writers can acquire the write slot
- checkpoint otherwise valid historical Codex token events with `model=unknown` when no model metadata or configured default exists
- cover live-writer fairness during a 4,096-message transcript scan and model-less offset advancement

## Live finding
After #1229, fresh Claude status-line quota ingestion succeeded, but a stack sample and two isolated lock failures showed the artifact scanner immediately reacquiring write transactions. Forty-two historical Codex artifacts also retried forever because model metadata was unavailable, preventing their offsets from advancing.

## Verification
- `cargo fmt --all -- --check`
- `cargo check --workspace`
- `cargo test -p sm-server usage_ledger::tests --lib` (32 passed)

Fixes #1226