### PR TITLE
Fix durable Codex review request stale-head supersession

### DIFF
--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -4975,12 +4975,14 @@ def cmd_request_codex_review_status(
 
     print(f"Request: {payload.get('id', 'unknown')}")
     print(f"PR: {payload.get('repo', '?')}#{payload.get('pr_number', '?')}")
+    print(f"Requested head: {payload.get('requested_head_sha') or '-'}")
     print(f"Notify: {payload.get('notify_name') or payload.get('notify_session_id') or '-'}")
     print(f"State: {payload.get('state') or '-'}")
     print(f"Attempts: {payload.get('attempt_count', 0)}")
     print(f"Pickup: {payload.get('pickup_detected_at') or '-'}")
     print(f"Review landed: {payload.get('review_landed_at') or '-'}")
     print(f"Review source: {payload.get('review_source') or '-'}")
+    print(f"Superseded by: {payload.get('superseded_by_request_id') or '-'}")
     print(f"Next retry: {payload.get('next_retry_at') or '-'}")
     print(f"Last error: {payload.get('last_error') or '-'}")
     return 0

--- a/src/github_reviews.py
+++ b/src/github_reviews.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import subprocess
 import time
 from datetime import datetime, timezone
@@ -162,7 +163,7 @@ def validate_open_pr(repo: str, pr_number: int) -> dict:
             "--repo",
             repo,
             "--json",
-            "number,state,title,url",
+            "number,state,title,url,headRefOid",
         ],
         capture_output=True,
         text=True,
@@ -290,40 +291,70 @@ def find_fresh_codex_review_or_comment(
     repo: str,
     pr_number: int,
     since: datetime,
+    *,
+    requested_head_sha: Optional[str] = None,
+    excluded_comment_ids: Optional[set[int]] = None,
 ) -> Optional[dict]:
-    """Find the first fresh Codex review or issue comment newer than `since`."""
+    """Find the first fresh Codex artifact bound to a requested PR head.
+
+    A GitHub review is authoritative only when its ``commit_id`` exactly equals
+    ``requested_head_sha``.  A Codex issue comment has no commit field, so it
+    is accepted only when its body explicitly records that exact full SHA.
+    Request-trigger comments are always excluded, even if GitHub attributes
+    them to an app.
+    """
     since_utc = _coerce_utc(since)
+    expected_head = requested_head_sha.lower() if requested_head_sha else None
+    excluded_ids = excluded_comment_ids or set()
     candidates: list[dict[str, Any]] = []
 
-    latest_review = _fetch_latest_codex_review_snapshot(repo, pr_number)
-    if latest_review:
-        submitted_at = _parse_github_datetime(latest_review.get("submitted_at"))
-        if submitted_at and submitted_at > since_utc:
-            latest_review = _resolve_review_snapshot_to_rest_review(repo, pr_number, latest_review)
+    for review in fetch_pr_reviews(repo, pr_number):
+        submitted_at = _parse_github_datetime(review.get("submitted_at"))
+        commit_id = str(review.get("commit_id") or "").lower()
+        if (
+            submitted_at
+            and submitted_at > since_utc
+            and is_codex_actor(review)
+            and (expected_head is None or commit_id == expected_head)
+        ):
             candidates.append(
                 {
                     "source": "review",
                     "created_at": submitted_at,
-                    "id": latest_review.get("id"),
-                    "url": latest_review.get("html_url") or latest_review.get("pull_request_url"),
-                    "state": latest_review.get("state"),
-                    "body": latest_review.get("body"),
-                    "actor": latest_review.get("user", {}).get("login"),
+                    "id": review.get("id"),
+                    "url": review.get("html_url") or review.get("pull_request_url"),
+                    "state": review.get("state"),
+                    "body": review.get("body"),
+                    "actor": review.get("user", {}).get("login"),
+                    "head_sha": commit_id,
                 }
             )
 
     for comment in fetch_pr_issue_comments(repo, pr_number, since=since_utc):
         created_at = _parse_github_datetime(comment.get("created_at"))
-        if created_at and created_at > since_utc and is_codex_actor(comment):
+        body = str(comment.get("body") or "")
+        comment_id = comment.get("id")
+        comment_head_match = re.search(r"Reviewed\s+commit\s*:\s*`([0-9a-fA-F]{40})`", body, re.IGNORECASE)
+        comment_head = comment_head_match.group(1).lower() if comment_head_match else None
+        if (
+            created_at
+            and created_at > since_utc
+            and isinstance(comment_id, int)
+            and comment_id not in excluded_ids
+            and is_codex_actor(comment)
+            and "@codex review" not in body.lower()
+            and (expected_head is None or comment_head == expected_head)
+        ):
             candidates.append(
                 {
                     "source": "comment",
                     "created_at": created_at,
-                    "id": comment.get("id"),
+                    "id": comment_id,
                     "url": comment.get("html_url"),
                     "state": None,
-                    "body": comment.get("body"),
+                    "body": body,
                     "actor": comment.get("user", {}).get("login"),
+                    "head_sha": comment_head,
                 }
             )
 

--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -37,6 +37,10 @@ from .github_reviews import (
 logger = logging.getLogger(__name__)
 
 
+class CodexReviewRequestConflict(ValueError):
+    """An active request belongs to another caller and cannot be replaced."""
+
+
 class MessageQueueManager:
     """
     Manages queued messages and delivers them reliably when sessions become idle.
@@ -368,6 +372,18 @@ class MessageQueueManager:
             CREATE INDEX IF NOT EXISTS idx_codex_review_notify_active
             ON codex_review_request_registrations(notify_session_id, is_active)
         """)
+        cursor.execute("PRAGMA table_info(codex_review_request_registrations)")
+        codex_review_columns = [col[1] for col in cursor.fetchall()]
+        for column, declaration in (
+            ("requested_head_sha", "TEXT"),
+            ("superseded_by_request_id", "TEXT"),
+            ("superseded_at", "TIMESTAMP"),
+        ):
+            if column not in codex_review_columns:
+                cursor.execute(
+                    f"ALTER TABLE codex_review_request_registrations ADD COLUMN {column} {declaration}"
+                )
+                logger.info("Migrated codex_review_request_registrations: added %s", column)
 
         self._db_conn.commit()
         logger.info(f"Message queue database initialized at {self.db_path} (WAL mode enabled)")
@@ -926,6 +942,9 @@ class MessageQueueManager:
             last_error=row[21],
             state=row[22],
             is_active=bool(row[23]),
