### PR TITLE
docs: adopt risk-tiered policy review

### DIFF
--- a/docs/working/pr_review_process.md
+++ b/docs/working/pr_review_process.md
@@ -41,7 +41,7 @@ one happens to be clean. Assign the review tier before the first request and
 record it in the PR body:
 
 - **R0 - ephemeral:** no review cycle for temporary working/execution docs.
-- **R1 - low risk:** one broad round. A reachable `P1` promotes the PR to R2;
+- **R1 - low risk:** one broad round. A reachable `P0`/`P1` promotes the PR to R2;
   clean or P2-only results meet the gate.
 - **R2 - medium risk:** at most three exact-head rounds. Use a broad review, one
   batched root-cause repair and sibling search, then a current-capability review
@@ -53,7 +53,9 @@ record it in the PR body:
 
 Record the requested and reviewed head, scope/steer, findings, disposition,
 resulting head, review wait, and available token estimate for every round. Do
-not request an unchanged head again.
+not request an unchanged head again except for R3's mandatory second round: a
+differently scoped confirmation may review the same immutable head once when
+round 1 produced no change.
 
 ## After Feedback
 

--- a/docs/working/pr_review_process.md
+++ b/docs/working/pr_review_process.md
@@ -37,13 +37,19 @@ When Codex review lands:
 - If the review is clean, exit criteria are **met**.
 
 Codex review is a sampled gate, not proof obtained by requesting reviews until
-one happens to be clean. A PR receives at most three exact-head review rounds:
+one happens to be clean. Assign the review tier before the first request and
+record it in the PR body:
 
-1. broad current-capability review;
-2. root-cause verification after one batched repair, including sibling instances
-   in the touched subsystem; and
-3. a final enabled-path/rollback/test review only when round 2 retains or
-   introduces a reachable `P0`/`P1`.
+- **R0 - ephemeral:** no review cycle for temporary working/execution docs.
+- **R1 - low risk:** one broad round. A reachable `P1` promotes the PR to R2;
+  clean or P2-only results meet the gate.
+- **R2 - medium risk:** at most three exact-head rounds. Use a broad review, one
+  batched root-cause repair and sibling search, then a current-capability review
+  only if a reachable `P0`/`P1` remains.
+- **R3 - high risk:** persisted shapes, authority, recovery, concurrency,
+  security, ambiguity semantics, hot paths, and public contracts. Run at least
+  two rounds and no more than five. A repeated or structural P1 at round 3
+  triggers design-return rather than more local patching.
 
 Record the requested and reviewed head, scope/steer, findings, disposition,
 resulting head, review wait, and available token estimate for every round. Do
@@ -57,18 +63,38 @@ not request an unchanged head again.
 If exit criteria are not met:
 
 1. Push the fixes.
-2. Request the next bounded round only if fewer than three rounds have run.
+2. Request the next bounded round only when the selected tier permits it and
+   the new head stays inside the frozen capability.
 
-At the three-round cap:
+At an R2 third-round P1 or an R3 design-return trigger:
 
