### PR TITLE
Handle Codex directory trust during spawn

### DIFF
--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -884,6 +884,21 @@ impl TmuxRuntime {
         Some(String::from_utf8_lossy(&output.stdout).to_string())
     }
 
+    pub fn accept_codex_directory_trust_prompt(&self, tmux_session: &str) -> Result<bool> {
+        let _guard = self.lock_session_input(tmux_session)?;
+        if !self.session_exists(tmux_session)? {
+            return Ok(false);
+        }
+        let Some(pane) = self.capture_pane_text(tmux_session) else {
+            return Ok(false);
+        };
+        if !is_codex_directory_trust_prompt(&pane) {
+            return Ok(false);
+        }
+        self.send_key(tmux_session, "Enter")?;
+        Ok(true)
+    }
+
     pub fn session_input_ready(&self, tmux_session: &str, provider: &str) -> bool {
         match provider {
             "codex" | "codex-fork" => self.codex_composer_is_ready(tmux_session, None),
@@ -1464,6 +1479,13 @@ fn managed_session_command(
     )
 }
 
+fn is_codex_directory_trust_prompt(pane: &str) -> bool {
+    pane.contains("Do you trust the contents of this directory?")
+        && pane.contains("Yes, continue")
+        && pane.contains("No, quit")
+        && pane.contains("Press enter to continue")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1513,6 +1535,50 @@ mod tests {
         assert_eq!(output, ">\n");
         let log = fs::read_to_string(log_path).unwrap();
         assert!(log.contains("capture-pane -p -S -1 -t sm-test"));
+    }
+
+    #[test]
+    fn codex_directory_trust_prompt_is_accepted_without_matching_incidental_text() {
+        let (tmux_binary, log_path, _temp_dir) = fake_tmux_binary();
+        fs::write(
+            &tmux_binary,
+            format!(
+                r#"#!/bin/sh
+printf '%s\n' "$*" >> "{}"
+case "$1" in
+  has-session) exit 0 ;;
+  capture-pane)
+    printf '%s\n' '> You are in /repo' \
+      'Do you trust the contents of this directory?' \
+      '1. Yes, continue' '2. No, quit' 'Press enter to continue'
+    exit 0
+    ;;
+  *) exit 0 ;;
+esac
+"#,
+                log_path.display(),
+            ),
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&tmux_binary).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&tmux_binary, permissions).unwrap();
+        let mut runtime = TmuxRuntime::from_config(&RustCoreConfig::default());
+        runtime.tmux_binary = tmux_binary.display().to_string();
+
+        assert!(runtime
+            .accept_codex_directory_trust_prompt("sm-test")
+            .unwrap());
+        assert!(fs::read_to_string(&log_path)
+            .unwrap()
+            .contains("send-keys -t sm-test Enter"));
+    }
+
+    #[test]
+    fn incidental_trust_text_does_not_submit_input() {
+        assert!(!is_codex_directory_trust_prompt(
+            "The docs ask: Do you trust the contents of this directory?"
+        ));
     }
 
     #[test]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -7802,7 +7802,9 @@ where
                 }
             }
         }