+            requested_head_sha=row[24],
+            superseded_by_request_id=row[25],
+            superseded_at=datetime.fromisoformat(row[26]) if row[26] else None,
         )
 
     def _load_codex_review_request_from_db(
@@ -940,7 +959,8 @@ class MessageQueueManager:
                    latest_request_posted_at, attempt_count, next_retry_at,
                    poll_interval_seconds, retry_interval_seconds, pickup_detected_at,
                    pickup_source, review_landed_at, review_source, review_comment_id,
-                   review_url, last_polled_at, last_error, state, is_active
+                   review_url, last_polled_at, last_error, state, is_active,
+                   requested_head_sha, superseded_by_request_id, superseded_at
             FROM codex_review_request_registrations
             WHERE id = ?
             """,
@@ -979,7 +999,8 @@ class MessageQueueManager:
                    latest_request_posted_at, attempt_count, next_retry_at,
                    poll_interval_seconds, retry_interval_seconds, pickup_detected_at,
                    pickup_source, review_landed_at, review_source, review_comment_id,
-                   review_url, last_polled_at, last_error, state, is_active
+                   review_url, last_polled_at, last_error, state, is_active,
+                   requested_head_sha, superseded_by_request_id, superseded_at
             FROM codex_review_request_registrations
         """
         if where_clauses:
@@ -989,23 +1010,95 @@ class MessageQueueManager:
         rows = self._execute_query(query, tuple(params))
         return [self._row_to_codex_review_request_registration(row) for row in rows]
 
-    def _find_active_codex_review_request(
+    @staticmethod
+    def _codex_review_owner_id(registration: CodexReviewRequestRegistration) -> str:
+        """Return the caller that owns replacement rights for a request."""
+        return registration.requester_session_id or registration.notify_session_id
+
+    def _codex_review_request_lock(
         self,
         repo: str,
         pr_number: int,
-        notify_session_id: str,
-    ) -> Optional[CodexReviewRequestRegistration]:
-        """Return an active duplicate request when one already exists."""
-        for registration in self._codex_review_requests.values():
-            if not registration.is_active:
-                continue
-            if (
-                registration.repo == repo
-                and registration.pr_number == pr_number
-                and registration.notify_session_id == notify_session_id
-            ):
-                return registration
-        return None
+        owner_session_id: str,
+    ) -> asyncio.Lock:
+        """Return the local serialization lock for one caller's PR requests."""
+        key = (repo, pr_number, owner_session_id)
+        return self._codex_review_request_creation_locks.setdefault(key, asyncio.Lock())
+
+    def _find_active_codex_review_requests(
+        self,
+        repo: str,
+        pr_number: int,
+    ) -> list[CodexReviewRequestRegistration]:
+        """Load active requests from durable state, including post-restart rows."""
+        registrations = self._load_codex_review_requests_from_db(
+            repo=repo,
+            pr_number=pr_number,
+            include_inactive=False,
+        )
+        resolved = []
+        for registration in registrations:
+            in_memory = self._codex_review_requests.get(registration.id)
+            if in_memory is None:
+                self._codex_review_requests[registration.id] = registration
+                in_memory = registration
+            resolved.append(in_memory)
+        return resolved
+
+    def _persist_codex_review_request_replacement(
+        self,
+        registration: CodexReviewRequestRegistration,
+        superseded: list[CodexReviewRequestRegistration],
+    ) -> None:
+        """Atomically retain old requests and insert their active replacement."""
+        superseded_at = datetime.now(timezone.utc).replace(tzinfo=None)
+        with self._db_lock:
+            cursor = self._db_conn.cursor()
+            try:
+                cursor.execute("BEGIN")
+                for prior in superseded:
+                    cursor.execute(
+                        """
+                        UPDATE codex_review_request_registrations
+                        SET is_active = 0, state = 'superseded',
+                            superseded_by_request_id = ?, superseded_at = ?
+                        WHERE id = ? AND is_active = 1
+                        """,
+                        (registration.id, superseded_at.isoformat(), prior.id),
+                    )
+                    prior.is_active = False
+                    prior.state = "superseded"
+                    prior.superseded_by_request_id = registration.id
+                    prior.superseded_at = superseded_at
+                cursor.execute(
+                    """
+                    INSERT INTO codex_review_request_registrations
+                    (id, repo, pr_number, requester_session_id, notify_session_id, steer,
+                     requested_at, latest_request_comment_id, latest_request_comment_url,
+                     latest_request_posted_at, attempt_count, next_retry_at,
+                     poll_interval_seconds, retry_interval_seconds, pickup_detected_at,
+                     pickup_source, review_landed_at, review_source, review_comment_id,
+                     review_url, last_polled_at, last_error, state, is_active,
+                     requested_head_sha, superseded_by_request_id, superseded_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?)
+                    """,
+                    (
+                        registration.id, registration.repo, registration.pr_number,
+                        registration.requester_session_id, registration.notify_session_id,
+                        registration.steer, registration.requested_at.isoformat(),
+                        registration.latest_request_comment_id, registration.latest_request_comment_url,
+                        registration.latest_request_posted_at.isoformat() if registration.latest_request_posted_at else None,
+                        registration.attempt_count,
+                        registration.next_retry_at.isoformat() if registration.next_retry_at else None,
+                        registration.poll_interval_seconds, registration.retry_interval_seconds,
+                        None, None, None, None, None, None, None, None, registration.state,
+                        registration.requested_head_sha, None, None,
+                    ),
+                )
+                self._db_conn.commit()
+            except Exception:
+                self._db_conn.rollback()
+                raise
 
     async def register_codex_review_request(
         self,
@@ -1031,15 +1124,40 @@ class MessageQueueManager:
             raise ValueError(f"Requester session {requester_session_id} not found")
 
         resolved_repo = await self._resolve_codex_review_repo(repo, requester_session_id)
-        creation_key = (resolved_repo, pr_number, notify_session_id)
-        creation_lock = self._codex_review_request_creation_locks.setdefault(creation_key, asyncio.Lock())
+        owner_session_id = requester_session_id or notify_session_id
+        creation_lock = self._codex_review_request_lock(resolved_repo, pr_number, owner_session_id)
         async with creation_lock:
-            if self._find_active_codex_review_request(resolved_repo, pr_number, notify_session_id):
-                raise ValueError(
-                    f"Active Codex review request already exists for {resolved_repo} PR #{pr_number}"
+            pr = await asyncio.to_thread(validate_open_pr, resolved_repo, pr_number)
+            requested_head_sha = str(pr.get("headRefOid") or "").lower()
+            if not requested_head_sha:
+                raise RuntimeError(
+                    f"PR #{pr_number} in {resolved_repo} did not provide an exact head SHA"
                 )
 
-            await asyncio.to_thread(validate_open_pr, resolved_repo, pr_number)
+            active_requests = self._find_active_codex_review_requests(resolved_repo, pr_number)
+            owned_active = [
+                registration for registration in active_requests
+                if self._codex_review_owner_id(registration) == owner_session_id
+            ]
+            same_head = next(
+                (registration for registration in owned_active
+                 if registration.requested_head_sha == requested_head_sha),
+                None,
+            )
+            if same_head:
+                return same_head
+            competing = next(
+                (registration for registration in active_requests
+                 if self._codex_review_owner_id(registration) != owner_session_id),
+                None,
+            )
+            if competing:
+                raise CodexReviewRequestConflict(
+                    "Active Codex review request "
+                    f"{competing.id} already owns {resolved_repo} PR #{pr_number} "
+                    f"for caller {self._codex_review_owner_id(competing)} at head "
+                    f"{competing.requested_head_sha or 'unknown'}; wait for it or have its caller cancel it."
+                )
             comment_result = await asyncio.to_thread(post_pr_review_comment, resolved_repo, pr_number, steer)
 
             latest_comment_id = comment_result.get("comment_id") or None
@@ -1080,45 +1198,14 @@ class MessageQueueManager:
                 next_retry_at=latest_posted_at + timedelta(seconds=retry_interval_seconds),
                 poll_interval_seconds=poll_interval_seconds,
                 retry_interval_seconds=retry_interval_seconds,
+                requested_head_sha=requested_head_sha,
             )
+            self._persist_codex_review_request_replacement(registration, owned_active)
             self._codex_review_requests[request_id] = registration
-            self._execute(
-                """
-                INSERT OR REPLACE INTO codex_review_request_registrations
-                (id, repo, pr_number, requester_session_id, notify_session_id, steer,
-                 requested_at, latest_request_comment_id, latest_request_comment_url,
-                 latest_request_posted_at, attempt_count, next_retry_at,
-                 poll_interval_seconds, retry_interval_seconds, pickup_detected_at,
-                 pickup_source, review_landed_at, review_source, review_comment_id,
-                 review_url, last_polled_at, last_error, state, is_active)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)
-                """,
-                (
-                    registration.id,
-                    registration.repo,
-                    registration.pr_number,
-                    registration.requester_session_id,
-                    registration.notify_session_id,
-                    registration.steer,
-                    registration.requested_at.isoformat(),
-                    registration.latest_request_comment_id,
-                    registration.latest_request_comment_url,
-                    registration.latest_request_posted_at.isoformat() if registration.latest_request_posted_at else None,
-                    registration.attempt_count,
-                    registration.next_retry_at.isoformat() if registration.next_retry_at else None,
-                    registration.poll_interval_seconds,
-                    registration.retry_interval_seconds,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    None,
-                    registration.state,
-                ),
-            )
+            for prior in owned_active:
+                task = self._codex_review_request_tasks.pop(prior.id, None)
+                if task:
+                    task.cancel()
 
             task = asyncio.create_task(self._run_codex_review_request_task(registration.id))
             self._codex_review_request_tasks[registration.id] = task
@@ -1226,6 +1313,52 @@ class MessageQueueManager:
             message = f"{message} {url}"
         return message
 
+    async def _complete_codex_review_request_if_current(
+        self,
+        registration: CodexReviewRequestRegistration,
+        review_match: dict,
+        now: datetime,
+    ) -> bool:
+        """Complete and wake only if this exact durable request is still active.
+
+        Matching happens outside the caller lock because it may invoke GitHub.
+        Re-checking and persisting inside the same lock used for replacement
+        prevents a late old task from waking a caller after supersession.
+        """
+        owner_session_id = self._codex_review_owner_id(registration)
+        lock = self._codex_review_request_lock(
+            registration.repo, registration.pr_number, owner_session_id
+        )
+        async with lock:
+            persisted = self._load_codex_review_request_from_db(registration.id)
+            if persisted is None or not persisted.is_active:
+                return False
+
+            review_landed_at = self._parse_iso_datetime(review_match.get("created_at")) or now
+            updates = {
+                "review_landed_at": review_landed_at,
+                "review_source": review_match.get("source"),
+                "review_comment_id": review_match.get("id"),
+                "review_url": review_match.get("url"),
+                "state": "completed",
+                "is_active": False,
+                "last_error": None,
+            }
+            self._update_codex_review_request_db(registration.id, **updates)
+            registration.review_landed_at = review_landed_at
+            registration.review_source = review_match.get("source")
+            registration.review_comment_id = review_match.get("id")
+            registration.review_url = review_match.get("url")
+            registration.state = "completed"
+            registration.is_active = False
+            registration.last_error = None
+            self.queue_message(
+                target_session_id=registration.notify_session_id,
+                text=self._render_codex_review_landed_message(registration, review_match),
+                delivery_mode="sequential",
+            )
+            return True
+
     async def _run_codex_review_request_task(self, request_id: str) -> None:
         """Poll GitHub until one Codex review request completes or is cancelled."""
         try:
@@ -1284,40 +1417,22 @@ class MessageQueueManager:
                         registration.repo,
                         registration.pr_number,
                         registration.latest_request_posted_at or registration.requested_at,
+                        requested_head_sha=registration.requested_head_sha,
+                        excluded_comment_ids={registration.latest_request_comment_id}
+                        if registration.latest_request_comment_id
+                        else set(),
                     )
                     if review_match:
-                        registration.review_landed_at = (
-                            self._parse_iso_datetime(review_match.get("created_at")) or now
-                        )
-                        registration.review_source = review_match.get("source")
-                        registration.review_comment_id = review_match.get("id")
-                        registration.review_url = review_match.get("url")
-                        registration.state = "completed"
-                        registration.is_active = False
-                        registration.last_error = None
-                        updates.update(
-                            {
-                                "review_landed_at": registration.review_landed_at,
-                                "review_source": registration.review_source,
-                                "review_comment_id": registration.review_comment_id,
-                                "review_url": registration.review_url,
-                                "state": "completed",
-                                "is_active": False,
-                                "last_error": None,
-                            }
-                        )
-                        self.queue_message(
-                            target_session_id=registration.notify_session_id,
-                            text=self._render_codex_review_landed_message(registration, review_match),
-                            delivery_mode="sequential",
-                        )
-                        self._update_codex_review_request_db(request_id, **updates)
-                        logger.info(
-                            "Codex review request %s completed for %s PR #%s",
-                            request_id,
-                            registration.repo,
-                            registration.pr_number,
-                        )
+                        if await self._complete_codex_review_request_if_current(
+                            registration, review_match, now
+                        ):
+                            logger.info(
+                                "Codex review request %s completed for %s PR #%s",
+                                request_id,
+                                registration.repo,
+                                registration.pr_number,
+                            )
+                            return
                         return
 
                     if registration.next_retry_at and now >= registration.next_retry_at:

--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -1019,10 +1019,15 @@ class MessageQueueManager:
         self,
         repo: str,
         pr_number: int,
-        owner_session_id: str,
+        _owner_session_id: str,
     ) -> asyncio.Lock:
