### PR TITLE
Bound Codex review rounds

### DIFF
--- a/docs/working/pr_review_process.md
+++ b/docs/working/pr_review_process.md
@@ -2,7 +2,7 @@
 
 Use this process whenever a pull request needs Codex review and merge handling.
 
-## Review Loop
+## Requesting A Review
 
 Preferred path:
 
@@ -19,7 +19,8 @@ Fallback path:
 4. If no review was posted, wait 5 more minutes.
 5. Poll again.
 6. If there is still no review after 10 minutes total, post another `@codex review` comment.
-7. Repeat the cycle until a fresh review is posted.
+7. Repeat the request-registration cycle until a fresh review is posted. These
+   retries obtain one review and do not count as additional review rounds.
 
 ## Review Triage
 
@@ -31,9 +32,22 @@ When Codex review lands:
 
 ## Exit Criteria
 
-- If there are any important feedback items (`P1`), exit criteria are **not met**.
+- If there are any important feedback items (`P1`), the PR is **not mergeable**.
 - If there are no important feedback items (`P2` or lower only), exit criteria are **met**.
 - If the review is clean, exit criteria are **met**.
+
+Codex review is a sampled gate, not proof obtained by requesting reviews until
+one happens to be clean. A PR receives at most three exact-head review rounds:
+
+1. broad current-capability review;
+2. root-cause verification after one batched repair, including sibling instances
+   in the touched subsystem; and
+3. a final enabled-path/rollback/test review only when round 2 retains or
+   introduces a reachable `P0`/`P1`.
+
+Record the requested and reviewed head, scope/steer, findings, disposition,
+resulting head, review wait, and available token estimate for every round. Do
+not request an unchanged head again.
 
 ## After Feedback
 
@@ -43,7 +57,18 @@ When Codex review lands:
 If exit criteria are not met:
 
 1. Push the fixes.
-2. Repeat the review loop until exit criteria are met.
+2. Request the next bounded round only if fewer than three rounds have run.
+
+At the three-round cap:
+
+1. A reachable `P0`/`P1` blocks merge. Simplify, revert, split, or mark the PR
+   blocked with the residual finding and evidence.
+2. A finding that only affects disabled or future capability becomes a linked
+   issue and acceptance criterion for that capability.
+3. Fix, explicitly accept with rationale, or file each `P2`/`P3`.
+4. Do not start a fourth round automatically. The owner may approve one bounded
+   extension with an explicit token/time budget. It cannot be extended again;
+   another reachable `P0`/`P1` requires a split or redesign.
 
 If exit criteria are met:
 
@@ -59,3 +84,9 @@ If exit criteria are met:
 - When using Session Manager wakeups, still verify that the landed review/comment is tied to the current request cycle before acting on it.
 - The blocking threshold is whether unresolved feedback contains any `P1` items.
 - `P2` or lower feedback can still be worth fixing before merge, but it does not block exit criteria.
+- Keep one deployable capability per PR. A head-expanding refactor discovered
+  during review belongs in a separate PR rather than silently increasing the
+  current review surface.
+- For unusually high-risk transactions, up to two focused reviews may run in
+  parallel on the same immutable head and be aggregated as one round. Record
+  their costs separately and deduplicate findings before one repair batch.


### PR DESCRIPTION
Applies the owner-approved three-round Codex review protocol from #1269 to the repository-wide maintainer workflow. P1 remains merge-blocking, but the process now splits, simplifies, or escalates at the cap instead of reviewing indefinitely.