-        directory_trust_accepted |= handle_startup_prompt()?;
+        if !directory_trust_accepted {
+            directory_trust_accepted = handle_startup_prompt()?;
+        }
         if started.elapsed() >= timeout {
             if directory_trust_accepted {
                 anyhow::bail!(
@@ -16403,6 +16405,15 @@ mod tests {
     fn codex_fork_launch_binding_accepts_trust_before_root_thread_starts() {
         let event_stream_path = unique_temp_path("codex-trust-bind-events");
         fs::write(&event_stream_path, "").unwrap();
+        let writer_path = event_stream_path.clone();
+        let writer = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(125));
+            fs::write(
+                writer_path,
+                "{\"event_type\":\"thread/started\",\"payload\":{\"thread\":{\"id\":\"trusted-root\",\"parentThreadId\":null,\"threadSource\":\"user\"}}}\n",
+            )
+            .unwrap();
+        });
         let mut prompt_checks = 0;
 
         let provider_resume_id = wait_for_codex_fork_provider_resume_id_after_offset_with_startup(
@@ -16411,20 +16422,14 @@ mod tests {
             Duration::from_secs(1),
             || {
                 prompt_checks += 1;
-                if prompt_checks == 1 {
-                    fs::write(
-                        &event_stream_path,
-                        "{\"event_type\":\"thread/started\",\"payload\":{\"thread\":{\"id\":\"trusted-root\",\"parentThreadId\":null,\"threadSource\":\"user\"}}}\n",
-                    )?;
-                    return Ok(true);
-                }
-                Ok(false)
+                Ok(true)
             },
         )
         .unwrap();
 
         assert_eq!(provider_resume_id, "trusted-root");
-        assert!(prompt_checks >= 1);
+        assert_eq!(prompt_checks, 1);
+        writer.join().unwrap();
         let _ = fs::remove_file(event_stream_path);
     }
 

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -824,9 +824,11 @@ impl SessionStore {
                 );
             }
             if let Some(artifacts) = codex_fork_artifacts.as_ref() {
-                match wait_for_codex_fork_provider_resume_id(
+                match wait_for_codex_fork_provider_resume_id_for_launch(
                     &artifacts.event_stream_path,
                     CODEX_FORK_THREAD_STARTED_TIMEOUT,
+                    &session_runtime,
+                    &launch.tmux_session,
                 ) {
                     Ok(provider_resume_id) => {
                         recovered_provider_resume_id = Some(provider_resume_id);
@@ -3827,9 +3829,11 @@ impl SessionStore {
             );
         }
         if let Some(artifacts) = &codex_fork_artifacts {
-            match wait_for_codex_fork_provider_resume_id(
+            match wait_for_codex_fork_provider_resume_id_for_launch(
                 &artifacts.event_stream_path,
                 CODEX_FORK_THREAD_STARTED_TIMEOUT,
+                runtime,
+                &record.tmux_session,
             ) {
                 Ok(provider_resume_id) => {
                     record.provider_resume_id = Some(provider_resume_id);
@@ -7726,11 +7730,18 @@ impl SessionStore {
     }
 }
 
-fn wait_for_codex_fork_provider_resume_id(
+fn wait_for_codex_fork_provider_resume_id_for_launch(
     event_stream_path: &Path,
     timeout: Duration,
+    runtime: &TmuxRuntime,
+    tmux_session: &str,
 ) -> Result<String> {
-    wait_for_codex_fork_provider_resume_id_after_offset(event_stream_path, 0, timeout)
+    wait_for_codex_fork_provider_resume_id_after_offset_with_startup(
+        event_stream_path,
+        0,
+        timeout,
+        || runtime.accept_codex_directory_trust_prompt(tmux_session),
+    )
 }
 
 fn usage_ledger_error_is_transient(error: &anyhow::Error) -> bool {
@@ -7756,9 +7767,27 @@ fn wait_for_codex_fork_provider_resume_id_after_offset(
     initial_offset: u64,
     timeout: Duration,
 ) -> Result<String> {
+    wait_for_codex_fork_provider_resume_id_after_offset_with_startup(
+        event_stream_path,
+        initial_offset,
+        timeout,
+        || Ok(false),
+    )
+}
+
+fn wait_for_codex_fork_provider_resume_id_after_offset_with_startup<F>(
+    event_stream_path: &Path,
+    initial_offset: u64,
+    timeout: Duration,
+    mut handle_startup_prompt: F,
+) -> Result<String>
+where
+    F: FnMut() -> Result<bool>,
+{
     let started = Instant::now();
     let mut offset = initial_offset;
     let mut buffer = String::new();
+    let mut directory_trust_accepted = false;
     loop {
         if let Ok(chunk) = read_file_from_offset(event_stream_path, &mut offset) {
             for line in split_complete_event_lines(&mut buffer, &chunk) {
@@ -7773,7 +7802,14 @@ fn wait_for_codex_fork_provider_resume_id_after_offset(
                 }
             }
         }
+        directory_trust_accepted |= handle_startup_prompt()?;
         if started.elapsed() >= timeout {
+            if directory_trust_accepted {
+                anyhow::bail!(
+                    "accepted the codex-fork directory trust prompt but timed out waiting for a new thread_started event in {}",
+                    event_stream_path.display()
+                );
+            }
             anyhow::bail!(
                 "timed out waiting for a new codex-fork thread_started event in {}",
                 event_stream_path.display()
@@ -16360,6 +16396,35 @@ mod tests {
             .unwrap(),
             "root-thread"
         );
+        let _ = fs::remove_file(event_stream_path);
+    }
+
+    #[test]
+    fn codex_fork_launch_binding_accepts_trust_before_root_thread_starts() {
+        let event_stream_path = unique_temp_path("codex-trust-bind-events");
+        fs::write(&event_stream_path, "").unwrap();
+        let mut prompt_checks = 0;
+
+        let provider_resume_id = wait_for_codex_fork_provider_resume_id_after_offset_with_startup(
+            &event_stream_path,
+            0,
+            Duration::from_secs(1),
+            || {
+                prompt_checks += 1;
+                if prompt_checks == 1 {
+                    fs::write(
+                        &event_stream_path,
+                        "{\"event_type\":\"thread/started\",\"payload\":{\"thread\":{\"id\":\"trusted-root\",\"parentThreadId\":null,\"threadSource\":\"user\"}}}\n",
+                    )?;
+                    return Ok(true);
+                }
+                Ok(false)
+            },
+        )
+        .unwrap();
+
+        assert_eq!(provider_resume_id, "trusted-root");
+        assert!(prompt_checks >= 1);
         let _ = fs::remove_file(event_stream_path);
     }
 


### PR DESCRIPTION
## Summary

- recognize the exact Codex-fork directory-trust onboarding screen during create-time provider binding
- submit the highlighted trust choice while retaining the existing root-only thread identity filter
- distinguish a post-trust thread-publication timeout from a generic missing resume ID
- cover exact prompt matching and trust-to-root-binding progression

## Verification

- cargo fmt --all --check
- cargo check -p sm-server
- cargo test -p sm-server directory_trust --lib
- cargo test -p sm-server runtime::tests::incidental_trust_text_does_not_submit_input -- --exact
- cargo test -p sm-server sessions::tests::codex_fork_launch_binding_accepts_trust_before_root_thread_starts -- --exact
- cargo test -p sm-server codex_fork --lib (36 passed)

Fixes #1236