-1. A reachable `P0`/`P1` blocks merge. Simplify, revert, split, or mark the PR
-   blocked with the residual finding and evidence.
-2. A finding that only affects disabled or future capability becomes a linked
-   issue and acceptance criterion for that capability.
-3. Fix, explicitly accept with rationale, or file each `P2`/`P3`.
-4. Do not start a fourth round automatically. The owner may approve one bounded
-   extension with an explicit token/time budget. It cannot be extended again;
-   another reachable `P0`/`P1` requires a split or redesign.
+1. A reachable `P0`/`P1` still blocks merge. Never merge a repair for the final
+   blocking finding without review of that repaired head.
+2. Classify the finding as localized, partitionable, or structural using its
+   enabled-path reachability, blast radius, recurrence across rounds, touched
+   files/interfaces, rollback quality, and hostile-test coverage.
+3. A newly discovered, localized R3 repair may receive a focused confirming
+   round while still below the five-round ceiling. A repeated finding class or
+   a repair that changes architecture goes to design-return. R2 does not grow a
+   fourth round; split the localized repair into a fresh bounded package if
+   confirmation is required.
+4. A partitionable finding produces a split proposal keyed by the findings'
+   file/interface list. Land no partition until its own bounded review passes.
+5. A structural or repeated finding enters design-return: a fresh design seat
+   receives the ticket, current code, and accumulated findings; it must produce
+   pieces that each have an independent gate. Execute those pieces as a
+   subepic, rerun the original full gate at the subepic head, and perform one
+   integration-focused review before landing.
+6. A finding that only affects disabled or future capability becomes a linked
+   issue and an activation criterion for that capability.
+7. Fix, explicitly accept with rationale, or file every `P2`/`P3`.
+
+At the R3 five-round ceiling, the maintainer chooses revert, split, redesign,
+or park from the recorded risk and cost evidence. Do not ask the owner to read
+or adjudicate code findings. Owner input is required only to accept a named
+residual risk, change product scope, or override policy. If owner input is not
+available, the fail-closed default is split/park, not an indefinite review loop
+and not a merge with unresolved P1s.
 
 If exit criteria are met:
 
@@ -87,6 +113,11 @@ If exit criteria are met:
 - Keep one deployable capability per PR. A head-expanding refactor discovered
   during review belongs in a separate PR rather than silently increasing the
   current review surface.
+- A review dominated by defects in verification infrastructure terminates the
+  product-code loop and files an apparatus issue, unless the PR itself changes
+  that apparatus.
+- A new gate, probe, fixture, or monitor does not count as protection until a
+  test or recorded trial demonstrates that it fires red.
 - For unusually high-risk transactions, up to two focused reviews may run in
   parallel on the same immutable head and be aggregated as one round. Record
   their costs separately and deduplicate findings before one repair batch.

--- a/docs/working/pr_review_process.md
+++ b/docs/working/pr_review_process.md
@@ -36,6 +36,9 @@ When Codex review lands:
   PR is **not mergeable**.
 - If there are no important feedback items (`P2` or lower only), exit criteria are **met**.
 - If the review is clean, exit criteria are **met**.
+- Meeting the severity gate does not waive the selected tier's minimum review
+  count. In particular, an R3 PR is not mergeable until at least two recorded
+  rounds have completed, even when its first round is clean.
 
 Codex review is a sampled gate, not proof obtained by requesting reviews until
 one happens to be clean. Assign the review tier before the first request and

--- a/docs/working/pr_review_process.md
+++ b/docs/working/pr_review_process.md
@@ -32,7 +32,8 @@ When Codex review lands:
 
 ## Exit Criteria
 
-- If there are any important feedback items (`P1`), the PR is **not mergeable**.
+- If there are any reachable critical/important feedback items (`P0`/`P1`), the
+  PR is **not mergeable**.
 - If there are no important feedback items (`P2` or lower only), exit criteria are **met**.
 - If the review is clean, exit criteria are **met**.
 
@@ -48,7 +49,7 @@ record it in the PR body:
   only if a reachable `P0`/`P1` remains.
 - **R3 - high risk:** persisted shapes, authority, recovery, concurrency,
   security, ambiguity semantics, hot paths, and public contracts. Run at least
-  two rounds and no more than five. A repeated or structural P1 at round 3
+  two rounds and no more than five. A repeated or structural P0/P1 at round 3
   triggers design-return rather than more local patching.
 
 Record the requested and reviewed head, scope/steer, findings, disposition,
@@ -68,7 +69,7 @@ If exit criteria are not met:
 2. Request the next bounded round only when the selected tier permits it and
    the new head stays inside the frozen capability.
 
-At an R2 third-round P1 or an R3 design-return trigger:
+At an R2 third-round P0/P1 or an R3 design-return trigger:
 
 1. A reachable `P0`/`P1` still blocks merge. Never merge a repair for the final
    blocking finding without review of that repaired head.
@@ -96,7 +97,7 @@ or park from the recorded risk and cost evidence. Do not ask the owner to read
 or adjudicate code findings. Owner input is required only to accept a named
 residual risk, change product scope, or override policy. If owner input is not
 available, the fail-closed default is split/park, not an indefinite review loop
