### PR TITLE
Keep retired sessions terminal across stale status writes

### DIFF
--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -15,6 +15,7 @@ use sm_server::{config::AppConfig, mobile_devices};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 
 const DEFAULT_API_URL: &str = "http://127.0.0.1:8420";
+const CONTEXT_COMPACT_STALE_SECONDS: i64 = 10 * 60;
 const CODEX_CONTEXT_MONITOR_FYI: &str =
     "Context monitoring is FYI only for Codex agents; they manage compaction inline.";
 const CLIENT_CONFIG_ENV: &str = "SM_CLIENT_CONFIG";
@@ -3650,7 +3651,15 @@ fn run_context(client: &ApiClient, args: ContextArgs) -> Result<()> {
 
     let percentage = format_context_percentage(payload.get("used_percentage"));
     if !(args.details || args.detailed) {
-        println!("{percentage}");
+        println!(
+            "{}",
+            format_compact_context(
+                &percentage,
+                payload["sampled_at"].as_str(),
+                payload["lifecycle_status"].as_str(),
+                OffsetDateTime::now_utc(),
+            )
+        );
         return Ok(());
     }
 
@@ -3687,8 +3696,12 @@ fn run_context(client: &ApiClient, args: ContextArgs) -> Result<()> {
 
     println!("Context: {percentage}{token_text}");
     println!(
-        "Sample: {}",
+        "Sample: {} (cached telemetry, not liveness)",
         format_context_sample_age(payload["sampled_at"].as_str())
+    );
+    println!(
+        "Lifecycle: {}",
+        payload["lifecycle_status"].as_str().unwrap_or("unknown")
     );
     println!("State: {state} (warning {warning}, critical {critical})");
     println!("Monitor: {monitor}, alerts -> {notify_text}");
@@ -3724,13 +3737,57 @@ fn format_context_percentage(value: Option<&Value>) -> String {
 }
 
 fn format_context_sample_age(sampled_at: Option<&str>) -> String {
+    format_context_sample_age_at(sampled_at, OffsetDateTime::now_utc())
+}
+
+fn format_compact_context(
+    percentage: &str,
+    sampled_at: Option<&str>,
+    lifecycle_status: Option<&str>,
+    now: OffsetDateTime,
+) -> String {
+    if percentage == "unknown" {
+        return percentage.to_owned();
+    }
+    let stopped = lifecycle_status == Some("stopped");
+    let sampled = sampled_at
+        .and_then(|value| OffsetDateTime::parse(value, &Rfc3339).ok())
+        .map(|timestamp| ((now - timestamp).whole_seconds()).max(0));
+    let stale = sampled.is_none_or(|seconds| seconds >= CONTEXT_COMPACT_STALE_SECONDS);
+    // Preserve the terse percentage for fresh live telemetry, but make cached
+    // or terminal snapshots impossible to mistake for a heartbeat.
+    if !stopped && !stale {
+        return percentage.to_owned();
+    }
+
+    let mut notes = Vec::new();
+    if stale {
+        let age = format_context_sample_age_at(sampled_at, now);
+        notes.push(if age == "unknown" {
+            "cached sample age unknown".to_owned()
+        } else {
+            format!("cached {age}")
+        });
+    } else {
+        notes.push("cached".to_owned());
+    }
+    if stopped {
+        notes.push("session stopped".to_owned());
+    }
+    format!("{percentage} ({})", notes.join("; "))
+}
+
+fn format_context_sample_age_at(sampled_at: Option<&str>, now: OffsetDateTime) -> String {
     let Some(sampled_at) = sampled_at else {
         return "unknown".to_owned();
     };
     let Ok(timestamp) = OffsetDateTime::parse(sampled_at, &Rfc3339) else {
         return "unknown".to_owned();
     };
-    let mut seconds = (OffsetDateTime::now_utc() - timestamp).whole_seconds();
+    format_elapsed_context_age((now - timestamp).whole_seconds())
+}
+
+fn format_elapsed_context_age(mut seconds: i64) -> String {
     if seconds < 0 {
         seconds = 0;
     }
@@ -5198,6 +5255,28 @@ mod tests {
                 .unwrap_err()
                 .to_string(),
             "Invalid retire response for session child001"
+        );
+    }
+
+    #[test]
+    fn compact_context_marks_stale_or_stopped_samples_as_cached() {
+        let now = OffsetDateTime::parse("2026-08-16T23:00:00Z", &Rfc3339).unwrap();
+
+        assert_eq!(
+            format_compact_context("43%", Some("2026-08-16T22:59:30Z"), Some("running"), now,),
+            "43%"
+        );
+        assert_eq!(
+            format_compact_context("38%", Some("2026-08-16T22:45:00Z"), Some("running"), now,),
+            "38% (cached 15min ago)"
+        );
+        assert_eq!(
+            format_compact_context("38%", Some("2026-08-16T22:59:30Z"), Some("stopped"), now,),
+            "38% (cached; session stopped)"
+        );
+        assert_eq!(
+            format_compact_context("unknown", None, Some("stopped"), now),
+            "unknown"
         );
     }
 

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -2514,7 +2514,7 @@ async fn inbound_email_webhook(
         return Err(ApiError::NotFound("Session not found"));
     };
     let mut restored = false;
-    if matches!(session.status.as_str(), "stopped" | "killed") {
+    if session.is_stopped() {
         let outcome = if state.config.rust_core.runtime_enabled {
             let runtime = TmuxRuntime::from_app_config(&state.config);
             state
@@ -7415,10 +7415,12 @@ fn teardown_btw_requests_for_session(state: &AppState, session_id: &str) -> anyh
 }
 
 fn ensure_btw_session_live(session: &SessionRecord, label: &str) -> Result<(), ApiError> {
-    if matches!(
-        session.status.trim().to_ascii_lowercase().as_str(),
-        "stopped" | "killed" | "completed" | "error"
-    ) {
+    if session.is_stopped()
+        || matches!(
+            session.status.trim().to_ascii_lowercase().as_str(),
+            "completed" | "error"
+        )
+    {
         return Err(ApiError::Status {
             status: StatusCode::CONFLICT,
             detail: format!("{label} session is not live"),

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -4846,10 +4846,7 @@ fn dispatch_due_scheduled_reminders(
         let target = state
             .session_store
             .get_session(&reminder.target_session_id)?;
-        if target
-            .as_ref()
-            .is_none_or(|session| session.status.trim().eq_ignore_ascii_case("stopped"))
-        {
+        if target.as_ref().is_none_or(SessionRecord::is_stopped) {
             queue.deactivate_scheduled_reminder(&reminder.id)?;
             continue;
         }
@@ -4877,6 +4874,15 @@ fn dispatch_due_scheduled_reminders(
                     anyhow::anyhow!("scheduled reminder compaction wait lock was poisoned")
                 })?
                 .remove(&reminder.id);
+        }
+        if state
+            .session_store
+            .get_session(&reminder.target_session_id)?
+            .as_ref()
+            .is_none_or(SessionRecord::is_stopped)
+        {
+            queue.deactivate_scheduled_reminder(&reminder.id)?;
+            continue;
         }
         let delivery = match queue.claim_due_scheduled_reminder(&reminder.id, now) {
             Ok(Some(delivery)) => delivery,
@@ -4935,7 +4941,7 @@ async fn schedule_reminder(
     let Some(session) = state.session_store.get_session(&payload.session_id)? else {
         return Err(ApiError::NotFound("Session not found"));
     };
-    if session.status.trim().eq_ignore_ascii_case("stopped") {
+    if session.is_stopped() {
         return Err(ApiError::Status {
             status: StatusCode::CONFLICT,
             detail: "Cannot schedule a reminder for a stopped session".to_owned(),
@@ -7836,6 +7842,10 @@ async fn clear_session(
     match result {
         CoreClearOutcome::Cleared(result) => Ok(Json(serde_json::to_value(result)?)),
         CoreClearOutcome::NotFound => Err(ApiError::NotFound("Session not found")),
+        CoreClearOutcome::NotRunning => Err(ApiError::Status {
+            status: StatusCode::CONFLICT,
+            detail: "Session is stopped; restore it before clearing".to_owned(),
+        }),
         CoreClearOutcome::Unauthorized(detail) => Err(ApiError::Status {
             status: StatusCode::FORBIDDEN,
             detail,
@@ -9280,10 +9290,8 @@ fn client_bootstrap_response(
 
 fn attach_descriptor_payload(session: SessionRecord) -> Value {
     let provider = session.provider.clone();
-    let is_stopped = matches!(
-        session.status.trim().to_ascii_lowercase().as_str(),
-        "stopped" | "killed"
-    );
+    let lifecycle_state = session.lifecycle_status().to_owned();
+    let is_stopped = session.is_stopped();
     let has_tmux_session = !session.tmux_session.trim().is_empty();
     let (attach_supported, message) = if is_stopped {
         (false, Some("Session is stopped".to_owned()))
@@ -9304,7 +9312,7 @@ fn attach_descriptor_payload(session: SessionRecord) -> Value {
         "tmux_session": session.tmux_session,
         "tmux_socket_name": session.tmux_socket_name,
         "runtime_id": null,
-        "lifecycle_state": session.status,
+        "lifecycle_state": lifecycle_state,
         "message": message,
     })
 }
@@ -10027,10 +10035,7 @@ fn authorize_mobile_terminal_ticket_request(
             detail: "Mobile terminal attach is disabled".to_owned(),
         });
     }
-    if matches!(
-        session.status.trim().to_ascii_lowercase().as_str(),
-        "stopped" | "killed"
-    ) {
+    if session.is_stopped() {
         return Err(ApiError::Status {
             status: StatusCode::CONFLICT,
             detail: "Session is not running".to_owned(),
@@ -11367,10 +11372,7 @@ fn consume_mobile_terminal_ticket(
             detail: "Session is no longer attachable".to_owned(),
         });
     };
-    if matches!(
-        session.status.trim().to_ascii_lowercase().as_str(),
-        "stopped" | "killed"
-    ) {
+    if session.is_stopped() {
         return Err(ApiError::Status {
             status: StatusCode::CONFLICT,
             detail: "Session is no longer attachable".to_owned(),
@@ -14420,6 +14422,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn reminder_http_rejects_killed_target_with_status_drift() {
+        let (config, queue_path) = reminder_test_config("idle");
+        let state_path = PathBuf::from(&config.paths.state_file);
+        let mut session_state: Value =
+            serde_json::from_slice(&fs::read(&state_path).unwrap()).unwrap();
+        session_state["sessions"][0]["completion_status"] = json!("killed");
+        fs::write(&state_path, serde_json::to_vec(&session_state).unwrap()).unwrap();
+        let app = router(AppState::new(config));
+
+        let response = app
+            .oneshot(local_request(
+                Method::POST,
+                "/scheduler/remind?session_id=reminder-agent&delay_seconds=60&message=Must%20not%20schedule",
+                Body::from("{}"),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let count: i64 = Connection::open(queue_path)
+            .unwrap()
+            .query_row("SELECT COUNT(*) FROM scheduled_reminders", [], |row| {
+                row.get(0)
+            })
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[tokio::test]
     async fn read_only_router_does_not_claim_or_dispatch_reminders() {
         let (mut config, queue_path) = reminder_test_config("running");
         let queue = RetainedQueueStore::new(queue_path.clone());
@@ -14461,7 +14492,12 @@ mod tests {
 
     #[test]
     fn reminder_dispatch_deactivates_stopped_targets_without_queueing() {
-        let (config, queue_path) = reminder_test_config("stopped");
+        let (config, queue_path) = reminder_test_config("idle");
+        let state_path = PathBuf::from(&config.paths.state_file);
+        let mut session_state: Value =
+            serde_json::from_slice(&fs::read(&state_path).unwrap()).unwrap();
+        session_state["sessions"][0]["completion_status"] = json!("killed");
+        fs::write(&state_path, serde_json::to_vec(&session_state).unwrap()).unwrap();
         let state = AppState::new(config);
         let queue = RetainedQueueStore::new(queue_path.clone());
         let reminder = queue
@@ -15269,6 +15305,28 @@ mod tests {
             .as_str()
             .unwrap()
             .contains(body["ticket_secret"].as_str().unwrap()));
+    }
+
+    #[tokio::test]
+    async fn mobile_attach_ticket_rejects_killed_session_with_status_drift() {
+        let signing_key = SigningKey::random(&mut OsRng);
+        let config = mobile_ticket_config(&signing_key);
+        let state_path = PathBuf::from(&config.paths.state_file);
+        let mut session_state: Value =
+            serde_json::from_slice(&fs::read(&state_path).unwrap()).unwrap();
+        session_state["sessions"][0]["status"] = json!("idle");
+        session_state["sessions"][0]["completion_status"] = json!("killed");
+        fs::write(&state_path, serde_json::to_vec(&session_state).unwrap()).unwrap();
+        let app = router(AppState::new(config));
+
+        let response = app
+            .oneshot(attach_ticket_request(&signing_key, "terminal-nonce"))
+            .await
+            .unwrap();
+        let (status, body) = response_json(response).await;
+
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(body["detail"], "Session is not running");
     }
 
     #[tokio::test]

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -3824,23 +3824,22 @@ fn spawn_session_wait_monitor(
                 idle_since = Instant::now();
             }
             let target_name = child_display_name(&target);
-            let notification = if session_status_is_stopped(&target.status)
-                || runtime_child_session_exited(&state, &target)
-            {
-                Some(format!(
-                    "[sm wait] {target_name} reached stopped (waited {elapsed}s)"
-                ))
-            } else if idle_since.elapsed() >= REVIEW_WAIT_IDLE_THRESHOLD {
-                Some(format!(
-                    "[sm wait] {target_name} is now idle (waited {elapsed}s)"
-                ))
-            } else if elapsed >= wait_seconds {
-                Some(format!(
-                    "[sm wait] Timeout: {target_name} still active after {wait_seconds}s"
-                ))
-            } else {
-                None
-            };
+            let notification =
+                if target.is_stopped() || runtime_child_session_exited(&state, &target) {
+                    Some(format!(
+                        "[sm wait] {target_name} reached stopped (waited {elapsed}s)"
+                    ))
+                } else if idle_since.elapsed() >= REVIEW_WAIT_IDLE_THRESHOLD {
+                    Some(format!(
+                        "[sm wait] {target_name} is now idle (waited {elapsed}s)"
+                    ))
+                } else if elapsed >= wait_seconds {
+                    Some(format!(
+                        "[sm wait] Timeout: {target_name} still active after {wait_seconds}s"
+                    ))
+                } else {
+                    None
+                };
             if let Some(notification) = notification {
                 queue_wait_notification(&state, &watcher_session_id, notification);
                 break;
@@ -3903,18 +3902,17 @@ fn spawn_child_wait_monitor(state: Arc<AppState>, child: SessionRecord, wait_sec
                 idle_since = Instant::now();
             }
 
-            let completion_message = if session_status_is_stopped(&child.status)
-                || runtime_child_session_exited(&state, &child)
-            {
-                Some("Session exited".to_owned())
-            } else {
-                Some(idle_since.elapsed().as_secs())
-                    .filter(|idle_seconds| *idle_seconds >= wait_seconds)
-                    .map(|idle_seconds| {
-                        completion_summary(&state.session_store, &child_session_id)
-                            .unwrap_or_else(|| format!("Idle for {idle_seconds}s"))
-                    })
-            };
+            let completion_message =
+                if child.is_stopped() || runtime_child_session_exited(&state, &child) {
+                    Some("Session exited".to_owned())
+                } else {
+                    Some(idle_since.elapsed().as_secs())
+                        .filter(|idle_seconds| *idle_seconds >= wait_seconds)
+                        .map(|idle_seconds| {
+                            completion_summary(&state.session_store, &child_session_id)
+                                .unwrap_or_else(|| format!("Idle for {idle_seconds}s"))
+                        })
+                };
             let Some(completion_message) = completion_message else {
                 continue;
             };
@@ -3939,13 +3937,6 @@ fn spawn_child_wait_monitor(state: Arc<AppState>, child: SessionRecord, wait_sec
             break;
         }
     });
-}
-
-fn session_status_is_stopped(status: &str) -> bool {
-    matches!(
-        status.trim().to_ascii_lowercase().as_str(),
-        "stopped" | "killed"
-    )
 }
 
 fn runtime_child_session_exited(state: &AppState, child: &SessionRecord) -> bool {

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -4065,7 +4065,7 @@ async fn list_node_restore_candidates(
         .session_store
         .list_sessions(true)?
         .into_iter()
-        .filter(|session| session.status.trim() == "stopped")
+        .filter(SessionRecord::is_stopped)
         .filter(|session| is_primary_node(&session.node))
         .map(|session| node_restore_candidate_value(session, &node_id))
         .collect::<Result<Vec<_>, _>>()?;
@@ -4104,7 +4104,7 @@ async fn restore_node_restore_candidate(
             detail: "Session not found".to_owned(),
         });
     };
-    if session.status.trim() != "stopped" {
+    if !session.is_stopped() {
         return Err(ApiError::Status {
             status: StatusCode::CONFLICT,
             detail: "Session is not stopped".to_owned(),
@@ -13077,6 +13077,7 @@ fn node_restore_candidate_value(session: SessionRecord, node_id: &str) -> Result
             .to_owned(),
         ),
     );
+    object.insert("status".to_owned(), Value::String("stopped".to_owned()));
     object.insert(
         "activity_state".to_owned(),
         Value::String("stopped".to_owned()),

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1458,7 +1458,7 @@ impl SessionStore {
                 transcript_path.map(ToOwned::to_owned),
             ));
         }
-        if normalized_status(&json_text(session.get("status")).unwrap_or_default()) == "stopped" {
+        if raw_session_is_stopped(session) {
             drop(_guard);
             for (provider_resume_id, artifact_path) in seat_session_appends {
                 self.append_seat_session(
@@ -1589,7 +1589,7 @@ impl SessionStore {
         let Some(session) = session_object_mut(sessions, session_id) else {
             return Ok(false);
         };
-        if normalized_status(&json_text(session.get("status")).unwrap_or_default()) == "stopped" {
+        if raw_session_is_stopped(session) {
             return Ok(false);
         }
 
@@ -1635,7 +1635,7 @@ impl SessionStore {
         let Some(session) = session_object_mut(sessions, session_id) else {
             return Ok(false);
         };
-        if normalized_status(&json_text(session.get("status")).unwrap_or_default()) == "stopped" {
+        if raw_session_is_stopped(session) {
             return Ok(false);
         }
 
@@ -5755,8 +5755,7 @@ impl SessionStore {
             .filter(|session| {
                 json_text(session.get("provider")).as_deref() == Some("claude")
                     && is_primary_node(&json_text(session.get("node")).unwrap_or_else(default_node))
-                    && normalized_status(&json_text(session.get("status")).unwrap_or_default())
-                        != "stopped"
+                    && !raw_session_is_stopped(session)
                     && json_text(session.get("pending_handoff_path")).is_some()
                     && json_text(session.get("pending_handoff_recorded_at")).is_some()
                     && (json_text(session.get("claude_handoff_in_progress_at")).is_some()
@@ -5788,7 +5787,7 @@ impl SessionStore {
                 let eligible = json_text(session.get("provider")).as_deref() == Some("claude")
                     && file_path.is_some()
                     && recorded_at.is_some()
-                    && normalized_status(&status) != "stopped"
+                    && !raw_session_is_stopped(session)
                     && is_primary_node(
                         &json_text(session.get("node")).unwrap_or_else(default_node),
                     );
@@ -5977,8 +5976,7 @@ impl SessionStore {
             return Ok(false);
         };
         let matches = json_text(session.get("provider")).as_deref() == Some("claude")
-            && normalized_status(&json_text(session.get("status")).unwrap_or_default())
-                != "stopped"
+            && !raw_session_is_stopped(session)
             && is_primary_node(&json_text(session.get("node")).unwrap_or_else(default_node))
             && json_text(session.get("tmux_session")).as_deref() == Some(tmux_session)
             && json_text(session.get("tmux_socket_name")).as_deref() == socket_name.as_deref()
@@ -6003,8 +6001,7 @@ impl SessionStore {
                 return Ok(false);
             };
             if json_text(session.get("provider")).as_deref() != Some("claude")
-                || normalized_status(&json_text(session.get("status")).unwrap_or_default())
-                    == "stopped"
+                || raw_session_is_stopped(session)
             {
                 return Ok(false);
             }
@@ -6111,9 +6108,8 @@ impl SessionStore {
         let Some(session) = session_object_mut(sessions, session_id) else {
             return Ok(false);
         };
-        let current_status = json_text(session.get("status")).unwrap_or_default();
         let still_same_session = json_text(session.get("provider")).as_deref() == Some("claude")
-            && normalized_status(&current_status) != "stopped"
+            && !raw_session_is_stopped(session)
             && is_primary_node(&json_text(session.get("node")).unwrap_or_else(default_node))
             && json_text(session.get("tmux_session")).as_deref() == Some(tmux_session.as_str())
             && json_text(session.get("tmux_socket_name")) == socket_name;
@@ -6407,6 +6403,9 @@ impl SessionStore {
         let Some(session) = session_object_mut(sessions, session_id) else {
             return Ok(false);
         };
+        if raw_session_is_stopped(session) {
+            return Ok(false);
+        }
         match result {
             Ok(provider_resume_id) => {
                 session.insert(
@@ -7428,8 +7427,7 @@ impl SessionStore {
         if provider != "codex-fork" {
             return Ok(false);
         }
-        let status = json_text(session.get("status")).unwrap_or_else(|| "running".to_owned());
-        Ok(normalized_status(&status) != "stopped")
+        Ok(!session.as_object().is_some_and(raw_session_is_stopped))
     }
 
     #[cfg(test)]
@@ -7465,7 +7463,7 @@ impl SessionStore {
             return Ok(());
         }
         let status = json_text(session.get("status")).unwrap_or_else(|| "running".to_owned());
-        if normalized_status(&status) == "stopped" {
+        if raw_session_is_stopped(session) {
             return Ok(());
         }
 
@@ -8626,6 +8624,7 @@ pub struct ContextSnapshotResponse {
     pub used_percentage: Option<f64>,
     pub total_input_tokens: Option<i64>,
     pub sampled_at: Option<String>,
+    pub lifecycle_status: String,
     pub state: String,
     pub warning_percentage: f64,
     pub critical_percentage: f64,
@@ -8639,6 +8638,12 @@ impl ContextSnapshotResponse {
     fn from_session(session: SessionRecord, config: &ContextMonitorConfig) -> Self {
         let used_percentage = session.context_used_percentage;
         let compaction_active = session.context_compaction_active;
+        let lifecycle_status = if session.is_stopped() {
+            "stopped"
+        } else {
+            normalized_status(&session.status)
+        }
+        .to_owned();
         let friendly_name = session.cached_display_name();
         let provider = non_empty_or(session.provider, "claude");
         let informational_only = provider_manages_context_inline(&provider);
@@ -8664,6 +8669,7 @@ impl ContextSnapshotResponse {
             used_percentage,
             total_input_tokens: session.context_total_input_tokens,
             sampled_at: session.context_sampled_at,
+            lifecycle_status,
             state,
             warning_percentage: config.warning_percentage,
             critical_percentage: config.critical_percentage,
@@ -10127,7 +10133,7 @@ fn claude_handoff_reservation_replaced_raw(
     reservation_at: &str,
 ) -> bool {
     if json_text(session.get("provider")).as_deref() != Some("claude")
-        || normalized_status(&json_text(session.get("status")).unwrap_or_default()) == "stopped"
+        || raw_session_is_stopped(session)
         || !is_primary_node(&json_text(session.get("node")).unwrap_or_else(default_node))
     {
         return false;
@@ -13665,8 +13671,11 @@ fn root_seat_id(record: &SessionRecord, records: &BTreeMap<&str, &SessionRecord>
 }
 
 impl SessionRecord {
-    fn is_stopped(&self) -> bool {
+    pub(crate) fn is_stopped(&self) -> bool {
+        // Retirement persists both fields. Keep the terminal marker authoritative
+        // if a delayed status-only writer leaves the activity status behind.
         normalized_status(&self.status) == "stopped"
+            || self.completion_status.as_deref() == Some("killed")
     }
 
     fn is_live_for_registry(&self) -> bool {
@@ -13979,6 +13988,11 @@ fn normalized_status(status: &str) -> &str {
         "running" | "idle" | "stopped" => status,
         _ => status,
     }
+}
+
+fn raw_session_is_stopped(session: &Map<String, Value>) -> bool {
+    normalized_status(&json_text(session.get("status")).unwrap_or_default()) == "stopped"
+        || json_text(session.get("completion_status")).as_deref() == Some("killed")
 }
 
 fn fallback_activity_state(status: &str) -> String {
@@ -15458,6 +15472,59 @@ mod tests {
         session.activity_hook_at = Some("2026-06-01T00:01:00Z".to_owned());
 
         assert_eq!(claude_hook_gate(&session), ClaudeHookGate::Stale);
+    }
+
+    #[test]
+    fn killed_completion_marker_keeps_status_drift_out_of_the_live_roster() {
+        let state_file = unique_temp_path("killed-status-drift");
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [{
+                    "id": "retired1",
+                    "name": "claude-retired1",
+                    "working_dir": "/repo",
+                    "tmux_session": "claude-retired1",
+                    "provider": "claude",
+                    "status": "idle",
+                    "completion_status": "killed",
+                    "completed_at": "2026-06-01T00:02:00Z",
+                    "stopped_at": "2026-06-01T00:02:00Z",
+                    "context_used_percentage": 38.0,
+                    "context_sampled_at": "2026-06-01T00:01:00Z",
+                    "created_at": "2026-06-01T00:00:00Z",
+                    "last_activity": "2026-06-01T00:02:00Z"
+                }]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let store = SessionStore::new(state_file.clone());
+
+        assert!(store.list_sessions(false).unwrap().is_empty());
+        let retained = store.list_sessions(true).unwrap();
+        assert_eq!(retained.len(), 1);
+        assert!(retained[0].is_stopped());
+        assert!(!store
+            .apply_claude_pre_tool_use_hook("retired1", Some("Bash"))
+            .unwrap());
+        assert!(!store
+            .apply_claude_user_prompt_submit_hook("retired1", None)
+            .unwrap());
+        assert_eq!(
+            store
+                .get_context_snapshot("retired1")
+                .unwrap()
+                .unwrap()
+                .lifecycle_status,
+            "stopped"
+        );
+        assert_eq!(
+            store.get_session("retired1").unwrap().unwrap().status,
+            "idle"
+        );
+
+        let _ = fs::remove_file(state_file);
     }
 
     #[test]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1349,7 +1349,9 @@ impl SessionStore {
             .filter(|value| !value.is_empty() && *value != "all");
         if let Some(status_filter) = status_filter {
             children.retain(|session| match status_filter {
-                "running" => normalized_status(&session.status) == "running",
+                "running" => {
+                    !session.is_stopped() && normalized_status(&session.status) == "running"
+                }
                 "completed" => session.completion_status.as_deref() == Some("completed"),
                 "error" => session.completion_status.as_deref() == Some("error"),
                 _ => true,
@@ -4360,6 +4362,9 @@ impl SessionStore {
         {
             return Ok(CoreClearOutcome::Unauthorized(message));
         }
+        if raw_session_is_stopped(session) {
+            return Ok(CoreClearOutcome::NotRunning);
+        }
         let now = now_rfc3339();
         reset_session_after_clear(session, &now);
         self.cancel_context_monitor_alerts(session_id)?;
@@ -4418,6 +4423,9 @@ impl SessionStore {
                 clear_authorization_error(session, request.requester_session_id.as_deref())
             {
                 return Ok(CoreClearOutcome::Unauthorized(message));
+            }
+            if raw_session_is_stopped(session) {
+                return Ok(CoreClearOutcome::NotRunning);
             }
             let node = json_text(session.get("node")).unwrap_or_else(default_node);
             ensure_runtime_local_node(&node)?;
@@ -4556,15 +4564,13 @@ impl SessionStore {
             let current_socket_name = json_text(session.get("tmux_socket_name"));
             let current_provider =
                 json_text(session.get("provider")).unwrap_or_else(default_provider);
-            let current_status =
-                json_text(session.get("status")).unwrap_or_else(|| "running".to_owned());
             if current_tmux_session.as_deref() != Some(tmux_session.as_str())
                 || current_socket_name != session_socket_name
                 || current_provider != provider
             {
                 anyhow::bail!("session {session_id} changed while clear was in progress");
             }
-            if normalized_status(&current_status) == "stopped" {
+            if raw_session_is_stopped(session) {
                 anyhow::bail!("session {session_id} stopped while clear was in progress");
             }
             if let Some((provider_resume_id, _)) = replacement_provider_resume_id.as_ref() {
@@ -4649,9 +4655,8 @@ impl SessionStore {
                 return Ok(false);
             };
             let provider = json_text(session.get("provider")).unwrap_or_else(default_provider);
-            let status = json_text(session.get("status")).unwrap_or_else(|| "running".to_owned());
             if provider != "codex"
-                || normalized_status(&status) == "stopped"
+                || raw_session_is_stopped(session)
                 || json_text(session.get("provider_resume_id")).as_deref()
                     != expected_provider_resume_id
             {
@@ -5025,6 +5030,7 @@ impl SessionStore {
                 && json_text(session.get("status"))
                     .as_deref()
                     .is_some_and(|status| normalized_status(status) == "stopped")
+                && json_text(session.get("completion_status")).as_deref() != Some("killed")
         }) else {
             return Ok(None);
         };
@@ -6237,7 +6243,7 @@ impl SessionStore {
             .filter(|session| {
                 session.provider == "codex-fork"
                     && is_primary_node(&session.node)
-                    && normalized_status(&session.status) != "stopped"
+                    && !session.is_stopped()
             })
             .filter_map(|session| {
                 codex_fork_event_stream_path(&session, runtime)
@@ -8589,6 +8595,7 @@ pub struct CoreClearResult {
 pub enum CoreClearOutcome {
     Cleared(CoreClearResult),
     NotFound,
+    NotRunning,
     Unauthorized(String),
 }
 
@@ -8637,12 +8644,7 @@ impl ContextSnapshotResponse {
     fn from_session(session: SessionRecord, config: &ContextMonitorConfig) -> Self {
         let used_percentage = session.context_used_percentage;
         let compaction_active = session.context_compaction_active;
-        let lifecycle_status = if session.is_stopped() {
-            "stopped"
-        } else {
-            normalized_status(&session.status)
-        }
-        .to_owned();
+        let lifecycle_status = session.lifecycle_status().to_owned();
         let friendly_name = session.cached_display_name();
         let provider = non_empty_or(session.provider, "claude");
         let informational_only = provider_manages_context_inline(&provider);
@@ -10870,7 +10872,7 @@ fn agent_registration_response(
     session: &SessionRecord,
     created_at: Option<&str>,
 ) -> AgentRegistrationResponse {
-    let status = normalized_status(&session.status);
+    let status = session.lifecycle_status();
     let activity_state = projected_activity_state(session, status);
     AgentRegistrationResponse {
         role: normalize_role(role),
@@ -11553,7 +11555,7 @@ fn session_lifetime_overlaps(
     let Some(seat_start) = parse_timestamp_ns(&session.created_at) else {
         return false;
     };
-    let seat_end = if normalized_status(&session.status) == "stopped" {
+    let seat_end = if session.is_stopped() {
         session
             .stopped_at
             .as_deref()
@@ -11942,7 +11944,7 @@ fn credential_rotation_has_fresh_idle_proof(
     rotation: &SessionCredentialRotationRecord,
     session: &SessionRecord,
 ) -> bool {
-    if normalized_status(&session.status) == "stopped" {
+    if session.is_stopped() {
         return false;
     }
     match session.provider.as_str() {
@@ -13658,6 +13660,14 @@ fn root_seat_id(record: &SessionRecord, records: &BTreeMap<&str, &SessionRecord>
 }
 
 impl SessionRecord {
+    pub(crate) fn lifecycle_status(&self) -> &str {
+        if self.is_stopped() {
+            "stopped"
+        } else {
+            normalized_status(&self.status)
+        }
+    }
+
     pub(crate) fn is_stopped(&self) -> bool {
         // Retirement persists both fields. Keep the terminal marker authoritative
         // if a delayed status-only writer leaves the activity status behind.
@@ -13794,16 +13804,16 @@ pub struct SessionResponse {
 
 impl From<SessionRecord> for SessionResponse {
     fn from(session: SessionRecord) -> Self {
-        let status = normalized_status(&session.status);
+        let status = session.lifecycle_status().to_owned();
         let friendly_name = session.cached_display_name();
         let is_maintainer = session.aliases.iter().any(|alias| alias == "maintainer");
         let telegram_thread_id = session.resolved_telegram_thread_id();
-        let activity_state = projected_activity_state(&session, status);
+        let activity_state = projected_activity_state(&session, &status);
         Self {
             id: session.id,
             name: session.name,
             working_dir: session.working_dir,
-            status: status.to_owned(),
+            status,
             created_at: session.created_at,
             last_activity: session.last_activity,
             completed_at: session.completed_at,
@@ -13874,7 +13884,7 @@ pub struct ChildSessionResponse {
 
 impl From<SessionRecord> for ChildSessionResponse {
     fn from(session: SessionRecord) -> Self {
-        let status = normalized_status(&session.status).to_owned();
+        let status = session.lifecycle_status().to_owned();
         let friendly_name = session.cached_display_name();
         let spawned_at = session
             .spawned_at
@@ -15481,6 +15491,7 @@ mod tests {
                     "working_dir": "/repo",
                     "tmux_session": "claude-retired1",
                     "provider": "claude",
+                    "parent_session_id": "parent1",
                     "status": "idle",
                     "completion_status": "killed",
                     "completed_at": "2026-06-01T00:02:00Z",
@@ -15528,6 +15539,26 @@ mod tests {
             .unwrap();
         assert!(!input.delivered);
         assert_eq!(input.status, "stopped");
+        let clear_request = ClearSessionRequest {
+            prompt: None,
+            requester_session_id: Some("parent1".to_owned()),
+        };
+        assert!(matches!(
+            store
+                .clear_core_session("retired1", clear_request.clone())
+                .unwrap(),
+            CoreClearOutcome::NotRunning
+        ));
+        assert!(matches!(
+            store
+                .clear_core_session_with_runtime(
+                    "retired1",
+                    clear_request,
+                    &TmuxRuntime::from_config(&crate::config::RustCoreConfig::default()),
+                )
+                .unwrap(),
+            CoreClearOutcome::NotRunning
+        ));
         assert_eq!(
             store
                 .get_context_snapshot("retired1")

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -4743,8 +4743,7 @@ impl SessionStore {
         let Some(session) = session_object_mut(sessions, session_id) else {
             return Ok(None);
         };
-        let status = json_text(session.get("status")).unwrap_or_else(|| "running".to_owned());
-        if normalized_status(&status) != "stopped" {
+        if !raw_session_is_stopped(session) {
             return Ok(Some(CoreRestoreOutcome::NotStopped));
         }
         let now = now_rfc3339();
@@ -4783,7 +4782,7 @@ impl SessionStore {
         else {
             return Ok(None);
         };
-        if normalized_status(&record.status) != "stopped" {
+        if !record.is_stopped() {
             return Ok(Some(CoreRestoreOutcome::NotStopped));
         }
         if !is_primary_node(&record.node) {
@@ -15541,6 +15540,13 @@ mod tests {
             store.get_session("retired1").unwrap().unwrap().status,
             "idle"
         );
+        let restored = store.restore_core_session("retired1").unwrap().unwrap();
+        let CoreRestoreOutcome::Restored(restored) = restored else {
+            panic!("killed-marker session should be restorable");
+        };
+        assert_eq!(restored.status, "running");
+        assert_eq!(restored.completion_status, None);
+        assert_eq!(store.list_sessions(false).unwrap().len(), 1);
 
         let _ = fs::remove_file(state_file);
     }

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -3948,8 +3948,8 @@ impl SessionStore {
         let Some(session) = session_object_mut(sessions, session_id) else {
             return Ok(None);
         };
-        let status = json_text(session.get("status")).unwrap_or_else(|| "running".to_owned());
-        let delivered = normalized_status(&status) != "stopped";
+        let status = effective_raw_session_status(session);
+        let delivered = !raw_session_is_stopped(session);
         if delivered {
             let now = now_rfc3339();
             mark_session_followup_activity(session, &now);
@@ -9573,9 +9573,7 @@ fn runtime_session_status_raw(state: &mut Value, session_id: &str) -> Result<Opt
     ensure_runtime_local_node(&node)?;
     let _tmux_session = json_text(session.get("tmux_session"))
         .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?;
-    Ok(Some(
-        json_text(session.get("status")).unwrap_or_else(|| "running".to_owned()),
-    ))
+    Ok(Some(effective_raw_session_status(session)))
 }
 
 fn deliver_runtime_text_to_session_raw(
@@ -9589,7 +9587,10 @@ fn deliver_runtime_text_to_session_raw(
         .ok_or_else(|| anyhow::anyhow!("session {session_id} disappeared during delivery"))?;
     let node = json_text(session.get("node")).unwrap_or_else(default_node);
     ensure_runtime_local_node(&node)?;
-    let mut status = json_text(session.get("status")).unwrap_or_else(|| "running".to_owned());
+    let mut status = effective_raw_session_status(session);
+    if raw_session_is_stopped(session) {
+        return Ok((status, false));
+    }
     if claude_handoff_is_reserved_raw(session) {
         return Ok((status, false));
     }
@@ -9597,33 +9598,23 @@ fn deliver_runtime_text_to_session_raw(
         .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?;
     let session_socket_name = json_text(session.get("tmux_socket_name"));
     let session_runtime = runtime.for_socket_name(session_socket_name.as_deref());
-    let mut delivered = false;
-    let mut mark_stopped_on_failure = true;
-    if normalized_status(&status) != "stopped" {
+    let (delivered, mark_stopped_on_failure) =
         match deliver_codex_fork_control_text_to_session_raw(session_id, session, text, runtime)? {
-            Some(true) => {
-                delivered = true;
-            }
+            Some(true) => (true, true),
             Some(false) if runtime.codex_fork_control_tmux_fallback_enabled() => {
-                delivered = session_runtime.send_input(&tmux_session, text)?;
+                (session_runtime.send_input(&tmux_session, text)?, true)
             }
-            Some(false) => {
-                delivered = false;
-                mark_stopped_on_failure = false;
-            }
-            None => {
-                delivered = session_runtime.send_input(&tmux_session, text)?;
-            }
-        }
-        let now = now_rfc3339();
-        if delivered {
-            mark_session_followup_activity(session, &now);
-        } else if mark_stopped_on_failure {
-            status = "stopped".to_owned();
-            session.insert("status".to_owned(), Value::String(status.clone()));
-            session.insert("stopped_at".to_owned(), Value::String(now.clone()));
-            session.insert("last_activity".to_owned(), Value::String(now));
-        }
+            Some(false) => (false, false),
+            None => (session_runtime.send_input(&tmux_session, text)?, true),
+        };
+    let now = now_rfc3339();
+    if delivered {
+        mark_session_followup_activity(session, &now);
+    } else if mark_stopped_on_failure {
+        status = "stopped".to_owned();
+        session.insert("status".to_owned(), Value::String(status.clone()));
+        session.insert("stopped_at".to_owned(), Value::String(now.clone()));
+        session.insert("last_activity".to_owned(), Value::String(now));
     }
     Ok((status, delivered))
 }
@@ -9639,7 +9630,10 @@ fn deliver_urgent_runtime_text_to_session_raw(
         .ok_or_else(|| anyhow::anyhow!("session {session_id} disappeared during delivery"))?;
     let node = json_text(session.get("node")).unwrap_or_else(default_node);
     ensure_runtime_local_node(&node)?;
-    let mut status = json_text(session.get("status")).unwrap_or_else(|| "running".to_owned());
+    let mut status = effective_raw_session_status(session);
+    if raw_session_is_stopped(session) {
+        return Ok((status, false));
+    }
     if claude_handoff_is_reserved_raw(session) {
         return Ok((status, false));
     }
@@ -9648,41 +9642,35 @@ fn deliver_urgent_runtime_text_to_session_raw(
     let provider = json_text(session.get("provider")).unwrap_or_else(|| "claude".to_owned());
     let session_socket_name = json_text(session.get("tmux_socket_name"));
     let session_runtime = runtime.for_socket_name(session_socket_name.as_deref());
-    let mut delivered = false;
-    let mut mark_stopped_on_failure = true;
-    if normalized_status(&status) != "stopped" {
+    let (delivered, mark_stopped_on_failure) =
         match deliver_codex_fork_control_text_to_session_raw(session_id, session, text, runtime)? {
-            Some(true) => {
-                delivered = true;
-            }
-            Some(false) if runtime.codex_fork_control_tmux_fallback_enabled() => {
-                delivered = session_runtime.send_urgent_input(
+            Some(true) => (true, true),
+            Some(false) if runtime.codex_fork_control_tmux_fallback_enabled() => (
+                session_runtime.send_urgent_input(
                     &tmux_session,
                     text,
                     provider.eq_ignore_ascii_case("claude"),
-                )?;
-            }
-            Some(false) => {
-                delivered = false;
-                mark_stopped_on_failure = false;
-            }
-            None => {
-                delivered = session_runtime.send_urgent_input(
+                )?,
+                true,
+            ),
+            Some(false) => (false, false),
+            None => (
+                session_runtime.send_urgent_input(
                     &tmux_session,
                     text,
                     provider.eq_ignore_ascii_case("claude"),
-                )?;
-            }
-        }
-        let now = now_rfc3339();
-        if delivered {
-            mark_session_followup_activity(session, &now);
-        } else if mark_stopped_on_failure {
-            status = "stopped".to_owned();
-            session.insert("status".to_owned(), Value::String(status.clone()));
-            session.insert("stopped_at".to_owned(), Value::String(now.clone()));
-            session.insert("last_activity".to_owned(), Value::String(now));
-        }
+                )?,
+                true,
+            ),
+        };
+    let now = now_rfc3339();
+    if delivered {
+        mark_session_followup_activity(session, &now);
+    } else if mark_stopped_on_failure {
+        status = "stopped".to_owned();
+        session.insert("status".to_owned(), Value::String(status.clone()));
+        session.insert("stopped_at".to_owned(), Value::String(now.clone()));
+        session.insert("last_activity".to_owned(), Value::String(now));
     }
     Ok((status, delivered))
 }
@@ -9698,8 +9686,8 @@ fn deliver_runtime_native_rename_to_session_raw(
         .ok_or_else(|| anyhow::anyhow!("session {session_id} disappeared during delivery"))?;
     let node = json_text(session.get("node")).unwrap_or_else(default_node);
     ensure_runtime_local_node(&node)?;
-    let status = json_text(session.get("status")).unwrap_or_else(|| "running".to_owned());
-    if normalized_status(&status) == "stopped" {
+    let status = effective_raw_session_status(session);
+    if raw_session_is_stopped(session) {
         return Ok((status, false));
     }
     if claude_handoff_is_reserved_raw(session) {
@@ -13995,6 +13983,14 @@ fn raw_session_is_stopped(session: &Map<String, Value>) -> bool {
         || json_text(session.get("completion_status")).as_deref() == Some("killed")
 }
 
+fn effective_raw_session_status(session: &Map<String, Value>) -> String {
+    if raw_session_is_stopped(session) {
+        "stopped".to_owned()
+    } else {
+        json_text(session.get("status")).unwrap_or_else(|| "running".to_owned())
+    }
+}
+
 fn fallback_activity_state(status: &str) -> String {
     match status {
         "stopped" => "stopped".to_owned(),
@@ -15511,6 +15507,28 @@ mod tests {
         assert!(!store
             .apply_claude_user_prompt_submit_hook("retired1", None)
             .unwrap());
+        let input = store
+            .send_core_input(
+                "retired1",
+                SendCoreInputRequest {
+                    text: "must not deliver".to_owned(),
+                    delivery_mode: "sequential".to_owned(),
+                    sender_session_id: None,
+                    from_sm_send: false,
+                    timeout_seconds: None,
+                    notify_on_delivery: false,
+                    notify_after_seconds: None,
+                    notify_on_stop: false,
+                    remind_soft_threshold: None,
+                    remind_hard_threshold: None,
+                    remind_cancel_on_reply_session_id: None,
+                    parent_session_id: None,
+                },
+            )
+            .unwrap()
+            .unwrap();
+        assert!(!input.delivered);
+        assert_eq!(input.status, "stopped");
         assert_eq!(
             store
                 .get_context_snapshot("retired1")

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -4115,6 +4115,11 @@ impl SessionStore {
         let Some(session) = session_object_mut(sessions, session_id) else {
             return Ok(CoreReviewOutcome::NotFound);
         };
+        if raw_session_is_stopped(session) {
+            return Ok(CoreReviewOutcome::Error(
+                "Session is stopped. Restore it before starting a review.".to_owned(),
+            ));
+        }
 
         let provider = json_text(session.get("provider")).unwrap_or_else(default_provider);
         if !matches!(provider.as_str(), "codex" | "codex-fork" | "codex-app") {

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -15040,7 +15040,7 @@ async fn runtime_core_marks_missing_tmux_stopped_on_send_and_retire() {
 }
 
 #[tokio::test]
-async fn runtime_core_does_not_queue_sends_to_already_stopped_sessions() {
+async fn runtime_core_does_not_queue_sends_to_terminal_sessions_with_status_drift() {
     if !tmux_available() {
         return;
     }
@@ -15057,7 +15057,8 @@ async fn runtime_core_does_not_queue_sends_to_already_stopped_sessions() {
                     "node": "primary",
                     "provider": "claude",
                     "log_file": "/tmp/runtimestopped.log",
-                    "status": "stopped",
+                    "status": "idle",
+                    "completion_status": "killed",
                     "created_at": "2026-06-01T00:00:00",
                     "last_activity": "2026-06-01T00:01:00",
                     "stopped_at": "2026-06-01T00:02:00"

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -15346,6 +15346,44 @@ async fn runtime_core_starts_review_on_existing_codex_session() {
     .await;
     assert_eq!(status, StatusCode::OK);
 
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let session = state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "reviewcodex")
+        .unwrap();
+    session["status"] = json!("idle");
+    session["completion_status"] = json!("killed");
+    fs::write(&state_file, serde_json::to_string_pretty(&state).unwrap()).unwrap();
+
+    let (status, payload) = post_json(
+        app.clone(),
+        "/sessions/reviewcodex/review",
+        json!({
+            "mode": "custom",
+            "custom_prompt": "must not dispatch to a retired session"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        payload,
+        json!({ "error": "Session is stopped. Restore it before starting a review." })
+    );
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let session = state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "reviewcodex")
+        .unwrap();
+    assert_eq!(session["status"], "idle");
+    assert_eq!(session["completion_status"], "killed");
+    assert!(session.get("review_config").is_none() || session["review_config"].is_null());
+    session["completion_status"] = Value::Null;
+    fs::write(&state_file, serde_json::to_string_pretty(&state).unwrap()).unwrap();
+
     let (status, payload) = post_json(
         app.clone(),
         "/sessions/reviewcodex/review",
@@ -15368,6 +15406,11 @@ async fn runtime_core_starts_review_on_existing_codex_session() {
         "runtime:/review inspect retained review route",
     )
     .await;
+    let (_status, output) = get_json(app.clone(), "/sessions/reviewcodex/output?lines=20").await;
+    assert!(!output["output"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("must not dispatch to a retired session"));
     wait_for_output_contains(
         app.clone(),
         "reviewwatcher",

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -7995,6 +7995,32 @@ async fn sessions_lists_running_sessions_and_filters_stopped_by_default() {
 }
 
 #[tokio::test]
+async fn sessions_excludes_killed_completion_even_if_status_drifted_idle() {
+    let state_file = write_session_fixture();
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let session = state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "oldstate")
+        .unwrap();
+    session["status"] = json!("idle");
+    session["completion_status"] = json!("killed");
+    session["stopped_at"] = json!("2026-06-01T00:02:00Z");
+    fs::write(&state_file, state.to_string()).unwrap();
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+
+    let (status, payload) = get_json(app, "/sessions").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert!(payload["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|session| session["id"] != "oldstate"));
+}
+
+#[tokio::test]
 async fn context_usage_hook_is_served_and_records_tokens() {
     // The route existed only in the Python server until #1132, so every status
     // line post 404'd and tokens_used stayed at its fixture value forever.
@@ -8024,6 +8050,7 @@ async fn context_usage_hook_is_served_and_records_tokens() {
     assert_eq!(payload["session_id"], "run12345");
     assert_eq!(payload["used_percentage"], json!(41.5));
     assert_eq!(payload["total_input_tokens"], json!(83_000));
+    assert_eq!(payload["lifecycle_status"], "running");
     assert_eq!(payload["state"], "normal");
     assert_eq!(payload["context_monitor_enabled"], true);
 

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -870,6 +870,16 @@ nodes:
 #[tokio::test]
 async fn node_restore_candidates_project_primary_stopped_sessions() {
     let state_file = write_session_fixture();
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let stopped = state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "stop1234")
+        .unwrap();
+    stopped["status"] = json!("idle");
+    stopped["completion_status"] = json!("killed");
+    fs::write(&state_file, state.to_string()).unwrap();
     let app = router(AppState::new(config_with_state_file(&state_file)));
 
     let (status, payload) = get_json(app, "/nodes/primary/restore-candidates?refresh=true").await;
@@ -925,6 +935,16 @@ nodes:
 #[tokio::test]
 async fn node_restore_candidate_restore_round_trips_primary_fixture() {
     let state_file = write_session_fixture();
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let stopped = state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "stop1234")
+        .unwrap();
+    stopped["status"] = json!("idle");
+    stopped["completion_status"] = json!("killed");
+    fs::write(&state_file, state.to_string()).unwrap();
     let mut config = config_with_state_file(&state_file);
     config.rust_core.fixture_writes_enabled = true;
     let app = router(AppState::new(config));
@@ -15168,6 +15188,10 @@ async fn runtime_core_restores_codex_session() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "killed");
     assert!(!tmux_session_exists(&tmux_socket, &tmux_session));
+
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    state["sessions"][0]["status"] = json!("idle");
+    fs::write(&state_file, state.to_string()).unwrap();
 
     let day_dir = state_file
         .with_extension("codex-home")

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -652,6 +652,16 @@ async fn what_request_is_durably_accepted_and_pollable() {
 #[tokio::test]
 async fn what_request_rejects_unsafe_prompt_and_stopped_target() {
     let state_file = write_session_fixture();
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let stopped = state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "stop1234")
+        .unwrap();
+    stopped["status"] = json!("idle");
+    stopped["completion_status"] = json!("killed");
+    fs::write(&state_file, state.to_string()).unwrap();
     let mut config = config_with_state_file_and_queue(&state_file);
     config.rust_core.fixture_writes_enabled = true;
     let app = router(AppState::new(config));
@@ -1747,6 +1757,17 @@ async fn explicit_human_email_is_required_for_human_recipients() {
 #[tokio::test]
 async fn inbound_email_requires_worker_proof_and_delivers_to_session() {
     let state_file = write_session_fixture();
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let stopped = state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "run12345")
+        .unwrap();
+    stopped["status"] = json!("idle");
+    stopped["completion_status"] = json!("killed");
+    stopped["stopped_at"] = json!("2026-06-01T00:02:00");
+    fs::write(&state_file, state.to_string()).unwrap();
     let bridge_config = write_email_bridge_config(None, Some("worker-secret"));
     let app = router(AppState::new(config_with_state_file_and_email(
         &state_file,
@@ -1823,7 +1844,7 @@ async fn inbound_email_requires_worker_proof_and_delivers_to_session() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "sent");
     assert_eq!(payload["session_id"], "run12345");
-    assert_eq!(payload["restored"], false);
+    assert_eq!(payload["restored"], true);
     assert_eq!(payload["delivery_result"], "delivered");
 
     let (_status, output) = get_json(app.clone(), "/sessions/run12345/output?lines=5").await;

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -5818,6 +5818,24 @@ async fn tmux_client_hook_revives_stopped_codex_fork_with_live_tmux_session() {
                     "last_activity": "2026-06-17T20:16:56Z"
                 },
                 {
+                    "id": "retired-local",
+                    "name": "codex-fork-retired-local",
+                    "working_dir": working_dir.display().to_string(),
+                    "tmux_session": tmux_session,
+                    "tmux_socket_name": tmux_socket,
+                    "provider": "codex-fork",
+                    "log_file": log_dir.join("retired-local.log").display().to_string(),
+                    "provider_resume_id": "retired-thread-123",
+                    "friendly_name": "retired-local-agent",
+                    "status": "stopped",
+                    "stopped_at": "2026-06-17T20:16:56Z",
+                    "completion_status": "killed",
+                    "completion_message": "Terminated via sm kill",
+                    "completed_at": "2026-06-17T20:16:56Z",
+                    "created_at": "2026-06-17T19:00:00Z",
+                    "last_activity": "2026-06-17T20:16:56Z"
+                },
+                {
                     "id": "revive1",
                     "name": "codex-fork-revive",
                     "working_dir": working_dir.display().to_string(),
@@ -5829,9 +5847,9 @@ async fn tmux_client_hook_revives_stopped_codex_fork_with_live_tmux_session() {
                     "friendly_name": "hidden-live-agent",
                     "status": "stopped",
                     "stopped_at": "2026-06-17T20:16:56Z",
-                    "completion_status": "killed",
-                    "completion_message": "retry error",
-                    "completed_at": "2026-06-17T20:16:56Z",
+                    "completion_status": null,
+                    "completion_message": null,
+                    "completed_at": null,
                     "error_message": "codex_fork_control_degraded: stale control socket",
                     "created_at": "2026-06-17T19:00:00Z",
                     "last_activity": "2026-06-17T20:16:56Z"
@@ -5897,6 +5915,14 @@ async fn tmux_client_hook_revives_stopped_codex_fork_with_live_tmux_session() {
         .unwrap();
     assert_eq!(remote["status"], "stopped");
     assert_eq!(remote["node"], "macbook");
+    let retired = state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "retired-local")
+        .unwrap();
+    assert_eq!(retired["status"], "stopped");
+    assert_eq!(retired["completion_status"], "killed");
     let restored = state["sessions"]
         .as_array()
         .unwrap()
@@ -9551,13 +9577,25 @@ async fn client_session_detail_explains_mobile_terminal_auth_gap_without_actor()
 #[tokio::test]
 async fn client_session_detail_preserves_attach_unsupported_primary_action_reason() {
     let state_file = write_session_fixture();
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let stopped = state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "stop1234")
+        .unwrap();
+    stopped["status"] = json!("idle");
+    stopped["completion_status"] = json!("killed");
+    fs::write(&state_file, state.to_string()).unwrap();
     let app = router(AppState::new(config_with_state_file(&state_file)));
 
     let (status, payload) = get_json(app, "/client/sessions/stop1234").await;
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["id"], "stop1234");
+    assert_eq!(payload["status"], "stopped");
     assert_eq!(payload["attach_descriptor"]["attach_supported"], false);
+    assert_eq!(payload["attach_descriptor"]["lifecycle_state"], "stopped");
     assert_eq!(
         payload["attach_descriptor"]["message"],
         "Session is stopped"

--- a/docs/product/lessons.md
+++ b/docs/product/lessons.md
@@ -4,7 +4,7 @@ Durable lessons from maintainer sessions. Read this before handling the maintain
 
 ## Current Lessons
 
-- Treat `completion_status=killed` as a terminal lifecycle marker even if a stale status-only writer leaves `status=idle` or `running`. Live roster, hook, routing, and context surfaces must agree on that invariant; explicit restore is the only path that clears the terminal markers.
+- Treat `completion_status=killed` as a terminal lifecycle marker even if a stale status-only writer leaves `status=idle` or `running`. Live roster, hooks, routing, attach, reminders, and context surfaces must agree on that invariant; automatic tmux-client revival must skip killed records, and explicit restore is the only path that clears the terminal markers.
 - Provider-native `/btw` runs in an isolated side conversation. Default `sm what` prompts must explicitly ask for the main conversation thread and exclude the `/btw` side conversation, or the summary can truthfully but uselessly report that no work happened.
 - Cutover removal decisions must be revisited when live agent workflows prove a surface is still operationally required. Durable `sm remind --recurring` belongs in the Rust queue database and scheduler; launchd timers are not an acceptable substitute because they bypass session teardown, cancellation, restart recovery, and queue observability.
 - Claude Code UI forks can create a new Session Manager session ID while continuing in the same tmux runtime. When that happens, inherited recurring reminders need to be self-identifying so the active fork can cancel them directly.

--- a/docs/product/lessons.md
+++ b/docs/product/lessons.md
@@ -4,6 +4,7 @@ Durable lessons from maintainer sessions. Read this before handling the maintain
 
 ## Current Lessons
 
+- Treat `completion_status=killed` as a terminal lifecycle marker even if a stale status-only writer leaves `status=idle` or `running`. Live roster, hook, routing, and context surfaces must agree on that invariant; explicit restore is the only path that clears the terminal markers.
 - Provider-native `/btw` runs in an isolated side conversation. Default `sm what` prompts must explicitly ask for the main conversation thread and exclude the `/btw` side conversation, or the summary can truthfully but uselessly report that no work happened.
 - Cutover removal decisions must be revisited when live agent workflows prove a surface is still operationally required. Durable `sm remind --recurring` belongs in the Rust queue database and scheduler; launchd timers are not an acceptable substitute because they bypass session teardown, cancellation, restart recovery, and queue observability.
 - Claude Code UI forks can create a new Session Manager session ID while continuing in the same tmux runtime. When that happens, inherited recurring reminders need to be self-identifying so the active fork can cancel them directly.


### PR DESCRIPTION
## Summary
- make `completion_status=killed` authoritative when a delayed status writer leaves a retired session marked idle or running
- prevent tmux client hooks from auto-reviving intentionally killed sessions; explicit restore remains the only path back to live state
- apply the terminal lifecycle invariant across roster projections, input, `/what`, and review admission, inbound email restore, attach, reminders, hooks, handoff workers, Codex events, waits, clear, and restore surfaces
- label stale or stopped context snapshots as cached telemetry and expose lifecycle state in detailed output

## Verification
- mutation: removing the killed-marker invariant makes the roster regression fail
- mutation: removing the auto-revive killed guard revives a retired fixture and fails the hook regression
- mutation: reverting inbound email to raw status returns 409 instead of explicitly restoring and delivering
- mutation: removing the review-dispatch guard starts a review in a retired live-tmux fixture
- exact-head queue job `job_b40b93b4935e`: 431 library tests, 68 CLI tests, and 269 HTTP tests passed at `b67a487`
- `cargo check -p sm-server`
- `cargo fmt --all -- --check`
- `git diff --check`

The unfiltered CLI gate is independently blocked on base by #1250; the exact-head gate skips only that one baseline TCP fixture test. A separate HOME-sensitive test race observed during broad filtering is tracked in #1249.

Fixes #1225
Closes #1248