-        """Return the local serialization lock for one caller's PR requests."""
-        key = (repo, pr_number, owner_session_id)
+        """Return the local admission lock for every request on one PR.
+
+        Ownership determines whether an existing request is replaceable, but
+        every owner must share this lock so two callers cannot both observe an
+        empty durable state and create competing active requests.
+        """
+        key = (repo, pr_number, "__pr_admission__")
         return self._codex_review_request_creation_locks.setdefault(key, asyncio.Lock())
 
     def _find_active_codex_review_requests(

--- a/src/message_queue.py
+++ b/src/message_queue.py
@@ -1071,10 +1071,11 @@ class MessageQueueManager:
                         """,
                         (registration.id, superseded_at.isoformat(), prior.id),
                     )
-                    prior.is_active = False
-                    prior.state = "superseded"
-                    prior.superseded_by_request_id = registration.id
-                    prior.superseded_at = superseded_at
+                    if cursor.rowcount:
+                        prior.is_active = False
+                        prior.state = "superseded"
+                        prior.superseded_by_request_id = registration.id
+                        prior.superseded_at = superseded_at
                 cursor.execute(
                     """
                     INSERT INTO codex_review_request_registrations
@@ -1340,16 +1341,23 @@ class MessageQueueManager:
                 return False
 
             review_landed_at = self._parse_iso_datetime(review_match.get("created_at")) or now
-            updates = {
-                "review_landed_at": review_landed_at,
-                "review_source": review_match.get("source"),
-                "review_comment_id": review_match.get("id"),
-                "review_url": review_match.get("url"),
-                "state": "completed",
-                "is_active": False,
-                "last_error": None,
-            }
-            self._update_codex_review_request_db(registration.id, **updates)
+            with self._db_lock:
+                cursor = self._db_conn.cursor()
+                cursor.execute(
+                    """
+                    UPDATE codex_review_request_registrations
+                    SET review_landed_at = ?, review_source = ?, review_comment_id = ?,
+                        review_url = ?, state = 'completed', is_active = 0, last_error = NULL
+                    WHERE id = ? AND is_active = 1
+                    """,
+                    (
+                        review_landed_at.isoformat(), review_match.get("source"),
+                        review_match.get("id"), review_match.get("url"), registration.id,
+                    ),
+                )
+                self._db_conn.commit()
+                if not cursor.rowcount:
+                    return False
             registration.review_landed_at = review_landed_at
             registration.review_source = review_match.get("source")
             registration.review_comment_id = review_match.get("id")

--- a/src/models.py
+++ b/src/models.py
@@ -786,6 +786,9 @@ class CodexReviewRequestRegistration:
     last_error: Optional[str] = None
     state: str = "active"
     is_active: bool = True
+    requested_head_sha: Optional[str] = None
+    superseded_by_request_id: Optional[str] = None
+    superseded_at: Optional[datetime] = None
 
     def to_dict(self) -> dict:
         """Convert registration to a JSON-serializable dictionary."""
@@ -814,6 +817,9 @@ class CodexReviewRequestRegistration:
             "last_error": self.last_error,
             "state": self.state,
             "is_active": self.is_active,
+            "requested_head_sha": self.requested_head_sha,
+            "superseded_by_request_id": self.superseded_by_request_id,
+            "superseded_at": self.superseded_at.isoformat() if self.superseded_at else None,
         }
 
     @classmethod