-and not a merge with unresolved P1s.
+and not a merge with unresolved P0/P1 findings.
 
 If exit criteria are met:
 
@@ -110,7 +111,8 @@ If exit criteria are met:
 - Prefer Session Manager ownership of the review loop when available. It handles retries, restart recovery, and "fresh review after current request" disambiguation better than ad-hoc shell polling.
 - Do not treat “a review exists” as sufficient by itself.
 - When using Session Manager wakeups, still verify that the landed review/comment is tied to the current request cycle before acting on it.
-- The blocking threshold is whether unresolved feedback contains any `P1` items.
+- The blocking threshold is whether unresolved feedback contains any reachable
+  `P0`/`P1` items.
 - `P2` or lower feedback can still be worth fixing before merge, but it does not block exit criteria.
 - Keep one deployable capability per PR. A head-expanding refactor discovered
   during review belongs in a separate PR rather than silently increasing the

--- a/specs/1268_lane_policy_scaffold.md
+++ b/specs/1268_lane_policy_scaffold.md
@@ -461,17 +461,35 @@ same action ID/version; prose such as `final` or `supersedes` has no authority b
 itself.
 
 The action state advances monotonically through proposed, authorized, started,
-and terminal. Immediately before its first side effect, the executor must claim
-`authorized -> started` with one compare-and-swap that verifies the current
-authority incarnation, highest decision version, exact scope, executor binding,
-and expiry. A failed claim performs no side effect and returns the current
-decision. The authority may revoke only before a successful `started` claim;
-once execution is recorded, later messages cannot authorize a competing action
-and recovery must reconcile the observed action first. Transferring decision
-authority is an atomic recorded handoff. Recipients act only on the highest
-durable version and default to inaction on conflicting or unverifiable
-messages. This prevents several coordinators from oscillating a one-shot probe
-or restart faster than the executing seat can observe the decisions.
+recovering, and terminal. Immediately before its first side effect, the executor
+must claim `authorized -> started` with one compare-and-swap that verifies the
+current authority incarnation, highest decision version, exact scope, executor
+binding, and expiry. The claim records an action-scoped idempotency key, attempt
+epoch, executor lease, and the evidence that can distinguish completed,
+not-executed, and ambiguous outcomes. A failed claim performs no side effect and
+returns the current decision. The authority may revoke only before a successful
+`started` claim; once execution is recorded, later messages cannot authorize a
+competing action.
+
+If the executor disappears after `started`, a replacement may claim
+`started -> recovering` only after the executor lease expires and only with a
+compare-and-swap over the same action ID, decision version, scope, and current
+attempt epoch. Recovery increments the attempt epoch and first reconciles the
+declared evidence. It marks terminal when execution is proved, resumes with the
+same idempotency key when non-execution is proved or the external operation
+provides equivalent idempotent replay, and otherwise records an explicit
+ambiguous blocker. It never creates a new authorization or performs a competing
+side effect merely because the original executor is absent. Actions whose
+effects cannot be made idempotent or distinguished after a crash are ineligible
+for automatic execution and require reconciliation before a new action ID can
+be authorized.
+
+Transferring decision authority is an atomic recorded handoff. Recipients act
+only on the highest durable version and default to inaction on conflicting or
+unverifiable messages. This prevents several coordinators from oscillating a
+one-shot probe or restart faster than the executing seat can observe the
+decisions, while leaving a bounded recovery path for a pre-effect executor
+crash.
 
 ### 6. Evaluation telemetry
 

--- a/specs/1268_lane_policy_scaffold.md
+++ b/specs/1268_lane_policy_scaffold.md
@@ -11,7 +11,17 @@ Apply evolving lane policy without a persistent watchdog/policy seat and without
 depending on orchestrators to remember `sm task`, context thresholds, rotation,
 or model-tier rules.
 
