### PR TITLE
Fix Codex spawn brief acknowledgement schema

### DIFF
--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -1450,15 +1450,8 @@ fn codex_event_stream_has_user_turn(path: &Path, initial_offset: u64, prompt: &s
         let legacy_user_turn_matches = event
             .get("payload")
             .and_then(|payload| payload.get("UserTurn"))
-            .and_then(|turn| turn.get("items"))
-            .and_then(Value::as_array)
-            .is_some_and(|items| {
-                items.iter().any(|item| {
-                    item.get("text")
-                        .and_then(Value::as_str)
-                        .is_some_and(|text| codex_brief_text_matches(text, prompt))
-                })
-            });
+            .and_then(codex_user_turn_text)
+            .is_some_and(|text| codex_brief_text_matches(&text, prompt));
         let schema_v2_user_message_matches = event.get("schema_version").and_then(Value::as_u64)
             == Some(2)
             && event.get("event_type").and_then(Value::as_str) == Some("item/started")
@@ -1493,15 +1486,27 @@ fn codex_brief_text_matches(provider_text: &str, submitted_brief: &str) -> bool 
 fn codex_user_message_text(content: &Value) -> Option<String> {
     match content {
         Value::String(text) => Some(text.clone()),
-        Value::Array(parts) => parts.iter().try_fold(String::new(), |mut text, part| {
-            if part.get("type").and_then(Value::as_str) != Some("text") {
-                return None;
-            }
-            text.push_str(part.get("text").and_then(Value::as_str)?);
-            Some(text)
-        }),
+        Value::Array(parts) => codex_text_parts(parts),
         _ => None,
     }
+}
+
+/// Return the complete text represented by a retained legacy `UserTurn`.
+fn codex_user_turn_text(turn: &Value) -> Option<String> {
+    turn.get("items")
+        .and_then(Value::as_array)
+        .and_then(|parts| codex_text_parts(parts))
+}
+
+/// Normalize text-only event parts without accepting a matching fragment.
+fn codex_text_parts(parts: &[Value]) -> Option<String> {
+    parts.iter().try_fold(String::new(), |mut text, part| {
+        if part.get("type").and_then(Value::as_str) != Some("text") {
+            return None;
+        }
+        text.push_str(part.get("text").and_then(Value::as_str)?);
+        Some(text)
+    })
 }
 
 fn split_send_text_chunks(text: &str, max_chunk_chars: usize) -> Vec<&str> {
@@ -2666,6 +2671,14 @@ esac
             "handoff prompt",
             "handoff prompt \n"
         ));
+        let fragmented_legacy_turn = serde_json::json!({
+            "items": [
+                {"type": "text", "text": "handoff prompt"},
+                {"type": "text", "text": " unexpected suffix"}
+            ]
+        });
+        assert!(!codex_user_turn_text(&fragmented_legacy_turn)
+            .is_some_and(|text| codex_brief_text_matches(&text, "handoff prompt\n")));
 
         let (_tmux_binary, _log_path, temp_dir) = fake_tmux_binary();
         let legacy_events = temp_dir.join("legacy-events.jsonl");

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -1453,20 +1453,35 @@ fn codex_event_stream_has_user_turn(path: &Path, initial_offset: u64, prompt: &s
             .and_then(|turn| turn.get("items"))
             .and_then(Value::as_array)
             .is_some_and(|items| {
-                items
-                    .iter()
-                    .any(|item| item.get("text").and_then(Value::as_str) == Some(prompt))
+                items.iter().any(|item| {
+                    item.get("text")
+                        .and_then(Value::as_str)
+                        .is_some_and(|text| codex_brief_text_matches(text, prompt))
+                })
             });
-        let schema_v2_user_message_matches = event.get("event_type").and_then(Value::as_str)
-            == Some("item/started")
+        let schema_v2_user_message_matches = event.get("schema_version").and_then(Value::as_u64)
+            == Some(2)
+            && event.get("event_type").and_then(Value::as_str) == Some("item/started")
             && event.pointer("/payload/item/type").and_then(Value::as_str) == Some("userMessage")
             && event
                 .pointer("/payload/item/content")
                 .and_then(codex_user_message_text)
-                .is_some_and(|text| text == prompt);
+                .is_some_and(|text| codex_brief_text_matches(&text, prompt));
 
         legacy_user_turn_matches || schema_v2_user_message_matches
     })
+}
+
+/// Match a provider acknowledgement to the immutable submitted brief.
+///
+/// Codex currently normalizes one terminal line-feed out of initial prompts.
+/// Accept that one observed normalization and nothing broader: a provider value
+/// otherwise has to equal the entire submitted brief exactly.
+fn codex_brief_text_matches(provider_text: &str, submitted_brief: &str) -> bool {
+    provider_text == submitted_brief
+        || submitted_brief
+            .strip_suffix('\n')
+            .is_some_and(|without_terminal_newline| provider_text == without_terminal_newline)
 }
 
 /// Return the complete textual content of a schema-v2 `userMessage` item.
