### PR TITLE
Add atomic spawn brief transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ If `target/release` is on your `PATH`, `sm` resolves to the Rust CLI.
 | `sm status` | Show your status and active sessions |
 | `sm me` | Show the current session identity |
 | `sm all` | List active sessions |
-| `sm spawn <provider> <prompt> \| --prompt-file <path> \| --prompt-stdin [--model <model>] [--effort <level>]` | Start a managed agent. File/stdin briefs are accepted atomically, copied into private durable state, and launched from that immutable copy. |
+| `sm spawn <provider> <prompt> \| --prompt-file <path> \| --prompt-stdin [--model <model>] [--effort <level>]` | Start a managed agent. File/stdin briefs are accepted atomically, copied into private durable state, then delivered to the runtime as the verified accepted bytes. |
 | `sm send <id> "<text>"` | Send input to an agent |
 | `sm what <id> [prompt]` / `sm btw ...` | Ask an agent for a provider-native context summary |
 | `sm wait <id> <seconds>` | Wait for a session state transition |

--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ Use the Rust CLI:
 target/release/sm status
 target/release/sm spawn claude "say hello and exit" --name hello-agent
 target/release/sm spawn codex --model gpt-5.6-terra --effort high "review this change"
+target/release/sm spawn codex --prompt-file specs/1264_implementation_brief.md --name implementer
+generate-brief | target/release/sm spawn claude --prompt-stdin --name researcher
 target/release/sm all
 ```
 
@@ -236,7 +238,7 @@ If `target/release` is on your `PATH`, `sm` resolves to the Rust CLI.
 | `sm status` | Show your status and active sessions |
 | `sm me` | Show the current session identity |
 | `sm all` | List active sessions |
-| `sm spawn <provider> "<prompt>" [--model <model>] [--effort <level>]` | Start a managed agent with optional provider model and reasoning effort |
+| `sm spawn <provider> <prompt> \| --prompt-file <path> \| --prompt-stdin [--model <model>] [--effort <level>]` | Start a managed agent. File/stdin briefs are accepted atomically, copied into private durable state, and launched from that immutable copy. |
 | `sm send <id> "<text>"` | Send input to an agent |
 | `sm what <id> [prompt]` / `sm btw ...` | Ask an agent for a provider-native context summary |
 | `sm wait <id> <seconds>` | Wait for a session state transition |
@@ -263,6 +265,12 @@ sm send agent "message"              # Sequential: wait for idle
 sm send agent "message" --important  # Queue behind current work
 sm send agent "message" --urgent     # Interrupt immediately
 ```
+
+For a multiline or large spawn brief, use `--prompt-file` or `--prompt-stdin`
+instead of a temporary stand-by prompt followed by `sm send`. The three prompt
+forms are mutually exclusive. The file/stdin content must be nonempty UTF-8;
+Session Manager records its SHA-256 and preserves the accepted bytes in its
+state directory before creating the child.
 
 The old transcript summarizer and its `--lines`/`--deep` options remain retired.
 `sm what` now delegates to the target provider's native `/btw` command. Use

--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -215,7 +215,25 @@ struct WaitArgs {
 #[derive(Args)]
 struct SpawnArgs {
     provider: String,
+    /// Legacy shell-argument prompt. Prefer --prompt-file or --prompt-stdin for briefs.
+    #[arg(
+        value_name = "PROMPT",
+        help = "Initial prompt (legacy shell-argument form)"
+    )]
     prompt: Vec<String>,
+    #[arg(
+        long,
+        value_name = "PATH",
+        conflicts_with = "prompt_stdin",
+        help = "Read the exact initial brief from a UTF-8 file"
+    )]
+    prompt_file: Option<PathBuf>,
+    #[arg(
+        long,
+        conflicts_with = "prompt_file",
+        help = "Read the exact initial brief from standard input"
+    )]
+    prompt_stdin: bool,
     #[arg(long)]
     name: Option<String>,
     #[arg(long, value_name = "SECONDS")]
@@ -232,6 +250,45 @@ struct SpawnArgs {
     json: bool,
     #[arg(long, hide = true)]
     id: Option<String>,
+}
+
+fn read_spawn_prompt(args: &SpawnArgs) -> Result<(String, Value)> {
+    let mut stdin = io::stdin();
+    read_spawn_prompt_from(args, &mut stdin)
+}
+
+fn read_spawn_prompt_from<R: Read>(args: &SpawnArgs, stdin: &mut R) -> Result<(String, Value)> {
+    let source_count = usize::from(!args.prompt.is_empty())
+        + usize::from(args.prompt_file.is_some())
+        + usize::from(args.prompt_stdin);
+    if source_count != 1 {
+        bail!("provide exactly one prompt source: positional PROMPT, --prompt-file PATH, or --prompt-stdin");
+    }
+
+    let (bytes, source) = if let Some(path) = args.prompt_file.as_ref() {
+        let bytes = fs::read(path)
+            .with_context(|| format!("failed to read spawn prompt file {}", path.display()))?;
+        (
+            bytes,
+            json!({"kind": "file", "path": path.display().to_string()}),
+        )
+    } else if args.prompt_stdin {
+        let mut bytes = Vec::new();
+        stdin
+            .read_to_end(&mut bytes)
+            .context("failed to read spawn prompt from stdin")?;
+        (bytes, json!({"kind": "stdin"}))
+    } else {
+        (
+            args.prompt.join(" ").into_bytes(),
+            json!({"kind": "positional"}),
+        )
+    };
+    if bytes.is_empty() || String::from_utf8_lossy(&bytes).trim().is_empty() {
+        bail!("spawn prompt must not be empty");
+    }
+    let prompt = String::from_utf8(bytes).context("spawn prompt must be valid UTF-8 text")?;
+    Ok((prompt, source))
 }
 
 #[derive(Args)]