-## Lane 355 policy examples
+## Historical lane 355 policy examples
+
+The examples below motivated this specification but are not current authority.
+Policy activation always reads an approved source identity consisting of
+repository, commit/ref, path, and content digest. As of 2026-08-17, the active
+successor policy is `docs/policy/355_operating_model.md` on the
+`epic/355-journey-lattice` branch of `fractal-algo-rust`; despite the historical
+filename, that document states that it governs epic 360. A projection must use
+the governed lane from the document/approval record, not infer `355` from its
+filename or branch. The superseded examples below remain design evidence only;
+they must not be materialized unless a currently approved clause restates them.
 
 - Orchestrator: Claude Opus/high, successor rotation around 35%, policy ceiling
   40% unless a durable scoped override exists.
@@ -111,9 +121,12 @@ Separate:
 - scoped rulings bound to a role, task, issue, transition, spawn request, or
   immutable prompt digest.
 
-Each amendment records source evidence, approver identity, effective time,
-explicit supersession, scope, enforcement class, and optional expiry/one-shot
-consumption. Later text does not silently supersede active policy.
+Each amendment records source evidence, source repository/ref/path/content
+digest, approver identity, effective time, explicit supersession, scope,
+enforcement class, and optional expiry/one-shot consumption. Every attempted
+operation pins the activated source commit and digest. A changed digest stales
+pending decisions and unused leases; later text does not silently supersede
+active policy.
 
 Normative clauses have stable lane-scoped IDs; rulings and supersession records
 bind those IDs, never line numbers or prose snippets. Superseded text remains
@@ -121,6 +134,12 @@ readable in place with a forward pointer to the replacing clause and amendment.
 An open-to-settled status change is invalid unless the same amendment names the
 external settling record; a policy document cannot cite itself as authority for
 its own settlement.
+
+The human policy document need not contain SM-specific IDs. When it does not,
+the operator-approved activation manifest assigns stable IDs to the selected
+clauses and records their source anchors and text digests. A later activation
+must explicitly retain, supersede, or retire those IDs; it cannot manufacture a
+new identity from a shifted line number or heading.
 
 Agent-generated natural language creates a document change proposal. A
 registered human approves/rejects the document diff through an operator-only
@@ -130,7 +149,10 @@ projection contains stable SM primitives such as model/effort defaults,
 context thresholds, rotation behavior, routing, and prompt guidance. A policy
 concept SM cannot enforce remains advisory and is injected at the applicable
 decision point; adding a new enforcement primitive can require development
-without making the policy itself inexpressible.
+without making the policy itself inexpressible. Each applicable requirement is
+reported as `enforced`, `injected`, `observed`, or `deferred`. A capability-
+subset canary may activate only its declared subset and must not claim that the
+whole source policy is enforced.
 
 Initially every lane-policy rule is overridable by the seat holder with a
 durable, scoped reason. Non-overridable safety and authority properties are SM
@@ -750,11 +772,14 @@ contains only:
 - actual provider/model/effort attestation after launch;
 - linked decision, token, wall-time, child-lifecycle, forecast, and breaker
   evidence; and
-- read-only owner/maintainer inspection surfaces.
+- read-only owner/maintainer inspection surfaces; and
+- generic injection/observation records for applicable requirements outside
+  the first typed enforcement subset, including review tier and disposition.
 
-Stable cross-lane seats, generalized routing, cleanup/relocation, context
-profiles, and rotation are not prerequisites for this first slice. They remain
-in the full plan and are added to the live canary only after their own review.
+Stable cross-lane seats, generalized routing, cleanup/relocation, compound
+context/message profiles, two-step stand-by/brief acknowledgement, and rotation
+are not prerequisites for this first slice. They remain in the full plan and
+are added to the live canary only after their own review.
 This avoids paying for the complete identity and lifecycle substrate before the
 spawn-policy hypothesis produces evidence.
 
@@ -1038,21 +1063,15 @@ sole objective.
 - The canonical maintainer owns contracts, dependency ordering, integration,
   active canary deployment, final epic review, and production rollout.
 
-#### Bounded Codex review protocol
+#### Risk-tiered Codex review protocol
 
 Codex review is a sampled engineering gate, not a proof obtained by repeatedly
 requesting reviews until one happens to return no finding. Each package or final