@@ -844,6 +850,9 @@ class CodexReviewRequestRegistration:
             last_error=data.get("last_error"),
             state=data.get("state", "active"),
             is_active=bool(data.get("is_active", True)),
+            requested_head_sha=data.get("requested_head_sha"),
+            superseded_by_request_id=data.get("superseded_by_request_id"),
+            superseded_at=datetime.fromisoformat(data["superseded_at"]) if data.get("superseded_at") else None,
         )
 
 

--- a/src/server.py
+++ b/src/server.py
@@ -61,6 +61,7 @@ from .models import (
     SubagentStatus,
     DeliveryResult,
 )
+from .message_queue import CodexReviewRequestConflict
 from .cli.commands import validate_friendly_name
 from .cli.dispatch import get_auto_remind_config
 from .bug_report_store import BugReportStore
@@ -964,6 +965,9 @@ class CodexReviewRequestResponse(BaseModel):
     last_error: Optional[str] = None
     state: str
     is_active: bool = True
+    requested_head_sha: Optional[str] = None
+    superseded_by_request_id: Optional[str] = None
+    superseded_at: Optional[str] = None
 
 
 class AgentStatusRequest(BaseModel):
@@ -2516,6 +2520,9 @@ def create_app(
             last_error=registration.last_error,
             state=registration.state,
             is_active=registration.is_active,
+            requested_head_sha=registration.requested_head_sha,
+            superseded_by_request_id=registration.superseded_by_request_id,
+            superseded_at=registration.superseded_at.isoformat() if registration.superseded_at else None,
         )
 
     def _response_dict(model: BaseModel) -> dict:
@@ -8726,6 +8733,8 @@ Provide ONLY the summary, no preamble or questions."""
                 poll_interval_seconds=request.poll_interval_seconds,
                 retry_interval_seconds=request.retry_interval_seconds,
             )
+        except CodexReviewRequestConflict as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         except RuntimeError as exc:

--- a/tests/unit/test_codex_review_request.py
+++ b/tests/unit/test_codex_review_request.py
@@ -250,6 +250,51 @@ async def test_register_current_head_owned_by_another_caller_returns_actionable_
 
 
 @pytest.mark.asyncio
+async def test_concurrent_different_callers_admit_only_one_active_request(mq, mock_session_manager, tmp_path):
+    other = Session(
+        id="other-agent",
+        name="other-agent",
+        working_dir=str(tmp_path),
+        tmux_session="claude-other-agent",
+        provider="claude",
+        log_file=str(tmp_path / "other.log"),
+        status=SessionStatus.RUNNING,
+    )
+    sessions = {"agent618": mock_session_manager.sessions["agent618"], other.id: other}
+    mock_session_manager.get_session.side_effect = sessions.get
+    post_started = asyncio.Event()
+    release_post = asyncio.Event()
+
+    async def delayed_post(*_args, **_kwargs):
+        post_started.set()
+        await release_post.wait()
+        return {"comment_id": 321, "comment_url": "https://example/321", "posted_at": "2026-04-17T00:00:00Z"}
+
+    with patch.object(mq, "_run_codex_review_request_task", AsyncMock()):
+        with patch("src.message_queue.validate_open_pr", return_value={"state": "OPEN", "headRefOid": "a" * 40}):
+            with patch("src.message_queue.post_pr_review_comment") as post_comment:
+                with patch("src.message_queue.fetch_issue_comment", return_value=None):
+                    async def fake_to_thread(function, *args, **kwargs):
+                        if function is post_comment:
+                            return await delayed_post(*args, **kwargs)
+                        return function(*args, **kwargs)
+                    with patch("src.message_queue.asyncio.to_thread", side_effect=fake_to_thread):
+                        first = asyncio.create_task(mq.register_codex_review_request(
+                            pr_number=42, repo="owner/repo", requester_session_id="agent618", notify_session_id="agent618"
+                        ))
+                        await post_started.wait()
+                        second = asyncio.create_task(mq.register_codex_review_request(
+                            pr_number=42, repo="owner/repo", requester_session_id="other-agent", notify_session_id="other-agent"
+                        ))
+                        release_post.set()
+                        first_result, second_result = await asyncio.gather(first, second, return_exceptions=True)
+
+    assert isinstance(first_result, CodexReviewRequestRegistration)
+    assert isinstance(second_result, CodexReviewRequestConflict)
+    assert len(mq.list_codex_review_requests(repo="owner/repo", pr_number=42)) == 1
+
+
+@pytest.mark.asyncio
 async def test_late_old_completion_cannot_complete_or_wake_replacement(mq):
     old_head = "a" * 40
     new_head = "b" * 40

--- a/tests/unit/test_codex_review_request.py
+++ b/tests/unit/test_codex_review_request.py
@@ -384,6 +384,7 @@ async def test_codex_review_request_task_completes_and_queues_message(mq):
         next_retry_at=datetime(2026, 4, 17, 0, 10, 0),
         requested_head_sha="a" * 40,
     )
+    mq._persist_codex_review_request_replacement(reg, [])
     mq._codex_review_requests[reg.id] = reg
     mq.queue_message = MagicMock()
 
@@ -427,6 +428,7 @@ async def test_codex_review_request_task_still_checks_review_when_pickup_lookup_
         next_retry_at=datetime(2026, 4, 17, 0, 10, 0),
         requested_head_sha="a" * 40,
     )
+    mq._persist_codex_review_request_replacement(reg, [])
     mq._codex_review_requests[reg.id] = reg
     mq.queue_message = MagicMock()
 

--- a/tests/unit/test_codex_review_request.py
+++ b/tests/unit/test_codex_review_request.py
@@ -17,7 +17,7 @@ from src.cli.commands import (
     cmd_request_codex_review_list,
     cmd_request_codex_review_status,
 )
-from src.message_queue import MessageQueueManager
+from src.message_queue import CodexReviewRequestConflict, MessageQueueManager
 from src.models import CodexReviewRequestRegistration, Session, SessionStatus
 from src.server import create_app
 
@@ -65,7 +65,7 @@ def mq(mock_session_manager, temp_db_path):
 @pytest.mark.asyncio
 async def test_register_codex_review_request_persists_and_lists(mq, mock_session_manager, temp_db_path):
     with patch.object(mq, "_run_codex_review_request_task", AsyncMock()):
-        with patch("src.message_queue.validate_open_pr", return_value={"state": "OPEN"}):
+        with patch("src.message_queue.validate_open_pr", return_value={"state": "OPEN", "headRefOid": "a" * 40}):
             with patch(
                 "src.message_queue.post_pr_review_comment",
                 return_value={
@@ -107,7 +107,7 @@ async def test_register_codex_review_request_persists_and_lists(mq, mock_session
 @pytest.mark.asyncio
 async def test_register_codex_review_request_rejects_duplicates(mq):
     with patch.object(mq, "_run_codex_review_request_task", AsyncMock()):
-        with patch("src.message_queue.validate_open_pr", return_value={"state": "OPEN"}):
+        with patch("src.message_queue.validate_open_pr", return_value={"state": "OPEN", "headRefOid": "a" * 40}):
             with patch(
                 "src.message_queue.post_pr_review_comment",
                 return_value={
@@ -123,13 +123,13 @@ async def test_register_codex_review_request_rejects_duplicates(mq):
                         requester_session_id="agent618",
                         notify_session_id="agent618",
                     )
-                    with pytest.raises(ValueError, match="already exists"):
-                        await mq.register_codex_review_request(
+                    repeated = await mq.register_codex_review_request(
                             pr_number=42,
                             repo="owner/repo",
                             requester_session_id="agent618",
                             notify_session_id="agent618",
-                        )
+                    )
+    assert repeated.id == mq.list_codex_review_requests(notify_session_id="agent618")[0].id
 
 
 @pytest.mark.asyncio
@@ -157,7 +157,7 @@ async def test_register_codex_review_request_serializes_duplicate_creation(mq):
         }
 
     with patch.object(mq, "_run_codex_review_request_task", AsyncMock()):
-        with patch("src.message_queue.validate_open_pr", return_value={"state": "OPEN"}):
+        with patch("src.message_queue.validate_open_pr", return_value={"state": "OPEN", "headRefOid": "a" * 40}):
             with patch("src.message_queue.post_pr_review_comment", side_effect=fake_post):
                 with patch("src.message_queue.fetch_issue_comment", return_value=None):
                     first = asyncio.create_task(
@@ -179,9 +179,147 @@ async def test_register_codex_review_request_serializes_duplicate_creation(mq):
                     first_result, second_result = await asyncio.gather(first, second, return_exceptions=True)
 
     assert isinstance(first_result, CodexReviewRequestRegistration)
-    assert isinstance(second_result, ValueError)
-    assert "already exists" in str(second_result)
+    assert isinstance(second_result, CodexReviewRequestRegistration)
+    assert second_result.id == first_result.id
     assert comment_call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_register_newer_head_supersedes_same_callers_old_request_and_preserves_history(mq):
+    old_head = "a" * 40
+    new_head = "b" * 40
+    with patch.object(mq, "_run_codex_review_request_task", AsyncMock()):
+        with patch(
+            "src.message_queue.validate_open_pr",
+            side_effect=[{"state": "OPEN", "headRefOid": old_head}, {"state": "OPEN", "headRefOid": new_head}],
+        ):
+            with patch(
+                "src.message_queue.post_pr_review_comment",
+                side_effect=[
+                    {"comment_id": 321, "comment_url": "https://example/321", "posted_at": "2026-04-17T00:00:00Z"},
+                    {"comment_id": 322, "comment_url": "https://example/322", "posted_at": "2026-04-17T00:01:00Z"},
+                ],
+            ):
+                with patch("src.message_queue.fetch_issue_comment", return_value=None):
+                    old = await mq.register_codex_review_request(
+                        pr_number=42, repo="owner/repo", requester_session_id="agent618", notify_session_id="agent618"
+                    )
+                    replacement = await mq.register_codex_review_request(
+                        pr_number=42, repo="owner/repo", requester_session_id="agent618", notify_session_id="agent618"
+                    )
+
+    assert old.is_active is False
+    assert old.state == "superseded"
+    assert old.superseded_by_request_id == replacement.id
+    assert replacement.is_active is True
+    assert replacement.requested_head_sha == new_head
+    rows = mq.list_codex_review_requests(
+        notify_session_id="agent618", repo="owner/repo", pr_number=42, include_inactive=True
+    )
+    assert [(row.id, row.state, row.requested_head_sha) for row in rows] == [
+        (old.id, "superseded", old_head),
+        (replacement.id, "active", new_head),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_register_current_head_owned_by_another_caller_returns_actionable_conflict(mq):
+    active = CodexReviewRequestRegistration(
+        id="other-request",
+        repo="owner/repo",
+        pr_number=42,
+        requester_session_id="other-agent",
+        notify_session_id="agent618",
+        steer=None,
+        requested_at=datetime(2026, 4, 17, 0, 0, 0),
+        latest_request_comment_id=321,
+        latest_request_comment_url="https://example/321",
+        latest_request_posted_at=datetime(2026, 4, 17, 0, 0, 0),
+        attempt_count=1,
+        next_retry_at=datetime(2026, 4, 17, 0, 10, 0),
+        requested_head_sha="a" * 40,
+    )
+    mq._persist_codex_review_request_replacement(active, [])
+    mq._codex_review_requests[active.id] = active
+
+    with patch("src.message_queue.validate_open_pr", return_value={"state": "OPEN", "headRefOid": "a" * 40}):
+        with pytest.raises(CodexReviewRequestConflict, match="other-request.*other-agent.*cancel"):
+            await mq.register_codex_review_request(
+                pr_number=42, repo="owner/repo", requester_session_id="agent618", notify_session_id="agent618"
+            )
+
+
+@pytest.mark.asyncio
+async def test_late_old_completion_cannot_complete_or_wake_replacement(mq):
+    old_head = "a" * 40
+    new_head = "b" * 40
+    with patch.object(mq, "_run_codex_review_request_task", AsyncMock()):
+        with patch(
+            "src.message_queue.validate_open_pr",
+            side_effect=[{"state": "OPEN", "headRefOid": old_head}, {"state": "OPEN", "headRefOid": new_head}],
+        ):
+            with patch(
+                "src.message_queue.post_pr_review_comment",
+                side_effect=[
+                    {"comment_id": 321, "comment_url": "https://example/321", "posted_at": "2026-04-17T00:00:00Z"},
+                    {"comment_id": 322, "comment_url": "https://example/322", "posted_at": "2026-04-17T00:01:00Z"},
+                ],
+            ):
+                with patch("src.message_queue.fetch_issue_comment", return_value=None):
+                    old = await mq.register_codex_review_request(
+                        pr_number=42, repo="owner/repo", requester_session_id="agent618", notify_session_id="agent618"
+                    )
+                    replacement = await mq.register_codex_review_request(
+                        pr_number=42, repo="owner/repo", requester_session_id="agent618", notify_session_id="agent618"
+                    )
+
+    mq.queue_message = MagicMock()
+    completed = await mq._complete_codex_review_request_if_current(
+        old,
+        {"source": "review", "created_at": "2026-04-17T00:02:00Z", "id": 777, "url": "https://example/777"},
+        datetime(2026, 4, 17, 0, 2, 0),
+    )
+    assert completed is False
+    assert replacement.state == "active"
+    assert replacement.is_active is True
+    mq.queue_message.assert_not_called()
+
+
+def test_restart_recovers_only_active_replacement_and_preserves_superseded_history(mock_session_manager, temp_db_path):
+    mq1 = MessageQueueManager(mock_session_manager, db_path=temp_db_path, config={}, notifier=None)
+    old_head = "a" * 40
+    new_head = "b" * 40
+    with patch.object(mq1, "_run_codex_review_request_task", AsyncMock()):
+        with patch(
+            "src.message_queue.validate_open_pr",
+            side_effect=[{"state": "OPEN", "headRefOid": old_head}, {"state": "OPEN", "headRefOid": new_head}],
+        ):
+            with patch(
+                "src.message_queue.post_pr_review_comment",
+                side_effect=[
+                    {"comment_id": 321, "comment_url": "https://example/321", "posted_at": "2026-04-17T00:00:00Z"},
+                    {"comment_id": 322, "comment_url": "https://example/322", "posted_at": "2026-04-17T00:01:00Z"},
+                ],
+            ):
+                with patch("src.message_queue.fetch_issue_comment", return_value=None):
+                    old = asyncio.run(mq1.register_codex_review_request(
+                        pr_number=42, repo="owner/repo", requester_session_id="agent618", notify_session_id="agent618"
+                    ))
+                    replacement = asyncio.run(mq1.register_codex_review_request(
+                        pr_number=42, repo="owner/repo", requester_session_id="agent618", notify_session_id="agent618"
+                    ))
+
+    mq2 = MessageQueueManager(mock_session_manager, db_path=temp_db_path, config={}, notifier=None)
+    with patch.object(mq2, "_run_codex_review_request_task", AsyncMock()):
+        asyncio.run(mq2._recover_codex_review_requests())
+
+    rows = mq2.list_codex_review_requests(notify_session_id="agent618", include_inactive=True)
+    assert [(row.id, row.state, row.requested_head_sha) for row in rows] == [
+        (old.id, "superseded", old_head),
+        (replacement.id, "active", new_head),
+    ]
+    assert old.id not in mq2._codex_review_request_tasks
+    assert replacement.id in mq2._codex_review_request_tasks
 
 
 @pytest.mark.asyncio
@@ -199,6 +337,7 @@ async def test_codex_review_request_task_completes_and_queues_message(mq):
         latest_request_posted_at=datetime(2026, 4, 17, 0, 0, 0),
         attempt_count=1,
         next_retry_at=datetime(2026, 4, 17, 0, 10, 0),
+        requested_head_sha="a" * 40,
     )
     mq._codex_review_requests[reg.id] = reg
     mq.queue_message = MagicMock()
@@ -208,7 +347,8 @@ async def test_codex_review_request_task_completes_and_queues_message(mq):
 
     with patch("asyncio.sleep", side_effect=immediate_sleep):
         with patch("src.message_queue.detect_codex_pickup", return_value=False):
-            with patch(
+            with patch.object(mq, "_load_codex_review_request_from_db", return_value=reg):
+                with patch(
                 "src.message_queue.find_fresh_codex_review_or_comment",
                 return_value={
                     "source": "comment",
@@ -216,8 +356,8 @@ async def test_codex_review_request_task_completes_and_queues_message(mq):
                     "id": 777,
                     "url": "https://github.com/owner/repo/pull/42#issuecomment-777",
                 },
-            ):
-                await mq._run_codex_review_request_task(reg.id)
+                ):
+                    await mq._run_codex_review_request_task(reg.id)
 
     assert reg.state == "completed"
     assert reg.is_active is False
@@ -240,6 +380,7 @@ async def test_codex_review_request_task_still_checks_review_when_pickup_lookup_
         latest_request_posted_at=datetime(2026, 4, 17, 0, 0, 0),
         attempt_count=1,
         next_retry_at=datetime(2026, 4, 17, 0, 10, 0),
+        requested_head_sha="a" * 40,
     )
     mq._codex_review_requests[reg.id] = reg
     mq.queue_message = MagicMock()
@@ -249,7 +390,8 @@ async def test_codex_review_request_task_still_checks_review_when_pickup_lookup_
 
     with patch("asyncio.sleep", side_effect=immediate_sleep):
         with patch("src.message_queue.detect_codex_pickup", side_effect=RuntimeError("boom")):
-            with patch(
+            with patch.object(mq, "_load_codex_review_request_from_db", return_value=reg):
+                with patch(
                 "src.message_queue.find_fresh_codex_review_or_comment",
                 return_value={
                     "source": "review",
@@ -257,8 +399,8 @@ async def test_codex_review_request_task_still_checks_review_when_pickup_lookup_
                     "id": 778,
                     "url": "https://github.com/owner/repo/pull/42#pullrequestreview-778",
                 },
-            ):
-                await mq._run_codex_review_request_task(reg.id)
+                ):
+                    await mq._run_codex_review_request_task(reg.id)
 
     assert reg.state == "completed"
     assert reg.is_active is False
@@ -271,7 +413,7 @@ def test_recover_codex_review_requests_restores_active_records(mock_session_mana
     mock_session_manager.message_queue_manager = mq1
 
     with patch.object(mq1, "_run_codex_review_request_task", AsyncMock()):
-        with patch("src.message_queue.validate_open_pr", return_value={"state": "OPEN"}):
+        with patch("src.message_queue.validate_open_pr", return_value={"state": "OPEN", "headRefOid": "a" * 40}):
             with patch(
                 "src.message_queue.post_pr_review_comment",
                 return_value={
@@ -304,7 +446,7 @@ def test_recover_codex_review_requests_preserves_inactive_history(mock_session_m
     mock_session_manager.message_queue_manager = mq1
 
     with patch.object(mq1, "_run_codex_review_request_task", AsyncMock()):
-        with patch("src.message_queue.validate_open_pr", return_value={"state": "OPEN"}):
+        with patch("src.message_queue.validate_open_pr", return_value={"state": "OPEN", "headRefOid": "a" * 40}):
             with patch(
                 "src.message_queue.post_pr_review_comment",
                 return_value={
@@ -377,7 +519,7 @@ async def test_register_codex_review_request_resolves_repo_via_to_thread(mq):
         return func(*args, **kwargs)
 
     with patch.object(mq, "_run_codex_review_request_task", AsyncMock()):
-        with patch("src.message_queue.validate_open_pr", return_value={"state": "OPEN"}):
+        with patch("src.message_queue.validate_open_pr", return_value={"state": "OPEN", "headRefOid": "a" * 40}):
             with patch(
                 "src.message_queue.post_pr_review_comment",
                 return_value={
@@ -467,6 +609,7 @@ def test_codex_review_request_endpoints_roundtrip(mock_session_manager):
         latest_request_posted_at=datetime(2026, 4, 17, 0, 0, 0),
         attempt_count=1,
         next_retry_at=datetime(2026, 4, 17, 0, 10, 0),
+        requested_head_sha="a" * 40,
     )
     queue_mgr.register_codex_review_request = AsyncMock(return_value=reg)
     queue_mgr.list_codex_review_requests.return_value = [reg]
@@ -503,6 +646,7 @@ def test_codex_review_request_endpoints_roundtrip(mock_session_manager):
     )
     assert create_response.status_code == 200
     assert create_response.json()["id"] == "req123"
+    assert create_response.json()["requested_head_sha"] == "a" * 40
 
     list_response = client.get("/codex-review-requests?notify_target=agent618")
     assert list_response.status_code == 200
@@ -547,6 +691,22 @@ def test_codex_review_request_endpoint_maps_operational_failures(mock_session_ma
     )
     assert response.status_code == 502
     assert response.json()["detail"] == "Failed to request Codex review: gh hung"
+
+
+def test_codex_review_request_endpoint_maps_ownership_conflict_to_409(mock_session_manager):
+    queue_mgr = MagicMock()
+    queue_mgr.register_codex_review_request = AsyncMock(
+        side_effect=CodexReviewRequestConflict("Active Codex review request other-request; have its caller cancel it.")
+    )
+    mock_session_manager.message_queue_manager = queue_mgr
+    client = TestClient(create_app(session_manager=mock_session_manager))
+
+    response = client.post(
+        "/codex-review-requests",
+        json={"pr_number": 42, "repo": "owner/repo", "requester_session_id": "agent618"},
+    )
+    assert response.status_code == 409
+    assert "other-request" in response.json()["detail"]
 
 
 def test_codex_review_request_endpoint_serializes_string_review_ids(mock_session_manager):
@@ -668,6 +828,7 @@ def test_cmd_request_codex_review_create_list_status_cancel(capsys):
             "pickup_detected_at": None,
             "review_landed_at": None,
             "review_source": None,
+            "requested_head_sha": "a" * 40,
             "next_retry_at": "2026-04-17T00:10:00",
             "last_error": None,
         },
@@ -724,7 +885,9 @@ def test_cmd_request_codex_review_create_list_status_cancel(capsys):
         json_output=False,
     )
     assert rc == 0
-    assert "Request: req123" in capsys.readouterr().out
+    status_output = capsys.readouterr().out
+    assert "Request: req123" in status_output
+    assert f"Requested head: {'a' * 40}" in status_output
 
     rc = cmd_request_codex_review_cancel(client, "req123")
     assert rc == 0

--- a/tests/unit/test_github_reviews.py
+++ b/tests/unit/test_github_reviews.py
@@ -255,18 +255,11 @@ class TestCodexHelpers:
         assert detect_codex_pickup("owner/repo", 12345) is False
 
     @patch("src.github_reviews.fetch_pr_issue_comments")
-    @patch("src.github_reviews._resolve_review_snapshot_to_rest_review")
-    @patch("src.github_reviews._fetch_latest_codex_review_snapshot")
-    def test_find_fresh_codex_review_or_comment_prefers_newer_than_since(self, mock_latest_review, mock_resolve_review, mock_comments):
+    @patch("src.github_reviews.fetch_pr_reviews")
+    def test_find_fresh_codex_review_or_comment_prefers_newer_than_since(self, mock_reviews, mock_comments):
         since = datetime(2026, 4, 16, 18, 27, 57)
-        mock_latest_review.return_value = {
-            "id": 100,
-            "user": {"login": "codex[bot]"},
-            "submitted_at": "2026-04-16T18:20:00Z",
-            "html_url": "https://example/review/100",
-            "state": "COMMENTED",
-        }
-        mock_resolve_review.return_value = mock_latest_review.return_value
+        head = "a" * 40
+        mock_reviews.return_value = []
         mock_comments.return_value = [
             {
                 "id": 200,
@@ -274,15 +267,72 @@ class TestCodexHelpers:
                 "performed_via_github_app": {"slug": "chatgpt-codex-connector"},
                 "created_at": "2026-04-16T18:32:59Z",
                 "html_url": "https://example/comment/200",
-                "body": "Codex Review: clean",
+                "body": f"Codex Review: clean\\n\\nReviewed commit: `{head}`",
             }
         ]
 
-        result = find_fresh_codex_review_or_comment("owner/repo", 42, since)
+        result = find_fresh_codex_review_or_comment("owner/repo", 42, since, requested_head_sha=head)
 
         assert result is not None
         assert result["source"] == "comment"
         assert result["id"] == 200
+
+    @patch("src.github_reviews.fetch_pr_issue_comments")
+    @patch("src.github_reviews.fetch_pr_reviews")
+    def test_find_fresh_codex_review_or_comment_rejects_request_comments_and_stale_heads(self, mock_reviews, mock_comments):
+        since = datetime(2026, 4, 16, 18, 27, 57)
+        requested_head = "a" * 40
+        mock_reviews.return_value = [
+            {
+                "id": 100,
+                "user": {"login": "codex[bot]"},
+                "submitted_at": "2026-04-16T18:32:59Z",
+                "commit_id": "b" * 40,
+                "html_url": "https://example/review/100",
+            }
+        ]
+        mock_comments.return_value = [
+            {
+                "id": 200,
+                "user": {"login": "chatgpt-codex-connector[bot]"},
+                "performed_via_github_app": {"slug": "chatgpt-codex-connector"},
+                "created_at": "2026-04-16T18:32:59Z",
+                "html_url": "https://example/comment/200",
+                "body": f"@codex review\\n\\nReviewed commit: `{requested_head}`",
+            },
+            {
+                "id": 201,
+                "user": {"login": "chatgpt-codex-connector[bot]"},
+                "created_at": "2026-04-16T18:33:00Z",
+                "html_url": "https://example/comment/201",
+                "body": "Unrelated discussion",
+            },
+        ]
+
+        assert find_fresh_codex_review_or_comment(
+            "owner/repo", 42, since, requested_head_sha=requested_head, excluded_comment_ids={200}
+        ) is None
+
+    @patch("src.github_reviews.fetch_pr_issue_comments")
+    @patch("src.github_reviews.fetch_pr_reviews")
+    def test_find_fresh_codex_review_or_comment_accepts_exact_head_review(self, mock_reviews, mock_comments):
+        since = datetime(2026, 4, 16, 18, 27, 57)
+        head = "a" * 40
+        mock_comments.return_value = []
+        mock_reviews.return_value = [
+            {
+                "id": 100,
+                "user": {"login": "codex[bot]"},
+                "submitted_at": "2026-04-16T18:32:59Z",
+                "commit_id": head,
+                "html_url": "https://example/review/100",
+            }
+        ]
+
+        result = find_fresh_codex_review_or_comment("owner/repo", 42, since, requested_head_sha=head)
+        assert result is not None
+        assert result["source"] == "review"
+        assert result["head_sha"] == head
 
     @patch("src.github_reviews.fetch_pr_reviews")
     @patch("src.github_reviews.subprocess.run")


### PR DESCRIPTION
Fixes #1294

## Risk tier

R3 — persisted request state, exact-head authority, restart recovery, concurrency, and caller wake delivery.

## Measured production cause

PR #649 registration `4abe0ff03f91` completed on caller request comment `5322627852`; GitHub’s only Codex review was tied to older head `0f54914c`, while the current head was `3c75030b`. The durable schema did not persist a requested head.

## Capability

- Persists `requested_head_sha` and supersession lineage.
- Idempotently returns an owner’s active exact-head request; atomically supersedes only that caller’s older head.
- Returns HTTP 409 with request/owner/cancel guidance for another active owner.
- Completes only a post-boundary Codex artifact tied to the requested exact head; trigger comments, unrelated comments, and stale-head artifacts do not wake a caller.
- Covers hostile supersession, restart, stale completion, API/CLI, and artifact filtering paths.

## R3 review record

- Superseded pre-round heads: `e641de3` (competing-caller admission race) and `ddf0d52` (late cancellation/completion transition race), both repaired before a review outcome.
- Round 1 requested/reviewed head: `9009eb8a7988027303fb98ea6f52507b1dde8b56`
- Scope/steer: persistence migration, PR-wide admission, supersession ownership, recovery, and exact-head completion binding.
- Review wait: production registration reproduced HTTP 400; fallback request comment posted at 02:38:03Z. A stale e641de3 review/wake was rejected.
- Findings: clean Codex review at 02:41:46Z on exact head `9009eb8`. Disposition: no findings. Resulting head: unchanged. Token estimate: not exposed by the integration.
- Round 2 requested/reviewed head: `9009eb8a7988027303fb98ea6f52507b1dde8b56` (unchanged-head R3 confirmation).
- Round 2 scope: cancellation-vs-completion authority, old-task wake suppression, SQLite migration/recovery, and cross-owner admission.
- Findings: clean Codex review at 02:49:43Z on exact head `9009eb8`; Session Manager request `873efaa3d66d` delivered its wake. Disposition: no findings. Resulting head: unchanged. Token estimate: not exposed by the integration.

## Verification

- `pytest -q tests/unit/test_codex_review_request.py tests/unit/test_github_reviews.py` (52 passed)
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p sm-server`