@@ -667,7 +724,7 @@ fn run() -> Result<()> {
             }
         }
         Command::Spawn(args) => {
-            let prompt = args.prompt.join(" ");
+            let (prompt, prompt_source) = read_spawn_prompt(&args)?;
             let parent_session_id = optional_current_session_id();
             let provider = launch_provider_for_alias(&args.provider)?;
             let payload = if let Some(parent_session_id) = parent_session_id {
@@ -677,6 +734,7 @@ fn run() -> Result<()> {
                         "id": args.id,
                         "parent_session_id": parent_session_id,
                         "prompt": prompt,
+                        "prompt_source": prompt_source,
                         "name": args.name,
                         "wait": args.wait,
                         "model": args.model,
@@ -696,6 +754,7 @@ fn run() -> Result<()> {
                         "provider": provider,
                         "node": args.node,
                         "initial_message": prompt,
+                        "spawn_prompt_source": prompt_source,
                         "model": args.model,
                         "reasoning_effort": args.effort,
                         "wait": args.wait
@@ -6683,6 +6742,84 @@ mod tests {
             launch_provider_for_alias(&args.provider).unwrap(),
             "codex-fork"
         );
+    }
+
+    #[test]
+    fn spawn_prompt_file_preserves_verbatim_unicode_markdown() {
+        let expected = "# Brief\n\nUse `$(never-run)` and 'apostrophes'.\n\nこんにちは 👋\n";
+        let path = write_temp_file("sm-rust-spawn-brief", ".md", expected);
+        let cli = Cli::try_parse_from([
+            "sm",
+            "spawn",
+            "claude",
+            "--prompt-file",
+            path.to_str().unwrap(),
+        ])
+        .unwrap();
+        let Command::Spawn(args) = cli.command else {
+            panic!("expected spawn command");
+        };
+
+        let (prompt, source) = read_spawn_prompt(&args).unwrap();
+        assert_eq!(prompt, expected);
+        assert_eq!(source["kind"], "file");
+        assert_eq!(source["path"], path.display().to_string());
+    }
+
+    #[test]
+    fn spawn_prompt_sources_are_exclusive_and_nonempty() {
+        let args = SpawnArgs {
+            provider: "claude".to_owned(),
+            prompt: vec!["stand by".to_owned()],
+            prompt_file: Some(PathBuf::from("brief.md")),
+            prompt_stdin: false,
+            name: None,
+            wait: None,
+            model: None,
+            effort: None,
+            working_dir: None,
+            node: None,
+            json: false,
+            id: None,
+        };
+        assert!(read_spawn_prompt(&args)
+            .unwrap_err()
+            .to_string()
+            .contains("exactly one"));
+
+        let empty = SpawnArgs {
+            prompt: Vec::new(),
+            prompt_file: None,
+            ..args
+        };
+        assert!(read_spawn_prompt(&empty)
+            .unwrap_err()
+            .to_string()
+            .contains("exactly one"));
+    }
+
+    #[test]
+    fn spawn_prompt_stdin_preserves_multiline_bytes() {
+        let args = SpawnArgs {
+            provider: "claude".to_owned(),
+            prompt: Vec::new(),
+            prompt_file: None,
+            prompt_stdin: true,
+            name: None,
+            wait: None,
+            model: None,
+            effort: None,
+            working_dir: None,
+            node: None,
+            json: false,
+            id: None,
+        };
+        let expected = "# Brief\n\nBackticks: `x`\n";
+        let mut input = io::Cursor::new(expected.as_bytes());
+        let (prompt, source) = read_spawn_prompt_from(&args, &mut input).unwrap();
+
+        assert_eq!(prompt, expected);
+        assert_eq!(source["kind"], "stdin");
     }
 
     #[test]

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -127,9 +127,10 @@ use crate::sessions::{
     ReparentMutationOutcome, ReparentRepairAction, RoleRegistrationRequest,
     SeatSessionReconciliationSnapshot, SendCoreInputBatchRequest, SendCoreInputRequest,
     SessionMetadataOutcome, SessionRecord, SessionResponse, SessionStore, SessionsEnvelope,
-    SetMaintainerRequest, SpawnBriefSource, SpawnReviewRequest, StartReviewRequest,
-    SubagentStartOutcome, SubagentStartRequest, SubagentStopOutcome, SubagentStopRequest,
-    TaskCompleteOutcome, TaskCompleteRequest, TurnCompleteOutcome, UpdateSessionMetadataRequest,
+    SetMaintainerRequest, SpawnBriefBinding, SpawnBriefSource, SpawnReviewRequest,
+    StartReviewRequest, SubagentStartOutcome, SubagentStartRequest, SubagentStopOutcome,
+    SubagentStopRequest, TaskCompleteOutcome, TaskCompleteRequest, TurnCompleteOutcome,
+    UpdateSessionMetadataRequest,
 };
 
 use crate::studio_ssh::{self, StudioSshStatus};
@@ -3499,11 +3500,11 @@ async fn create_session(
             payload.working_dir.clone(),
         )?;
         payload.initial_message = Some(accepted.0);
-        payload.spawn_launch_intent_id = Some(accepted.1);
-        payload.spawn_brief_sha256 = Some(accepted.2);
-        payload.spawn_brief_path = Some(accepted.3);
+        payload.spawn_brief = Some(SpawnBriefBinding {
+            intent_id: accepted.1,
+            sha256: accepted.2,
+        });
     }
-    let spawn_launch_intent_id = payload.spawn_launch_intent_id.clone();
     let log_dir = state.config.rust_core.log_dir.as_deref().map(expand_home);
     let session = if state.config.rust_core.runtime_enabled {
         ensure_core_runtime_provider_supported(&payload)?;
@@ -3516,12 +3517,6 @@ async fn create_session(
     } else {
         state.session_store.create_core_session(payload, log_dir)?
     };
-    if let Some(intent_id) = spawn_launch_intent_id {
-        state
-            .session_store
-            .bind_spawn_launch_intent(&intent_id, &session.id)
-            .map_err(core_session_create_api_error)?;
-    }
     Ok(Json(session_response_with_live_activity(&state, session)))
 }
 
@@ -3539,7 +3534,7 @@ fn accept_spawn_brief(
     parent_session_id: Option<String>,
     requested_node: Option<String>,
     requested_working_dir: Option<String>,
-) -> Result<(String, String, String, String), ApiError> {
+) -> Result<(String, String, String), ApiError> {
     let Some(prompt) = prompt else {
         return Err(ApiError::Status {
             status: StatusCode::BAD_REQUEST,
@@ -3564,12 +3559,7 @@ fn accept_spawn_brief(
         .session_store
         .read_spawn_brief(&intent.artifact)
         .map_err(core_session_create_api_error)?;
-    Ok((
-        accepted_prompt,
-        intent.id,
-        intent.artifact.sha256,
-        intent.artifact.path,
-    ))
+    Ok((accepted_prompt, intent.id, intent.artifact.sha256))
 }
 
 async fn spawn_session(
@@ -3641,9 +3631,10 @@ async fn spawn_session(
         reasoning_effort: payload.reasoning_effort,
         wait: wait_seconds,
         spawn_prompt_source: None,
-        spawn_launch_intent_id: Some(accepted.1.clone()),
-        spawn_brief_sha256: Some(accepted.2),
-        spawn_brief_path: Some(accepted.3),
+        spawn_brief: Some(SpawnBriefBinding {
+            intent_id: accepted.1,
+            sha256: accepted.2,
+        }),
     };
     let log_dir = state.config.rust_core.log_dir.as_deref().map(expand_home);
     let child = if state.config.rust_core.runtime_enabled {
@@ -3659,10 +3650,6 @@ async fn spawn_session(
             .session_store
             .create_core_session(create_payload, log_dir)?
     };
-    state
-        .session_store
-        .bind_spawn_launch_intent(&accepted.1, &child.id)
-        .map_err(core_session_create_api_error)?;
     if parent.is_em && child.provider != "codex-fork" {
         let _ = state.session_store.arm_stop_notify(
             &child.id,
@@ -3789,9 +3776,7 @@ async fn spawn_review_session(
         reasoning_effort: None,
         wait: None,
         spawn_prompt_source: None,
-        spawn_launch_intent_id: None,
-        spawn_brief_sha256: None,
-        spawn_brief_path: None,
+        spawn_brief: None,
     };
     let log_dir = state.config.rust_core.log_dir.as_deref().map(expand_home);
     let runtime = TmuxRuntime::from_app_config(&state.config);
@@ -9994,6 +9979,7 @@ fn codex_fork_event_stream_path_for_session(
         log_file: expand_home(log_file),
         provider: session.provider.clone(),
         initial_message: None,
+        force_initial_prompt_stdin: false,
         model: session.model.clone(),
         reasoning_effort: session.reasoning_effort.clone(),
     };
@@ -14188,6 +14174,7 @@ mod tests {
             log_file: log_file.clone(),
             provider: session.provider.clone(),
             initial_message: None,
+            force_initial_prompt_stdin: false,
             model: session.model.clone(),
             reasoning_effort: session.reasoning_effort.clone(),
         };
@@ -14238,6 +14225,7 @@ mod tests {
             log_file: log_file.clone(),
             provider: session.provider.clone(),
             initial_message: None,
+            force_initial_prompt_stdin: false,
             model: session.model.clone(),
             reasoning_effort: session.reasoning_effort.clone(),
         };
@@ -14291,6 +14279,7 @@ mod tests {
             log_file: log_file.clone(),
             provider: session.provider.clone(),
             initial_message: None,
+            force_initial_prompt_stdin: false,
             model: session.model.clone(),
             reasoning_effort: session.reasoning_effort.clone(),
         };

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -116,20 +116,20 @@ use crate::sessions::codex_fork_legacy_event_stream_path_from_log_file;
 use crate::sessions::{
     claude_hook_gate, codex_fork_event_line_matches_root_thread, codex_fork_event_line_starts_turn,
     codex_fork_newest_event_stream_path, codex_fork_status_for_event_line, expand_home,
-    is_primary_node, submit_codex_fork_btw, AgentRegistrationResponse, AgentStatusRequest,
-    ArmStopNotifyOutcome, ArmStopNotifyRequest, ChildSessionResponse, ClaudeHookGate,
-    ClearSessionRequest, ClientSessionResponse, ContextMonitorOutcome, ContextMonitorRequest,
-    ContextSnapshotResponse, ContextUsageEvent, ContextUsageOutcome, CoreClearOutcome,
-    CoreInputBatchResponse, CoreInputBatchResult, CoreRestoreOutcome, CoreRetireOutcome,
-    CoreReviewOutcome, CreateCoreSessionRequest, CreateReparentRequest, CreateReparentTreeRequest,
-    CredentialRotationOutcome, DecideReparentRequest, HandoffOutcome, HandoffRequest,
-    MaintainerMutationOutcome, RegistryMutationOutcome, ReparentDecision, ReparentMutationOutcome,
-    ReparentRepairAction, RoleRegistrationRequest, SeatSessionReconciliationSnapshot,
-    SendCoreInputBatchRequest, SendCoreInputRequest, SessionMetadataOutcome, SessionRecord,
-    SessionResponse, SessionStore, SessionsEnvelope, SetMaintainerRequest, SpawnReviewRequest,
-    StartReviewRequest, SubagentStartOutcome, SubagentStartRequest, SubagentStopOutcome,
-    SubagentStopRequest, TaskCompleteOutcome, TaskCompleteRequest, TurnCompleteOutcome,
-    UpdateSessionMetadataRequest,
+    is_primary_node, submit_codex_fork_btw, AcceptSpawnBriefRequest, AgentRegistrationResponse,
+    AgentStatusRequest, ArmStopNotifyOutcome, ArmStopNotifyRequest, ChildSessionResponse,
+    ClaudeHookGate, ClearSessionRequest, ClientSessionResponse, ContextMonitorOutcome,
+    ContextMonitorRequest, ContextSnapshotResponse, ContextUsageEvent, ContextUsageOutcome,
+    CoreClearOutcome, CoreInputBatchResponse, CoreInputBatchResult, CoreRestoreOutcome,
+    CoreRetireOutcome, CoreReviewOutcome, CreateCoreSessionRequest, CreateReparentRequest,
+    CreateReparentTreeRequest, CredentialRotationOutcome, DecideReparentRequest, HandoffOutcome,
+    HandoffRequest, MaintainerMutationOutcome, RegistryMutationOutcome, ReparentDecision,
+    ReparentMutationOutcome, ReparentRepairAction, RoleRegistrationRequest,
+    SeatSessionReconciliationSnapshot, SendCoreInputBatchRequest, SendCoreInputRequest,
+    SessionMetadataOutcome, SessionRecord, SessionResponse, SessionStore, SessionsEnvelope,
+    SetMaintainerRequest, SpawnBriefSource, SpawnReviewRequest, StartReviewRequest,
+    SubagentStartOutcome, SubagentStartRequest, SubagentStopOutcome, SubagentStopRequest,
+    TaskCompleteOutcome, TaskCompleteRequest, TurnCompleteOutcome, UpdateSessionMetadataRequest,
 };
 
 use crate::studio_ssh::{self, StudioSshStatus};
@@ -3478,10 +3478,32 @@ async fn create_session(
     State(state): State<Arc<AppState>>,
     ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
     headers: HeaderMap,
-    Json(payload): Json<CreateCoreSessionRequest>,
+    Json(mut payload): Json<CreateCoreSessionRequest>,
 ) -> Result<Json<SessionResponse>, ApiError> {
     ensure_session_allowed_from_parts(&state.config, &headers, Some(peer_addr), "/sessions")?;
     ensure_core_writes_enabled(&state)?;
+    if let Some(source) = payload.spawn_prompt_source.take() {
+        let accepted = accept_spawn_brief(
+            &state,
+            payload.initial_message.as_deref(),
+            source,
+            payload
+                .provider
+                .clone()
+                .unwrap_or_else(|| "claude".to_owned()),
+            payload.model.clone(),
+            payload.reasoning_effort.clone(),
+            payload.name.clone(),
+            payload.parent_session_id.clone(),
+            payload.node.clone(),
+            payload.working_dir.clone(),
+        )?;
+        payload.initial_message = Some(accepted.0);
+        payload.spawn_launch_intent_id = Some(accepted.1);
+        payload.spawn_brief_sha256 = Some(accepted.2);
+        payload.spawn_brief_path = Some(accepted.3);
+    }
+    let spawn_launch_intent_id = payload.spawn_launch_intent_id.clone();
     let log_dir = state.config.rust_core.log_dir.as_deref().map(expand_home);
     let session = if state.config.rust_core.runtime_enabled {
         ensure_core_runtime_provider_supported(&payload)?;
@@ -3494,7 +3516,60 @@ async fn create_session(
     } else {
         state.session_store.create_core_session(payload, log_dir)?
     };
+    if let Some(intent_id) = spawn_launch_intent_id {
+        state
+            .session_store
+            .bind_spawn_launch_intent(&intent_id, &session.id)
+            .map_err(core_session_create_api_error)?;
+    }
     Ok(Json(session_response_with_live_activity(&state, session)))
+}
+
+/// Accept a textual brief durably before session creation.  The returned prompt
+/// is read back from the artifact so the runtime never launches from mutable
+/// caller input.
+fn accept_spawn_brief(
+    state: &AppState,
+    prompt: Option<&str>,
+    source: SpawnBriefSource,
+    requested_provider: String,
+    requested_model: Option<String>,
+    requested_reasoning_effort: Option<String>,
+    requested_name: Option<String>,
+    parent_session_id: Option<String>,
+    requested_node: Option<String>,
+    requested_working_dir: Option<String>,
+) -> Result<(String, String, String, String), ApiError> {
+    let Some(prompt) = prompt else {
+        return Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: "spawn prompt is required when spawn prompt source is supplied".to_owned(),
+        });
+    };
+    let intent = state
+        .session_store
+        .accept_spawn_brief(AcceptSpawnBriefRequest {
+            prompt: prompt.to_owned(),
+            source,
+            requested_provider,
+            requested_model,
+            requested_reasoning_effort,
+            requested_name,
+            parent_session_id,
+            requested_node,
+            requested_working_dir,
+        })
+        .map_err(core_session_create_api_error)?;
+    let accepted_prompt = state
+        .session_store
+        .read_spawn_brief(&intent.artifact)
+        .map_err(core_session_create_api_error)?;
+    Ok((
+        accepted_prompt,
+        intent.id,
+        intent.artifact.sha256,
+        intent.artifact.path,
+    ))
 }
 
 async fn spawn_session(
@@ -3539,6 +3614,21 @@ async fn spawn_session(
         .filter(|value| !value.is_empty())
         .unwrap_or(parent.node.as_str())
         .to_owned();
+    let accepted = accept_spawn_brief(
+        &state,
+        Some(&payload.prompt),
+        payload.prompt_source.unwrap_or(SpawnBriefSource {
+            kind: "positional".to_owned(),
+            path: None,
+        }),
+        provider.clone(),
+        payload.model.clone(),
+        payload.reasoning_effort.clone(),
+        payload.name.clone(),
+        Some(parent.id.clone()),
+        Some(node.clone()),
+        Some(working_dir.clone()),
+    )?;
     let create_payload = CreateCoreSessionRequest {
         id: payload.id,
         name: payload.name,
@@ -3546,10 +3636,14 @@ async fn spawn_session(
         provider: Some(provider),
         parent_session_id: Some(parent.id.clone()),
         node: Some(node),
-        initial_message: Some(payload.prompt),
+        initial_message: Some(accepted.0),
         model: payload.model,
         reasoning_effort: payload.reasoning_effort,
         wait: wait_seconds,
+        spawn_prompt_source: None,
+        spawn_launch_intent_id: Some(accepted.1.clone()),
+        spawn_brief_sha256: Some(accepted.2),
+        spawn_brief_path: Some(accepted.3),
     };
     let log_dir = state.config.rust_core.log_dir.as_deref().map(expand_home);
     let child = if state.config.rust_core.runtime_enabled {
@@ -3565,6 +3659,10 @@ async fn spawn_session(
             .session_store
             .create_core_session(create_payload, log_dir)?
     };
+    state
+        .session_store
+        .bind_spawn_launch_intent(&accepted.1, &child.id)
+        .map_err(core_session_create_api_error)?;
     if parent.is_em && child.provider != "codex-fork" {
         let _ = state.session_store.arm_stop_notify(
             &child.id,
@@ -3690,6 +3788,10 @@ async fn spawn_review_session(
         model: payload.model.clone(),
         reasoning_effort: None,
         wait: None,
+        spawn_prompt_source: None,
+        spawn_launch_intent_id: None,
+        spawn_brief_sha256: None,
+        spawn_brief_path: None,
     };
     let log_dir = state.config.rust_core.log_dir.as_deref().map(expand_home);
     let runtime = TmuxRuntime::from_app_config(&state.config);
@@ -13072,6 +13174,8 @@ struct SpawnCoreSessionRequest {
     id: Option<String>,
     parent_session_id: String,
     prompt: String,
+    #[serde(default)]
+    prompt_source: Option<SpawnBriefSource>,
     #[serde(default)]
     name: Option<String>,
     #[serde(default)]

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -371,12 +371,7 @@ impl TmuxRuntime {
         if prompt_mode != "argv" && prompt_mode != "stdin" {
             bail!("unsupported runtime prompt mode: {}", self.prompt_mode);
         }
-        let has_initial_stdin_prompt = prompt_mode == "stdin"
-            && spec
-                .initial_message
-                .as_deref()
-                .map(str::trim)
-                .is_some_and(|value| !value.is_empty());
+        let has_initial_stdin_prompt = initial_stdin_prompt(spec, &prompt_mode).is_some();
 
         let mut command = self.launch_command(spec, &prompt_mode)?;
         command = managed_session_command(
@@ -1218,14 +1213,7 @@ impl TmuxRuntime {
     }
 
     fn attach_session_log(&self, spec: &TmuxSessionSpec, prompt_mode: &str) -> Result<()> {
-        let initial_stdin_prompt = (prompt_mode == "stdin")
-            .then(|| {
-                spec.initial_message
-                    .as_deref()
-                    .map(str::trim)
-                    .filter(|value| !value.is_empty())
-            })
-            .flatten();
+        let initial_stdin_prompt = initial_stdin_prompt(spec, prompt_mode);
         let pipe_command = format!("cat >> {}", shell_quote_path(&spec.log_file));
         if let Err(error) = self.run_tmux([
             "pipe-pane",
@@ -1722,10 +1710,44 @@ fn is_codex_directory_trust_prompt(pane: &str) -> bool {
         && pane.contains("Press enter to continue")
 }
 
+fn initial_stdin_prompt<'a>(spec: &'a TmuxSessionSpec, prompt_mode: &str) -> Option<&'a str> {
+    if prompt_mode != "stdin" {
+        return None;
+    }
+    let prompt = spec.initial_message.as_deref()?;
+    if spec.force_initial_prompt_stdin {
+        // Accepted briefs have already been validated as non-blank. Do not
+        // trim them here: their recorded digest binds the exact UTF-8 bytes.
+        (!prompt.is_empty()).then_some(prompt)
+    } else {
+        let trimmed = prompt.trim();
+        (!trimmed.is_empty()).then_some(trimmed)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn verified_spawn_stdin_prompt_preserves_outer_whitespace() {
+        let prompt = "  # Exact brief\n\n  indented detail  \n";
+        let spec = TmuxSessionSpec {
+            session_id: "abc12345".to_owned(),
+            session_credential: None,
+            tmux_session: "sm-test".to_owned(),
+            working_dir: "/tmp".to_owned(),
+            log_file: PathBuf::from("/tmp/session.log"),
+            provider: "claude".to_owned(),
+            initial_message: Some(prompt.to_owned()),
+            force_initial_prompt_stdin: true,
+            model: None,
+            reasoning_effort: None,
+        };
+
+        assert_eq!(initial_stdin_prompt(&spec, "stdin"), Some(prompt));
+    }
 
     #[test]
     fn codex_model_validation_uses_selectable_models_from_live_catalog() {

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -90,6 +90,9 @@ pub struct TmuxSessionSpec {
     pub log_file: PathBuf,
     pub provider: String,
     pub initial_message: Option<String>,
+    /// Bypass argv prompt mode to deliver an already-verified spawn brief via
+    /// tmux stdin, avoiding both command-line size limits and path races.
+    pub force_initial_prompt_stdin: bool,
     pub model: Option<String>,
     pub reasoning_effort: Option<String>,
 }
@@ -360,7 +363,11 @@ impl TmuxRuntime {
             .open(&spec.log_file)
             .with_context(|| format!("failed to prepare log file {}", spec.log_file.display()))?;
 
-        let prompt_mode = self.prompt_mode.to_ascii_lowercase();
+        let prompt_mode = if spec.force_initial_prompt_stdin {
+            "stdin".to_owned()
+        } else {
+            self.prompt_mode.to_ascii_lowercase()
+        };
         if prompt_mode != "argv" && prompt_mode != "stdin" {
             bail!("unsupported runtime prompt mode: {}", self.prompt_mode);
         }
@@ -1973,6 +1980,7 @@ esac
             log_file: temp_dir.join("session.log"),
             provider: "claude".to_owned(),
             initial_message: None,
+            force_initial_prompt_stdin: false,
             model: None,
             reasoning_effort: None,
         };
@@ -2043,6 +2051,7 @@ esac
             log_file: temp_dir.join("session.log"),
             provider: "claude".to_owned(),
             initial_message: None,
+            force_initial_prompt_stdin: false,
             model: None,
             reasoning_effort: None,
         };
@@ -2082,6 +2091,7 @@ esac
             log_file: temp_dir.join("session.log"),
             provider: "claude".to_owned(),
             initial_message: None,
+            force_initial_prompt_stdin: false,
             model: None,
             reasoning_effort: None,
         };
@@ -2116,6 +2126,7 @@ esac
             log_file: temp_dir.join("session.log"),
             provider: "claude".to_owned(),
             initial_message: None,
+            force_initial_prompt_stdin: false,
             model: None,
             reasoning_effort: Some("high".to_owned()),
         };

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -12252,37 +12252,78 @@ fn persist_spawn_brief_artifact(
     fs::set_permissions(&artifact_dir, fs::Permissions::from_mode(0o700))?;
     let sha256 = sha256_bytes(bytes);
     let path = artifact_dir.join(format!("{sha256}.md"));
-    let mut options = fs::OpenOptions::new();
-    options.write(true).create_new(true);
-    #[cfg(unix)]
-    options.mode(0o600);
-    match options.open(&path) {
-        Ok(mut file) => {
-            file.write_all(bytes)
-                .with_context(|| format!("failed to write spawn brief {}", path.display()))?;
-            file.sync_all()
-                .with_context(|| format!("failed to sync spawn brief {}", path.display()))?;
-        }
+    match write_and_publish_spawn_brief(&artifact_dir, &path, bytes) {
+        Ok(()) => {}
         Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-            let existing = fs::read(&path)
-                .with_context(|| format!("failed to verify spawn brief {}", path.display()))?;
-            if existing != bytes {
-                anyhow::bail!("existing spawn brief artifact digest does not match its contents");
-            }
+            verify_spawn_brief_artifact(&path, bytes)?;
         }
         Err(error) => {
             return Err(error)
-                .with_context(|| format!("failed to create spawn brief {}", path.display()));
+                .with_context(|| format!("failed to publish spawn brief {}", path.display()));
         }
     }
     #[cfg(unix)]
-    fs::set_permissions(&path, fs::Permissions::from_mode(0o600))?;
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o400))?;
     Ok(SpawnBriefArtifact {
         sha256,
         path: path.display().to_string(),
         byte_length: bytes.len(),
         source,
     })
+}
+
+fn write_and_publish_spawn_brief(artifact_dir: &Path, path: &Path, bytes: &[u8]) -> io::Result<()> {
+    let (temporary_path, mut file) = (0..32)
+        .find_map(|_| {
+            let mut random = [0_u8; 8];
+            OsRng.fill_bytes(&mut random);
+            let temporary_path = artifact_dir.join(format!(
+                ".spawn-brief-{:016x}.tmp",
+                u64::from_be_bytes(random)
+            ));
+            let mut options = fs::OpenOptions::new();
+            options.write(true).create_new(true);
+            #[cfg(unix)]
+            options.mode(0o600);
+            match options.open(&temporary_path) {
+                Ok(file) => Some(Ok((temporary_path, file))),
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => None,
+                Err(error) => Some(Err(error)),
+            }
+        })
+        .transpose()?
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::AlreadyExists,
+                "could not reserve spawn brief temporary path",
+            )
+        })?;
+
+    let write_result = (|| -> io::Result<()> {
+        file.write_all(bytes)?;
+        file.sync_all()?;
+        #[cfg(unix)]
+        fs::set_permissions(&temporary_path, fs::Permissions::from_mode(0o400))?;
+        Ok(())
+    })();
+    drop(file);
+    if let Err(error) = write_result {
+        let _ = fs::remove_file(&temporary_path);
+        return Err(error);
+    }
+
+    let publish_result = fs::hard_link(&temporary_path, path);
+    let _ = fs::remove_file(&temporary_path);
+    publish_result
+}
+
+fn verify_spawn_brief_artifact(path: &Path, bytes: &[u8]) -> Result<()> {
+    let existing = fs::read(path)
+        .with_context(|| format!("failed to verify spawn brief {}", path.display()))?;
+    if existing != bytes {
+        anyhow::bail!("existing spawn brief artifact digest does not match its contents");
+    }
+    Ok(())
 }
 
 fn generate_unique_spawn_launch_intent_id(intents: &[Value]) -> Result<String> {
@@ -14742,7 +14783,7 @@ mod tests {
                 .permissions()
                 .mode()
                 & 0o777,
-            0o600
+            0o400
         );
 
         store

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -137,6 +137,13 @@ pub struct AcceptSpawnBriefRequest {
     pub requested_working_dir: Option<String>,
 }
 
+/// Set only by the HTTP handler after it has persisted and re-read the brief.
+#[derive(Debug, Clone)]
+pub struct SpawnBriefBinding {
+    pub intent_id: String,
+    pub sha256: String,
+}
+
 #[derive(Debug)]
 pub struct SeatSessionReconciliationSnapshot {
     records: Vec<SessionRecord>,
@@ -241,19 +248,7 @@ impl SessionStore {
     pub fn bind_spawn_launch_intent(&self, intent_id: &str, session_id: &str) -> Result<()> {
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
-        let Some(intents) = state
-            .get_mut("spawn_launch_intents")
-            .and_then(Value::as_array_mut)
-        else {
-            anyhow::bail!("spawn launch intent {intent_id} is missing");
-        };
-        let Some(intent) = intents
-            .iter_mut()
-            .find(|intent| intent.get("id").and_then(Value::as_str) == Some(intent_id))
-        else {
-            anyhow::bail!("spawn launch intent {intent_id} is missing");
-        };
-        intent["session_id"] = Value::String(session_id.to_owned());
+        bind_spawn_launch_intent_in_state(&mut state, intent_id, session_id)?;
         self.write_raw_json_value(&state)
     }
 
@@ -878,6 +873,7 @@ impl SessionStore {
             log_file: PathBuf::from(&launch.log_file),
             provider: launch.provider.clone(),
             initial_message: launch.initial_message.clone(),
+            force_initial_prompt_stdin: launch.force_initial_prompt_stdin,
             model: launch.model.clone(),
             reasoning_effort: launch.reasoning_effort.clone(),
         };
@@ -1250,6 +1246,7 @@ impl SessionStore {
             log_file,
             provider: session.provider.clone(),
             initial_message: None,
+            force_initial_prompt_stdin: false,
             model: session.model.clone(),
             reasoning_effort: session.reasoning_effort.clone(),
         };
@@ -1273,6 +1270,7 @@ impl SessionStore {
             reasoning_effort: session.reasoning_effort.clone(),
             spawn_launch_intent_id: None,
             spawn_brief_sha256: None,
+            force_initial_prompt_stdin: false,
             credential_sha256: credential_sha256.clone(),
             status: "launching".to_owned(),
             created_at: now.clone(),
@@ -3809,9 +3807,18 @@ impl SessionStore {
         if let Some(parent_id) = request.parent_session_id.as_deref() {
             ensure_session_not_reparent_fenced(&state, parent_id)?;
         }
-        let sessions = ensure_sessions_array_mut(&mut state)?;
-        let record =
-            self.build_core_session_record(sessions, &request, log_dir.as_deref(), false, None)?;
+        let record = {
+            let sessions = ensure_sessions_array_mut(&mut state)?;
+            let record = self.build_core_session_record(
+                sessions,
+                &request,
+                log_dir.as_deref(),
+                false,
+                None,
+            )?;
+            sessions.push(serde_json::to_value(&record)?);
+            record
+        };
         let log_file = record
             .log_file
             .as_deref()
@@ -3832,7 +3839,9 @@ impl SessionStore {
                 &format!("[sm-rust] fixture watch requested: {wait}s"),
             )?;
         }
-        sessions.push(serde_json::to_value(&record)?);
+        if let Some(brief) = request.spawn_brief.as_ref() {
+            bind_spawn_launch_intent_in_state(&mut state, &brief.intent_id, &record.id)?;
+        }
         self.write_raw_json_value(&state)?;
         Ok(record)
     }
@@ -3897,11 +3906,8 @@ impl SessionStore {
             .as_deref()
             .map(expand_home)
             .ok_or_else(|| anyhow::anyhow!("runtime session missing log file"))?;
-        let runtime_initial_message = request
-            .spawn_brief_path
-            .as_deref()
-            .map(spawn_brief_bootstrap_prompt)
-            .or_else(|| request.initial_message.clone());
+        let runtime_initial_message = request.initial_message.clone();
+        let force_initial_prompt_stdin = request.spawn_brief.is_some();
         let spec = TmuxSessionSpec {
             session_id: record.id.clone(),
             session_credential: Some(session_credential),
@@ -3910,6 +3916,7 @@ impl SessionStore {
             log_file,
             provider: record.provider.clone(),
             initial_message: runtime_initial_message.clone(),
+            force_initial_prompt_stdin,
             model: request.model.clone(),
             reasoning_effort: request.reasoning_effort.clone(),
         };
@@ -3948,8 +3955,15 @@ impl SessionStore {
             initial_message: runtime_initial_message,
             model: request.model.clone(),
             reasoning_effort: request.reasoning_effort.clone(),
-            spawn_launch_intent_id: request.spawn_launch_intent_id.clone(),
-            spawn_brief_sha256: request.spawn_brief_sha256.clone(),
+            spawn_launch_intent_id: request
+                .spawn_brief
+                .as_ref()
+                .map(|brief| brief.intent_id.clone()),
+            spawn_brief_sha256: request
+                .spawn_brief
+                .as_ref()
+                .map(|brief| brief.sha256.clone()),
+            force_initial_prompt_stdin,
             credential_sha256,
             status: "launching".to_owned(),
             created_at: launch_time.clone(),
@@ -3959,6 +3973,9 @@ impl SessionStore {
         record.status = "stopped".to_owned();
         record.stopped_at = Some(now_rfc3339());
         ensure_sessions_array_mut(&mut state)?.push(serde_json::to_value(&record)?);
+        if let Some(brief) = request.spawn_brief.as_ref() {
+            bind_spawn_launch_intent_in_state(&mut state, &brief.intent_id, &record.id)?;
+        }
         store_session_runtime_launch_records(&mut state, &launch_records)?;
         self.write_raw_json_value(&state)?;
 
@@ -5045,6 +5062,7 @@ impl SessionStore {
             log_file,
             provider: record.provider.clone(),
             initial_message: None,
+            force_initial_prompt_stdin: false,
             model: record.model.clone(),
             reasoning_effort: record.reasoning_effort.clone(),
         };
@@ -5068,6 +5086,7 @@ impl SessionStore {
             reasoning_effort: record.reasoning_effort.clone(),
             spawn_launch_intent_id: None,
             spawn_brief_sha256: None,
+            force_initial_prompt_stdin: false,
             credential_sha256: credential_sha256.clone(),
             status: "launching".to_owned(),
             created_at: launch_time.clone(),
@@ -8470,12 +8489,8 @@ pub struct CreateCoreSessionRequest {
     pub wait: Option<u64>,
     #[serde(default)]
     pub spawn_prompt_source: Option<SpawnBriefSource>,
-    #[serde(default)]
-    pub spawn_launch_intent_id: Option<String>,
-    #[serde(default)]
-    pub spawn_brief_sha256: Option<String>,
-    #[serde(default)]
-    pub spawn_brief_path: Option<String>,
+    #[serde(skip)]
+    pub spawn_brief: Option<SpawnBriefBinding>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -10093,6 +10108,7 @@ fn codex_fork_spec_for_session_raw(
         log_file: expand_home(&log_file),
         provider: "codex-fork".to_owned(),
         initial_message: None,
+        force_initial_prompt_stdin: false,
         model: json_text(session.get("model")),
         reasoning_effort: json_text(session.get("reasoning_effort")),
     })
@@ -10133,6 +10149,7 @@ pub fn submit_codex_fork_btw(
             .ok_or_else(|| anyhow::anyhow!("session {} missing log_file", session.id))?,
         provider: "codex-fork".to_owned(),
         initial_message: None,
+        force_initial_prompt_stdin: false,
         model: session.model.clone(),
         reasoning_effort: session.reasoning_effort.clone(),
     };
@@ -11800,6 +11817,7 @@ fn codex_fork_event_stream_path(session: &SessionRecord, runtime: &TmuxRuntime) 
         log_file: log_file.clone(),
         provider: session.provider.clone(),
         initial_message: None,
+        force_initial_prompt_stdin: false,
         model: session.model.clone(),
         reasoning_effort: session.reasoning_effort.clone(),
     };
@@ -12214,12 +12232,6 @@ fn sha256_bytes(value: &[u8]) -> String {
     format!("{:x}", hasher.finalize())
 }
 
-fn spawn_brief_bootstrap_prompt(path: &str) -> String {
-    format!(
-        "[Session Manager] Read the immutable launch brief at {path} exactly as written. It is the complete task specification; begin work from it now."
-    )
-}
-
 fn validate_spawn_brief_source(source: &SpawnBriefSource) -> Result<()> {
     match source.kind.as_str() {
         "positional" | "stdin" if source.path.is_none() => Ok(()),
@@ -12264,6 +12276,7 @@ fn persist_spawn_brief_artifact(
     }
     #[cfg(unix)]
     fs::set_permissions(&path, fs::Permissions::from_mode(0o400))?;
+    sync_spawn_brief_directory(&artifact_dir)?;
     Ok(SpawnBriefArtifact {
         sha256,
         path: path.display().to_string(),
@@ -12323,6 +12336,53 @@ fn verify_spawn_brief_artifact(path: &Path, bytes: &[u8]) -> Result<()> {
     if existing != bytes {
         anyhow::bail!("existing spawn brief artifact digest does not match its contents");
     }
+    Ok(())
+}
+
+/// Persist the directory entry before its path is recorded in session state.
+/// Without this barrier, a machine crash could preserve the intent state while
+/// losing a just-published hard link.
+fn sync_spawn_brief_directory(directory: &Path) -> Result<()> {
+    #[cfg(unix)]
+    {
+        fs::File::open(directory)
+            .with_context(|| {
+                format!(
+                    "failed to open spawn brief directory {}",
+                    directory.display()
+                )
+            })?
+            .sync_all()
+            .with_context(|| {
+                format!(
+                    "failed to sync spawn brief directory {}",
+                    directory.display()
+                )
+            })?;
+    }
+    #[cfg(not(unix))]
+    let _ = directory;
+    Ok(())
+}
+
+fn bind_spawn_launch_intent_in_state(
+    state: &mut Value,
+    intent_id: &str,
+    session_id: &str,
+) -> Result<()> {
+    let Some(intents) = state
+        .get_mut("spawn_launch_intents")
+        .and_then(Value::as_array_mut)
+    else {
+        anyhow::bail!("spawn launch intent {intent_id} is missing");
+    };
+    let Some(intent) = intents
+        .iter_mut()
+        .find(|intent| intent.get("id").and_then(Value::as_str) == Some(intent_id))
+    else {
+        anyhow::bail!("spawn launch intent {intent_id} is missing");
+    };
+    intent["session_id"] = Value::String(session_id.to_owned());
     Ok(())
 }
 
@@ -13842,6 +13902,8 @@ pub struct SessionRuntimeLaunchRecord {
     pub spawn_launch_intent_id: Option<String>,
     #[serde(default)]
     pub spawn_brief_sha256: Option<String>,
+    #[serde(default)]
+    pub force_initial_prompt_stdin: bool,
     pub credential_sha256: String,
     pub status: String,
     pub created_at: String,
@@ -14797,6 +14859,23 @@ mod tests {
         assert_eq!(fs::read_to_string(&intent.artifact.path).unwrap(), prompt);
     }
 
+    #[test]
+    fn inbound_session_requests_cannot_supply_an_accepted_brief_binding() {
+        let request: CreateCoreSessionRequest = serde_json::from_value(json!({
+            "initial_message": "untrusted prompt",
+            "spawn_launch_intent_id": "forged-intent",
+            "spawn_brief_sha256": "forged-digest",
+            "spawn_brief_path": "/tmp/forged-brief",
+            "spawn_brief": {
+                "intent_id": "forged-intent",
+                "sha256": "forged-digest"
+            }
+        }))
+        .unwrap();
+
+        assert!(request.spawn_brief.is_none());
+    }
+
     static TEST_ENV_LOCK: Mutex<()> = Mutex::new(());
 
     struct EnvVarRestore {
@@ -14860,9 +14939,7 @@ mod tests {
             reasoning_effort: None,
             wait: None,
             spawn_prompt_source: None,
-            spawn_launch_intent_id: None,
-            spawn_brief_sha256: None,
-            spawn_brief_path: None,
+            spawn_brief: None,
         };
 
         let error = store
@@ -16883,6 +16960,7 @@ mod tests {
             log_file,
             provider: record.provider.clone(),
             initial_message: None,
+            force_initial_prompt_stdin: false,
             model: None,
             reasoning_effort: None,
         };

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1,4 +1,6 @@
 #[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+#[cfg(unix)]
 use std::os::unix::net::UnixStream;
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -85,6 +87,56 @@ pub struct SessionStore {
     usage_project_keys: Arc<Mutex<BTreeMap<String, (String, String)>>>,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct SpawnBriefSource {
+    pub kind: String,
+    #[serde(default)]
+    pub path: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct SpawnBriefArtifact {
+    pub sha256: String,
+    pub path: String,
+    pub byte_length: usize,
+    pub source: SpawnBriefSource,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct SpawnLaunchIntentRecord {
+    pub id: String,
+    pub artifact: SpawnBriefArtifact,
+    pub requested_provider: String,
+    #[serde(default)]
+    pub requested_model: Option<String>,
+    #[serde(default)]
+    pub requested_reasoning_effort: Option<String>,
+    #[serde(default)]
+    pub requested_name: Option<String>,
+    #[serde(default)]
+    pub parent_session_id: Option<String>,
+    #[serde(default)]
+    pub requested_node: Option<String>,
+    #[serde(default)]
+    pub requested_working_dir: Option<String>,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    pub accepted_at: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct AcceptSpawnBriefRequest {
+    pub prompt: String,
+    pub source: SpawnBriefSource,
+    pub requested_provider: String,
+    pub requested_model: Option<String>,
+    pub requested_reasoning_effort: Option<String>,
+    pub requested_name: Option<String>,
+    pub parent_session_id: Option<String>,
+    pub requested_node: Option<String>,
+    pub requested_working_dir: Option<String>,
+}
+
 #[derive(Debug)]
 pub struct SeatSessionReconciliationSnapshot {
     records: Vec<SessionRecord>,
@@ -139,6 +191,79 @@ impl SessionStore {
             usage_report_store: None,
             usage_project_keys: Arc::new(Mutex::new(BTreeMap::new())),
         }
+    }
+
+    /// Durably accept a launch brief before a session ID or runtime is allocated.
+    /// The artifact is content-addressed and never rewritten after it is accepted.
+    pub fn accept_spawn_brief(
+        &self,
+        request: AcceptSpawnBriefRequest,
+    ) -> Result<SpawnLaunchIntentRecord> {
+        validate_spawn_brief_source(&request.source)?;
+        if request.prompt.trim().is_empty() {
+            anyhow::bail!("spawn prompt must not be empty");
+        }
+        let _guard = self.write_guard()?;
+        let artifact = persist_spawn_brief_artifact(
+            &self.state_file,
+            request.prompt.as_bytes(),
+            request.source,
+        )?;
+        let mut state = self.load_raw_json_value()?;
+        let intents = state
+            .as_object_mut()
+            .ok_or_else(|| anyhow::anyhow!("session state must be a JSON object"))?
+            .entry("spawn_launch_intents")
+            .or_insert_with(|| Value::Array(Vec::new()))
+            .as_array_mut()
+            .ok_or_else(|| anyhow::anyhow!("spawn_launch_intents must be an array"))?;
+        let id = generate_unique_spawn_launch_intent_id(intents)?;
+        let intent = SpawnLaunchIntentRecord {
+            id,
+            artifact,
+            requested_provider: request.requested_provider,
+            requested_model: optional_trimmed(request.requested_model.as_deref()),
+            requested_reasoning_effort: optional_trimmed(
+                request.requested_reasoning_effort.as_deref(),
+            ),
+            requested_name: optional_trimmed(request.requested_name.as_deref()),
+            parent_session_id: optional_trimmed(request.parent_session_id.as_deref()),
+            requested_node: optional_trimmed(request.requested_node.as_deref()),
+            requested_working_dir: optional_trimmed(request.requested_working_dir.as_deref()),
+            session_id: None,
+            accepted_at: now_rfc3339(),
+        };
+        intents.push(serde_json::to_value(&intent)?);
+        self.write_raw_json_value(&state)?;
+        Ok(intent)
+    }
+
+    pub fn bind_spawn_launch_intent(&self, intent_id: &str, session_id: &str) -> Result<()> {
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let Some(intents) = state
+            .get_mut("spawn_launch_intents")
+            .and_then(Value::as_array_mut)
+        else {
+            anyhow::bail!("spawn launch intent {intent_id} is missing");
+        };
+        let Some(intent) = intents
+            .iter_mut()
+            .find(|intent| intent.get("id").and_then(Value::as_str) == Some(intent_id))
+        else {
+            anyhow::bail!("spawn launch intent {intent_id} is missing");
+        };
+        intent["session_id"] = Value::String(session_id.to_owned());
+        self.write_raw_json_value(&state)
+    }
+
+    pub fn read_spawn_brief(&self, artifact: &SpawnBriefArtifact) -> Result<String> {
+        let bytes = fs::read(&artifact.path)
+            .with_context(|| format!("failed to read accepted spawn brief {}", artifact.path))?;
+        if bytes.len() != artifact.byte_length || sha256_bytes(&bytes) != artifact.sha256 {
+            anyhow::bail!("accepted spawn brief artifact failed integrity verification");
+        }
+        String::from_utf8(bytes).context("accepted spawn brief is not valid UTF-8 text")
     }
 
     pub fn new_with_queue(state_file: PathBuf, queue_db_path: PathBuf) -> Self {
@@ -1146,6 +1271,8 @@ impl SessionStore {
             initial_message: None,
             model: session.model.clone(),
             reasoning_effort: session.reasoning_effort.clone(),
+            spawn_launch_intent_id: None,
+            spawn_brief_sha256: None,
             credential_sha256: credential_sha256.clone(),
             status: "launching".to_owned(),
             created_at: now.clone(),
@@ -3770,6 +3897,11 @@ impl SessionStore {
             .as_deref()
             .map(expand_home)
             .ok_or_else(|| anyhow::anyhow!("runtime session missing log file"))?;
+        let runtime_initial_message = request
+            .spawn_brief_path
+            .as_deref()
+            .map(spawn_brief_bootstrap_prompt)
+            .or_else(|| request.initial_message.clone());
         let spec = TmuxSessionSpec {
             session_id: record.id.clone(),
             session_credential: Some(session_credential),
@@ -3777,7 +3909,7 @@ impl SessionStore {
             working_dir: expand_home(&record.working_dir).display().to_string(),
             log_file,
             provider: record.provider.clone(),
-            initial_message: request.initial_message.clone(),
+            initial_message: runtime_initial_message.clone(),
             model: request.model.clone(),
             reasoning_effort: request.reasoning_effort.clone(),
         };
@@ -3813,9 +3945,11 @@ impl SessionStore {
             provider: record.provider.clone(),
             provider_resume_id: None,
             credential_rotation_id: None,
-            initial_message: request.initial_message.clone(),
+            initial_message: runtime_initial_message,
             model: request.model.clone(),
             reasoning_effort: request.reasoning_effort.clone(),
+            spawn_launch_intent_id: request.spawn_launch_intent_id.clone(),
+            spawn_brief_sha256: request.spawn_brief_sha256.clone(),
             credential_sha256,
             status: "launching".to_owned(),
             created_at: launch_time.clone(),
@@ -4932,6 +5066,8 @@ impl SessionStore {
             initial_message: None,
             model: record.model.clone(),
             reasoning_effort: record.reasoning_effort.clone(),
+            spawn_launch_intent_id: None,
+            spawn_brief_sha256: None,
             credential_sha256: credential_sha256.clone(),
             status: "launching".to_owned(),
             created_at: launch_time.clone(),
@@ -8332,6 +8468,14 @@ pub struct CreateCoreSessionRequest {
     pub reasoning_effort: Option<String>,
     #[serde(default)]
     pub wait: Option<u64>,
+    #[serde(default)]
+    pub spawn_prompt_source: Option<SpawnBriefSource>,
+    #[serde(default)]
+    pub spawn_launch_intent_id: Option<String>,
+    #[serde(default)]
+    pub spawn_brief_sha256: Option<String>,
+    #[serde(default)]
+    pub spawn_brief_path: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -12064,6 +12208,98 @@ fn sha256_text(value: &str) -> String {
     digest.iter().map(|byte| format!("{byte:02x}")).collect()
 }
 
+fn sha256_bytes(value: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(value);
+    format!("{:x}", hasher.finalize())
+}
+
+fn spawn_brief_bootstrap_prompt(path: &str) -> String {
+    format!(
+        "[Session Manager] Read the immutable launch brief at {path} exactly as written. It is the complete task specification; begin work from it now."
+    )
+}
+
+fn validate_spawn_brief_source(source: &SpawnBriefSource) -> Result<()> {
+    match source.kind.as_str() {
+        "positional" | "stdin" if source.path.is_none() => Ok(()),
+        "file"
+            if source
+                .path
+                .as_deref()
+                .is_some_and(|path| !path.trim().is_empty()) =>
+        {
+            Ok(())
+        }
+        _ => anyhow::bail!("invalid spawn prompt source metadata"),
+    }
+}
+
+fn persist_spawn_brief_artifact(
+    state_file: &Path,
+    bytes: &[u8],
+    source: SpawnBriefSource,
+) -> Result<SpawnBriefArtifact> {
+    let state_dir = state_file.parent().unwrap_or_else(|| Path::new("."));
+    let artifact_dir = state_dir.join("spawn-briefs");
+    fs::create_dir_all(&artifact_dir).with_context(|| {
+        format!(
+            "failed to create spawn brief directory {}",
+            artifact_dir.display()
+        )
+    })?;
+    #[cfg(unix)]
+    fs::set_permissions(&artifact_dir, fs::Permissions::from_mode(0o700))?;
+    let sha256 = sha256_bytes(bytes);
+    let path = artifact_dir.join(format!("{sha256}.md"));
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    options.mode(0o600);
+    match options.open(&path) {
+        Ok(mut file) => {
+            file.write_all(bytes)
+                .with_context(|| format!("failed to write spawn brief {}", path.display()))?;
+            file.sync_all()
+                .with_context(|| format!("failed to sync spawn brief {}", path.display()))?;
+        }
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            let existing = fs::read(&path)
+                .with_context(|| format!("failed to verify spawn brief {}", path.display()))?;
+            if existing != bytes {
+                anyhow::bail!("existing spawn brief artifact digest does not match its contents");
+            }
+        }
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("failed to create spawn brief {}", path.display()));
+        }
+    }
+    #[cfg(unix)]
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o600))?;
+    Ok(SpawnBriefArtifact {
+        sha256,
+        path: path.display().to_string(),
+        byte_length: bytes.len(),
+        source,
+    })
+}
+
+fn generate_unique_spawn_launch_intent_id(intents: &[Value]) -> Result<String> {
+    for _ in 0..32 {
+        let mut bytes = [0_u8; 8];
+        OsRng.fill_bytes(&mut bytes);
+        let id = format!("spawn-brief-{:016x}", u64::from_be_bytes(bytes));
+        if !intents
+            .iter()
+            .any(|intent| intent.get("id").and_then(Value::as_str) == Some(id.as_str()))
+        {
+            return Ok(id);
+        }
+    }
+    anyhow::bail!("failed to generate a unique spawn launch intent ID")
+}
+
 fn constant_time_text_eq(left: &str, right: &str) -> bool {
     if left.len() != right.len() {
         return false;
@@ -13561,6 +13797,10 @@ pub struct SessionRuntimeLaunchRecord {
     pub model: Option<String>,
     #[serde(default)]
     pub reasoning_effort: Option<String>,
+    #[serde(default)]
+    pub spawn_launch_intent_id: Option<String>,
+    #[serde(default)]
+    pub spawn_brief_sha256: Option<String>,
     pub credential_sha256: String,
     pub status: String,
     pub created_at: String,
@@ -14466,6 +14706,56 @@ mod tests {
     use crate::usage_identity::{AccountIdentity, Provider, UsageIdentityStore};
     use rusqlite::Connection;
 
+    #[test]
+    fn accepted_spawn_brief_is_private_immutable_and_records_launch_intent() {
+        let state_file = unique_temp_path("spawn-brief");
+        fs::write(&state_file, r#"{"sessions":[]}"#).unwrap();
+        let store = SessionStore::new(state_file.clone());
+        let prompt = "# Large brief\n\n`$(not executed)` 'quotes'\n日本語\n";
+        let mutable_source = unique_temp_path("mutable-spawn-brief");
+        fs::write(&mutable_source, prompt).unwrap();
+
+        let intent = store
+            .accept_spawn_brief(AcceptSpawnBriefRequest {
+                prompt: prompt.to_owned(),
+                source: SpawnBriefSource {
+                    kind: "file".to_owned(),
+                    path: Some(mutable_source.display().to_string()),
+                },
+                requested_provider: "codex-fork".to_owned(),
+                requested_model: Some("gpt-5.6".to_owned()),
+                requested_reasoning_effort: Some("high".to_owned()),
+                requested_name: Some("implementer".to_owned()),
+                parent_session_id: Some("parent001".to_owned()),
+                requested_node: Some("primary".to_owned()),
+                requested_working_dir: Some("/repo".to_owned()),
+            })
+            .unwrap();
+
+        fs::write(&mutable_source, "mutated after acceptance").unwrap();
+        assert_eq!(store.read_spawn_brief(&intent.artifact).unwrap(), prompt);
+        assert!(intent.artifact.path.contains("spawn-briefs"));
+        #[cfg(unix)]
+        assert_eq!(
+            fs::metadata(&intent.artifact.path)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+
+        store
+            .bind_spawn_launch_intent(&intent.id, "child001")
+            .unwrap();
+        let state: Value = serde_json::from_slice(&fs::read(&state_file).unwrap()).unwrap();
+        let persisted = &state["spawn_launch_intents"][0];
+        assert_eq!(persisted["session_id"], "child001");
+        assert_eq!(persisted["artifact"]["sha256"], intent.artifact.sha256);
+        assert_eq!(persisted["requested_provider"], "codex-fork");
+        assert_eq!(fs::read_to_string(&intent.artifact.path).unwrap(), prompt);
+    }
+
     static TEST_ENV_LOCK: Mutex<()> = Mutex::new(());
 
     struct EnvVarRestore {
@@ -14528,6 +14818,10 @@ mod tests {
             model: Some("luna".to_owned()),
             reasoning_effort: None,
             wait: None,
+            spawn_prompt_source: None,
+            spawn_launch_intent_id: None,
+            spawn_brief_sha256: None,
+            spawn_brief_path: None,
         };
 
         let error = store

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -14738,7 +14738,7 @@ async fn runtime_core_spawn_endpoint_uses_tmux_and_parent_fields() {
     wait_for_output_contains(
         app.clone(),
         "runtimechild",
-        "runtime:spawn endpoint runtime prompt",
+        "runtime:[Session Manager] Read the immutable launch brief at",
     )
     .await;
     wait_for_output_contains(
@@ -14760,6 +14760,29 @@ async fn runtime_core_spawn_endpoint_uses_tmux_and_parent_fields() {
         .unwrap();
     assert_eq!(runtime_child["model"], "opus");
     assert_eq!(runtime_child["reasoning_effort"], "xhigh");
+    let intent = state["spawn_launch_intents"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|intent| intent["session_id"] == "runtimechild")
+        .unwrap();
+    let launch = state["session_runtime_launches"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|launch| launch["session_id"] == "runtimechild")
+        .unwrap();
+    assert_eq!(intent["artifact"]["source"]["kind"], "positional");
+    assert_eq!(launch["spawn_launch_intent_id"], intent["id"]);
+    assert_eq!(launch["spawn_brief_sha256"], intent["artifact"]["sha256"]);
+    assert!(launch["initial_message"]
+        .as_str()
+        .unwrap()
+        .contains(intent["artifact"]["path"].as_str().unwrap()));
+    assert_eq!(
+        fs::read_to_string(intent["artifact"]["path"].as_str().unwrap()).unwrap(),
+        "spawn endpoint runtime prompt"
+    );
 
     let (status, payload) =
         post_json(app.clone(), "/sessions/runtimechild/retire", json!({})).await;

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -14826,7 +14826,7 @@ async fn runtime_core_spawn_wait_detects_naturally_exited_tmux_child() {
         &state_file,
         &log_dir,
         &tmux_socket,
-        r#"/bin/sh -lc 'while IFS= read -r line; do printf "runtime:%s\n" "$line"; case "$line" in *natural-child-prompt*) exit 0;; esac; done' runtime-sh"#,
+        r#"/bin/sh -lc 'while IFS= read -r line; do printf "runtime:%s\n" "$line"; case "$line" in *"[Session Manager] Read the immutable launch brief at"*) exit 0;; esac; done' runtime-sh"#,
     );
 
     let (status, parent_payload) = post_json(
@@ -14897,7 +14897,7 @@ async fn runtime_core_spawn_wait_uses_runtime_output_as_activity() {
         &state_file,
         &log_dir,
         &tmux_socket,
-        r#"/bin/sh -lc 'while IFS= read -r line; do case "$line" in *active-child-prompt*) for i in 1 2 3 4 5 6 7 8; do printf "runtime:heartbeat-%s\n" "$i"; sleep 0.2; done; exit 0;; *) printf "runtime:%s\n" "$line";; esac; done' runtime-sh"#,
+        r#"/bin/sh -lc 'while IFS= read -r line; do case "$line" in *"[Session Manager] Read the immutable launch brief at"*) for i in 1 2 3 4 5 6 7 8; do printf "runtime:heartbeat-%s\n" "$i"; sleep 0.2; done; exit 0;; *) printf "runtime:%s\n" "$line";; esac; done' runtime-sh"#,
     );
 
     let (status, parent_payload) = post_json(

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -14738,7 +14738,7 @@ async fn runtime_core_spawn_endpoint_uses_tmux_and_parent_fields() {
     wait_for_output_contains(
         app.clone(),
         "runtimechild",
-        "runtime:[Session Manager] Read the immutable launch brief at",
+        "runtime:spawn endpoint runtime prompt",
     )
     .await;
     wait_for_output_contains(
@@ -14775,10 +14775,8 @@ async fn runtime_core_spawn_endpoint_uses_tmux_and_parent_fields() {
     assert_eq!(intent["artifact"]["source"]["kind"], "positional");
     assert_eq!(launch["spawn_launch_intent_id"], intent["id"]);
     assert_eq!(launch["spawn_brief_sha256"], intent["artifact"]["sha256"]);
-    assert!(launch["initial_message"]
-        .as_str()
-        .unwrap()
-        .contains(intent["artifact"]["path"].as_str().unwrap()));
+    assert_eq!(launch["initial_message"], "spawn endpoint runtime prompt");
+    assert_eq!(launch["force_initial_prompt_stdin"], true);
     assert_eq!(
         fs::read_to_string(intent["artifact"]["path"].as_str().unwrap()).unwrap(),
         "spawn endpoint runtime prompt"
@@ -14826,7 +14824,7 @@ async fn runtime_core_spawn_wait_detects_naturally_exited_tmux_child() {
         &state_file,
         &log_dir,
         &tmux_socket,
-        r#"/bin/sh -lc 'while IFS= read -r line; do printf "runtime:%s\n" "$line"; case "$line" in *"[Session Manager] Read the immutable launch brief at"*) exit 0;; esac; done' runtime-sh"#,
+        r#"/bin/sh -lc 'while IFS= read -r line; do printf "runtime:%s\n" "$line"; case "$line" in natural-child-prompt) exit 0;; esac; done' runtime-sh"#,
     );
 
     let (status, parent_payload) = post_json(
@@ -14897,7 +14895,7 @@ async fn runtime_core_spawn_wait_uses_runtime_output_as_activity() {
         &state_file,
         &log_dir,
         &tmux_socket,
-        r#"/bin/sh -lc 'while IFS= read -r line; do case "$line" in *"[Session Manager] Read the immutable launch brief at"*) for i in 1 2 3 4 5 6 7 8; do printf "runtime:heartbeat-%s\n" "$i"; sleep 0.2; done; exit 0;; *) printf "runtime:%s\n" "$line";; esac; done' runtime-sh"#,
+        r#"/bin/sh -lc 'while IFS= read -r line; do case "$line" in active-child-prompt) for i in 1 2 3 4 5 6 7 8; do printf "runtime:heartbeat-%s\n" "$i"; sleep 0.2; done; exit 0;; *) printf "runtime:%s\n" "$line";; esac; done' runtime-sh"#,
     );
 
     let (status, parent_payload) = post_json(

--- a/specs/1264_spawn_brief_transport.md
+++ b/specs/1264_spawn_brief_transport.md
@@ -1,0 +1,24 @@
+# 1264: Atomic spawn-brief transport
+
+`sm spawn` accepts exactly one initial-prompt source:
+
+```bash
+sm spawn claude "short positional prompt"
+sm spawn codex --prompt-file /path/to/brief.md
+generate-brief | sm spawn claude --prompt-stdin
+```
+
+The file and stdin forms read UTF-8 bytes without caller-shell interpolation.
+Before Session Manager allocates a session or starts a runtime, it writes the
+accepted brief to `spawn-briefs/<sha256>.md` beside `sessions.json`, with private
+directory/file permissions. It records a launch-intent entry containing the
+source metadata, artifact digest, requested provider/model/effort/name, parent,
+node, and working directory.
+
+The runtime reads the persisted artifact back after acceptance; it does not
+depend on the caller's source file or temporary input after that point. Runtime
+launch records retain the intent ID and digest. Unsupported remote runtime nodes
+continue to fail explicitly before a child is launched.
+
+Do not use a stand-by spawn followed by `sm send` for a large implementation
+brief. Use the atomic file or stdin transport instead.

--- a/specs/1264_spawn_brief_transport.md
+++ b/specs/1264_spawn_brief_transport.md
@@ -11,14 +11,16 @@ generate-brief | sm spawn claude --prompt-stdin
 The file and stdin forms read UTF-8 bytes without caller-shell interpolation.
 Before Session Manager allocates a session or starts a runtime, it writes the
 accepted brief to `spawn-briefs/<sha256>.md` beside `sessions.json`, with private
-directory/file permissions. It records a launch-intent entry containing the
+directory/file permissions. Publication syncs the file and directory before it
+records a launch-intent entry containing the
 source metadata, artifact digest, requested provider/model/effort/name, parent,
 node, and working directory.
 
-The runtime reads the persisted artifact back after acceptance; it does not
-depend on the caller's source file or temporary input after that point. Runtime
-launch records retain the intent ID and digest. Unsupported remote runtime nodes
-continue to fail explicitly before a child is launched.
+The server verifies and reads the persisted artifact back after acceptance, then
+delivers those accepted bytes to the runtime through stdin; the runtime never
+launches from either a caller-controlled path or an artifact path. Runtime launch
+records retain the intent ID and digest. Unsupported remote runtime nodes continue
+to fail explicitly before a child is launched.
 
 Do not use a stand-by spawn followed by `sm send` for a large implementation
 brief. Use the atomic file or stdin transport instead.


### PR DESCRIPTION
## Summary
- add file and stdin prompt sources to the Rust CLI
- persist private content-addressed spawn briefs and launch intent metadata before child allocation
- bind runtime launch records to accepted brief digests and document the transport

## Validation
- cargo test --manifest-path crates/sm-server/Cargo.toml --lib
- cargo test --manifest-path crates/sm-server/Cargo.toml runtime_core_spawn_endpoint_uses_tmux_and_parent_fields -- --nocapture
- cargo test --manifest-path crates/sm-server/Cargo.toml --bin sm spawn_prompt