### PR TITLE
fix: supersede stale tracked Codex review requests

### DIFF
--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -1993,6 +1993,10 @@ fn codex_review_requests_list_path(
     include_inactive: bool,
 ) -> Result<String> {
     let mut query = Vec::new();
+    let status_without_id = matches!(
+        &args.command,
+        Some(RequestCodexReviewCommand::Status { request_id: None })
+    );
     let effective_notify = args
         .notify
         .as_deref()
@@ -2000,13 +2004,13 @@ fn codex_review_requests_list_path(
         .filter(|value| !value.is_empty())
         .map(ToOwned::to_owned)
         .or_else(|| {
-            if args.all {
+            if args.all || status_without_id {
                 None
             } else {
                 optional_current_session_id()
             }
         });
-    if !args.all && effective_notify.is_none() {
+    if !args.all && !status_without_id && effective_notify.is_none() {
         bail!("No session context. Use --notify or --all.");
     }
     if let Some(notify) = effective_notify {
@@ -6512,6 +6516,24 @@ mod tests {
         assert_eq!(
             codex_review_requests_list_path(&all_args, true).unwrap(),
             "/codex-review-requests?include_inactive=true"
+        );
+
+        let status_args = RequestCodexReviewArgs {
+            action_or_pr: None,
+            notify: None,
+            repo: Some("rajeshgoli/session-manager".to_owned()),
+            steer: None,
+            all: false,
+            inactive: false,
+            json: false,
+            pr_number: Some(964),
+            poll_interval_seconds: 30,
+            retry_interval_seconds: 600,
+            command: Some(RequestCodexReviewCommand::Status { request_id: None }),
+        };
+        assert_eq!(
+            codex_review_requests_list_path(&status_args, true).unwrap(),
+            "/codex-review-requests?repo=rajeshgoli%2Fsession-manager&pr_number=964&include_inactive=true"
         );
     }
 

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -292,6 +292,7 @@ pub struct GitHubReviewMatch {
     pub created_at: String,
     pub id: Option<Value>,
     pub url: Option<String>,
+    pub head_sha: Option<String>,
 }
 
 pub trait GitHubReviewPoster: Send + Sync {
@@ -306,11 +307,17 @@ pub trait GitHubReviewPoster: Send + Sync {
         Ok(false)
     }
 
+    fn current_open_pr_head(&self, _repo: &str, _pr_number: i64) -> Result<String, String> {
+        Err("GitHub review poster cannot resolve the current PR head".to_owned())
+    }
+
     fn find_fresh_codex_review_or_comment(
         &self,
         _repo: &str,
         _pr_number: i64,
         _since: &str,
+        _requested_head_sha: &str,
+        _request_comment_id: Option<i64>,
     ) -> Result<Option<GitHubReviewMatch>, String> {
         Ok(None)
     }
@@ -343,13 +350,25 @@ impl GitHubReviewPoster for GhCliReviewPoster {
         detect_codex_pickup_with_gh(repo, comment_id)
     }
 
+    fn current_open_pr_head(&self, repo: &str, pr_number: i64) -> Result<String, String> {
+        current_open_pr_head_with_gh(repo, pr_number)
+    }
+
     fn find_fresh_codex_review_or_comment(
         &self,
         repo: &str,
         pr_number: i64,
         since: &str,
+        requested_head_sha: &str,
+        request_comment_id: Option<i64>,
     ) -> Result<Option<GitHubReviewMatch>, String> {
-        find_fresh_codex_review_or_comment_with_gh(repo, pr_number, since)
+        find_fresh_codex_review_or_comment_with_gh(
+            repo,
+            pr_number,
+            since,
+            requested_head_sha,
+            request_comment_id,
+        )
     }
 
     fn find_fresh_codex_review(
@@ -535,6 +554,8 @@ fn should_use_configured_usage_db_path(config: &UsageConfig) -> bool {
 #[derive(Debug, Deserialize)]
 struct GhPrViewPayload {
     state: Option<String>,
+    #[serde(rename = "headRefOid")]
+    head_ref_oid: Option<String>,
 }
 
 const GH_TRANSPORT_ATTEMPTS: usize = 3;
@@ -605,7 +626,7 @@ fn gh_command_output(args: &[String], timeout_duration: Duration) -> Result<Outp
     )
 }
 
-fn validate_open_pr_with_gh(repo: &str, pr_number: i64) -> Result<(), String> {
+fn current_open_pr_head_with_gh(repo: &str, pr_number: i64) -> Result<String, String> {
     let args = vec![
         "pr".to_owned(),
         "view".to_owned(),
@@ -613,7 +634,7 @@ fn validate_open_pr_with_gh(repo: &str, pr_number: i64) -> Result<(), String> {
         "--repo".to_owned(),
         repo.to_owned(),
         "--json".to_owned(),
-        "number,state,title,url".to_owned(),
+        "number,state,title,url,headRefOid".to_owned(),
     ];
     let output = gh_command_output(&args, Duration::from_secs(10))
         .map_err(|error| format!("gh pr view failed: {error}"))?;
@@ -634,7 +655,14 @@ fn validate_open_pr_with_gh(repo: &str, pr_number: i64) -> Result<(), String> {
             payload.state.as_deref().unwrap_or("unknown")
         ));
     }
-    Ok(())
+    payload
+        .head_ref_oid
+        .filter(|head| !head.trim().is_empty())
+        .ok_or_else(|| format!("PR #{} in {} has no head commit", pr_number, repo))
+}
+
+fn validate_open_pr_with_gh(repo: &str, pr_number: i64) -> Result<(), String> {
+    current_open_pr_head_with_gh(repo, pr_number).map(|_| ())
 }
 
 fn post_pr_review_comment_with_gh(
@@ -791,8 +819,96 @@ fn find_fresh_codex_review_or_comment_with_gh(
     repo: &str,
     pr_number: i64,
     since: &str,
+    requested_head_sha: &str,
+    request_comment_id: Option<i64>,
 ) -> Result<Option<GitHubReviewMatch>, String> {
-    find_fresh_codex_review_or_comment_with_gh_filtered(repo, pr_number, since, None)
+    let Some(since_dt) = parse_github_datetime(since) else {
+        return Ok(None);
+    };
+    let mut candidates = Vec::<GitHubReviewMatch>::new();
+    let reviews = gh_api_json(repo, &format!("pulls/{pr_number}/reviews"), true)?;
+    if let Some(items) = reviews.as_array() {
+        for review in items {
+            let Some(created_at) = review
+                .get("submitted_at")
+                .and_then(Value::as_str)
+                .and_then(parse_github_datetime)
+            else {
+                continue;
+            };
+            if created_at > since_dt
+                && github_actor_is_codex(review)
+                && review.get("commit_id").and_then(Value::as_str) == Some(requested_head_sha)
+            {
+                candidates.push(GitHubReviewMatch {
+                    source: "review".to_owned(),
+                    created_at: created_at
+                        .format(&Rfc3339)
+                        .unwrap_or_else(|_| now_rfc3339()),
+                    id: review.get("id").cloned(),
+                    url: review
+                        .get("html_url")
+                        .and_then(Value::as_str)
+                        .map(ToOwned::to_owned),
+                    head_sha: Some(requested_head_sha.to_owned()),
+                });
+            }
+        }
+    }
+    let comments = gh_api_json(
+        repo,
+        &format!(
+            "issues/{pr_number}/comments?since={}",
+            since_dt
+                .format(&Rfc3339)
+                .unwrap_or_else(|_| since.to_owned())
+        ),
+        true,
+    )?;
+    if let Some(items) = comments.as_array() {
+        for comment in items {
+            let Some(created_at) = comment
+                .get("created_at")
+                .and_then(Value::as_str)
+                .and_then(parse_github_datetime)
+            else {
+                continue;
+            };
+            if created_at > since_dt
+                && codex_comment_is_bound(comment, requested_head_sha, request_comment_id)
+            {
+                candidates.push(GitHubReviewMatch {
+                    source: "comment".to_owned(),
+                    created_at: created_at
+                        .format(&Rfc3339)
+                        .unwrap_or_else(|_| now_rfc3339()),
+                    id: comment.get("id").cloned(),
+                    url: comment
+                        .get("html_url")
+                        .and_then(Value::as_str)
+                        .map(ToOwned::to_owned),
+                    head_sha: Some(requested_head_sha.to_owned()),
+                });
+            }
+        }
+    }
+    candidates.sort_by(|left, right| left.created_at.cmp(&right.created_at));
+    Ok(candidates.into_iter().next())
+}
+
+fn codex_comment_is_bound(
+    comment: &Value,
+    requested_head_sha: &str,
+    request_comment_id: Option<i64>,
+) -> bool {
+    let body = comment
+        .get("body")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    comment.get("id").and_then(Value::as_i64) != request_comment_id
+        && github_actor_is_codex(comment)
+        && !body.to_ascii_lowercase().contains("@codex review")
+        && body.contains(&format!("Reviewed commit: `{requested_head_sha}`"))
 }
 
 fn find_fresh_codex_review_with_gh(
@@ -830,6 +946,7 @@ fn find_fresh_codex_review_or_comment_with_gh_filtered(
                     .get("url")
                     .and_then(Value::as_str)
                     .map(ToOwned::to_owned),
+                head_sha: None,
             };
             if source_filter.map_or(true, |source| source == review_match.source) {
                 candidates.push(review_match);
@@ -868,6 +985,7 @@ fn find_fresh_codex_review_or_comment_with_gh_filtered(
                             .get("html_url")
                             .and_then(Value::as_str)
                             .map(ToOwned::to_owned),
+                        head_sha: None,
                     });
                 }
             }
@@ -1065,6 +1183,11 @@ pub fn router(state: AppState) -> Router {
         .map(|bridge| bridge.webhook_path())
         .unwrap_or_else(|| DEFAULT_EMAIL_WEBHOOK_PATH.to_owned());
     let state = Arc::new(state);
+    if let Err(error) = RetainedQueueStore::ensure_codex_review_requests_schema_from_path(
+        &expand_home(&state.config.sm_send.db_path),
+    ) {
+        eprintln!("Codex review request schema initialization failed: {error:#}");
+    }
     recover_codex_review_request_watchers(state.clone());
     recover_btw_requests(state.clone());
     if state.config.rust_core.runtime_enabled {
@@ -4311,17 +4434,14 @@ async fn create_codex_review_request(
     )
     .await?;
     let queue_db_path = expand_home(&state.config.sm_send.db_path);
-    let creation_key = format!(
-        "{}\u{1f}{}\u{1f}{}",
-        repo, payload.pr_number, notify_session.id
-    );
+    let creation_key = format!("{}\u{1f}{}", repo, payload.pr_number);
     {
         let mut locks = state.codex_review_creation_locks.lock().await;
         if !locks.insert(creation_key.clone()) {
             return Err(ApiError::Status {
-                status: StatusCode::BAD_REQUEST,
+                status: StatusCode::CONFLICT,
                 detail: format!(
-                    "Active Codex review request already exists for {} PR #{}",
+                    "A Codex review request is being created for {} PR #{}; retry after it finishes registration",
                     repo, payload.pr_number
                 ),
             });
@@ -4329,27 +4449,47 @@ async fn create_codex_review_request(
     }
 
     let create_result = async {
-        match RetainedQueueStore::active_codex_review_request_exists_from_path(
+        let poster = state.github_review_poster.clone();
+        let repo_for_head = repo.clone();
+        let requested_head_sha = tokio::task::spawn_blocking(move || {
+            poster.current_open_pr_head(&repo_for_head, payload.pr_number)
+        })
+        .await
+        .map_err(|error| ApiError::Status {
+            status: StatusCode::BAD_GATEWAY,
+            detail: format!("Failed to resolve current PR head: {error}"),
+        })?
+        .map_err(codex_review_poster_error)?;
+        let owner = trimmed(&payload.requester_session_id)
+            .unwrap_or_else(|| notify_session.id.clone());
+        let active = RetainedQueueStore::active_codex_review_requests_for_pr_from_path(
             &queue_db_path,
             &repo,
             payload.pr_number,
-            &notify_session.id,
-        ) {
-            Ok(true) => {
+        )
+        .map_err(|error| ApiError::Status {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            detail: format!("Failed to inspect Codex review requests: {error}"),
+        })?;
+        for existing in active {
+            let existing_owner = existing
+                .requester_session_id
+                .as_deref()
+                .filter(|value| !value.trim().is_empty())
+                .unwrap_or(&existing.notify_session_id);
+            if existing_owner != owner {
                 return Err(ApiError::Status {
-                    status: StatusCode::BAD_REQUEST,
+                    status: StatusCode::CONFLICT,
                     detail: format!(
-                        "Active Codex review request already exists for {} PR #{}",
-                        repo, payload.pr_number
+                        "Active Codex review request {} for {} PR #{} is owned by {}; cancel it or wait for completion",
+                        existing.id, repo, payload.pr_number, existing_owner
                     ),
                 });
             }
-            Ok(false) => {}
-            Err(error) => {
-                return Err(ApiError::Status {
-                    status: StatusCode::INTERNAL_SERVER_ERROR,
-                    detail: format!("Failed to inspect Codex review requests: {error}"),
-                });
+            if existing.requested_head_sha.as_deref() == Some(requested_head_sha.as_str()) {
+                let response = codex_review_request_response(&state, existing.clone())?;
+                spawn_codex_review_request_watcher(state.clone(), existing.id);
+                return Ok(Json(response));
             }
         }
 
@@ -4378,6 +4518,7 @@ async fn create_codex_review_request(
                 requester_session_id: trimmed(&payload.requester_session_id),
                 notify_session_id: notify_session.id.clone(),
                 steer: trimmed(&payload.steer),
+                requested_head_sha,
                 latest_request_comment_id: comment.comment_id,
                 latest_request_comment_url: comment.comment_url,
                 latest_request_posted_at: comment.posted_at,
@@ -4385,7 +4526,16 @@ async fn create_codex_review_request(
                 retry_interval_seconds: payload.retry_interval_seconds,
             },
         )
-        .map_err(codex_review_store_error)?;
+        .map_err(|error| {
+            if error.to_string().starts_with("CONFLICT:") {
+                ApiError::Status {
+                    status: StatusCode::CONFLICT,
+                    detail: error.to_string().trim_start_matches("CONFLICT: ").to_owned(),
+                }
+            } else {
+                codex_review_store_error(error)
+            }
+        })?;
         let response = codex_review_request_response(&state, registration.clone())?;
         spawn_codex_review_request_watcher(state.clone(), registration.id);
         Ok(Json(response))
@@ -4590,6 +4740,12 @@ fn recover_codex_review_request_watchers(state: Arc<AppState>) {
         return;
     }
     let queue_db_path = expand_home(&state.config.sm_send.db_path);
+    if let Err(error) =
+        RetainedQueueStore::ensure_codex_review_requests_schema_from_path(&queue_db_path)
+    {
+        eprintln!("Codex review request recovery failed to migrate schema: {error:#}");
+        return;
+    }
     match RetainedQueueStore::list_active_codex_review_requests_from_path(&queue_db_path) {
         Ok(registrations) => {
             for registration in registrations {
@@ -4730,6 +4886,8 @@ async fn run_codex_review_request_watcher(
             &registration.repo,
             registration.pr_number,
             &since,
+            registration.requested_head_sha.as_deref(),
+            registration.latest_request_comment_id,
         )
         .await
         {
@@ -4821,11 +4979,23 @@ async fn github_find_fresh_review(
     repo: &str,
     pr_number: i64,
     since: &str,
+    requested_head_sha: Option<&str>,
+    request_comment_id: Option<i64>,
 ) -> Result<Option<GitHubReviewMatch>, String> {
     let repo = repo.to_owned();
     let since = since.to_owned();
+    let requested_head_sha = requested_head_sha.map(ToOwned::to_owned);
     tokio::task::spawn_blocking(move || {
-        poster.find_fresh_codex_review_or_comment(&repo, pr_number, &since)
+        let Some(requested_head_sha) = requested_head_sha else {
+            return Ok(None);
+        };
+        poster.find_fresh_codex_review_or_comment(
+            &repo,
+            pr_number,
+            &since,
+            &requested_head_sha,
+            request_comment_id,
+        )
     })
     .await
     .map_err(|error| format!("review poll task failed: {error}"))?
@@ -4867,35 +5037,38 @@ fn complete_codex_review_request(
     review_match: GitHubReviewMatch,
     last_polled_at: &str,
 ) -> Result<(), String> {
+    if review_match.head_sha.as_deref() != registration.requested_head_sha.as_deref() {
+        return Ok(());
+    }
     let text = render_codex_review_landed_message(registration, &review_match);
-    let queue = RetainedQueueStore::new(queue_db_path.to_path_buf());
-    queue
-        .enqueue_message(&registration.notify_session_id, &text, "sequential", None)
-        .map_err(|error| error.to_string())?;
+    let Some(completed) = RetainedQueueStore::complete_codex_review_request_and_enqueue_in_path(
+        queue_db_path,
+        request_id,
+        CompleteCodexReviewRequest {
+            review_landed_at: review_match.created_at.clone(),
+            review_source: Some(review_match.source.clone()),
+            review_comment_id: review_match.id.clone(),
+            review_url: review_match.url.clone(),
+            last_polled_at: last_polled_at.to_owned(),
+        },
+        &text,
+    )
+    .map_err(|error| error.to_string())?
+    else {
+        return Ok(());
+    };
     if state.config.rust_core.runtime_enabled {
         let runtime = TmuxRuntime::from_app_config(&state.config);
         if let Err(error) = state
             .session_store
-            .drain_runtime_pending_messages_for_session(&registration.notify_session_id, &runtime)
+            .drain_runtime_pending_messages_for_session(&completed.notify_session_id, &runtime)
         {
             eprintln!(
                 "failed to immediately deliver Codex review completion message {request_id} to {}: {error:#}",
-                registration.notify_session_id
+                completed.notify_session_id
             );
         }
     }
-    RetainedQueueStore::complete_codex_review_request_in_path(
-        queue_db_path,
-        request_id,
-        CompleteCodexReviewRequest {
-            review_landed_at: review_match.created_at,
-            review_source: Some(review_match.source),
-            review_comment_id: review_match.id,
-            review_url: review_match.url,
-            last_polled_at: last_polled_at.to_owned(),
-        },
-    )
-    .map_err(|error| error.to_string())?;
     Ok(())
 }
 
@@ -13432,6 +13605,9 @@ fn codex_review_request_response(
         "notify_session_id": registration.notify_session_id,
         "notify_name": notify_name,
         "steer": registration.steer,
+        "requested_head_sha": registration.requested_head_sha,
+        "superseded_by_request_id": registration.superseded_by_request_id,
+        "superseded_at": registration.superseded_at,
         "requested_at": registration.requested_at,
         "latest_request_comment_id": registration.latest_request_comment_id,
         "latest_request_comment_url": registration.latest_request_comment_url,
@@ -17383,5 +17559,37 @@ mod tests {
             .lock()
             .unwrap()
             .contains_key(ticket["ticket_id"].as_str().unwrap()));
+    }
+
+    #[test]
+    fn codex_comment_binding_rejects_trigger_unrelated_and_stale_artifacts() {
+        let head = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+        let trigger = json!({
+            "id": 77,
+            "body": "@codex review",
+            "user": { "login": "codex" }
+        });
+        assert!(!codex_comment_is_bound(&trigger, head, Some(77)));
+
+        let unrelated = json!({
+            "id": 78,
+            "body": "Looks good to me.",
+            "user": { "login": "codex" }
+        });
+        assert!(!codex_comment_is_bound(&unrelated, head, Some(77)));
+
+        let stale = json!({
+            "id": 79,
+            "body": "Reviewed commit: `bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb`",
+            "user": { "login": "codex" }
+        });
+        assert!(!codex_comment_is_bound(&stale, head, Some(77)));
+
+        let exact = json!({
+            "id": 80,
+            "body": "Reviewed commit: `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`\nNo findings.",
+            "user": { "login": "codex" }
+        });
+        assert!(codex_comment_is_bound(&exact, head, Some(77)));
     }
 }

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -905,10 +905,15 @@ fn codex_comment_is_bound(
         .get("body")
         .and_then(Value::as_str)
         .unwrap_or_default();
+    let reviewed_commit = format!("Reviewed commit: `{requested_head_sha}`");
+    let bold_reviewed_commit = format!("**Reviewed commit:** `{requested_head_sha}`");
     comment.get("id").and_then(Value::as_i64) != request_comment_id
         && github_actor_is_codex(comment)
-        && !body.to_ascii_lowercase().contains("@codex review")
-        && body.contains(&format!("Reviewed commit: `{requested_head_sha}`"))
+        && !body
+            .trim_start()
+            .to_ascii_lowercase()
+            .starts_with("@codex review")
+        && (body.contains(&reviewed_commit) || body.contains(&bold_reviewed_commit))
 }
 
 fn find_fresh_codex_review_with_gh(
@@ -17591,5 +17596,16 @@ mod tests {
             "user": { "login": "codex" }
         });
         assert!(codex_comment_is_bound(&exact, head, Some(77)));
+
+        let exact_bold_with_boilerplate = json!({
+            "id": 81,
+            "body": "Codex Review: no findings.\n\n**Reviewed commit:** `aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa`\n\nReplies may say @codex review.",
+            "user": { "login": "chatgpt-codex-connector[bot]" }
+        });
+        assert!(codex_comment_is_bound(
+            &exact_bold_with_boilerplate,
+            head,
+            Some(77)
+        ));
     }
 }

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -905,15 +905,29 @@ fn codex_comment_is_bound(
         .get("body")
         .and_then(Value::as_str)
         .unwrap_or_default();
-    let reviewed_commit = format!("Reviewed commit: `{requested_head_sha}`");
-    let bold_reviewed_commit = format!("**Reviewed commit:** `{requested_head_sha}`");
     comment.get("id").and_then(Value::as_i64) != request_comment_id
         && github_actor_is_codex(comment)
         && !body
             .trim_start()
             .to_ascii_lowercase()
             .starts_with("@codex review")
-        && (body.contains(&reviewed_commit) || body.contains(&bold_reviewed_commit))
+        && reviewed_commit_matches_requested_head(body, requested_head_sha)
+}
+
+fn reviewed_commit_matches_requested_head(body: &str, requested_head_sha: &str) -> bool {
+    body.match_indices("Reviewed commit:").any(|(offset, _)| {
+        let suffix = &body[offset + "Reviewed commit:".len()..];
+        let Some((_, candidate_and_rest)) = suffix.split_once('`') else {
+            return false;
+        };
+        let Some((candidate, _)) = candidate_and_rest.split_once('`') else {
+            return false;
+        };
+        candidate.len() >= 7
+            && candidate.len() <= requested_head_sha.len()
+            && candidate.bytes().all(|byte| byte.is_ascii_hexdigit())
+            && requested_head_sha.starts_with(candidate)
+    })
 }
 
 fn find_fresh_codex_review_with_gh(
@@ -17607,5 +17621,19 @@ mod tests {
             head,
             Some(77)
         ));
+
+        let exact_abbreviated = json!({
+            "id": 82,
+            "body": "**Reviewed commit:** `aaaaaaaaaa`",
+            "user": { "login": "chatgpt-codex-connector[bot]" }
+        });
+        assert!(codex_comment_is_bound(&exact_abbreviated, head, Some(77)));
+
+        let stale_abbreviated = json!({
+            "id": 83,
+            "body": "**Reviewed commit:** `bbbbbbbbbb`",
+            "user": { "login": "chatgpt-codex-connector[bot]" }
+        });
+        assert!(!codex_comment_is_bound(&stale_abbreviated, head, Some(77)));
     }
 }

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -78,6 +78,9 @@ pub struct CodexReviewRequestRegistration {
     pub requester_session_id: Option<String>,
     pub notify_session_id: String,
     pub steer: Option<String>,
+    pub requested_head_sha: Option<String>,
+    pub superseded_by_request_id: Option<String>,
+    pub superseded_at: Option<String>,
     pub requested_at: String,
     pub latest_request_comment_id: Option<i64>,
     pub latest_request_comment_url: Option<String>,
@@ -105,6 +108,7 @@ pub struct CreateCodexReviewRequest {
     pub requester_session_id: Option<String>,
     pub notify_session_id: String,
     pub steer: Option<String>,
+    pub requested_head_sha: String,
     pub latest_request_comment_id: Option<i64>,
     pub latest_request_comment_url: Option<String>,
     pub latest_request_posted_at: String,
@@ -350,6 +354,16 @@ impl RetainedQueueStore {
         list_codex_review_requests_conn(&conn, filters)
     }
 
+    pub fn ensure_codex_review_requests_schema_from_path(db_path: &Path) -> Result<()> {
+        if !db_path.exists() {
+            return Ok(());
+        }
+        let conn = Connection::open(db_path)?;
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        conn.pragma_update(None, "busy_timeout", 5000)?;
+        init_codex_review_requests_schema(&conn)
+    }
+
     pub fn list_active_codex_review_requests_from_path(
         db_path: &Path,
     ) -> Result<Vec<CodexReviewRequestRegistration>> {
@@ -457,7 +471,18 @@ impl RetainedQueueStore {
         conn.pragma_update(None, "journal_mode", "WAL")?;
         conn.pragma_update(None, "busy_timeout", 5000)?;
         init_codex_review_requests_schema(&conn)?;
-        create_codex_review_request_conn(&conn, request)
+        conn.execute_batch("BEGIN IMMEDIATE")?;
+        let result = create_codex_review_request_conn(&conn, request);
+        match result {
+            Ok(registration) => {
+                conn.execute_batch("COMMIT")?;
+                Ok(registration)
+            }
+            Err(error) => {
+                let _ = conn.execute_batch("ROLLBACK");
+                Err(error)
+            }
+        }
     }
 
     pub fn active_codex_review_request_exists_from_path(
@@ -476,6 +501,22 @@ impl RetainedQueueStore {
         active_codex_review_request_exists_conn(&conn, repo, pr_number, notify_session_id)
     }
 
+    pub fn active_codex_review_requests_for_pr_from_path(
+        db_path: &Path,
+        repo: &str,
+        pr_number: i64,
+    ) -> Result<Vec<CodexReviewRequestRegistration>> {
+        Self::list_codex_review_requests_from_path(
+            db_path,
+            CodexReviewRequestFilters {
+                repo: Some(repo.to_owned()),
+                pr_number: Some(pr_number),
+                include_inactive: false,
+                ..CodexReviewRequestFilters::default()
+            },
+        )
+    }
+
     pub fn mark_codex_review_request_pickup_in_path(
         db_path: &Path,
         request_id: &str,
@@ -485,7 +526,7 @@ impl RetainedQueueStore {
             return Ok(None);
         }
         let conn = Connection::open(db_path)?;
-        conn.execute(
+        let changed = conn.execute(
             r#"
             UPDATE codex_review_request_registrations
             SET pickup_detected_at = COALESCE(pickup_detected_at, ?2),
@@ -496,6 +537,9 @@ impl RetainedQueueStore {
             "#,
             params![request_id, last_polled_at],
         )?;
+        if changed == 0 {
+            return Ok(None);
+        }
         get_codex_review_request_conn(&conn, request_id)
     }
 
@@ -510,7 +554,7 @@ impl RetainedQueueStore {
             return Ok(None);
         }
         let conn = Connection::open(db_path)?;
-        conn.execute(
+        let changed = conn.execute(
             r#"
             UPDATE codex_review_request_registrations
             SET last_polled_at = ?2,
@@ -520,6 +564,9 @@ impl RetainedQueueStore {
             "#,
             params![request_id, last_polled_at, last_error, next_retry_at],
         )?;
+        if changed == 0 {
+            return Ok(None);
+        }
         get_codex_review_request_conn(&conn, request_id)
     }
 
@@ -532,7 +579,7 @@ impl RetainedQueueStore {
             return Ok(None);
         }
         let conn = Connection::open(db_path)?;
-        conn.execute(
+        let changed = conn.execute(
             r#"
             UPDATE codex_review_request_registrations
             SET last_polled_at = ?2,
@@ -541,6 +588,9 @@ impl RetainedQueueStore {
             "#,
             params![request_id, last_polled_at],
         )?;
+        if changed == 0 {
+            return Ok(None);
+        }
         get_codex_review_request_conn(&conn, request_id)
     }
 
@@ -554,7 +604,7 @@ impl RetainedQueueStore {
             return Ok(None);
         }
         let conn = Connection::open(db_path)?;
-        conn.execute(
+        let changed = conn.execute(
             r#"
             UPDATE codex_review_request_registrations
             SET attempt_count = attempt_count + 1,
@@ -577,6 +627,9 @@ impl RetainedQueueStore {
                 last_polled_at,
             ],
         )?;
+        if changed == 0 {
+            return Ok(None);
+        }
         get_codex_review_request_conn(&conn, request_id)
     }
 
@@ -590,7 +643,7 @@ impl RetainedQueueStore {
         }
         let conn = Connection::open(db_path)?;
         let review_comment_id = completion.review_comment_id.map(json_scalar_to_sql_value);
-        conn.execute(
+        let changed = conn.execute(
             r#"
             UPDATE codex_review_request_registrations
             SET review_landed_at = ?2,
@@ -612,7 +665,74 @@ impl RetainedQueueStore {
                 completion.last_polled_at,
             ],
         )?;
+        if changed == 0 {
+            return Ok(None);
+        }
         get_codex_review_request_conn(&conn, request_id)
+    }
+
+    pub fn complete_codex_review_request_and_enqueue_in_path(
+        db_path: &Path,
+        request_id: &str,
+        completion: CompleteCodexReviewRequest,
+        wake_text: &str,
+    ) -> Result<Option<CodexReviewRequestRegistration>> {
+        if !db_path.exists() {
+            return Ok(None);
+        }
+        let conn = Connection::open(db_path)?;
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        conn.pragma_update(None, "busy_timeout", 5000)?;
+        init_schema(&conn)?;
+        conn.execute_batch("BEGIN IMMEDIATE")?;
+        let result = (|| {
+            let review_comment_id = completion.review_comment_id.map(json_scalar_to_sql_value);
+            let changed = conn.execute(
+                r#"
+                UPDATE codex_review_request_registrations
+                SET review_landed_at = ?2,
+                    review_source = ?3,
+                    review_comment_id = ?4,
+                    review_url = ?5,
+                    state = 'completed',
+                    is_active = 0,
+                    last_polled_at = ?6,
+                    last_error = NULL
+                WHERE id = ?1 AND is_active = 1
+                "#,
+                params![
+                    request_id,
+                    completion.review_landed_at,
+                    completion.review_source,
+                    review_comment_id,
+                    completion.review_url,
+                    completion.last_polled_at,
+                ],
+            )?;
+            if changed == 0 {
+                return Ok(None);
+            }
+            let registration = get_codex_review_request_conn(&conn, request_id)?
+                .ok_or_else(|| anyhow::anyhow!("completed Codex review request disappeared"))?;
+            enqueue_message_with_metadata_conn(
+                &conn,
+                &registration.notify_session_id,
+                wake_text,
+                "sequential",
+                QueueMessageMetadata::default(),
+            )?;
+            Ok(Some(registration))
+        })();
+        match result {
+            Ok(registration) => {
+                conn.execute_batch("COMMIT")?;
+                Ok(registration)
+            }
+            Err(error) => {
+                let _ = conn.execute_batch("ROLLBACK");
+                Err(error)
+            }
+        }
     }
 
     pub fn list_queue_jobs_from_path(
@@ -2299,6 +2419,7 @@ fn init_schema(conn: &Connection) -> Result<()> {
         "persistent_tracking",
         "INTEGER DEFAULT 0",
     )?;
+    init_codex_review_requests_schema(conn)?;
     Ok(())
 }
 
@@ -2372,6 +2493,9 @@ fn init_codex_review_requests_schema(conn: &Connection) -> Result<()> {
             requester_session_id TEXT,
             notify_session_id TEXT NOT NULL,
             steer TEXT,
+            requested_head_sha TEXT,
+            superseded_by_request_id TEXT,
+            superseded_at TIMESTAMP,
             requested_at TIMESTAMP NOT NULL,
             latest_request_comment_id INTEGER,
             latest_request_comment_url TEXT,
@@ -2392,6 +2516,24 @@ fn init_codex_review_requests_schema(conn: &Connection) -> Result<()> {
             is_active INTEGER DEFAULT 1
         );
         "#,
+    )?;
+    ensure_column(
+        conn,
+        "codex_review_request_registrations",
+        "requested_head_sha",
+        "TEXT",
+    )?;
+    ensure_column(
+        conn,
+        "codex_review_request_registrations",
+        "superseded_by_request_id",
+        "TEXT",
+    )?;
+    ensure_column(
+        conn,
+        "codex_review_request_registrations",
+        "superseded_at",
+        "TIMESTAMP",
     )?;
     Ok(())
 }
@@ -3681,6 +3823,7 @@ fn list_codex_review_requests_conn(
 
     let mut query = r#"
         SELECT id, repo, pr_number, requester_session_id, notify_session_id, steer,
+               requested_head_sha, superseded_by_request_id, superseded_at,
                requested_at, latest_request_comment_id, latest_request_comment_url,
                latest_request_posted_at, attempt_count, next_retry_at,
                poll_interval_seconds, retry_interval_seconds, pickup_detected_at,
@@ -3750,17 +3893,39 @@ fn create_codex_review_request_conn(
     if request.retry_interval_seconds <= 0 {
         anyhow::bail!("retry_interval_seconds must be > 0");
     }
-    if active_codex_review_request_exists_conn(
+    let owner = request
+        .requester_session_id
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+        .unwrap_or(&request.notify_session_id)
+        .to_owned();
+    let active = list_codex_review_requests_conn(
         conn,
-        &request.repo,
-        request.pr_number,
-        &request.notify_session_id,
-    )? {
-        anyhow::bail!(
-            "Active Codex review request already exists for {} PR #{}",
-            request.repo,
-            request.pr_number
-        );
+        CodexReviewRequestFilters {
+            repo: Some(request.repo.clone()),
+            pr_number: Some(request.pr_number),
+            include_inactive: false,
+            ..CodexReviewRequestFilters::default()
+        },
+    )?;
+    for existing in &active {
+        let existing_owner = existing
+            .requester_session_id
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or(&existing.notify_session_id);
+        if existing_owner != owner {
+            anyhow::bail!(
+                "CONFLICT: active Codex review request {} for {} PR #{} is owned by {}; cancel it or wait for completion",
+                existing.id,
+                request.repo,
+                request.pr_number,
+                existing_owner
+            );
+        }
+        if existing.requested_head_sha.as_deref() == Some(request.requested_head_sha.as_str()) {
+            return Ok(existing.clone());
+        }
     }
 
     let latest_posted_at = request.latest_request_posted_at;
@@ -3773,6 +3938,9 @@ fn create_codex_review_request_conn(
         requester_session_id: request.requester_session_id,
         notify_session_id: request.notify_session_id,
         steer: request.steer,
+        requested_head_sha: Some(request.requested_head_sha),
+        superseded_by_request_id: None,
+        superseded_at: None,
         requested_at: latest_posted_at.clone(),
         latest_request_comment_id: request.latest_request_comment_id,
         latest_request_comment_url: request.latest_request_comment_url,
@@ -3794,8 +3962,30 @@ fn create_codex_review_request_conn(
     };
     conn.execute(
         r#"
+        UPDATE codex_review_request_registrations
+        SET is_active = 0,
+            state = 'superseded',
+            superseded_by_request_id = ?1,
+            superseded_at = ?2,
+            last_error = 'Superseded by a newer requested PR head'
+        WHERE repo = ?3
+            AND pr_number = ?4
+            AND is_active = 1
+            AND COALESCE(NULLIF(requester_session_id, ''), notify_session_id) = ?5
+        "#,
+        params![
+            registration.id,
+            registration.requested_at,
+            registration.repo,
+            registration.pr_number,
+            owner,
+        ],
+    )?;
+    conn.execute(
+        r#"
         INSERT INTO codex_review_request_registrations
             (id, repo, pr_number, requester_session_id, notify_session_id, steer,
+             requested_head_sha, superseded_by_request_id, superseded_at,
              requested_at, latest_request_comment_id, latest_request_comment_url,
              latest_request_posted_at, attempt_count, next_retry_at,
              poll_interval_seconds, retry_interval_seconds, pickup_detected_at,
@@ -3803,11 +3993,12 @@ fn create_codex_review_request_conn(
              review_url, last_polled_at, last_error, state, is_active)
         VALUES
             (?1, ?2, ?3, ?4, ?5, ?6,
-             ?7, ?8, ?9,
-             ?10, ?11, ?12,
-             ?13, ?14, NULL,
+             ?7, NULL, NULL,
+             ?8, ?9, ?10,
+             ?11, ?12, ?13,
+             ?14, ?15, NULL,
              NULL, NULL, NULL, NULL,
-             NULL, NULL, NULL, ?15, 1)
+             NULL, NULL, NULL, ?16, 1)
         "#,
         params![
             registration.id,
@@ -3816,6 +4007,7 @@ fn create_codex_review_request_conn(
             registration.requester_session_id,
             registration.notify_session_id,
             registration.steer,
+            registration.requested_head_sha,
             registration.requested_at,
             registration.latest_request_comment_id,
             registration.latest_request_comment_url,
@@ -3837,6 +4029,7 @@ fn get_codex_review_request_conn(
     let mut statement = match conn.prepare(
         r#"
         SELECT id, repo, pr_number, requester_session_id, notify_session_id, steer,
+               requested_head_sha, superseded_by_request_id, superseded_at,
                requested_at, latest_request_comment_id, latest_request_comment_url,
                latest_request_posted_at, attempt_count, next_retry_at,
                poll_interval_seconds, retry_interval_seconds, pickup_detected_at,
@@ -3874,24 +4067,27 @@ fn codex_review_request_registration_from_row(
         requester_session_id: row.get(3)?,
         notify_session_id: row.get(4)?,
         steer: row.get(5)?,
-        requested_at: row.get(6)?,
-        latest_request_comment_id: row.get(7)?,
-        latest_request_comment_url: row.get(8)?,
-        latest_request_posted_at: row.get(9)?,
-        attempt_count: row.get(10)?,
-        next_retry_at: row.get(11)?,
-        poll_interval_seconds: row.get(12)?,
-        retry_interval_seconds: row.get(13)?,
-        pickup_detected_at: row.get(14)?,
-        pickup_source: row.get(15)?,
-        review_landed_at: row.get(16)?,
-        review_source: row.get(17)?,
-        review_comment_id: optional_sqlite_json_scalar(row.get_ref(18)?),
-        review_url: row.get(19)?,
-        last_polled_at: row.get(20)?,
-        last_error: row.get(21)?,
-        state: row.get(22)?,
-        is_active: row.get::<_, Option<i64>>(23)?.unwrap_or(1) != 0,
+        requested_head_sha: row.get(6)?,
+        superseded_by_request_id: row.get(7)?,
+        superseded_at: row.get(8)?,
+        requested_at: row.get(9)?,
+        latest_request_comment_id: row.get(10)?,
+        latest_request_comment_url: row.get(11)?,
+        latest_request_posted_at: row.get(12)?,
+        attempt_count: row.get(13)?,
+        next_retry_at: row.get(14)?,
+        poll_interval_seconds: row.get(15)?,
+        retry_interval_seconds: row.get(16)?,
+        pickup_detected_at: row.get(17)?,
+        pickup_source: row.get(18)?,
+        review_landed_at: row.get(19)?,
+        review_source: row.get(20)?,
+        review_comment_id: optional_sqlite_json_scalar(row.get_ref(21)?),
+        review_url: row.get(22)?,
+        last_polled_at: row.get(23)?,
+        last_error: row.get(24)?,
+        state: row.get(25)?,
+        is_active: row.get::<_, Option<i64>>(26)?.unwrap_or(1) != 0,
     })
 }
 

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -201,6 +201,7 @@ struct StubGitHubReviewPoster {
     result: Arc<Mutex<Result<GitHubReviewComment, String>>>,
     calls: Arc<Mutex<Vec<(String, i64, Option<String>)>>>,
     fresh_reviews: Arc<Mutex<VecDeque<GitHubReviewMatch>>>,
+    current_head_sha: Arc<Mutex<String>>,
 }
 
 impl StubGitHubReviewPoster {
@@ -216,6 +217,9 @@ impl StubGitHubReviewPoster {
             }))),
             calls: Arc::new(Mutex::new(Vec::new())),
             fresh_reviews: Arc::new(Mutex::new(VecDeque::new())),
+            current_head_sha: Arc::new(Mutex::new(
+                "1111111111111111111111111111111111111111".to_owned(),
+            )),
         }
     }
 
@@ -224,6 +228,9 @@ impl StubGitHubReviewPoster {
             result: Arc::new(Mutex::new(Err(message.to_owned()))),
             calls: Arc::new(Mutex::new(Vec::new())),
             fresh_reviews: Arc::new(Mutex::new(VecDeque::new())),
+            current_head_sha: Arc::new(Mutex::new(
+                "1111111111111111111111111111111111111111".to_owned(),
+            )),
         }
     }
 
@@ -239,6 +246,14 @@ impl StubGitHubReviewPoster {
     fn with_fresh_reviews(self, review_matches: Vec<GitHubReviewMatch>) -> Self {
         *self.fresh_reviews.lock().unwrap() = review_matches.into_iter().collect();
         self
+    }
+
+    fn set_current_head(&self, head_sha: &str) {
+        *self.current_head_sha.lock().unwrap() = head_sha.to_owned();
+    }
+
+    fn push_fresh_review(&self, review_match: GitHubReviewMatch) {
+        self.fresh_reviews.lock().unwrap().push_back(review_match);
     }
 }
 
@@ -256,18 +271,30 @@ impl GitHubReviewPoster for StubGitHubReviewPoster {
         self.result.lock().unwrap().clone()
     }
 
+    fn current_open_pr_head(&self, _repo: &str, _pr_number: i64) -> Result<String, String> {
+        Ok(self.current_head_sha.lock().unwrap().clone())
+    }
+
     fn find_fresh_codex_review_or_comment(
         &self,
         _repo: &str,
         _pr_number: i64,
         _since: &str,
+        requested_head_sha: &str,
+        request_comment_id: Option<i64>,
     ) -> Result<Option<GitHubReviewMatch>, String> {
         let mut fresh_reviews = self.fresh_reviews.lock().unwrap();
-        if fresh_reviews.len() > 1 {
-            Ok(fresh_reviews.pop_front())
-        } else {
-            Ok(fresh_reviews.front().cloned())
-        }
+        let position = fresh_reviews.iter().position(|review_match| {
+            review_match.head_sha.as_deref() == Some(requested_head_sha)
+                && review_match.id.as_ref().and_then(Value::as_i64) != request_comment_id
+        });
+        Ok(position.and_then(|position| {
+            if fresh_reviews.len() > 1 {
+                fresh_reviews.remove(position)
+            } else {
+                fresh_reviews.get(position).cloned()
+            }
+        }))
     }
 
     fn find_fresh_codex_review(
@@ -2488,6 +2515,7 @@ async fn pr_review_route_posts_comment_and_returns_python_shape() {
         url: Some(
             "https://github.com/rajeshgoli/session-manager/pull/967#pullrequestreview-1".to_owned(),
         ),
+        head_sha: Some("1111111111111111111111111111111111111111".to_owned()),
     });
     let mut config = AppConfig::default();
     config.paths.state_file = state_file.display().to_string();
@@ -2563,6 +2591,7 @@ async fn pr_review_route_wait_ignores_issue_comments_until_review_or_timeout() {
             "https://github.com/rajeshgoli/session-manager/pull/967#issuecomment-4701300000"
                 .to_owned(),
         ),
+        head_sha: Some("1111111111111111111111111111111111111111".to_owned()),
     });
     let mut config = AppConfig::default();
     config.paths.state_file = state_file.display().to_string();
@@ -2624,6 +2653,7 @@ async fn pr_review_route_wait_completes_when_comment_precedes_review() {
                 "https://github.com/rajeshgoli/session-manager/pull/967#issuecomment-4701300000"
                     .to_owned(),
             ),
+            head_sha: Some("1111111111111111111111111111111111111111".to_owned()),
         },
         GitHubReviewMatch {
             source: "review".to_owned(),
@@ -2633,6 +2663,7 @@ async fn pr_review_route_wait_completes_when_comment_precedes_review() {
                 "https://github.com/rajeshgoli/session-manager/pull/967#pullrequestreview-1"
                     .to_owned(),
             ),
+            head_sha: Some("1111111111111111111111111111111111111111".to_owned()),
         },
     ]);
     let mut config = AppConfig::default();
@@ -2737,6 +2768,7 @@ async fn codex_review_request_watcher_completes_and_queues_wake() {
             "https://github.com/rajeshgoli/session-manager/pull/967#issuecomment-4701300000"
                 .to_owned(),
         ),
+        head_sha: Some("1111111111111111111111111111111111111111".to_owned()),
     });
     let mut config = AppConfig {
         paths: PathsConfig {
@@ -2832,6 +2864,7 @@ async fn codex_review_request_watcher_delivers_sequential_wake_to_runtime_sessio
         url: Some(
             "https://github.com/rajeshgoli/session-manager/pull/978#pullrequestreview-1".to_owned(),
         ),
+        head_sha: Some("1111111111111111111111111111111111111111".to_owned()),
     });
     let app = router(
         AppState::new(AppConfig {
@@ -2963,6 +2996,7 @@ async fn codex_review_request_recovery_spawns_active_watchers() {
         url: Some(
             "https://github.com/rajeshgoli/session-manager/pull/971#pullrequestreview-1".to_owned(),
         ),
+        head_sha: Some("1111111111111111111111111111111111111111".to_owned()),
     });
     let mut config = AppConfig {
         paths: PathsConfig {
@@ -3053,7 +3087,7 @@ async fn codex_review_request_recovery_keeps_missing_notify_session_active() {
 }
 
 #[tokio::test]
-async fn codex_review_request_create_rejects_duplicates_before_github_post() {
+async fn codex_review_request_create_returns_actionable_conflict_for_other_owner() {
     let state_file = unique_temp_path();
     let queue_db = state_file.with_extension("codex-review-create-duplicate.db");
     fs::write(
@@ -3100,12 +3134,133 @@ async fn codex_review_request_create_rejects_duplicates_before_github_post() {
     )
     .await;
 
-    assert_eq!(status, StatusCode::BAD_REQUEST);
-    assert_eq!(
-        payload["detail"],
-        "Active Codex review request already exists for rajeshgoli/session-manager PR #830"
-    );
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert!(payload["detail"].as_str().unwrap().contains("active-old"));
+    assert!(payload["detail"].as_str().unwrap().contains("cancel it"));
     assert!(poster.calls().is_empty());
+}
+
+#[tokio::test]
+async fn codex_review_request_supersedes_same_owner_stale_head_and_ignores_late_completion() {
+    let state_file = unique_temp_path();
+    let queue_db = state_file.with_extension("codex-review-supersede.db");
+    fs::write(
+        &state_file,
+        json!({
+            "sessions": [{
+                "id": "notify1", "name": "notify1", "working_dir": "/repo/notify",
+                "tmux_session": "notify1", "log_file": "/tmp/notify1.log", "status": "running",
+                "created_at": "2026-06-01T00:00:00Z", "last_activity": "2026-06-01T00:01:00Z"
+            }]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let poster = StubGitHubReviewPoster::successful();
+    let mut config = AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        sm_send: SmSendConfig {
+            db_path: queue_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    };
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config).with_github_review_poster(Arc::new(poster.clone())));
+
+    let (status, first) = post_json(
+        app.clone(),
+        "/codex-review-requests",
+        json!({
+            "pr_number": 992, "repo": "rajeshgoli/session-manager", "notify_target": "notify1",
+            "poll_interval_seconds": 1, "retry_interval_seconds": 900
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let first_id = first["id"].as_str().unwrap().to_owned();
+    let (status, repeated) = post_json(
+        app.clone(),
+        "/codex-review-requests",
+        json!({
+            "pr_number": 992, "repo": "rajeshgoli/session-manager", "notify_target": "notify1",
+            "poll_interval_seconds": 1, "retry_interval_seconds": 900
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(repeated["id"], first_id);
+    assert_eq!(
+        poster.calls().len(),
+        1,
+        "same-head retry must not post another trigger"
+    );
+    poster.push_fresh_review(GitHubReviewMatch {
+        source: "review".to_owned(),
+        created_at: "2026-06-14T02:31:00Z".to_owned(),
+        id: Some(json!(991)),
+        url: Some("https://example.test/review-a".to_owned()),
+        head_sha: Some("1111111111111111111111111111111111111111".to_owned()),
+    });
+    poster.set_current_head("2222222222222222222222222222222222222222");
+    let (status, second) = post_json(
+        app,
+        "/codex-review-requests",
+        json!({
+            "pr_number": 992, "repo": "rajeshgoli/session-manager", "notify_target": "notify1",
+            "poll_interval_seconds": 1, "retry_interval_seconds": 900
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let second_id = second["id"].as_str().unwrap().to_owned();
+    assert_ne!(first_id, second_id);
+
+    tokio::time::sleep(Duration::from_millis(1200)).await;
+    let conn = Connection::open(&queue_db).unwrap();
+    let first_row: (String, i64, Option<String>) = conn.query_row(
+        "SELECT state, is_active, superseded_by_request_id FROM codex_review_request_registrations WHERE id = ?1",
+        [&first_id], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+    ).unwrap();
+    assert_eq!(
+        first_row,
+        ("superseded".to_owned(), 0, Some(second_id.clone()))
+    );
+    assert!(queued_message_texts(&queue_db, "notify1").is_empty());
+    drop(conn);
+
+    poster.push_fresh_review(GitHubReviewMatch {
+        source: "review".to_owned(),
+        created_at: "2026-06-14T02:32:00Z".to_owned(),
+        id: Some(json!(992)),
+        url: Some("https://example.test/review-b".to_owned()),
+        head_sha: Some("2222222222222222222222222222222222222222".to_owned()),
+    });
+    for _ in 0..30 {
+        let conn = Connection::open(&queue_db).unwrap();
+        let state: String = conn
+            .query_row(
+                "SELECT state FROM codex_review_request_registrations WHERE id = ?1",
+                [&second_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        if state == "completed" {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    let conn = Connection::open(&queue_db).unwrap();
+    let state: String = conn
+        .query_row(
+            "SELECT state FROM codex_review_request_registrations WHERE id = ?1",
+            [&second_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(state, "completed");
+    assert_eq!(queued_message_texts(&queue_db, "notify1").len(), 1);
 }
 
 #[tokio::test]
@@ -18849,6 +19004,9 @@ fn create_codex_review_request_fixture_db(path: &PathBuf) {
             requester_session_id TEXT,
             notify_session_id TEXT NOT NULL,
             steer TEXT,
+            requested_head_sha TEXT,
+            superseded_by_request_id TEXT,
+            superseded_at TIMESTAMP,
             requested_at TIMESTAMP NOT NULL,
             latest_request_comment_id INTEGER,
             latest_request_comment_url TEXT,
@@ -18874,26 +19032,26 @@ fn create_codex_review_request_fixture_db(path: &PathBuf) {
     conn.execute(
         r#"
         INSERT INTO codex_review_request_registrations
-            (id, repo, pr_number, requester_session_id, notify_session_id, steer,
+            (id, repo, pr_number, requester_session_id, notify_session_id, steer, requested_head_sha,
              requested_at, latest_request_comment_id, latest_request_comment_url,
              latest_request_posted_at, attempt_count, next_retry_at,
              poll_interval_seconds, retry_interval_seconds, pickup_detected_at,
              pickup_source, review_landed_at, review_source, review_comment_id,
              review_url, last_polled_at, last_error, state, is_active)
         VALUES
-            ('active-old', 'rajeshgoli/session-manager', 830, 'requester1', 'notify1', 'focus nodes',
+            ('active-old', 'rajeshgoli/session-manager', 830, 'requester1', 'notify1', 'focus nodes', '1111111111111111111111111111111111111111',
              '2026-06-01T00:00:00', 111, 'https://example.com/comment/111',
              '2026-06-01T00:00:01', 2, '2026-06-01T00:10:00',
              30, 600, '2026-06-01T00:02:00',
              'issue_comment', '2026-06-01T00:03:00', 'pull_review', 222,
              'https://example.com/review/222', '2026-06-01T00:04:00', NULL, 'completed', 1),
-            ('inactive', 'rajeshgoli/session-manager', 831, NULL, 'notify1', NULL,
+            ('inactive', 'rajeshgoli/session-manager', 831, NULL, 'notify1', NULL, NULL,
              '2026-06-01T00:01:00', NULL, NULL,
              NULL, 1, NULL,
              30, 600, NULL,
              NULL, NULL, NULL, NULL,
              NULL, NULL, 'cancelled', 'cancelled', 0),
-            ('active-new', 'rajeshgoli/other', 7, NULL, 'notify2', NULL,
+            ('active-new', 'rajeshgoli/other', 7, NULL, 'notify2', NULL, '1111111111111111111111111111111111111111',
              '2026-06-01T00:02:00', NULL, NULL,
              NULL, 1, NULL,
              45, 900, NULL,
@@ -18921,6 +19079,9 @@ fn create_active_codex_review_request_fixture_db(
             requester_session_id TEXT,
             notify_session_id TEXT NOT NULL,
             steer TEXT,
+            requested_head_sha TEXT,
+            superseded_by_request_id TEXT,
+            superseded_at TIMESTAMP,
             requested_at TIMESTAMP NOT NULL,
             latest_request_comment_id INTEGER,
             latest_request_comment_url TEXT,
@@ -18946,14 +19107,14 @@ fn create_active_codex_review_request_fixture_db(
     conn.execute(
         r#"
         INSERT INTO codex_review_request_registrations
-            (id, repo, pr_number, requester_session_id, notify_session_id, steer,
+            (id, repo, pr_number, requester_session_id, notify_session_id, steer, requested_head_sha,
              requested_at, latest_request_comment_id, latest_request_comment_url,
              latest_request_posted_at, attempt_count, next_retry_at,
              poll_interval_seconds, retry_interval_seconds, pickup_detected_at,
              pickup_source, review_landed_at, review_source, review_comment_id,
              review_url, last_polled_at, last_error, state, is_active)
         VALUES
-            (?1, 'rajeshgoli/session-manager', 971, 'requester1', ?2, 'recover watchers',
+            (?1, 'rajeshgoli/session-manager', 971, 'requester1', ?2, 'recover watchers', '1111111111111111111111111111111111111111',
              '2026-06-14T02:30:00Z', 4701290334,
              'https://github.com/rajeshgoli/session-manager/pull/971#issuecomment-4701290334',
              '2026-06-14T02:30:00Z', 1, '2026-06-14T02:45:00Z',


### PR DESCRIPTION
Fixes #1294

Review tier: R3 — persisted lifecycle/schema migration, exact-head attribution, concurrent ownership, restart recovery, watcher completion and production control path.

Changes:
- Persist requested PR head and supersession lineage; same owner automatically supersedes an older active head while retaining the old audit row.
- Same exact head is idempotent; another current owner receives actionable HTTP 409 including request ID and owner. `status --pr` projects across owners.
- Require a post-request Codex artifact bound to repo/PR/requested head; ignore request triggers, unrelated comments, stale-head reviews, and late old-request completions.
- Complete registration and enqueue wake in one SQLite transaction; a cancelled/superseded request cannot wake a replacement.

Hostile coverage: same-head idempotency, A→B supersession, late old completion, restart recovery, actionable cross-owner conflict, caller trigger/unrelated/stale comments, full and abbreviated exact-head comment forms.

Validation at `9130519adfc06ab965519fa01b4b4417418ff8af`:
- `cargo test -p sm-server` full suite passed
- `cargo fmt --check`
- `git diff --check`

R3 records:
- Round 1: fc61678, clean review PRR_kwDORB1-tM8AAAABJ3Qpfg at 03:16:46Z.
- Round 2: P1 valid; live comment used bold label and quoted trigger boilerplate. Localized repair 5527f50.
- Round 3: P1 valid; live comment used exact 10-char GitHub head abbreviation 5527f50a03. Localized repair 9130519 accepts only hex prefixes of length >=7 matching the stored full head; stale prefix remains rejected.
- Round 4: requested 03:29:11Z; reviewed exact head `9130519adfc06ab965519fa01b4b4417418ff8af`; clean Codex bot comment 5323245441 at 03:31:58Z with matching abbreviated `9130519adf`; no P0/P1. Wait: 2m47s. R3 gate satisfied.