### PR TITLE
Require verified initial spawn brief delivery

### DIFF
--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -1242,6 +1242,10 @@ pub struct RustCoreConfig {
     #[serde(default)]
     pub runtime_start_settle_ms: Option<u64>,
     #[serde(default)]
+    pub runtime_initial_brief_ready_timeout_ms: Option<u64>,
+    #[serde(default)]
+    pub runtime_initial_brief_ack_timeout_ms: Option<u64>,
+    #[serde(default)]
     pub send_keys_settle_ms: Option<f64>,
     #[serde(default)]
     pub send_keys_settle_max_ms: Option<f64>,

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -3512,11 +3512,7 @@ async fn create_session(
     let session = if state.config.rust_core.runtime_enabled {
         ensure_core_runtime_provider_supported(&payload)?;
         ensure_core_runtime_request_node_supported(&state, &payload)?;
-        let runtime = TmuxRuntime::from_app_config(&state.config);
-        state
-            .session_store
-            .create_core_session_with_runtime(payload, log_dir, &runtime)
-            .map_err(core_session_create_api_error)?
+        create_runtime_core_session(state.clone(), payload, log_dir).await?
     } else {
         state.session_store.create_core_session(payload, log_dir)?
     };
@@ -3643,11 +3639,7 @@ async fn spawn_session(
     let child = if state.config.rust_core.runtime_enabled {
         ensure_core_runtime_provider_supported(&create_payload)?;
         ensure_core_runtime_request_node_supported(&state, &create_payload)?;
-        let runtime = TmuxRuntime::from_app_config(&state.config);
-        state
-            .session_store
-            .create_core_session_with_runtime(create_payload, log_dir, &runtime)
-            .map_err(core_session_create_api_error)?
+        create_runtime_core_session(state.clone(), create_payload, log_dir).await?
     } else {
         state
             .session_store
@@ -3669,6 +3661,27 @@ async fn spawn_session(
     Ok(Json(serde_json::to_value(SpawnSessionResponse::from(
         child,
     ))?))
+}
+
+/// Runtime creation includes tmux and provider polling. Keep it off Axum's
+/// async workers; its launch record is made durable before those waits begin.
+async fn create_runtime_core_session(
+    state: Arc<AppState>,
+    payload: CreateCoreSessionRequest,
+    log_dir: Option<PathBuf>,
+) -> Result<SessionRecord, ApiError> {
+    let runtime = TmuxRuntime::from_app_config(&state.config);
+    let store = state.session_store.clone();
+    tokio::task::spawn_blocking(move || {
+        store.create_core_session_with_runtime(payload, log_dir, &runtime)
+    })
+    .await
+    .map_err(|error| {
+        ApiError::Internal(anyhow::anyhow!(
+            "runtime session creation worker failed: {error}"
+        ))
+    })?
+    .map_err(core_session_create_api_error)
 }
 
 async fn start_session_review(

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -110,7 +110,7 @@ use crate::queue::{
     QueueJobRecord, QueueMessageMetadata, RetainedQueueStore, RetryCodexReviewRequest,
     ScheduledReminder,
 };
-use crate::runtime::{CodexModelValidationError, TmuxRuntime};
+use crate::runtime::{CodexModelValidationError, InitialBriefDeliveryError, TmuxRuntime};
 #[cfg(test)]
 use crate::sessions::codex_fork_legacy_event_stream_path_from_log_file;
 use crate::sessions::{
@@ -12165,6 +12165,17 @@ fn core_session_create_api_error(error: anyhow::Error) -> ApiError {
         return ApiError::Status {
             status,
             detail: validation.to_string(),
+        };
+    }
+    if error
+        .chain()
+        .any(|cause| cause.downcast_ref::<InitialBriefDeliveryError>().is_some())
+    {
+        return ApiError::Status {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            detail: format!(
+                "{error}. The immutable accepted brief and its launch record were retained; retry only after confirming provider state."
+            ),
         };
     }
     error.into()

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -23,6 +23,8 @@ const DEFAULT_SEND_KEYS_SETTLE_PER_KI_MS: f64 = 60.0;
 const DEFAULT_SEND_KEYS_SETTLE_PER_EXTRA_LINE_MS: f64 = 15.0;
 const DEFAULT_SEND_KEYS_MAX_CHUNK_CHARS: usize = 4096;
 const CODEX_MODEL_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(5);
+const DEFAULT_INITIAL_BRIEF_READY_TIMEOUT: Duration = Duration::from_secs(10);
+const DEFAULT_INITIAL_BRIEF_ACK_TIMEOUT: Duration = Duration::from_secs(30);
 static SESSION_INPUT_LOCKS: OnceLock<Mutex<HashMap<String, Weak<SessionInputLock>>>> =
     OnceLock::new();
 
@@ -65,6 +67,8 @@ pub struct TmuxRuntime {
     tmux_history_limit: Option<u64>,
     prompt_mode: String,
     start_settle_ms: u64,
+    initial_brief_ready_timeout: Duration,
+    initial_brief_ack_timeout: Duration,
     send_keys_settle_ms: f64,
     send_keys_settle_max_ms: f64,
     send_keys_settle_per_ki_ms: f64,
@@ -111,6 +115,41 @@ pub enum CodexModelValidationError {
     },
     DiscoveryUnavailable(String),
 }
+
+/// A spawn brief reached the runtime but could not be proved accepted by its
+/// provider. The immutable artifact remains recorded for recovery.
+#[derive(Debug)]
+pub enum InitialBriefDeliveryError {
+    ProviderAcknowledgementUnavailable { provider: String },
+    ProviderReadinessTimedOut { provider: String },
+    ProviderAcceptanceTimedOut { provider: String },
+    SessionExited { provider: String },
+}
+
+impl std::fmt::Display for InitialBriefDeliveryError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ProviderAcknowledgementUnavailable { provider } => write!(
+                formatter,
+                "initial spawn brief delivery is unverified for {provider}: this provider has no equivalent provider-originated acknowledgement"
+            ),
+            Self::ProviderReadinessTimedOut { provider } => write!(
+                formatter,
+                "timed out waiting for {provider} to become ready for the initial spawn brief"
+            ),
+            Self::ProviderAcceptanceTimedOut { provider } => write!(
+                formatter,
+                "timed out waiting for {provider} to acknowledge the initial spawn brief; it was not resent to avoid duplicate work"
+            ),
+            Self::SessionExited { provider } => write!(
+                formatter,
+                "{provider} exited before the initial spawn brief could be delivered"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for InitialBriefDeliveryError {}
 
 impl std::fmt::Display for CodexModelValidationError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -178,6 +217,14 @@ impl TmuxRuntime {
                 .unwrap_or("argv")
                 .to_owned(),
             start_settle_ms: config.runtime_start_settle_ms.unwrap_or(300),
+            initial_brief_ready_timeout: config
+                .runtime_initial_brief_ready_timeout_ms
+                .map(Duration::from_millis)
+                .unwrap_or(DEFAULT_INITIAL_BRIEF_READY_TIMEOUT),
+            initial_brief_ack_timeout: config
+                .runtime_initial_brief_ack_timeout_ms
+                .map(Duration::from_millis)
+                .unwrap_or(DEFAULT_INITIAL_BRIEF_ACK_TIMEOUT),
             send_keys_settle_ms: finite_nonnegative_or_default(
                 config.send_keys_settle_ms,
                 DEFAULT_SEND_KEYS_SETTLE_MS,
@@ -1228,19 +1275,123 @@ impl TmuxRuntime {
         }
 
         if let Some(initial_message) = initial_stdin_prompt {
-            thread::sleep(Duration::from_millis(self.start_settle_ms));
-            match self.send_input(&spec.tmux_session, initial_message) {
-                Ok(true) => {}
-                Ok(false) => {
-                    bail!("tmux session exited before initial prompt could be delivered");
+            if spec.force_initial_prompt_stdin {
+                self.deliver_verified_initial_brief(spec, initial_message)?;
+            } else {
+                thread::sleep(Duration::from_millis(self.start_settle_ms));
+                match self.send_input(&spec.tmux_session, initial_message) {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        bail!("tmux session exited before initial prompt could be delivered");
+                    }
+                    Err(error) if is_tmux_session_gone_error(&error) => {
+                        bail!("tmux session exited before initial prompt could be delivered");
+                    }
+                    Err(error) => return Err(error),
                 }
-                Err(error) if is_tmux_session_gone_error(&error) => {
-                    bail!("tmux session exited before initial prompt could be delivered");
-                }
-                Err(error) => return Err(error),
             }
         }
         Ok(())
+    }
+
+    /// Deliver an immutable spawn brief only after the provider exposes a
+    /// usable composer, and only report success after provider-side evidence.
+    ///
+    /// This deliberately does not retry after submission: a missing event can
+    /// mean the first submission was accepted, so another paste could run the
+    /// brief twice.
+    fn deliver_verified_initial_brief(&self, spec: &TmuxSessionSpec, prompt: &str) -> Result<()> {
+        let _guard = self.lock_session_input(&spec.tmux_session)?;
+        self.wait_for_initial_brief_readiness(&spec.tmux_session, &spec.provider)?;
+
+        if spec.provider != "codex-fork" {
+            return Err(
+                InitialBriefDeliveryError::ProviderAcknowledgementUnavailable {
+                    provider: spec.provider.clone(),
+                }
+                .into(),
+            );
+        }
+
+        let artifacts = self
+            .codex_fork_runtime_artifacts(spec)?
+            .expect("codex-fork must have runtime artifacts");
+        let initial_event_offset = fs::metadata(&artifacts.event_stream_path)
+            .map(|metadata| metadata.len())
+            .unwrap_or(0);
+        if !self.session_exists(&spec.tmux_session)? {
+            return Err(InitialBriefDeliveryError::SessionExited {
+                provider: spec.provider.clone(),
+            }
+            .into());
+        }
+        self.send_text_then_enter(&spec.tmux_session, prompt)?;
+        self.wait_for_codex_fork_initial_brief_acceptance(
+            &spec.tmux_session,
+            &artifacts.event_stream_path,
+            initial_event_offset,
+            prompt,
+        )
+    }
+
+    fn wait_for_initial_brief_readiness(&self, tmux_session: &str, provider: &str) -> Result<()> {
+        let deadline = Instant::now() + self.initial_brief_ready_timeout;
+        let mut directory_trust_accepted = false;
+        loop {
+            if !self.session_exists(tmux_session)? {
+                return Err(InitialBriefDeliveryError::SessionExited {
+                    provider: provider.to_owned(),
+                }
+                .into());
+            }
+            if !directory_trust_accepted && matches!(provider, "codex" | "codex-fork") {
+                if self
+                    .capture_pane_text(tmux_session)
+                    .is_some_and(|pane| is_codex_directory_trust_prompt(&pane))
+                {
+                    self.send_key(tmux_session, "Enter")?;
+                    directory_trust_accepted = true;
+                }
+            }
+            if self.session_input_ready(tmux_session, provider) {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err(InitialBriefDeliveryError::ProviderReadinessTimedOut {
+                    provider: provider.to_owned(),
+                }
+                .into());
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    fn wait_for_codex_fork_initial_brief_acceptance(
+        &self,
+        tmux_session: &str,
+        event_stream_path: &Path,
+        initial_event_offset: u64,
+        prompt: &str,
+    ) -> Result<()> {
+        let deadline = Instant::now() + self.initial_brief_ack_timeout;
+        loop {
+            if codex_event_stream_has_user_turn(event_stream_path, initial_event_offset, prompt) {
+                return Ok(());
+            }
+            if !self.session_exists(tmux_session)? {
+                return Err(InitialBriefDeliveryError::SessionExited {
+                    provider: "codex-fork".to_owned(),
+                }
+                .into());
+            }
+            if Instant::now() >= deadline {
+                return Err(InitialBriefDeliveryError::ProviderAcceptanceTimedOut {
+                    provider: "codex-fork".to_owned(),
+                }
+                .into());
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
     }
 
     fn compute_settle_delay(&self, text: &str) -> Duration {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -4058,17 +4058,44 @@ impl SessionStore {
         }
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
-        record.status = "running".to_owned();
-        record.stopped_at = None;
-        record.last_activity = now_rfc3339();
         let sessions = ensure_sessions_array_mut(&mut state)?;
         let Some(session) = sessions
             .iter_mut()
             .find(|session| session.get("id").and_then(Value::as_str) == Some(record.id.as_str()))
         else {
+            let _ = runtime.kill_session(&record.tmux_session);
+            mark_runtime_launch_failed(
+                &mut state,
+                &launch_id,
+                &record.id,
+                false,
+                "provisional runtime session disappeared while waiting for provider startup",
+            )?;
+            self.write_raw_json_value(&state)?;
             anyhow::bail!("provisional runtime session {} disappeared", record.id);
         };
-        *session = serde_json::to_value(&record)?;
+        if completion_status_is_retired(json_text(session.get("completion_status")).as_deref()) {
+            let _ = runtime.kill_session(&record.tmux_session);
+            mark_runtime_launch_failed(
+                &mut state,
+                &launch_id,
+                &record.id,
+                false,
+                "session was retired while waiting for provider startup",
+            )?;
+            self.write_raw_json_value(&state)?;
+            anyhow::bail!(
+                "session {} was retired while waiting for provider startup",
+                record.id
+            );
+        }
+        let mut current_record = serde_json::from_value::<SessionRecord>(session.clone())?;
+        current_record.provider_resume_id = record.provider_resume_id.clone();
+        current_record.status = "running".to_owned();
+        current_record.stopped_at = None;
+        current_record.last_activity = now_rfc3339();
+        *session = serde_json::to_value(&current_record)?;
+        record = current_record;
         mark_runtime_launch_applied(&mut state, &launch_id, record.provider_resume_id.as_deref())?;
         if let Err(error) = self.write_raw_json_value(&state) {
             let _ = runtime.kill_session(&record.tmux_session);

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -3978,8 +3978,14 @@ impl SessionStore {
         }
         store_session_runtime_launch_records(&mut state, &launch_records)?;
         self.write_raw_json_value(&state)?;
+        // Runtime startup and provider acknowledgement can wait for tens of
+        // seconds. The launch record is durable now, so never retain the
+        // global state mutex while waiting for external provider progress.
+        drop(_guard);
 
         if let Err(error) = runtime.create_session(&spec) {
+            let _guard = self.write_guard()?;
+            let mut state = self.load_raw_json_value()?;
             let error_message = error.to_string();
             let recovery_detail = request.spawn_brief.as_ref().and_then(|brief| {
                 state
@@ -4031,6 +4037,8 @@ impl SessionStore {
                 }
                 Err(error) => {
                     let _ = runtime.kill_session(&record.tmux_session);
+                    let _guard = self.write_guard()?;
+                    let mut state = self.load_raw_json_value()?;
                     mark_runtime_launch_failed(
                         &mut state,
                         &launch_id,
@@ -4048,6 +4056,8 @@ impl SessionStore {
                 }
             }
         }
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
         record.status = "running".to_owned();
         record.stopped_at = None;
         record.last_activity = now_rfc3339();

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -3980,15 +3980,35 @@ impl SessionStore {
         self.write_raw_json_value(&state)?;
 
         if let Err(error) = runtime.create_session(&spec) {
-            mark_runtime_launch_failed(
-                &mut state,
-                &launch_id,
-                &record.id,
-                true,
-                &error.to_string(),
-            )?;
+            let error_message = error.to_string();
+            let recovery_detail = request.spawn_brief.as_ref().and_then(|brief| {
+                state
+                    .get("spawn_launch_intents")
+                    .and_then(Value::as_array)
+                    .and_then(|intents| {
+                        intents.iter().find(|intent| {
+                            intent.get("id").and_then(Value::as_str) == Some(brief.intent_id.as_str())
+                        })
+                    })
+                    .and_then(|intent| intent.get("artifact"))
+                    .and_then(|artifact| {
+                        let path = artifact.get("path").and_then(Value::as_str)?;
+                        let sha256 = artifact.get("sha256").and_then(Value::as_str)?;
+                        Some(format!(
+                            "accepted brief retained at {path} (sha256 {sha256}); inspect provider state before manually recovering it"
+                        ))
+                    })
+            });
+            let failure_reason = recovery_detail
+                .as_deref()
+                .map(|detail| format!("{error_message}; {detail}"))
+                .unwrap_or_else(|| error_message.clone());
+            mark_runtime_launch_failed(&mut state, &launch_id, &record.id, true, &failure_reason)?;
             self.write_raw_json_value(&state)?;
-            return Err(error);
+            return Err(match recovery_detail {
+                Some(detail) => error.context(format!("{error_message}; {detail}")),
+                None => error,
+            });
         }
         if let Some((excluded_ids, launched_at_ns)) = codex_cli_creation_binding.as_ref() {
             record.provider_resume_id = wait_for_codex_cli_provider_resume_id(

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -4009,7 +4009,15 @@ impl SessionStore {
                 .as_deref()
                 .map(|detail| format!("{error_message}; {detail}"))
                 .unwrap_or_else(|| error_message.clone());
-            mark_runtime_launch_failed(&mut state, &launch_id, &record.id, true, &failure_reason)?;
+            let remove_provisional_session =
+                remove_failed_provisional_runtime_session(&state, &record.id);
+            mark_runtime_launch_failed(
+                &mut state,
+                &launch_id,
+                &record.id,
+                remove_provisional_session,
+                &failure_reason,
+            )?;
             self.write_raw_json_value(&state)?;
             return Err(match recovery_detail {
                 Some(detail) => error.context(format!("{error_message}; {detail}")),
@@ -4039,11 +4047,13 @@ impl SessionStore {
                     let _ = runtime.kill_session(&record.tmux_session);
                     let _guard = self.write_guard()?;
                     let mut state = self.load_raw_json_value()?;
+                    let remove_provisional_session =
+                        remove_failed_provisional_runtime_session(&state, &record.id);
                     mark_runtime_launch_failed(
                         &mut state,
                         &launch_id,
                         &record.id,
-                        true,
+                        remove_provisional_session,
                         &error.to_string(),
                     )?;
                     self.write_raw_json_value(&state)?;
@@ -13057,6 +13067,20 @@ fn mark_runtime_launch_applied(
     Ok(())
 }
 
+fn remove_failed_provisional_runtime_session(state: &Value, session_id: &str) -> bool {
+    !state
+        .get("sessions")
+        .and_then(Value::as_array)
+        .and_then(|sessions| {
+            sessions
+                .iter()
+                .find(|session| session.get("id").and_then(Value::as_str) == Some(session_id))
+        })
+        .is_some_and(|session| {
+            completion_status_is_retired(json_text(session.get("completion_status")).as_deref())
+        })
+}
+
 fn mark_runtime_launch_failed(
     state: &mut Value,
     launch_id: &str,
@@ -14931,6 +14955,54 @@ mod tests {
         .unwrap();
 
         assert!(request.spawn_brief.is_none());
+    }
+
+    #[test]
+    fn failed_create_launch_preserves_a_concurrently_retired_session() {
+        let mut retired = reparent_test_session("retired01", None, "secret");
+        let retired = retired.as_object_mut().unwrap();
+        retired.insert("status".to_owned(), Value::String("stopped".to_owned()));
+        retired.insert(
+            "completion_status".to_owned(),
+            Value::String("retired".to_owned()),
+        );
+        retired.insert(
+            "stopped_at".to_owned(),
+            Value::String("2026-06-01T00:02:00Z".to_owned()),
+        );
+        let mut state = json!({
+            "sessions": [retired],
+            "session_runtime_launches": [{
+                "id": "launch01",
+                "operation_kind": "create",
+                "session_id": "retired01",
+                "tmux_session": "claude-retired01",
+                "working_dir": "/repo",
+                "log_file": "/tmp/retired01.log",
+                "provider": "codex-fork",
+                "credential_sha256": sha256_text("secret"),
+                "status": "launching",
+                "created_at": "2026-06-01T00:00:00Z",
+                "updated_at": "2026-06-01T00:00:00Z"
+            }]
+        });
+
+        assert!(!remove_failed_provisional_runtime_session(
+            &state,
+            "retired01"
+        ));
+        mark_runtime_launch_failed(
+            &mut state,
+            "launch01",
+            "retired01",
+            false,
+            "runtime exited during startup",
+        )
+        .unwrap();
+
+        assert_eq!(state["sessions"].as_array().unwrap().len(), 1);
+        assert_eq!(state["sessions"][0]["completion_status"], "retired");
+        assert_eq!(state["session_runtime_launches"][0]["status"], "failed");
     }
 
     static TEST_ENV_LOCK: Mutex<()> = Mutex::new(());

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -14685,7 +14685,14 @@ async fn runtime_core_spawn_endpoint_uses_tmux_and_parent_fields() {
             .as_nanos()
     );
     let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
-    let app = runtime_app(&state_file, &log_dir, &tmux_socket);
+    let app = runtime_app_with_codex_fork_initial_brief_provider(
+        &state_file,
+        &log_dir,
+        &tmux_socket,
+        true,
+        Duration::from_millis(200),
+        true,
+    );
 
     let (status, parent_payload) = post_json(
         app.clone(),
@@ -14718,33 +14725,28 @@ async fn runtime_core_spawn_endpoint_uses_tmux_and_parent_fields() {
             "name": "runtime-child",
             "model": "opus",
             "reasoning_effort": "xhigh",
+            "provider": "codex-fork",
             "wait": 5
         }),
     )
     .await;
 
-    assert_eq!(status, StatusCode::OK);
+    assert_eq!(status, StatusCode::OK, "{payload}");
     assert_eq!(payload["session_id"], "runtimechild");
     assert_eq!(payload["friendly_name"], "runtime-child");
     assert_eq!(payload["parent_session_id"], "runtimeparent");
     assert_eq!(payload["working_dir"], parent_dir.display().to_string());
     assert_eq!(payload["node"], "primary");
-    assert_eq!(payload["provider"], "claude");
+    assert_eq!(payload["provider"], "codex-fork");
     assert_eq!(payload["model"], "opus");
     assert_eq!(payload["reasoning_effort"], "xhigh");
     let tmux_session = payload["tmux_session"].as_str().unwrap().to_owned();
-    assert!(tmux_session.starts_with("sm-rust-claude-runtimechild-"));
+    assert!(tmux_session.starts_with("sm-rust-codex-fork-runtimechild-"));
 
     wait_for_output_contains(
         app.clone(),
         "runtimechild",
-        "runtime:spawn endpoint runtime prompt",
-    )
-    .await;
-    wait_for_output_contains(
-        app.clone(),
-        "runtimechild",
-        "argv:--model opus --effort xhigh",
+        "received:spawn endpoint runtime prompt",
     )
     .await;
 
@@ -14803,6 +14805,201 @@ async fn runtime_core_spawn_endpoint_uses_tmux_and_parent_fields() {
 }
 
 #[tokio::test]
+async fn runtime_core_spawn_brief_accepts_file_and_stdin_sources_after_delayed_composer_ready() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let working_dir = unique_temp_path();
+    fs::create_dir_all(&working_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-test-spawn-brief-sources-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app_with_codex_fork_initial_brief_provider(
+        &state_file,
+        &log_dir,
+        &tmux_socket,
+        false,
+        Duration::from_millis(200),
+        true,
+    );
+
+    for (id, prompt, source) in [
+        (
+            "brieffile",
+            "FILE_BRIEF_SENTINEL",
+            json!({"kind": "file", "path": "/tmp/brief.md"}),
+        ),
+        (
+            "briefstdin",
+            "STDIN_BRIEF_SENTINEL",
+            json!({"kind": "stdin"}),
+        ),
+    ] {
+        let (status, payload) = post_json(
+            app.clone(),
+            "/sessions",
+            json!({
+                "id": id,
+                "name": id,
+                "working_dir": working_dir.display().to_string(),
+                "provider": "codex-fork",
+                "initial_message": prompt,
+                "spawn_prompt_source": source
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{payload}");
+        wait_for_output_contains(app.clone(), id, &format!("received:{prompt}")).await;
+    }
+
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let intents = state["spawn_launch_intents"].as_array().unwrap();
+    assert_eq!(intents.len(), 2);
+    for (intent, source) in intents.iter().zip(["file", "stdin"]) {
+        assert_eq!(intent["artifact"]["source"]["kind"], source);
+        assert!(intent["session_id"].is_string());
+        assert!(fs::metadata(intent["artifact"]["path"].as_str().unwrap()).is_ok());
+    }
+}
+
+#[tokio::test]
+async fn runtime_core_spawn_brief_ack_timeout_is_recoverable_and_never_retries() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let working_dir = unique_temp_path();
+    fs::create_dir_all(&working_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-test-spawn-brief-timeout-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app_with_codex_fork_initial_brief_provider(
+        &state_file,
+        &log_dir,
+        &tmux_socket,
+        false,
+        Duration::ZERO,
+        false,
+    );
+
+    let (status, payload) = post_json(
+        app,
+        "/sessions",
+        json!({
+            "id": "briefnoack",
+            "name": "brief-no-ack",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "codex-fork",
+            "initial_message": "ACK_TIMEOUT_SENTINEL",
+            "spawn_prompt_source": {"kind": "stdin"}
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    let detail = payload["detail"].as_str().unwrap();
+    assert!(
+        detail.contains("not resent to avoid duplicate work"),
+        "{detail}"
+    );
+    assert!(detail.contains("accepted brief retained at"), "{detail}");
+
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    assert!(state["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|session| session["id"] != "briefnoack"));
+    let intent = &state["spawn_launch_intents"][0];
+    assert_eq!(
+        fs::read_to_string(intent["artifact"]["path"].as_str().unwrap()).unwrap(),
+        "ACK_TIMEOUT_SENTINEL"
+    );
+    let launch = &state["session_runtime_launches"][0];
+    assert_eq!(launch["status"], "failed");
+    assert!(launch["failure_reason"]
+        .as_str()
+        .unwrap()
+        .contains("accepted brief retained at"));
+    let logs = fs::read_to_string(
+        state["session_runtime_launches"][0]["log_file"]
+            .as_str()
+            .unwrap(),
+    )
+    .unwrap_or_default();
+    assert_eq!(
+        logs.matches("received:ACK_TIMEOUT_SENTINEL").count(),
+        1,
+        "{logs}"
+    );
+}
+
+#[tokio::test]
+async fn runtime_core_spawn_brief_fails_closed_when_provider_has_no_acknowledgement() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let working_dir = unique_temp_path();
+    fs::create_dir_all(&working_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-test-spawn-brief-unverified-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let app = runtime_app_with_command(
+        &state_file,
+        &log_dir,
+        &tmux_socket,
+        r#"/bin/sh -lc 'printf ">\n"; while IFS= read -r line; do printf "received:%s\n>\n" "$line"; done' runtime-sh"#,
+    );
+
+    let (status, payload) = post_json(
+        app,
+        "/sessions",
+        json!({
+            "id": "briefunverified",
+            "name": "brief-unverified",
+            "working_dir": working_dir.display().to_string(),
+            "provider": "claude",
+            "initial_message": "UNVERIFIED_SENTINEL",
+            "spawn_prompt_source": {"kind": "positional"}
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE, "{payload}");
+    assert!(payload["detail"]
+        .as_str()
+        .unwrap()
+        .contains("no equivalent provider-originated acknowledgement"));
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let launch = &state["session_runtime_launches"][0];
+    assert_eq!(launch["status"], "failed");
+    assert!(!fs::read_to_string(launch["log_file"].as_str().unwrap())
+        .unwrap_or_default()
+        .contains("UNVERIFIED_SENTINEL"));
+}
+
+#[tokio::test]
 async fn runtime_core_spawn_wait_detects_naturally_exited_tmux_child() {
     if !tmux_available() {
         return;
@@ -14820,11 +15017,13 @@ async fn runtime_core_spawn_wait_detects_naturally_exited_tmux_child() {
             .as_nanos()
     );
     let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
-    let app = runtime_app_with_command(
+    let app = runtime_app_with_codex_fork_initial_brief_provider(
         &state_file,
         &log_dir,
         &tmux_socket,
-        r#"/bin/sh -lc 'while IFS= read -r line; do printf "runtime:%s\n" "$line"; case "$line" in natural-child-prompt) exit 0;; esac; done' runtime-sh"#,
+        false,
+        Duration::ZERO,
+        true,
     );
 
     let (status, parent_payload) = post_json(
@@ -14851,6 +15050,7 @@ async fn runtime_core_spawn_wait_detects_naturally_exited_tmux_child() {
             "parent_session_id": "naturalparent",
             "prompt": "natural-child-prompt",
             "name": "natural-child",
+            "provider": "codex-fork",
             "wait": 10
         }),
     )
@@ -14891,11 +15091,13 @@ async fn runtime_core_spawn_wait_uses_runtime_output_as_activity() {
             .as_nanos()
     );
     let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
-    let app = runtime_app_with_command(
+    let app = runtime_app_with_codex_fork_initial_brief_provider(
         &state_file,
         &log_dir,
         &tmux_socket,
-        r#"/bin/sh -lc 'while IFS= read -r line; do case "$line" in active-child-prompt) for i in 1 2 3 4 5 6 7 8; do printf "runtime:heartbeat-%s\n" "$i"; sleep 0.2; done; exit 0;; *) printf "runtime:%s\n" "$line";; esac; done' runtime-sh"#,
+        false,
+        Duration::ZERO,
+        true,
     );
 
     let (status, parent_payload) = post_json(
@@ -14922,6 +15124,7 @@ async fn runtime_core_spawn_wait_uses_runtime_output_as_activity() {
             "parent_session_id": "activeparent",
             "prompt": "active-child-prompt",
             "name": "active-child",
+            "provider": "codex-fork",
             "wait": 1
         }),
     )
@@ -19389,6 +19592,82 @@ fn runtime_app(state_file: &PathBuf, log_dir: &PathBuf, tmux_socket: &str) -> ax
         tmux_socket,
         r#"/bin/sh -lc 'while IFS= read -r line; do printf "argv:%s\nids:%s:%s:%s\nruntime:%s\n" "$*" "$SESSION_MANAGER_ID" "$CLAUDE_SESSION_MANAGER_ID" "$ENABLE_TOOL_SEARCH" "$line"; done' runtime-sh"#,
     )
+}
+
+fn runtime_app_with_codex_fork_initial_brief_provider(
+    state_file: &PathBuf,
+    log_dir: &PathBuf,
+    tmux_socket: &str,
+    directory_trust: bool,
+    composer_delay: Duration,
+    acknowledge: bool,
+) -> axum::Router {
+    fs::create_dir_all(log_dir).unwrap();
+    let provider = log_dir.join("fake-codex-fork-initial-brief");
+    let trust = if directory_trust {
+        "printf 'Do you trust the contents of this directory?\\nYes, continue\\nNo, quit\\nPress enter to continue\\n'; IFS= read -r ignored;\n"
+    } else {
+        ""
+    };
+    let delay = if composer_delay.is_zero() {
+        "".to_owned()
+    } else {
+        format!("sleep {}\n", composer_delay.as_secs_f64())
+    };
+    let acknowledgement = if acknowledge {
+        r#"printf '{"event_type":"op_submitted","payload":{"UserTurn":{"items":[{"type":"text","text":"%s"}]}}}\n' "$line" >> "$event_stream"
+"#
+    } else {
+        ""
+    };
+    let script = [
+        "#!/bin/sh\nif [ \"$1\" = \"debug\" ] && [ \"$2\" = \"models\" ]; then printf '{\"models\":[{\"slug\":\"opus\",\"visibility\":\"list\"}]}' ; exit 0; fi\nevent_stream=''\nprevious=''\nfor arg in \"$@\"; do\n  if [ \"$previous\" = \"--event-stream\" ]; then event_stream=\"$arg\"; fi\n  previous=\"$arg\"\ndone\nprintf '{\"event_type\":\"thread/started\",\"payload\":{\"thread\":{\"id\":\"initial-brief-thread\"}}}\n' >> \"$event_stream\"\n",
+        trust,
+        delay.as_str(),
+        "printf '› '\nwhile IFS= read -r line; do\n  printf 'received:%s\\n' \"$line\"\n",
+        acknowledgement,
+        "  case \"$line\" in\n    natural-child-prompt) exit 0 ;;\n    active-child-prompt) for i in 1 2 3 4 5 6 7 8; do printf 'runtime:heartbeat-%s\\n' \"$i\"; sleep 0.2; done; exit 0 ;;\n  esac\n  printf '› '\ndone\n",
+    ]
+    .concat();
+    fs::write(&provider, script).unwrap();
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&provider).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&provider, permissions).unwrap();
+    }
+    let runtime_command = r#"/bin/sh -lc 'while IFS= read -r line; do printf "runtime:%s\n" "$line"; done' runtime-sh"#;
+    router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        sm_send: SmSendConfig {
+            db_path: queue_db_path_for_state_file(state_file)
+                .display()
+                .to_string(),
+        },
+        codex_fork: CodexForkLaunchConfig {
+            command: provider.display().to_string(),
+            args: Vec::new(),
+            default_model: None,
+            event_schema_version: 2,
+            control_tmux_fallback_enabled: true,
+        },
+        rust_core: RustCoreConfig {
+            runtime_enabled: true,
+            log_dir: Some(log_dir.display().to_string()),
+            tmux_socket_name: Some(tmux_socket.to_owned()),
+            runtime_command: Some(runtime_command.to_owned()),
+            runtime_prompt_mode: Some("stdin".to_owned()),
+            runtime_initial_brief_ready_timeout_ms: Some(2_000),
+            runtime_initial_brief_ack_timeout_ms: Some(300),
+            send_keys_settle_ms: Some(10.0),
+            send_keys_settle_max_ms: Some(50.0),
+            send_keys_max_chunk_chars: Some(128),
+            ..RustCoreConfig::default()
+        },
+        ..AppConfig::default()
+    }))
 }
 
 fn runtime_app_with_codex_composer(


### PR DESCRIPTION
## Summary

- wait for provider composer readiness under the input lock before submitting accepted spawn briefs
- require a matching codex-fork `UserTurn` acknowledgement; never retry an ambiguous submission
- preserve brief artifacts and launch records with an actionable recoverable failure; fail closed for providers without equivalent acknowledgement

## Test Plan

- [x] `cargo fmt --check`
- [x] `cargo check -p sm-server`
- [x] `cargo test -p sm-server --test read_only_http runtime_core_spawn -- --nocapture`
- [x] `cargo test -p sm-server` — exercised; blocked only by pre-existing `codex_review_request_watcher_delivers_sequential_wake_to_runtime_session` returning 502. Reproduced unchanged on `main`; tracked by #1189 and #1261.

Fixes #1272