-integration PR is limited to one deployable capability and receives at most
-three exact-head review rounds:
-
-1. **Broad review.** Review the current capability for correctness, concurrency,
-   authority, recovery, security, and missing tests.
-2. **Root-cause verification.** After one batched repair, verify every accepted
-   finding and search the touched subsystem for sibling instances of the same
-   failure class. The steer excludes unrelated roadmap and disabled capabilities.
-3. **Current-capability gate.** Run only when round 2 retains or introduces a
-   reachable P0/P1. Review the enabled path, rollback, and tests; do not reopen
-   future-wave design.
+integration PR is limited to one deployable capability and declares R0-R3 risk
+before review. R0 needs no cycle; R1 receives one broad round and promotes to R2
+on a reachable P1; R2 receives at most three exact-head rounds; R3 receives at
+least two and at most five. Broad, root-cause/sibling, and current-capability
+steers remain the default sequence.
 
 Every round records requested/reviewed head, steer and scope, queue/review wait,
 estimated or direct token counters, findings, disposition, and resulting head.
@@ -1060,17 +1079,21 @@ Unchanged heads are not re-requested. A head-expanding refactor discovered
 during review becomes a separate package rather than silently enlarging the
 review surface.
 
-At the three-round cap:
+An R2 third-round P1 or an R3 P1 at/after round 3 triggers measured repair
+selection, not owner code review. A newly discovered localized R3 repair may use
+a focused confirming round within the five-round ceiling; a repeated finding
+class or architecture-changing repair enters design-return. R2 repairs needing
+confirmation become a fresh bounded package. Partitionable findings split by
+touched files/interfaces; structural or repeated findings enter design-return
+under a fresh design seat, then execute as independently gated subepic pieces
+with an original full-gate rerun and one integration review. Unresolved
+reachable P0/P1 remains unmergeable.
 
-- a reachable P0/P1 means the package is not mergeable; simplify, revert, split,
-  or block it with the residual finding and evidence;
-- a finding that can only affect a disabled or later capability becomes a
-  linked issue and acceptance criterion for that capability, not a blocker for
-  the current package;
-- each P2/P3 is fixed, explicitly accepted with rationale, or filed; and
-- no fourth round starts automatically. The owner may authorize one additional
-  bounded round with a stated benefit and token/time budget. That extension is
-  never recursively extended; another reachable P0/P1 forces split or redesign.
+At the R3 five-round ceiling, the maintainer selects revert, split, redesign, or
+park from recorded reachability, blast radius, recurrence, rollback, hostile
+tests, review cost, and expected benefit. The owner is asked only to accept a
+named residual risk, change scope, or override policy, never to inspect the code
+finding. Without such an owner decision, split/park is the fail-closed default.
 
 For an unusually high-risk transaction, up to two focused specialist reviews
 may run in parallel against the same immutable head and be aggregated as one

--- a/specs/1268_lane_policy_scaffold.md
+++ b/specs/1268_lane_policy_scaffold.md
@@ -461,13 +461,17 @@ same action ID/version; prose such as `final` or `supersedes` has no authority b
 itself.
 
 The action state advances monotonically through proposed, authorized, started,
-and terminal. The authority may revoke only before `started`; once execution is
-recorded, later messages cannot authorize a competing action and recovery must
-reconcile the observed action first. Transferring decision authority is an
-atomic recorded handoff. Recipients act only on the highest durable version and
-default to inaction on conflicting or unverifiable messages. This prevents
-several coordinators from oscillating a one-shot probe or restart faster than
-the executing seat can observe the decisions.
+and terminal. Immediately before its first side effect, the executor must claim
+`authorized -> started` with one compare-and-swap that verifies the current
+authority incarnation, highest decision version, exact scope, executor binding,
+and expiry. A failed claim performs no side effect and returns the current
+decision. The authority may revoke only before a successful `started` claim;
+once execution is recorded, later messages cannot authorize a competing action
+and recovery must reconcile the observed action first. Transferring decision
+authority is an atomic recorded handoff. Recipients act only on the highest
+durable version and default to inaction on conflicting or unverifiable
+messages. This prevents several coordinators from oscillating a one-shot probe
+or restart faster than the executing seat can observe the decisions.
 
 ### 6. Evaluation telemetry
 