@@ -2638,11 +2653,69 @@ esac
     }
 
     #[test]
+    fn codex_prompt_confirmation_allows_only_one_terminal_newline_omission() {
+        assert!(codex_brief_text_matches(
+            "handoff prompt",
+            "handoff prompt\n"
+        ));
+        assert!(!codex_brief_text_matches(
+            "handoff prompt",
+            "handoff prompt\n\n"
+        ));
+        assert!(!codex_brief_text_matches(
+            "handoff prompt",
+            "handoff prompt \n"
+        ));
+
+        let (_tmux_binary, _log_path, temp_dir) = fake_tmux_binary();
+        let legacy_events = temp_dir.join("legacy-events.jsonl");
+        let legacy_prefix = r#"{"event_type":"op_submitted","payload":{"ListSkills":{}}}"#;
+        let legacy_acknowledgement = serde_json::json!({
+            "event_type": "op_submitted",
+            "payload": {"UserTurn": {"items": [{"type": "text", "text": "handoff prompt"}]}}
+        });
+        fs::write(
+            &legacy_events,
+            format!(
+                "{legacy_prefix}\n{}\n",
+                serde_json::to_string(&legacy_acknowledgement).unwrap()
+            ),
+        )
+        .unwrap();
+        assert!(codex_event_stream_has_user_turn(
+            &legacy_events,
+            legacy_prefix.len() as u64 + 1,
+            "handoff prompt\n"
+        ));
+
+        let schema_v2_events = temp_dir.join("schema-v2-events.jsonl");
+        let schema_v2_prefix = r#"{"schema_version":2,"event_type":"thread/started","payload":{}}"#;
+        let schema_v2_acknowledgement = serde_json::json!({
+            "schema_version": 2,
+            "event_type": "item/started",
+            "payload": {"item": {"type": "userMessage", "content": [{"type": "text", "text": "handoff prompt"}]}}
+        });
+        fs::write(
+            &schema_v2_events,
+            format!(
+                "{schema_v2_prefix}\n{}\n",
+                serde_json::to_string(&schema_v2_acknowledgement).unwrap()
+            ),
+        )
+        .unwrap();
+        assert!(codex_event_stream_has_user_turn(
+            &schema_v2_events,
+            schema_v2_prefix.len() as u64 + 1,
+            "handoff prompt\n"
+        ));
+    }
+
+    #[test]
     fn codex_prompt_confirmation_accepts_exact_schema_v2_large_user_message_after_offset() {
         let (_tmux_binary, _log_path, temp_dir) = fake_tmux_binary();
         let events = temp_dir.join("events.jsonl");
         let prompt = format!(
-            "# Large immutable brief\n\n{}\n\nfinal acceptance sentinel",
+            "# Large immutable brief\n\n{}\n\nfinal acceptance sentinel\n",
             "multiline evidence paragraph\n".repeat(512)
         );
         let pre_offset = serde_json::json!({
@@ -2661,11 +2734,19 @@ esac
             "event_type": "item/started",
             "payload": {"item": {"type": "userMessage", "content": [{"type": "text", "text": &prompt[..32]}]}}
         });
+        let unversioned_full_user_message = serde_json::json!({
+            "event_type": "item/started",
+            "payload": {"item": {"type": "userMessage", "content": [{"type": "text", "text": prompt.strip_suffix('\n').unwrap()}]}}
+        });
         let agent_echo_line = serde_json::to_string(&agent_echo).unwrap();
         let partial_user_message_line = serde_json::to_string(&partial_user_message).unwrap();
+        let unversioned_full_user_message_line =
+            serde_json::to_string(&unversioned_full_user_message).unwrap();
         fs::write(
             &events,
-            format!("{pre_offset_line}\n{agent_echo_line}\n{partial_user_message_line}\n",),
+            format!(
+                "{pre_offset_line}\n{agent_echo_line}\n{partial_user_message_line}\n{unversioned_full_user_message_line}\n",
+            ),
         )
         .unwrap();
         assert!(!codex_event_stream_has_user_turn(&events, offset, &prompt));
@@ -2673,13 +2754,13 @@ esac
         let exact_user_message = serde_json::json!({
             "schema_version": 2,
             "event_type": "item/started",
-            "payload": {"item": {"type": "userMessage", "content": [{"type": "text", "text": prompt}]}}
+            "payload": {"item": {"type": "userMessage", "content": [{"type": "text", "text": prompt.strip_suffix('\n').unwrap()}]}}
         });
         let exact_user_message_line = serde_json::to_string(&exact_user_message).unwrap();
         fs::write(
             &events,
             format!(
-                "{pre_offset_line}\n{agent_echo_line}\n{partial_user_message_line}\n{exact_user_message_line}\n"
+                "{pre_offset_line}\n{agent_echo_line}\n{partial_user_message_line}\n{unversioned_full_user_message_line}\n{exact_user_message_line}\n"
             ),
         )
         .unwrap();

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -1447,7 +1447,7 @@ fn codex_event_stream_has_user_turn(path: &Path, initial_offset: u64, prompt: &s
         let Ok(event) = serde_json::from_str::<Value>(line) else {
             return false;
         };
-        event
+        let legacy_user_turn_matches = event
             .get("payload")
             .and_then(|payload| payload.get("UserTurn"))
             .and_then(|turn| turn.get("items"))
@@ -1456,8 +1456,37 @@ fn codex_event_stream_has_user_turn(path: &Path, initial_offset: u64, prompt: &s
                 items
                     .iter()
                     .any(|item| item.get("text").and_then(Value::as_str) == Some(prompt))
-            })
+            });
+        let schema_v2_user_message_matches = event.get("event_type").and_then(Value::as_str)
+            == Some("item/started")
+            && event.pointer("/payload/item/type").and_then(Value::as_str) == Some("userMessage")
+            && event
+                .pointer("/payload/item/content")
+                .and_then(codex_user_message_text)
+                .is_some_and(|text| text == prompt);
+
+        legacy_user_turn_matches || schema_v2_user_message_matches
     })
