### PR TITLE
Fix atomic peer-root reparent succession

### DIFF
--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -3028,18 +3028,20 @@ fn reparent_edges_for_display(record: &Value) -> Vec<Value> {
         .unwrap_or("unknown");
     let old_parent = record["expected_parent_session_id"].as_str();
     if record["kind"] == "tree" {
-        let mut edges = vec![
-            json!({
+        let peer_root_succession = record["peer_root_succession"].as_bool().unwrap_or(false);
+        let mut edges = Vec::new();
+        if !peer_root_succession {
+            edges.push(json!({
                 "session_id": target,
                 "expected_parent_session_id": source,
                 "new_parent_session_id": old_parent,
-            }),
-            json!({
-                "session_id": source,
-                "expected_parent_session_id": old_parent,
-                "new_parent_session_id": target,
-            }),
-        ];
+            }));
+        }
+        edges.push(json!({
+            "session_id": source,
+            "expected_parent_session_id": old_parent,
+            "new_parent_session_id": target,
+        }));
         edges.extend(
             record["frozen_live_child_ids"]
                 .as_array()
@@ -7019,6 +7021,34 @@ mod tests {
         assert_eq!(format_context_percentage(Some(&json!(43.5))), "43.5%");
         assert_eq!(format_context_percentage(Some(&Value::Null)), "unknown");
         assert_eq!(format_context_percentage(None), "unknown");
+    }
+
+    #[test]
+    fn peer_root_pending_request_display_has_no_successor_move() {
+        let record = json!({
+            "kind": "tree",
+            "subject_session_id": "outgoing",
+            "target_parent_session_id": "successor",
+            "expected_parent_session_id": null,
+            "peer_root_succession": true,
+            "frozen_live_child_ids": ["worker"]
+        });
+
+        assert_eq!(
+            reparent_edges_for_display(&record),
+            vec![
+                json!({
+                    "session_id": "outgoing",
+                    "expected_parent_session_id": null,
+                    "new_parent_session_id": "successor",
+                }),
+                json!({
+                    "session_id": "worker",
+                    "expected_parent_session_id": "outgoing",
+                    "new_parent_session_id": "successor",
+                }),
+            ]
+        );
     }
 
     #[test]

--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -3071,6 +3071,9 @@ fn print_reparent_tree_preview(preview: &Value) {
         preview["source_session_id"].as_str().unwrap_or("unknown"),
         preview["target_session_id"].as_str().unwrap_or("unknown")
     );
+    if preview["peer_root_succession"].as_bool().unwrap_or(false) {
+        println!("mode: peer-root succession");
+    }
     print_reparent_edges(preview["edge_changes"].as_array());
     for blocker in preview["blockers"].as_array().into_iter().flatten() {
         println!("blocker: {}", blocker.as_str().unwrap_or("unknown"));

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -13210,13 +13210,7 @@ fn refresh_reparent_requests(
     for index in 0..records.len() {
         let superseded_by_request_id = records
             .iter()
-            .filter(|other| {
-                other.id != records[index].id
-                    && other.status == "applied"
-                    && other.kind == records[index].kind
-                    && other.subject_session_id == records[index].subject_session_id
-                    && other.target_parent_session_id == records[index].target_parent_session_id
-            })
+            .filter(|other| reparent_request_supersedes(other, &records[index]))
             .min_by(|left, right| (&left.applied_at, &left.id).cmp(&(&right.applied_at, &right.id)))
             .map(|record| record.id.clone());
         let record = &mut records[index];
@@ -13257,6 +13251,28 @@ fn refresh_reparent_requests(
         }
     }
     changed
+}
+
+/// An applied request is the winner only when it committed precisely the same
+/// immutable plan after this request was opened.  Matching the subject and
+/// destination alone can confuse an earlier, unrelated move with a winner.
+fn reparent_request_supersedes(
+    applied: &ReparentRequestRecord,
+    pending: &ReparentRequestRecord,
+) -> bool {
+    if applied.id == pending.id
+        || applied.status != "applied"
+        || applied.topology_fingerprint != pending.topology_fingerprint
+    {
+        return false;
+    }
+    let (Some(applied_at), Some(created_at)) = (
+        applied.applied_at.as_deref().and_then(parse_timestamp),
+        parse_timestamp(&pending.created_at),
+    ) else {
+        return false;
+    };
+    applied_at > created_at
 }
 
 fn reparent_stale_reason(

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -65,6 +65,11 @@ pub struct SessionStore {
     codex_sessions_root: PathBuf,
     claude_projects_roots: Vec<PathBuf>,
     write_lock: Arc<Mutex<()>>,
+    /// Applies span the JSON registry and the retained queue, so their durable
+    /// lease must have exactly one in-process driver. The persisted lease still
+    /// provides restart recovery; this lock prevents a second HTTP request from
+    /// racing a completed driver and mistaking its released lease for failure.
+    reparent_apply_lock: Arc<Mutex<()>>,
     queue_store: Option<RetainedQueueStore>,
     /// Carried on the store rather than read per-request because the codex-fork
     /// event monitor threads evaluate the same thresholds and have no access to
@@ -183,6 +188,7 @@ impl SessionStore {
             codex_sessions_root: expand_home("~/.codex/sessions"),
             claude_projects_roots: claude_projects_roots(None),
             write_lock: Arc::new(Mutex::new(())),
+            reparent_apply_lock: Arc::new(Mutex::new(())),
             queue_store: None,
             context_monitor: ContextMonitorConfig::default(),
             delivery_runtime: None,
@@ -1396,6 +1402,7 @@ impl SessionStore {
             codex_sessions_root: expand_home("~/.codex/sessions"),
             claude_projects_roots: claude_projects_roots(None),
             write_lock: Arc::new(Mutex::new(())),
+            reparent_apply_lock: Arc::new(Mutex::new(())),
             queue_store: None,
             context_monitor: ContextMonitorConfig::default(),
             delivery_runtime: None,
@@ -1982,6 +1989,7 @@ impl SessionStore {
             target_parent_session_id,
             expected_parent_session_id.as_deref(),
             &[],
+            false,
         );
         let approvals = vec![ReparentApprovalRecord {
             actor_kind: "agent".to_owned(),
@@ -2002,6 +2010,7 @@ impl SessionStore {
             expected_parent_session_id,
             expected_parent_is_live,
             detach_non_live_parent: false,
+            peer_root_succession: false,
             frozen_live_child_ids: Vec::new(),
             initiator_session_id: requester_session_id.to_owned(),
             required_agent_approvals,
@@ -2014,6 +2023,7 @@ impl SessionStore {
             decided_at: None,
             applied_at: None,
             failure_reason: None,
+            superseded_by_request_id: None,
             topology_fingerprint,
             apply_stage: None,
             apply_plan: None,
@@ -2086,9 +2096,12 @@ impl SessionStore {
                 "target session {target_session_id} cannot participate in credential-bound consent"
             ));
         }
-        if target.parent_session_id.as_deref() != Some(source_session_id) {
+        let target_is_direct_child = target.parent_session_id.as_deref() == Some(source_session_id);
+        let peer_root_succession =
+            source.parent_session_id.is_none() && target.parent_session_id.is_none();
+        if !target_is_direct_child && !peer_root_succession {
             blockers.push(format!(
-                "target session {target_session_id} is not a live direct child of {source_session_id}"
+                "target session {target_session_id} must be a live direct child of {source_session_id}, or both source and target must be roots for peer-root succession"
             ));
         }
         let expected_parent_session_id = source.parent_session_id.clone();
@@ -2137,6 +2150,7 @@ impl SessionStore {
             expected_parent_session_id.as_deref(),
             target_parent_session_id,
             &frozen_live_child_ids,
+            peer_root_succession,
         );
         if reparent_plan_would_create_cycle(&sessions, &edge_changes) {
             blockers.push("tree promotion would create a session hierarchy cycle".to_owned());
@@ -2156,6 +2170,7 @@ impl SessionStore {
             kind: "tree".to_owned(),
             source_session_id: source_session_id.to_owned(),
             target_session_id: target_session_id.to_owned(),
+            peer_root_succession,
             frozen_live_child_ids: frozen_live_child_ids.clone(),
             edge_changes,
             json_routing_changes,
@@ -2254,13 +2269,16 @@ impl SessionStore {
             decided_at: None,
             applied_at: None,
             failure_reason: None,
+            superseded_by_request_id: None,
             topology_fingerprint: reparent_topology_fingerprint(
                 "tree",
                 source_session_id,
                 target_session_id,
                 source.parent_session_id.as_deref(),
                 &preview.frozen_live_child_ids,
+                peer_root_succession,
             ),
+            peer_root_succession,
             apply_stage: None,
             apply_plan: None,
             notification_intents: Vec::new(),
@@ -2571,6 +2589,14 @@ impl SessionStore {
     }
 
     pub fn reconcile_reparent_requests(&self) -> Result<Option<ReparentRequestRecord>> {
+        let _apply_guard = self
+            .reparent_apply_lock
+            .lock()
+            .map_err(|_| anyhow::anyhow!("reparent apply lock poisoned"))?;
+        self.reconcile_reparent_requests_locked()
+    }
+
+    fn reconcile_reparent_requests_locked(&self) -> Result<Option<ReparentRequestRecord>> {
         let mut first = None;
         loop {
             let request_id = match self.acquire_reparent_apply_lease()? {
@@ -2770,21 +2796,26 @@ impl SessionStore {
             store_reparent_request_records(&mut state, &records)?;
             self.write_raw_json_value(&state)?;
         }
-        match action {
-            ReparentRepairAction::Resume => {
-                if let Err(error) = self.apply_reparent_request(request_id) {
-                    self.fail_reparent_apply(request_id, &error.to_string())?;
+        let repaired = {
+            let _apply_guard = self
+                .reparent_apply_lock
+                .lock()
+                .map_err(|_| anyhow::anyhow!("reparent apply lock poisoned"))?;
+            match action {
+                ReparentRepairAction::Resume => {
+                    if let Err(error) = self.apply_reparent_request(request_id) {
+                        self.fail_reparent_apply(request_id, &error.to_string())?;
+                    }
+                }
+                ReparentRepairAction::RollbackPrecommit => {
+                    if let Err(error) = self.rollback_reparent_precommit(request_id, None) {
+                        self.fail_reparent_apply(request_id, &error.to_string())?;
+                    }
                 }
             }
-            ReparentRepairAction::RollbackPrecommit => {
-                if let Err(error) = self.rollback_reparent_precommit(request_id, None) {
-                    self.fail_reparent_apply(request_id, &error.to_string())?;
-                }
-            }
-        }
-        let repaired = self
-            .get_reparent_request(request_id)?
-            .filter(|record| matches!(record.status.as_str(), "applied" | "repaired"));
+            self.get_reparent_request(request_id)?
+                .filter(|record| matches!(record.status.as_str(), "applied" | "repaired"))
+        };
         if repaired.is_some() {
             self.verify_reparent_repair(request_id, &attempted_at)?;
             self.reconcile_reparent_requests()?;
@@ -2940,6 +2971,7 @@ impl SessionStore {
                 record.expected_parent_session_id.as_deref(),
                 tree_target_parent_session_id(record),
                 &record.frozen_live_child_ids,
+                record.peer_root_succession,
             )
         } else {
             vec![ReparentEdgeChange {
@@ -13127,16 +13159,22 @@ fn reparent_topology_fingerprint(
     target_parent_session_id: &str,
     expected_parent_session_id: Option<&str>,
     frozen_live_child_ids: &[String],
+    peer_root_succession: bool,
 ) -> String {
     let mut children = frozen_live_child_ids.to_vec();
     children.sort();
-    let canonical = json!({
+    let mut canonical = json!({
         "kind": kind,
         "subject_session_id": subject_session_id,
         "target_parent_session_id": target_parent_session_id,
         "expected_parent_session_id": expected_parent_session_id,
         "frozen_live_child_ids": children,
     });
+    // Keep the old canonical shape for existing direct-child requests so their
+    // persisted fingerprints remain valid across this schema extension.
+    if peer_root_succession {
+        canonical["tree_mode"] = Value::String("peer_root_succession".to_owned());
+    }
     let digest = Sha256::digest(serde_json::to_vec(&canonical).unwrap_or_default());
     digest.iter().map(|byte| format!("{byte:02x}")).collect()
 }
@@ -13169,7 +13207,19 @@ fn refresh_reparent_requests(
     let decided_at = now
         .format(&Rfc3339)
         .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned());
-    for record in records {
+    for index in 0..records.len() {
+        let superseded_by_request_id = records
+            .iter()
+            .filter(|other| {
+                other.id != records[index].id
+                    && other.status == "applied"
+                    && other.kind == records[index].kind
+                    && other.subject_session_id == records[index].subject_session_id
+                    && other.target_parent_session_id == records[index].target_parent_session_id
+            })
+            .min_by(|left, right| (&left.applied_at, &left.id).cmp(&(&right.applied_at, &right.id)))
+            .map(|record| record.id.clone());
+        let record = &mut records[index];
         if record.status != "pending" {
             continue;
         }
@@ -13193,9 +13243,15 @@ fn refresh_reparent_requests(
             _ => {}
         }
         if let Some(reason) = reparent_stale_reason(record, sessions) {
-            record.status = "stale".to_owned();
+            if let Some(winner) = superseded_by_request_id {
+                record.status = "superseded".to_owned();
+                record.superseded_by_request_id = Some(winner.clone());
+                record.failure_reason = Some(format!("request superseded by {winner}"));
+            } else {
+                record.status = "stale".to_owned();
+                record.failure_reason = Some(reason);
+            }
             record.decided_at = Some(decided_at.clone());
-            record.failure_reason = Some(reason);
             record.ready_to_apply = false;
             changed = true;
         }
@@ -13213,6 +13269,7 @@ fn reparent_stale_reason(
         &record.target_parent_session_id,
         record.expected_parent_session_id.as_deref(),
         &record.frozen_live_child_ids,
+        record.peer_root_succession,
     );
     if record.topology_fingerprint != expected_fingerprint {
         return Some("stored topology fingerprint does not match the request plan".to_owned());
@@ -13252,7 +13309,11 @@ fn reparent_stale_reason(
         return Some("target parent session is no longer live".to_owned());
     }
     if record.kind == "tree" {
-        if target.parent_session_id.as_deref() != Some(&record.subject_session_id) {
+        if record.peer_root_succession {
+            if target.parent_session_id.is_some() {
+                return Some("peer-root successor is no longer a root".to_owned());
+            }
+        } else if target.parent_session_id.as_deref() != Some(&record.subject_session_id) {
             return Some("tree target is no longer a direct child of the source".to_owned());
         }
         let current_live_children = sessions
@@ -13273,6 +13334,7 @@ fn reparent_stale_reason(
             record.expected_parent_session_id.as_deref(),
             tree_target_parent_session_id(record),
             &record.frozen_live_child_ids,
+            record.peer_root_succession,
         );
         if reparent_plan_would_create_cycle(sessions, &changes) {
             return Some("current tree plan would create a hierarchy cycle".to_owned());
@@ -13293,19 +13355,21 @@ fn tree_reparent_edge_changes(
     expected_source_parent_session_id: Option<&str>,
     target_parent_session_id: Option<&str>,
     frozen_live_child_ids: &[String],
+    peer_root_succession: bool,
 ) -> Vec<ReparentEdgeChange> {
-    let mut changes = vec![
-        ReparentEdgeChange {
+    let mut changes = Vec::new();
+    if !peer_root_succession {
+        changes.push(ReparentEdgeChange {
             session_id: target_session_id.to_owned(),
             expected_parent_session_id: Some(source_session_id.to_owned()),
             new_parent_session_id: target_parent_session_id.map(ToOwned::to_owned),
-        },
-        ReparentEdgeChange {
-            session_id: source_session_id.to_owned(),
-            expected_parent_session_id: expected_source_parent_session_id.map(ToOwned::to_owned),
-            new_parent_session_id: Some(target_session_id.to_owned()),
-        },
-    ];
+        });
+    }
+    changes.push(ReparentEdgeChange {
+        session_id: source_session_id.to_owned(),
+        expected_parent_session_id: expected_source_parent_session_id.map(ToOwned::to_owned),
+        new_parent_session_id: Some(target_session_id.to_owned()),
+    });
     changes.extend(
         frozen_live_child_ids
             .iter()
@@ -13692,6 +13756,7 @@ pub struct ReparentTreePreview {
     pub kind: String,
     pub source_session_id: String,
     pub target_session_id: String,
+    pub peer_root_succession: bool,
     pub frozen_live_child_ids: Vec<String>,
     pub edge_changes: Vec<ReparentEdgeChange>,
     pub json_routing_changes: Vec<ReparentRoutingChange>,
@@ -13767,7 +13832,7 @@ fn desired_reparent_notifications(
         }
     } else if matches!(
         record.status.as_str(),
-        "applied" | "rejected" | "expired" | "stale" | "failed" | "repaired"
+        "applied" | "rejected" | "expired" | "stale" | "superseded" | "failed" | "repaired"
     ) {
         let event = format!("terminal:{}", record.status);
         for recipient in record
@@ -13839,6 +13904,14 @@ fn reparent_progress_notification_text(
 }
 
 fn reparent_terminal_notification_text(record: &ReparentRequestRecord) -> String {
+    if let Some(winner) = record.superseded_by_request_id.as_deref() {
+        return format!(
+            "[sm reparent] Request {} was superseded by request {}. {}",
+            record.id,
+            winner,
+            reparent_edge_summary(record),
+        );
+    }
     format!(
         "[sm reparent] Request {} is {}. {}{}",
         record.id,
@@ -13865,6 +13938,7 @@ fn reparent_edge_summary(record: &ReparentRequestRecord) -> String {
                     record.expected_parent_session_id.as_deref(),
                     tree_target_parent_session_id(record),
                     &record.frozen_live_child_ids,
+                    record.peer_root_succession,
                 )
             } else {
                 vec![ReparentEdgeChange {
@@ -13925,6 +13999,10 @@ pub struct ReparentRequestRecord {
     pub expected_parent_is_live: bool,
     #[serde(default)]
     pub detach_non_live_parent: bool,
+    /// A root-to-root succession does not move the successor upward; it moves
+    /// the outgoing root and its frozen children underneath that peer root.
+    #[serde(default)]
+    pub peer_root_succession: bool,
     #[serde(default)]
     pub frozen_live_child_ids: Vec<String>,
     pub initiator_session_id: String,
@@ -13945,6 +14023,10 @@ pub struct ReparentRequestRecord {
     pub applied_at: Option<String>,
     #[serde(default)]
     pub failure_reason: Option<String>,
+    /// When a same-edge request completed elsewhere, retain this request as
+    /// audit history and tell a caller exactly which request won.
+    #[serde(default)]
+    pub superseded_by_request_id: Option<String>,
     pub topology_fingerprint: String,
     #[serde(default)]
     pub apply_stage: Option<String>,
@@ -20437,6 +20519,125 @@ mod tests {
         assert!(state["reparent_apply_lease"].is_null());
         let _ = fs::remove_file(state_file);
         let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
+    fn concurrent_reparent_reconcilers_return_committed_state_without_losing_the_lease() {
+        let (store, _queue, state_file, queue_db, request_id) =
+            prepared_reparent_transaction("reparent-concurrent-reconcile");
+        let store = std::sync::Arc::new(store);
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(3));
+        let workers = (0..2)
+            .map(|_| {
+                let store = store.clone();
+                let barrier = barrier.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    store.reconcile_reparent_requests()
+                })
+            })
+            .collect::<Vec<_>>();
+        barrier.wait();
+        for worker in workers {
+            assert!(worker.join().unwrap().is_ok());
+        }
+
+        let record = store.get_reparent_request(&request_id).unwrap().unwrap();
+        assert_eq!(record.status, "applied");
+        assert_eq!(record.apply_stage.as_deref(), Some("applied"));
+        let state = store.load_raw_json_value().unwrap();
+        assert!(state["reparent_apply_lease"].is_null());
+
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
+    fn peer_root_succession_recovers_from_a_persisted_apply_stage_after_restart() {
+        let state_file = unique_temp_path("peer-root-restart");
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [
+                    reparent_test_session("outgoing", None, "outgoing-secret"),
+                    reparent_test_session("successor", None, "successor-secret"),
+                    reparent_test_session("worker", Some("outgoing"), "worker-secret")
+                ]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let store = SessionStore::new(state_file.clone());
+        let request = match store
+            .create_reparent_tree_request(
+                "outgoing",
+                CreateReparentTreeRequest {
+                    requester_session_id: "outgoing".to_owned(),
+                    target_session_id: "successor".to_owned(),
+                    dry_run: false,
+                },
+                "outgoing-secret",
+            )
+            .unwrap()
+        {
+            ReparentMutationOutcome::Created(record) => record,
+            other => panic!("unexpected create outcome: {other:?}"),
+        };
+        assert!(request.peer_root_succession);
+        {
+            let _guard = store.write_guard().unwrap();
+            let mut state = store.load_raw_json_value().unwrap();
+            let mut records = reparent_request_records(&state).unwrap();
+            let record = records
+                .iter_mut()
+                .find(|record| record.id == request.id)
+                .unwrap();
+            record.approvals.push(ReparentApprovalRecord {
+                actor_kind: "agent".to_owned(),
+                actor_id: "successor".to_owned(),
+                decision: "approved".to_owned(),
+                decided_at: now_rfc3339(),
+            });
+            record.ready_to_apply = true;
+            store_reparent_request_records(&mut state, &records).unwrap();
+            store.write_raw_json_value(&state).unwrap();
+        }
+        assert_eq!(
+            store.acquire_reparent_apply_lease().unwrap().as_deref(),
+            Some(request.id.as_str())
+        );
+        store.quiesce_reparent_json_routing(&request.id).unwrap();
+        drop(store);
+
+        let recovered = SessionStore::new(state_file.clone())
+            .reconcile_reparent_requests()
+            .unwrap()
+            .unwrap();
+        assert_eq!(recovered.status, "applied");
+        let final_store = SessionStore::new(state_file.clone());
+        assert_eq!(
+            final_store
+                .get_session("successor")
+                .unwrap()
+                .unwrap()
+                .parent_session_id,
+            None
+        );
+        for session_id in ["outgoing", "worker"] {
+            assert_eq!(
+                final_store
+                    .get_session(session_id)
+                    .unwrap()
+                    .unwrap()
+                    .parent_session_id
+                    .as_deref(),
+                Some("successor")
+            );
+        }
+        let state = final_store.load_raw_json_value().unwrap();
+        assert!(state["reparent_apply_lease"].is_null());
+
+        let _ = fs::remove_file(state_file);
     }
 
     #[test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -18023,6 +18023,7 @@ async fn reparent_request_projects_a_same_edge_winner_as_durable_supersession() 
     // Reproduce a request that was advertised before another same-edge request
     // won. The old request must remain addressable rather than becoming a 404.
     let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    state["reparent_requests"][0]["created_at"] = json!("2026-08-18T00:59:00Z");
     let mut winner = state["reparent_requests"][0].clone();
     winner["id"] = json!("winner01");
     winner["status"] = json!("applied");
@@ -18061,6 +18062,54 @@ async fn reparent_request_projects_a_same_edge_winner_as_durable_supersession() 
     .await;
     assert_eq!(status, StatusCode::CONFLICT);
     assert!(response["detail"].as_str().unwrap().contains("winner01"));
+}
+
+#[tokio::test]
+async fn reparent_request_does_not_supersede_from_an_unrelated_historical_plan() {
+    let state_file = write_reparent_fixture();
+    let mut config = config_with_state_file(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, loser) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/sessions/child/reparent-requests",
+        json!({
+            "requester_session_id": "oldparent",
+            "target_parent_session_id": "newparent"
+        }),
+        &[("x-sm-session-credential", "old-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let loser_id = loser["id"].as_str().unwrap();
+
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    state["reparent_requests"][0]["created_at"] = json!("2026-08-18T00:59:00Z");
+    let mut historical = state["reparent_requests"][0].clone();
+    historical["id"] = json!("oldwinner");
+    historical["status"] = json!("applied");
+    historical["ready_to_apply"] = json!(false);
+    historical["applied_at"] = json!("2026-08-18T01:00:00Z");
+    // Same child/destination but a different immutable topology plan.
+    historical["topology_fingerprint"] = json!("different-historical-plan");
+    state["reparent_requests"]
+        .as_array_mut()
+        .unwrap()
+        .push(historical);
+    state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "newparent")
+        .unwrap()["status"] = json!("stopped");
+    fs::write(&state_file, serde_json::to_vec_pretty(&state).unwrap()).unwrap();
+
+    let (status, projected) = get_json(app, &format!("/reparent-requests/{loser_id}")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(projected["status"], "stale");
+    assert!(projected["superseded_by_request_id"].is_null());
 }
 
 #[tokio::test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -18000,6 +18000,70 @@ async fn reparent_request_creation_persists_and_queues_exact_actionable_notifica
 }
 
 #[tokio::test]
+async fn reparent_request_projects_a_same_edge_winner_as_durable_supersession() {
+    let state_file = write_reparent_fixture();
+    let mut config = config_with_state_file(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, loser) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/sessions/child/reparent-requests",
+        json!({
+            "requester_session_id": "oldparent",
+            "target_parent_session_id": "newparent"
+        }),
+        &[("x-sm-session-credential", "old-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let loser_id = loser["id"].as_str().unwrap().to_owned();
+
+    // Reproduce a request that was advertised before another same-edge request
+    // won. The old request must remain addressable rather than becoming a 404.
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let mut winner = state["reparent_requests"][0].clone();
+    winner["id"] = json!("winner01");
+    winner["status"] = json!("applied");
+    winner["ready_to_apply"] = json!(false);
+    winner["applied_at"] = json!("2026-08-18T01:00:00Z");
+    winner["decided_at"] = json!("2026-08-18T01:00:00Z");
+    state["reparent_requests"]
+        .as_array_mut()
+        .unwrap()
+        .push(winner);
+    state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "child")
+        .unwrap()["parent_session_id"] = json!("newparent");
+    fs::write(&state_file, serde_json::to_vec_pretty(&state).unwrap()).unwrap();
+
+    let (status, projected) =
+        get_json(app.clone(), &format!("/reparent-requests/{loser_id}")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(projected["status"], "superseded");
+    assert_eq!(projected["superseded_by_request_id"], "winner01");
+    assert!(projected["failure_reason"]
+        .as_str()
+        .unwrap()
+        .contains("winner01"));
+
+    let (status, response) = post_json_with_headers_and_peer(
+        app,
+        &format!("/reparent-requests/{loser_id}/approve"),
+        json!({ "requester_session_id": "newparent" }),
+        &[("x-sm-session-credential", "new-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert!(response["detail"].as_str().unwrap().contains("winner01"));
+}
+
+#[tokio::test]
 async fn reparent_request_immediately_delivers_approval_prompt_to_an_idle_runtime() {
     if !tmux_available() {
         return;
@@ -18448,6 +18512,79 @@ async fn reparent_tree_promotes_a_root_child_without_stranding_parent_routes() {
         .unwrap();
     assert_eq!(target_wake["parent_session_id"], "source01");
     assert_eq!(target_wake["is_active"], false);
+}
+
+#[tokio::test]
+async fn reparent_tree_atomically_succeeds_between_owner_started_peer_roots() {
+    let state_file = write_reparent_tree_fixture();
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let sessions = state["sessions"].as_array_mut().unwrap();
+    for session_id in ["source01", "target01"] {
+        let session = sessions
+            .iter_mut()
+            .find(|session| session["id"] == session_id)
+            .unwrap();
+        session["parent_session_id"] = Value::Null;
+        session["context_monitor_enabled"] = json!(false);
+        session["context_monitor_notify"] = Value::Null;
+    }
+    sessions.retain(|session| session["id"] != "grand001");
+    state["retained_parent_wake_registrations"]
+        .as_array_mut()
+        .unwrap()
+        .retain(|wake| {
+            wake["child_session_id"] != "source01" && wake["child_session_id"] != "target01"
+        });
+    fs::write(&state_file, serde_json::to_vec_pretty(&state).unwrap()).unwrap();
+
+    let mut config = config_with_state_file(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+    let (status, created) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/sessions/source01/reparent-tree-requests",
+        json!({
+            "requester_session_id": "source01",
+            "target_session_id": "target01"
+        }),
+        &[("x-sm-session-credential", "source-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(created["peer_root_succession"], true);
+    assert_eq!(
+        created["required_agent_approvals"],
+        json!(["source01", "target01"])
+    );
+
+    let (status, applied) = post_json_with_headers_and_peer(
+        app,
+        &format!(
+            "/reparent-requests/{}/approve",
+            created["id"].as_str().unwrap()
+        ),
+        json!({ "requester_session_id": "target01" }),
+        &[("x-sm-session-credential", "target-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(applied["status"], "applied");
+
+    let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let parent = |id: &str| {
+        state["sessions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|session| session["id"] == id)
+            .and_then(|session| session["parent_session_id"].as_str())
+    };
+    assert_eq!(parent("target01"), None);
+    assert_eq!(parent("source01"), Some("target01"));
+    assert_eq!(parent("sibling01"), Some("target01"));
+    assert_eq!(parent("stopped01"), Some("source01"));
 }
 
 #[tokio::test]

--- a/specs/1285_peer_root_reparent_outcomes.md
+++ b/specs/1285_peer_root_reparent_outcomes.md
@@ -1,0 +1,40 @@
+# 1285 - Peer-root succession and truthful reparent outcomes
+
+Status: implementation contract
+
+Issue: #1285
+
+## Incident evidence
+
+On 2026-08-18, owner-started peer roots `459a100f` and `d7216556` could not
+use `sm reparent-tree`: the successor was not a direct child. Seven manual
+single-edge moves then raced. `ce188350bb5a` returned `500 reparent apply lease
+disappeared` twice despite later reaching `applied`; `368eda611f75` was
+advertised as pending, then returned a bare 404 after same-edge request
+`f7d87ce301e2` won. The safe completion proof was committed child topology:
+the outgoing root had no children and the successor had the expected child set.
+
+## Contract
+
+`sm reparent-tree --to <successor> <outgoing>` supports either the existing
+direct-child promotion or a peer-root succession. The peer form is valid only
+when both source and target are live roots. It freezes source's live children
+and, after source/target consent, atomically makes the outgoing source and
+every frozen live child direct children of the successor. The successor remains
+a root; stopped children keep their historical parent. The persisted request
+identifies this mode and restart revalidation requires the successor to remain
+a root.
+
+Apply drivers are serialized in-process in addition to the durable global
+lease. A second approval/reconciliation must return the durable terminal state,
+not mistake a lease released by the first completed driver for a failed apply.
+Post-quiesce ambiguity remains durable, failed, and repair-gated.
+
+If an already-advertised same-edge request loses to an applied request, it is
+retained as terminal `superseded`, names `superseded_by_request_id`, and returns
+an informative conflict on an attempted decision. It must never become a 404.
+Completion consumers use committed topology, not notification delivery.
+
+## Classification
+
+Single ticket.


### PR DESCRIPTION
## Summary

- support consented atomic `reparent-tree` handoff between owner-started peer roots
- serialize in-process reparent apply drivers so a completed lease cannot surface as a false HTTP 500
- durably project same-edge winners as `superseded` requests that name the winner

## Spec Reference

`specs/1285_peer_root_reparent_outcomes.md`

## Test Plan

- `cargo test -p sm-server --no-fail-fast`
- focused reparent unit and HTTP suites
- `cargo fmt --check`
- `git diff --check`

Fixes #1285