@@ -1073,7 +1077,7 @@ sole objective.
   review, before its consumer starts.
 - Each implementation agent owns its focused tests, full applicable gates,
   `docs/working/pr_review_process.md`, merge to the epic branch, and worktree
-  cleanup. Codex review follows the bounded protocol below; a P1 blocks merge
+  cleanup. Codex review follows the bounded protocol below; a P0/P1 blocks merge
   but does not authorize indefinite review rounds.
 - Limit active implementation to four agents: at most two Sol, two Terra, and
   one Luna where the wave permits. More parallelism would increase merge and
@@ -1098,7 +1102,7 @@ differently scoped confirmation may review the same immutable head once when
 round 1 produced no change. A head-expanding refactor discovered during review
 becomes a separate package rather than silently enlarging the review surface.
 
-An R2 third-round P1 or an R3 P1 at/after round 3 triggers measured repair
+An R2 third-round P0/P1 or an R3 P0/P1 at/after round 3 triggers measured repair
 selection, not owner code review. A newly discovered localized R3 repair may use
 a focused confirming round within the five-round ceiling; a repeated finding
 class or architecture-changing repair enters design-return. R2 repairs needing

--- a/specs/1268_lane_policy_scaffold.md
+++ b/specs/1268_lane_policy_scaffold.md
@@ -451,46 +451,6 @@ success. Internal request and rejected-launch evidence remains observable for
 recovery and diagnostics but is not an active child or the normal caller
 contract.
 
-#### Bounded operational action authority
-
-An incident or live verification that permits one bounded production action
-has exactly one named decision authority. Its durable decision records incident
-ID, action ID, monotonically increasing version, authority incarnation, exact
-scope, state, expiry, and evidence requirement. Other seats may relay only that
-same action ID/version; prose such as `final` or `supersedes` has no authority by
-itself.
-
-The action state advances monotonically through proposed, authorized, started,
-recovering, and terminal. Immediately before its first side effect, the executor
-must claim `authorized -> started` with one compare-and-swap that verifies the
-current authority incarnation, highest decision version, exact scope, executor
-binding, and expiry. The claim records an action-scoped idempotency key, attempt
-epoch, executor lease, and the evidence that can distinguish completed,
-not-executed, and ambiguous outcomes. A failed claim performs no side effect and
-returns the current decision. The authority may revoke only before a successful
-`started` claim; once execution is recorded, later messages cannot authorize a
-competing action.
-
-If the executor disappears after `started`, a replacement may claim
-`started -> recovering` only after the executor lease expires and only with a
-compare-and-swap over the same action ID, decision version, scope, and current
-attempt epoch. Recovery increments the attempt epoch and first reconciles the
-declared evidence. It marks terminal when execution is proved, resumes with the
-same idempotency key when non-execution is proved or the external operation
-provides equivalent idempotent replay, and otherwise records an explicit
-ambiguous blocker. It never creates a new authorization or performs a competing
-side effect merely because the original executor is absent. Actions whose
-effects cannot be made idempotent or distinguished after a crash are ineligible
-for automatic execution and require reconciliation before a new action ID can
-be authorized.
-
-Transferring decision authority is an atomic recorded handoff. Recipients act
-only on the highest durable version and default to inaction on conflicting or
-unverifiable messages. This prevents several coordinators from oscillating a
-one-shot probe or restart faster than the executing seat can observe the
-decisions, while leaving a bounded recovery path for a pre-effect executor
-crash.
-
 ### 6. Evaluation telemetry
 
 Every policy evaluation records one canonical, non-duplicated usage row keyed
@@ -820,6 +780,9 @@ Stable cross-lane seats, generalized routing, cleanup/relocation, compound
 context/message profiles, two-step stand-by/brief acknowledgement, and rotation
 are not prerequisites for this first slice. They remain in the full plan and
 are added to the live canary only after their own review.