+}
+
+/// Return the complete textual content of a schema-v2 `userMessage` item.
+///
+/// Acknowledgement is deliberately strict: every content part must be a text
+/// part, and their concatenation must equal the submitted brief. This prevents
+/// a matching substring, an agent message, or mixed content from confirming a
+/// different prompt.
+fn codex_user_message_text(content: &Value) -> Option<String> {
+    match content {
+        Value::String(text) => Some(text.clone()),
+        Value::Array(parts) => parts.iter().try_fold(String::new(), |mut text, part| {
+            if part.get("type").and_then(Value::as_str) != Some("text") {
+                return None;
+            }
+            text.push_str(part.get("text").and_then(Value::as_str)?);
+            Some(text)
+        }),
+        _ => None,
+    }
 }
 
 fn split_send_text_chunks(text: &str, max_chunk_chars: usize) -> Vec<&str> {
@@ -2606,6 +2635,56 @@ esac
             offset - 3,
             "handoff prompt"
         ));
+    }
+
+    #[test]
+    fn codex_prompt_confirmation_accepts_exact_schema_v2_large_user_message_after_offset() {
+        let (_tmux_binary, _log_path, temp_dir) = fake_tmux_binary();
+        let events = temp_dir.join("events.jsonl");
+        let prompt = format!(
+            "# Large immutable brief\n\n{}\n\nfinal acceptance sentinel",
+            "multiline evidence paragraph\n".repeat(512)
+        );
+        let pre_offset = serde_json::json!({
+            "event_type": "item/started",
+            "payload": {"item": {"type": "userMessage", "content": [{"type": "text", "text": prompt}]}}
+        });
+        let pre_offset_line = serde_json::to_string(&pre_offset).unwrap();
+        fs::write(&events, format!("{pre_offset_line}\n")).unwrap();
+        let offset = fs::metadata(&events).unwrap().len();
+
+        let agent_echo = serde_json::json!({
+            "event_type": "item/started",
+            "payload": {"item": {"type": "agentMessage", "content": [{"type": "text", "text": prompt}]}}
+        });
+        let partial_user_message = serde_json::json!({
+            "event_type": "item/started",
+            "payload": {"item": {"type": "userMessage", "content": [{"type": "text", "text": &prompt[..32]}]}}
+        });
+        let agent_echo_line = serde_json::to_string(&agent_echo).unwrap();
+        let partial_user_message_line = serde_json::to_string(&partial_user_message).unwrap();
+        fs::write(
+            &events,
+            format!("{pre_offset_line}\n{agent_echo_line}\n{partial_user_message_line}\n",),
+        )
+        .unwrap();
+        assert!(!codex_event_stream_has_user_turn(&events, offset, &prompt));
+
+        let exact_user_message = serde_json::json!({
+            "schema_version": 2,
+            "event_type": "item/started",
+            "payload": {"item": {"type": "userMessage", "content": [{"type": "text", "text": prompt}]}}
+        });
+        let exact_user_message_line = serde_json::to_string(&exact_user_message).unwrap();
+        fs::write(
+            &events,
+            format!(
+                "{pre_offset_line}\n{agent_echo_line}\n{partial_user_message_line}\n{exact_user_message_line}\n"
+            ),
+        )
+        .unwrap();
+
+        assert!(codex_event_stream_has_user_turn(&events, offset, &prompt));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1276

Recognize schema-v2 Codex `item/started` user-message acknowledgements only when the complete provider text exactly matches the immutable submitted brief after the captured event offset.

Tests:
- cargo test -p sm-server
- cargo fmt --check
- git diff --check