### PR TITLE
Fix queue runner executable path

### DIFF
--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -1328,7 +1328,11 @@ fn run_queue_run(client: &ApiClient, args: QueueRunArgs) -> Result<()> {
     if argv.is_some() == script.is_some() {
         bail!("exactly one of command or --script-file is required");
     }
-    let mut env_values = BTreeMap::new();
+    // Queue jobs run from a deliberately cleared process environment. Capture
+    // the small, documented execution context at submission time so the job
+    // resolves the same managed-session tools without inheriting credentials
+    // or unrelated server state.
+    let mut env_values = captured_queue_environment();
     for pair in args.env_pairs {
         let (key, value) = pair
             .split_once('=')
@@ -1369,6 +1373,25 @@ fn run_queue_run(client: &ApiClient, args: QueueRunArgs) -> Result<()> {
         println!("Log: {log_path}");
     }
     Ok(())
+}
+
+fn captured_queue_environment() -> BTreeMap<String, String> {
+    queue_environment_from(|key| env::var(key).ok())
+}
+
+fn queue_environment_from<F>(mut lookup: F) -> BTreeMap<String, String>
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    ["PATH", "PYTHONPATH", "VIRTUAL_ENV"]
+        .into_iter()
+        .filter_map(|key| {
+            lookup(key)
+                .filter(|value| !value.is_empty())
+                .map(|value| (key, value))
+        })
+        .map(|(key, value)| (key.to_owned(), value))
+        .collect()
 }
 
 fn run_queue_list(client: &ApiClient, args: QueueListArgs) -> Result<()> {
@@ -6079,6 +6102,25 @@ mod tests {
         assert_eq!(parse_duration_seconds("1d").unwrap(), 86400);
         assert_eq!(parse_queue_timeout_seconds("none").unwrap(), 0);
         assert_eq!(parse_queue_timeout_seconds("2h").unwrap(), 7200);
+    }
+
+    #[test]
+    fn queue_run_captures_the_documented_execution_environment() {
+        let captured = queue_environment_from(|key| match key {
+            "PATH" => Some("/opt/homebrew/bin:/usr/bin".to_owned()),
+            "PYTHONPATH" => Some("/workspace".to_owned()),
+            "VIRTUAL_ENV" => Some("/workspace/.venv".to_owned()),
+            _ => None,
+        });
+
+        assert_eq!(
+            captured,
+            BTreeMap::from([
+                ("PATH".to_owned(), "/opt/homebrew/bin:/usr/bin".to_owned()),
+                ("PYTHONPATH".to_owned(), "/workspace".to_owned()),
+                ("VIRTUAL_ENV".to_owned(), "/workspace/.venv".to_owned()),
+            ])
+        );
     }
 
     #[test]

--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -1332,16 +1332,8 @@ fn run_queue_run(client: &ApiClient, args: QueueRunArgs) -> Result<()> {
     // the small, documented execution context at submission time so the job
     // resolves the same managed-session tools without inheriting credentials
     // or unrelated server state.
-    let mut env_values = captured_queue_environment();
-    for pair in args.env_pairs {
-        let (key, value) = pair
-            .split_once('=')
-            .ok_or_else(|| anyhow!("invalid --env value {pair:?}; expected KEY=VALUE"))?;
-        if key.trim().is_empty() {
-            bail!("invalid --env value {pair:?}; key is empty");
-        }
-        env_values.insert(key.to_owned(), value.to_owned());
-    }
+    let env_values =
+        apply_queue_environment_overrides(captured_queue_environment(), args.env_pairs)?;
     let timeout_seconds = args
         .timeout
         .as_deref()
@@ -1375,6 +1367,22 @@ fn run_queue_run(client: &ApiClient, args: QueueRunArgs) -> Result<()> {
     Ok(())
 }
 
+fn apply_queue_environment_overrides(
+    mut env_values: BTreeMap<String, String>,
+    pairs: impl IntoIterator<Item = String>,
+) -> Result<BTreeMap<String, String>> {
+    for pair in pairs {
+        let (key, value) = pair
+            .split_once('=')
+            .ok_or_else(|| anyhow!("invalid --env value {pair:?}; expected KEY=VALUE"))?;
+        if key.trim().is_empty() {
+            bail!("invalid --env value {pair:?}; key is empty");
+        }
+        env_values.insert(key.to_owned(), value.to_owned());
+    }
+    Ok(env_values)
+}
+
 fn captured_queue_environment() -> BTreeMap<String, String> {
     queue_environment_from(|key| env::var(key).ok())
 }
@@ -1383,7 +1391,7 @@ fn queue_environment_from<F>(mut lookup: F) -> BTreeMap<String, String>
 where
     F: FnMut(&str) -> Option<String>,
 {
-    ["PATH", "PYTHONPATH", "VIRTUAL_ENV"]
+    ["PATH"]
         .into_iter()
         .filter_map(|key| {
             lookup(key)
@@ -6105,7 +6113,7 @@ mod tests {
     }
 
     #[test]
-    fn queue_run_captures_the_documented_execution_environment() {
+    fn queue_run_captures_only_path_and_allows_an_explicit_path_override() {
         let captured = queue_environment_from(|key| match key {
             "PATH" => Some("/opt/homebrew/bin:/usr/bin".to_owned()),
             "PYTHONPATH" => Some("/workspace".to_owned()),
@@ -6115,11 +6123,12 @@ mod tests {
 
         assert_eq!(
             captured,
-            BTreeMap::from([
-                ("PATH".to_owned(), "/opt/homebrew/bin:/usr/bin".to_owned()),
-                ("PYTHONPATH".to_owned(), "/workspace".to_owned()),
-                ("VIRTUAL_ENV".to_owned(), "/workspace/.venv".to_owned()),
-            ])
+            BTreeMap::from([("PATH".to_owned(), "/opt/homebrew/bin:/usr/bin".to_owned())])
+        );
+        assert_eq!(
+            apply_queue_environment_overrides(captured, vec!["PATH=/custom/bin".to_owned()],)
+                .unwrap(),
+            BTreeMap::from([("PATH".to_owned(), "/custom/bin".to_owned())])
         );
     }
 

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -2478,11 +2478,6 @@ fn write_queue_job_wrapper(
     let mut lines = vec![
         "#!/bin/zsh".to_owned(),
         "set +e".to_owned(),
-        "function command_not_found_handler() {".to_owned(),
-        "  print -u2 -- \"[sm queue] command not found: $1\"".to_owned(),
-        "  print -u2 -- \"[sm queue] effective PATH: $PATH\"".to_owned(),
-        "  return 127".to_owned(),
-        "}".to_owned(),
         format!("cd {} || exit 127", shell_quote(cwd)),
     ];
     for (key, value) in env {
@@ -2500,20 +2495,13 @@ fn write_queue_job_wrapper(
                 .join(" "),
         );
     } else if let Some(script_path) = script_path {
-        let script_runner = r#"function command_not_found_handler() {
-  print -u2 -- "[sm queue] command not found: $1"
-  print -u2 -- "[sm queue] effective PATH: $PATH"
-  return 127
-}
-source "$1""#;
-        lines.push(format!(
-            "/bin/zsh -c {} -- {}",
-            shell_quote(script_runner),
-            shell_quote(script_path)
-        ));
+        lines.push(format!("/bin/zsh {}", shell_quote(script_path)));
     }
     lines.extend([
         "code=$?".to_owned(),
+        "if [ \"$code\" -eq 127 ]; then".to_owned(),
+        "  print -u2 -- \"[sm queue] effective PATH: $PATH\"".to_owned(),
+        "fi".to_owned(),
         format!(
             "printf '%s\\n' \"$code\" > {}",
             shell_quote(&exit_code_path.display().to_string())
@@ -4333,7 +4321,7 @@ mod tests {
     }
 
     #[test]
-    fn queue_wrapper_reports_effective_path_when_an_executable_is_missing() {
+    fn queue_argv_wrapper_reports_effective_path_when_an_executable_is_missing() {
         let job_dir = unique_temp_path("missing-executable");
         fs::create_dir_all(&job_dir).unwrap();
         let wrapper_path = job_dir.join("run.zsh");
@@ -4372,8 +4360,63 @@ mod tests {
         let status = spawn_queue_job_process(&job).unwrap().wait().unwrap();
         let log = fs::read_to_string(&log_path).unwrap();
         assert_eq!(status.code(), Some(127));
-        assert!(log.contains("[sm queue] command not found: sm-command-that-does-not-exist"));
+        assert!(log.contains("command not found: sm-command-that-does-not-exist"));
         assert!(log.contains("[sm queue] effective PATH: /queue-test/bin"));
+        assert_eq!(fs::read_to_string(exit_code_path).unwrap().trim(), "127");
+
+        fs::remove_dir_all(job_dir).unwrap();
+    }
+
+    #[test]
+    fn queue_script_wrapper_reports_effective_path_when_an_executable_is_missing() {
+        let job_dir = unique_temp_path("missing-script-executable");
+        fs::create_dir_all(&job_dir).unwrap();
+        let script_path = job_dir.join("submitted.zsh");
+        fs::write(&script_path, "sm-script-command-that-does-not-exist\n").unwrap();
+        let wrapper_path = job_dir.join("run.zsh");
+        let exit_code_path = job_dir.join("exit.code");
+        let log_path = job_dir.join("job.log");
+        let path = "/queue-test/script-bin";
+
+        write_queue_job_wrapper(
+            &wrapper_path,
+            "/tmp",
+            None,
+            Some(script_path.to_str().unwrap()),
+            &BTreeMap::from([("PATH".to_owned(), path.to_owned())]),
+            &exit_code_path,
+        )
+        .unwrap();
+        let wrapper = fs::read_to_string(&wrapper_path).unwrap();
+        assert!(wrapper.contains(&format!(
+            "/bin/zsh {}",
+            shell_quote(script_path.to_str().unwrap())
+        )));
+        assert!(!wrapper.contains("source \"$1\""));
+        let job = QueueJobRuntimeRecord {
+            id: "job-missing-script-executable".to_owned(),
+            job_type: "tests".to_owned(),
+            state: "pending".to_owned(),
+            notify_session_id: None,
+            queued_at: now_rfc3339(),
+            started_at: None,
+            finished_at: None,
+            holding_reason: None,
+            wrapper_path: Some(wrapper_path.display().to_string()),
+            log_path: Some(log_path.display().to_string()),
+            exit_code_path: Some(exit_code_path.display().to_string()),
+            timeout_seconds: 60,
+            pid: None,
+            process_group_id: None,
+            exit_code: None,
+            completion_notified_at: None,
+        };
+
+        let status = spawn_queue_job_process(&job).unwrap().wait().unwrap();
+        let log = fs::read_to_string(&log_path).unwrap();
+        assert_eq!(status.code(), Some(127));
+        assert!(log.contains("command not found: sm-script-command-that-does-not-exist"));
+        assert!(log.contains("[sm queue] effective PATH: /queue-test/script-bin"));
         assert_eq!(fs::read_to_string(exit_code_path).unwrap().trim(), "127");
 
         fs::remove_dir_all(job_dir).unwrap();

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -2478,6 +2478,11 @@ fn write_queue_job_wrapper(
     let mut lines = vec![
         "#!/bin/zsh".to_owned(),
         "set +e".to_owned(),
+        "function command_not_found_handler() {".to_owned(),
+        "  print -u2 -- \"[sm queue] command not found: $1\"".to_owned(),
+        "  print -u2 -- \"[sm queue] effective PATH: $PATH\"".to_owned(),
+        "  return 127".to_owned(),
+        "}".to_owned(),
         format!("cd {} || exit 127", shell_quote(cwd)),
     ];
     for (key, value) in env {
@@ -2495,7 +2500,17 @@ fn write_queue_job_wrapper(
                 .join(" "),
         );
     } else if let Some(script_path) = script_path {
-        lines.push(format!("/bin/zsh {}", shell_quote(script_path)));
+        let script_runner = r#"function command_not_found_handler() {
+  print -u2 -- "[sm queue] command not found: $1"
+  print -u2 -- "[sm queue] effective PATH: $PATH"
+  return 127
+}
+source "$1""#;
+        lines.push(format!(
+            "/bin/zsh -c {} -- {}",
+            shell_quote(script_runner),
+            shell_quote(script_path)
+        ));
     }
     lines.extend([
         "code=$?".to_owned(),
@@ -4315,6 +4330,53 @@ mod tests {
         let displaced = queue_job_completion_text(&job, "displaced", None, "2026-08-16T20:04:24Z");
         assert!(displaced.contains("termination=perf_displacement"));
         assert!(displaced.contains("exit=unknown"));
+    }
+
+    #[test]
+    fn queue_wrapper_reports_effective_path_when_an_executable_is_missing() {
+        let job_dir = unique_temp_path("missing-executable");
+        fs::create_dir_all(&job_dir).unwrap();
+        let wrapper_path = job_dir.join("run.zsh");
+        let exit_code_path = job_dir.join("exit.code");
+        let log_path = job_dir.join("job.log");
+        let path = "/queue-test/bin";
+
+        write_queue_job_wrapper(
+            &wrapper_path,
+            "/tmp",
+            Some(&["sm-command-that-does-not-exist".to_owned()]),
+            None,
+            &BTreeMap::from([("PATH".to_owned(), path.to_owned())]),
+            &exit_code_path,
+        )
+        .unwrap();
+        let job = QueueJobRuntimeRecord {
+            id: "job-missing-executable".to_owned(),
+            job_type: "tests".to_owned(),
+            state: "pending".to_owned(),
+            notify_session_id: None,
+            queued_at: now_rfc3339(),
+            started_at: None,
+            finished_at: None,
+            holding_reason: None,
+            wrapper_path: Some(wrapper_path.display().to_string()),
+            log_path: Some(log_path.display().to_string()),
+            exit_code_path: Some(exit_code_path.display().to_string()),
+            timeout_seconds: 60,
+            pid: None,
+            process_group_id: None,
+            exit_code: None,
+            completion_notified_at: None,
+        };
+
+        let status = spawn_queue_job_process(&job).unwrap().wait().unwrap();
+        let log = fs::read_to_string(&log_path).unwrap();
+        assert_eq!(status.code(), Some(127));
+        assert!(log.contains("[sm queue] command not found: sm-command-that-does-not-exist"));
+        assert!(log.contains("[sm queue] effective PATH: /queue-test/bin"));
+        assert_eq!(fs::read_to_string(exit_code_path).unwrap().trim(), "127");
+
+        fs::remove_dir_all(job_dir).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Capture only PATH when `sm queue run` submits a job; callers can explicitly supply any additional variables with `--env`.
- Preserve the submitted-script execution contract as `/bin/zsh <script>`.
- Append the effective PATH to queue logs when either an argv or script-file job exits 127.

## Root cause

The Rust CLI sent no PATH for queue jobs. The runner intentionally clears its inherited environment and therefore fell back to a system-only PATH, excluding Homebrew npm.

## Validation

- Focused CLI capture/override and argv/script exit-127 diagnostics tests
- `cargo test -p sm-server`
- `cargo fmt --check`
- `git diff --check`

Fixes #1252