+Restart-safe bounded operational actions are likewise deferred to issue #1291;
+the spawn-policy canary does not implement or claim that control-plane
+transaction.
 This avoids paying for the complete identity and lifecycle substrate before the
 spawn-policy hypothesis produces evidence.
 

--- a/specs/1268_lane_policy_scaffold.md
+++ b/specs/1268_lane_policy_scaffold.md
@@ -451,6 +451,24 @@ success. Internal request and rejected-launch evidence remains observable for
 recovery and diagnostics but is not an active child or the normal caller
 contract.
 
+#### Bounded operational action authority
+
+An incident or live verification that permits one bounded production action
+has exactly one named decision authority. Its durable decision records incident
+ID, action ID, monotonically increasing version, authority incarnation, exact
+scope, state, expiry, and evidence requirement. Other seats may relay only that
+same action ID/version; prose such as `final` or `supersedes` has no authority by
+itself.
+
+The action state advances monotonically through proposed, authorized, started,
+and terminal. The authority may revoke only before `started`; once execution is
+recorded, later messages cannot authorize a competing action and recovery must
+reconcile the observed action first. Transferring decision authority is an
+atomic recorded handoff. Recipients act only on the highest durable version and
+default to inaction on conflicting or unverifiable messages. This prevents
+several coordinators from oscillating a one-shot probe or restart faster than
+the executing seat can observe the decisions.
+
 ### 6. Evaluation telemetry
 
 Every policy evaluation records one canonical, non-duplicated usage row keyed
@@ -1069,15 +1087,16 @@ Codex review is a sampled engineering gate, not a proof obtained by repeatedly
 requesting reviews until one happens to return no finding. Each package or final
 integration PR is limited to one deployable capability and declares R0-R3 risk
 before review. R0 needs no cycle; R1 receives one broad round and promotes to R2
-on a reachable P1; R2 receives at most three exact-head rounds; R3 receives at
-least two and at most five. Broad, root-cause/sibling, and current-capability
+on a reachable P0/P1; R2 receives at most three exact-head rounds; R3 receives
+at least two and at most five. Broad, root-cause/sibling, and current-capability
 steers remain the default sequence.
 
 Every round records requested/reviewed head, steer and scope, queue/review wait,
 estimated or direct token counters, findings, disposition, and resulting head.
-Unchanged heads are not re-requested. A head-expanding refactor discovered
-during review becomes a separate package rather than silently enlarging the
-review surface.
+Unchanged heads are not re-requested except for R3's mandatory second round: a
+differently scoped confirmation may review the same immutable head once when
+round 1 produced no change. A head-expanding refactor discovered during review
+becomes a separate package rather than silently enlarging the review surface.
 
 An R2 third-round P1 or an R3 P1 at/after round 3 triggers measured repair
 selection, not owner code review. A newly discovered localized R3 repair may use


### PR DESCRIPTION
## Summary\n- replace owner-gated review exhaustion with risk-tiered R0-R3 review and agent-executed design-return\n- pin fluid policy activation to repository/ref/commit/path/digest and expose enforced/injected/observed/deferred status\n- incorporate the current epic-360 operating model without expanding the first policy slice to compound message caps or two-step brief delivery\n- defer restart-safe bounded operational actions to #1291 after repeated recovery findings showed it is a separate control-plane transaction\n\n## Risk\nR3: normative review and lane-policy execution contract. Reachable P0/P1 blocks merge. Five-round ceiling; repeated or structural findings return to design.\n\n## Review ledger\n- R1 broad at aabb52d: two P1s repaired in e476e1c\n- R2 current-capability at e476e1c: two P1s repaired in 275ed84\n- R3 authority/recovery at 275ed84: one localized P1 repaired in 33b47c9\n- R4 focused at 33b47c9: one localized review-state P1 fixed; repeated operational-recovery P1 split to #1291 and removed in fac056b\n- R5 final reduced-head confirmation requested; no sixth round is permitted\n\n## Verification\n- git diff --check\n- documentation-only review\n\nRefs #1268 and #1291