### PR TITLE
Wire atomic policy admission into bootstrap spawn

### DIFF
--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -728,8 +728,9 @@ fn run() -> Result<()> {
             let parent_session_id = optional_current_session_id();
             let provider = launch_provider_for_alias(&args.provider)?;
             let payload = if let Some(parent_session_id) = parent_session_id {
-                client.post_json(
-                    "/sessions/spawn",
+                let credential = current_session_credential(&parent_session_id)?;
+                post_managed_spawn(
+                    &client,
                     json!({
                         "id": args.id,
                         "parent_session_id": parent_session_id,
@@ -743,6 +744,7 @@ fn run() -> Result<()> {
                         "provider": provider,
                         "node": args.node
                     }),
+                    &credential,
                 )?
             } else {
                 client.post_json(
@@ -2948,6 +2950,10 @@ fn current_session_credential(session_id: &str) -> Result<String> {
         })
 }
 
+fn post_managed_spawn(client: &ApiClient, payload: Value, credential: &str) -> Result<Value> {
+    client.post_json_with_session_credential("/sessions/spawn", payload, credential)
+}
+
 fn get_reparent_json(client: &ApiClient, path: &str) -> Result<Value> {
     let Some(session_id) = optional_current_session_id() else {
         return client.get_json(path);
@@ -5099,9 +5105,29 @@ mod tests {
             stream
                 .set_read_timeout(Some(std::time::Duration::from_secs(2)))
                 .unwrap();
-            let mut buffer = [0_u8; 8192];
-            let bytes_read = stream.read(&mut buffer).unwrap();
-            let request = String::from_utf8_lossy(&buffer[..bytes_read]).to_string();
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+            let mut request = String::new();
+            let mut content_length = 0_usize;
+            loop {
+                let mut line = String::new();
+                reader.read_line(&mut line).unwrap();
+                if line.is_empty() {
+                    break;
+                }
+                request.push_str(&line);
+                let trimmed = line.trim_end_matches(['\r', '\n']);
+                if let Some((name, value)) = trimmed.split_once(':') {
+                    if name.eq_ignore_ascii_case("content-length") {
+                        content_length = value.trim().parse().unwrap();
+                    }
+                }
+                if trimmed.is_empty() {
+                    break;
+                }
+            }
+            let mut request_body = vec![0_u8; content_length];
+            reader.read_exact(&mut request_body).unwrap();
+            request.push_str(&String::from_utf8(request_body).unwrap());
             let reason = if status == 200 { "OK" } else { "Error" };
             let response = format!(
                 "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
@@ -5618,6 +5644,28 @@ mod tests {
         let requests = handle.join().unwrap();
         assert!(requests[0].contains("X-SM-Session-Credential: opaque-secret\r\n"));
         assert!(!requests[0].contains("\"opaque-secret\""));
+    }
+
+    #[test]
+    fn managed_spawn_sends_caller_credential_only_in_the_header() {
+        let (client, handle) = single_request_server(200, r#"{"session_id":"child1"}"#);
+
+        let response = post_managed_spawn(
+            &client,
+            json!({
+                "parent_session_id": "parent1",
+                "prompt": "review this",
+                "provider": "codex-fork"
+            }),
+            "spawn-secret",
+        )
+        .unwrap();
+
+        assert_eq!(response["session_id"], "child1");
+        let requests = handle.join().unwrap();
+        assert!(requests[0].starts_with("POST /sessions/spawn HTTP/1.1\r\n"));
+        assert!(requests[0].contains("X-SM-Session-Credential: spawn-secret\r\n"));
+        assert!(!requests[0].contains("\"spawn-secret\""));
     }
 
     #[test]

--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -2021,6 +2021,35 @@ sm_send:
     }
 
     #[test]
+    fn policy_admission_is_disabled_without_explicit_operator_config() {
+        let config = AppConfig::default();
+
+        assert!(!config.policy.enabled);
+        assert!(config.policy.projection_path.is_empty());
+        assert_eq!(config.policy.override_ttl_seconds, 900);
+    }
+
+    #[test]
+    fn raw_config_reads_explicit_policy_activation() {
+        let raw: RawConfig = serde_yaml::from_str(
+            r#"
+policy:
+  enabled: true
+  projection_path: /tmp/policy-projection.json
+  db_path: /tmp/policy.db
+  override_ttl_seconds: 300
+"#,
+        )
+        .unwrap();
+        let config = AppConfig::from(raw);
+
+        assert!(config.policy.enabled);
+        assert_eq!(config.policy.projection_path, "/tmp/policy-projection.json");
+        assert_eq!(config.policy.db_path, "/tmp/policy.db");
+        assert_eq!(config.policy.override_ttl_seconds, 300);
+    }
+
+    #[test]
     fn raw_config_reads_top_level_human_names_and_aliases() {
         let raw: RawConfig = serde_yaml::from_str(
             r#"

--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -27,6 +27,7 @@ pub struct AppConfig {
     pub tool_logging: ToolLoggingConfig,
     pub context_monitor: ContextMonitorConfig,
     pub usage: UsageConfig,
+    pub policy: PolicyConfig,
     pub codex_rollout: CodexRolloutConfig,
     pub codex_requests: CodexRequestsConfig,
     pub codex_events: CodexEventsConfig,
@@ -60,6 +61,7 @@ impl Default for AppConfig {
             tool_logging: ToolLoggingConfig::default(),
             context_monitor: ContextMonitorConfig::default(),
             usage: UsageConfig::default(),
+            policy: PolicyConfig::default(),
             codex_rollout: CodexRolloutConfig::default(),
             codex_requests: CodexRequestsConfig::default(),
             codex_events: CodexEventsConfig::default(),
@@ -853,6 +855,30 @@ pub struct UsageConfig {
     pub accounts: Vec<UsageAccountConfig>,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+pub struct PolicyConfig {
+    /// Operator-owned activation gate. A stored projection cannot enable
+    /// policy admission by itself.
+    pub enabled: bool,
+    /// Exact externally approved materialized projection consumed at startup.
+    pub projection_path: String,
+    /// Durable request, decision, override, and capacity-lease store.
+    pub db_path: String,
+    pub override_ttl_seconds: u64,
+}
+
+impl Default for PolicyConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            projection_path: String::new(),
+            db_path: "~/.local/share/claude-sessions/policy.db".to_owned(),
+            override_ttl_seconds: 900,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
 pub struct UsageAccountConfig {
     pub key: String,
@@ -1288,6 +1314,8 @@ struct RawConfig {
     #[serde(default)]
     usage: UsageConfig,
     #[serde(default)]
+    policy: PolicyConfig,
+    #[serde(default)]
     codex_rollout: CodexRolloutConfig,
     #[serde(default)]
     codex_requests: Option<RawCodexRequestsConfig>,
@@ -1394,6 +1422,7 @@ impl From<RawConfig> for AppConfig {
             tool_logging: raw.tool_logging,
             context_monitor: raw.context_monitor,
             usage: raw.usage,
+            policy: raw.policy,
             codex_rollout: raw.codex_rollout,
             codex_requests,
             codex_events,

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -882,14 +882,35 @@ fn attest_policy_session(
     let event_stream_path = session_store
         .codex_fork_event_stream_path(child, &runtime)
         .context("provider event stream path is unavailable")?;
-    let attestation = attest_codex_fork_launch_file(
-        &event_stream_path,
-        profile,
-        &admission.decision.decision_id,
-        &admission.request.launch_intent_id,
-        &child.id,
-        provider_resume_id,
-    )?;
+    let started = Instant::now();
+    let evidence_wait = if config.rust_core.runtime_enabled {
+        Duration::from_secs(10)
+    } else {
+        Duration::ZERO
+    };
+    let attestation = loop {
+        match attest_codex_fork_launch_file(
+            &event_stream_path,
+            profile,
+            &admission.decision.decision_id,
+            &admission.request.launch_intent_id,
+            &child.id,
+            provider_resume_id,
+        ) {
+            Ok(attestation) => break attestation,
+            Err(error)
+                if matches!(
+                    error.code,
+                    "codex_event_stream_unavailable"
+                        | "missing_codex_launch_settings"
+                        | "invalid_codex_event_json"
+                ) && started.elapsed() < evidence_wait =>
+            {
+                thread::sleep(Duration::from_millis(50));
+            }
+            Err(error) => return Err(error.into()),
+        }
+    };
     let result = PolicyAdmissionResult {
         schema: ADMISSION_RESULT_SCHEMA.to_owned(),
         outcome: PolicyAdmissionOutcome::Allowed {

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -105,10 +105,11 @@ use crate::google_auth::{
 use crate::mobile_analytics::build_mobile_analytics_summary;
 use crate::mobile_devices::{self, mobile_device_db_path};
 use crate::policy_contracts::{
-    PolicyCallerBinding, PolicyClassification, PolicyRequestedLaunch, PolicySpawnRequest,
-    PolicyVehicle, SPAWN_REQUEST_SCHEMA,
+    PolicyCallerBinding, PolicyClassification, PolicyDecisionOutcome, PolicyRequestedLaunch,
+    PolicySpawnRequest, PolicyVehicle, SPAWN_REQUEST_SCHEMA,
 };
-use crate::policy_store::{PolicyProjection, PolicyStore};
+use crate::policy_runtime_attestation::attest_codex_fork_launch_file;
+use crate::policy_store::{PolicyProjection, PolicyStore, PolicyStoreError, PreparedDecision};
 use crate::queue::{
     CodexReviewRequestFilters, CodexReviewRequestRegistration, CompleteCodexReviewRequest,
     CreateCodexReviewRequest, CreateQueueJob, QueueAdmissionPolicy, QueueJobFilters,
@@ -3778,6 +3779,120 @@ fn freeze_policy_spawn_request(
     Ok(request)
 }
 
+#[derive(Debug)]
+struct PreparedPolicySpawn {
+    request: PolicySpawnRequest,
+    prepared: PreparedDecision,
+}
+
+fn policy_store_api_error(error: PolicyStoreError) -> ApiError {
+    let (status, detail) = match error {
+        PolicyStoreError::Invalid(detail) => (StatusCode::UNPROCESSABLE_ENTITY, detail),
+        PolicyStoreError::RequestNotFound(detail)
+        | PolicyStoreError::OverrideNotFound(detail)
+        | PolicyStoreError::ProjectionNotFound(detail) => (StatusCode::NOT_FOUND, detail),
+        PolicyStoreError::Stale(detail) | PolicyStoreError::CapacityUnavailable(detail) => {
+            (StatusCode::CONFLICT, detail)
+        }
+        PolicyStoreError::CanaryDenied(detail) | PolicyStoreError::OverrideDenied(detail) => {
+            (StatusCode::FORBIDDEN, detail)
+        }
+        PolicyStoreError::Sqlite(error) => return ApiError::Internal(error.into()),
+        PolicyStoreError::Json(error) => return ApiError::Internal(error.into()),
+    };
+    ApiError::Status { status, detail }
+}
+
+fn prepare_policy_spawn(
+    state: &AppState,
+    headers: &HeaderMap,
+    parent: &SessionRecord,
+    payload: &SpawnCoreSessionRequest,
+    launch_intent_id: &str,
+    prompt_digest: &str,
+    provider: &str,
+    working_dir: &str,
+    node: &str,
+) -> Result<Option<PreparedPolicySpawn>, ApiError> {
+    let Some(runtime) = state.policy_runtime() else {
+        return Ok(None);
+    };
+    if payload
+        .id
+        .as_deref()
+        .is_some_and(|id| !id.trim().is_empty())
+    {
+        return Err(ApiError::Status {
+            status: StatusCode::BAD_REQUEST,
+            detail: "policy admission allocates the child ID; --id is not supported".to_owned(),
+        });
+    }
+    let requested_name = payload
+        .name
+        .as_deref()
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| ApiError::Status {
+            status: StatusCode::UNPROCESSABLE_ENTITY,
+            detail:
+                "policy-enabled spawn requires an explicit name for deterministic classification"
+                    .to_owned(),
+        })?;
+    let caller = bootstrap_policy_caller(state, headers, &parent.id)?;
+    let (vehicle, classification) =
+        deterministic_policy_classification(&runtime.projection, requested_name)?;
+    let request = freeze_policy_spawn_request(
+        runtime,
+        caller,
+        launch_intent_id,
+        prompt_digest,
+        requested_name,
+        vehicle,
+        provider,
+        payload.model.as_deref(),
+        payload.reasoning_effort.as_deref(),
+        working_dir,
+        node,
+    )?;
+    runtime
+        .store
+        .create_request(&request)
+        .map_err(policy_store_api_error)?;
+    let child_session_id = state.session_store.allocate_core_session_id()?;
+    let prepared = runtime
+        .store
+        .prepare_admission(
+            &request.request_id,
+            &classification,
+            None,
+            &child_session_id,
+            OffsetDateTime::now_utc(),
+        )
+        .map_err(policy_store_api_error)?;
+    if !matches!(prepared.decision.outcome, PolicyDecisionOutcome::Allow) {
+        let command = prepared
+            .decision
+            .override_command
+            .as_deref()
+            .unwrap_or("no override is available");
+        return Err(ApiError::Status {
+            status: StatusCode::CONFLICT,
+            detail: format!(
+                "policy {:?} for request {}: {}. {}",
+                prepared.decision.outcome, request.request_id, prepared.decision.reason, command
+            ),
+        });
+    }
+    if prepared.provisional_child_session_id.as_deref() != Some(child_session_id.as_str()) {
+        let _ = runtime.store.release_by_child(&child_session_id);
+        return Err(ApiError::Status {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            detail: "policy admission did not preserve the provisional child binding".to_owned(),
+        });
+    }
+    Ok(Some(PreparedPolicySpawn { request, prepared }))
+}
+
 async fn spawn_session(
     State(state): State<Arc<AppState>>,
     ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
@@ -3823,7 +3938,7 @@ async fn spawn_session(
     let accepted = accept_spawn_brief(
         &state,
         Some(&payload.prompt),
-        payload.prompt_source.unwrap_or(SpawnBriefSource {
+        payload.prompt_source.clone().unwrap_or(SpawnBriefSource {
             kind: "positional".to_owned(),
             path: None,
         }),
@@ -3835,16 +3950,41 @@ async fn spawn_session(
         Some(node.clone()),
         Some(working_dir.clone()),
     )?;
+    let policy_spawn = prepare_policy_spawn(
+        &state,
+        &headers,
+        &parent,
+        &payload,
+        &accepted.1,
+        &accepted.2,
+        &provider,
+        &working_dir,
+        &node,
+    )?;
+    let policy_profile = policy_spawn
+        .as_ref()
+        .and_then(|policy| policy.prepared.decision.resolved_profile.as_ref());
     let create_payload = CreateCoreSessionRequest {
-        id: payload.id,
+        id: policy_spawn
+            .as_ref()
+            .and_then(|policy| policy.prepared.provisional_child_session_id.clone())
+            .or(payload.id),
         name: payload.name,
         working_dir: Some(working_dir),
-        provider: Some(provider),
+        provider: Some(
+            policy_profile
+                .map(|profile| profile.provider.clone())
+                .unwrap_or(provider),
+        ),
         parent_session_id: Some(parent.id.clone()),
         node: Some(node),
         initial_message: Some(accepted.0),
-        model: payload.model,
-        reasoning_effort: payload.reasoning_effort,
+        model: policy_profile
+            .map(|profile| profile.model.clone())
+            .or(payload.model),
+        reasoning_effort: policy_profile
+            .map(|profile| profile.effort.clone())
+            .or(payload.reasoning_effort),
         wait: wait_seconds,
         spawn_prompt_source: None,
         spawn_brief: Some(SpawnBriefBinding {
@@ -3853,14 +3993,26 @@ async fn spawn_session(
         }),
     };
     let log_dir = state.config.rust_core.log_dir.as_deref().map(expand_home);
-    let child = if state.config.rust_core.runtime_enabled {
+    let child_result = if state.config.rust_core.runtime_enabled {
         ensure_core_runtime_provider_supported(&create_payload)?;
         ensure_core_runtime_request_node_supported(&state, &create_payload)?;
-        create_runtime_core_session(state.clone(), create_payload, log_dir).await?
+        create_runtime_core_session(state.clone(), create_payload, log_dir).await
     } else {
         state
             .session_store
-            .create_core_session(create_payload, log_dir)?
+            .create_core_session(create_payload, log_dir)
+            .map_err(core_session_create_api_error)
+    };
+    let child = match child_result {
+        Ok(child) => child,
+        Err(error) => {
+            if let (Some(runtime), Some(policy)) = (state.policy_runtime(), policy_spawn.as_ref()) {
+                if let Some(child_id) = policy.prepared.provisional_child_session_id.as_deref() {
+                    let _ = runtime.store.release_by_child(child_id);
+                }
+            }
+            return Err(error);
+        }
     };
     if parent.is_em && child.provider != "codex-fork" {
         let _ = state.session_store.arm_stop_notify(

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -104,6 +104,10 @@ use crate::google_auth::{
 };
 use crate::mobile_analytics::build_mobile_analytics_summary;
 use crate::mobile_devices::{self, mobile_device_db_path};
+use crate::policy_contracts::{
+    PolicyCallerBinding, PolicyClassification, PolicyRequestedLaunch, PolicySpawnRequest,
+    PolicyVehicle, SPAWN_REQUEST_SCHEMA,
+};
 use crate::policy_store::{PolicyProjection, PolicyStore};
 use crate::queue::{
     CodexReviewRequestFilters, CodexReviewRequestRegistration, CompleteCodexReviewRequest,
@@ -3613,6 +3617,165 @@ fn accept_spawn_brief(
         .read_spawn_brief(&intent.artifact)
         .map_err(core_session_create_api_error)?;
     Ok((accepted_prompt, intent.id, intent.artifact.sha256))
+}
+
+fn bootstrap_policy_caller(
+    state: &AppState,
+    headers: &HeaderMap,
+    parent_session_id: &str,
+) -> Result<PolicyCallerBinding, ApiError> {
+    let runtime = state.policy_runtime().ok_or_else(|| ApiError::Status {
+        status: StatusCode::SERVICE_UNAVAILABLE,
+        detail: "policy runtime is not active".to_owned(),
+    })?;
+    let authority = runtime
+        .projection
+        .bootstrap_authority
+        .as_ref()
+        .ok_or_else(|| ApiError::Status {
+            status: StatusCode::FORBIDDEN,
+            detail: "policy bootstrap authority is not configured".to_owned(),
+        })?;
+    let credential = reparent_session_credential(headers)?;
+    if !state
+        .session_store
+        .verify_session_credential(parent_session_id, &credential)?
+    {
+        return Err(ApiError::Status {
+            status: StatusCode::FORBIDDEN,
+            detail: "session credential does not match the policy caller".to_owned(),
+        });
+    }
+    let credential_fingerprint = sha256_hex(credential.as_bytes());
+    if authority.session_id != parent_session_id
+        || authority.credential_fingerprint != credential_fingerprint
+    {
+        return Err(ApiError::Status {
+            status: StatusCode::FORBIDDEN,
+            detail: "caller is outside the configured policy canary".to_owned(),
+        });
+    }
+    Ok(PolicyCallerBinding::IncarnationBootstrap {
+        lane: runtime.projection.lane.clone(),
+        session_id: parent_session_id.to_owned(),
+        credential_fingerprint,
+        binding_digest: authority.binding_digest.clone(),
+    })
+}
+
+fn deterministic_policy_classification(
+    projection: &PolicyProjection,
+    requested_name: &str,
+) -> Result<(PolicyVehicle, PolicyClassification), ApiError> {
+    let role_matches = projection
+        .rules
+        .iter()
+        .filter(|rule| rule.role_id.as_deref() == Some(requested_name))
+        .collect::<Vec<_>>();
+    let class_matches = projection
+        .rules
+        .iter()
+        .filter(|rule| rule.class_id.as_deref() == Some(requested_name))
+        .collect::<Vec<_>>();
+    let (matches, method, role_id) = if role_matches.is_empty() {
+        (class_matches, "explicit_class", None)
+    } else {
+        (
+            role_matches,
+            "explicit_role",
+            Some(requested_name.to_owned()),
+        )
+    };
+    let Some(first) = matches.first() else {
+        return Ok((
+            PolicyVehicle::TaskAgent,
+            PolicyClassification {
+                class_id: requested_name.to_owned(),
+                role_id: None,
+                turn_profile: "initial_task".to_owned(),
+                method: "unclassified_explicit_name".to_owned(),
+                confidence: "exact".to_owned(),
+            },
+        ));
+    };
+    if matches.iter().skip(1).any(|rule| {
+        rule.profile.vehicle != first.profile.vehicle || rule.class_id != first.class_id
+    }) {
+        return Err(ApiError::Status {
+            status: StatusCode::CONFLICT,
+            detail: format!(
+                "policy clauses disagree on the deterministic vehicle or class for {requested_name}"
+            ),
+        });
+    }
+    Ok((
+        first.profile.vehicle.clone(),
+        PolicyClassification {
+            class_id: first
+                .class_id
+                .clone()
+                .unwrap_or_else(|| requested_name.to_owned()),
+            role_id,
+            turn_profile: "initial_task".to_owned(),
+            method: method.to_owned(),
+            confidence: "exact".to_owned(),
+        },
+    ))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn freeze_policy_spawn_request(
+    runtime: &PolicyRuntimeState,
+    caller: PolicyCallerBinding,
+    launch_intent_id: &str,
+    prompt_digest: &str,
+    requested_name: &str,
+    vehicle: PolicyVehicle,
+    provider: &str,
+    model: Option<&str>,
+    effort: Option<&str>,
+    working_dir: &str,
+    node: &str,
+) -> Result<PolicySpawnRequest, ApiError> {
+    let request_id = sha256_hex(
+        format!(
+            "sm-policy-request-v1\0{}\0{}\0{}\0{}",
+            runtime.projection.lane,
+            runtime.projection.policy_digest,
+            launch_intent_id,
+            prompt_digest
+        )
+        .as_bytes(),
+    );
+    let created_at = OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .map_err(|error| ApiError::Internal(error.into()))?;
+    let request = PolicySpawnRequest {
+        schema: SPAWN_REQUEST_SCHEMA.to_owned(),
+        request_id,
+        caller,
+        prompt_digest: prompt_digest.to_owned(),
+        launch_intent_id: launch_intent_id.to_owned(),
+        policy_version: runtime.projection.policy_version.clone(),
+        policy_digest: runtime.projection.policy_digest.clone(),
+        requested: PolicyRequestedLaunch {
+            name: requested_name.to_owned(),
+            vehicle,
+            provider: provider.to_owned(),
+            model: model.map(ToOwned::to_owned),
+            effort: effort.map(ToOwned::to_owned),
+            working_dir: working_dir.to_owned(),
+            node: node.to_owned(),
+        },
+        topology_version: 0,
+        capacity_version: 0,
+        created_at,
+    };
+    request.validate().map_err(|error| ApiError::Status {
+        status: StatusCode::UNPROCESSABLE_ENTITY,
+        detail: error.to_string(),
+    })?;
+    Ok(request)
 }
 
 async fn spawn_session(
@@ -13732,6 +13895,103 @@ mod tests {
     use serde::Serialize;
     use std::{env, process};
     use tower::ServiceExt;
+
+    fn policy_projection_with_rules(
+        rules: Vec<crate::policy_store::MaterializedPolicyRule>,
+    ) -> PolicyProjection {
+        PolicyProjection {
+            lane: "sm-policy-1268".to_owned(),
+            policy_version: "v1".to_owned(),
+            policy_digest: "a".repeat(64),
+            enabled: true,
+            bootstrap_authority: None,
+            seat_authority: None,
+            rules,
+            capacity_limits: vec![crate::policy_store::PolicyCapacityLimit {
+                dimension: "provider".to_owned(),
+                key: "codex-fork".to_owned(),
+                maximum_units: 2,
+            }],
+        }
+    }
+
+    fn policy_rule(
+        clause_id: &str,
+        role_id: Option<&str>,
+        class_id: Option<&str>,
+        vehicle: PolicyVehicle,
+    ) -> crate::policy_store::MaterializedPolicyRule {
+        crate::policy_store::MaterializedPolicyRule {
+            clause_id: clause_id.to_owned(),
+            rank: 1,
+            class_id: class_id.map(ToOwned::to_owned),
+            role_id: role_id.map(ToOwned::to_owned),
+            vehicle: Some(vehicle.clone()),
+            profile: crate::policy_contracts::PolicyLaunchProfile {
+                vehicle,
+                provider: "codex-fork".to_owned(),
+                model: "gpt-5.6-terra".to_owned(),
+                effort: "high".to_owned(),
+                context_profile: "provider_native_compaction".to_owned(),
+            },
+            outcome: crate::policy_store::PolicyRuleOutcome::Allow,
+            overridable: true,
+            capacity_claims: vec![crate::policy_contracts::PolicyCapacityClaim {
+                dimension: "provider".to_owned(),
+                key: "codex-fork".to_owned(),
+                units: 1,
+            }],
+            lease_ttl_seconds: 900,
+            reason: "test policy".to_owned(),
+        }
+    }
+
+    #[test]
+    fn deterministic_policy_classification_distinguishes_named_seats_from_workers() {
+        let projection = policy_projection_with_rules(vec![policy_rule(
+            "role.watchdog",
+            Some("sm-policy-1268-watchdog"),
+            Some("monitoring"),
+            PolicyVehicle::NamedSeat,
+        )]);
+
+        let (vehicle, classification) =
+            deterministic_policy_classification(&projection, "sm-policy-1268-watchdog").unwrap();
+        assert_eq!(vehicle, PolicyVehicle::NamedSeat);
+        assert_eq!(classification.class_id, "monitoring");
+        assert_eq!(
+            classification.role_id.as_deref(),
+            Some("sm-policy-1268-watchdog")
+        );
+
+        let (vehicle, classification) =
+            deterministic_policy_classification(&projection, "ticket-1284").unwrap();
+        assert_eq!(vehicle, PolicyVehicle::TaskAgent);
+        assert_eq!(classification.class_id, "ticket-1284");
+        assert!(classification.role_id.is_none());
+    }
+
+    #[test]
+    fn deterministic_policy_classification_rejects_vehicle_conflicts() {
+        let projection = policy_projection_with_rules(vec![
+            policy_rule(
+                "role.one",
+                Some("sm-policy-1268-owner"),
+                Some("orchestration"),
+                PolicyVehicle::NamedSeat,
+            ),
+            policy_rule(
+                "role.two",
+                Some("sm-policy-1268-owner"),
+                Some("orchestration"),
+                PolicyVehicle::TaskAgent,
+            ),
+        ]);
+
+        let error =
+            deterministic_policy_classification(&projection, "sm-policy-1268-owner").unwrap_err();
+        assert_eq!(api_error_status_detail(error).0, StatusCode::CONFLICT);
+    }
 
     #[test]
     fn codex_model_validation_errors_have_actionable_http_statuses() {

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -104,6 +104,7 @@ use crate::google_auth::{
 };
 use crate::mobile_analytics::build_mobile_analytics_summary;
 use crate::mobile_devices::{self, mobile_device_db_path};
+use crate::policy_store::{PolicyProjection, PolicyStore};
 use crate::queue::{
     CodexReviewRequestFilters, CodexReviewRequestRegistration, CompleteCodexReviewRequest,
     CreateCodexReviewRequest, CreateQueueJob, QueueAdmissionPolicy, QueueJobFilters,
@@ -366,6 +367,7 @@ impl GitHubReviewPoster for GhCliReviewPoster {
 pub struct AppState {
     config: AppConfig,
     session_store: SessionStore,
+    policy_runtime: Option<PolicyRuntimeState>,
     github_review_poster: Arc<dyn GitHubReviewPoster>,
     codex_review_creation_locks: Arc<AsyncMutex<BTreeSet<String>>>,
     codex_review_watcher_ids: Arc<Mutex<BTreeSet<String>>>,
@@ -381,6 +383,12 @@ pub struct AppState {
     mobile_terminal_runtime_disabled: Arc<AtomicBool>,
     studio_ssh_enabled: Arc<AtomicBool>,
     mobile_terminal_secret: [u8; 32],
+}
+
+#[derive(Clone)]
+struct PolicyRuntimeState {
+    store: PolicyStore,
+    projection: PolicyProjection,
 }
 
 impl AppState {
@@ -456,6 +464,7 @@ impl AppState {
         if let Err(error) = session_store.recover_codex_fork_event_monitors() {
             eprintln!("codex-fork event monitor recovery failed: {error:#}");
         }
+        let policy_runtime = load_policy_runtime(&config)?;
         let mut mobile_terminal_secret = [0u8; 32];
         OsRng.fill_bytes(&mut mobile_terminal_secret);
         let (tmux_client_event_tx, _) = broadcast::channel(128);
@@ -463,6 +472,7 @@ impl AppState {
         Ok(Self {
             config,
             session_store,
+            policy_runtime,
             github_review_poster: Arc::new(GhCliReviewPoster),
             codex_review_creation_locks: Arc::new(AsyncMutex::new(BTreeSet::new())),
             codex_review_watcher_ids: Arc::new(Mutex::new(BTreeSet::new())),
@@ -501,6 +511,10 @@ impl AppState {
         &self.config
     }
 
+    fn policy_runtime(&self) -> Option<&PolicyRuntimeState> {
+        self.policy_runtime.as_ref()
+    }
+
     pub fn reconcile_current_seat_sessions(&self) -> anyhow::Result<()> {
         self.session_store.reconcile_current_seat_sessions()
     }
@@ -523,6 +537,46 @@ impl AppState {
     pub fn scan_usage_ledger(&self) -> anyhow::Result<ScanSummary> {
         self.session_store.scan_usage_ledger()
     }
+}
+
+fn load_policy_runtime(config: &AppConfig) -> anyhow::Result<Option<PolicyRuntimeState>> {
+    if !config.policy.enabled {
+        return Ok(None);
+    }
+    if config.policy.override_ttl_seconds == 0 {
+        anyhow::bail!("policy override_ttl_seconds must be greater than zero");
+    }
+    let projection_path = config.policy.projection_path.trim();
+    if projection_path.is_empty() {
+        anyhow::bail!("policy projection_path is required when policy is enabled");
+    }
+    let projection_path = expand_home(projection_path);
+    let encoded = fs::read_to_string(&projection_path).with_context(|| {
+        format!(
+            "failed to read policy projection {}",
+            projection_path.display()
+        )
+    })?;
+    let projection = serde_json::from_str::<PolicyProjection>(&encoded)
+        .or_else(|_| serde_yaml::from_str::<PolicyProjection>(&encoded))
+        .with_context(|| {
+            format!(
+                "failed to parse policy projection {}",
+                projection_path.display()
+            )
+        })?;
+    if !projection.enabled {
+        anyhow::bail!(
+            "policy projection {} is not explicitly enabled",
+            projection_path.display()
+        );
+    }
+    let store = PolicyStore::new(expand_home(&config.policy.db_path))
+        .context("failed to initialize policy store")?;
+    store
+        .install_projection(&projection)
+        .context("failed to install policy projection")?;
+    Ok(Some(PolicyRuntimeState { store, projection }))
 }
 
 fn should_use_configured_usage_db_path(config: &UsageConfig) -> bool {

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -3856,6 +3856,7 @@ struct PreparedPolicySpawn {
 
 fn policy_store_api_error(error: PolicyStoreError) -> ApiError {
     let (status, detail) = match error {
+        PolicyStoreError::Schema(detail) => (StatusCode::SERVICE_UNAVAILABLE, detail),
         PolicyStoreError::Invalid(detail) => (StatusCode::UNPROCESSABLE_ENTITY, detail),
         PolicyStoreError::RequestNotFound(detail)
         | PolicyStoreError::OverrideNotFound(detail)

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -105,11 +105,17 @@ use crate::google_auth::{
 use crate::mobile_analytics::build_mobile_analytics_summary;
 use crate::mobile_devices::{self, mobile_device_db_path};
 use crate::policy_contracts::{
-    PolicyCallerBinding, PolicyClassification, PolicyDecisionOutcome, PolicyRequestedLaunch,
-    PolicySpawnRequest, PolicyVehicle, SPAWN_REQUEST_SCHEMA,
+    EstimatedAmount, EstimatedCounter, PolicyAdmissionOutcome, PolicyAdmissionResult,
+    PolicyCallerBinding, PolicyClassification, PolicyDecision, PolicyDecisionOutcome,
+    PolicyEventEnvelope, PolicyRequestedLaunch, PolicyRuntimeAttestation, PolicySpawnRequest,
+    PolicyUsageCounters, PolicyVehicle, ADMISSION_RESULT_SCHEMA, EVENT_SCHEMA,
+    SPAWN_REQUEST_SCHEMA, USAGE_SCHEMA,
 };
 use crate::policy_runtime_attestation::attest_codex_fork_launch_file;
-use crate::policy_store::{PolicyProjection, PolicyStore, PolicyStoreError, PreparedDecision};
+use crate::policy_store::{
+    PolicyChildAdmission, PolicyChildState, PolicyProjection, PolicyStore, PolicyStoreError,
+    PreparedDecision,
+};
 use crate::queue::{
     CodexReviewRequestFilters, CodexReviewRequestRegistration, CompleteCodexReviewRequest,
     CreateCodexReviewRequest, CreateQueueJob, QueueAdmissionPolicy, QueueJobFilters,
@@ -396,6 +402,17 @@ pub struct AppState {
 struct PolicyRuntimeState {
     store: PolicyStore,
     projection: PolicyProjection,
+    reconciliation: PolicyReconciliationReport,
+    admission_blocker: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+struct PolicyReconciliationReport {
+    expected: usize,
+    visited: usize,
+    resolved: usize,
+    blocked: usize,
+    blockers: Vec<String>,
 }
 
 impl AppState {
@@ -476,7 +493,7 @@ impl AppState {
         if let Err(error) = session_store.recover_codex_fork_event_monitors() {
             eprintln!("codex-fork event monitor recovery failed: {error:#}");
         }
-        let policy_runtime = load_policy_runtime(&config)?;
+        let policy_runtime = load_policy_runtime(&config, &session_store, &policy_evidence_store)?;
         let mut mobile_terminal_secret = [0u8; 32];
         OsRng.fill_bytes(&mut mobile_terminal_secret);
         let (tmux_client_event_tx, _) = broadcast::channel(128);
@@ -558,7 +575,11 @@ impl AppState {
     }
 }
 
-fn load_policy_runtime(config: &AppConfig) -> anyhow::Result<Option<PolicyRuntimeState>> {
+fn load_policy_runtime(
+    config: &AppConfig,
+    session_store: &SessionStore,
+    evidence_store: &PolicyEvidenceStore,
+) -> anyhow::Result<Option<PolicyRuntimeState>> {
     if !config.policy.enabled {
         return Ok(None);
     }
@@ -595,7 +616,357 @@ fn load_policy_runtime(config: &AppConfig) -> anyhow::Result<Option<PolicyRuntim
     store
         .install_projection(&projection)
         .context("failed to install policy projection")?;
-    Ok(Some(PolicyRuntimeState { store, projection }))
+    store
+        .activate_projection(
+            &projection.lane,
+            &projection.policy_version,
+            &projection.policy_digest,
+        )
+        .context("failed to activate configured policy projection")?;
+    let reconciliation =
+        reconcile_policy_runtime(config, session_store, evidence_store, &store, &projection)?;
+    let admission_blocker = (!reconciliation.blockers.is_empty()).then(|| {
+        format!(
+            "policy admission disabled: restart reconciliation blocked {}/{} items: {}",
+            reconciliation.blocked,
+            reconciliation.expected,
+            reconciliation.blockers.join("; ")
+        )
+    });
+    Ok(Some(PolicyRuntimeState {
+        store,
+        projection,
+        reconciliation,
+        admission_blocker,
+    }))
+}
+
+fn reconcile_policy_runtime(
+    config: &AppConfig,
+    session_store: &SessionStore,
+    evidence_store: &PolicyEvidenceStore,
+    store: &PolicyStore,
+    projection: &PolicyProjection,
+) -> anyhow::Result<PolicyReconciliationReport> {
+    let snapshot = store
+        .reconciliation_snapshot()
+        .context("failed to snapshot policy admission reconciliation")?;
+    let mut report = PolicyReconciliationReport {
+        expected: snapshot.expected,
+        visited: snapshot.blockers.len(),
+        blocked: snapshot.blockers.len(),
+        blockers: snapshot.blockers,
+        ..PolicyReconciliationReport::default()
+    };
+    for reservation in snapshot.reservations {
+        report.visited += 1;
+        let admission = store
+            .admission_for_child(&reservation.child_session_id)
+            .with_context(|| {
+                format!(
+                    "failed to load policy admission for child {}",
+                    reservation.child_session_id
+                )
+            })?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "reconciliation snapshot child {} disappeared",
+                    reservation.child_session_id
+                )
+            })?;
+        let result =
+            reconcile_policy_child(config, session_store, evidence_store, store, &admission);
+        match result {
+            Ok(()) => report.resolved += 1,
+            Err(error) => {
+                report.blocked += 1;
+                report.blockers.push(format!(
+                    "child {}: {error:#}",
+                    admission.reservation.child_session_id
+                ));
+            }
+        }
+    }
+    let occurred_at = OffsetDateTime::now_utc().format(&Rfc3339)?;
+    append_policy_event(
+        evidence_store,
+        &projection.lane,
+        "restart_reconciliation",
+        &format!(
+            "restart-reconciliation:{}:{}",
+            projection.policy_version, occurred_at
+        ),
+        0,
+        None,
+        &occurred_at,
+        "sm.policy.reconciliation.v1",
+        serde_json::to_value(&report)?,
+    )
+    .context("failed to append policy restart reconciliation evidence")?;
+    Ok(report)
+}
+
+fn reconcile_policy_child(
+    config: &AppConfig,
+    session_store: &SessionStore,
+    evidence_store: &PolicyEvidenceStore,
+    store: &PolicyStore,
+    admission: &PolicyChildAdmission,
+) -> anyhow::Result<()> {
+    let child_id = admission.reservation.child_session_id.as_str();
+    let session = session_store.get_session(child_id)?;
+    match admission.reservation.child_state {
+        PolicyChildState::Reserved => match session {
+            None => release_policy_child(
+                config,
+                session_store,
+                evidence_store,
+                store,
+                admission,
+                None,
+                "restart found reserved admission without a materialized session",
+            ),
+            Some(session) => {
+                if !policy_session_is_live(config, &session)? {
+                    return release_policy_child(
+                        config,
+                        session_store,
+                        evidence_store,
+                        store,
+                        admission,
+                        Some(&session),
+                        "restart found a dead pre-mark policy session",
+                    );
+                }
+                match attest_policy_session(config, session_store, admission, &session) {
+                    Ok(attestation) => {
+                        append_policy_attestation_event(
+                            evidence_store,
+                            &admission.request,
+                            &admission.decision,
+                            &attestation,
+                        )?;
+                        if let Err(error) = store.mark_child_launched(child_id) {
+                            return release_policy_child(
+                                config,
+                                session_store,
+                                evidence_store,
+                                store,
+                                admission,
+                                Some(&session),
+                                &format!("restart launch promotion failed: {error}"),
+                            );
+                        }
+                        if let Err(error) = promote_policy_session(session_store, admission) {
+                            return release_policy_child(
+                                config,
+                                session_store,
+                                evidence_store,
+                                store,
+                                admission,
+                                Some(&session),
+                                &format!("restart hierarchy promotion failed: {error:#}"),
+                            );
+                        }
+                        append_policy_lifecycle_event(
+                            evidence_store,
+                            &admission.request,
+                            &admission.decision,
+                            child_id,
+                            "launched",
+                            4,
+                            "provider profile attested and capacity lease committed",
+                        )
+                    }
+                    Err(error) => release_policy_child(
+                        config,
+                        session_store,
+                        evidence_store,
+                        store,
+                        admission,
+                        Some(&session),
+                        &format!("restart attestation failed: {error:#}"),
+                    ),
+                }
+            }
+        },
+        PolicyChildState::Launched => match session {
+            Some(session) if policy_session_is_live(config, &session)? => {
+                promote_policy_session(session_store, admission)?;
+                append_policy_lifecycle_event(
+                    evidence_store,
+                    &admission.request,
+                    &admission.decision,
+                    child_id,
+                    "launched",
+                    4,
+                    "provider profile attested and capacity lease committed",
+                )
+            }
+            Some(session) => release_policy_child(
+                config,
+                session_store,
+                evidence_store,
+                store,
+                admission,
+                Some(&session),
+                "restart found launched policy child dead",
+            ),
+            None => release_policy_child(
+                config,
+                session_store,
+                evidence_store,
+                store,
+                admission,
+                None,
+                "restart found launched policy child missing",
+            ),
+        },
+        PolicyChildState::ReleasePending => release_policy_child(
+            config,
+            session_store,
+            evidence_store,
+            store,
+            admission,
+            session.as_ref(),
+            "restart resumed pending policy child release",
+        ),
+        PolicyChildState::Released | PolicyChildState::Expired => anyhow::bail!(
+            "terminal child state {:?} appeared in non-terminal reconciliation snapshot",
+            admission.reservation.child_state
+        ),
+    }
+}
+
+fn policy_session_is_live(config: &AppConfig, session: &SessionRecord) -> anyhow::Result<bool> {
+    if session.is_stopped() {
+        return Ok(false);
+    }
+    if !config.rust_core.runtime_enabled {
+        return Ok(true);
+    }
+    if !is_primary_node(&session.node) {
+        anyhow::bail!(
+            "cannot determine liveness for policy child {} on node {}",
+            session.id,
+            session.node
+        );
+    }
+    TmuxRuntime::from_app_config(config)
+        .for_socket_name(session.tmux_socket_name.as_deref())
+        .session_exists(&session.tmux_session)
+        .with_context(|| {
+            format!(
+                "failed to inspect runtime liveness for policy child {}",
+                session.id
+            )
+        })
+}
+
+fn attest_policy_session(
+    config: &AppConfig,
+    session_store: &SessionStore,
+    admission: &PolicyChildAdmission,
+    child: &SessionRecord,
+) -> anyhow::Result<PolicyRuntimeAttestation> {
+    let profile = admission
+        .decision
+        .resolved_profile
+        .as_ref()
+        .context("allow decision is missing its resolved profile")?;
+    let provider_resume_id = child
+        .provider_resume_id
+        .as_deref()
+        .context("provider did not publish a runtime thread ID")?;
+    let runtime = TmuxRuntime::from_app_config(config);
+    let event_stream_path = session_store
+        .codex_fork_event_stream_path(child, &runtime)
+        .context("provider event stream path is unavailable")?;
+    let attestation = attest_codex_fork_launch_file(
+        &event_stream_path,
+        profile,
+        &admission.decision.decision_id,
+        &admission.request.launch_intent_id,
+        &child.id,
+        provider_resume_id,
+    )?;
+    let result = PolicyAdmissionResult {
+        schema: ADMISSION_RESULT_SCHEMA.to_owned(),
+        outcome: PolicyAdmissionOutcome::Allowed {
+            decision_id: admission.decision.decision_id.clone(),
+            child_session_id: child.id.clone(),
+            profile: profile.clone(),
+        },
+    };
+    result.validate_allowed_launch(&admission.request, &admission.decision, &attestation)?;
+    Ok(attestation)
+}
+
+fn policy_parent_session_id(request: &PolicySpawnRequest) -> &str {
+    match &request.caller {
+        PolicyCallerBinding::Seat {
+            holder_session_id, ..
+        } => holder_session_id,
+        PolicyCallerBinding::IncarnationBootstrap { session_id, .. } => session_id,
+    }
+}
+
+fn promote_policy_session(
+    session_store: &SessionStore,
+    admission: &PolicyChildAdmission,
+) -> anyhow::Result<()> {
+    session_store.promote_policy_provisional_session(
+        &admission.reservation.child_session_id,
+        policy_parent_session_id(&admission.request),
+    )?;
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn release_policy_child(
+    config: &AppConfig,
+    session_store: &SessionStore,
+    evidence_store: &PolicyEvidenceStore,
+    store: &PolicyStore,
+    admission: &PolicyChildAdmission,
+    session: Option<&SessionRecord>,
+    reason: &str,
+) -> anyhow::Result<()> {
+    let child_id = admission.reservation.child_session_id.as_str();
+    if admission.reservation.child_state != PolicyChildState::ReleasePending {
+        store.mark_child_release_pending(child_id)?;
+    }
+    if session.is_some() {
+        let runtime = config
+            .rust_core
+            .runtime_enabled
+            .then(|| TmuxRuntime::from_app_config(config));
+        let retained =
+            session_store.reject_policy_provisional_session(child_id, reason, runtime.as_ref())?;
+        if !retained {
+            anyhow::bail!("policy child disappeared before rejected audit row was retained");
+        }
+        append_policy_lifecycle_event(
+            evidence_store,
+            &admission.request,
+            &admission.decision,
+            child_id,
+            "launch_rejected",
+            6,
+            reason,
+        )?;
+    }
+    store.release_by_child(child_id)?;
+    append_policy_lifecycle_event(
+        evidence_store,
+        &admission.request,
+        &admission.decision,
+        child_id,
+        "released",
+        7,
+        reason,
+    )?;
+    Ok(())
 }
 
 fn should_use_configured_usage_db_path(config: &UsageConfig) -> bool {
@@ -3533,9 +3904,19 @@ async fn get_policy_status(
     request: Request,
 ) -> Result<Json<Value>, ApiError> {
     ensure_policy_evidence_read_allowed(&state, &request, &query.lane)?;
-    Ok(Json(serde_json::to_value(
-        state.policy_evidence_store().status(&query.lane)?,
-    )?))
+    let mut status = serde_json::to_value(state.policy_evidence_store().status(&query.lane)?)?;
+    if let Some(runtime) = state
+        .policy_runtime()
+        .filter(|runtime| runtime.projection.lane == query.lane)
+    {
+        status["admission_enabled"] = Value::Bool(runtime.admission_blocker.is_none());
+        status["admission_blocker"] = runtime
+            .admission_blocker
+            .as_ref()
+            .map_or(Value::Null, |value| Value::String(value.clone()));
+        status["restart_reconciliation"] = serde_json::to_value(&runtime.reconciliation)?;
+    }
+    Ok(Json(status))
 }
 
 async fn get_policy_explain(
@@ -3793,6 +4174,32 @@ fn deterministic_policy_classification(
     ))
 }
 
+fn frozen_policy_request_vehicle(
+    projection: &PolicyProjection,
+    requested_name: &str,
+) -> Result<PolicyVehicle, ApiError> {
+    let role_vehicles = projection
+        .rules
+        .iter()
+        .filter(|rule| rule.role_id.as_deref() == Some(requested_name))
+        .map(|rule| rule.profile.vehicle.clone())
+        .collect::<Vec<_>>();
+    let vehicle = role_vehicles.first();
+    if role_vehicles
+        .iter()
+        .skip(1)
+        .any(|candidate| Some(candidate) != vehicle)
+    {
+        return Err(ApiError::Status {
+            status: StatusCode::CONFLICT,
+            detail: format!(
+                "policy clauses disagree on the frozen requested vehicle for {requested_name}"
+            ),
+        });
+    }
+    Ok(vehicle.cloned().unwrap_or(PolicyVehicle::TaskAgent))
+}
+
 #[allow(clippy::too_many_arguments)]
 fn freeze_policy_spawn_request(
     runtime: &PolicyRuntimeState,
@@ -3873,6 +4280,257 @@ fn policy_store_api_error(error: PolicyStoreError) -> ApiError {
     ApiError::Status { status, detail }
 }
 
+fn append_policy_event(
+    store: &PolicyEvidenceStore,
+    lane: &str,
+    event_type: &str,
+    operation_id: &str,
+    sequence: u64,
+    session_id: Option<&str>,
+    occurred_at: &str,
+    payload_schema: &str,
+    payload: Value,
+) -> anyhow::Result<()> {
+    let event_id = sha256_hex(
+        format!(
+            "sm-policy-event-v1\0{}\0{}\0{}\0{}\0{}",
+            lane,
+            operation_id,
+            sequence,
+            event_type,
+            session_id.unwrap_or("")
+        )
+        .as_bytes(),
+    );
+    store.append(&PolicyEventEnvelope {
+        schema: EVENT_SCHEMA.to_owned(),
+        event_id,
+        sequence,
+        event_type: event_type.to_owned(),
+        operation_id: operation_id.to_owned(),
+        lane: lane.to_owned(),
+        seat_key: None,
+        session_id: session_id.map(ToOwned::to_owned),
+        occurred_at: occurred_at.to_owned(),
+        payload_schema: payload_schema.to_owned(),
+        payload,
+    })?;
+    Ok(())
+}
+
+fn append_policy_decision_event(
+    store: &PolicyEvidenceStore,
+    projection: &PolicyProjection,
+    request: &PolicySpawnRequest,
+    prepared: &PreparedDecision,
+) -> anyhow::Result<()> {
+    append_policy_event(
+        store,
+        &projection.lane,
+        "admission_decision",
+        &prepared.decision.decision_id,
+        1,
+        prepared.provisional_child_session_id.as_deref(),
+        &prepared.decision.decided_at,
+        "sm.policy.admission_decision.v1",
+        json!({
+            "request": request,
+            "decision": prepared.decision,
+            "reused": prepared.reused,
+            "child_state": prepared.child_state,
+            "links": {"decision_id": prepared.decision.decision_id, "request_id": request.request_id}
+        }),
+    )
+}
+
+fn append_policy_lifecycle_event(
+    store: &PolicyEvidenceStore,
+    request: &PolicySpawnRequest,
+    decision: &PolicyDecision,
+    child_session_id: &str,
+    lifecycle: &str,
+    sequence: u64,
+    detail: &str,
+) -> anyhow::Result<()> {
+    append_policy_event(
+        store,
+        request.caller.lane(),
+        "child_lifecycle",
+        &decision.decision_id,
+        sequence,
+        Some(child_session_id),
+        &decision.decided_at,
+        "sm.policy.child_lifecycle.v1",
+        json!({
+            "decision_id": decision.decision_id,
+            "request_id": request.request_id,
+            "child_session_id": child_session_id,
+            "lifecycle": lifecycle,
+            "detail": detail,
+            "links": {"decision_id": decision.decision_id, "request_id": request.request_id}
+        }),
+    )
+}
+
+fn zero_policy_usage(source: &str) -> PolicyUsageCounters {
+    let counter = || EstimatedCounter {
+        value: 0,
+        lower_bound: 0,
+        upper_bound: 0,
+        source: source.to_owned(),
+        estimated: false,
+        method: "provider_event_boundary".to_owned(),
+        confidence: "exact".to_owned(),
+    };
+    let amount = |unit: &str| EstimatedAmount {
+        value: 0.0,
+        lower_bound: 0.0,
+        upper_bound: 0.0,
+        unit: unit.to_owned(),
+        source: source.to_owned(),
+        estimated: false,
+        method: "provider_event_boundary".to_owned(),
+        confidence: "exact".to_owned(),
+    };
+    PolicyUsageCounters {
+        schema: USAGE_SCHEMA.to_owned(),
+        input_tokens: counter(),
+        cache_read_tokens: counter(),
+        cache_write_5m_tokens: counter(),
+        cache_write_1h_tokens: counter(),
+        output_tokens: counter(),
+        reasoning_tokens: counter(),
+        cost_usd: amount("usd"),
+        quota_points: amount("quota_points"),
+    }
+}
+
+fn append_policy_attestation_event(
+    store: &PolicyEvidenceStore,
+    request: &PolicySpawnRequest,
+    decision: &PolicyDecision,
+    attestation: &PolicyRuntimeAttestation,
+) -> anyhow::Result<()> {
+    append_policy_event(
+        store,
+        request.caller.lane(),
+        "provider_attestation",
+        &decision.decision_id,
+        3,
+        Some(&attestation.session_id),
+        &attestation.observed_at,
+        "sm.policy.provider_attestation.v1",
+        json!({
+            "decision_id": decision.decision_id,
+            "request_id": request.request_id,
+            "attestation": attestation,
+            "usage": zero_policy_usage("provider_attestation_event"),
+            "provider_boundary": {
+                "thread_id": attestation.evidence_id,
+                "before": {"event": "launch_requested"},
+                "after": {"event": "profile_attested"}
+            },
+            "links": {"decision_id": decision.decision_id, "request_id": request.request_id}
+        }),
+    )
+}
+
+fn cleanup_failed_policy_spawn(
+    state: &AppState,
+    policy: &PreparedPolicySpawn,
+    reason: &str,
+) -> Result<(), ApiError> {
+    let runtime = state.policy_runtime().ok_or_else(|| ApiError::Status {
+        status: StatusCode::SERVICE_UNAVAILABLE,
+        detail: "policy runtime disappeared during launch cleanup".to_owned(),
+    })?;
+    let child_id = policy
+        .prepared
+        .provisional_child_session_id
+        .as_deref()
+        .ok_or_else(|| ApiError::Status {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            detail: "policy launch cleanup has no provisional child binding".to_owned(),
+        })?;
+    // Cleanup crosses two durable stores plus the provider runtime. Attempt
+    // every convergent action even when an earlier one fails, then surface all
+    // failures. In particular, a policy-store error must never leave a
+    // provisional runtime attached, and a runtime/evidence error must never
+    // hide a capacity-release failure.
+    let mut failures = Vec::new();
+    if let Err(error) = runtime.store.mark_child_release_pending(child_id) {
+        failures.push(format!("persist release intent: {error}"));
+    }
+    match state.session_store.get_session(child_id) {
+        Ok(Some(_)) => {
+            let provider_runtime = state
+                .config
+                .rust_core
+                .runtime_enabled
+                .then(|| TmuxRuntime::from_app_config(&state.config));
+            match state.session_store.reject_policy_provisional_session(
+                child_id,
+                reason,
+                provider_runtime.as_ref(),
+            ) {
+                Ok(true) => {
+                    if let Err(error) = append_policy_lifecycle_event(
+                        state.policy_evidence_store(),
+                        &policy.request,
+                        &policy.prepared.decision,
+                        child_id,
+                        "launch_rejected",
+                        6,
+                        reason,
+                    ) {
+                        failures.push(format!("append rejection evidence: {error:#}"));
+                    }
+                }
+                Ok(false) => failures.push(
+                    "provisional session disappeared before rejected audit row was retained"
+                        .to_owned(),
+                ),
+                Err(error) => {
+                    failures.push(format!("stop and detach provisional runtime: {error:#}"))
+                }
+            }
+        }
+        Ok(None) => {}
+        Err(error) => failures.push(format!("load provisional session: {error:#}")),
+    }
+    let released = match runtime.store.release_by_child(child_id) {
+        Ok(()) => true,
+        Err(error) => {
+            failures.push(format!("release capacity lease: {error}"));
+            false
+        }
+    };
+    if released {
+        if let Err(error) = append_policy_lifecycle_event(
+            state.policy_evidence_store(),
+            &policy.request,
+            &policy.prepared.decision,
+            child_id,
+            "released",
+            7,
+            reason,
+        ) {
+            failures.push(format!("append release evidence: {error:#}"));
+        }
+    }
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(ApiError::Status {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            detail: format!(
+                "policy launch cleanup failed for child {child_id}: {}",
+                failures.join("; ")
+            ),
+        })
+    }
+}
+
 fn prepare_policy_spawn(
     state: &AppState,
     headers: &HeaderMap,
@@ -3887,6 +4545,12 @@ fn prepare_policy_spawn(
     let Some(runtime) = state.policy_runtime() else {
         return Ok(None);
     };
+    if let Some(blocker) = runtime.admission_blocker.as_deref() {
+        return Err(ApiError::Status {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            detail: blocker.to_owned(),
+        });
+    }
     if payload
         .id
         .as_deref()
@@ -3909,8 +4573,9 @@ fn prepare_policy_spawn(
                     .to_owned(),
         })?;
     let caller = bootstrap_policy_caller(state, headers, &parent.id)?;
-    let (vehicle, classification) =
-        deterministic_policy_classification(&runtime.projection, requested_name)?;
+    // Freeze caller authority and all launch inputs before deriving the
+    // classification that will be persisted on the terminal decision.
+    let vehicle = frozen_policy_request_vehicle(&runtime.projection, requested_name)?;
     let request = freeze_policy_spawn_request(
         runtime,
         caller,
@@ -3928,6 +4593,14 @@ fn prepare_policy_spawn(
         .store
         .create_request(&request)
         .map_err(policy_store_api_error)?;
+    let (classified_vehicle, classification) =
+        deterministic_policy_classification(&runtime.projection, requested_name)?;
+    if classified_vehicle != request.requested.vehicle {
+        return Err(ApiError::Status {
+            status: StatusCode::CONFLICT,
+            detail: "deterministic classification changed the frozen requested vehicle".to_owned(),
+        });
+    }
     let child_session_id = state.session_store.allocate_core_session_id()?;
     let prepared = runtime
         .store
@@ -3939,6 +4612,13 @@ fn prepare_policy_spawn(
             OffsetDateTime::now_utc(),
         )
         .map_err(policy_store_api_error)?;
+    append_policy_decision_event(
+        state.policy_evidence_store(),
+        &runtime.projection,
+        &request,
+        &prepared,
+    )
+    .map_err(ApiError::Internal)?;
     if !matches!(prepared.decision.outcome, PolicyDecisionOutcome::Allow) {
         let command = prepared
             .decision
@@ -3953,11 +4633,10 @@ fn prepare_policy_spawn(
             ),
         });
     }
-    if prepared.provisional_child_session_id.as_deref() != Some(child_session_id.as_str()) {
-        let _ = runtime.store.release_by_child(&child_session_id);
+    if prepared.provisional_child_session_id.is_none() || prepared.child_state.is_none() {
         return Err(ApiError::Status {
             status: StatusCode::SERVICE_UNAVAILABLE,
-            detail: "policy admission did not preserve the provisional child binding".to_owned(),
+            detail: "allow decision is missing its durable provisional child binding".to_owned(),
         });
     }
     Ok(Some(PreparedPolicySpawn { request, prepared }))
@@ -4034,6 +4713,89 @@ async fn spawn_session(
     let policy_profile = policy_spawn
         .as_ref()
         .and_then(|policy| policy.prepared.decision.resolved_profile.as_ref());
+    let existing_policy_child = if let Some(policy) = policy_spawn.as_ref() {
+        let child_id = policy
+            .prepared
+            .provisional_child_session_id
+            .as_deref()
+            .expect("allow binding checked by prepare_policy_spawn");
+        match policy
+            .prepared
+            .child_state
+            .expect("allow lifecycle checked")
+        {
+            PolicyChildState::Released | PolicyChildState::Expired => {
+                return Err(ApiError::Status {
+                    status: StatusCode::CONFLICT,
+                    detail: format!(
+                        "policy request {} already terminalized with child reservation state {:?}; no new child or capacity claim was created",
+                        policy.request.request_id,
+                        policy.prepared.child_state.expect("checked above")
+                    ),
+                });
+            }
+            PolicyChildState::ReleasePending => {
+                return Err(ApiError::Status {
+                    status: StatusCode::SERVICE_UNAVAILABLE,
+                    detail: format!(
+                        "policy request {} is awaiting durable release reconciliation for child {child_id}",
+                        policy.request.request_id
+                    ),
+                });
+            }
+            PolicyChildState::Launched => {
+                let child = state.session_store.get_session(child_id)?.ok_or_else(|| {
+                    ApiError::Status {
+                        status: StatusCode::SERVICE_UNAVAILABLE,
+                        detail: format!(
+                            "committed policy child {child_id} is missing; restart reconciliation is required"
+                        ),
+                    }
+                })?;
+                if !policy_session_is_live(&state.config, &child).map_err(ApiError::Internal)? {
+                    cleanup_failed_policy_spawn(
+                        &state,
+                        policy,
+                        "ordinary retry found committed policy child dead",
+                    )?;
+                    return Err(ApiError::Status {
+                        status: StatusCode::SERVICE_UNAVAILABLE,
+                        detail: format!("committed policy child {child_id} was dead and released"),
+                    });
+                }
+                if let Err(error) = state.session_store.promote_policy_provisional_session(
+                    child_id,
+                    policy_parent_session_id(&policy.request),
+                ) {
+                    cleanup_failed_policy_spawn(
+                        &state,
+                        policy,
+                        &format!("ordinary retry found unpublishable hierarchy: {error:#}"),
+                    )?;
+                    return Err(ApiError::Status {
+                        status: StatusCode::SERVICE_UNAVAILABLE,
+                        detail: format!(
+                            "committed policy child {child_id} could not publish its hierarchy: {error:#}"
+                        ),
+                    });
+                }
+                let child = state.session_store.get_session(child_id)?.ok_or_else(|| {
+                    ApiError::Status {
+                        status: StatusCode::SERVICE_UNAVAILABLE,
+                        detail: format!(
+                            "committed policy child {child_id} disappeared after hierarchy promotion"
+                        ),
+                    }
+                })?;
+                return Ok(Json(serde_json::to_value(SpawnSessionResponse::from(
+                    child,
+                ))?));
+            }
+            PolicyChildState::Reserved => state.session_store.get_session(child_id)?,
+        }
+    } else {
+        None
+    };
     let create_payload = CreateCoreSessionRequest {
         id: policy_spawn
             .as_ref()
@@ -4046,7 +4808,9 @@ async fn spawn_session(
                 .map(|profile| profile.provider.clone())
                 .unwrap_or(provider),
         ),
-        parent_session_id: Some(parent.id.clone()),
+        // A policy child remains outside active hierarchy/routing until its
+        // provider profile is attested and its lease is committed.
+        parent_session_id: policy_spawn.is_none().then(|| parent.id.clone()),
         node: Some(node),
         initial_message: Some(accepted.0),
         model: policy_profile
@@ -4063,9 +4827,21 @@ async fn spawn_session(
         }),
     };
     let log_dir = state.config.rust_core.log_dir.as_deref().map(expand_home);
-    let child_result = if state.config.rust_core.runtime_enabled {
-        ensure_core_runtime_provider_supported(&create_payload)?;
-        ensure_core_runtime_request_node_supported(&state, &create_payload)?;
+    let child_result = if let Some(existing) = existing_policy_child {
+        Ok(existing)
+    } else if state.config.rust_core.runtime_enabled {
+        if let Err(error) = ensure_core_runtime_provider_supported(&create_payload)
+            .and_then(|_| ensure_core_runtime_request_node_supported(&state, &create_payload))
+        {
+            if let Some(policy) = policy_spawn.as_ref() {
+                cleanup_failed_policy_spawn(
+                    &state,
+                    policy,
+                    &format!("launch validation failed: {error:?}"),
+                )?;
+            }
+            return Err(error);
+        }
         create_runtime_core_session(state.clone(), create_payload, log_dir).await
     } else {
         state
@@ -4073,17 +4849,132 @@ async fn spawn_session(
             .create_core_session(create_payload, log_dir)
             .map_err(core_session_create_api_error)
     };
-    let child = match child_result {
+    let mut child = match child_result {
         Ok(child) => child,
         Err(error) => {
-            if let (Some(runtime), Some(policy)) = (state.policy_runtime(), policy_spawn.as_ref()) {
-                if let Some(child_id) = policy.prepared.provisional_child_session_id.as_deref() {
-                    let _ = runtime.store.release_by_child(child_id);
-                }
+            if let Some(policy) = policy_spawn.as_ref() {
+                cleanup_failed_policy_spawn(
+                    &state,
+                    policy,
+                    &format!("provider launch failed: {error:?}"),
+                )?;
             }
             return Err(error);
         }
     };
+    if let Some(policy) = policy_spawn.as_ref() {
+        let runtime = state
+            .policy_runtime()
+            .expect("policy runtime remains loaded");
+        if let Err(error) = append_policy_lifecycle_event(
+            state.policy_evidence_store(),
+            &policy.request,
+            &policy.prepared.decision,
+            &child.id,
+            "materialized",
+            2,
+            "provider runtime materialized provisionally",
+        ) {
+            cleanup_failed_policy_spawn(
+                &state,
+                policy,
+                &format!("materialization evidence append failed: {error:#}"),
+            )?;
+            return Err(ApiError::Internal(error));
+        }
+        let admission = match runtime.store.admission_for_child(&child.id) {
+            Ok(Some(admission)) => admission,
+            Ok(None) => {
+                cleanup_failed_policy_spawn(
+                    &state,
+                    policy,
+                    "materialized policy child lost its admission binding",
+                )?;
+                return Err(ApiError::Status {
+                    status: StatusCode::SERVICE_UNAVAILABLE,
+                    detail: format!("policy child {} lost its admission binding", child.id),
+                });
+            }
+            Err(error) => {
+                cleanup_failed_policy_spawn(
+                    &state,
+                    policy,
+                    &format!("cannot reload materialized admission binding: {error}"),
+                )?;
+                return Err(policy_store_api_error(error));
+            }
+        };
+        let attestation =
+            match attest_policy_session(&state.config, &state.session_store, &admission, &child) {
+                Ok(attestation) => attestation,
+                Err(error) => {
+                    cleanup_failed_policy_spawn(
+                        &state,
+                        policy,
+                        &format!("provider attestation failed: {error:#}"),
+                    )?;
+                    return Err(ApiError::Status {
+                        status: StatusCode::BAD_GATEWAY,
+                        detail: format!("policy provider attestation failed: {error:#}"),
+                    });
+                }
+            };
+        if let Err(error) = append_policy_attestation_event(
+            state.policy_evidence_store(),
+            &policy.request,
+            &policy.prepared.decision,
+            &attestation,
+        ) {
+            cleanup_failed_policy_spawn(
+                &state,
+                policy,
+                &format!("attestation evidence append failed: {error:#}"),
+            )?;
+            return Err(ApiError::Internal(error));
+        }
+        if let Err(error) = runtime.store.mark_child_launched(&child.id) {
+            cleanup_failed_policy_spawn(
+                &state,
+                policy,
+                &format!("launch commit failed after attestation: {error}"),
+            )?;
+            return Err(policy_store_api_error(error));
+        }
+        if let Err(error) = promote_policy_session(&state.session_store, &admission) {
+            cleanup_failed_policy_spawn(
+                &state,
+                policy,
+                &format!("hierarchy promotion failed after launch commit: {error:#}"),
+            )?;
+            return Err(ApiError::Status {
+                status: StatusCode::SERVICE_UNAVAILABLE,
+                detail: format!("policy hierarchy promotion failed: {error:#}"),
+            });
+        }
+        child = state
+            .session_store
+            .get_session(&child.id)?
+            .ok_or_else(|| ApiError::Status {
+                status: StatusCode::SERVICE_UNAVAILABLE,
+                detail: "policy child disappeared after hierarchy promotion".to_owned(),
+            })?;
+        if let Err(error) = append_policy_lifecycle_event(
+            state.policy_evidence_store(),
+            &policy.request,
+            &policy.prepared.decision,
+            &child.id,
+            "launched",
+            4,
+            "provider profile attested and capacity lease committed",
+        ) {
+            cleanup_failed_policy_spawn(
+                &state,
+                policy,
+                &format!("launch evidence append failed after commit: {error:#}"),
+            )?;
+            return Err(ApiError::Internal(error));
+        }
+    }
     if parent.is_em && child.provider != "codex-fork" {
         let _ = state.session_store.arm_stop_notify(
             &child.id,
@@ -8414,6 +9305,27 @@ async fn retire_session(
                 requester.is_empty() || session.parent_session_id.as_deref() == Some(requester)
             }) && (!state.config.rust_core.runtime_enabled || is_primary_node(&session.node))
         });
+    let policy_admission = if may_retire {
+        state
+            .policy_runtime()
+            .map(|runtime| runtime.store.admission_for_child(&session_id))
+            .transpose()
+            .map_err(policy_store_api_error)?
+            .flatten()
+    } else {
+        None
+    };
+    if let (Some(runtime), Some(admission)) = (state.policy_runtime(), policy_admission.as_ref()) {
+        if matches!(
+            admission.reservation.child_state,
+            PolicyChildState::Reserved | PolicyChildState::Launched
+        ) {
+            runtime
+                .store
+                .mark_child_release_pending(&session_id)
+                .map_err(policy_store_api_error)?;
+        }
+    }
     if may_retire {
         teardown_btw_requests_for_session(&state, &session_id)?;
     }
@@ -8430,7 +9342,27 @@ async fn retire_session(
             .retire_core_session(&session_id, requester_session_id)?
     };
     match outcome {
-        CoreRetireOutcome::Retired(result) => Ok(Json(serde_json::to_value(result)?)),
+        CoreRetireOutcome::Retired(result) => {
+            if let (Some(runtime), Some(admission)) =
+                (state.policy_runtime(), policy_admission.as_ref())
+            {
+                runtime
+                    .store
+                    .release_by_child(&session_id)
+                    .map_err(policy_store_api_error)?;
+                append_policy_lifecycle_event(
+                    state.policy_evidence_store(),
+                    &admission.request,
+                    &admission.decision,
+                    &session_id,
+                    "released",
+                    7,
+                    "policy child retired and capacity released",
+                )
+                .map_err(ApiError::Internal)?;
+            }
+            Ok(Json(serde_json::to_value(result)?))
+        }
         CoreRetireOutcome::NotFound => Ok(Json(json!({
             "error": format!("Session {session_id} not found")
         }))),
@@ -14212,6 +15144,498 @@ mod tests {
             lease_ttl_seconds: 900,
             reason: "test policy".to_owned(),
         }
+    }
+
+    struct PolicyCrashFixture {
+        config: AppConfig,
+        session_store: SessionStore,
+        evidence_store: PolicyEvidenceStore,
+        store: PolicyStore,
+        projection: PolicyProjection,
+        state_path: PathBuf,
+        root: PathBuf,
+    }
+
+    fn policy_crash_fixture(label: &str) -> PolicyCrashFixture {
+        let root = env::temp_dir().join(format!(
+            "sm-policy-crash-{label}-{}-{}",
+            process::id(),
+            random_urlsafe_token(8)
+        ));
+        fs::create_dir_all(&root).unwrap();
+        let state_path = root.join("sessions.json");
+        fs::write(&state_path, r#"{"sessions":[]}"#).unwrap();
+        let session_store = SessionStore::new(state_path.clone());
+        session_store
+            .create_core_session(
+                CreateCoreSessionRequest {
+                    id: Some("maintainer-1".to_owned()),
+                    name: Some("maintainer".to_owned()),
+                    working_dir: Some(root.display().to_string()),
+                    provider: Some("codex-fork".to_owned()),
+                    parent_session_id: None,
+                    node: Some("primary".to_owned()),
+                    initial_message: None,
+                    model: Some("gpt-5.6-terra".to_owned()),
+                    reasoning_effort: Some("high".to_owned()),
+                    wait: None,
+                    spawn_prompt_source: None,
+                    spawn_brief: None,
+                },
+                Some(root.clone()),
+            )
+            .unwrap();
+        let evidence_store = PolicyEvidenceStore::new(root.join("evidence.db")).unwrap();
+        let store = PolicyStore::new(root.join("policy.db")).unwrap();
+        let mut projection = policy_projection_with_rules(vec![policy_rule(
+            "sm-policy-1268.routine",
+            None,
+            Some("routine_bounded"),
+            PolicyVehicle::TaskAgent,
+        )]);
+        projection.bootstrap_authority = Some(crate::policy_store::BootstrapAuthority {
+            session_id: "maintainer-1".to_owned(),
+            credential_fingerprint: "credential-1".to_owned(),
+            binding_digest: "b".repeat(64),
+        });
+        store.install_projection(&projection).unwrap();
+        store
+            .activate_projection(
+                &projection.lane,
+                &projection.policy_version,
+                &projection.policy_digest,
+            )
+            .unwrap();
+        let mut config = AppConfig::default();
+        config.paths.state_file = state_path.display().to_string();
+        PolicyCrashFixture {
+            config,
+            session_store,
+            evidence_store,
+            store,
+            projection,
+            state_path,
+            root,
+        }
+    }
+
+    fn prepare_policy_crash(fixture: &PolicyCrashFixture, suffix: &str) -> PolicyChildAdmission {
+        let request = PolicySpawnRequest {
+            schema: SPAWN_REQUEST_SCHEMA.to_owned(),
+            request_id: format!("request-{suffix}"),
+            caller: PolicyCallerBinding::IncarnationBootstrap {
+                lane: fixture.projection.lane.clone(),
+                session_id: "maintainer-1".to_owned(),
+                credential_fingerprint: "credential-1".to_owned(),
+                binding_digest: "b".repeat(64),
+            },
+            prompt_digest: "c".repeat(64),
+            launch_intent_id: format!("intent-{suffix}"),
+            policy_version: fixture.projection.policy_version.clone(),
+            policy_digest: fixture.projection.policy_digest.clone(),
+            requested: PolicyRequestedLaunch {
+                name: format!("worker-{suffix}"),
+                vehicle: PolicyVehicle::TaskAgent,
+                provider: "codex-fork".to_owned(),
+                model: Some("gpt-5.6-terra".to_owned()),
+                effort: Some("high".to_owned()),
+                working_dir: fixture.root.display().to_string(),
+                node: "primary".to_owned(),
+            },
+            topology_version: 0,
+            capacity_version: 0,
+            created_at: "2026-08-17T00:00:00Z".to_owned(),
+        };
+        fixture.store.create_request(&request).unwrap();
+        let child_id = format!("child-{suffix}");
+        fixture
+            .store
+            .prepare_admission(
+                &request.request_id,
+                &PolicyClassification {
+                    class_id: "routine_bounded".to_owned(),
+                    role_id: None,
+                    turn_profile: "initial_task".to_owned(),
+                    method: "deterministic".to_owned(),
+                    confidence: "exact".to_owned(),
+                },
+                None,
+                &child_id,
+                OffsetDateTime::parse("2026-08-17T00:01:00Z", &Rfc3339).unwrap(),
+            )
+            .unwrap();
+        fixture
+            .store
+            .admission_for_child(&child_id)
+            .unwrap()
+            .unwrap()
+    }
+
+    fn materialize_policy_fixture_session(
+        fixture: &PolicyCrashFixture,
+        admission: &PolicyChildAdmission,
+        with_attestation: bool,
+    ) -> SessionRecord {
+        let child_id = admission.reservation.child_session_id.clone();
+        fixture
+            .session_store
+            .create_core_session(
+                CreateCoreSessionRequest {
+                    id: Some(child_id.clone()),
+                    name: Some(format!("policy-{child_id}")),
+                    working_dir: Some(fixture.root.display().to_string()),
+                    provider: Some("codex-fork".to_owned()),
+                    parent_session_id: None,
+                    node: Some("primary".to_owned()),
+                    initial_message: Some("frozen brief".to_owned()),
+                    model: Some("gpt-5.6-terra".to_owned()),
+                    reasoning_effort: Some("high".to_owned()),
+                    wait: None,
+                    spawn_prompt_source: None,
+                    spawn_brief: None,
+                },
+                Some(fixture.root.clone()),
+            )
+            .unwrap();
+        let mut state: Value =
+            serde_json::from_slice(&fs::read(&fixture.state_path).unwrap()).unwrap();
+        let child = state["sessions"]
+            .as_array_mut()
+            .unwrap()
+            .iter_mut()
+            .find(|session| session["id"] == child_id)
+            .unwrap();
+        child["provider_resume_id"] = Value::String("thread-policy-1".to_owned());
+        fs::write(&fixture.state_path, serde_json::to_vec(&state).unwrap()).unwrap();
+        let record = fixture
+            .session_store
+            .get_session(&child_id)
+            .unwrap()
+            .unwrap();
+        if with_attestation {
+            let runtime = TmuxRuntime::from_app_config(&fixture.config);
+            let path = fixture
+                .session_store
+                .codex_fork_event_stream_path(&record, &runtime)
+                .unwrap();
+            fs::create_dir_all(path.parent().unwrap()).unwrap();
+            let events = [
+                json!({
+                    "schema_version": 2,
+                    "session_epoch": 7,
+                    "seq": 1,
+                    "event_type": "session_start",
+                    "ts": "2026-08-17T00:01:01Z",
+                    "payload": {"model_provider_id": "openai", "model": "gpt-5.6-terra"}
+                }),
+                json!({
+                    "schema_version": 2,
+                    "session_epoch": 7,
+                    "seq": 2,
+                    "event_type": "thread/settings/updated",
+                    "session_id": "thread-policy-1",
+                    "ts": "2026-08-17T00:01:02Z",
+                    "payload": {
+                        "threadId": "thread-policy-1",
+                        "threadSettings": {
+                            "model": "gpt-5.6-terra",
+                            "effort": "high",
+                            "modelProvider": "openai"
+                        }
+                    }
+                }),
+            ];
+            fs::write(
+                path,
+                format!(
+                    "{}\n{}\n",
+                    serde_json::to_string(&events[0]).unwrap(),
+                    serde_json::to_string(&events[1]).unwrap()
+                ),
+            )
+            .unwrap();
+        }
+        record
+    }
+
+    #[test]
+    fn policy_restart_crash_matrix_converges_without_capacity_or_child_leaks() {
+        // Crash after admission commit: reserved/no-session releases.
+        let fixture = policy_crash_fixture("after-admission");
+        let admission = prepare_policy_crash(&fixture, "after-admission");
+        let report = reconcile_policy_runtime(
+            &fixture.config,
+            &fixture.session_store,
+            &fixture.evidence_store,
+            &fixture.store,
+            &fixture.projection,
+        )
+        .unwrap();
+        assert_eq!(
+            (
+                report.expected,
+                report.visited,
+                report.resolved,
+                report.blocked
+            ),
+            (1, 1, 1, 0)
+        );
+        assert_eq!(
+            fixture
+                .store
+                .resolve_child(&admission.reservation.child_session_id)
+                .unwrap()
+                .unwrap()
+                .child_state,
+            PolicyChildState::Released
+        );
+
+        // Crash after session create: missing attestation rejects, detaches, and releases.
+        let fixture = policy_crash_fixture("after-session-create");
+        let admission = prepare_policy_crash(&fixture, "after-session-create");
+        materialize_policy_fixture_session(&fixture, &admission, false);
+        let report = reconcile_policy_runtime(
+            &fixture.config,
+            &fixture.session_store,
+            &fixture.evidence_store,
+            &fixture.store,
+            &fixture.projection,
+        )
+        .unwrap();
+        assert_eq!(
+            (
+                report.expected,
+                report.visited,
+                report.resolved,
+                report.blocked
+            ),
+            (1, 1, 1, 0)
+        );
+        let rejected = fixture
+            .session_store
+            .get_session(&admission.reservation.child_session_id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            rejected.completion_status.as_deref(),
+            Some("launch_rejected")
+        );
+        assert!(rejected.parent_session_id.is_none());
+
+        // Crash after attestation but before mark: restart re-attests and promotes.
+        let fixture = policy_crash_fixture("after-attestation");
+        let admission = prepare_policy_crash(&fixture, "after-attestation");
+        materialize_policy_fixture_session(&fixture, &admission, true);
+        let report = reconcile_policy_runtime(
+            &fixture.config,
+            &fixture.session_store,
+            &fixture.evidence_store,
+            &fixture.store,
+            &fixture.projection,
+        )
+        .unwrap();
+        assert_eq!(
+            (
+                report.expected,
+                report.visited,
+                report.resolved,
+                report.blocked
+            ),
+            (1, 1, 1, 0)
+        );
+        assert_eq!(
+            fixture
+                .store
+                .resolve_child(&admission.reservation.child_session_id)
+                .unwrap()
+                .unwrap()
+                .child_state,
+            PolicyChildState::Launched
+        );
+        assert_eq!(
+            fixture
+                .session_store
+                .get_session(&admission.reservation.child_session_id)
+                .unwrap()
+                .unwrap()
+                .parent_session_id
+                .as_deref(),
+            Some("maintainer-1")
+        );
+        let event_types = fixture
+            .evidence_store
+            .events(&fixture.projection.lane)
+            .unwrap()
+            .into_iter()
+            .map(|event| event.envelope.event_type)
+            .collect::<Vec<_>>();
+        assert!(event_types.contains(&"provider_attestation".to_owned()));
+        assert!(event_types.contains(&"child_lifecycle".to_owned()));
+
+        // Crash after mark with a dead child: restart releases committed capacity.
+        let fixture = policy_crash_fixture("after-mark");
+        let admission = prepare_policy_crash(&fixture, "after-mark");
+        materialize_policy_fixture_session(&fixture, &admission, true);
+        fixture
+            .store
+            .mark_child_launched(&admission.reservation.child_session_id)
+            .unwrap();
+        fixture
+            .session_store
+            .retire_core_session(&admission.reservation.child_session_id, None)
+            .unwrap();
+        let report = reconcile_policy_runtime(
+            &fixture.config,
+            &fixture.session_store,
+            &fixture.evidence_store,
+            &fixture.store,
+            &fixture.projection,
+        )
+        .unwrap();
+        assert_eq!(
+            (
+                report.expected,
+                report.visited,
+                report.resolved,
+                report.blocked
+            ),
+            (1, 1, 1, 0)
+        );
+        assert_eq!(
+            fixture
+                .store
+                .resolve_child(&admission.reservation.child_session_id)
+                .unwrap()
+                .unwrap()
+                .child_state,
+            PolicyChildState::Released
+        );
+
+        // Crash during release: the durable pending state is completed.
+        let fixture = policy_crash_fixture("during-release");
+        let admission = prepare_policy_crash(&fixture, "during-release");
+        materialize_policy_fixture_session(&fixture, &admission, true);
+        fixture
+            .store
+            .mark_child_launched(&admission.reservation.child_session_id)
+            .unwrap();
+        fixture
+            .store
+            .mark_child_release_pending(&admission.reservation.child_session_id)
+            .unwrap();
+        let report = reconcile_policy_runtime(
+            &fixture.config,
+            &fixture.session_store,
+            &fixture.evidence_store,
+            &fixture.store,
+            &fixture.projection,
+        )
+        .unwrap();
+        assert_eq!(
+            (
+                report.expected,
+                report.visited,
+                report.resolved,
+                report.blocked
+            ),
+            (1, 1, 1, 0)
+        );
+        assert_eq!(
+            fixture.store.reconciliation_snapshot().unwrap().expected,
+            0,
+            "release completion leaves no capacity-counted reconciliation item"
+        );
+
+        // Crash after release: terminal audit rows remain outside admission
+        // reconciliation and cannot reacquire capacity.
+        let fixture = policy_crash_fixture("after-release");
+        let admission = prepare_policy_crash(&fixture, "after-release");
+        let session = materialize_policy_fixture_session(&fixture, &admission, true);
+        fixture
+            .store
+            .mark_child_launched(&admission.reservation.child_session_id)
+            .unwrap();
+        fixture
+            .store
+            .mark_child_release_pending(&admission.reservation.child_session_id)
+            .unwrap();
+        fixture
+            .session_store
+            .reject_policy_provisional_session(
+                &admission.reservation.child_session_id,
+                "release completed before crash",
+                None,
+            )
+            .unwrap();
+        fixture
+            .store
+            .release_by_child(&admission.reservation.child_session_id)
+            .unwrap();
+        let report = reconcile_policy_runtime(
+            &fixture.config,
+            &fixture.session_store,
+            &fixture.evidence_store,
+            &fixture.store,
+            &fixture.projection,
+        )
+        .unwrap();
+        assert_eq!(
+            (
+                report.expected,
+                report.visited,
+                report.resolved,
+                report.blocked
+            ),
+            (0, 0, 0, 0)
+        );
+        let retained = fixture
+            .session_store
+            .get_session(&session.id)
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            retained.completion_status.as_deref(),
+            Some("launch_rejected")
+        );
+        assert!(retained.parent_session_id.is_none());
+    }
+
+    #[test]
+    fn ambiguous_policy_restart_state_reports_exact_blocker_and_disables_admission() {
+        let fixture = policy_crash_fixture("ambiguous");
+        let admission = prepare_policy_crash(&fixture, "ambiguous");
+        let conn = Connection::open(fixture.root.join("policy.db")).unwrap();
+        conn.execute(
+            "UPDATE policy_provisional_children SET state = 'launched' WHERE child_session_id = ?1",
+            [&admission.reservation.child_session_id],
+        )
+        .unwrap();
+        drop(conn);
+        let report = reconcile_policy_runtime(
+            &fixture.config,
+            &fixture.session_store,
+            &fixture.evidence_store,
+            &fixture.store,
+            &fixture.projection,
+        )
+        .unwrap();
+        assert_eq!(
+            (
+                report.expected,
+                report.visited,
+                report.resolved,
+                report.blocked
+            ),
+            (1, 1, 0, 1)
+        );
+        assert!(report.blockers[0].contains("Launched/Active"));
+        let blocker = format!(
+            "policy admission disabled: restart reconciliation blocked {}/{} items: {}",
+            report.blocked,
+            report.expected,
+            report.blockers.join("; ")
+        );
+        assert!(blocker.contains(&admission.reservation.child_session_id));
     }
 
     #[test]

--- a/crates/sm-server/src/lib.rs
+++ b/crates/sm-server/src/lib.rs
@@ -12,6 +12,7 @@ pub mod http;
 pub mod mobile_analytics;
 pub mod mobile_devices;
 pub mod policy_contracts;
+pub mod policy_runtime_attestation;
 pub mod queue;
 pub mod queue_authority;
 pub mod runtime;

--- a/crates/sm-server/src/lib.rs
+++ b/crates/sm-server/src/lib.rs
@@ -12,6 +12,7 @@ pub mod http;
 pub mod mobile_analytics;
 pub mod mobile_devices;
 pub mod policy_contracts;
+pub mod policy_store;
 pub mod queue;
 pub mod queue_authority;
 pub mod runtime;

--- a/crates/sm-server/src/policy_runtime_attestation.rs
+++ b/crates/sm-server/src/policy_runtime_attestation.rs
@@ -1,3 +1,7 @@
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
 use serde_json::{Map, Value};
 
 use crate::policy_contracts::{
@@ -6,6 +10,7 @@ use crate::policy_contracts::{
 
 const CODEX_FORK_PROVIDER: &str = "codex-fork";
 const CODEX_PROVIDER_ID: &str = "openai";
+const MAX_RELEVANT_LAUNCH_EVENTS: usize = 128;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RuntimeAttestationError {
@@ -35,6 +40,81 @@ struct CodexSessionStart {
     epoch: u64,
     seq: u64,
     model: String,
+}
+
+pub fn attest_codex_fork_launch_file(
+    event_stream_path: &Path,
+    expected: &PolicyLaunchProfile,
+    decision_id: &str,
+    launch_intent_id: &str,
+    child_session_id: &str,
+    provider_resume_id: &str,
+) -> Result<PolicyRuntimeAttestation, RuntimeAttestationError> {
+    let file = File::open(event_stream_path).map_err(|error| {
+        RuntimeAttestationError::new(
+            "codex_event_stream_unavailable",
+            format!(
+                "failed to open provider event stream {}: {error}",
+                event_stream_path.display()
+            ),
+        )
+    })?;
+    let mut relevant = Vec::new();
+    for line in BufReader::new(file).lines() {
+        let line = line.map_err(|error| {
+            RuntimeAttestationError::new(
+                "codex_event_stream_read_failed",
+                format!(
+                    "failed to read provider event stream {}: {error}",
+                    event_stream_path.display()
+                ),
+            )
+        })?;
+        let event = serde_json::from_str::<Value>(&line).map_err(|error| {
+            RuntimeAttestationError::new(
+                "invalid_codex_event_json",
+                format!(
+                    "provider event stream {} contains invalid JSON: {error}",
+                    event_stream_path.display()
+                ),
+            )
+        })?;
+        let event_type = event.get("event_type").and_then(Value::as_str);
+        if !matches!(
+            event_type,
+            Some("session_start" | "thread/settings/updated")
+        ) {
+            continue;
+        }
+        let is_target_settings = event_type == Some("thread/settings/updated")
+            && event.get("session_id").and_then(Value::as_str) == Some(provider_resume_id)
+            && event
+                .get("payload")
+                .and_then(|payload| payload.get("threadId"))
+                .and_then(Value::as_str)
+                == Some(provider_resume_id);
+        relevant.push(event);
+        if relevant.len() > MAX_RELEVANT_LAUNCH_EVENTS {
+            return Err(RuntimeAttestationError::new(
+                "codex_launch_evidence_limit_exceeded",
+                format!(
+                    "provider launch evidence exceeded {MAX_RELEVANT_LAUNCH_EVENTS} relevant events"
+                ),
+            ));
+        }
+        if is_target_settings {
+            break;
+        }
+    }
+
+    attest_codex_fork_launch(
+        &relevant,
+        expected,
+        decision_id,
+        launch_intent_id,
+        child_session_id,
+        provider_resume_id,
+    )
 }
 
 /// Builds provider-originated launch evidence from the bounded event range for
@@ -234,6 +314,9 @@ fn required_text_object<'a>(
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
     use serde_json::json;
 
     use super::*;
@@ -360,5 +443,72 @@ mod tests {
         }));
 
         assert!(attest(&evidence).is_ok());
+    }
+
+    #[test]
+    fn codex_launch_file_reads_real_jsonl_shape_and_stops_at_initial_settings() {
+        let path = unique_temp_path("codex-launch-events");
+        let mut evidence = events("gpt-5.6-terra", "high");
+        evidence.insert(
+            1,
+            json!({
+                "schema_version": 2,
+                "ts": "2026-08-17T23:00:00.500Z",
+                "session_id": "thread-1",
+                "seq": 4,
+                "session_epoch": 7,
+                "event_type": "op_submitted",
+                "payload": {"UserTurn": {"items": [{"type": "text", "text": "brief"}]}}
+            }),
+        );
+        evidence.push(json!({"this later line": "does not need to be parsed"}));
+        let body = evidence
+            .iter()
+            .map(Value::to_string)
+            .collect::<Vec<_>>()
+            .join("\n");
+        fs::write(&path, body).unwrap();
+
+        let attestation = attest_codex_fork_launch_file(
+            &path,
+            &expected(),
+            "decision-1",
+            "intent-1",
+            "child-1",
+            "thread-1",
+        )
+        .unwrap();
+
+        assert_eq!(attestation.evidence_id, "codex-fork:thread-1:7:8");
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn codex_launch_file_fails_closed_on_malformed_evidence_before_settings() {
+        let path = unique_temp_path("codex-launch-malformed");
+        let start = events("gpt-5.6-terra", "high").remove(0);
+        fs::write(&path, format!("{}\nnot-json\n", start)).unwrap();
+
+        let error = attest_codex_fork_launch_file(
+            &path,
+            &expected(),
+            "decision-1",
+            "intent-1",
+            "child-1",
+            "thread-1",
+        )
+        .unwrap_err();
+
+        assert_eq!(error.code, "invalid_codex_event_json");
+        fs::remove_file(path).unwrap();
+    }
+
+    fn unique_temp_path(label: &str) -> std::path::PathBuf {
+        static NEXT_ID: AtomicU64 = AtomicU64::new(0);
+        std::env::temp_dir().join(format!(
+            "sm-policy-{label}-{}-{}",
+            std::process::id(),
+            NEXT_ID.fetch_add(1, Ordering::Relaxed)
+        ))
     }
 }

--- a/crates/sm-server/src/policy_runtime_attestation.rs
+++ b/crates/sm-server/src/policy_runtime_attestation.rs
@@ -1,0 +1,364 @@
+use serde_json::{Map, Value};
+
+use crate::policy_contracts::{
+    PolicyLaunchProfile, PolicyRuntimeAttestation, RuntimeAttestationEvidence, ATTESTATION_SCHEMA,
+};
+
+const CODEX_FORK_PROVIDER: &str = "codex-fork";
+const CODEX_PROVIDER_ID: &str = "openai";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeAttestationError {
+    pub code: &'static str,
+    pub detail: String,
+}
+
+impl RuntimeAttestationError {
+    fn new(code: &'static str, detail: impl Into<String>) -> Self {
+        Self {
+            code,
+            detail: detail.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for RuntimeAttestationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}: {}", self.code, self.detail)
+    }
+}
+
+impl std::error::Error for RuntimeAttestationError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CodexSessionStart {
+    epoch: u64,
+    seq: u64,
+    model: String,
+}
+
+/// Builds provider-originated launch evidence from the bounded event range for
+/// one newly launched Codex thread. The first settings event is the launch
+/// profile; later settings changes belong to subsequent turns.
+pub fn attest_codex_fork_launch<'a>(
+    events: impl IntoIterator<Item = &'a Value>,
+    expected: &PolicyLaunchProfile,
+    decision_id: &str,
+    launch_intent_id: &str,
+    child_session_id: &str,
+    provider_resume_id: &str,
+) -> Result<PolicyRuntimeAttestation, RuntimeAttestationError> {
+    if expected.provider != CODEX_FORK_PROVIDER {
+        return Err(RuntimeAttestationError::new(
+            "unsupported_attestation_provider",
+            format!(
+                "Codex launch evidence cannot attest provider {}",
+                expected.provider
+            ),
+        ));
+    }
+
+    let mut starts = Vec::new();
+    for event in events {
+        let event_type = event.get("event_type").and_then(Value::as_str);
+        if !matches!(
+            event_type,
+            Some("session_start" | "thread/settings/updated")
+        ) {
+            continue;
+        }
+        require_schema_v2(event)?;
+        let epoch = required_u64(event, "session_epoch")?;
+        let seq = required_u64(event, "seq")?;
+        let payload = required_object(event, "payload")?;
+
+        if event_type == Some("session_start") {
+            let provider_id = required_text(payload, "model_provider_id")?;
+            if provider_id != CODEX_PROVIDER_ID {
+                return Err(RuntimeAttestationError::new(
+                    "unexpected_codex_provider",
+                    format!("session_start reports model provider {provider_id}"),
+                ));
+            }
+            starts.push(CodexSessionStart {
+                epoch,
+                seq,
+                model: required_text(payload, "model")?.to_owned(),
+            });
+            continue;
+        }
+
+        let root_session_id = required_text_object(event, "session_id")?;
+        let thread_id = required_text(payload, "threadId")?;
+        if root_session_id != provider_resume_id || thread_id != provider_resume_id {
+            continue;
+        }
+        let settings = payload
+            .get("threadSettings")
+            .and_then(Value::as_object)
+            .ok_or_else(|| {
+                RuntimeAttestationError::new(
+                    "invalid_codex_settings_event",
+                    "thread/settings/updated is missing threadSettings",
+                )
+            })?;
+        let model = required_text(settings, "model")?;
+        let effort = required_text(settings, "effort")?;
+        let provider = required_text(settings, "modelProvider")?;
+        if provider != CODEX_PROVIDER_ID {
+            return Err(RuntimeAttestationError::new(
+                "unexpected_codex_provider",
+                format!("thread settings report model provider {provider}"),
+            ));
+        }
+
+        let start = starts
+            .iter()
+            .rev()
+            .find(|start| start.epoch == epoch && start.seq < seq)
+            .ok_or_else(|| {
+                RuntimeAttestationError::new(
+                    "missing_codex_session_start",
+                    "no preceding schema-v2 session_start exists for the launch settings event",
+                )
+            })?;
+        if start.model != model {
+            return Err(RuntimeAttestationError::new(
+                "conflicting_codex_launch_profile",
+                format!(
+                    "session_start model {} disagrees with thread settings model {model}",
+                    start.model
+                ),
+            ));
+        }
+        if model != expected.model || effort != expected.effort {
+            return Err(RuntimeAttestationError::new(
+                "codex_launch_profile_mismatch",
+                format!(
+                    "expected model/effort {}/{}, provider reported {model}/{effort}",
+                    expected.model, expected.effort
+                ),
+            ));
+        }
+
+        let observed_at = required_text_object(event, "ts")?.to_owned();
+        let attestation = PolicyRuntimeAttestation {
+            schema: ATTESTATION_SCHEMA.to_owned(),
+            decision_id: decision_id.to_owned(),
+            launch_intent_id: launch_intent_id.to_owned(),
+            session_id: child_session_id.to_owned(),
+            provider: CODEX_FORK_PROVIDER.to_owned(),
+            model: model.to_owned(),
+            effort: effort.to_owned(),
+            evidence: RuntimeAttestationEvidence::ProviderEvent,
+            evidence_id: format!("codex-fork:{provider_resume_id}:{epoch}:{seq}"),
+            observed_at,
+        };
+        attestation.validate().map_err(|error| {
+            RuntimeAttestationError::new("invalid_runtime_attestation", error.to_string())
+        })?;
+        return Ok(attestation);
+    }
+
+    Err(RuntimeAttestationError::new(
+        "missing_codex_launch_settings",
+        format!(
+            "no schema-v2 launch settings event was observed for provider thread {provider_resume_id}"
+        ),
+    ))
+}
+
+fn require_schema_v2(event: &Value) -> Result<(), RuntimeAttestationError> {
+    if event.get("schema_version").and_then(Value::as_u64) == Some(2) {
+        Ok(())
+    } else {
+        Err(RuntimeAttestationError::new(
+            "unsupported_codex_event_schema",
+            "launch evidence requires numeric schema_version 2",
+        ))
+    }
+}
+
+fn required_u64(event: &Value, field: &'static str) -> Result<u64, RuntimeAttestationError> {
+    event.get(field).and_then(Value::as_u64).ok_or_else(|| {
+        RuntimeAttestationError::new(
+            "invalid_codex_launch_event",
+            format!("launch evidence is missing numeric {field}"),
+        )
+    })
+}
+
+fn required_object<'a>(
+    event: &'a Value,
+    field: &'static str,
+) -> Result<&'a Map<String, Value>, RuntimeAttestationError> {
+    event.get(field).and_then(Value::as_object).ok_or_else(|| {
+        RuntimeAttestationError::new(
+            "invalid_codex_launch_event",
+            format!("launch evidence is missing object {field}"),
+        )
+    })
+}
+
+fn required_text<'a>(
+    object: &'a Map<String, Value>,
+    field: &'static str,
+) -> Result<&'a str, RuntimeAttestationError> {
+    object
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            RuntimeAttestationError::new(
+                "invalid_codex_launch_event",
+                format!("launch evidence is missing text {field}"),
+            )
+        })
+}
+
+fn required_text_object<'a>(
+    event: &'a Value,
+    field: &'static str,
+) -> Result<&'a str, RuntimeAttestationError> {
+    event
+        .get(field)
+        .and_then(Value::as_str)
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| {
+            RuntimeAttestationError::new(
+                "invalid_codex_launch_event",
+                format!("launch evidence is missing text {field}"),
+            )
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::policy_contracts::PolicyVehicle;
+
+    fn expected() -> PolicyLaunchProfile {
+        PolicyLaunchProfile {
+            vehicle: PolicyVehicle::TaskAgent,
+            provider: "codex-fork".to_owned(),
+            model: "gpt-5.6-terra".to_owned(),
+            effort: "high".to_owned(),
+            context_profile: "provider_native_compaction".to_owned(),
+        }
+    }
+
+    fn events(model: &str, effort: &str) -> Vec<Value> {
+        vec![
+            json!({
+                "schema_version": 2,
+                "ts": "2026-08-17T23:00:00Z",
+                "session_id": "unknown",
+                "seq": 1,
+                "session_epoch": 7,
+                "event_type": "session_start",
+                "payload": {
+                    "model": model,
+                    "model_provider_id": "openai",
+                    "model_provider_name": "OpenAI"
+                }
+            }),
+            json!({
+                "schema_version": 2,
+                "ts": "2026-08-17T23:00:01Z",
+                "session_id": "thread-1",
+                "seq": 8,
+                "session_epoch": 7,
+                "event_type": "thread/settings/updated",
+                "payload": {
+                    "threadId": "thread-1",
+                    "threadSettings": {
+                        "model": model,
+                        "modelProvider": "openai",
+                        "effort": effort
+                    }
+                }
+            }),
+        ]
+    }
+
+    fn attest(events: &[Value]) -> Result<PolicyRuntimeAttestation, RuntimeAttestationError> {
+        attest_codex_fork_launch(
+            events,
+            &expected(),
+            "decision-1",
+            "intent-1",
+            "child-1",
+            "thread-1",
+        )
+    }
+
+    #[test]
+    fn codex_launch_requires_agreeing_provider_originated_profile_events() {
+        let attestation = attest(&events("gpt-5.6-terra", "high")).unwrap();
+
+        assert_eq!(attestation.model, "gpt-5.6-terra");
+        assert_eq!(attestation.effort, "high");
+        assert_eq!(attestation.session_id, "child-1");
+        assert_eq!(attestation.evidence_id, "codex-fork:thread-1:7:8");
+    }
+
+    #[test]
+    fn codex_launch_rejects_omitted_or_wrong_requested_tier() {
+        let error = attest(&events("gpt-5.6-sol", "high")).unwrap_err();
+        assert_eq!(error.code, "codex_launch_profile_mismatch");
+
+        let error = attest(&events("gpt-5.6-terra", "xhigh")).unwrap_err();
+        assert_eq!(error.code, "codex_launch_profile_mismatch");
+    }
+
+    #[test]
+    fn codex_launch_rejects_conflicting_start_and_settings_models() {
+        let mut evidence = events("gpt-5.6-terra", "high");
+        evidence[0]["payload"]["model"] = json!("gpt-5.6-sol");
+
+        let error = attest(&evidence).unwrap_err();
+        assert_eq!(error.code, "conflicting_codex_launch_profile");
+    }
+
+    #[test]
+    fn codex_launch_rejects_unversioned_or_foreign_thread_evidence() {
+        let mut unversioned = events("gpt-5.6-terra", "high");
+        unversioned[1]
+            .as_object_mut()
+            .unwrap()
+            .remove("schema_version");
+        let error = attest(&unversioned).unwrap_err();
+        assert_eq!(error.code, "unsupported_codex_event_schema");
+
+        let mut foreign = events("gpt-5.6-terra", "high");
+        foreign[1]["session_id"] = json!("thread-2");
+        foreign[1]["payload"]["threadId"] = json!("thread-2");
+        let error = attest(&foreign).unwrap_err();
+        assert_eq!(error.code, "missing_codex_launch_settings");
+    }
+
+    #[test]
+    fn codex_launch_uses_initial_settings_not_later_turn_changes() {
+        let mut evidence = events("gpt-5.6-terra", "high");
+        evidence.push(json!({
+            "schema_version": 2,
+            "ts": "2026-08-17T23:05:00Z",
+            "session_id": "thread-1",
+            "seq": 50,
+            "session_epoch": 7,
+            "event_type": "thread/settings/updated",
+            "payload": {
+                "threadId": "thread-1",
+                "threadSettings": {
+                    "model": "gpt-5.6-sol",
+                    "modelProvider": "openai",
+                    "effort": "xhigh"
+                }
+            }
+        }));
+
+        assert!(attest(&evidence).is_ok());
+    }
+}

--- a/crates/sm-server/src/policy_store.rs
+++ b/crates/sm-server/src/policy_store.rs
@@ -373,8 +373,8 @@ impl PolicyStore {
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
         load_projection_tx(&tx, lane, policy_version, policy_digest)?;
         tx.execute(
-            "INSERT INTO policy_active_projections (lane, policy_version, policy_digest) VALUES (?1, ?2, ?3) ON CONFLICT(lane) DO UPDATE SET policy_version = excluded.policy_version, policy_digest = excluded.policy_digest",
-            params![lane, policy_version, policy_digest],
+            "INSERT INTO policy_active_projections (lane, policy_version, policy_digest, active_projection_digest) VALUES (?1, ?2, ?3, ?4) ON CONFLICT(lane) DO UPDATE SET policy_version = excluded.policy_version, policy_digest = excluded.policy_digest, active_projection_digest = excluded.active_projection_digest",
+            params![lane, policy_version, policy_digest, active_projection_digest(lane, policy_version, policy_digest)?],
         )?;
         tx.commit()?;
         Ok(())
@@ -457,7 +457,7 @@ impl PolicyStore {
             &request.policy_version,
             &request.policy_digest,
         )?;
-        let active: (String, String) = tx.query_row("SELECT policy_version, policy_digest FROM policy_active_projections WHERE lane = ?1", [request.caller.lane()], |row| Ok((row.get(0)?, row.get(1)?))).optional()?.ok_or_else(|| PolicyStoreError::ProjectionNotFound(request.caller.lane().into()))?;
+        let active = load_active_projection_tx(&tx, request.caller.lane())?;
         if active
             != (
                 request.policy_version.clone(),
@@ -509,6 +509,7 @@ impl PolicyStore {
         let resolved = resolve_rule(&projection, &request, &effective_classification);
         let mut outcome = resolved.outcome.clone();
         let mut override_used = None;
+        let mut override_terminal_decision_id = None;
         if let Some(override_id) = override_id {
             let override_record = load_override_tx(&tx, override_id)?;
             let terminal = load_terminal_decision(&tx, &request, &override_record.decision_id)?;
@@ -522,6 +523,7 @@ impl PolicyStore {
             }
             outcome = PolicyDecisionOutcome::Allow;
             override_used = Some(override_id);
+            override_terminal_decision_id = Some(override_record.decision_id);
         }
         let decision_id = derived_id(
             "decision",
@@ -589,7 +591,7 @@ impl PolicyStore {
             .validate_for_request(&request)
             .map_err(|e| PolicyStoreError::Invalid(e.to_string()))?;
         let decision_json = serde_json::to_string(&decision)?;
-        tx.execute("INSERT INTO policy_decisions (decision_id, request_id, attempt, override_id, decision_json, decision_digest, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)", params![decision.decision_id, request_id, attempt, override_used, decision_json, canonical_json_digest(&decision)?, decision.decided_at])?;
+        tx.execute("INSERT INTO policy_decisions (decision_id, request_id, attempt, override_id, override_terminal_decision_id, decision_json, decision_digest, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)", params![decision.decision_id, request_id, attempt, override_used, override_terminal_decision_id, decision_json, canonical_json_digest(&decision)?, decision.decided_at])?;
         if let Some(override_id) = override_used {
             consume_override_tx(&tx, override_id, now)?;
         }
@@ -681,6 +683,17 @@ impl PolicyStore {
     pub fn release_lease(&self, lease_id: &str) -> Result<()> {
         let mut conn = self.open()?;
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        if tx
+            .query_row(
+                "SELECT lease_id FROM policy_capacity_leases WHERE lease_id = ?1",
+                [lease_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?
+            .is_some()
+        {
+            load_lease_tx(&tx, lease_id)?;
+        }
         let released_at = now()?;
         tx.execute("UPDATE policy_capacity_leases SET state = 'released', released_at = ?2 WHERE lease_id = ?1 AND state IN ('active', 'committed')", params![lease_id, released_at])?;
         tx.execute("UPDATE policy_provisional_children SET state = 'released', released_at = ?2 WHERE lease_id = ?1 AND state IN ('reserved', 'launched')", params![lease_id, now()?])?;
@@ -694,13 +707,7 @@ impl PolicyStore {
         required(child_session_id, "provisional child session ID")?;
         let mut conn = self.open()?;
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
-        let lease_id = tx
-            .query_row(
-                "SELECT lease_id FROM policy_provisional_children WHERE child_session_id = ?1",
-                [child_session_id],
-                |row| row.get::<_, String>(0),
-            )
-            .optional()?;
+        let lease_id = load_child_lease_tx(&tx, child_session_id, false)?;
         if let Some(lease_id) = lease_id {
             let released_at = now()?;
             tx.execute("UPDATE policy_capacity_leases SET state = 'released', released_at = ?2 WHERE lease_id = ?1 AND state IN ('active', 'committed')", params![lease_id, released_at])?;
@@ -717,13 +724,7 @@ impl PolicyStore {
         required(child_session_id, "provisional child session ID")?;
         let mut conn = self.open()?;
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
-        let lease_id = tx
-            .query_row(
-                "SELECT lease_id FROM policy_provisional_children WHERE child_session_id = ?1 AND state = 'reserved'",
-                [child_session_id],
-                |row| row.get::<_, String>(0),
-            )
-            .optional()?;
+        let lease_id = load_child_lease_tx(&tx, child_session_id, true)?;
         if let Some(lease_id) = lease_id {
             tx.execute(
                 "UPDATE policy_capacity_leases SET state = 'committed' WHERE lease_id = ?1 AND state = 'active'",
@@ -778,10 +779,10 @@ impl PolicyStore {
 
 const POLICY_SCHEMA_V1: &str = r#"
     CREATE TABLE policy_projections (lane TEXT NOT NULL, policy_version TEXT NOT NULL, policy_digest TEXT NOT NULL, projection_json TEXT NOT NULL, projection_record_digest TEXT NOT NULL, created_at TEXT NOT NULL, PRIMARY KEY (lane, policy_version, policy_digest));
-    CREATE TABLE policy_active_projections (lane TEXT PRIMARY KEY, policy_version TEXT NOT NULL, policy_digest TEXT NOT NULL);
+    CREATE TABLE policy_active_projections (lane TEXT PRIMARY KEY, policy_version TEXT NOT NULL, policy_digest TEXT NOT NULL, active_projection_digest TEXT NOT NULL);
     CREATE TABLE policy_runtime_versions (lane TEXT PRIMARY KEY, topology_version INTEGER NOT NULL, capacity_version INTEGER NOT NULL);
     CREATE TABLE policy_requests (request_id TEXT PRIMARY KEY, lane TEXT NOT NULL, request_digest TEXT NOT NULL, request_json TEXT NOT NULL, created_at TEXT NOT NULL);
-    CREATE TABLE policy_decisions (decision_id TEXT PRIMARY KEY, request_id TEXT NOT NULL, attempt INTEGER NOT NULL, override_id TEXT, decision_json TEXT NOT NULL, decision_digest TEXT NOT NULL, created_at TEXT NOT NULL, UNIQUE(request_id, attempt), UNIQUE(request_id, override_id));
+    CREATE TABLE policy_decisions (decision_id TEXT PRIMARY KEY, request_id TEXT NOT NULL, attempt INTEGER NOT NULL, override_id TEXT, override_terminal_decision_id TEXT, decision_json TEXT NOT NULL, decision_digest TEXT NOT NULL, created_at TEXT NOT NULL, UNIQUE(request_id, attempt), UNIQUE(request_id, override_id));
     CREATE TABLE policy_capacity_leases (lease_id TEXT PRIMARY KEY, request_id TEXT NOT NULL, topology_version INTEGER NOT NULL, capacity_version INTEGER NOT NULL, provisional_child_session_id TEXT NOT NULL, state TEXT NOT NULL, expires_at TEXT NOT NULL, released_at TEXT, lease_json TEXT NOT NULL, lease_digest TEXT NOT NULL);
     CREATE TABLE policy_capacity_claims (lease_id TEXT NOT NULL, dimension TEXT NOT NULL, claim_key TEXT NOT NULL, units INTEGER NOT NULL, PRIMARY KEY (lease_id, dimension, claim_key));
     CREATE TABLE policy_provisional_children (child_session_id TEXT PRIMARY KEY, lease_id TEXT NOT NULL UNIQUE, request_id TEXT NOT NULL, decision_id TEXT NOT NULL, state TEXT NOT NULL, created_at TEXT NOT NULL, released_at TEXT);
@@ -1023,7 +1024,15 @@ fn insert_lease(
 }
 
 fn expire_leases(tx: &Transaction<'_>, now: OffsetDateTime) -> Result<()> {
-    tx.execute("UPDATE policy_capacity_leases SET state = 'expired' WHERE state = 'active' AND expires_at <= ?1", [format_time(now)?])?;
+    let now = format_time(now)?;
+    let lease_ids = tx
+        .prepare("SELECT lease_id FROM policy_capacity_leases WHERE state = 'active' AND expires_at <= ?1")?
+        .query_map([&now], |row| row.get::<_, String>(0))?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    for lease_id in lease_ids {
+        load_lease_tx(tx, &lease_id)?;
+    }
+    tx.execute("UPDATE policy_capacity_leases SET state = 'expired' WHERE state = 'active' AND expires_at <= ?1", [&now])?;
     tx.execute("UPDATE policy_provisional_children SET state = 'expired' WHERE state = 'reserved' AND lease_id IN (SELECT lease_id FROM policy_capacity_leases WHERE state = 'expired')", [])?;
     Ok(())
 }
@@ -1108,6 +1117,26 @@ fn load_projection_tx(
         ));
     }
     Ok(projection)
+}
+
+fn load_active_projection_tx(tx: &Transaction<'_>, lane: &str) -> Result<(String, String)> {
+    let (stored_lane, policy_version, policy_digest, digest): (String, String, String, String) = tx
+        .query_row(
+            "SELECT lane, policy_version, policy_digest, active_projection_digest FROM policy_active_projections WHERE lane = ?1",
+            [lane],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .optional()?
+        .ok_or_else(|| PolicyStoreError::ProjectionNotFound(lane.into()))?;
+    if stored_lane != lane
+        || active_projection_digest(&stored_lane, &policy_version, &policy_digest)? != digest
+    {
+        return Err(PolicyStoreError::Invalid(
+            "active projection pointer does not match its canonical digest".into(),
+        ));
+    }
+    load_projection_tx(tx, &stored_lane, &policy_version, &policy_digest)?;
+    Ok((policy_version, policy_digest))
 }
 
 fn parse_stored_request(
@@ -1223,11 +1252,11 @@ fn load_terminal_decision(
     request: &PolicySpawnRequest,
     decision_id: &str,
 ) -> Result<PolicyDecision> {
-    let (stored_decision_id, stored_request_id, attempt, override_id, digest, value, created_at): (String, String, u32, Option<String>, String, String, String) = tx
+    let (stored_decision_id, stored_request_id, attempt, override_id, override_terminal_decision_id, digest, value, created_at): (String, String, u32, Option<String>, Option<String>, String, String, String) = tx
         .query_row(
-            "SELECT decision_id, request_id, attempt, override_id, decision_digest, decision_json, created_at FROM policy_decisions WHERE request_id = ?1 AND decision_id = ?2",
+            "SELECT decision_id, request_id, attempt, override_id, override_terminal_decision_id, decision_digest, decision_json, created_at FROM policy_decisions WHERE request_id = ?1 AND decision_id = ?2",
             params![request.request_id, decision_id],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?, row.get(5)?, row.get(6)?)),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?, row.get(5)?, row.get(6)?, row.get(7)?)),
         )
         .optional()?
         .ok_or_else(|| {
@@ -1240,6 +1269,7 @@ fn load_terminal_decision(
         &stored_request_id,
         attempt,
         override_id.as_deref(),
+        override_terminal_decision_id.as_deref(),
         &digest,
         &value,
         &created_at,
@@ -1250,11 +1280,11 @@ fn load_latest_terminal_decision(
     tx: &Transaction<'_>,
     request: &PolicySpawnRequest,
 ) -> Result<PolicyDecision> {
-    let (decision_id, request_id, attempt, override_id, digest, value, created_at): (String, String, u32, Option<String>, String, String, String) = tx
+    let (decision_id, request_id, attempt, override_id, override_terminal_decision_id, digest, value, created_at): (String, String, u32, Option<String>, Option<String>, String, String, String) = tx
         .query_row(
-            "SELECT decision_id, request_id, attempt, override_id, decision_digest, decision_json, created_at FROM policy_decisions WHERE request_id = ?1 ORDER BY attempt DESC LIMIT 1",
+            "SELECT decision_id, request_id, attempt, override_id, override_terminal_decision_id, decision_digest, decision_json, created_at FROM policy_decisions WHERE request_id = ?1 ORDER BY attempt DESC LIMIT 1",
             [&request.request_id],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?, row.get(5)?, row.get(6)?)),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?, row.get(5)?, row.get(6)?, row.get(7)?)),
         )
         .optional()?
         .ok_or_else(|| PolicyStoreError::OverrideDenied("request has no terminal decision".into()))?;
@@ -1265,6 +1295,7 @@ fn load_latest_terminal_decision(
         &request_id,
         attempt,
         override_id.as_deref(),
+        override_terminal_decision_id.as_deref(),
         &digest,
         &value,
         &created_at,
@@ -1279,6 +1310,7 @@ fn parse_stored_decision(
     request_id: &str,
     attempt: u32,
     override_id: Option<&str>,
+    override_terminal_decision_id: Option<&str>,
     digest: &str,
     value: &str,
     created_at: &str,
@@ -1297,15 +1329,22 @@ fn parse_stored_decision(
             "stored decision does not match authoritative row columns".into(),
         ));
     }
-    if let Some(override_id) = override_id {
+    if let (Some(override_id), Some(override_terminal_decision_id)) =
+        (override_id, override_terminal_decision_id)
+    {
         let override_record = load_override_tx(tx, override_id)?;
         if override_record.request_id != request.request_id
             || override_record.policy_version != request.policy_version
+            || override_record.decision_id != override_terminal_decision_id
         {
             return Err(PolicyStoreError::Invalid(
                 "stored decision override does not bind to this frozen request".into(),
             ));
         }
+    } else if override_id.is_some() || override_terminal_decision_id.is_some() {
+        return Err(PolicyStoreError::Invalid(
+            "stored decision has an incomplete override binding".into(),
+        ));
     }
     if let Some(embedded_lease) = &decision.capacity_lease {
         let stored_lease = load_lease_tx(tx, &embedded_lease.lease_id)?;
@@ -1368,6 +1407,42 @@ fn load_lease_tx(tx: &Transaction<'_>, lease_id: &str) -> Result<PolicyCapacityL
     Ok(lease)
 }
 
+fn load_child_lease_tx(
+    tx: &Transaction<'_>,
+    child_session_id: &str,
+    require_reserved: bool,
+) -> Result<Option<String>> {
+    let row: Option<(String, String, String, String)> = tx
+        .query_row(
+            "SELECT lease_id, request_id, decision_id, state FROM policy_provisional_children WHERE child_session_id = ?1",
+            [child_session_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+        )
+        .optional()?;
+    let Some((lease_id, request_id, decision_id, state)) = row else {
+        return Ok(None);
+    };
+    if require_reserved && state != "reserved" {
+        return Ok(None);
+    }
+    let request = load_request_tx(tx, &request_id)?;
+    let decision = load_terminal_decision(tx, &request, &decision_id)?;
+    let lease = load_lease_tx(tx, &lease_id)?;
+    if decision.request_id != request_id
+        || lease.request_id != request_id
+        || decision
+            .capacity_lease
+            .as_ref()
+            .map(|embedded| embedded.lease_id.as_str())
+            != Some(lease_id.as_str())
+    {
+        return Err(PolicyStoreError::Invalid(
+            "provisional child does not match its decision and capacity lease".into(),
+        ));
+    }
+    Ok(Some(lease_id))
+}
+
 fn authorize_override_tx(
     tx: &Transaction<'_>,
     record: &PolicyOverrideRecord,
@@ -1405,14 +1480,15 @@ fn load_reusable_decision(
     override_id: Option<&str>,
 ) -> Result<Option<PolicyDecision>> {
     let value = match override_id {
-        Some(id) => tx.query_row("SELECT decision_id, request_id, attempt, override_id, decision_digest, decision_json, created_at FROM policy_decisions WHERE request_id = ?1 AND override_id = ?2", params![request.request_id, id], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, u32>(2)?, row.get::<_, Option<String>>(3)?, row.get::<_, String>(4)?, row.get::<_, String>(5)?, row.get::<_, String>(6)?))).optional()?,
-        None => tx.query_row("SELECT decision_id, request_id, attempt, override_id, decision_digest, decision_json, created_at FROM policy_decisions WHERE request_id = ?1 AND override_id IS NULL ORDER BY attempt ASC LIMIT 1", [&request.request_id], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, u32>(2)?, row.get::<_, Option<String>>(3)?, row.get::<_, String>(4)?, row.get::<_, String>(5)?, row.get::<_, String>(6)?))).optional()?,
+        Some(id) => tx.query_row("SELECT decision_id, request_id, attempt, override_id, override_terminal_decision_id, decision_digest, decision_json, created_at FROM policy_decisions WHERE request_id = ?1 AND override_id = ?2", params![request.request_id, id], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, u32>(2)?, row.get::<_, Option<String>>(3)?, row.get::<_, Option<String>>(4)?, row.get::<_, String>(5)?, row.get::<_, String>(6)?, row.get::<_, String>(7)?))).optional()?,
+        None => tx.query_row("SELECT decision_id, request_id, attempt, override_id, override_terminal_decision_id, decision_digest, decision_json, created_at FROM policy_decisions WHERE request_id = ?1 AND override_id IS NULL ORDER BY attempt ASC LIMIT 1", [&request.request_id], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, u32>(2)?, row.get::<_, Option<String>>(3)?, row.get::<_, Option<String>>(4)?, row.get::<_, String>(5)?, row.get::<_, String>(6)?, row.get::<_, String>(7)?))).optional()?,
     };
     let Some((
         stored_decision_id,
         stored_request_id,
         attempt,
         stored_override_id,
+        stored_override_terminal_decision_id,
         digest,
         json,
         created_at,
@@ -1427,6 +1503,7 @@ fn load_reusable_decision(
         &stored_request_id,
         attempt,
         stored_override_id.as_deref(),
+        stored_override_terminal_decision_id.as_deref(),
         &digest,
         &json,
         &created_at,
@@ -1529,6 +1606,13 @@ fn canonical_json_digest(value: &impl Serialize) -> Result<String> {
     serde_json::to_vec(value)
         .map(|encoded| format!("{:x}", Sha256::digest(encoded)))
         .map_err(PolicyStoreError::Json)
+}
+fn active_projection_digest(
+    lane: &str,
+    policy_version: &str,
+    policy_digest: &str,
+) -> Result<String> {
+    canonical_json_digest(&(lane, policy_version, policy_digest))
 }
 fn override_state_name(state: &PolicyOverrideState) -> &'static str {
     match state {
@@ -2482,6 +2566,167 @@ mod tests {
             Err(PolicyStoreError::Invalid(_))
         ));
         for path in [schema_path, override_path, capacity_path] {
+            std::fs::remove_file(path).ok();
+        }
+    }
+
+    #[test]
+    fn override_lifecycle_and_active_pointer_rebinding_fail_closed() {
+        let (override_store, path) = store("round-two-authority-tamper");
+        let mut override_projection = projection(true, 2);
+        for rule in &mut override_projection.rules {
+            rule.lease_ttl_seconds = 1;
+        }
+        install(&override_store, &override_projection);
+        override_store
+            .set_runtime_versions(&override_projection.lane, 1, 1)
+            .unwrap();
+        let rewrite = request(
+            "round-two-rewrite",
+            PolicyVehicle::NamedSeat,
+            Some("fable"),
+            "round-two-rewrite-intent",
+        );
+        override_store.create_request(&rewrite).unwrap();
+        let now = instant("2026-08-17T00:01:00Z");
+        let rejected = override_store
+            .prepare_admission(
+                &rewrite.request_id,
+                &class("named_orchestrator", Some("maintainer")),
+                None,
+                "round-two-rewrite-child",
+                now,
+            )
+            .unwrap()
+            .decision;
+        let override_record = override_store
+            .authorize_request_override(
+                &rewrite.request_id,
+                &rewrite.caller,
+                "same-request rebinding test",
+                now,
+                time::Duration::minutes(1),
+            )
+            .unwrap();
+        let allowed = override_store
+            .prepare_admission(
+                &rewrite.request_id,
+                &class("named_orchestrator", Some("maintainer")),
+                Some(&override_record.override_id),
+                "round-two-allowed-child",
+                now,
+            )
+            .unwrap()
+            .decision;
+        let conn = Connection::open(&path).unwrap();
+        conn.execute(
+            "UPDATE policy_decisions SET override_id = NULL WHERE decision_id = ?1",
+            [&allowed.decision_id],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE policy_decisions SET override_id = ?2 WHERE decision_id = ?1",
+            params![rejected.decision_id, override_record.override_id],
+        )
+        .unwrap();
+        drop(conn);
+        assert!(matches!(
+            override_store.prepare_admission(
+                &rewrite.request_id,
+                &class("named_orchestrator", Some("maintainer")),
+                Some(&override_record.override_id),
+                "round-two-allowed-child",
+                now,
+            ),
+            Err(PolicyStoreError::Invalid(_))
+        ));
+
+        let (lease_store, lease_path) = store("round-two-expired-lease-tamper");
+        let mut lease_projection = projection(true, 1);
+        for rule in &mut lease_projection.rules {
+            rule.lease_ttl_seconds = 1;
+        }
+        install(&lease_store, &lease_projection);
+        lease_store
+            .set_runtime_versions(&lease_projection.lane, 1, 1)
+            .unwrap();
+        let first = request(
+            "round-two-first",
+            PolicyVehicle::TaskAgent,
+            None,
+            "round-two-first-intent",
+        );
+        let second = request(
+            "round-two-second",
+            PolicyVehicle::TaskAgent,
+            None,
+            "round-two-second-intent",
+        );
+        lease_store.create_request(&first).unwrap();
+        lease_store.create_request(&second).unwrap();
+        let first_decision = lease_store
+            .prepare_admission(
+                &first.request_id,
+                &class("routine_bounded", None),
+                None,
+                "round-two-first-child",
+                now,
+            )
+            .unwrap()
+            .decision;
+        let conn = Connection::open(&lease_path).unwrap();
+        conn.execute(
+            "UPDATE policy_capacity_leases SET lease_json = '{\"bad\":true}' WHERE lease_id = ?1",
+            [&first_decision.capacity_lease.unwrap().lease_id],
+        )
+        .unwrap();
+        drop(conn);
+        assert!(matches!(
+            lease_store.prepare_admission(
+                &second.request_id,
+                &class("routine_bounded", None),
+                None,
+                "round-two-second-child",
+                now + time::Duration::seconds(2),
+            ),
+            Err(PolicyStoreError::Json(_))
+        ));
+
+        let (pointer_store, pointer_path) = store("round-two-pointer-tamper");
+        let v1 = projection(true, 1);
+        install(&pointer_store, &v1);
+        pointer_store.set_runtime_versions(&v1.lane, 1, 1).unwrap();
+        let v1_request = request(
+            "round-two-pointer",
+            PolicyVehicle::TaskAgent,
+            None,
+            "round-two-pointer-intent",
+        );
+        pointer_store.create_request(&v1_request).unwrap();
+        let mut v2 = v1.clone();
+        v2.policy_version = "v2".into();
+        pointer_store.install_projection(&v2).unwrap();
+        pointer_store
+            .activate_projection(&v2.lane, &v2.policy_version, &v2.policy_digest)
+            .unwrap();
+        let conn = Connection::open(&pointer_path).unwrap();
+        conn.execute(
+            "UPDATE policy_active_projections SET policy_version = ?2 WHERE lane = ?1",
+            params![v1.lane, v1.policy_version],
+        )
+        .unwrap();
+        drop(conn);
+        assert!(matches!(
+            pointer_store.prepare_admission(
+                &v1_request.request_id,
+                &class("routine_bounded", None),
+                None,
+                "round-two-pointer-child",
+                now,
+            ),
+            Err(PolicyStoreError::Invalid(_))
+        ));
+        for path in [path, lease_path, pointer_path] {
             std::fs::remove_file(path).ok();
         }
     }

--- a/crates/sm-server/src/policy_store.rs
+++ b/crates/sm-server/src/policy_store.rs
@@ -827,26 +827,26 @@ fn expire_overrides_tx(tx: &Transaction<'_>, now: OffsetDateTime) -> Result<usiz
 }
 
 fn load_request(conn: &Connection, request_id: &str) -> Result<PolicySpawnRequest> {
-    let value = conn
+    let (digest, value): (String, String) = conn
         .query_row(
-            "SELECT request_json FROM policy_requests WHERE request_id = ?1",
+            "SELECT request_digest, request_json FROM policy_requests WHERE request_id = ?1",
             [request_id],
-            |row| row.get::<_, String>(0),
+            |row| Ok((row.get(0)?, row.get(1)?)),
         )
         .optional()?
         .ok_or_else(|| PolicyStoreError::RequestNotFound(request_id.into()))?;
-    Ok(serde_json::from_str(&value)?)
+    parse_stored_request(request_id, &digest, &value)
 }
 fn load_request_tx(tx: &Transaction<'_>, request_id: &str) -> Result<PolicySpawnRequest> {
-    let value = tx
+    let (digest, value): (String, String) = tx
         .query_row(
-            "SELECT request_json FROM policy_requests WHERE request_id = ?1",
+            "SELECT request_digest, request_json FROM policy_requests WHERE request_id = ?1",
             [request_id],
-            |row| row.get::<_, String>(0),
+            |row| Ok((row.get(0)?, row.get(1)?)),
         )
         .optional()?
         .ok_or_else(|| PolicyStoreError::RequestNotFound(request_id.into()))?;
-    Ok(serde_json::from_str(&value)?)
+    parse_stored_request(request_id, &digest, &value)
 }
 fn load_projection_tx(
     tx: &Transaction<'_>,
@@ -855,7 +855,35 @@ fn load_projection_tx(
     digest: &str,
 ) -> Result<PolicyProjection> {
     let value = tx.query_row("SELECT projection_json FROM policy_projections WHERE lane = ?1 AND policy_version = ?2 AND policy_digest = ?3", params![lane, version, digest], |row| row.get::<_, String>(0)).optional()?.ok_or_else(|| PolicyStoreError::ProjectionNotFound(lane.into()))?;
-    Ok(serde_json::from_str(&value)?)
+    let projection: PolicyProjection = serde_json::from_str(&value)?;
+    projection.validate()?;
+    if projection.lane != lane
+        || projection.policy_version != version
+        || projection.policy_digest != digest
+    {
+        return Err(PolicyStoreError::Invalid(
+            "stored projection does not match its immutable lookup key".into(),
+        ));
+    }
+    Ok(projection)
+}
+
+fn parse_stored_request(request_id: &str, digest: &str, value: &str) -> Result<PolicySpawnRequest> {
+    let request: PolicySpawnRequest = serde_json::from_str(value)?;
+    request
+        .validate()
+        .map_err(|error| PolicyStoreError::Invalid(error.to_string()))?;
+    if request.request_id != request_id
+        || request
+            .canonical_digest()
+            .map_err(|error| PolicyStoreError::Invalid(error.to_string()))?
+            != digest
+    {
+        return Err(PolicyStoreError::Invalid(
+            "stored request does not match its immutable lookup key".into(),
+        ));
+    }
+    Ok(request)
 }
 fn load_override_conn(conn: &Connection, override_id: &str) -> Result<PolicyOverrideRecord> {
     let value = conn

--- a/crates/sm-server/src/policy_store.rs
+++ b/crates/sm-server/src/policy_store.rs
@@ -353,6 +353,13 @@ pub struct PolicyReconciliationSnapshot {
     pub blockers: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PolicyChildAdmission {
+    pub reservation: PolicyChildReservation,
+    pub request: PolicySpawnRequest,
+    pub decision: PolicyDecision,
+}
+
 #[derive(Debug, Clone)]
 pub struct PolicyStore {
     db_path: PathBuf,
@@ -766,11 +773,9 @@ impl PolicyStore {
         let reservation = load_child_reservation_tx(&tx, child_session_id)?;
         if let Some(reservation) = reservation {
             if matches!(
-                reservation.child_state,
-                PolicyChildState::Released | PolicyChildState::Expired
-            ) && matches!(
-                reservation.lease_state,
-                PolicyLeaseState::Released | PolicyLeaseState::Expired
+                (reservation.child_state, reservation.lease_state),
+                (PolicyChildState::Released, PolicyLeaseState::Released)
+                    | (PolicyChildState::Expired, PolicyLeaseState::Expired)
             ) {
                 tx.commit()?;
                 return Ok(());
@@ -880,13 +885,34 @@ impl PolicyStore {
         Ok(reservation)
     }
 
+    pub fn admission_for_child(
+        &self,
+        child_session_id: &str,
+    ) -> Result<Option<PolicyChildAdmission>> {
+        required(child_session_id, "provisional child session ID")?;
+        let mut conn = self.open()?;
+        let tx = conn.transaction()?;
+        let Some(reservation) = load_child_reservation_tx(&tx, child_session_id)? else {
+            tx.commit()?;
+            return Ok(None);
+        };
+        let request = load_request_tx(&tx, &reservation.request_id)?;
+        let decision = load_terminal_decision(&tx, &request, &reservation.decision_id)?;
+        tx.commit()?;
+        Ok(Some(PolicyChildAdmission {
+            reservation,
+            request,
+            decision,
+        }))
+    }
+
     /// Enumerates every non-terminal lease/child pair before admission is
     /// enabled. Structural mismatches are returned as exact blockers instead of
     /// being silently omitted from the sweep denominator.
     pub fn reconciliation_snapshot(&self) -> Result<PolicyReconciliationSnapshot> {
         let mut conn = self.open()?;
         let tx = conn.transaction()?;
-        let expected = tx.query_row(
+        let expected_leases = tx.query_row(
             "SELECT COUNT(*) FROM policy_capacity_leases WHERE state IN ('active', 'committed', 'release_pending')",
             [],
             |row| row.get::<_, usize>(0),
@@ -922,15 +948,13 @@ impl PolicyStore {
             .prepare("SELECT child_session_id, lease_id FROM policy_provisional_children WHERE state IN ('reserved', 'launched', 'release_pending') AND lease_id NOT IN (SELECT lease_id FROM policy_capacity_leases WHERE state IN ('active', 'committed', 'release_pending')) ORDER BY child_session_id")?
             .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))?
             .collect::<std::result::Result<Vec<_>, _>>()?;
+        let orphan_count = orphan_children.len();
         for (child_session_id, lease_id) in orphan_children {
             blockers.push(format!(
                 "provisional child {child_session_id} has no matching non-terminal lease {lease_id}"
             ));
         }
-        let expected = expected
-            + blockers
-                .len()
-                .saturating_sub(expected.saturating_sub(reservations.len()));
+        let expected = expected_leases + orphan_count;
         tx.commit()?;
         Ok(PolicyReconciliationSnapshot {
             expected,

--- a/crates/sm-server/src/policy_store.rs
+++ b/crates/sm-server/src/policy_store.rs
@@ -432,7 +432,7 @@ impl PolicyStore {
                 capacity_version
             )));
         }
-        if let Some(existing) = load_reusable_decision(&tx, request_id, override_id)? {
+        if let Some(existing) = load_reusable_decision(&tx, &request, override_id)? {
             tx.commit()?;
             return Ok(PreparedDecision {
                 decision: existing,
@@ -927,17 +927,25 @@ fn load_terminal_decision(
 }
 fn load_reusable_decision(
     tx: &Transaction<'_>,
-    request_id: &str,
+    request: &PolicySpawnRequest,
     override_id: Option<&str>,
 ) -> Result<Option<PolicyDecision>> {
     let value = match override_id {
-        Some(id) => tx.query_row("SELECT decision_json FROM policy_decisions WHERE request_id = ?1 AND override_id = ?2", params![request_id, id], |row| row.get::<_, String>(0)).optional()?,
-        None => tx.query_row("SELECT decision_json FROM policy_decisions WHERE request_id = ?1 AND override_id IS NULL ORDER BY attempt ASC LIMIT 1", [request_id], |row| row.get::<_, String>(0)).optional()?,
+        Some(id) => tx.query_row("SELECT decision_id, decision_json FROM policy_decisions WHERE request_id = ?1 AND override_id = ?2", params![request.request_id, id], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))).optional()?,
+        None => tx.query_row("SELECT decision_id, decision_json FROM policy_decisions WHERE request_id = ?1 AND override_id IS NULL ORDER BY attempt ASC LIMIT 1", [&request.request_id], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))).optional()?,
     };
-    let Some(json) = value else {
+    let Some((stored_decision_id, json)) = value else {
         return Ok(None);
     };
     let decision: PolicyDecision = serde_json::from_str(&json)?;
+    decision
+        .validate_for_request(request)
+        .map_err(|error| PolicyStoreError::Invalid(error.to_string()))?;
+    if decision.decision_id != stored_decision_id {
+        return Err(PolicyStoreError::Invalid(
+            "stored decision does not match its immutable lookup key".into(),
+        ));
+    }
     if let Some(lease) = &decision.capacity_lease {
         let active: bool = tx
             .query_row(
@@ -1364,6 +1372,51 @@ mod tests {
         assert!(matches!(
             after_restart.override_record("override-1").unwrap().state,
             PolicyOverrideState::Consumed
+        ));
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn damaged_reusable_decision_fails_closed_after_restart() {
+        let (store, path) = store("damaged-decision");
+        store.install_projection(&projection(true, 1)).unwrap();
+        store.set_runtime_versions("sm-policy-1268", 1, 1).unwrap();
+        store
+            .create_request(&request(
+                "damaged",
+                PolicyVehicle::TaskAgent,
+                None,
+                "intent-damaged",
+            ))
+            .unwrap();
+        let now = instant("2026-08-17T00:01:00Z");
+        let decision = store
+            .prepare_admission("damaged", &class("routine_bounded", None), None, now)
+            .unwrap()
+            .decision;
+        let conn = Connection::open(&path).unwrap();
+        let json: String = conn
+            .query_row(
+                "SELECT decision_json FROM policy_decisions WHERE decision_id = ?1",
+                [&decision.decision_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        let mut damaged: serde_json::Value = serde_json::from_str(&json).unwrap();
+        damaged["capacity_lease"] = serde_json::Value::Null;
+        conn.execute(
+            "UPDATE policy_decisions SET decision_json = ?2 WHERE decision_id = ?1",
+            params![
+                decision.decision_id,
+                serde_json::to_string(&damaged).unwrap()
+            ],
+        )
+        .unwrap();
+        drop(conn);
+        let after_restart = PolicyStore::new(&path).unwrap();
+        assert!(matches!(
+            after_restart.prepare_admission("damaged", &class("routine_bounded", None), None, now),
+            Err(PolicyStoreError::Invalid(_))
         ));
         std::fs::remove_file(path).ok();
     }

--- a/crates/sm-server/src/policy_store.rs
+++ b/crates/sm-server/src/policy_store.rs
@@ -1,0 +1,1340 @@
+//! Durable, deliberately small policy projection and admission preparation.
+//!
+//! This module is the D1 boundary.  It owns immutable requests/decisions and
+//! the transaction which reserves capacity (and, when applicable, consumes a
+//! one-shot override).  D3 owns child allocation and runtime attestation.
+
+use std::{collections::BTreeMap, fmt, path::PathBuf, time::Duration};
+
+use rusqlite::{params, Connection, OptionalExtension, Transaction, TransactionBehavior};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+
+use crate::policy_contracts::{
+    PolicyCallerBinding, PolicyCapacityClaim, PolicyCapacityLease, PolicyClassification,
+    PolicyDecision, PolicyDecisionOutcome, PolicyLaunchProfile, PolicyOverrideRecord,
+    PolicyOverrideState, PolicySpawnRequest, DECISION_SCHEMA,
+};
+
+const BUSY_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Debug)]
+pub enum PolicyStoreError {
+    Invalid(String),
+    RequestNotFound(String),
+    OverrideNotFound(String),
+    ProjectionNotFound(String),
+    Stale(String),
+    CapacityUnavailable(String),
+    CanaryDenied(String),
+    OverrideDenied(String),
+    Sqlite(rusqlite::Error),
+    Json(serde_json::Error),
+}
+
+impl fmt::Display for PolicyStoreError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Invalid(detail) => write!(f, "invalid policy data: {detail}"),
+            Self::RequestNotFound(id) => write!(f, "policy request {id} was not found"),
+            Self::OverrideNotFound(id) => write!(f, "policy override {id} was not found"),
+            Self::ProjectionNotFound(lane) => {
+                write!(f, "policy projection for lane {lane} was not found")
+            }
+            Self::Stale(detail) => write!(f, "stale policy request: {detail}"),
+            Self::CapacityUnavailable(detail) => write!(f, "capacity unavailable: {detail}"),
+            Self::CanaryDenied(detail) => write!(f, "policy canary denied: {detail}"),
+            Self::OverrideDenied(detail) => write!(f, "override cannot be consumed: {detail}"),
+            Self::Sqlite(error) => error.fmt(f),
+            Self::Json(error) => error.fmt(f),
+        }
+    }
+}
+impl std::error::Error for PolicyStoreError {}
+impl From<rusqlite::Error> for PolicyStoreError {
+    fn from(error: rusqlite::Error) -> Self {
+        Self::Sqlite(error)
+    }
+}
+impl From<serde_json::Error> for PolicyStoreError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
+}
+
+pub type Result<T> = std::result::Result<T, PolicyStoreError>;
+
+/// The externally approved bootstrap binding.  Merely storing a projection
+/// cannot manufacture this evidence: it must be supplied by the deployer.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BootstrapAuthority {
+    pub session_id: String,
+    pub credential_fingerprint: String,
+    pub binding_digest: String,
+}
+
+impl BootstrapAuthority {
+    fn matches(&self, caller: &PolicyCallerBinding) -> bool {
+        matches!(caller, PolicyCallerBinding::IncarnationBootstrap {
+            session_id,
+            credential_fingerprint,
+            binding_digest,
+            ..
+        } if session_id == &self.session_id
+            && credential_fingerprint == &self.credential_fingerprint
+            && binding_digest == &self.binding_digest)
+    }
+
+    fn validate(&self) -> Result<()> {
+        required(&self.session_id, "bootstrap session_id")?;
+        required(
+            &self.credential_fingerprint,
+            "bootstrap credential_fingerprint",
+        )?;
+        sha256(&self.binding_digest, "bootstrap binding_digest")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PolicyCapacityLimit {
+    pub dimension: String,
+    pub key: String,
+    pub maximum_units: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyRuleOutcome {
+    Allow,
+    Rewrite,
+    Block,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MaterializedPolicyRule {
+    /// Stable, lane-scoped authority identifier, never a prose line number.
+    pub clause_id: String,
+    /// Lower ranks take precedence.  Equal-rank disagreement blocks.
+    pub rank: u32,
+    #[serde(default)]
+    pub class_id: Option<String>,
+    #[serde(default)]
+    pub role_id: Option<String>,
+    #[serde(default)]
+    pub vehicle: Option<crate::policy_contracts::PolicyVehicle>,
+    pub profile: PolicyLaunchProfile,
+    #[serde(default)]
+    pub outcome: PolicyRuleOutcome,
+    #[serde(default = "default_true")]
+    pub overridable: bool,
+    #[serde(default)]
+    pub capacity_claims: Vec<PolicyCapacityClaim>,
+    #[serde(default = "default_lease_ttl_seconds")]
+    pub lease_ttl_seconds: u64,
+    pub reason: String,
+}
+
+impl Default for PolicyRuleOutcome {
+    fn default() -> Self {
+        Self::Allow
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PolicyProjection {
+    pub lane: String,
+    pub policy_version: String,
+    pub policy_digest: String,
+    /// Defaults false: a persisted projection is not authority to activate its
+    /// own canary.
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default)]
+    pub bootstrap_authority: Option<BootstrapAuthority>,
+    pub rules: Vec<MaterializedPolicyRule>,
+    #[serde(default)]
+    pub capacity_limits: Vec<PolicyCapacityLimit>,
+}
+
+impl PolicyProjection {
+    pub fn validate(&self) -> Result<()> {
+        required(&self.lane, "projection lane")?;
+        required(&self.policy_version, "projection policy_version")?;
+        sha256(&self.policy_digest, "projection policy_digest")?;
+        if let Some(authority) = &self.bootstrap_authority {
+            authority.validate()?;
+        }
+        if self.rules.is_empty() {
+            return Err(PolicyStoreError::Invalid(
+                "projection must contain a rule".into(),
+            ));
+        }
+        let mut clause_ids = std::collections::BTreeSet::new();
+        for rule in &self.rules {
+            required(&rule.clause_id, "rule clause_id")?;
+            if !clause_ids.insert(&rule.clause_id) {
+                return Err(PolicyStoreError::Invalid(format!(
+                    "duplicate stable clause ID {}",
+                    rule.clause_id
+                )));
+            }
+            optional(&rule.class_id, "rule class_id")?;
+            optional(&rule.role_id, "rule role_id")?;
+            rule.profile
+                .validate()
+                .map_err(|error| PolicyStoreError::Invalid(error.to_string()))?;
+            if rule
+                .vehicle
+                .as_ref()
+                .is_some_and(|vehicle| vehicle != &rule.profile.vehicle)
+            {
+                return Err(PolicyStoreError::Invalid(
+                    "rule vehicle must agree with its resolved profile".into(),
+                ));
+            }
+            required(&rule.reason, "rule reason")?;
+            if rule.lease_ttl_seconds == 0 {
+                return Err(PolicyStoreError::Invalid(
+                    "lease ttl must be positive".into(),
+                ));
+            }
+            for claim in &rule.capacity_claims {
+                claim
+                    .validate()
+                    .map_err(|error| PolicyStoreError::Invalid(error.to_string()))?;
+            }
+            if matches!(rule.outcome, PolicyRuleOutcome::Allow) && rule.capacity_claims.is_empty() {
+                return Err(PolicyStoreError::Invalid(
+                    "allow rule must reserve at least one capacity claim".into(),
+                ));
+            }
+        }
+        let mut limits = std::collections::BTreeSet::new();
+        for limit in &self.capacity_limits {
+            required(&limit.dimension, "capacity limit dimension")?;
+            required(&limit.key, "capacity limit key")?;
+            if limit.maximum_units == 0 {
+                return Err(PolicyStoreError::Invalid(
+                    "capacity maximum must be positive".into(),
+                ));
+            }
+            if !limits.insert((&limit.dimension, &limit.key)) {
+                return Err(PolicyStoreError::Invalid("duplicate capacity limit".into()));
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PreparedDecision {
+    pub decision: PolicyDecision,
+    pub reused: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct PolicyStore {
+    db_path: PathBuf,
+}
+
+impl PolicyStore {
+    pub fn new(db_path: impl Into<PathBuf>) -> Result<Self> {
+        let store = Self {
+            db_path: db_path.into(),
+        };
+        store.open()?;
+        Ok(store)
+    }
+
+    pub fn install_projection(&self, projection: &PolicyProjection) -> Result<()> {
+        projection.validate()?;
+        let conn = self.open()?;
+        let projection_json = serde_json::to_string(projection)?;
+        let inserted = conn.execute(
+            "INSERT OR IGNORE INTO policy_projections (lane, policy_version, policy_digest, projection_json, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![projection.lane, projection.policy_version, projection.policy_digest, projection_json, now()?],
+        )?;
+        if inserted == 0 {
+            let existing: String = conn.query_row(
+                "SELECT projection_json FROM policy_projections WHERE lane = ?1 AND policy_version = ?2 AND policy_digest = ?3",
+                params![projection.lane, projection.policy_version, projection.policy_digest],
+                |row| row.get(0),
+            )?;
+            if existing != projection_json {
+                return Err(PolicyStoreError::Invalid(
+                    "policy version/digest is already bound to different projection bytes".into(),
+                ));
+            }
+        }
+        conn.execute(
+            "INSERT INTO policy_runtime_versions (lane, topology_version, capacity_version) VALUES (?1, 0, 0) ON CONFLICT(lane) DO NOTHING",
+            [&projection.lane],
+        )?;
+        Ok(())
+    }
+
+    /// D3 sets the current provider-derived versions before preparing admission.
+    pub fn set_runtime_versions(
+        &self,
+        lane: &str,
+        topology_version: u64,
+        capacity_version: u64,
+    ) -> Result<()> {
+        required(lane, "lane")?;
+        let conn = self.open()?;
+        let changed = conn.execute(
+            "UPDATE policy_runtime_versions SET topology_version = ?2, capacity_version = ?3 WHERE lane = ?1",
+            params![lane, topology_version, capacity_version],
+        )?;
+        if changed == 0 {
+            return Err(PolicyStoreError::ProjectionNotFound(lane.into()));
+        }
+        Ok(())
+    }
+
+    /// Inserts exactly one immutable serialized request. Repeating the same
+    /// request is safe; changing any frozen byte under an existing ID is not.
+    pub fn create_request(&self, request: &PolicySpawnRequest) -> Result<()> {
+        request
+            .validate()
+            .map_err(|error| PolicyStoreError::Invalid(error.to_string()))?;
+        let digest = request
+            .canonical_digest()
+            .map_err(|error| PolicyStoreError::Invalid(error.to_string()))?;
+        let conn = self.open()?;
+        let json = serde_json::to_string(request)?;
+        let inserted = conn.execute(
+            "INSERT OR IGNORE INTO policy_requests (request_id, lane, request_digest, request_json, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![request.request_id, request.caller.lane(), digest, json, request.created_at],
+        )?;
+        if inserted == 0 {
+            let existing: String = conn.query_row(
+                "SELECT request_digest FROM policy_requests WHERE request_id = ?1",
+                [&request.request_id],
+                |row| row.get(0),
+            )?;
+            if existing != digest {
+                return Err(PolicyStoreError::Invalid(
+                    "request ID is already bound to different immutable input".into(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn request(&self, request_id: &str) -> Result<PolicySpawnRequest> {
+        let conn = self.open()?;
+        load_request(&conn, request_id)
+    }
+
+    /// Evaluates and atomically reserves all capacity. A passed override is
+    /// consumed in the same transaction only after capacity is available.
+    pub fn prepare_admission(
+        &self,
+        request_id: &str,
+        classification: &PolicyClassification,
+        override_id: Option<&str>,
+        now: OffsetDateTime,
+    ) -> Result<PreparedDecision> {
+        classification
+            .validate()
+            .map_err(|error| PolicyStoreError::Invalid(error.to_string()))?;
+        let mut conn = self.open()?;
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        expire_leases(&tx, now)?;
+        expire_overrides_tx(&tx, now)?;
+        let request = load_request_tx(&tx, request_id)?;
+        let projection = load_projection_tx(
+            &tx,
+            request.caller.lane(),
+            &request.policy_version,
+            &request.policy_digest,
+        )?;
+        authorize_caller(&projection, &request)?;
+        let (topology_version, capacity_version): (u64, u64) = tx.query_row(
+            "SELECT topology_version, capacity_version FROM policy_runtime_versions WHERE lane = ?1",
+            [request.caller.lane()], |row| Ok((row.get(0)?, row.get(1)?)),
+        ).optional()?.ok_or_else(|| PolicyStoreError::ProjectionNotFound(request.caller.lane().into()))?;
+        if request.topology_version != topology_version
+            || request.capacity_version != capacity_version
+        {
+            return Err(PolicyStoreError::Stale(format!(
+                "request observed topology/capacity {}/{} but current versions are {}/{}",
+                request.topology_version,
+                request.capacity_version,
+                topology_version,
+                capacity_version
+            )));
+        }
+        if let Some(existing) = load_reusable_decision(&tx, request_id, override_id)? {
+            tx.commit()?;
+            return Ok(PreparedDecision {
+                decision: existing,
+                reused: true,
+            });
+        }
+        let attempt = next_attempt(&tx, request_id)?;
+        let resolved = resolve_rule(&projection, &request, classification);
+        let mut outcome = resolved.outcome.clone();
+        let mut override_used = None;
+        if let Some(override_id) = override_id {
+            let override_record = load_override_tx(&tx, override_id)?;
+            let terminal = load_terminal_decision(&tx, request_id, &override_record.decision_id)?;
+            override_record
+                .validate_for_consumption(&request, &terminal, now)
+                .map_err(|error| PolicyStoreError::OverrideDenied(error.to_string()))?;
+            if !resolved.overridable || resolved.profile.is_none() {
+                return Err(PolicyStoreError::OverrideDenied(
+                    "the applicable policy outcome is not overridable".into(),
+                ));
+            }
+            outcome = PolicyDecisionOutcome::Allow;
+            override_used = Some(override_id);
+        }
+        let decision_id = derived_id(
+            "decision",
+            &[
+                &request
+                    .canonical_digest()
+                    .map_err(|e| PolicyStoreError::Invalid(e.to_string()))?,
+                &attempt.to_string(),
+                override_id.unwrap_or(""),
+            ],
+        );
+        let decided_at = format_time(now)?;
+        let mut decision = PolicyDecision {
+            schema: DECISION_SCHEMA.into(),
+            decision_id,
+            request_id: request.request_id.clone(),
+            attempt,
+            policy_version: request.policy_version.clone(),
+            policy_digest: request.policy_digest.clone(),
+            outcome: outcome.clone(),
+            classification: classification.clone(),
+            applicable_clause_ids: resolved.clause_ids.clone(),
+            resolved_profile: resolved.profile.clone(),
+            reason: resolved.reason.clone(),
+            override_command: None,
+            capacity_lease: None,
+            decided_at,
+        };
+        if matches!(outcome, PolicyDecisionOutcome::Allow) {
+            let profile = decision.resolved_profile.as_ref().ok_or_else(|| {
+                PolicyStoreError::Invalid("allow policy has no resolved profile".into())
+            })?;
+            profile
+                .validate()
+                .map_err(|e| PolicyStoreError::Invalid(e.to_string()))?;
+            let claims = resolved.claims.clone();
+            ensure_capacity(&tx, &projection, &claims)?;
+            let lease = PolicyCapacityLease {
+                lease_id: derived_id("lease", &[&decision.decision_id]),
+                request_id: request.request_id.clone(),
+                topology_version,
+                capacity_version,
+                claims: claims.clone(),
+                expires_at: format_time(
+                    now + time::Duration::seconds(resolved.lease_ttl_seconds as i64),
+                )?,
+            };
+            lease
+                .validate()
+                .map_err(|e| PolicyStoreError::Invalid(e.to_string()))?;
+            insert_lease(&tx, &lease)?;
+            decision.capacity_lease = Some(lease);
+        } else {
+            decision.override_command = Some(format!(
+                "sm policy override --request {} --reason <text>",
+                request.request_id
+            ));
+        }
+        decision
+            .validate_for_request(&request)
+            .map_err(|e| PolicyStoreError::Invalid(e.to_string()))?;
+        tx.execute("INSERT INTO policy_decisions (decision_id, request_id, attempt, override_id, decision_json, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)", params![decision.decision_id, request_id, attempt, override_used, serde_json::to_string(&decision)?, decision.decided_at])?;
+        if let Some(override_id) = override_used {
+            consume_override_tx(&tx, override_id, now)?;
+        }
+        tx.commit()?;
+        Ok(PreparedDecision {
+            decision,
+            reused: false,
+        })
+    }
+
+    /// Authorizes a single exact frozen request. The record itself carries the
+    /// authoritative cross-record binding; no caller supplied shortcut exists.
+    pub fn authorize_override(
+        &self,
+        record: &PolicyOverrideRecord,
+        now: OffsetDateTime,
+    ) -> Result<()> {
+        record
+            .validate()
+            .map_err(|e| PolicyStoreError::Invalid(e.to_string()))?;
+        if !matches!(record.state, PolicyOverrideState::Authorized) {
+            return Err(PolicyStoreError::Invalid(
+                "new override must start authorized".into(),
+            ));
+        }
+        let mut conn = self.open()?;
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let request = load_request_tx(&tx, &record.request_id)?;
+        let decision = load_terminal_decision(&tx, &record.request_id, &record.decision_id)?;
+        record
+            .validate_for_consumption(&request, &decision, now)
+            .map_err(|e| PolicyStoreError::OverrideDenied(e.to_string()))?;
+        let json = serde_json::to_string(record)?;
+        let inserted = tx.execute("INSERT OR IGNORE INTO policy_overrides (override_id, request_id, decision_id, state, override_json, created_at) VALUES (?1, ?2, ?3, 'authorized', ?4, ?5)", params![record.override_id, record.request_id, record.decision_id, json, record.created_at])?;
+        if inserted == 0 {
+            let existing = load_override_tx(&tx, &record.override_id)?;
+            if existing != *record {
+                return Err(PolicyStoreError::Invalid(
+                    "override ID is already bound to different immutable authorization".into(),
+                ));
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub fn release_lease(&self, lease_id: &str) -> Result<()> {
+        let conn = self.open()?;
+        conn.execute("UPDATE policy_capacity_leases SET state = 'released', released_at = ?2 WHERE lease_id = ?1 AND state = 'active'", params![lease_id, now()?])?;
+        Ok(())
+    }
+
+    pub fn expire_overrides(&self, now: OffsetDateTime) -> Result<usize> {
+        let mut conn = self.open()?;
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let count = expire_overrides_tx(&tx, now)?;
+        tx.commit()?;
+        Ok(count)
+    }
+
+    pub fn override_record(&self, override_id: &str) -> Result<PolicyOverrideRecord> {
+        load_override_conn(&self.open()?, override_id)
+    }
+
+    fn open(&self) -> Result<Connection> {
+        if let Some(parent) = self.db_path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|e| PolicyStoreError::Invalid(e.to_string()))?;
+        }
+        let conn = Connection::open(&self.db_path)?;
+        conn.busy_timeout(BUSY_TIMEOUT)?;
+        conn.pragma_update(None, "journal_mode", "WAL")?;
+        conn.execute_batch(r#"
+            CREATE TABLE IF NOT EXISTS policy_projections (lane TEXT NOT NULL, policy_version TEXT NOT NULL, policy_digest TEXT NOT NULL, projection_json TEXT NOT NULL, created_at TEXT NOT NULL, PRIMARY KEY (lane, policy_version, policy_digest));
+            CREATE TABLE IF NOT EXISTS policy_runtime_versions (lane TEXT PRIMARY KEY, topology_version INTEGER NOT NULL, capacity_version INTEGER NOT NULL);
+            CREATE TABLE IF NOT EXISTS policy_requests (request_id TEXT PRIMARY KEY, lane TEXT NOT NULL, request_digest TEXT NOT NULL, request_json TEXT NOT NULL, created_at TEXT NOT NULL);
+            CREATE TABLE IF NOT EXISTS policy_decisions (decision_id TEXT PRIMARY KEY, request_id TEXT NOT NULL, attempt INTEGER NOT NULL, override_id TEXT, decision_json TEXT NOT NULL, created_at TEXT NOT NULL, UNIQUE(request_id, attempt), UNIQUE(request_id, override_id));
+            CREATE TABLE IF NOT EXISTS policy_capacity_leases (lease_id TEXT PRIMARY KEY, request_id TEXT NOT NULL, state TEXT NOT NULL, expires_at TEXT NOT NULL, released_at TEXT, lease_json TEXT NOT NULL);
+            CREATE TABLE IF NOT EXISTS policy_capacity_claims (lease_id TEXT NOT NULL, dimension TEXT NOT NULL, claim_key TEXT NOT NULL, units INTEGER NOT NULL, PRIMARY KEY (lease_id, dimension, claim_key));
+            CREATE TABLE IF NOT EXISTS policy_overrides (override_id TEXT PRIMARY KEY, request_id TEXT NOT NULL, decision_id TEXT NOT NULL, state TEXT NOT NULL, override_json TEXT NOT NULL, created_at TEXT NOT NULL);
+            CREATE INDEX IF NOT EXISTS idx_policy_active_claims ON policy_capacity_claims(dimension, claim_key);
+            CREATE INDEX IF NOT EXISTS idx_policy_leases_active ON policy_capacity_leases(state, expires_at);
+        "#)?;
+        Ok(conn)
+    }
+}
+
+#[derive(Debug)]
+struct ResolvedRule {
+    outcome: PolicyDecisionOutcome,
+    profile: Option<PolicyLaunchProfile>,
+    clause_ids: Vec<String>,
+    reason: String,
+    claims: Vec<PolicyCapacityClaim>,
+    lease_ttl_seconds: u64,
+    overridable: bool,
+}
+
+fn resolve_rule(
+    projection: &PolicyProjection,
+    request: &PolicySpawnRequest,
+    classification: &PolicyClassification,
+) -> ResolvedRule {
+    let mut matches: Vec<&MaterializedPolicyRule> = projection
+        .rules
+        .iter()
+        .filter(|rule| {
+            rule.class_id
+                .as_deref()
+                .map_or(true, |value| value == classification.class_id)
+                && rule.role_id.as_deref().map_or(true, |value| {
+                    classification.role_id.as_deref() == Some(value)
+                })
+                && rule
+                    .vehicle
+                    .as_ref()
+                    .map_or(true, |value| value == &request.requested.vehicle)
+        })
+        .collect();
+    matches.sort_by(|a, b| {
+        a.rank
+            .cmp(&b.rank)
+            .then_with(|| a.clause_id.cmp(&b.clause_id))
+    });
+    let Some(first) = matches.first().copied() else {
+        return ResolvedRule {
+            outcome: PolicyDecisionOutcome::Block,
+            profile: None,
+            clause_ids: vec!["unclassified-request".into()],
+            reason: "no materialized policy clause applies to this frozen request".into(),
+            claims: vec![],
+            lease_ttl_seconds: default_lease_ttl_seconds(),
+            overridable: false,
+        };
+    };
+    let winning: Vec<_> = matches
+        .into_iter()
+        .take_while(|rule| rule.rank == first.rank)
+        .collect();
+    let conflicting = winning.iter().skip(1).any(|rule| {
+        rule.profile != first.profile
+            || rule.outcome != first.outcome
+            || rule.capacity_claims != first.capacity_claims
+    });
+    let clause_ids = winning.iter().map(|rule| rule.clause_id.clone()).collect();
+    if conflicting {
+        return ResolvedRule {
+            outcome: PolicyDecisionOutcome::Block,
+            profile: None,
+            clause_ids,
+            reason: "same-rank materialized policy clauses conflict".into(),
+            claims: vec![],
+            lease_ttl_seconds: first.lease_ttl_seconds,
+            overridable: false,
+        };
+    }
+    let mut outcome = match first.outcome {
+        PolicyRuleOutcome::Allow => PolicyDecisionOutcome::Allow,
+        PolicyRuleOutcome::Rewrite => PolicyDecisionOutcome::Rewrite,
+        PolicyRuleOutcome::Block => PolicyDecisionOutcome::Block,
+    };
+    if matches!(outcome, PolicyDecisionOutcome::Allow)
+        && requested_profile_conflicts(request, &first.profile)
+    {
+        outcome = PolicyDecisionOutcome::Rewrite;
+    }
+    ResolvedRule {
+        outcome,
+        profile: Some(first.profile.clone()),
+        clause_ids,
+        reason: first.reason.clone(),
+        claims: first.capacity_claims.clone(),
+        lease_ttl_seconds: first.lease_ttl_seconds,
+        overridable: first.overridable,
+    }
+}
+
+fn requested_profile_conflicts(
+    request: &PolicySpawnRequest,
+    profile: &PolicyLaunchProfile,
+) -> bool {
+    request.requested.vehicle != profile.vehicle
+        || request.requested.provider != profile.provider
+        || request
+            .requested
+            .model
+            .as_deref()
+            .is_some_and(|model| model != profile.model)
+        || request
+            .requested
+            .effort
+            .as_deref()
+            .is_some_and(|effort| effort != profile.effort)
+}
+
+fn authorize_caller(projection: &PolicyProjection, request: &PolicySpawnRequest) -> Result<()> {
+    if !projection.enabled {
+        return Err(PolicyStoreError::CanaryDenied(
+            "projection is disabled".into(),
+        ));
+    }
+    match &request.caller {
+        PolicyCallerBinding::Seat { .. } => Ok(()),
+        PolicyCallerBinding::IncarnationBootstrap { .. } => projection
+            .bootstrap_authority
+            .as_ref()
+            .filter(|authority| authority.matches(&request.caller))
+            .map(|_| ())
+            .ok_or_else(|| {
+                PolicyStoreError::CanaryDenied(
+                    "bootstrap caller does not match externally configured authority".into(),
+                )
+            }),
+    }
+}
+
+fn ensure_capacity(
+    tx: &Transaction<'_>,
+    projection: &PolicyProjection,
+    claims: &[PolicyCapacityClaim],
+) -> Result<()> {
+    let mut requested = BTreeMap::<(&str, &str), u64>::new();
+    for claim in claims {
+        *requested.entry((&claim.dimension, &claim.key)).or_default() += claim.units;
+    }
+    for ((dimension, key), units) in requested {
+        let maximum = projection
+            .capacity_limits
+            .iter()
+            .find(|limit| limit.dimension == dimension && limit.key == key)
+            .map(|limit| limit.maximum_units)
+            .ok_or_else(|| {
+                PolicyStoreError::CapacityUnavailable(format!("no limit for {dimension}/{key}"))
+            })?;
+        let active: u64 = tx.query_row(r#"SELECT COALESCE(SUM(c.units), 0) FROM policy_capacity_claims c JOIN policy_capacity_leases l ON l.lease_id = c.lease_id WHERE c.dimension = ?1 AND c.claim_key = ?2 AND l.state = 'active'"#, params![dimension, key], |row| row.get(0))?;
+        if active.saturating_add(units) > maximum {
+            return Err(PolicyStoreError::CapacityUnavailable(format!(
+                "{dimension}/{key}: requested {units}, active {active}, maximum {maximum}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn insert_lease(tx: &Transaction<'_>, lease: &PolicyCapacityLease) -> Result<()> {
+    tx.execute("INSERT INTO policy_capacity_leases (lease_id, request_id, state, expires_at, lease_json) VALUES (?1, ?2, 'active', ?3, ?4)", params![lease.lease_id, lease.request_id, lease.expires_at, serde_json::to_string(lease)?])?;
+    for claim in &lease.claims {
+        tx.execute("INSERT INTO policy_capacity_claims (lease_id, dimension, claim_key, units) VALUES (?1, ?2, ?3, ?4)", params![lease.lease_id, claim.dimension, claim.key, claim.units])?;
+    }
+    Ok(())
+}
+
+fn expire_leases(tx: &Transaction<'_>, now: OffsetDateTime) -> Result<()> {
+    tx.execute("UPDATE policy_capacity_leases SET state = 'expired' WHERE state = 'active' AND expires_at <= ?1", [format_time(now)?])?;
+    Ok(())
+}
+
+fn consume_override_tx(tx: &Transaction<'_>, override_id: &str, now: OffsetDateTime) -> Result<()> {
+    let mut record = load_override_tx(tx, override_id)?;
+    if !matches!(record.state, PolicyOverrideState::Authorized) {
+        return Err(PolicyStoreError::OverrideDenied(
+            "override is no longer authorized".into(),
+        ));
+    }
+    record.state = PolicyOverrideState::Consumed;
+    record.consumed_at = Some(format_time(now)?);
+    let changed = tx.execute("UPDATE policy_overrides SET state = 'consumed', override_json = ?2 WHERE override_id = ?1 AND state = 'authorized'", params![override_id, serde_json::to_string(&record)?])?;
+    if changed != 1 {
+        return Err(PolicyStoreError::OverrideDenied(
+            "override was concurrently consumed".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn expire_overrides_tx(tx: &Transaction<'_>, now: OffsetDateTime) -> Result<usize> {
+    let mut statement = tx.prepare(
+        "SELECT override_id, override_json FROM policy_overrides WHERE state = 'authorized'",
+    )?;
+    let records = statement
+        .query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    drop(statement);
+    let mut count = 0;
+    for (id, json) in records {
+        let mut record: PolicyOverrideRecord = serde_json::from_str(&json)?;
+        let expiry = OffsetDateTime::parse(&record.expires_at, &Rfc3339)
+            .map_err(|e| PolicyStoreError::Invalid(format!("invalid override expiry: {e}")))?;
+        if now >= expiry {
+            record.state = PolicyOverrideState::Expired;
+            tx.execute("UPDATE policy_overrides SET state = 'expired', override_json = ?2 WHERE override_id = ?1 AND state = 'authorized'", params![id, serde_json::to_string(&record)?])?;
+            count += 1;
+        }
+    }
+    Ok(count)
+}
+
+fn load_request(conn: &Connection, request_id: &str) -> Result<PolicySpawnRequest> {
+    let value = conn
+        .query_row(
+            "SELECT request_json FROM policy_requests WHERE request_id = ?1",
+            [request_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .ok_or_else(|| PolicyStoreError::RequestNotFound(request_id.into()))?;
+    Ok(serde_json::from_str(&value)?)
+}
+fn load_request_tx(tx: &Transaction<'_>, request_id: &str) -> Result<PolicySpawnRequest> {
+    let value = tx
+        .query_row(
+            "SELECT request_json FROM policy_requests WHERE request_id = ?1",
+            [request_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .ok_or_else(|| PolicyStoreError::RequestNotFound(request_id.into()))?;
+    Ok(serde_json::from_str(&value)?)
+}
+fn load_projection_tx(
+    tx: &Transaction<'_>,
+    lane: &str,
+    version: &str,
+    digest: &str,
+) -> Result<PolicyProjection> {
+    let value = tx.query_row("SELECT projection_json FROM policy_projections WHERE lane = ?1 AND policy_version = ?2 AND policy_digest = ?3", params![lane, version, digest], |row| row.get::<_, String>(0)).optional()?.ok_or_else(|| PolicyStoreError::ProjectionNotFound(lane.into()))?;
+    Ok(serde_json::from_str(&value)?)
+}
+fn load_override_conn(conn: &Connection, override_id: &str) -> Result<PolicyOverrideRecord> {
+    let value = conn
+        .query_row(
+            "SELECT override_json FROM policy_overrides WHERE override_id = ?1",
+            [override_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .ok_or_else(|| PolicyStoreError::OverrideNotFound(override_id.into()))?;
+    Ok(serde_json::from_str(&value)?)
+}
+fn load_override_tx(tx: &Transaction<'_>, override_id: &str) -> Result<PolicyOverrideRecord> {
+    let value = tx
+        .query_row(
+            "SELECT override_json FROM policy_overrides WHERE override_id = ?1",
+            [override_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .ok_or_else(|| PolicyStoreError::OverrideNotFound(override_id.into()))?;
+    Ok(serde_json::from_str(&value)?)
+}
+
+fn load_terminal_decision(
+    tx: &Transaction<'_>,
+    request_id: &str,
+    decision_id: &str,
+) -> Result<PolicyDecision> {
+    let value = tx
+        .query_row(
+            "SELECT decision_json FROM policy_decisions WHERE request_id = ?1 AND decision_id = ?2",
+            params![request_id, decision_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .ok_or_else(|| {
+            PolicyStoreError::OverrideDenied("override points to a missing decision".into())
+        })?;
+    Ok(serde_json::from_str(&value)?)
+}
+fn load_reusable_decision(
+    tx: &Transaction<'_>,
+    request_id: &str,
+    override_id: Option<&str>,
+) -> Result<Option<PolicyDecision>> {
+    let value = match override_id {
+        Some(id) => tx.query_row("SELECT decision_json FROM policy_decisions WHERE request_id = ?1 AND override_id = ?2", params![request_id, id], |row| row.get::<_, String>(0)).optional()?,
+        None => tx.query_row("SELECT decision_json FROM policy_decisions WHERE request_id = ?1 AND override_id IS NULL ORDER BY attempt ASC LIMIT 1", [request_id], |row| row.get::<_, String>(0)).optional()?,
+    };
+    let Some(json) = value else {
+        return Ok(None);
+    };
+    let decision: PolicyDecision = serde_json::from_str(&json)?;
+    if let Some(lease) = &decision.capacity_lease {
+        let active: bool = tx
+            .query_row(
+                "SELECT state = 'active' FROM policy_capacity_leases WHERE lease_id = ?1",
+                [&lease.lease_id],
+                |row| row.get(0),
+            )
+            .optional()?
+            .unwrap_or(false);
+        if !active {
+            return Ok(None);
+        }
+    }
+    Ok(Some(decision))
+}
+fn next_attempt(tx: &Transaction<'_>, request_id: &str) -> Result<u32> {
+    let current: u32 = tx.query_row(
+        "SELECT COALESCE(MAX(attempt), 0) FROM policy_decisions WHERE request_id = ?1",
+        [request_id],
+        |row| row.get(0),
+    )?;
+    Ok(current + 1)
+}
+
+fn required(value: &str, field: &str) -> Result<()> {
+    if value.trim().is_empty() {
+        Err(PolicyStoreError::Invalid(format!("{field} is required")))
+    } else {
+        Ok(())
+    }
+}
+fn optional(value: &Option<String>, field: &str) -> Result<()> {
+    if value
+        .as_deref()
+        .is_some_and(|value| value.trim().is_empty())
+    {
+        Err(PolicyStoreError::Invalid(format!(
+            "{field} cannot be empty"
+        )))
+    } else {
+        Ok(())
+    }
+}
+fn sha256(value: &str, field: &str) -> Result<()> {
+    if value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        Ok(())
+    } else {
+        Err(PolicyStoreError::Invalid(format!(
+            "{field} must be a SHA-256 digest"
+        )))
+    }
+}
+fn now() -> Result<String> {
+    format_time(OffsetDateTime::now_utc())
+}
+fn format_time(value: OffsetDateTime) -> Result<String> {
+    value
+        .format(&Rfc3339)
+        .map_err(|e| PolicyStoreError::Invalid(e.to_string()))
+}
+fn derived_id(prefix: &str, values: &[&str]) -> String {
+    let mut digest = Sha256::new();
+    for value in values {
+        digest.update(value.as_bytes());
+        digest.update([0]);
+    }
+    format!("{prefix}-{:x}", digest.finalize())
+}
+fn default_true() -> bool {
+    true
+}
+fn default_lease_ttl_seconds() -> u64 {
+    300
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy_contracts::{
+        PolicyRequestedLaunch, PolicyVehicle, OVERRIDE_SCHEMA, SPAWN_REQUEST_SCHEMA,
+    };
+
+    const DIGEST: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    fn instant(value: &str) -> OffsetDateTime {
+        OffsetDateTime::parse(value, &Rfc3339).unwrap()
+    }
+
+    fn store(label: &str) -> (PolicyStore, PathBuf) {
+        let path = std::env::temp_dir().join(format!(
+            "sm-policy-store-{label}-{}-{}.sqlite",
+            std::process::id(),
+            OffsetDateTime::now_utc().unix_timestamp_nanos()
+        ));
+        (PolicyStore::new(&path).unwrap(), path)
+    }
+
+    fn bootstrap() -> BootstrapAuthority {
+        BootstrapAuthority {
+            session_id: "maintainer-1".into(),
+            credential_fingerprint: "credential-1".into(),
+            binding_digest: DIGEST.into(),
+        }
+    }
+
+    fn projection(enabled: bool, capacity: u64) -> PolicyProjection {
+        PolicyProjection {
+            lane: "sm-policy-1268".into(),
+            policy_version: "v1".into(),
+            policy_digest: DIGEST.into(),
+            enabled,
+            bootstrap_authority: Some(bootstrap()),
+            capacity_limits: vec![PolicyCapacityLimit {
+                dimension: "concurrency".into(),
+                key: "lane".into(),
+                maximum_units: capacity,
+            }],
+            rules: vec![
+                MaterializedPolicyRule {
+                    clause_id: "sm-policy-1268.named-maintainer".into(),
+                    rank: 10,
+                    class_id: Some("named_orchestrator".into()),
+                    role_id: Some("maintainer".into()),
+                    vehicle: Some(PolicyVehicle::NamedSeat),
+                    profile: PolicyLaunchProfile {
+                        vehicle: PolicyVehicle::NamedSeat,
+                        provider: "claude".into(),
+                        model: "opus".into(),
+                        effort: "high".into(),
+                        context_profile: "standard".into(),
+                    },
+                    outcome: PolicyRuleOutcome::Allow,
+                    overridable: true,
+                    capacity_claims: vec![PolicyCapacityClaim {
+                        dimension: "concurrency".into(),
+                        key: "lane".into(),
+                        units: 1,
+                    }],
+                    lease_ttl_seconds: 300,
+                    reason: "canonical named role".into(),
+                },
+                MaterializedPolicyRule {
+                    clause_id: "sm-policy-1268.routine-worker".into(),
+                    rank: 20,
+                    class_id: Some("routine_bounded".into()),
+                    role_id: None,
+                    vehicle: Some(PolicyVehicle::TaskAgent),
+                    profile: PolicyLaunchProfile {
+                        vehicle: PolicyVehicle::TaskAgent,
+                        provider: "claude".into(),
+                        model: "sonnet".into(),
+                        effort: "high".into(),
+                        context_profile: "standard".into(),
+                    },
+                    outcome: PolicyRuleOutcome::Allow,
+                    overridable: true,
+                    capacity_claims: vec![PolicyCapacityClaim {
+                        dimension: "concurrency".into(),
+                        key: "lane".into(),
+                        units: 1,
+                    }],
+                    lease_ttl_seconds: 300,
+                    reason: "routine canonical profile".into(),
+                },
+            ],
+        }
+    }
+
+    fn request(
+        id: &str,
+        vehicle: PolicyVehicle,
+        model: Option<&str>,
+        intent: &str,
+    ) -> PolicySpawnRequest {
+        PolicySpawnRequest {
+            schema: SPAWN_REQUEST_SCHEMA.into(),
+            request_id: id.into(),
+            caller: PolicyCallerBinding::IncarnationBootstrap {
+                lane: "sm-policy-1268".into(),
+                session_id: "maintainer-1".into(),
+                credential_fingerprint: "credential-1".into(),
+                binding_digest: DIGEST.into(),
+            },
+            prompt_digest: DIGEST.into(),
+            launch_intent_id: intent.into(),
+            policy_version: "v1".into(),
+            policy_digest: DIGEST.into(),
+            requested: PolicyRequestedLaunch {
+                name: id.into(),
+                vehicle,
+                provider: "claude".into(),
+                model: model.map(str::to_owned),
+                effort: None,
+                working_dir: "/tmp/work".into(),
+                node: "local".into(),
+            },
+            topology_version: 1,
+            capacity_version: 1,
+            created_at: "2026-08-17T00:00:00Z".into(),
+        }
+    }
+
+    fn class(class_id: &str, role_id: Option<&str>) -> PolicyClassification {
+        PolicyClassification {
+            class_id: class_id.into(),
+            role_id: role_id.map(str::to_owned),
+            turn_profile: "initial_task".into(),
+            method: "deterministic".into(),
+            confidence: "high".into(),
+        }
+    }
+
+    #[test]
+    fn omitted_models_for_aa6c1120_and_2260296e_resolve_to_explicit_profiles() {
+        let (store, path) = store("omitted-models");
+        store.install_projection(&projection(true, 2)).unwrap();
+        store.set_runtime_versions("sm-policy-1268", 1, 1).unwrap();
+        let aa6c1120 = request("aa6c1120", PolicyVehicle::TaskAgent, None, "intent-aa");
+        let root = request("2260296e", PolicyVehicle::NamedSeat, None, "intent-root");
+        store.create_request(&aa6c1120).unwrap();
+        store.create_request(&root).unwrap();
+        let now = instant("2026-08-17T00:01:00Z");
+        let worker = store
+            .prepare_admission("aa6c1120", &class("routine_bounded", None), None, now)
+            .unwrap()
+            .decision;
+        let named = store
+            .prepare_admission(
+                "2260296e",
+                &class("named_orchestrator", Some("maintainer")),
+                None,
+                now,
+            )
+            .unwrap()
+            .decision;
+        assert_eq!(worker.resolved_profile.unwrap().model, "sonnet");
+        assert_eq!(named.resolved_profile.unwrap().model, "opus");
+        assert!(matches!(worker.outcome, PolicyDecisionOutcome::Allow));
+        assert!(matches!(named.outcome, PolicyDecisionOutcome::Allow));
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn disabled_or_wrong_bootstrap_canary_never_admits() {
+        let (policy_store, path) = store("canary");
+        policy_store
+            .install_projection(&projection(false, 1))
+            .unwrap();
+        policy_store
+            .set_runtime_versions("sm-policy-1268", 1, 1)
+            .unwrap();
+        let disabled_request = request(
+            "disabled",
+            PolicyVehicle::TaskAgent,
+            None,
+            "intent-disabled",
+        );
+        policy_store.create_request(&disabled_request).unwrap();
+        assert!(matches!(
+            policy_store.prepare_admission(
+                "disabled",
+                &class("routine_bounded", None),
+                None,
+                instant("2026-08-17T00:01:00Z")
+            ),
+            Err(PolicyStoreError::CanaryDenied(_))
+        ));
+        let (wrong_store, wrong_path) = store("wrong-bootstrap");
+        wrong_store
+            .install_projection(&projection(true, 1))
+            .unwrap();
+        wrong_store
+            .set_runtime_versions("sm-policy-1268", 1, 1)
+            .unwrap();
+        let mut wrong = request("wrong", PolicyVehicle::TaskAgent, None, "intent-wrong");
+        if let PolicyCallerBinding::IncarnationBootstrap {
+            credential_fingerprint: fingerprint,
+            ..
+        } = &mut wrong.caller
+        {
+            *fingerprint = "wrong-credential".to_owned();
+        }
+        wrong_store.create_request(&wrong).unwrap();
+        assert!(matches!(
+            wrong_store.prepare_admission(
+                "wrong",
+                &class("routine_bounded", None),
+                None,
+                instant("2026-08-17T00:01:00Z")
+            ),
+            Err(PolicyStoreError::CanaryDenied(_))
+        ));
+        std::fs::remove_file(path).ok();
+        std::fs::remove_file(wrong_path).ok();
+    }
+
+    #[test]
+    fn capacity_is_atomic_and_stale_versions_fail_closed() {
+        let (store, path) = store("capacity");
+        store.install_projection(&projection(true, 1)).unwrap();
+        store.set_runtime_versions("sm-policy-1268", 1, 1).unwrap();
+        store
+            .create_request(&request(
+                "first",
+                PolicyVehicle::TaskAgent,
+                None,
+                "intent-first",
+            ))
+            .unwrap();
+        store
+            .create_request(&request(
+                "second",
+                PolicyVehicle::TaskAgent,
+                None,
+                "intent-second",
+            ))
+            .unwrap();
+        let now = instant("2026-08-17T00:01:00Z");
+        store
+            .prepare_admission("first", &class("routine_bounded", None), None, now)
+            .unwrap();
+        assert!(matches!(
+            store.prepare_admission("second", &class("routine_bounded", None), None, now),
+            Err(PolicyStoreError::CapacityUnavailable(_))
+        ));
+        store.set_runtime_versions("sm-policy-1268", 2, 1).unwrap();
+        assert!(matches!(
+            store.prepare_admission("second", &class("routine_bounded", None), None, now),
+            Err(PolicyStoreError::Stale(_))
+        ));
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn exact_override_is_bound_consumed_once_and_persists() {
+        let (store, path) = store("override");
+        store.install_projection(&projection(true, 2)).unwrap();
+        store.set_runtime_versions("sm-policy-1268", 1, 1).unwrap();
+        let request = request(
+            "rewrite-me",
+            PolicyVehicle::NamedSeat,
+            Some("fable"),
+            "intent-rewrite",
+        );
+        store.create_request(&request).unwrap();
+        let now = instant("2026-08-17T00:01:00Z");
+        let rejected = store
+            .prepare_admission(
+                "rewrite-me",
+                &class("named_orchestrator", Some("maintainer")),
+                None,
+                now,
+            )
+            .unwrap()
+            .decision;
+        assert!(matches!(rejected.outcome, PolicyDecisionOutcome::Rewrite));
+        let record = PolicyOverrideRecord {
+            schema: OVERRIDE_SCHEMA.into(),
+            override_id: "override-1".into(),
+            request_id: request.request_id.clone(),
+            request_digest: request.canonical_digest().unwrap(),
+            decision_id: rejected.decision_id.clone(),
+            policy_version: request.policy_version.clone(),
+            issuer: request.caller.clone(),
+            reason: "operator accepts exact model exception".into(),
+            self_benefiting: true,
+            state: PolicyOverrideState::Authorized,
+            created_at: "2026-08-17T00:01:00Z".into(),
+            expires_at: "2026-08-17T00:10:00Z".into(),
+            consumed_at: None,
+        };
+        store.authorize_override(&record, now).unwrap();
+        let allowed = store
+            .prepare_admission(
+                "rewrite-me",
+                &class("named_orchestrator", Some("maintainer")),
+                Some("override-1"),
+                now,
+            )
+            .unwrap();
+        assert!(matches!(
+            allowed.decision.outcome,
+            PolicyDecisionOutcome::Allow
+        ));
+        assert!(!allowed.reused);
+        assert!(matches!(
+            store.override_record("override-1").unwrap().state,
+            PolicyOverrideState::Consumed
+        ));
+        assert!(matches!(
+            store.prepare_admission(
+                "rewrite-me",
+                &class("named_orchestrator", Some("maintainer")),
+                Some("override-1"),
+                now
+            ),
+            Ok(PreparedDecision { reused: true, .. })
+        ));
+        let after_restart = PolicyStore::new(&path).unwrap();
+        assert!(matches!(
+            after_restart.override_record("override-1").unwrap().state,
+            PolicyOverrideState::Consumed
+        ));
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn conflicting_equal_rank_clauses_block_deterministically() {
+        let (store, path) = store("conflict");
+        let mut projection = projection(true, 1);
+        let mut conflict = projection.rules[1].clone();
+        conflict.clause_id = "sm-policy-1268.routine-worker-conflict".into();
+        conflict.profile.model = "opus".into();
+        projection.rules.push(conflict);
+        store.install_projection(&projection).unwrap();
+        store.set_runtime_versions("sm-policy-1268", 1, 1).unwrap();
+        store
+            .create_request(&request(
+                "conflict",
+                PolicyVehicle::TaskAgent,
+                None,
+                "intent-conflict",
+            ))
+            .unwrap();
+        let decision = store
+            .prepare_admission(
+                "conflict",
+                &class("routine_bounded", None),
+                None,
+                instant("2026-08-17T00:01:00Z"),
+            )
+            .unwrap()
+            .decision;
+        assert!(matches!(decision.outcome, PolicyDecisionOutcome::Block));
+        assert_eq!(
+            decision.applicable_clause_ids,
+            vec![
+                "sm-policy-1268.routine-worker".to_string(),
+                "sm-policy-1268.routine-worker-conflict".to_string()
+            ]
+        );
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn competing_reservations_cannot_both_consume_one_slot() {
+        use std::sync::{Arc, Barrier};
+
+        let (store, path) = store("concurrent-capacity");
+        store.install_projection(&projection(true, 1)).unwrap();
+        store.set_runtime_versions("sm-policy-1268", 1, 1).unwrap();
+        store
+            .create_request(&request(
+                "racer-a",
+                PolicyVehicle::TaskAgent,
+                None,
+                "intent-racer-a",
+            ))
+            .unwrap();
+        store
+            .create_request(&request(
+                "racer-b",
+                PolicyVehicle::TaskAgent,
+                None,
+                "intent-racer-b",
+            ))
+            .unwrap();
+        let gate = Arc::new(Barrier::new(3));
+        let mut handles = Vec::new();
+        for request_id in ["racer-a", "racer-b"] {
+            let store = store.clone();
+            let gate = gate.clone();
+            handles.push(std::thread::spawn(move || {
+                gate.wait();
+                store.prepare_admission(
+                    request_id,
+                    &class("routine_bounded", None),
+                    None,
+                    instant("2026-08-17T00:01:00Z"),
+                )
+            }));
+        }
+        gate.wait();
+        let outcomes = handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(outcomes.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(
+            outcomes
+                .iter()
+                .filter(|result| matches!(result, Err(PolicyStoreError::CapacityUnavailable(_))))
+                .count(),
+            1
+        );
+        std::fs::remove_file(path).ok();
+    }
+}

--- a/crates/sm-server/src/policy_store.rs
+++ b/crates/sm-server/src/policy_store.rs
@@ -18,9 +18,11 @@ use crate::policy_contracts::{
 };
 
 const BUSY_TIMEOUT: Duration = Duration::from_secs(2);
+const POLICY_SCHEMA_VERSION: i64 = 1;
 
 #[derive(Debug)]
 pub enum PolicyStoreError {
+    Schema(String),
     Invalid(String),
     RequestNotFound(String),
     OverrideNotFound(String),
@@ -36,6 +38,11 @@ pub enum PolicyStoreError {
 impl fmt::Display for PolicyStoreError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Schema(detail) => write!(
+                f,
+                "policy.db is not the unshipped v1 canary schema ({detail}); archive {} and restart to recreate it. No in-place migration is supported",
+                "the policy.db file"
+            ),
             Self::Invalid(detail) => write!(f, "invalid policy data: {detail}"),
             Self::RequestNotFound(id) => write!(f, "policy request {id} was not found"),
             Self::OverrideNotFound(id) => write!(f, "policy override {id} was not found"),
@@ -322,31 +329,54 @@ impl PolicyStore {
 
     pub fn install_projection(&self, projection: &PolicyProjection) -> Result<()> {
         projection.validate()?;
-        let conn = self.open()?;
+        let mut conn = self.open()?;
         let projection_json = serde_json::to_string(projection)?;
+        let projection_record_digest = canonical_json_digest(projection)?;
         let inserted = conn.execute(
-            "INSERT OR IGNORE INTO policy_projections (lane, policy_version, policy_digest, projection_json, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
-            params![projection.lane, projection.policy_version, projection.policy_digest, projection_json, now()?],
+            "INSERT OR IGNORE INTO policy_projections (lane, policy_version, policy_digest, projection_json, projection_record_digest, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![projection.lane, projection.policy_version, projection.policy_digest, projection_json, projection_record_digest, now()?],
         )?;
         if inserted == 0 {
-            let existing: String = conn.query_row(
-                "SELECT projection_json FROM policy_projections WHERE lane = ?1 AND policy_version = ?2 AND policy_digest = ?3",
-                params![projection.lane, projection.policy_version, projection.policy_digest],
-                |row| row.get(0),
+            let tx = conn.transaction()?;
+            let existing = load_projection_tx(
+                &tx,
+                &projection.lane,
+                &projection.policy_version,
+                &projection.policy_digest,
             )?;
-            if existing != projection_json {
+            if existing != *projection {
                 return Err(PolicyStoreError::Invalid(
-                    "policy version/digest is already bound to different projection bytes".into(),
+                    "policy version/digest is already bound to a different projection".into(),
                 ));
             }
+            tx.commit()?;
         }
         conn.execute(
             "INSERT INTO policy_runtime_versions (lane, topology_version, capacity_version) VALUES (?1, 0, 0) ON CONFLICT(lane) DO NOTHING",
             [&projection.lane],
         )?;
-        if inserted != 0 {
-            conn.execute("INSERT INTO policy_active_projections (lane, policy_version, policy_digest) VALUES (?1, ?2, ?3) ON CONFLICT(lane) DO UPDATE SET policy_version = excluded.policy_version, policy_digest = excluded.policy_digest", params![projection.lane, projection.policy_version, projection.policy_digest])?;
-        }
+        Ok(())
+    }
+
+    /// Changes the active policy only after the immutable projection has been
+    /// installed and validated. Installation itself never grants authority.
+    pub fn activate_projection(
+        &self,
+        lane: &str,
+        policy_version: &str,
+        policy_digest: &str,
+    ) -> Result<()> {
+        required(lane, "projection lane")?;
+        required(policy_version, "projection policy_version")?;
+        sha256(policy_digest, "projection policy_digest")?;
+        let mut conn = self.open()?;
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        load_projection_tx(&tx, lane, policy_version, policy_digest)?;
+        tx.execute(
+            "INSERT INTO policy_active_projections (lane, policy_version, policy_digest) VALUES (?1, ?2, ?3) ON CONFLICT(lane) DO UPDATE SET policy_version = excluded.policy_version, policy_digest = excluded.policy_digest",
+            params![lane, policy_version, policy_digest],
+        )?;
+        tx.commit()?;
         Ok(())
     }
 
@@ -378,23 +408,21 @@ impl PolicyStore {
         let digest = request
             .canonical_digest()
             .map_err(|error| PolicyStoreError::Invalid(error.to_string()))?;
-        let conn = self.open()?;
+        let mut conn = self.open()?;
         let json = serde_json::to_string(request)?;
         let inserted = conn.execute(
             "INSERT OR IGNORE INTO policy_requests (request_id, lane, request_digest, request_json, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
             params![request.request_id, request.caller.lane(), digest, json, request.created_at],
         )?;
         if inserted == 0 {
-            let existing: String = conn.query_row(
-                "SELECT request_digest FROM policy_requests WHERE request_id = ?1",
-                [&request.request_id],
-                |row| row.get(0),
-            )?;
-            if existing != digest {
+            let tx = conn.transaction()?;
+            let existing = load_request_tx(&tx, &request.request_id)?;
+            if existing != *request {
                 return Err(PolicyStoreError::Invalid(
                     "request ID is already bound to different immutable input".into(),
                 ));
             }
+            tx.commit()?;
         }
         Ok(())
     }
@@ -469,7 +497,7 @@ impl PolicyStore {
         let mut effective_classification = classification.clone();
         if let Some(override_id) = override_id {
             let override_record = load_override_tx(&tx, override_id)?;
-            let terminal = load_terminal_decision(&tx, request_id, &override_record.decision_id)?;
+            let terminal = load_terminal_decision(&tx, &request, &override_record.decision_id)?;
             override_record
                 .validate_for_consumption(&request, &terminal, now)
                 .map_err(|error| PolicyStoreError::OverrideDenied(error.to_string()))?;
@@ -483,7 +511,7 @@ impl PolicyStore {
         let mut override_used = None;
         if let Some(override_id) = override_id {
             let override_record = load_override_tx(&tx, override_id)?;
-            let terminal = load_terminal_decision(&tx, request_id, &override_record.decision_id)?;
+            let terminal = load_terminal_decision(&tx, &request, &override_record.decision_id)?;
             override_record
                 .validate_for_consumption(&request, &terminal, now)
                 .map_err(|error| PolicyStoreError::OverrideDenied(error.to_string()))?;
@@ -561,7 +589,7 @@ impl PolicyStore {
             .validate_for_request(&request)
             .map_err(|e| PolicyStoreError::Invalid(e.to_string()))?;
         let decision_json = serde_json::to_string(&decision)?;
-        tx.execute("INSERT INTO policy_decisions (decision_id, request_id, attempt, override_id, decision_json, decision_digest, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)", params![decision.decision_id, request_id, attempt, override_used, decision_json, text_digest(&serde_json::to_string(&decision)?), decision.decided_at])?;
+        tx.execute("INSERT INTO policy_decisions (decision_id, request_id, attempt, override_id, decision_json, decision_digest, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)", params![decision.decision_id, request_id, attempt, override_used, decision_json, canonical_json_digest(&decision)?, decision.decided_at])?;
         if let Some(override_id) = override_used {
             consume_override_tx(&tx, override_id, now)?;
         }
@@ -654,8 +682,8 @@ impl PolicyStore {
         let mut conn = self.open()?;
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
         let released_at = now()?;
-        tx.execute("UPDATE policy_capacity_leases SET state = 'released', released_at = ?2 WHERE lease_id = ?1 AND state = 'active'", params![lease_id, released_at])?;
-        tx.execute("UPDATE policy_provisional_children SET state = 'released', released_at = ?2 WHERE lease_id = ?1 AND state = 'reserved'", params![lease_id, now()?])?;
+        tx.execute("UPDATE policy_capacity_leases SET state = 'released', released_at = ?2 WHERE lease_id = ?1 AND state IN ('active', 'committed')", params![lease_id, released_at])?;
+        tx.execute("UPDATE policy_provisional_children SET state = 'released', released_at = ?2 WHERE lease_id = ?1 AND state IN ('reserved', 'launched')", params![lease_id, now()?])?;
         tx.commit()?;
         Ok(())
     }
@@ -675,8 +703,36 @@ impl PolicyStore {
             .optional()?;
         if let Some(lease_id) = lease_id {
             let released_at = now()?;
-            tx.execute("UPDATE policy_capacity_leases SET state = 'released', released_at = ?2 WHERE lease_id = ?1 AND state = 'active'", params![lease_id, released_at])?;
-            tx.execute("UPDATE policy_provisional_children SET state = 'released', released_at = ?2 WHERE child_session_id = ?1 AND state = 'reserved'", params![child_session_id, now()?])?;
+            tx.execute("UPDATE policy_capacity_leases SET state = 'released', released_at = ?2 WHERE lease_id = ?1 AND state IN ('active', 'committed')", params![lease_id, released_at])?;
+            tx.execute("UPDATE policy_provisional_children SET state = 'released', released_at = ?2 WHERE child_session_id = ?1 AND state IN ('reserved', 'launched')", params![child_session_id, now()?])?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// D3 promotes a persisted same-store provisional child after its core
+    /// runtime is materialized and attested. Committed leases never expire by
+    /// reservation TTL and remain capacity-counted until release_by_child.
+    pub fn mark_child_launched(&self, child_session_id: &str) -> Result<()> {
+        required(child_session_id, "provisional child session ID")?;
+        let mut conn = self.open()?;
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let lease_id = tx
+            .query_row(
+                "SELECT lease_id FROM policy_provisional_children WHERE child_session_id = ?1 AND state = 'reserved'",
+                [child_session_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        if let Some(lease_id) = lease_id {
+            tx.execute(
+                "UPDATE policy_capacity_leases SET state = 'committed' WHERE lease_id = ?1 AND state = 'active'",
+                [&lease_id],
+            )?;
+            tx.execute(
+                "UPDATE policy_provisional_children SET state = 'launched' WHERE child_session_id = ?1 AND state = 'reserved'",
+                [child_session_id],
+            )?;
         }
         tx.commit()?;
         Ok(())
@@ -699,33 +755,164 @@ impl PolicyStore {
             std::fs::create_dir_all(parent)
                 .map_err(|e| PolicyStoreError::Invalid(e.to_string()))?;
         }
-        let conn = Connection::open(&self.db_path)?;
-        conn.busy_timeout(BUSY_TIMEOUT)?;
-        conn.pragma_update(None, "journal_mode", "WAL")?;
-        conn.execute_batch(r#"
-            CREATE TABLE IF NOT EXISTS policy_projections (lane TEXT NOT NULL, policy_version TEXT NOT NULL, policy_digest TEXT NOT NULL, projection_json TEXT NOT NULL, created_at TEXT NOT NULL, PRIMARY KEY (lane, policy_version, policy_digest));
-            CREATE TABLE IF NOT EXISTS policy_active_projections (lane TEXT PRIMARY KEY, policy_version TEXT NOT NULL, policy_digest TEXT NOT NULL);
-            CREATE TABLE IF NOT EXISTS policy_runtime_versions (lane TEXT PRIMARY KEY, topology_version INTEGER NOT NULL, capacity_version INTEGER NOT NULL);
-            CREATE TABLE IF NOT EXISTS policy_requests (request_id TEXT PRIMARY KEY, lane TEXT NOT NULL, request_digest TEXT NOT NULL, request_json TEXT NOT NULL, created_at TEXT NOT NULL);
-            CREATE TABLE IF NOT EXISTS policy_decisions (decision_id TEXT PRIMARY KEY, request_id TEXT NOT NULL, attempt INTEGER NOT NULL, override_id TEXT, decision_json TEXT NOT NULL, decision_digest TEXT NOT NULL, created_at TEXT NOT NULL, UNIQUE(request_id, attempt), UNIQUE(request_id, override_id));
-            CREATE TABLE IF NOT EXISTS policy_capacity_leases (lease_id TEXT PRIMARY KEY, request_id TEXT NOT NULL, provisional_child_session_id TEXT NOT NULL, state TEXT NOT NULL, expires_at TEXT NOT NULL, released_at TEXT, lease_json TEXT NOT NULL);
-            CREATE TABLE IF NOT EXISTS policy_capacity_claims (lease_id TEXT NOT NULL, dimension TEXT NOT NULL, claim_key TEXT NOT NULL, units INTEGER NOT NULL, PRIMARY KEY (lease_id, dimension, claim_key));
-            CREATE TABLE IF NOT EXISTS policy_provisional_children (child_session_id TEXT PRIMARY KEY, lease_id TEXT NOT NULL UNIQUE, request_id TEXT NOT NULL, decision_id TEXT NOT NULL, state TEXT NOT NULL, created_at TEXT NOT NULL, released_at TEXT);
-            CREATE TABLE IF NOT EXISTS policy_overrides (override_id TEXT PRIMARY KEY, request_id TEXT NOT NULL, decision_id TEXT NOT NULL, state TEXT NOT NULL, override_json TEXT NOT NULL, created_at TEXT NOT NULL);
-            CREATE INDEX IF NOT EXISTS idx_policy_active_claims ON policy_capacity_claims(dimension, claim_key);
-            CREATE INDEX IF NOT EXISTS idx_policy_leases_active ON policy_capacity_leases(state, expires_at);
-        "#)?;
-        ensure_column(
-            &conn,
-            "policy_capacity_leases",
-            "provisional_child_session_id",
-            "TEXT",
-        )?;
-        ensure_column(&conn, "policy_decisions", "decision_digest", "TEXT")?;
-        conn.execute_batch("CREATE UNIQUE INDEX IF NOT EXISTS idx_policy_active_lease_child ON policy_capacity_leases(provisional_child_session_id) WHERE state = 'active';")?;
+        let is_new = !self.db_path.exists();
+        let conn = Connection::open(&self.db_path).map_err(|error| self.schema_error(error))?;
+        conn.busy_timeout(BUSY_TIMEOUT)
+            .map_err(|error| self.schema_error(error))?;
+        conn.pragma_update(None, "journal_mode", "WAL")
+            .map_err(|error| self.schema_error(error))?;
+        if is_new {
+            conn.execute_batch(POLICY_SCHEMA_V1)
+                .map_err(|error| self.schema_error(error))?;
+            conn.pragma_update(None, "user_version", POLICY_SCHEMA_VERSION)
+                .map_err(|error| self.schema_error(error))?;
+        }
+        verify_schema_v1(&conn).map_err(|detail| self.schema_error(detail))?;
         Ok(conn)
     }
+
+    fn schema_error(&self, error: impl fmt::Display) -> PolicyStoreError {
+        PolicyStoreError::Schema(format!("{} at {}", error, self.db_path.display()))
+    }
 }
+
+const POLICY_SCHEMA_V1: &str = r#"
+    CREATE TABLE policy_projections (lane TEXT NOT NULL, policy_version TEXT NOT NULL, policy_digest TEXT NOT NULL, projection_json TEXT NOT NULL, projection_record_digest TEXT NOT NULL, created_at TEXT NOT NULL, PRIMARY KEY (lane, policy_version, policy_digest));
+    CREATE TABLE policy_active_projections (lane TEXT PRIMARY KEY, policy_version TEXT NOT NULL, policy_digest TEXT NOT NULL);
+    CREATE TABLE policy_runtime_versions (lane TEXT PRIMARY KEY, topology_version INTEGER NOT NULL, capacity_version INTEGER NOT NULL);
+    CREATE TABLE policy_requests (request_id TEXT PRIMARY KEY, lane TEXT NOT NULL, request_digest TEXT NOT NULL, request_json TEXT NOT NULL, created_at TEXT NOT NULL);
+    CREATE TABLE policy_decisions (decision_id TEXT PRIMARY KEY, request_id TEXT NOT NULL, attempt INTEGER NOT NULL, override_id TEXT, decision_json TEXT NOT NULL, decision_digest TEXT NOT NULL, created_at TEXT NOT NULL, UNIQUE(request_id, attempt), UNIQUE(request_id, override_id));
+    CREATE TABLE policy_capacity_leases (lease_id TEXT PRIMARY KEY, request_id TEXT NOT NULL, topology_version INTEGER NOT NULL, capacity_version INTEGER NOT NULL, provisional_child_session_id TEXT NOT NULL, state TEXT NOT NULL, expires_at TEXT NOT NULL, released_at TEXT, lease_json TEXT NOT NULL, lease_digest TEXT NOT NULL);
+    CREATE TABLE policy_capacity_claims (lease_id TEXT NOT NULL, dimension TEXT NOT NULL, claim_key TEXT NOT NULL, units INTEGER NOT NULL, PRIMARY KEY (lease_id, dimension, claim_key));
+    CREATE TABLE policy_provisional_children (child_session_id TEXT PRIMARY KEY, lease_id TEXT NOT NULL UNIQUE, request_id TEXT NOT NULL, decision_id TEXT NOT NULL, state TEXT NOT NULL, created_at TEXT NOT NULL, released_at TEXT);
+    CREATE TABLE policy_overrides (override_id TEXT PRIMARY KEY, request_id TEXT NOT NULL, request_digest TEXT NOT NULL, decision_id TEXT NOT NULL, policy_version TEXT NOT NULL, state TEXT NOT NULL, override_json TEXT NOT NULL, override_digest TEXT NOT NULL, created_at TEXT NOT NULL, expires_at TEXT NOT NULL, consumed_at TEXT);
+    CREATE INDEX idx_policy_active_claims ON policy_capacity_claims(dimension, claim_key);
+    CREATE INDEX idx_policy_leases_active ON policy_capacity_leases(state, expires_at);
+    CREATE UNIQUE INDEX idx_policy_active_lease_child ON policy_capacity_leases(provisional_child_session_id) WHERE state = 'active';
+"#;
+
+fn verify_schema_v1(conn: &Connection) -> std::result::Result<(), String> {
+    let version: i64 = conn
+        .pragma_query_value(None, "user_version", |row| row.get(0))
+        .map_err(|error| format!("cannot read PRAGMA user_version: {error}"))?;
+    if version != POLICY_SCHEMA_VERSION {
+        return Err(format!(
+            "expected PRAGMA user_version={POLICY_SCHEMA_VERSION}, found {version}"
+        ));
+    }
+    let integrity: String = conn
+        .query_row("PRAGMA integrity_check", [], |row| row.get(0))
+        .map_err(|error| format!("integrity check failed: {error}"))?;
+    if integrity != "ok" {
+        return Err(format!("integrity check failed: {integrity}"));
+    }
+    for (table, columns) in POLICY_SCHEMA_TABLES {
+        let actual = conn
+            .prepare(&format!("PRAGMA table_info({table})"))
+            .map_err(|error| format!("cannot inspect {table}: {error}"))?
+            .query_map([], |row| row.get::<_, String>(1))
+            .map_err(|error| format!("cannot read {table} columns: {error}"))?
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|error| format!("cannot read {table} columns: {error}"))?;
+        if actual != *columns {
+            return Err(format!(
+                "v1 table {table} is missing or has different columns"
+            ));
+        }
+    }
+    Ok(())
+}
+
+const POLICY_SCHEMA_TABLES: &[(&str, &[&str])] = &[
+    (
+        "policy_projections",
+        &[
+            "lane",
+            "policy_version",
+            "policy_digest",
+            "projection_json",
+            "projection_record_digest",
+            "created_at",
+        ],
+    ),
+    (
+        "policy_active_projections",
+        &["lane", "policy_version", "policy_digest"],
+    ),
+    (
+        "policy_runtime_versions",
+        &["lane", "topology_version", "capacity_version"],
+    ),
+    (
+        "policy_requests",
+        &[
+            "request_id",
+            "lane",
+            "request_digest",
+            "request_json",
+            "created_at",
+        ],
+    ),
+    (
+        "policy_decisions",
+        &[
+            "decision_id",
+            "request_id",
+            "attempt",
+            "override_id",
+            "decision_json",
+            "decision_digest",
+            "created_at",
+        ],
+    ),
+    (
+        "policy_capacity_leases",
+        &[
+            "lease_id",
+            "request_id",
+            "topology_version",
+            "capacity_version",
+            "provisional_child_session_id",
+            "state",
+            "expires_at",
+            "released_at",
+            "lease_json",
+            "lease_digest",
+        ],
+    ),
+    (
+        "policy_capacity_claims",
+        &["lease_id", "dimension", "claim_key", "units"],
+    ),
+    (
+        "policy_provisional_children",
+        &[
+            "child_session_id",
+            "lease_id",
+            "request_id",
+            "decision_id",
+            "state",
+            "created_at",
+            "released_at",
+        ],
+    ),
+    (
+        "policy_overrides",
+        &[
+            "override_id",
+            "request_id",
+            "request_digest",
+            "decision_id",
+            "policy_version",
+            "state",
+            "override_json",
+            "override_digest",
+            "created_at",
+            "expires_at",
+            "consumed_at",
+        ],
+    ),
+];
 
 #[derive(Debug)]
 struct ResolvedRule {
@@ -875,7 +1062,7 @@ fn ensure_capacity(
             .ok_or_else(|| {
                 PolicyStoreError::CapacityUnavailable(format!("no limit for {dimension}/{key}"))
             })?;
-        let active: u64 = tx.query_row(r#"SELECT COALESCE(SUM(c.units), 0) FROM policy_capacity_claims c JOIN policy_capacity_leases l ON l.lease_id = c.lease_id WHERE c.dimension = ?1 AND c.claim_key = ?2 AND l.state = 'active'"#, params![dimension, key], |row| row.get(0))?;
+        let active: u64 = tx.query_row(r#"SELECT COALESCE(SUM(c.units), 0) FROM policy_capacity_claims c JOIN policy_capacity_leases l ON l.lease_id = c.lease_id WHERE c.dimension = ?1 AND c.claim_key = ?2 AND l.state IN ('active', 'committed')"#, params![dimension, key], |row| row.get(0))?;
         if active.saturating_add(units) > maximum {
             return Err(PolicyStoreError::CapacityUnavailable(format!(
                 "{dimension}/{key}: requested {units}, active {active}, maximum {maximum}"
@@ -891,7 +1078,7 @@ fn insert_lease(
     decision_id: &str,
     provisional_child_session_id: &str,
 ) -> Result<()> {
-    tx.execute("INSERT INTO policy_capacity_leases (lease_id, request_id, provisional_child_session_id, state, expires_at, lease_json) VALUES (?1, ?2, ?3, 'active', ?4, ?5)", params![lease.lease_id, lease.request_id, provisional_child_session_id, lease.expires_at, serde_json::to_string(lease)?])?;
+    tx.execute("INSERT INTO policy_capacity_leases (lease_id, request_id, topology_version, capacity_version, provisional_child_session_id, state, expires_at, lease_json, lease_digest) VALUES (?1, ?2, ?3, ?4, ?5, 'active', ?6, ?7, ?8)", params![lease.lease_id, lease.request_id, lease.topology_version, lease.capacity_version, provisional_child_session_id, lease.expires_at, serde_json::to_string(lease)?, canonical_json_digest(lease)?])?;
     tx.execute("INSERT INTO policy_provisional_children (child_session_id, lease_id, request_id, decision_id, state, created_at) VALUES (?1, ?2, ?3, ?4, 'reserved', ?5)", params![provisional_child_session_id, lease.lease_id, lease.request_id, decision_id, now()?])?;
     for claim in &lease.claims {
         tx.execute("INSERT INTO policy_capacity_claims (lease_id, dimension, claim_key, units) VALUES (?1, ?2, ?3, ?4)", params![lease.lease_id, claim.dimension, claim.key, claim.units])?;
@@ -914,7 +1101,7 @@ fn consume_override_tx(tx: &Transaction<'_>, override_id: &str, now: OffsetDateT
     }
     record.state = PolicyOverrideState::Consumed;
     record.consumed_at = Some(format_time(now)?);
-    let changed = tx.execute("UPDATE policy_overrides SET state = 'consumed', override_json = ?2 WHERE override_id = ?1 AND state = 'authorized'", params![override_id, serde_json::to_string(&record)?])?;
+    let changed = tx.execute("UPDATE policy_overrides SET state = 'consumed', override_json = ?2, override_digest = ?3, consumed_at = ?4 WHERE override_id = ?1 AND state = 'authorized'", params![override_id, serde_json::to_string(&record)?, canonical_json_digest(&record)?, record.consumed_at])?;
     if changed != 1 {
         return Err(PolicyStoreError::OverrideDenied(
             "override was concurrently consumed".into(),
@@ -924,23 +1111,20 @@ fn consume_override_tx(tx: &Transaction<'_>, override_id: &str, now: OffsetDateT
 }
 
 fn expire_overrides_tx(tx: &Transaction<'_>, now: OffsetDateTime) -> Result<usize> {
-    let mut statement = tx.prepare(
-        "SELECT override_id, override_json FROM policy_overrides WHERE state = 'authorized'",
-    )?;
+    let mut statement =
+        tx.prepare("SELECT override_id FROM policy_overrides WHERE state = 'authorized'")?;
     let records = statement
-        .query_map([], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))
-        })?
+        .query_map([], |row| row.get::<_, String>(0))?
         .collect::<std::result::Result<Vec<_>, _>>()?;
     drop(statement);
     let mut count = 0;
-    for (id, json) in records {
-        let mut record: PolicyOverrideRecord = serde_json::from_str(&json)?;
+    for id in records {
+        let mut record = load_override_tx(tx, &id)?;
         let expiry = OffsetDateTime::parse(&record.expires_at, &Rfc3339)
             .map_err(|e| PolicyStoreError::Invalid(format!("invalid override expiry: {e}")))?;
         if now >= expiry {
             record.state = PolicyOverrideState::Expired;
-            tx.execute("UPDATE policy_overrides SET state = 'expired', override_json = ?2 WHERE override_id = ?1 AND state = 'authorized'", params![id, serde_json::to_string(&record)?])?;
+            tx.execute("UPDATE policy_overrides SET state = 'expired', override_json = ?2, override_digest = ?3 WHERE override_id = ?1 AND state = 'authorized'", params![id, serde_json::to_string(&record)?, canonical_json_digest(&record)?])?;
             count += 1;
         }
     }
@@ -948,26 +1132,26 @@ fn expire_overrides_tx(tx: &Transaction<'_>, now: OffsetDateTime) -> Result<usiz
 }
 
 fn load_request(conn: &Connection, request_id: &str) -> Result<PolicySpawnRequest> {
-    let (digest, value): (String, String) = conn
+    let (lane, digest, value, created_at): (String, String, String, String) = conn
         .query_row(
-            "SELECT request_digest, request_json FROM policy_requests WHERE request_id = ?1",
+            "SELECT lane, request_digest, request_json, created_at FROM policy_requests WHERE request_id = ?1",
             [request_id],
-            |row| Ok((row.get(0)?, row.get(1)?)),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
         )
         .optional()?
         .ok_or_else(|| PolicyStoreError::RequestNotFound(request_id.into()))?;
-    parse_stored_request(request_id, &digest, &value)
+    parse_stored_request(request_id, &lane, &digest, &value, &created_at)
 }
 fn load_request_tx(tx: &Transaction<'_>, request_id: &str) -> Result<PolicySpawnRequest> {
-    let (digest, value): (String, String) = tx
+    let (lane, digest, value, created_at): (String, String, String, String) = tx
         .query_row(
-            "SELECT request_digest, request_json FROM policy_requests WHERE request_id = ?1",
+            "SELECT lane, request_digest, request_json, created_at FROM policy_requests WHERE request_id = ?1",
             [request_id],
-            |row| Ok((row.get(0)?, row.get(1)?)),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
         )
         .optional()?
         .ok_or_else(|| PolicyStoreError::RequestNotFound(request_id.into()))?;
-    parse_stored_request(request_id, &digest, &value)
+    parse_stored_request(request_id, &lane, &digest, &value, &created_at)
 }
 fn load_projection_tx(
     tx: &Transaction<'_>,
@@ -975,12 +1159,13 @@ fn load_projection_tx(
     version: &str,
     digest: &str,
 ) -> Result<PolicyProjection> {
-    let value = tx.query_row("SELECT projection_json FROM policy_projections WHERE lane = ?1 AND policy_version = ?2 AND policy_digest = ?3", params![lane, version, digest], |row| row.get::<_, String>(0)).optional()?.ok_or_else(|| PolicyStoreError::ProjectionNotFound(lane.into()))?;
+    let (stored_lane, stored_version, stored_digest, value, record_digest): (String, String, String, String, String) = tx.query_row("SELECT lane, policy_version, policy_digest, projection_json, projection_record_digest FROM policy_projections WHERE lane = ?1 AND policy_version = ?2 AND policy_digest = ?3", params![lane, version, digest], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?))).optional()?.ok_or_else(|| PolicyStoreError::ProjectionNotFound(lane.into()))?;
     let projection: PolicyProjection = serde_json::from_str(&value)?;
     projection.validate()?;
-    if projection.lane != lane
-        || projection.policy_version != version
-        || projection.policy_digest != digest
+    if canonical_json_digest(&projection)? != record_digest
+        || projection.lane != stored_lane
+        || projection.policy_version != stored_version
+        || projection.policy_digest != stored_digest
     {
         return Err(PolicyStoreError::Invalid(
             "stored projection does not match its immutable lookup key".into(),
@@ -989,12 +1174,20 @@ fn load_projection_tx(
     Ok(projection)
 }
 
-fn parse_stored_request(request_id: &str, digest: &str, value: &str) -> Result<PolicySpawnRequest> {
+fn parse_stored_request(
+    request_id: &str,
+    lane: &str,
+    digest: &str,
+    value: &str,
+    created_at: &str,
+) -> Result<PolicySpawnRequest> {
     let request: PolicySpawnRequest = serde_json::from_str(value)?;
     request
         .validate()
         .map_err(|error| PolicyStoreError::Invalid(error.to_string()))?;
     if request.request_id != request_id
+        || request.caller.lane() != lane
+        || request.created_at != created_at
         || request
             .canonical_digest()
             .map_err(|error| PolicyStoreError::Invalid(error.to_string()))?
@@ -1007,68 +1200,226 @@ fn parse_stored_request(request_id: &str, digest: &str, value: &str) -> Result<P
     Ok(request)
 }
 fn load_override_conn(conn: &Connection, override_id: &str) -> Result<PolicyOverrideRecord> {
-    let value = conn
+    let (request_id, request_digest, decision_id, policy_version, state, value, digest, created_at, expires_at, consumed_at): (String, String, String, String, String, String, String, String, String, Option<String>) = conn
         .query_row(
-            "SELECT override_json FROM policy_overrides WHERE override_id = ?1",
+            "SELECT request_id, request_digest, decision_id, policy_version, state, override_json, override_digest, created_at, expires_at, consumed_at FROM policy_overrides WHERE override_id = ?1",
             [override_id],
-            |row| row.get::<_, String>(0),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?, row.get(5)?, row.get(6)?, row.get(7)?, row.get(8)?, row.get(9)?)),
         )
         .optional()?
         .ok_or_else(|| PolicyStoreError::OverrideNotFound(override_id.into()))?;
-    Ok(serde_json::from_str(&value)?)
+    parse_stored_override(
+        override_id,
+        &request_id,
+        &request_digest,
+        &decision_id,
+        &policy_version,
+        &state,
+        &value,
+        &digest,
+        &created_at,
+        &expires_at,
+        consumed_at.as_deref(),
+    )
 }
 fn load_override_tx(tx: &Transaction<'_>, override_id: &str) -> Result<PolicyOverrideRecord> {
-    let value = tx
+    let (request_id, request_digest, decision_id, policy_version, state, value, digest, created_at, expires_at, consumed_at): (String, String, String, String, String, String, String, String, String, Option<String>) = tx
         .query_row(
-            "SELECT override_json FROM policy_overrides WHERE override_id = ?1",
+            "SELECT request_id, request_digest, decision_id, policy_version, state, override_json, override_digest, created_at, expires_at, consumed_at FROM policy_overrides WHERE override_id = ?1",
             [override_id],
-            |row| row.get::<_, String>(0),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?, row.get(5)?, row.get(6)?, row.get(7)?, row.get(8)?, row.get(9)?)),
         )
         .optional()?
         .ok_or_else(|| PolicyStoreError::OverrideNotFound(override_id.into()))?;
-    Ok(serde_json::from_str(&value)?)
+    parse_stored_override(
+        override_id,
+        &request_id,
+        &request_digest,
+        &decision_id,
+        &policy_version,
+        &state,
+        &value,
+        &digest,
+        &created_at,
+        &expires_at,
+        consumed_at.as_deref(),
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn parse_stored_override(
+    override_id: &str,
+    request_id: &str,
+    request_digest: &str,
+    decision_id: &str,
+    policy_version: &str,
+    state: &str,
+    value: &str,
+    digest: &str,
+    created_at: &str,
+    expires_at: &str,
+    consumed_at: Option<&str>,
+) -> Result<PolicyOverrideRecord> {
+    let record: PolicyOverrideRecord = serde_json::from_str(value)?;
+    record
+        .validate()
+        .map_err(|error| PolicyStoreError::Invalid(error.to_string()))?;
+    if canonical_json_digest(&record)? != digest
+        || record.override_id != override_id
+        || record.request_id != request_id
+        || record.request_digest != request_digest
+        || record.decision_id != decision_id
+        || record.policy_version != policy_version
+        || override_state_name(&record.state) != state
+        || record.created_at != created_at
+        || record.expires_at != expires_at
+        || record.consumed_at.as_deref() != consumed_at
+    {
+        return Err(PolicyStoreError::Invalid(
+            "stored override does not match authoritative row columns".into(),
+        ));
+    }
+    Ok(record)
 }
 
 fn load_terminal_decision(
     tx: &Transaction<'_>,
-    request_id: &str,
+    request: &PolicySpawnRequest,
     decision_id: &str,
 ) -> Result<PolicyDecision> {
-    let (stored_decision_id, digest, value): (String, String, String) = tx
+    let (stored_decision_id, stored_request_id, attempt, override_id, digest, value, created_at): (String, String, u32, Option<String>, String, String, String) = tx
         .query_row(
-            "SELECT decision_id, decision_digest, decision_json FROM policy_decisions WHERE request_id = ?1 AND decision_id = ?2",
-            params![request_id, decision_id],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            "SELECT decision_id, request_id, attempt, override_id, decision_digest, decision_json, created_at FROM policy_decisions WHERE request_id = ?1 AND decision_id = ?2",
+            params![request.request_id, decision_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?, row.get(5)?, row.get(6)?)),
         )
         .optional()?
         .ok_or_else(|| {
             PolicyStoreError::OverrideDenied("override points to a missing decision".into())
         })?;
-    if stored_decision_id != decision_id || text_digest(&value) != digest {
-        return Err(PolicyStoreError::Invalid(
-            "stored terminal decision digest does not match".into(),
-        ));
-    }
-    Ok(serde_json::from_str(&value)?)
+    parse_stored_decision(
+        tx,
+        request,
+        &stored_decision_id,
+        &stored_request_id,
+        attempt,
+        override_id.as_deref(),
+        &digest,
+        &value,
+        &created_at,
+    )
 }
 
 fn load_latest_terminal_decision(
     tx: &Transaction<'_>,
     request: &PolicySpawnRequest,
 ) -> Result<PolicyDecision> {
-    let value = tx
+    let (decision_id, request_id, attempt, override_id, digest, value, created_at): (String, String, u32, Option<String>, String, String, String) = tx
         .query_row(
-            "SELECT decision_json FROM policy_decisions WHERE request_id = ?1 ORDER BY attempt DESC LIMIT 1",
+            "SELECT decision_id, request_id, attempt, override_id, decision_digest, decision_json, created_at FROM policy_decisions WHERE request_id = ?1 ORDER BY attempt DESC LIMIT 1",
             [&request.request_id],
-            |row| row.get::<_, String>(0),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?, row.get(5)?, row.get(6)?)),
         )
         .optional()?
         .ok_or_else(|| PolicyStoreError::OverrideDenied("request has no terminal decision".into()))?;
-    let decision: PolicyDecision = serde_json::from_str(&value)?;
+    parse_stored_decision(
+        tx,
+        request,
+        &decision_id,
+        &request_id,
+        attempt,
+        override_id.as_deref(),
+        &digest,
+        &value,
+        &created_at,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn parse_stored_decision(
+    tx: &Transaction<'_>,
+    request: &PolicySpawnRequest,
+    decision_id: &str,
+    request_id: &str,
+    attempt: u32,
+    _override_id: Option<&str>,
+    digest: &str,
+    value: &str,
+    created_at: &str,
+) -> Result<PolicyDecision> {
+    let decision: PolicyDecision = serde_json::from_str(value)?;
     decision
         .validate_for_request(request)
         .map_err(|error| PolicyStoreError::Invalid(error.to_string()))?;
+    if canonical_json_digest(&decision)? != digest
+        || decision.decision_id != decision_id
+        || decision.request_id != request_id
+        || decision.attempt != attempt
+        || decision.decided_at != created_at
+    {
+        return Err(PolicyStoreError::Invalid(
+            "stored decision does not match authoritative row columns".into(),
+        ));
+    }
+    if let Some(embedded_lease) = &decision.capacity_lease {
+        let stored_lease = load_lease_tx(tx, &embedded_lease.lease_id)?;
+        if stored_lease != *embedded_lease {
+            return Err(PolicyStoreError::Invalid(
+                "decision capacity lease does not match authoritative lease row".into(),
+            ));
+        }
+    }
     Ok(decision)
+}
+
+fn load_lease_tx(tx: &Transaction<'_>, lease_id: &str) -> Result<PolicyCapacityLease> {
+    let (request_id, topology_version, capacity_version, state, expires_at, value, digest): (String, u64, u64, String, String, String, String) = tx
+        .query_row(
+            "SELECT request_id, topology_version, capacity_version, state, expires_at, lease_json, lease_digest FROM policy_capacity_leases WHERE lease_id = ?1",
+            [lease_id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?, row.get(5)?, row.get(6)?)),
+        )
+        .optional()?
+        .ok_or_else(|| PolicyStoreError::Invalid("decision points to a missing capacity lease".into()))?;
+    let lease: PolicyCapacityLease = serde_json::from_str(&value)?;
+    lease
+        .validate()
+        .map_err(|error| PolicyStoreError::Invalid(error.to_string()))?;
+    if canonical_json_digest(&lease)? != digest
+        || lease.lease_id != lease_id
+        || lease.request_id != request_id
+        || lease.topology_version != topology_version
+        || lease.capacity_version != capacity_version
+        || lease.expires_at != expires_at
+    {
+        return Err(PolicyStoreError::Invalid(
+            "stored capacity lease does not match authoritative row columns".into(),
+        ));
+    }
+    let mut claims = tx
+        .prepare("SELECT dimension, claim_key, units FROM policy_capacity_claims WHERE lease_id = ?1 ORDER BY dimension, claim_key")?
+        .query_map([lease_id], |row| {
+            Ok(PolicyCapacityClaim {
+                dimension: row.get(0)?,
+                key: row.get(1)?,
+                units: row.get(2)?,
+            })
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    let mut expected_claims = lease.claims.clone();
+    claims.sort_by(|a, b| (&a.dimension, &a.key).cmp(&(&b.dimension, &b.key)));
+    expected_claims.sort_by(|a, b| (&a.dimension, &a.key).cmp(&(&b.dimension, &b.key)));
+    if claims != expected_claims
+        || !matches!(
+            state.as_str(),
+            "active" | "committed" | "released" | "expired"
+        )
+    {
+        return Err(PolicyStoreError::Invalid(
+            "stored capacity lease claims or state are invalid".into(),
+        ));
+    }
+    Ok(lease)
 }
 
 fn authorize_override_tx(
@@ -1085,12 +1436,12 @@ fn authorize_override_tx(
         ));
     }
     let request = load_request_tx(tx, &record.request_id)?;
-    let decision = load_terminal_decision(tx, &record.request_id, &record.decision_id)?;
+    let decision = load_terminal_decision(tx, &request, &record.decision_id)?;
     record
         .validate_for_consumption(&request, &decision, now)
         .map_err(|error| PolicyStoreError::OverrideDenied(error.to_string()))?;
     let json = serde_json::to_string(record)?;
-    let inserted = tx.execute("INSERT OR IGNORE INTO policy_overrides (override_id, request_id, decision_id, state, override_json, created_at) VALUES (?1, ?2, ?3, 'authorized', ?4, ?5)", params![record.override_id, record.request_id, record.decision_id, json, record.created_at])?;
+    let inserted = tx.execute("INSERT OR IGNORE INTO policy_overrides (override_id, request_id, request_digest, decision_id, policy_version, state, override_json, override_digest, created_at, expires_at, consumed_at) VALUES (?1, ?2, ?3, ?4, ?5, 'authorized', ?6, ?7, ?8, ?9, ?10)", params![record.override_id, record.request_id, record.request_digest, record.decision_id, record.policy_version, json, canonical_json_digest(record)?, record.created_at, record.expires_at, record.consumed_at])?;
     if inserted == 0 {
         let existing = load_override_tx(tx, &record.override_id)?;
         if existing != *record {
@@ -1108,26 +1459,32 @@ fn load_reusable_decision(
     override_id: Option<&str>,
 ) -> Result<Option<PolicyDecision>> {
     let value = match override_id {
-        Some(id) => tx.query_row("SELECT decision_id, decision_digest, decision_json FROM policy_decisions WHERE request_id = ?1 AND override_id = ?2", params![request.request_id, id], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?))).optional()?,
-        None => tx.query_row("SELECT decision_id, decision_digest, decision_json FROM policy_decisions WHERE request_id = ?1 AND override_id IS NULL ORDER BY attempt ASC LIMIT 1", [&request.request_id], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?))).optional()?,
+        Some(id) => tx.query_row("SELECT decision_id, request_id, attempt, override_id, decision_digest, decision_json, created_at FROM policy_decisions WHERE request_id = ?1 AND override_id = ?2", params![request.request_id, id], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, u32>(2)?, row.get::<_, Option<String>>(3)?, row.get::<_, String>(4)?, row.get::<_, String>(5)?, row.get::<_, String>(6)?))).optional()?,
+        None => tx.query_row("SELECT decision_id, request_id, attempt, override_id, decision_digest, decision_json, created_at FROM policy_decisions WHERE request_id = ?1 AND override_id IS NULL ORDER BY attempt ASC LIMIT 1", [&request.request_id], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, u32>(2)?, row.get::<_, Option<String>>(3)?, row.get::<_, String>(4)?, row.get::<_, String>(5)?, row.get::<_, String>(6)?))).optional()?,
     };
-    let Some((stored_decision_id, digest, json)) = value else {
+    let Some((
+        stored_decision_id,
+        stored_request_id,
+        attempt,
+        stored_override_id,
+        digest,
+        json,
+        created_at,
+    )) = value
+    else {
         return Ok(None);
     };
-    if text_digest(&json) != digest {
-        return Err(PolicyStoreError::Invalid(
-            "stored reusable decision digest does not match".into(),
-        ));
-    }
-    let decision: PolicyDecision = serde_json::from_str(&json)?;
-    decision
-        .validate_for_request(request)
-        .map_err(|error| PolicyStoreError::Invalid(error.to_string()))?;
-    if decision.decision_id != stored_decision_id {
-        return Err(PolicyStoreError::Invalid(
-            "stored decision does not match its immutable lookup key".into(),
-        ));
-    }
+    let decision = parse_stored_decision(
+        tx,
+        request,
+        &stored_decision_id,
+        &stored_request_id,
+        attempt,
+        stored_override_id.as_deref(),
+        &digest,
+        &json,
+        &created_at,
+    )?;
     if let Some(lease) = &decision.capacity_lease {
         let active: bool = tx
             .query_row(
@@ -1222,27 +1579,24 @@ fn derived_id(prefix: &str, values: &[&str]) -> String {
     }
     format!("{prefix}-{:x}", digest.finalize())
 }
-fn text_digest(value: &str) -> String {
-    format!("{:x}", Sha256::digest(value.as_bytes()))
+fn canonical_json_digest(value: &impl Serialize) -> Result<String> {
+    serde_json::to_vec(value)
+        .map(|encoded| format!("{:x}", Sha256::digest(encoded)))
+        .map_err(PolicyStoreError::Json)
+}
+fn override_state_name(state: &PolicyOverrideState) -> &'static str {
+    match state {
+        PolicyOverrideState::Authorized => "authorized",
+        PolicyOverrideState::Consumed => "consumed",
+        PolicyOverrideState::Expired => "expired",
+        PolicyOverrideState::Rejected => "rejected",
+    }
 }
 fn default_true() -> bool {
     true
 }
 fn default_lease_ttl_seconds() -> u64 {
     300
-}
-
-fn ensure_column(conn: &Connection, table: &str, column: &str, declaration: &str) -> Result<()> {
-    let columns = conn
-        .prepare(&format!("PRAGMA table_info({table})"))?
-        .query_map([], |row| row.get::<_, String>(1))?
-        .collect::<std::result::Result<std::collections::BTreeSet<_>, _>>()?;
-    if !columns.contains(column) {
-        conn.execute_batch(&format!(
-            "ALTER TABLE {table} ADD COLUMN {column} {declaration}"
-        ))?;
-    }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -1337,6 +1691,17 @@ mod tests {
         }
     }
 
+    fn install(store: &PolicyStore, projection: &PolicyProjection) {
+        store.install_projection(projection).unwrap();
+        store
+            .activate_projection(
+                &projection.lane,
+                &projection.policy_version,
+                &projection.policy_digest,
+            )
+            .unwrap();
+    }
+
     fn request(
         id: &str,
         vehicle: PolicyVehicle,
@@ -1388,7 +1753,7 @@ mod tests {
     #[test]
     fn omitted_models_for_aa6c1120_and_2260296e_resolve_to_explicit_profiles() {
         let (store, path) = store("omitted-models");
-        store.install_projection(&projection(true, 2)).unwrap();
+        install(&store, &projection(true, 2));
         store.set_runtime_versions("sm-policy-1268", 1, 1).unwrap();
         let mut aa6c1120 = request("aa6c1120", PolicyVehicle::TaskAgent, None, "intent-aa");
         aa6c1120.requested.model = None;
@@ -1429,9 +1794,7 @@ mod tests {
     #[test]
     fn disabled_or_wrong_bootstrap_canary_never_admits() {
         let (policy_store, path) = store("canary");
-        policy_store
-            .install_projection(&projection(false, 1))
-            .unwrap();
+        install(&policy_store, &projection(false, 1));
         policy_store
             .set_runtime_versions("sm-policy-1268", 1, 1)
             .unwrap();
@@ -1453,9 +1816,7 @@ mod tests {
             Err(PolicyStoreError::CanaryDenied(_))
         ));
         let (wrong_store, wrong_path) = store("wrong-bootstrap");
-        wrong_store
-            .install_projection(&projection(true, 1))
-            .unwrap();
+        install(&wrong_store, &projection(true, 1));
         wrong_store
             .set_runtime_versions("sm-policy-1268", 1, 1)
             .unwrap();
@@ -1479,7 +1840,7 @@ mod tests {
             Err(PolicyStoreError::CanaryDenied(_))
         ));
         let (seat_store, seat_path) = store("unscoped-seat");
-        seat_store.install_projection(&projection(true, 1)).unwrap();
+        install(&seat_store, &projection(true, 1));
         seat_store
             .set_runtime_versions("sm-policy-1268", 1, 1)
             .unwrap();
@@ -1509,7 +1870,7 @@ mod tests {
     #[test]
     fn capacity_is_atomic_and_stale_versions_fail_closed() {
         let (store, path) = store("capacity");
-        store.install_projection(&projection(true, 1)).unwrap();
+        install(&store, &projection(true, 1));
         store.set_runtime_versions("sm-policy-1268", 1, 1).unwrap();
         store
             .create_request(&request(
@@ -1564,7 +1925,7 @@ mod tests {
     #[test]
     fn exact_override_is_bound_consumed_once_and_persists() {
         let (store, path) = store("override");
-        store.install_projection(&projection(true, 2)).unwrap();
+        install(&store, &projection(true, 2));
         store.set_runtime_versions("sm-policy-1268", 1, 1).unwrap();
         let request = request(
             "rewrite-me",
@@ -1636,7 +1997,7 @@ mod tests {
     #[test]
     fn damaged_reusable_decision_fails_closed_after_restart() {
         let (store, path) = store("damaged-decision");
-        store.install_projection(&projection(true, 1)).unwrap();
+        install(&store, &projection(true, 1));
         store.set_runtime_versions("sm-policy-1268", 1, 1).unwrap();
         store
             .create_request(&request(
@@ -1693,7 +2054,7 @@ mod tests {
     #[test]
     fn provisional_child_reservation_is_restart_safe_and_releases_by_child() {
         let (store, path) = store("provisional-child");
-        store.install_projection(&projection(true, 1)).unwrap();
+        install(&store, &projection(true, 1));
         store.set_runtime_versions("sm-policy-1268", 1, 1).unwrap();
         store
             .create_request(&request(
@@ -1740,6 +2101,7 @@ mod tests {
             ),
             Err(PolicyStoreError::Invalid(_))
         ));
+        after_restart.mark_child_launched("provisional-1").unwrap();
         after_restart.release_by_child("provisional-1").unwrap();
         after_restart.release_by_child("provisional-1").unwrap();
         let conn = Connection::open(&path).unwrap();
@@ -1757,7 +2119,7 @@ mod tests {
     #[test]
     fn server_constructed_override_rejects_cross_caller_and_cross_request() {
         let (store, path) = store("override-authority");
-        store.install_projection(&projection(true, 2)).unwrap();
+        install(&store, &projection(true, 2));
         store.set_runtime_versions("sm-policy-1268", 1, 1).unwrap();
         let first = request(
             "override-a",
@@ -1830,7 +2192,7 @@ mod tests {
         conflict.clause_id = "sm-policy-1268.routine-worker-conflict".into();
         conflict.profile.model = "opus".into();
         projection.rules.push(conflict);
-        store.install_projection(&projection).unwrap();
+        install(&store, &projection);
         store.set_runtime_versions("sm-policy-1268", 1, 1).unwrap();
         store
             .create_request(&request(
@@ -1862,11 +2224,234 @@ mod tests {
     }
 
     #[test]
+    fn installation_requires_explicit_projection_activation() {
+        let (store, path) = store("explicit-activation");
+        let projection = projection(true, 1);
+        store.install_projection(&projection).unwrap();
+        store.set_runtime_versions(&projection.lane, 1, 1).unwrap();
+        let request = request(
+            "inactive",
+            PolicyVehicle::TaskAgent,
+            None,
+            "intent-inactive",
+        );
+        store.create_request(&request).unwrap();
+        assert!(matches!(
+            store.prepare_admission(
+                &request.request_id,
+                &class("routine_bounded", None),
+                None,
+                "child-inactive",
+                instant("2026-08-17T00:01:00Z")
+            ),
+            Err(PolicyStoreError::ProjectionNotFound(_))
+        ));
+        store
+            .activate_projection(
+                &projection.lane,
+                &projection.policy_version,
+                &projection.policy_digest,
+            )
+            .unwrap();
+        assert!(store
+            .prepare_admission(
+                &request.request_id,
+                &class("routine_bounded", None),
+                None,
+                "child-active",
+                instant("2026-08-17T00:01:00Z")
+            )
+            .is_ok());
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn tampered_json_for_each_persisted_record_type_fails_closed() {
+        let (store, path) = store("tampered-json");
+        let projection = projection(true, 2);
+        install(&store, &projection);
+        store.set_runtime_versions(&projection.lane, 1, 1).unwrap();
+        let allow = request(
+            "tamper-allow",
+            PolicyVehicle::TaskAgent,
+            None,
+            "intent-allow",
+        );
+        let rewrite = request(
+            "tamper-rewrite",
+            PolicyVehicle::NamedSeat,
+            Some("fable"),
+            "intent-rewrite",
+        );
+        store.create_request(&allow).unwrap();
+        store.create_request(&rewrite).unwrap();
+        let now = instant("2026-08-17T00:01:00Z");
+        let allowed = store
+            .prepare_admission(
+                &allow.request_id,
+                &class("routine_bounded", None),
+                None,
+                "child-tamper",
+                now,
+            )
+            .unwrap()
+            .decision;
+        let rejected = store
+            .prepare_admission(
+                &rewrite.request_id,
+                &class("named_orchestrator", Some("maintainer")),
+                None,
+                "child-rewrite",
+                now,
+            )
+            .unwrap()
+            .decision;
+        assert!(matches!(rejected.outcome, PolicyDecisionOutcome::Rewrite));
+        let override_record = store
+            .authorize_request_override(
+                &rewrite.request_id,
+                &rewrite.caller,
+                "tamper test",
+                now,
+                time::Duration::minutes(1),
+            )
+            .unwrap();
+        let conn = Connection::open(&path).unwrap();
+        conn.execute(
+            "UPDATE policy_overrides SET override_json = '{\"bad\":true}' WHERE override_id = ?1",
+            [&override_record.override_id],
+        )
+        .unwrap();
+        drop(conn);
+        assert!(matches!(
+            store.override_record(&override_record.override_id),
+            Err(PolicyStoreError::Json(_))
+        ));
+
+        let conn = Connection::open(&path).unwrap();
+        conn.execute(
+            "UPDATE policy_capacity_leases SET lease_json = '{\"bad\":true}' WHERE lease_id = ?1",
+            [&allowed.capacity_lease.unwrap().lease_id],
+        )
+        .unwrap();
+        drop(conn);
+        assert!(matches!(
+            store.prepare_admission(
+                &allow.request_id,
+                &class("routine_bounded", None),
+                None,
+                "child-tamper",
+                now
+            ),
+            Err(PolicyStoreError::Json(_))
+        ));
+
+        let conn = Connection::open(&path).unwrap();
+        conn.execute(
+            "UPDATE policy_decisions SET decision_json = '{\"bad\":true}' WHERE decision_id = ?1",
+            [&rejected.decision_id],
+        )
+        .unwrap();
+        drop(conn);
+        assert!(matches!(
+            store.prepare_admission(
+                &rewrite.request_id,
+                &class("named_orchestrator", Some("maintainer")),
+                None,
+                "child-rewrite",
+                now
+            ),
+            Err(PolicyStoreError::Json(_))
+        ));
+
+        let conn = Connection::open(&path).unwrap();
+        conn.execute(
+            "UPDATE policy_requests SET request_json = '{\"bad\":true}' WHERE request_id = ?1",
+            [&allow.request_id],
+        )
+        .unwrap();
+        drop(conn);
+        assert!(matches!(
+            store.request(&allow.request_id),
+            Err(PolicyStoreError::Json(_))
+        ));
+
+        let conn = Connection::open(&path).unwrap();
+        conn.execute(
+            "UPDATE policy_projections SET projection_json = '{\"bad\":true}' WHERE lane = ?1",
+            [&projection.lane],
+        )
+        .unwrap();
+        drop(conn);
+        assert!(matches!(
+            store.activate_projection(
+                &projection.lane,
+                &projection.policy_version,
+                &projection.policy_digest
+            ),
+            Err(PolicyStoreError::Json(_))
+        ));
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn row_json_identity_mismatch_fails_closed() {
+        let (store, path) = store("row-json-mismatch");
+        let request = request("row-mismatch", PolicyVehicle::TaskAgent, None, "intent-row");
+        store.create_request(&request).unwrap();
+        let conn = Connection::open(&path).unwrap();
+        conn.execute(
+            "UPDATE policy_requests SET lane = 'other-lane' WHERE request_id = ?1",
+            [&request.request_id],
+        )
+        .unwrap();
+        drop(conn);
+        assert!(matches!(
+            store.request(&request.request_id),
+            Err(PolicyStoreError::Invalid(_))
+        ));
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn wrong_missing_or_truncated_schema_fails_closed_with_recreate_guidance() {
+        let wrong = std::env::temp_dir().join(format!(
+            "sm-policy-store-wrong-version-{}.sqlite",
+            OffsetDateTime::now_utc().unix_timestamp_nanos()
+        ));
+        let _store = PolicyStore::new(&wrong).unwrap();
+        let conn = Connection::open(&wrong).unwrap();
+        conn.pragma_update(None, "user_version", 2).unwrap();
+        drop(conn);
+        let error = PolicyStore::new(&wrong).unwrap_err().to_string();
+        assert!(error.contains("archive") && error.contains("recreate"));
+
+        let missing = std::env::temp_dir().join(format!(
+            "sm-policy-store-missing-version-{}.sqlite",
+            OffsetDateTime::now_utc().unix_timestamp_nanos()
+        ));
+        Connection::open(&missing).unwrap();
+        let error = PolicyStore::new(&missing).unwrap_err().to_string();
+        assert!(error.contains("user_version=1"));
+
+        let truncated = std::env::temp_dir().join(format!(
+            "sm-policy-store-truncated-{}.sqlite",
+            OffsetDateTime::now_utc().unix_timestamp_nanos()
+        ));
+        std::fs::write(&truncated, b"not sqlite").unwrap();
+        let error = PolicyStore::new(&truncated).unwrap_err().to_string();
+        assert!(error.contains("archive") && error.contains("recreate"));
+        for path in [wrong, missing, truncated] {
+            std::fs::remove_file(path).ok();
+        }
+    }
+
+    #[test]
     fn competing_reservations_cannot_both_consume_one_slot() {
         use std::sync::{Arc, Barrier};
 
         let (store, path) = store("concurrent-capacity");
-        store.install_projection(&projection(true, 1)).unwrap();
+        install(&store, &projection(true, 1));
         store.set_runtime_versions("sm-policy-1268", 1, 1).unwrap();
         store
             .create_request(&request(

--- a/crates/sm-server/src/policy_store.rs
+++ b/crates/sm-server/src/policy_store.rs
@@ -806,113 +806,36 @@ fn verify_schema_v1(conn: &Connection) -> std::result::Result<(), String> {
     if integrity != "ok" {
         return Err(format!("integrity check failed: {integrity}"));
     }
-    for (table, columns) in POLICY_SCHEMA_TABLES {
-        let actual = conn
-            .prepare(&format!("PRAGMA table_info({table})"))
-            .map_err(|error| format!("cannot inspect {table}: {error}"))?
-            .query_map([], |row| row.get::<_, String>(1))
-            .map_err(|error| format!("cannot read {table} columns: {error}"))?
-            .collect::<std::result::Result<Vec<_>, _>>()
-            .map_err(|error| format!("cannot read {table} columns: {error}"))?;
-        if actual != *columns {
-            return Err(format!(
-                "v1 table {table} is missing or has different columns"
-            ));
-        }
+    let mut expected = POLICY_SCHEMA_V1
+        .split(';')
+        .map(str::trim)
+        .filter(|statement| !statement.is_empty())
+        .map(normalize_schema_sql)
+        .collect::<Vec<_>>();
+    let mut actual = conn
+        .prepare("SELECT sql FROM sqlite_master WHERE type IN ('table', 'index') AND name NOT LIKE 'sqlite_%' ORDER BY name")
+        .map_err(|error| format!("cannot inspect v1 schema: {error}"))?
+        .query_map([], |row| row.get::<_, String>(0))
+        .map_err(|error| format!("cannot read v1 schema: {error}"))?
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .map_err(|error| format!("cannot read v1 schema: {error}"))?
+        .into_iter()
+        .map(|statement| normalize_schema_sql(&statement))
+        .collect::<Vec<_>>();
+    expected.sort();
+    actual.sort();
+    if actual != expected {
+        return Err("v1 schema objects or constraints differ from the frozen definition".into());
     }
     Ok(())
 }
 
-const POLICY_SCHEMA_TABLES: &[(&str, &[&str])] = &[
-    (
-        "policy_projections",
-        &[
-            "lane",
-            "policy_version",
-            "policy_digest",
-            "projection_json",
-            "projection_record_digest",
-            "created_at",
-        ],
-    ),
-    (
-        "policy_active_projections",
-        &["lane", "policy_version", "policy_digest"],
-    ),
-    (
-        "policy_runtime_versions",
-        &["lane", "topology_version", "capacity_version"],
-    ),
-    (
-        "policy_requests",
-        &[
-            "request_id",
-            "lane",
-            "request_digest",
-            "request_json",
-            "created_at",
-        ],
-    ),
-    (
-        "policy_decisions",
-        &[
-            "decision_id",
-            "request_id",
-            "attempt",
-            "override_id",
-            "decision_json",
-            "decision_digest",
-            "created_at",
-        ],
-    ),
-    (
-        "policy_capacity_leases",
-        &[
-            "lease_id",
-            "request_id",
-            "topology_version",
-            "capacity_version",
-            "provisional_child_session_id",
-            "state",
-            "expires_at",
-            "released_at",
-            "lease_json",
-            "lease_digest",
-        ],
-    ),
-    (
-        "policy_capacity_claims",
-        &["lease_id", "dimension", "claim_key", "units"],
-    ),
-    (
-        "policy_provisional_children",
-        &[
-            "child_session_id",
-            "lease_id",
-            "request_id",
-            "decision_id",
-            "state",
-            "created_at",
-            "released_at",
-        ],
-    ),
-    (
-        "policy_overrides",
-        &[
-            "override_id",
-            "request_id",
-            "request_digest",
-            "decision_id",
-            "policy_version",
-            "state",
-            "override_json",
-            "override_digest",
-            "created_at",
-            "expires_at",
-            "consumed_at",
-        ],
-    ),
-];
+fn normalize_schema_sql(value: &str) -> String {
+    value
+        .chars()
+        .filter(|character| !character.is_whitespace())
+        .collect()
+}
 
 #[derive(Debug)]
 struct ResolvedRule {
@@ -1062,7 +985,20 @@ fn ensure_capacity(
             .ok_or_else(|| {
                 PolicyStoreError::CapacityUnavailable(format!("no limit for {dimension}/{key}"))
             })?;
-        let active: u64 = tx.query_row(r#"SELECT COALESCE(SUM(c.units), 0) FROM policy_capacity_claims c JOIN policy_capacity_leases l ON l.lease_id = c.lease_id WHERE c.dimension = ?1 AND c.claim_key = ?2 AND l.state IN ('active', 'committed')"#, params![dimension, key], |row| row.get(0))?;
+        let lease_ids = tx
+            .prepare(r#"SELECT DISTINCT l.lease_id FROM policy_capacity_leases l JOIN policy_capacity_claims c ON c.lease_id = l.lease_id WHERE c.dimension = ?1 AND c.claim_key = ?2 AND l.state IN ('active', 'committed')"#)?
+            .query_map(params![dimension, key], |row| row.get::<_, String>(0))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        let active = lease_ids.into_iter().try_fold(0_u64, |total, lease_id| {
+            let lease = load_lease_tx(tx, &lease_id)?;
+            let units = lease
+                .claims
+                .iter()
+                .filter(|claim| claim.dimension == dimension && claim.key == key)
+                .map(|claim| claim.units)
+                .sum::<u64>();
+            Ok::<_, PolicyStoreError>(total.saturating_add(units))
+        })?;
         if active.saturating_add(units) > maximum {
             return Err(PolicyStoreError::CapacityUnavailable(format!(
                 "{dimension}/{key}: requested {units}, active {active}, maximum {maximum}"
@@ -1342,7 +1278,7 @@ fn parse_stored_decision(
     decision_id: &str,
     request_id: &str,
     attempt: u32,
-    _override_id: Option<&str>,
+    override_id: Option<&str>,
     digest: &str,
     value: &str,
     created_at: &str,
@@ -1360,6 +1296,16 @@ fn parse_stored_decision(
         return Err(PolicyStoreError::Invalid(
             "stored decision does not match authoritative row columns".into(),
         ));
+    }
+    if let Some(override_id) = override_id {
+        let override_record = load_override_tx(tx, override_id)?;
+        if override_record.request_id != request.request_id
+            || override_record.policy_version != request.policy_version
+        {
+            return Err(PolicyStoreError::Invalid(
+                "stored decision override does not bind to this frozen request".into(),
+            ));
+        }
     }
     if let Some(embedded_lease) = &decision.capacity_lease {
         let stored_lease = load_lease_tx(tx, &embedded_lease.lease_id)?;
@@ -2411,6 +2357,133 @@ mod tests {
             Err(PolicyStoreError::Invalid(_))
         ));
         std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn frozen_schema_override_binding_and_capacity_claims_fail_closed_when_tampered() {
+        let (schema_store, schema_path) = store("schema-constraint-tamper");
+        drop(schema_store);
+        let conn = Connection::open(&schema_path).unwrap();
+        conn.execute_batch("DROP INDEX idx_policy_leases_active;")
+            .unwrap();
+        drop(conn);
+        assert!(matches!(
+            PolicyStore::new(&schema_path),
+            Err(PolicyStoreError::Schema(_))
+        ));
+
+        let (override_store, override_path) = store("override-row-tamper");
+        let override_projection = projection(true, 2);
+        install(&override_store, &override_projection);
+        override_store
+            .set_runtime_versions(&override_projection.lane, 1, 1)
+            .unwrap();
+        let allow = request("override-allow", PolicyVehicle::TaskAgent, None, "intent-a");
+        let rewrite = request(
+            "override-rewrite",
+            PolicyVehicle::NamedSeat,
+            Some("fable"),
+            "intent-b",
+        );
+        override_store.create_request(&allow).unwrap();
+        override_store.create_request(&rewrite).unwrap();
+        let now = instant("2026-08-17T00:01:00Z");
+        let allowed = override_store
+            .prepare_admission(
+                &allow.request_id,
+                &class("routine_bounded", None),
+                None,
+                "override-child-a",
+                now,
+            )
+            .unwrap()
+            .decision;
+        override_store
+            .prepare_admission(
+                &rewrite.request_id,
+                &class("named_orchestrator", Some("maintainer")),
+                None,
+                "override-child-b",
+                now,
+            )
+            .unwrap();
+        let override_record = override_store
+            .authorize_request_override(
+                &rewrite.request_id,
+                &rewrite.caller,
+                "cross-request rebinding test",
+                now,
+                time::Duration::minutes(1),
+            )
+            .unwrap();
+        let conn = Connection::open(&override_path).unwrap();
+        conn.execute(
+            "UPDATE policy_decisions SET override_id = ?2 WHERE decision_id = ?1",
+            params![allowed.decision_id, override_record.override_id],
+        )
+        .unwrap();
+        drop(conn);
+        assert!(matches!(
+            override_store.prepare_admission(
+                &allow.request_id,
+                &class("routine_bounded", None),
+                Some(&override_record.override_id),
+                "override-child-a",
+                now,
+            ),
+            Err(PolicyStoreError::Invalid(_))
+        ));
+
+        let (capacity_store, capacity_path) = store("capacity-claim-tamper");
+        let projection = projection(true, 1);
+        install(&capacity_store, &projection);
+        capacity_store
+            .set_runtime_versions(&projection.lane, 1, 1)
+            .unwrap();
+        let first = request(
+            "capacity-first",
+            PolicyVehicle::TaskAgent,
+            None,
+            "intent-first",
+        );
+        let second = request(
+            "capacity-second",
+            PolicyVehicle::TaskAgent,
+            None,
+            "intent-second",
+        );
+        capacity_store.create_request(&first).unwrap();
+        capacity_store.create_request(&second).unwrap();
+        let first_decision = capacity_store
+            .prepare_admission(
+                &first.request_id,
+                &class("routine_bounded", None),
+                None,
+                "capacity-child-a",
+                now,
+            )
+            .unwrap()
+            .decision;
+        let conn = Connection::open(&capacity_path).unwrap();
+        conn.execute(
+            "UPDATE policy_capacity_claims SET units = 0 WHERE lease_id = ?1",
+            [&first_decision.capacity_lease.unwrap().lease_id],
+        )
+        .unwrap();
+        drop(conn);
+        assert!(matches!(
+            capacity_store.prepare_admission(
+                &second.request_id,
+                &class("routine_bounded", None),
+                None,
+                "capacity-child-b",
+                now,
+            ),
+            Err(PolicyStoreError::Invalid(_))
+        ));
+        for path in [schema_path, override_path, capacity_path] {
+            std::fs::remove_file(path).ok();
+        }
     }
 
     #[test]

--- a/crates/sm-server/src/policy_store.rs
+++ b/crates/sm-server/src/policy_store.rs
@@ -208,6 +208,11 @@ impl PolicyProjection {
         if let Some(authority) = &self.seat_authority {
             authority.validate(&self.lane)?;
         }
+        if self.enabled && (self.bootstrap_authority.is_some() == self.seat_authority.is_some()) {
+            return Err(PolicyStoreError::Invalid(
+                "an enabled canary requires exactly one bootstrap or seat authority".into(),
+            ));
+        }
         if self.rules.is_empty() {
             return Err(PolicyStoreError::Invalid(
                 "projection must contain a rule".into(),
@@ -339,6 +344,9 @@ impl PolicyStore {
             "INSERT INTO policy_runtime_versions (lane, topology_version, capacity_version) VALUES (?1, 0, 0) ON CONFLICT(lane) DO NOTHING",
             [&projection.lane],
         )?;
+        if inserted != 0 {
+            conn.execute("INSERT INTO policy_active_projections (lane, policy_version, policy_digest) VALUES (?1, ?2, ?3) ON CONFLICT(lane) DO UPDATE SET policy_version = excluded.policy_version, policy_digest = excluded.policy_digest", params![projection.lane, projection.policy_version, projection.policy_digest])?;
+        }
         Ok(())
     }
 
@@ -421,6 +429,17 @@ impl PolicyStore {
             &request.policy_version,
             &request.policy_digest,
         )?;
+        let active: (String, String) = tx.query_row("SELECT policy_version, policy_digest FROM policy_active_projections WHERE lane = ?1", [request.caller.lane()], |row| Ok((row.get(0)?, row.get(1)?))).optional()?.ok_or_else(|| PolicyStoreError::ProjectionNotFound(request.caller.lane().into()))?;
+        if active
+            != (
+                request.policy_version.clone(),
+                request.policy_digest.clone(),
+            )
+        {
+            return Err(PolicyStoreError::Stale(
+                "request policy projection is no longer active".into(),
+            ));
+        }
         authorize_caller(&projection, &request)?;
         let (topology_version, capacity_version): (u64, u64) = tx.query_row(
             "SELECT topology_version, capacity_version FROM policy_runtime_versions WHERE lane = ?1",
@@ -447,7 +466,19 @@ impl PolicyStore {
             });
         }
         let attempt = next_attempt(&tx, request_id)?;
-        let resolved = resolve_rule(&projection, &request, classification);
+        let mut effective_classification = classification.clone();
+        if let Some(override_id) = override_id {
+            let override_record = load_override_tx(&tx, override_id)?;
+            let terminal = load_terminal_decision(&tx, request_id, &override_record.decision_id)?;
+            override_record
+                .validate_for_consumption(&request, &terminal, now)
+                .map_err(|error| PolicyStoreError::OverrideDenied(error.to_string()))?;
+            if classification != &terminal.classification {
+                return Err(PolicyStoreError::OverrideDenied("override re-admission classification differs from its frozen terminal decision".into()));
+            }
+            effective_classification = terminal.classification;
+        }
+        let resolved = resolve_rule(&projection, &request, &effective_classification);
         let mut outcome = resolved.outcome.clone();
         let mut override_used = None;
         if let Some(override_id) = override_id {
@@ -483,7 +514,7 @@ impl PolicyStore {
             policy_version: request.policy_version.clone(),
             policy_digest: request.policy_digest.clone(),
             outcome: outcome.clone(),
-            classification: classification.clone(),
+            classification: effective_classification,
             applicable_clause_ids: resolved.clause_ids.clone(),
             resolved_profile: resolved.profile.clone(),
             reason: resolved.reason.clone(),
@@ -529,7 +560,8 @@ impl PolicyStore {
         decision
             .validate_for_request(&request)
             .map_err(|e| PolicyStoreError::Invalid(e.to_string()))?;
-        tx.execute("INSERT INTO policy_decisions (decision_id, request_id, attempt, override_id, decision_json, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)", params![decision.decision_id, request_id, attempt, override_used, serde_json::to_string(&decision)?, decision.decided_at])?;
+        let decision_json = serde_json::to_string(&decision)?;
+        tx.execute("INSERT INTO policy_decisions (decision_id, request_id, attempt, override_id, decision_json, decision_digest, created_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)", params![decision.decision_id, request_id, attempt, override_used, decision_json, text_digest(&serde_json::to_string(&decision)?), decision.decided_at])?;
         if let Some(override_id) = override_used {
             consume_override_tx(&tx, override_id, now)?;
         }
@@ -672,9 +704,10 @@ impl PolicyStore {
         conn.pragma_update(None, "journal_mode", "WAL")?;
         conn.execute_batch(r#"
             CREATE TABLE IF NOT EXISTS policy_projections (lane TEXT NOT NULL, policy_version TEXT NOT NULL, policy_digest TEXT NOT NULL, projection_json TEXT NOT NULL, created_at TEXT NOT NULL, PRIMARY KEY (lane, policy_version, policy_digest));
+            CREATE TABLE IF NOT EXISTS policy_active_projections (lane TEXT PRIMARY KEY, policy_version TEXT NOT NULL, policy_digest TEXT NOT NULL);
             CREATE TABLE IF NOT EXISTS policy_runtime_versions (lane TEXT PRIMARY KEY, topology_version INTEGER NOT NULL, capacity_version INTEGER NOT NULL);
             CREATE TABLE IF NOT EXISTS policy_requests (request_id TEXT PRIMARY KEY, lane TEXT NOT NULL, request_digest TEXT NOT NULL, request_json TEXT NOT NULL, created_at TEXT NOT NULL);
-            CREATE TABLE IF NOT EXISTS policy_decisions (decision_id TEXT PRIMARY KEY, request_id TEXT NOT NULL, attempt INTEGER NOT NULL, override_id TEXT, decision_json TEXT NOT NULL, created_at TEXT NOT NULL, UNIQUE(request_id, attempt), UNIQUE(request_id, override_id));
+            CREATE TABLE IF NOT EXISTS policy_decisions (decision_id TEXT PRIMARY KEY, request_id TEXT NOT NULL, attempt INTEGER NOT NULL, override_id TEXT, decision_json TEXT NOT NULL, decision_digest TEXT NOT NULL, created_at TEXT NOT NULL, UNIQUE(request_id, attempt), UNIQUE(request_id, override_id));
             CREATE TABLE IF NOT EXISTS policy_capacity_leases (lease_id TEXT PRIMARY KEY, request_id TEXT NOT NULL, provisional_child_session_id TEXT NOT NULL, state TEXT NOT NULL, expires_at TEXT NOT NULL, released_at TEXT, lease_json TEXT NOT NULL);
             CREATE TABLE IF NOT EXISTS policy_capacity_claims (lease_id TEXT NOT NULL, dimension TEXT NOT NULL, claim_key TEXT NOT NULL, units INTEGER NOT NULL, PRIMARY KEY (lease_id, dimension, claim_key));
             CREATE TABLE IF NOT EXISTS policy_provisional_children (child_session_id TEXT PRIMARY KEY, lease_id TEXT NOT NULL UNIQUE, request_id TEXT NOT NULL, decision_id TEXT NOT NULL, state TEXT NOT NULL, created_at TEXT NOT NULL, released_at TEXT);
@@ -688,6 +721,7 @@ impl PolicyStore {
             "provisional_child_session_id",
             "TEXT",
         )?;
+        ensure_column(&conn, "policy_decisions", "decision_digest", "TEXT")?;
         conn.execute_batch("CREATE UNIQUE INDEX IF NOT EXISTS idx_policy_active_lease_child ON policy_capacity_leases(provisional_child_session_id) WHERE state = 'active';")?;
         Ok(conn)
     }
@@ -789,16 +823,8 @@ fn requested_profile_conflicts(
 ) -> bool {
     request.requested.vehicle != profile.vehicle
         || request.requested.provider != profile.provider
-        || request
-            .requested
-            .model
-            .as_deref()
-            .is_some_and(|model| model != profile.model)
-        || request
-            .requested
-            .effort
-            .as_deref()
-            .is_some_and(|effort| effort != profile.effort)
+        || request.requested.model.as_deref() != Some(profile.model.as_str())
+        || request.requested.effort.as_deref() != Some(profile.effort.as_str())
 }
 
 fn authorize_caller(projection: &PolicyProjection, request: &PolicySpawnRequest) -> Result<()> {
@@ -1008,16 +1034,21 @@ fn load_terminal_decision(
     request_id: &str,
     decision_id: &str,
 ) -> Result<PolicyDecision> {
-    let value = tx
+    let (stored_decision_id, digest, value): (String, String, String) = tx
         .query_row(
-            "SELECT decision_json FROM policy_decisions WHERE request_id = ?1 AND decision_id = ?2",
+            "SELECT decision_id, decision_digest, decision_json FROM policy_decisions WHERE request_id = ?1 AND decision_id = ?2",
             params![request_id, decision_id],
-            |row| row.get::<_, String>(0),
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
         )
         .optional()?
         .ok_or_else(|| {
             PolicyStoreError::OverrideDenied("override points to a missing decision".into())
         })?;
+    if stored_decision_id != decision_id || text_digest(&value) != digest {
+        return Err(PolicyStoreError::Invalid(
+            "stored terminal decision digest does not match".into(),
+        ));
+    }
     Ok(serde_json::from_str(&value)?)
 }
 
@@ -1077,12 +1108,17 @@ fn load_reusable_decision(
     override_id: Option<&str>,
 ) -> Result<Option<PolicyDecision>> {
     let value = match override_id {
-        Some(id) => tx.query_row("SELECT decision_id, decision_json FROM policy_decisions WHERE request_id = ?1 AND override_id = ?2", params![request.request_id, id], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))).optional()?,
-        None => tx.query_row("SELECT decision_id, decision_json FROM policy_decisions WHERE request_id = ?1 AND override_id IS NULL ORDER BY attempt ASC LIMIT 1", [&request.request_id], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?))).optional()?,
+        Some(id) => tx.query_row("SELECT decision_id, decision_digest, decision_json FROM policy_decisions WHERE request_id = ?1 AND override_id = ?2", params![request.request_id, id], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?))).optional()?,
+        None => tx.query_row("SELECT decision_id, decision_digest, decision_json FROM policy_decisions WHERE request_id = ?1 AND override_id IS NULL ORDER BY attempt ASC LIMIT 1", [&request.request_id], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?, row.get::<_, String>(2)?))).optional()?,
     };
-    let Some((stored_decision_id, json)) = value else {
+    let Some((stored_decision_id, digest, json)) = value else {
         return Ok(None);
     };
+    if text_digest(&json) != digest {
+        return Err(PolicyStoreError::Invalid(
+            "stored reusable decision digest does not match".into(),
+        ));
+    }
     let decision: PolicyDecision = serde_json::from_str(&json)?;
     decision
         .validate_for_request(request)
@@ -1185,6 +1221,9 @@ fn derived_id(prefix: &str, values: &[&str]) -> String {
         digest.update([0]);
     }
     format!("{prefix}-{:x}", digest.finalize())
+}
+fn text_digest(value: &str) -> String {
+    format!("{:x}", Sha256::digest(value.as_bytes()))
 }
 fn default_true() -> bool {
     true
@@ -1304,6 +1343,10 @@ mod tests {
         model: Option<&str>,
         intent: &str,
     ) -> PolicySpawnRequest {
+        let canonical_model = match vehicle {
+            PolicyVehicle::NamedSeat => "opus",
+            PolicyVehicle::TaskAgent => "sonnet",
+        };
         PolicySpawnRequest {
             schema: SPAWN_REQUEST_SCHEMA.into(),
             request_id: id.into(),
@@ -1321,8 +1364,8 @@ mod tests {
                 name: id.into(),
                 vehicle,
                 provider: "claude".into(),
-                model: model.map(str::to_owned),
-                effort: None,
+                model: Some(model.unwrap_or(canonical_model).to_owned()),
+                effort: Some("high".into()),
                 working_dir: "/tmp/work".into(),
                 node: "local".into(),
             },
@@ -1347,8 +1390,12 @@ mod tests {
         let (store, path) = store("omitted-models");
         store.install_projection(&projection(true, 2)).unwrap();
         store.set_runtime_versions("sm-policy-1268", 1, 1).unwrap();
-        let aa6c1120 = request("aa6c1120", PolicyVehicle::TaskAgent, None, "intent-aa");
-        let root = request("2260296e", PolicyVehicle::NamedSeat, None, "intent-root");
+        let mut aa6c1120 = request("aa6c1120", PolicyVehicle::TaskAgent, None, "intent-aa");
+        aa6c1120.requested.model = None;
+        aa6c1120.requested.effort = None;
+        let mut root = request("2260296e", PolicyVehicle::NamedSeat, None, "intent-root");
+        root.requested.model = None;
+        root.requested.effort = None;
         store.create_request(&aa6c1120).unwrap();
         store.create_request(&root).unwrap();
         let now = instant("2026-08-17T00:01:00Z");
@@ -1374,8 +1421,8 @@ mod tests {
             .decision;
         assert_eq!(worker.resolved_profile.unwrap().model, "sonnet");
         assert_eq!(named.resolved_profile.unwrap().model, "opus");
-        assert!(matches!(worker.outcome, PolicyDecisionOutcome::Allow));
-        assert!(matches!(named.outcome, PolicyDecisionOutcome::Allow));
+        assert!(matches!(worker.outcome, PolicyDecisionOutcome::Rewrite));
+        assert!(matches!(named.outcome, PolicyDecisionOutcome::Rewrite));
         std::fs::remove_file(path).ok();
     }
 

--- a/crates/sm-server/src/policy_store.rs
+++ b/crates/sm-server/src/policy_store.rs
@@ -75,6 +75,40 @@ pub struct BootstrapAuthority {
     pub binding_digest: String,
 }
 
+/// The post-bootstrap equivalent of `BootstrapAuthority`.  A canary is never
+/// widened merely because it has been migrated to stable-seat identity.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SeatAuthority {
+    pub seat_key: String,
+    pub generation: u64,
+    pub holder_session_id: String,
+}
+
+impl SeatAuthority {
+    fn matches(&self, caller: &PolicyCallerBinding) -> bool {
+        matches!(caller, PolicyCallerBinding::Seat {
+            seat_key,
+            generation,
+            holder_session_id,
+            ..
+        } if seat_key == &self.seat_key
+            && generation == &self.generation
+            && holder_session_id == &self.holder_session_id)
+    }
+
+    fn validate(&self, lane: &str) -> Result<()> {
+        required(&self.seat_key, "seat authority seat_key")?;
+        required(&self.holder_session_id, "seat authority holder_session_id")?;
+        if self.generation == 0 || !self.seat_key.starts_with(&format!("{lane}-")) {
+            return Err(PolicyStoreError::Invalid(
+                "seat authority must name a current lane-prefixed seat generation".into(),
+            ));
+        }
+        Ok(())
+    }
+}
+
 impl BootstrapAuthority {
     fn matches(&self, caller: &PolicyCallerBinding) -> bool {
         matches!(caller, PolicyCallerBinding::IncarnationBootstrap {
@@ -156,6 +190,8 @@ pub struct PolicyProjection {
     pub enabled: bool,
     #[serde(default)]
     pub bootstrap_authority: Option<BootstrapAuthority>,
+    #[serde(default)]
+    pub seat_authority: Option<SeatAuthority>,
     pub rules: Vec<MaterializedPolicyRule>,
     #[serde(default)]
     pub capacity_limits: Vec<PolicyCapacityLimit>,
@@ -168,6 +204,9 @@ impl PolicyProjection {
         sha256(&self.policy_digest, "projection policy_digest")?;
         if let Some(authority) = &self.bootstrap_authority {
             authority.validate()?;
+        }
+        if let Some(authority) = &self.seat_authority {
+            authority.validate(&self.lane)?;
         }
         if self.rules.is_empty() {
             return Err(PolicyStoreError::Invalid(
@@ -203,12 +242,20 @@ impl PolicyProjection {
                     "lease ttl must be positive".into(),
                 ));
             }
+            let mut claim_keys = std::collections::BTreeSet::new();
             for claim in &rule.capacity_claims {
                 claim
                     .validate()
                     .map_err(|error| PolicyStoreError::Invalid(error.to_string()))?;
+                if !claim_keys.insert((&claim.dimension, &claim.key)) {
+                    return Err(PolicyStoreError::Invalid(
+                        "a rule cannot contain duplicate capacity claims".into(),
+                    ));
+                }
             }
-            if matches!(rule.outcome, PolicyRuleOutcome::Allow) && rule.capacity_claims.is_empty() {
+            if (matches!(rule.outcome, PolicyRuleOutcome::Allow) || rule.overridable)
+                && rule.capacity_claims.is_empty()
+            {
                 return Err(PolicyStoreError::Invalid(
                     "allow rule must reserve at least one capacity claim".into(),
                 ));
@@ -225,6 +272,20 @@ impl PolicyProjection {
             }
             if !limits.insert((&limit.dimension, &limit.key)) {
                 return Err(PolicyStoreError::Invalid("duplicate capacity limit".into()));
+            }
+        }
+        for rule in &self.rules {
+            for claim in &rule.capacity_claims {
+                if !self
+                    .capacity_limits
+                    .iter()
+                    .any(|limit| limit.dimension == claim.dimension && limit.key == claim.key)
+                {
+                    return Err(PolicyStoreError::Invalid(format!(
+                        "rule {} has no capacity limit for {}/{}",
+                        rule.clause_id, claim.dimension, claim.key
+                    )));
+                }
             }
         }
         Ok(())
@@ -659,7 +720,16 @@ fn authorize_caller(projection: &PolicyProjection, request: &PolicySpawnRequest)
         ));
     }
     match &request.caller {
-        PolicyCallerBinding::Seat { .. } => Ok(()),
+        PolicyCallerBinding::Seat { .. } => projection
+            .seat_authority
+            .as_ref()
+            .filter(|authority| authority.matches(&request.caller))
+            .map(|_| ())
+            .ok_or_else(|| {
+                PolicyStoreError::CanaryDenied(
+                    "seat caller does not match externally configured canary authority".into(),
+                )
+            }),
         PolicyCallerBinding::IncarnationBootstrap { .. } => projection
             .bootstrap_authority
             .as_ref()
@@ -952,6 +1022,7 @@ mod tests {
             policy_digest: DIGEST.into(),
             enabled,
             bootstrap_authority: Some(bootstrap()),
+            seat_authority: None,
             capacity_limits: vec![PolicyCapacityLimit {
                 dimension: "concurrency".into(),
                 key: "lane".into(),
@@ -1132,8 +1203,31 @@ mod tests {
             ),
             Err(PolicyStoreError::CanaryDenied(_))
         ));
+        let (seat_store, seat_path) = store("unscoped-seat");
+        seat_store.install_projection(&projection(true, 1)).unwrap();
+        seat_store
+            .set_runtime_versions("sm-policy-1268", 1, 1)
+            .unwrap();
+        let mut seat_request = request("seat", PolicyVehicle::TaskAgent, None, "intent-seat");
+        seat_request.caller = PolicyCallerBinding::Seat {
+            lane: "sm-policy-1268".into(),
+            seat_key: "sm-policy-1268-maintainer".into(),
+            generation: 1,
+            holder_session_id: "maintainer-1".into(),
+        };
+        seat_store.create_request(&seat_request).unwrap();
+        assert!(matches!(
+            seat_store.prepare_admission(
+                "seat",
+                &class("routine_bounded", None),
+                None,
+                instant("2026-08-17T00:01:00Z")
+            ),
+            Err(PolicyStoreError::CanaryDenied(_))
+        ));
         std::fs::remove_file(path).ok();
         std::fs::remove_file(wrong_path).ok();
+        std::fs::remove_file(seat_path).ok();
     }
 
     #[test]

--- a/crates/sm-server/src/policy_store.rs
+++ b/crates/sm-server/src/policy_store.rs
@@ -296,6 +296,9 @@ impl PolicyProjection {
 pub struct PreparedDecision {
     pub decision: PolicyDecision,
     pub reused: bool,
+    /// Present only for allow. D3 must use this exact ID when creating its
+    /// provisional core-session record and release it at completion/retirement.
+    pub provisional_child_session_id: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -400,8 +403,10 @@ impl PolicyStore {
         request_id: &str,
         classification: &PolicyClassification,
         override_id: Option<&str>,
+        provisional_child_session_id: &str,
         now: OffsetDateTime,
     ) -> Result<PreparedDecision> {
+        required(provisional_child_session_id, "provisional child session ID")?;
         classification
             .validate()
             .map_err(|error| PolicyStoreError::Invalid(error.to_string()))?;
@@ -433,10 +438,12 @@ impl PolicyStore {
             )));
         }
         if let Some(existing) = load_reusable_decision(&tx, &request, override_id)? {
+            let child = reusable_child_binding(&tx, &existing, provisional_child_session_id)?;
             tx.commit()?;
             return Ok(PreparedDecision {
                 decision: existing,
                 reused: true,
+                provisional_child_session_id: child,
             });
         }
         let attempt = next_attempt(&tx, request_id)?;
@@ -506,7 +513,12 @@ impl PolicyStore {
             lease
                 .validate()
                 .map_err(|e| PolicyStoreError::Invalid(e.to_string()))?;
-            insert_lease(&tx, &lease)?;
+            insert_lease(
+                &tx,
+                &lease,
+                &decision.decision_id,
+                provisional_child_session_id,
+            )?;
             decision.capacity_lease = Some(lease);
         } else {
             decision.override_command = Some(format!(
@@ -525,48 +537,116 @@ impl PolicyStore {
         Ok(PreparedDecision {
             decision,
             reused: false,
+            provisional_child_session_id: if matches!(outcome, PolicyDecisionOutcome::Allow) {
+                Some(provisional_child_session_id.to_owned())
+            } else {
+                None
+            },
         })
     }
 
     /// Authorizes a single exact frozen request. The record itself carries the
     /// authoritative cross-record binding; no caller supplied shortcut exists.
-    pub fn authorize_override(
+    /// Creates the only caller-facing exact-request override record.  All
+    /// binding fields are loaded from the frozen request and terminal decision;
+    /// D3 never reconstructs them from mutable caller input.
+    pub fn authorize_request_override(
         &self,
-        record: &PolicyOverrideRecord,
+        request_id: &str,
+        issuer: &PolicyCallerBinding,
+        reason: &str,
         now: OffsetDateTime,
-    ) -> Result<()> {
-        record
+        ttl: time::Duration,
+    ) -> Result<PolicyOverrideRecord> {
+        issuer
             .validate()
-            .map_err(|e| PolicyStoreError::Invalid(e.to_string()))?;
-        if !matches!(record.state, PolicyOverrideState::Authorized) {
+            .map_err(|error| PolicyStoreError::Invalid(error.to_string()))?;
+        required(reason, "override reason")?;
+        if ttl <= time::Duration::ZERO {
             return Err(PolicyStoreError::Invalid(
-                "new override must start authorized".into(),
+                "override ttl must be positive".into(),
             ));
         }
+        let expires_at = now.checked_add(ttl).ok_or_else(|| {
+            PolicyStoreError::Invalid("override expiry overflows timestamp".into())
+        })?;
         let mut conn = self.open()?;
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
-        let request = load_request_tx(&tx, &record.request_id)?;
-        let decision = load_terminal_decision(&tx, &record.request_id, &record.decision_id)?;
-        record
-            .validate_for_consumption(&request, &decision, now)
-            .map_err(|e| PolicyStoreError::OverrideDenied(e.to_string()))?;
-        let json = serde_json::to_string(record)?;
-        let inserted = tx.execute("INSERT OR IGNORE INTO policy_overrides (override_id, request_id, decision_id, state, override_json, created_at) VALUES (?1, ?2, ?3, 'authorized', ?4, ?5)", params![record.override_id, record.request_id, record.decision_id, json, record.created_at])?;
-        if inserted == 0 {
-            let existing = load_override_tx(&tx, &record.override_id)?;
-            if existing != *record {
-                return Err(PolicyStoreError::Invalid(
-                    "override ID is already bound to different immutable authorization".into(),
-                ));
-            }
+        expire_overrides_tx(&tx, now)?;
+        let request = load_request_tx(&tx, request_id)?;
+        if issuer != &request.caller {
+            return Err(PolicyStoreError::OverrideDenied(
+                "override issuer does not match the frozen request caller".into(),
+            ));
         }
+        let decision = load_latest_terminal_decision(&tx, &request)?;
+        if !matches!(
+            decision.outcome,
+            PolicyDecisionOutcome::Rewrite | PolicyDecisionOutcome::Block
+        ) {
+            return Err(PolicyStoreError::OverrideDenied(
+                "only a current rewrite or block decision can be overridden".into(),
+            ));
+        }
+        let record = PolicyOverrideRecord {
+            schema: crate::policy_contracts::OVERRIDE_SCHEMA.into(),
+            override_id: derived_id(
+                "override",
+                &[
+                    &request
+                        .canonical_digest()
+                        .map_err(|error| PolicyStoreError::Invalid(error.to_string()))?,
+                    &decision.decision_id,
+                ],
+            ),
+            request_id: request.request_id.clone(),
+            request_digest: request
+                .canonical_digest()
+                .map_err(|error| PolicyStoreError::Invalid(error.to_string()))?,
+            decision_id: decision.decision_id.clone(),
+            policy_version: request.policy_version.clone(),
+            issuer: issuer.clone(),
+            reason: reason.to_owned(),
+            self_benefiting: true,
+            state: PolicyOverrideState::Authorized,
+            created_at: format_time(now)?,
+            expires_at: format_time(expires_at)?,
+            consumed_at: None,
+        };
+        authorize_override_tx(&tx, &record, now)?;
+        tx.commit()?;
+        Ok(record)
+    }
+
+    pub fn release_lease(&self, lease_id: &str) -> Result<()> {
+        let mut conn = self.open()?;
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let released_at = now()?;
+        tx.execute("UPDATE policy_capacity_leases SET state = 'released', released_at = ?2 WHERE lease_id = ?1 AND state = 'active'", params![lease_id, released_at])?;
+        tx.execute("UPDATE policy_provisional_children SET state = 'released', released_at = ?2 WHERE lease_id = ?1 AND state = 'reserved'", params![lease_id, now()?])?;
         tx.commit()?;
         Ok(())
     }
 
-    pub fn release_lease(&self, lease_id: &str) -> Result<()> {
-        let conn = self.open()?;
-        conn.execute("UPDATE policy_capacity_leases SET state = 'released', released_at = ?2 WHERE lease_id = ?1 AND state = 'active'", params![lease_id, now()?])?;
+    /// Idempotent lifecycle cleanup for D3's completion, launch rejection, or
+    /// retirement paths. It releases the exact child-bound lease only.
+    pub fn release_by_child(&self, child_session_id: &str) -> Result<()> {
+        required(child_session_id, "provisional child session ID")?;
+        let mut conn = self.open()?;
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let lease_id = tx
+            .query_row(
+                "SELECT lease_id FROM policy_provisional_children WHERE child_session_id = ?1",
+                [child_session_id],
+                |row| row.get::<_, String>(0),
+            )
+            .optional()?;
+        if let Some(lease_id) = lease_id {
+            let released_at = now()?;
+            tx.execute("UPDATE policy_capacity_leases SET state = 'released', released_at = ?2 WHERE lease_id = ?1 AND state = 'active'", params![lease_id, released_at])?;
+            tx.execute("UPDATE policy_provisional_children SET state = 'released', released_at = ?2 WHERE child_session_id = ?1 AND state = 'reserved'", params![child_session_id, now()?])?;
+        }
+        tx.commit()?;
         Ok(())
     }
 
@@ -595,12 +675,20 @@ impl PolicyStore {
             CREATE TABLE IF NOT EXISTS policy_runtime_versions (lane TEXT PRIMARY KEY, topology_version INTEGER NOT NULL, capacity_version INTEGER NOT NULL);
             CREATE TABLE IF NOT EXISTS policy_requests (request_id TEXT PRIMARY KEY, lane TEXT NOT NULL, request_digest TEXT NOT NULL, request_json TEXT NOT NULL, created_at TEXT NOT NULL);
             CREATE TABLE IF NOT EXISTS policy_decisions (decision_id TEXT PRIMARY KEY, request_id TEXT NOT NULL, attempt INTEGER NOT NULL, override_id TEXT, decision_json TEXT NOT NULL, created_at TEXT NOT NULL, UNIQUE(request_id, attempt), UNIQUE(request_id, override_id));
-            CREATE TABLE IF NOT EXISTS policy_capacity_leases (lease_id TEXT PRIMARY KEY, request_id TEXT NOT NULL, state TEXT NOT NULL, expires_at TEXT NOT NULL, released_at TEXT, lease_json TEXT NOT NULL);
+            CREATE TABLE IF NOT EXISTS policy_capacity_leases (lease_id TEXT PRIMARY KEY, request_id TEXT NOT NULL, provisional_child_session_id TEXT NOT NULL, state TEXT NOT NULL, expires_at TEXT NOT NULL, released_at TEXT, lease_json TEXT NOT NULL);
             CREATE TABLE IF NOT EXISTS policy_capacity_claims (lease_id TEXT NOT NULL, dimension TEXT NOT NULL, claim_key TEXT NOT NULL, units INTEGER NOT NULL, PRIMARY KEY (lease_id, dimension, claim_key));
+            CREATE TABLE IF NOT EXISTS policy_provisional_children (child_session_id TEXT PRIMARY KEY, lease_id TEXT NOT NULL UNIQUE, request_id TEXT NOT NULL, decision_id TEXT NOT NULL, state TEXT NOT NULL, created_at TEXT NOT NULL, released_at TEXT);
             CREATE TABLE IF NOT EXISTS policy_overrides (override_id TEXT PRIMARY KEY, request_id TEXT NOT NULL, decision_id TEXT NOT NULL, state TEXT NOT NULL, override_json TEXT NOT NULL, created_at TEXT NOT NULL);
             CREATE INDEX IF NOT EXISTS idx_policy_active_claims ON policy_capacity_claims(dimension, claim_key);
             CREATE INDEX IF NOT EXISTS idx_policy_leases_active ON policy_capacity_leases(state, expires_at);
         "#)?;
+        ensure_column(
+            &conn,
+            "policy_capacity_leases",
+            "provisional_child_session_id",
+            "TEXT",
+        )?;
+        conn.execute_batch("CREATE UNIQUE INDEX IF NOT EXISTS idx_policy_active_lease_child ON policy_capacity_leases(provisional_child_session_id) WHERE state = 'active';")?;
         Ok(conn)
     }
 }
@@ -771,8 +859,14 @@ fn ensure_capacity(
     Ok(())
 }
 
-fn insert_lease(tx: &Transaction<'_>, lease: &PolicyCapacityLease) -> Result<()> {
-    tx.execute("INSERT INTO policy_capacity_leases (lease_id, request_id, state, expires_at, lease_json) VALUES (?1, ?2, 'active', ?3, ?4)", params![lease.lease_id, lease.request_id, lease.expires_at, serde_json::to_string(lease)?])?;
+fn insert_lease(
+    tx: &Transaction<'_>,
+    lease: &PolicyCapacityLease,
+    decision_id: &str,
+    provisional_child_session_id: &str,
+) -> Result<()> {
+    tx.execute("INSERT INTO policy_capacity_leases (lease_id, request_id, provisional_child_session_id, state, expires_at, lease_json) VALUES (?1, ?2, ?3, 'active', ?4, ?5)", params![lease.lease_id, lease.request_id, provisional_child_session_id, lease.expires_at, serde_json::to_string(lease)?])?;
+    tx.execute("INSERT INTO policy_provisional_children (child_session_id, lease_id, request_id, decision_id, state, created_at) VALUES (?1, ?2, ?3, ?4, 'reserved', ?5)", params![provisional_child_session_id, lease.lease_id, lease.request_id, decision_id, now()?])?;
     for claim in &lease.claims {
         tx.execute("INSERT INTO policy_capacity_claims (lease_id, dimension, claim_key, units) VALUES (?1, ?2, ?3, ?4)", params![lease.lease_id, claim.dimension, claim.key, claim.units])?;
     }
@@ -781,6 +875,7 @@ fn insert_lease(tx: &Transaction<'_>, lease: &PolicyCapacityLease) -> Result<()>
 
 fn expire_leases(tx: &Transaction<'_>, now: OffsetDateTime) -> Result<()> {
     tx.execute("UPDATE policy_capacity_leases SET state = 'expired' WHERE state = 'active' AND expires_at <= ?1", [format_time(now)?])?;
+    tx.execute("UPDATE policy_provisional_children SET state = 'expired' WHERE state = 'reserved' AND lease_id IN (SELECT lease_id FROM policy_capacity_leases WHERE state = 'expired')", [])?;
     Ok(())
 }
 
@@ -925,6 +1020,57 @@ fn load_terminal_decision(
         })?;
     Ok(serde_json::from_str(&value)?)
 }
+
+fn load_latest_terminal_decision(
+    tx: &Transaction<'_>,
+    request: &PolicySpawnRequest,
+) -> Result<PolicyDecision> {
+    let value = tx
+        .query_row(
+            "SELECT decision_json FROM policy_decisions WHERE request_id = ?1 ORDER BY attempt DESC LIMIT 1",
+            [&request.request_id],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()?
+        .ok_or_else(|| PolicyStoreError::OverrideDenied("request has no terminal decision".into()))?;
+    let decision: PolicyDecision = serde_json::from_str(&value)?;
+    decision
+        .validate_for_request(request)
+        .map_err(|error| PolicyStoreError::Invalid(error.to_string()))?;
+    Ok(decision)
+}
+
+fn authorize_override_tx(
+    tx: &Transaction<'_>,
+    record: &PolicyOverrideRecord,
+    now: OffsetDateTime,
+) -> Result<()> {
+    record
+        .validate()
+        .map_err(|error| PolicyStoreError::Invalid(error.to_string()))?;
+    if !matches!(record.state, PolicyOverrideState::Authorized) {
+        return Err(PolicyStoreError::Invalid(
+            "new override must start authorized".into(),
+        ));
+    }
+    let request = load_request_tx(tx, &record.request_id)?;
+    let decision = load_terminal_decision(tx, &record.request_id, &record.decision_id)?;
+    record
+        .validate_for_consumption(&request, &decision, now)
+        .map_err(|error| PolicyStoreError::OverrideDenied(error.to_string()))?;
+    let json = serde_json::to_string(record)?;
+    let inserted = tx.execute("INSERT OR IGNORE INTO policy_overrides (override_id, request_id, decision_id, state, override_json, created_at) VALUES (?1, ?2, ?3, 'authorized', ?4, ?5)", params![record.override_id, record.request_id, record.decision_id, json, record.created_at])?;
+    if inserted == 0 {
+        let existing = load_override_tx(tx, &record.override_id)?;
+        if existing != *record {
+            return Err(PolicyStoreError::Invalid(
+                "override ID is already bound to different immutable authorization".into(),
+            ));
+        }
+    }
+    Ok(())
+}
+
 fn load_reusable_decision(
     tx: &Transaction<'_>,
     request: &PolicySpawnRequest,
@@ -960,6 +1106,32 @@ fn load_reusable_decision(
         }
     }
     Ok(Some(decision))
+}
+
+fn reusable_child_binding(
+    tx: &Transaction<'_>,
+    decision: &PolicyDecision,
+    proposed_child_session_id: &str,
+) -> Result<Option<String>> {
+    let Some(lease) = &decision.capacity_lease else {
+        return Ok(None);
+    };
+    let child_session_id: String = tx
+        .query_row(
+            "SELECT child_session_id FROM policy_provisional_children WHERE lease_id = ?1 AND request_id = ?2 AND decision_id = ?3 AND state = 'reserved'",
+            params![lease.lease_id, decision.request_id, decision.decision_id],
+            |row| row.get(0),
+        )
+        .optional()?
+        .ok_or_else(|| PolicyStoreError::Invalid(
+            "active reusable lease has no matching provisional child reservation".into(),
+        ))?;
+    if child_session_id != proposed_child_session_id {
+        return Err(PolicyStoreError::Invalid(
+            "reused admission must use its originally reserved provisional child ID".into(),
+        ));
+    }
+    Ok(Some(child_session_id))
 }
 fn next_attempt(tx: &Transaction<'_>, request_id: &str) -> Result<u32> {
     let current: u32 = tx.query_row(
@@ -1021,12 +1193,23 @@ fn default_lease_ttl_seconds() -> u64 {
     300
 }
 
+fn ensure_column(conn: &Connection, table: &str, column: &str, declaration: &str) -> Result<()> {
+    let columns = conn
+        .prepare(&format!("PRAGMA table_info({table})"))?
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<std::result::Result<std::collections::BTreeSet<_>, _>>()?;
+    if !columns.contains(column) {
+        conn.execute_batch(&format!(
+            "ALTER TABLE {table} ADD COLUMN {column} {declaration}"
+        ))?;
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::policy_contracts::{
-        PolicyRequestedLaunch, PolicyVehicle, OVERRIDE_SCHEMA, SPAWN_REQUEST_SCHEMA,
-    };
+    use crate::policy_contracts::{PolicyRequestedLaunch, PolicyVehicle, SPAWN_REQUEST_SCHEMA};
 
     const DIGEST: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
@@ -1170,7 +1353,13 @@ mod tests {
         store.create_request(&root).unwrap();
         let now = instant("2026-08-17T00:01:00Z");
         let worker = store
-            .prepare_admission("aa6c1120", &class("routine_bounded", None), None, now)
+            .prepare_admission(
+                "aa6c1120",
+                &class("routine_bounded", None),
+                None,
+                "child-aa",
+                now,
+            )
             .unwrap()
             .decision;
         let named = store
@@ -1178,6 +1367,7 @@ mod tests {
                 "2260296e",
                 &class("named_orchestrator", Some("maintainer")),
                 None,
+                "child-root",
                 now,
             )
             .unwrap()
@@ -1210,6 +1400,7 @@ mod tests {
                 "disabled",
                 &class("routine_bounded", None),
                 None,
+                "child-disabled",
                 instant("2026-08-17T00:01:00Z")
             ),
             Err(PolicyStoreError::CanaryDenied(_))
@@ -1235,6 +1426,7 @@ mod tests {
                 "wrong",
                 &class("routine_bounded", None),
                 None,
+                "child-wrong",
                 instant("2026-08-17T00:01:00Z")
             ),
             Err(PolicyStoreError::CanaryDenied(_))
@@ -1257,6 +1449,7 @@ mod tests {
                 "seat",
                 &class("routine_bounded", None),
                 None,
+                "child-seat",
                 instant("2026-08-17T00:01:00Z")
             ),
             Err(PolicyStoreError::CanaryDenied(_))
@@ -1289,15 +1482,33 @@ mod tests {
             .unwrap();
         let now = instant("2026-08-17T00:01:00Z");
         store
-            .prepare_admission("first", &class("routine_bounded", None), None, now)
+            .prepare_admission(
+                "first",
+                &class("routine_bounded", None),
+                None,
+                "child-first",
+                now,
+            )
             .unwrap();
         assert!(matches!(
-            store.prepare_admission("second", &class("routine_bounded", None), None, now),
+            store.prepare_admission(
+                "second",
+                &class("routine_bounded", None),
+                None,
+                "child-second",
+                now
+            ),
             Err(PolicyStoreError::CapacityUnavailable(_))
         ));
         store.set_runtime_versions("sm-policy-1268", 2, 1).unwrap();
         assert!(matches!(
-            store.prepare_admission("second", &class("routine_bounded", None), None, now),
+            store.prepare_admission(
+                "second",
+                &class("routine_bounded", None),
+                None,
+                "child-second",
+                now
+            ),
             Err(PolicyStoreError::Stale(_))
         ));
         std::fs::remove_file(path).ok();
@@ -1321,32 +1532,27 @@ mod tests {
                 "rewrite-me",
                 &class("named_orchestrator", Some("maintainer")),
                 None,
+                "child-rewrite",
                 now,
             )
             .unwrap()
             .decision;
         assert!(matches!(rejected.outcome, PolicyDecisionOutcome::Rewrite));
-        let record = PolicyOverrideRecord {
-            schema: OVERRIDE_SCHEMA.into(),
-            override_id: "override-1".into(),
-            request_id: request.request_id.clone(),
-            request_digest: request.canonical_digest().unwrap(),
-            decision_id: rejected.decision_id.clone(),
-            policy_version: request.policy_version.clone(),
-            issuer: request.caller.clone(),
-            reason: "operator accepts exact model exception".into(),
-            self_benefiting: true,
-            state: PolicyOverrideState::Authorized,
-            created_at: "2026-08-17T00:01:00Z".into(),
-            expires_at: "2026-08-17T00:10:00Z".into(),
-            consumed_at: None,
-        };
-        store.authorize_override(&record, now).unwrap();
+        let record = store
+            .authorize_request_override(
+                "rewrite-me",
+                &request.caller,
+                "operator accepts exact model exception",
+                now,
+                time::Duration::minutes(9),
+            )
+            .unwrap();
         let allowed = store
             .prepare_admission(
                 "rewrite-me",
                 &class("named_orchestrator", Some("maintainer")),
-                Some("override-1"),
+                Some(&record.override_id),
+                "child-override",
                 now,
             )
             .unwrap();
@@ -1356,21 +1562,25 @@ mod tests {
         ));
         assert!(!allowed.reused);
         assert!(matches!(
-            store.override_record("override-1").unwrap().state,
+            store.override_record(&record.override_id).unwrap().state,
             PolicyOverrideState::Consumed
         ));
         assert!(matches!(
             store.prepare_admission(
                 "rewrite-me",
                 &class("named_orchestrator", Some("maintainer")),
-                Some("override-1"),
+                Some(&record.override_id),
+                "child-override",
                 now
             ),
             Ok(PreparedDecision { reused: true, .. })
         ));
         let after_restart = PolicyStore::new(&path).unwrap();
         assert!(matches!(
-            after_restart.override_record("override-1").unwrap().state,
+            after_restart
+                .override_record(&record.override_id)
+                .unwrap()
+                .state,
             PolicyOverrideState::Consumed
         ));
         std::fs::remove_file(path).ok();
@@ -1391,7 +1601,13 @@ mod tests {
             .unwrap();
         let now = instant("2026-08-17T00:01:00Z");
         let decision = store
-            .prepare_admission("damaged", &class("routine_bounded", None), None, now)
+            .prepare_admission(
+                "damaged",
+                &class("routine_bounded", None),
+                None,
+                "child-damaged",
+                now,
+            )
             .unwrap()
             .decision;
         let conn = Connection::open(&path).unwrap();
@@ -1415,8 +1631,146 @@ mod tests {
         drop(conn);
         let after_restart = PolicyStore::new(&path).unwrap();
         assert!(matches!(
-            after_restart.prepare_admission("damaged", &class("routine_bounded", None), None, now),
+            after_restart.prepare_admission(
+                "damaged",
+                &class("routine_bounded", None),
+                None,
+                "child-damaged",
+                now
+            ),
             Err(PolicyStoreError::Invalid(_))
+        ));
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn provisional_child_reservation_is_restart_safe_and_releases_by_child() {
+        let (store, path) = store("provisional-child");
+        store.install_projection(&projection(true, 1)).unwrap();
+        store.set_runtime_versions("sm-policy-1268", 1, 1).unwrap();
+        store
+            .create_request(&request(
+                "child-bound",
+                PolicyVehicle::TaskAgent,
+                None,
+                "intent-child-bound",
+            ))
+            .unwrap();
+        let now = instant("2026-08-17T00:01:00Z");
+        let first = store
+            .prepare_admission(
+                "child-bound",
+                &class("routine_bounded", None),
+                None,
+                "provisional-1",
+                now,
+            )
+            .unwrap();
+        assert_eq!(
+            first.provisional_child_session_id.as_deref(),
+            Some("provisional-1")
+        );
+        let after_restart = PolicyStore::new(&path).unwrap();
+        assert!(
+            after_restart
+                .prepare_admission(
+                    "child-bound",
+                    &class("routine_bounded", None),
+                    None,
+                    "provisional-1",
+                    now,
+                )
+                .unwrap()
+                .reused
+        );
+        assert!(matches!(
+            after_restart.prepare_admission(
+                "child-bound",
+                &class("routine_bounded", None),
+                None,
+                "other-provisional",
+                now,
+            ),
+            Err(PolicyStoreError::Invalid(_))
+        ));
+        after_restart.release_by_child("provisional-1").unwrap();
+        after_restart.release_by_child("provisional-1").unwrap();
+        let conn = Connection::open(&path).unwrap();
+        let states: (String, String) = conn
+            .query_row(
+                "SELECT l.state, p.state FROM policy_capacity_leases l JOIN policy_provisional_children p ON p.lease_id = l.lease_id WHERE p.child_session_id = 'provisional-1'",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(states, ("released".into(), "released".into()));
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn server_constructed_override_rejects_cross_caller_and_cross_request() {
+        let (store, path) = store("override-authority");
+        store.install_projection(&projection(true, 2)).unwrap();
+        store.set_runtime_versions("sm-policy-1268", 1, 1).unwrap();
+        let first = request(
+            "override-a",
+            PolicyVehicle::NamedSeat,
+            Some("fable"),
+            "intent-override-a",
+        );
+        let second = request(
+            "override-b",
+            PolicyVehicle::NamedSeat,
+            Some("fable"),
+            "intent-override-b",
+        );
+        store.create_request(&first).unwrap();
+        store.create_request(&second).unwrap();
+        let now = instant("2026-08-17T00:01:00Z");
+        for (request_id, child) in [("override-a", "child-a"), ("override-b", "child-b")] {
+            store
+                .prepare_admission(
+                    request_id,
+                    &class("named_orchestrator", Some("maintainer")),
+                    None,
+                    child,
+                    now,
+                )
+                .unwrap();
+        }
+        let mut other_issuer = first.caller.clone();
+        if let PolicyCallerBinding::IncarnationBootstrap { session_id, .. } = &mut other_issuer {
+            *session_id = "another-maintainer".into();
+        }
+        assert!(matches!(
+            store.authorize_request_override(
+                "override-a",
+                &other_issuer,
+                "wrong caller",
+                now,
+                time::Duration::minutes(1),
+            ),
+            Err(PolicyStoreError::OverrideDenied(_))
+        ));
+        let override_a = store
+            .authorize_request_override(
+                "override-a",
+                &first.caller,
+                "exact request only",
+                now,
+                time::Duration::minutes(1),
+            )
+            .unwrap();
+        assert_eq!(override_a.request_id, "override-a");
+        assert!(matches!(
+            store.prepare_admission(
+                "override-b",
+                &class("named_orchestrator", Some("maintainer")),
+                Some(&override_a.override_id),
+                "child-b-override",
+                now,
+            ),
+            Err(PolicyStoreError::OverrideDenied(_))
         ));
         std::fs::remove_file(path).ok();
     }
@@ -1444,6 +1798,7 @@ mod tests {
                 "conflict",
                 &class("routine_bounded", None),
                 None,
+                "child-conflict",
                 instant("2026-08-17T00:01:00Z"),
             )
             .unwrap()
@@ -1493,6 +1848,7 @@ mod tests {
                     request_id,
                     &class("routine_bounded", None),
                     None,
+                    request_id,
                     instant("2026-08-17T00:01:00Z"),
                 )
             }));

--- a/crates/sm-server/src/policy_store.rs
+++ b/crates/sm-server/src/policy_store.rs
@@ -311,6 +311,46 @@ pub struct PreparedDecision {
     /// Present only for allow. D3 must use this exact ID when creating its
     /// provisional core-session record and release it at completion/retirement.
     pub provisional_child_session_id: Option<String>,
+    /// Durable lifecycle state of the returned child binding. Retries always
+    /// return the original binding, including after it terminalizes.
+    pub child_state: Option<PolicyChildState>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyLeaseState {
+    Active,
+    Committed,
+    ReleasePending,
+    Released,
+    Expired,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PolicyChildState {
+    Reserved,
+    Launched,
+    ReleasePending,
+    Released,
+    Expired,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PolicyChildReservation {
+    pub child_session_id: String,
+    pub lease_id: String,
+    pub request_id: String,
+    pub decision_id: String,
+    pub lease_state: PolicyLeaseState,
+    pub child_state: PolicyChildState,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PolicyReconciliationSnapshot {
+    pub expected: usize,
+    pub reservations: Vec<PolicyChildReservation>,
+    pub blockers: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -485,12 +525,15 @@ impl PolicyStore {
             )));
         }
         if let Some(existing) = load_reusable_decision(&tx, &request, override_id)? {
-            let child = reusable_child_binding(&tx, &existing, provisional_child_session_id)?;
+            let reservation = reusable_child_binding(&tx, &existing)?;
             tx.commit()?;
             return Ok(PreparedDecision {
                 decision: existing,
                 reused: true,
-                provisional_child_session_id: child,
+                provisional_child_session_id: reservation
+                    .as_ref()
+                    .map(|reservation| reservation.child_session_id.clone()),
+                child_state: reservation.map(|reservation| reservation.child_state),
             });
         }
         let attempt = next_attempt(&tx, request_id)?;
@@ -525,6 +568,14 @@ impl PolicyStore {
             override_used = Some(override_id);
             override_terminal_decision_id = Some(override_record.decision_id);
         }
+        let resolved_profile = if override_used.is_some() {
+            resolved
+                .profile
+                .as_ref()
+                .map(|profile| override_granted_profile(&request, profile))
+        } else {
+            resolved.profile.clone()
+        };
         let decision_id = derived_id(
             "decision",
             &[
@@ -546,7 +597,7 @@ impl PolicyStore {
             outcome: outcome.clone(),
             classification: effective_classification,
             applicable_clause_ids: resolved.clause_ids.clone(),
-            resolved_profile: resolved.profile.clone(),
+            resolved_profile,
             reason: resolved.reason.clone(),
             override_command: None,
             capacity_lease: None,
@@ -601,6 +652,11 @@ impl PolicyStore {
             reused: false,
             provisional_child_session_id: if matches!(outcome, PolicyDecisionOutcome::Allow) {
                 Some(provisional_child_session_id.to_owned())
+            } else {
+                None
+            },
+            child_state: if matches!(outcome, PolicyDecisionOutcome::Allow) {
+                Some(PolicyChildState::Reserved)
             } else {
                 None
             },
@@ -707,11 +763,72 @@ impl PolicyStore {
         required(child_session_id, "provisional child session ID")?;
         let mut conn = self.open()?;
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
-        let lease_id = load_child_lease_tx(&tx, child_session_id, false)?;
-        if let Some(lease_id) = lease_id {
+        let reservation = load_child_reservation_tx(&tx, child_session_id)?;
+        if let Some(reservation) = reservation {
+            if matches!(
+                reservation.child_state,
+                PolicyChildState::Released | PolicyChildState::Expired
+            ) && matches!(
+                reservation.lease_state,
+                PolicyLeaseState::Released | PolicyLeaseState::Expired
+            ) {
+                tx.commit()?;
+                return Ok(());
+            }
             let released_at = now()?;
-            tx.execute("UPDATE policy_capacity_leases SET state = 'released', released_at = ?2 WHERE lease_id = ?1 AND state IN ('active', 'committed')", params![lease_id, released_at])?;
-            tx.execute("UPDATE policy_provisional_children SET state = 'released', released_at = ?2 WHERE child_session_id = ?1 AND state IN ('reserved', 'launched')", params![child_session_id, now()?])?;
+            let lease_changed = tx.execute("UPDATE policy_capacity_leases SET state = 'released', released_at = ?2 WHERE lease_id = ?1 AND state IN ('active', 'committed', 'release_pending')", params![reservation.lease_id, released_at])?;
+            let child_changed = tx.execute("UPDATE policy_provisional_children SET state = 'released', released_at = ?2 WHERE child_session_id = ?1 AND state IN ('reserved', 'launched', 'release_pending')", params![child_session_id, now()?])?;
+            if lease_changed != 1 || child_changed != 1 {
+                return Err(PolicyStoreError::Invalid(
+                    "child and lease could not be released from one matching lifecycle state"
+                        .into(),
+                ));
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Persists release intent before D3 stops or detaches the runtime. A crash
+    /// after this point is resumed by startup reconciliation.
+    pub fn mark_child_release_pending(&self, child_session_id: &str) -> Result<()> {
+        required(child_session_id, "provisional child session ID")?;
+        let mut conn = self.open()?;
+        let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
+        let reservation = load_child_reservation_tx(&tx, child_session_id)?.ok_or_else(|| {
+            PolicyStoreError::Invalid(
+                "release-pending requires exactly one matching child reservation".into(),
+            )
+        })?;
+        if reservation.child_state == PolicyChildState::ReleasePending
+            && reservation.lease_state == PolicyLeaseState::ReleasePending
+        {
+            tx.commit()?;
+            return Ok(());
+        }
+        let admissible = matches!(
+            (reservation.child_state, reservation.lease_state),
+            (PolicyChildState::Reserved, PolicyLeaseState::Active)
+                | (PolicyChildState::Launched, PolicyLeaseState::Committed)
+        );
+        if !admissible {
+            return Err(PolicyStoreError::Invalid(format!(
+                "cannot begin release from child/lease states {:?}/{:?}",
+                reservation.child_state, reservation.lease_state
+            )));
+        }
+        let lease_changed = tx.execute(
+            "UPDATE policy_capacity_leases SET state = 'release_pending' WHERE lease_id = ?1 AND state IN ('active', 'committed')",
+            [&reservation.lease_id],
+        )?;
+        let child_changed = tx.execute(
+            "UPDATE policy_provisional_children SET state = 'release_pending' WHERE child_session_id = ?1 AND state IN ('reserved', 'launched')",
+            [child_session_id],
+        )?;
+        if lease_changed != 1 || child_changed != 1 {
+            return Err(PolicyStoreError::Invalid(
+                "release-pending transition did not update exactly one child and lease".into(),
+            ));
         }
         tx.commit()?;
         Ok(())
@@ -724,19 +841,102 @@ impl PolicyStore {
         required(child_session_id, "provisional child session ID")?;
         let mut conn = self.open()?;
         let tx = conn.transaction_with_behavior(TransactionBehavior::Immediate)?;
-        let lease_id = load_child_lease_tx(&tx, child_session_id, true)?;
-        if let Some(lease_id) = lease_id {
-            tx.execute(
-                "UPDATE policy_capacity_leases SET state = 'committed' WHERE lease_id = ?1 AND state = 'active'",
-                [&lease_id],
-            )?;
-            tx.execute(
-                "UPDATE policy_provisional_children SET state = 'launched' WHERE child_session_id = ?1 AND state = 'reserved'",
-                [child_session_id],
-            )?;
+        let reservation = load_child_reservation_tx(&tx, child_session_id)?.ok_or_else(|| {
+            PolicyStoreError::Invalid(
+                "launch promotion requires exactly one matching child reservation".into(),
+            )
+        })?;
+        if reservation.child_state != PolicyChildState::Reserved
+            || reservation.lease_state != PolicyLeaseState::Active
+        {
+            return Err(PolicyStoreError::Invalid(format!(
+                "launch promotion requires reserved/active state, found {:?}/{:?}",
+                reservation.child_state, reservation.lease_state
+            )));
+        }
+        let lease_changed = tx.execute(
+            "UPDATE policy_capacity_leases SET state = 'committed' WHERE lease_id = ?1 AND state = 'active'",
+            [&reservation.lease_id],
+        )?;
+        let child_changed = tx.execute(
+            "UPDATE policy_provisional_children SET state = 'launched' WHERE child_session_id = ?1 AND state = 'reserved'",
+            [child_session_id],
+        )?;
+        if lease_changed != 1 || child_changed != 1 {
+            return Err(PolicyStoreError::Invalid(
+                "launch promotion did not update exactly one matching child and lease".into(),
+            ));
         }
         tx.commit()?;
         Ok(())
+    }
+
+    pub fn resolve_child(&self, child_session_id: &str) -> Result<Option<PolicyChildReservation>> {
+        required(child_session_id, "provisional child session ID")?;
+        let mut conn = self.open()?;
+        let tx = conn.transaction()?;
+        let reservation = load_child_reservation_tx(&tx, child_session_id)?;
+        tx.commit()?;
+        Ok(reservation)
+    }
+
+    /// Enumerates every non-terminal lease/child pair before admission is
+    /// enabled. Structural mismatches are returned as exact blockers instead of
+    /// being silently omitted from the sweep denominator.
+    pub fn reconciliation_snapshot(&self) -> Result<PolicyReconciliationSnapshot> {
+        let mut conn = self.open()?;
+        let tx = conn.transaction()?;
+        let expected = tx.query_row(
+            "SELECT COUNT(*) FROM policy_capacity_leases WHERE state IN ('active', 'committed', 'release_pending')",
+            [],
+            |row| row.get::<_, usize>(0),
+        )?;
+        let rows = tx
+            .prepare("SELECT lease_id, provisional_child_session_id FROM policy_capacity_leases WHERE state IN ('active', 'committed', 'release_pending') ORDER BY lease_id")?
+            .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        let mut reservations = Vec::new();
+        let mut blockers = Vec::new();
+        for (lease_id, child_session_id) in rows {
+            match load_child_reservation_tx(&tx, &child_session_id)? {
+                Some(reservation) if reservation.lease_id == lease_id => {
+                    if reservation_states_are_reconcilable(&reservation) {
+                        reservations.push(reservation);
+                    } else {
+                        blockers.push(format!(
+                            "child {} has ambiguous child/lease states {:?}/{:?}",
+                            child_session_id, reservation.child_state, reservation.lease_state
+                        ));
+                    }
+                }
+                Some(reservation) => blockers.push(format!(
+                    "lease {lease_id} points to child {child_session_id}, but that child binds lease {}",
+                    reservation.lease_id
+                )),
+                None => blockers.push(format!(
+                    "lease {lease_id} has no matching provisional child {child_session_id}"
+                )),
+            }
+        }
+        let orphan_children = tx
+            .prepare("SELECT child_session_id, lease_id FROM policy_provisional_children WHERE state IN ('reserved', 'launched', 'release_pending') AND lease_id NOT IN (SELECT lease_id FROM policy_capacity_leases WHERE state IN ('active', 'committed', 'release_pending')) ORDER BY child_session_id")?
+            .query_map([], |row| Ok((row.get::<_, String>(0)?, row.get::<_, String>(1)?)))?
+            .collect::<std::result::Result<Vec<_>, _>>()?;
+        for (child_session_id, lease_id) in orphan_children {
+            blockers.push(format!(
+                "provisional child {child_session_id} has no matching non-terminal lease {lease_id}"
+            ));
+        }
+        let expected = expected
+            + blockers
+                .len()
+                .saturating_sub(expected.saturating_sub(reservations.len()));
+        tx.commit()?;
+        Ok(PolicyReconciliationSnapshot {
+            expected,
+            reservations,
+            blockers,
+        })
     }
 
     pub fn expire_overrides(&self, now: OffsetDateTime) -> Result<usize> {
@@ -894,6 +1094,8 @@ fn resolve_rule(
         rule.profile != first.profile
             || rule.outcome != first.outcome
             || rule.capacity_claims != first.capacity_claims
+            || rule.overridable != first.overridable
+            || rule.lease_ttl_seconds != first.lease_ttl_seconds
     });
     let clause_ids = winning.iter().map(|rule| rule.clause_id.clone()).collect();
     if conflicting {
@@ -936,6 +1138,26 @@ fn requested_profile_conflicts(
         || request.requested.provider != profile.provider
         || request.requested.model.as_deref() != Some(profile.model.as_str())
         || request.requested.effort.as_deref() != Some(profile.effort.as_str())
+}
+
+fn override_granted_profile(
+    request: &PolicySpawnRequest,
+    rewrite_target: &PolicyLaunchProfile,
+) -> PolicyLaunchProfile {
+    match (
+        request.requested.model.as_deref(),
+        request.requested.effort.as_deref(),
+    ) {
+        (Some(model), Some(effort)) => PolicyLaunchProfile {
+            vehicle: request.requested.vehicle.clone(),
+            provider: request.requested.provider.clone(),
+            model: model.to_owned(),
+            effort: effort.to_owned(),
+            // Context profiles are policy-owned and are not caller supplied.
+            context_profile: rewrite_target.context_profile.clone(),
+        },
+        _ => rewrite_target.clone(),
+    }
 }
 
 fn authorize_caller(projection: &PolicyProjection, request: &PolicySpawnRequest) -> Result<()> {
@@ -1397,7 +1619,7 @@ fn load_lease_tx(tx: &Transaction<'_>, lease_id: &str) -> Result<PolicyCapacityL
     if claims != expected_claims
         || !matches!(
             state.as_str(),
-            "active" | "committed" | "released" | "expired"
+            "active" | "committed" | "release_pending" | "released" | "expired"
         )
     {
         return Err(PolicyStoreError::Invalid(
@@ -1407,24 +1629,36 @@ fn load_lease_tx(tx: &Transaction<'_>, lease_id: &str) -> Result<PolicyCapacityL
     Ok(lease)
 }
 
-fn load_child_lease_tx(
+fn load_child_reservation_tx(
     tx: &Transaction<'_>,
     child_session_id: &str,
-    require_reserved: bool,
-) -> Result<Option<String>> {
-    let row: Option<(String, String, String, String)> = tx
-        .query_row(
-            "SELECT lease_id, request_id, decision_id, state FROM policy_provisional_children WHERE child_session_id = ?1",
-            [child_session_id],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
-        )
-        .optional()?;
-    let Some((lease_id, request_id, decision_id, state)) = row else {
+) -> Result<Option<PolicyChildReservation>> {
+    let rows = tx
+        .prepare(
+            "SELECT p.lease_id, p.request_id, p.decision_id, p.state, l.state FROM policy_provisional_children p JOIN policy_capacity_leases l ON l.lease_id = p.lease_id WHERE p.child_session_id = ?1",
+        )?
+        .query_map([child_session_id], |row| {
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, String>(1)?,
+                row.get::<_, String>(2)?,
+                row.get::<_, String>(3)?,
+                row.get::<_, String>(4)?,
+            ))
+        })?
+        .collect::<std::result::Result<Vec<_>, _>>()?;
+    if rows.len() > 1 {
+        return Err(PolicyStoreError::Invalid(
+            "provisional child matched more than one lease".into(),
+        ));
+    }
+    let Some((lease_id, request_id, decision_id, child_state, lease_state)) =
+        rows.into_iter().next()
+    else {
         return Ok(None);
     };
-    if require_reserved && state != "reserved" {
-        return Ok(None);
-    }
+    let child_state = parse_child_state(&child_state)?;
+    let lease_state = parse_lease_state(&lease_state)?;
     let request = load_request_tx(tx, &request_id)?;
     let decision = load_terminal_decision(tx, &request, &decision_id)?;
     let lease = load_lease_tx(tx, &lease_id)?;
@@ -1440,7 +1674,52 @@ fn load_child_lease_tx(
             "provisional child does not match its decision and capacity lease".into(),
         ));
     }
-    Ok(Some(lease_id))
+    Ok(Some(PolicyChildReservation {
+        child_session_id: child_session_id.to_owned(),
+        lease_id,
+        request_id,
+        decision_id,
+        lease_state,
+        child_state,
+    }))
+}
+
+fn parse_lease_state(value: &str) -> Result<PolicyLeaseState> {
+    match value {
+        "active" => Ok(PolicyLeaseState::Active),
+        "committed" => Ok(PolicyLeaseState::Committed),
+        "release_pending" => Ok(PolicyLeaseState::ReleasePending),
+        "released" => Ok(PolicyLeaseState::Released),
+        "expired" => Ok(PolicyLeaseState::Expired),
+        _ => Err(PolicyStoreError::Invalid(format!(
+            "unknown capacity lease state {value}"
+        ))),
+    }
+}
+
+fn parse_child_state(value: &str) -> Result<PolicyChildState> {
+    match value {
+        "reserved" => Ok(PolicyChildState::Reserved),
+        "launched" => Ok(PolicyChildState::Launched),
+        "release_pending" => Ok(PolicyChildState::ReleasePending),
+        "released" => Ok(PolicyChildState::Released),
+        "expired" => Ok(PolicyChildState::Expired),
+        _ => Err(PolicyStoreError::Invalid(format!(
+            "unknown provisional child state {value}"
+        ))),
+    }
+}
+
+fn reservation_states_are_reconcilable(reservation: &PolicyChildReservation) -> bool {
+    matches!(
+        (reservation.child_state, reservation.lease_state),
+        (PolicyChildState::Reserved, PolicyLeaseState::Active)
+            | (PolicyChildState::Launched, PolicyLeaseState::Committed)
+            | (
+                PolicyChildState::ReleasePending,
+                PolicyLeaseState::ReleasePending
+            )
+    )
 }
 
 fn authorize_override_tx(
@@ -1508,33 +1787,19 @@ fn load_reusable_decision(
         &json,
         &created_at,
     )?;
-    if let Some(lease) = &decision.capacity_lease {
-        let active: bool = tx
-            .query_row(
-                "SELECT state = 'active' FROM policy_capacity_leases WHERE lease_id = ?1",
-                [&lease.lease_id],
-                |row| row.get(0),
-            )
-            .optional()?
-            .unwrap_or(false);
-        if !active {
-            return Ok(None);
-        }
-    }
     Ok(Some(decision))
 }
 
 fn reusable_child_binding(
     tx: &Transaction<'_>,
     decision: &PolicyDecision,
-    proposed_child_session_id: &str,
-) -> Result<Option<String>> {
+) -> Result<Option<PolicyChildReservation>> {
     let Some(lease) = &decision.capacity_lease else {
         return Ok(None);
     };
     let child_session_id: String = tx
         .query_row(
-            "SELECT child_session_id FROM policy_provisional_children WHERE lease_id = ?1 AND request_id = ?2 AND decision_id = ?3 AND state = 'reserved'",
+            "SELECT child_session_id FROM policy_provisional_children WHERE lease_id = ?1 AND request_id = ?2 AND decision_id = ?3",
             params![lease.lease_id, decision.request_id, decision.decision_id],
             |row| row.get(0),
         )
@@ -1542,12 +1807,10 @@ fn reusable_child_binding(
         .ok_or_else(|| PolicyStoreError::Invalid(
             "active reusable lease has no matching provisional child reservation".into(),
         ))?;
-    if child_session_id != proposed_child_session_id {
-        return Err(PolicyStoreError::Invalid(
-            "reused admission must use its originally reserved provisional child ID".into(),
-        ));
-    }
-    Ok(Some(child_session_id))
+    let reservation = load_child_reservation_tx(tx, &child_session_id)?.ok_or_else(|| {
+        PolicyStoreError::Invalid("reusable decision has no matching child reservation".into())
+    })?;
+    Ok(Some(reservation))
 }
 fn next_attempt(tx: &Transaction<'_>, request_id: &str) -> Result<u32> {
     let current: u32 = tx.query_row(
@@ -1998,6 +2261,11 @@ mod tests {
             allowed.decision.outcome,
             PolicyDecisionOutcome::Allow
         ));
+        assert_eq!(
+            allowed.decision.resolved_profile.as_ref().unwrap().model,
+            "fable",
+            "a fully specified exact-request override grants the frozen requested model"
+        );
         assert!(!allowed.reused);
         assert!(matches!(
             store.override_record(&record.override_id).unwrap().state,
@@ -2121,16 +2389,22 @@ mod tests {
                 .unwrap()
                 .reused
         );
-        assert!(matches!(
-            after_restart.prepare_admission(
+        let retry_with_discarded_preallocation = after_restart
+            .prepare_admission(
                 "child-bound",
                 &class("routine_bounded", None),
                 None,
                 "other-provisional",
                 now,
-            ),
-            Err(PolicyStoreError::Invalid(_))
-        ));
+            )
+            .unwrap();
+        assert!(retry_with_discarded_preallocation.reused);
+        assert_eq!(
+            retry_with_discarded_preallocation
+                .provisional_child_session_id
+                .as_deref(),
+            Some("provisional-1")
+        );
         after_restart.mark_child_launched("provisional-1").unwrap();
         after_restart.release_by_child("provisional-1").unwrap();
         after_restart.release_by_child("provisional-1").unwrap();
@@ -2144,6 +2418,253 @@ mod tests {
             .unwrap();
         assert_eq!(states, ("released".into(), "released".into()));
         std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn ordinary_retries_reuse_terminal_decision_in_every_lease_state() {
+        for terminal in ["active", "committed", "released", "expired"] {
+            let (store, path) = store(&format!("retry-{terminal}"));
+            let mut projection = projection(true, 1);
+            for rule in &mut projection.rules {
+                rule.lease_ttl_seconds = 1;
+            }
+            install(&store, &projection);
+            store.set_runtime_versions("sm-policy-1268", 1, 1).unwrap();
+            let request_id = format!("retry-{terminal}");
+            let child_id = format!("child-{terminal}");
+            store
+                .create_request(&request(
+                    &request_id,
+                    PolicyVehicle::TaskAgent,
+                    None,
+                    &format!("intent-{terminal}"),
+                ))
+                .unwrap();
+            let now = instant("2026-08-17T00:01:00Z");
+            let first = store
+                .prepare_admission(
+                    &request_id,
+                    &class("routine_bounded", None),
+                    None,
+                    &child_id,
+                    now,
+                )
+                .unwrap();
+            match terminal {
+                "active" => {}
+                "committed" => store.mark_child_launched(&child_id).unwrap(),
+                "released" => store.release_by_child(&child_id).unwrap(),
+                "expired" => {
+                    let retry = store
+                        .prepare_admission(
+                            &request_id,
+                            &class("routine_bounded", None),
+                            None,
+                            "discarded-expiry-preallocation",
+                            now + time::Duration::seconds(2),
+                        )
+                        .unwrap();
+                    assert_eq!(retry.child_state, Some(PolicyChildState::Expired));
+                }
+                _ => unreachable!(),
+            }
+            let retried = store
+                .prepare_admission(
+                    &request_id,
+                    &class("routine_bounded", None),
+                    None,
+                    "discarded-retry-preallocation",
+                    now + time::Duration::seconds(if terminal == "active" { 0 } else { 2 }),
+                )
+                .unwrap();
+            assert!(retried.reused, "{terminal}");
+            assert_eq!(retried.decision.decision_id, first.decision.decision_id);
+            assert_eq!(
+                retried.provisional_child_session_id.as_deref(),
+                Some(child_id.as_str())
+            );
+            let conn = Connection::open(&path).unwrap();
+            let counts: (u64, u64, u64, u64) = conn
+                .query_row(
+                    "SELECT (SELECT COUNT(*) FROM policy_decisions), (SELECT COUNT(*) FROM policy_capacity_leases), (SELECT COUNT(*) FROM policy_capacity_claims), (SELECT COUNT(*) FROM policy_provisional_children)",
+                    [],
+                    |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+                )
+                .unwrap();
+            assert_eq!(counts, (1, 1, 1, 1), "{terminal}");
+            std::fs::remove_file(path).ok();
+        }
+    }
+
+    #[test]
+    fn launch_promotion_requires_exactly_one_reserved_active_binding() {
+        let cases = ["missing", "released", "expired", "launched", "conflicting"];
+        for case in cases {
+            let (store, path) = store(&format!("strict-mark-{case}"));
+            let mut projection = projection(true, 1);
+            for rule in &mut projection.rules {
+                rule.lease_ttl_seconds = 1;
+            }
+            install(&store, &projection);
+            store.set_runtime_versions("sm-policy-1268", 1, 1).unwrap();
+            let child = format!("strict-child-{case}");
+            if case != "missing" {
+                let request_id = format!("strict-request-{case}");
+                store
+                    .create_request(&request(
+                        &request_id,
+                        PolicyVehicle::TaskAgent,
+                        None,
+                        &format!("strict-intent-{case}"),
+                    ))
+                    .unwrap();
+                let now = instant("2026-08-17T00:01:00Z");
+                store
+                    .prepare_admission(
+                        &request_id,
+                        &class("routine_bounded", None),
+                        None,
+                        &child,
+                        now,
+                    )
+                    .unwrap();
+                match case {
+                    "released" => store.release_by_child(&child).unwrap(),
+                    "expired" => {
+                        store
+                            .prepare_admission(
+                                &request_id,
+                                &class("routine_bounded", None),
+                                None,
+                                "discarded-expired-id",
+                                now + time::Duration::seconds(2),
+                            )
+                            .unwrap();
+                    }
+                    "launched" => store.mark_child_launched(&child).unwrap(),
+                    "conflicting" => {
+                        Connection::open(&path)
+                            .unwrap()
+                            .execute(
+                                "UPDATE policy_provisional_children SET state = 'launched' WHERE child_session_id = ?1",
+                                [&child],
+                            )
+                            .unwrap();
+                    }
+                    _ => {}
+                }
+            }
+            assert!(matches!(
+                store.mark_child_launched(&child),
+                Err(PolicyStoreError::Invalid(_))
+            ));
+            std::fs::remove_file(path).ok();
+        }
+    }
+
+    #[test]
+    fn omission_override_uses_rewrite_target_while_full_override_uses_request() {
+        let (store, path) = store("override-profile-semantics");
+        install(&store, &projection(true, 2));
+        store.set_runtime_versions("sm-policy-1268", 1, 1).unwrap();
+        let now = instant("2026-08-17T00:01:00Z");
+        for (request_id, specified, expected_model) in [
+            ("full-profile", true, "fable"),
+            ("omitted-profile", false, "opus"),
+        ] {
+            let mut frozen = request(
+                request_id,
+                PolicyVehicle::NamedSeat,
+                Some("fable"),
+                &format!("intent-{request_id}"),
+            );
+            if !specified {
+                frozen.requested.model = None;
+                frozen.requested.effort = None;
+            }
+            store.create_request(&frozen).unwrap();
+            store
+                .prepare_admission(
+                    request_id,
+                    &class("named_orchestrator", Some("maintainer")),
+                    None,
+                    &format!("rejected-{request_id}"),
+                    now,
+                )
+                .unwrap();
+            let authorization = store
+                .authorize_request_override(
+                    request_id,
+                    &frozen.caller,
+                    "frozen exception",
+                    now,
+                    time::Duration::minutes(1),
+                )
+                .unwrap();
+            let allowed = store
+                .prepare_admission(
+                    request_id,
+                    &class("named_orchestrator", Some("maintainer")),
+                    Some(&authorization.override_id),
+                    &format!("allowed-{request_id}"),
+                    now,
+                )
+                .unwrap();
+            assert_eq!(
+                allowed.decision.resolved_profile.unwrap().model,
+                expected_model
+            );
+        }
+        std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn equal_rank_conflicts_include_all_enforcement_fields() {
+        for field in ["profile", "outcome", "claims", "overridable", "ttl"] {
+            let (store, path) = store(&format!("enforcement-conflict-{field}"));
+            let mut projection = projection(true, 1);
+            let mut conflict = projection.rules[1].clone();
+            conflict.clause_id = format!("sm-policy-1268.conflict-{field}");
+            match field {
+                "profile" => conflict.profile.model = "opus".into(),
+                "outcome" => conflict.outcome = PolicyRuleOutcome::Rewrite,
+                "claims" => conflict.capacity_claims[0].units = 2,
+                "overridable" => conflict.overridable = false,
+                "ttl" => conflict.lease_ttl_seconds += 1,
+                _ => unreachable!(),
+            }
+            if field == "claims" {
+                projection.capacity_limits[0].maximum_units = 2;
+            }
+            projection.rules.push(conflict);
+            install(&store, &projection);
+            store.set_runtime_versions("sm-policy-1268", 1, 1).unwrap();
+            let request_id = format!("conflict-{field}");
+            store
+                .create_request(&request(
+                    &request_id,
+                    PolicyVehicle::TaskAgent,
+                    None,
+                    &format!("intent-{field}"),
+                ))
+                .unwrap();
+            let decision = store
+                .prepare_admission(
+                    &request_id,
+                    &class("routine_bounded", None),
+                    None,
+                    &format!("child-{field}"),
+                    instant("2026-08-17T00:01:00Z"),
+                )
+                .unwrap()
+                .decision;
+            assert!(
+                matches!(decision.outcome, PolicyDecisionOutcome::Block),
+                "{field}"
+            );
+            assert!(decision.capacity_lease.is_none(), "{field}");
+            std::fs::remove_file(path).ok();
+        }
     }
 
     #[test]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -252,6 +252,25 @@ impl SessionStore {
         self.write_raw_json_value(&state)
     }
 
+    pub fn spawn_launch_intent(&self, intent_id: &str) -> Result<Option<SpawnLaunchIntentRecord>> {
+        let intent_id = intent_id.trim();
+        if intent_id.is_empty() {
+            return Ok(None);
+        }
+        let _guard = self.write_guard()?;
+        let state = self.load_raw_json_value()?;
+        state
+            .get("spawn_launch_intents")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .find(|intent| intent.get("id").and_then(Value::as_str) == Some(intent_id))
+            .cloned()
+            .map(serde_json::from_value)
+            .transpose()
+            .map_err(Into::into)
+    }
+
     pub fn read_spawn_brief(&self, artifact: &SpawnBriefArtifact) -> Result<String> {
         let bytes = fs::read(&artifact.path)
             .with_context(|| format!("failed to read accepted spawn brief {}", artifact.path))?;
@@ -3871,6 +3890,14 @@ impl SessionStore {
             .map(Vec::as_slice)
             .unwrap_or_default();
         generate_unique_session_id(sessions)
+    }
+
+    pub fn codex_fork_event_stream_path(
+        &self,
+        session: &SessionRecord,
+        runtime: &TmuxRuntime,
+    ) -> Option<PathBuf> {
+        codex_fork_event_stream_path(session, runtime)
     }
 
     pub fn create_core_session_with_runtime(

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1519,6 +1519,19 @@ impl SessionStore {
         }))
     }
 
+    pub fn verify_session_credential(
+        &self,
+        session_id: &str,
+        session_credential: &str,
+    ) -> Result<bool> {
+        let sessions = self.load_snapshot()?.into_sessions();
+        Ok(session_credential_matches(
+            &sessions,
+            session_id,
+            session_credential,
+        ))
+    }
+
     pub fn get_context_snapshot(
         &self,
         session_id: &str,
@@ -20950,6 +20963,37 @@ mod tests {
             "parent_session_id": parent,
             "session_credential_sha256": sha256_text(credential)
         })
+    }
+
+    #[test]
+    fn session_store_verifies_credentials_against_the_bound_session() {
+        let state_file = unique_temp_path("verify-session-credential");
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [
+                    reparent_test_session("parent01", None, "parent-secret"),
+                    reparent_test_session("other001", None, "other-secret")
+                ]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let store = SessionStore::new(state_file);
+
+        assert!(store
+            .verify_session_credential("parent01", "parent-secret")
+            .unwrap());
+        assert!(!store
+            .verify_session_credential("parent01", "other-secret")
+            .unwrap());
+        assert!(!store
+            .verify_session_credential("other001", "parent-secret")
+            .unwrap());
+        assert!(!store
+            .verify_session_credential("missing", "secret")
+            .unwrap());
+        assert!(!store.verify_session_credential("parent01", "").unwrap());
     }
 
     fn unique_temp_path(label: &str) -> PathBuf {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -7209,6 +7209,135 @@ impl SessionStore {
         }))
     }
 
+    /// Fail-closed cleanup for a policy-admitted runtime that did not complete
+    /// attestation. The row is retained as audit evidence, but it no longer
+    /// owns a live hierarchy edge, role alias, wake, reminder, or runtime.
+    pub fn reject_policy_provisional_session(
+        &self,
+        session_id: &str,
+        reason: &str,
+        runtime: Option<&TmuxRuntime>,
+    ) -> Result<bool> {
+        let session_id = session_id.trim();
+        if session_id.is_empty() {
+            anyhow::bail!("policy provisional session ID is required");
+        }
+        if reason.trim().is_empty() {
+            anyhow::bail!("policy launch rejection reason is required");
+        }
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let (node, tmux_session, socket_name) = {
+            let sessions = ensure_sessions_array_mut(&mut state)?;
+            let Some(session) = session_object_mut(sessions, session_id) else {
+                return Ok(false);
+            };
+            (
+                json_text(session.get("node")).unwrap_or_else(default_node),
+                json_text(session.get("tmux_session")),
+                json_text(session.get("tmux_socket_name")),
+            )
+        };
+        if let (Some(runtime), Some(tmux_session)) = (runtime, tmux_session.as_deref()) {
+            if !is_primary_node(&node) {
+                anyhow::bail!(
+                    "cannot stop policy provisional session {session_id} on unsupported node {node}"
+                );
+            }
+            runtime
+                .for_socket_name(socket_name.as_deref())
+                .kill_session(tmux_session)?;
+        }
+        let now = now_rfc3339();
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let session = session_object_mut(sessions, session_id).ok_or_else(|| {
+            anyhow::anyhow!("policy provisional session {session_id} disappeared during cleanup")
+        })?;
+        session.insert("status".to_owned(), Value::String("stopped".to_owned()));
+        session.insert(
+            "completion_status".to_owned(),
+            Value::String("launch_rejected".to_owned()),
+        );
+        session.insert(
+            "completion_message".to_owned(),
+            Value::String(reason.to_owned()),
+        );
+        session.insert("completed_at".to_owned(), Value::String(now.clone()));
+        session.insert("stopped_at".to_owned(), Value::String(now.clone()));
+        session.insert("last_activity".to_owned(), Value::String(now));
+        session.insert("parent_session_id".to_owned(), Value::Null);
+        session.insert("role".to_owned(), Value::Null);
+        session.insert("aliases".to_owned(), Value::Array(Vec::new()));
+        prune_agent_registrations_raw(&mut state)?;
+        self.write_raw_json_value(&state)?;
+        if let Some(queue) = &self.queue_store {
+            queue.cancel_parent_wake(session_id)?;
+            queue.cancel_remind(session_id)?;
+        }
+        Ok(true)
+    }
+
+    /// Publishes the hierarchy edge for an already attested policy child.
+    /// Policy materialization deliberately creates the runtime without an
+    /// active parent edge, so it cannot receive routed work before admission
+    /// commits. The operation is idempotent only for the exact intended edge.
+    pub fn promote_policy_provisional_session(
+        &self,
+        session_id: &str,
+        parent_session_id: &str,
+    ) -> Result<bool> {
+        let session_id = session_id.trim();
+        let parent_session_id = parent_session_id.trim();
+        if session_id.is_empty() || parent_session_id.is_empty() {
+            anyhow::bail!("policy child and parent session IDs are required");
+        }
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        ensure_session_not_reparent_fenced(&state, session_id)?;
+        ensure_session_not_reparent_fenced(&state, parent_session_id)?;
+        let snapshot = snapshot_from_raw_value(&state)?.into_sessions();
+        let parent = snapshot
+            .iter()
+            .find(|session| session.id == parent_session_id)
+            .ok_or_else(|| {
+                anyhow::anyhow!("policy parent session {parent_session_id} does not exist")
+            })?;
+        if !parent.is_live_for_registry() {
+            anyhow::bail!("policy parent session {parent_session_id} is stopped");
+        }
+        let child = snapshot
+            .iter()
+            .find(|session| session.id == session_id)
+            .ok_or_else(|| anyhow::anyhow!("policy child session {session_id} does not exist"))?;
+        if !child.is_live_for_registry() {
+            anyhow::bail!("policy child session {session_id} is stopped");
+        }
+        if let Some(current_parent) = child.parent_session_id.as_deref() {
+            if current_parent == parent_session_id {
+                return Ok(false);
+            }
+            anyhow::bail!(
+                "policy child {session_id} already belongs to conflicting parent {current_parent}"
+            );
+        }
+        if reparent_would_create_cycle(&snapshot, session_id, parent_session_id) {
+            anyhow::bail!(
+                "publishing policy child {session_id} under {parent_session_id} would create a cycle"
+            );
+        }
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let child = session_object_mut(sessions, session_id).ok_or_else(|| {
+            anyhow::anyhow!("policy child session {session_id} disappeared during promotion")
+        })?;
+        child.insert(
+            "parent_session_id".to_owned(),
+            Value::String(parent_session_id.to_owned()),
+        );
+        child.insert("last_activity".to_owned(), Value::String(now_rfc3339()));
+        self.write_raw_json_value(&state)?;
+        Ok(true)
+    }
+
     pub fn set_agent_status(
         &self,
         session_id: &str,
@@ -14623,7 +14752,7 @@ fn normalized_status(status: &str) -> &str {
 }
 
 fn completion_status_is_retired(status: Option<&str>) -> bool {
-    matches!(status, Some("retired" | "killed"))
+    matches!(status, Some("retired" | "killed" | "launch_rejected"))
 }
 
 fn raw_session_is_stopped(session: &Map<String, Value>) -> bool {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -3859,6 +3859,20 @@ impl SessionStore {
         Ok(record)
     }
 
+    /// Allocates a collision-checked core session ID before policy admission.
+    /// Creation still verifies uniqueness, so a concurrent collision fails
+    /// closed and the caller can release its provisional policy lease.
+    pub fn allocate_core_session_id(&self) -> Result<String> {
+        let _guard = self.write_guard()?;
+        let state = self.load_raw_json_value()?;
+        let sessions = state
+            .get("sessions")
+            .and_then(Value::as_array)
+            .map(Vec::as_slice)
+            .unwrap_or_default();
+        generate_unique_session_id(sessions)
+    }
+
     pub fn create_core_session_with_runtime(
         &self,
         request: CreateCoreSessionRequest,

--- a/specs/1268_d3_integration_return.md
+++ b/specs/1268_d3_integration_return.md
@@ -1,0 +1,103 @@
+# 1268 D3 atomic admission integration return
+
+Status: implementation complete; R3 review pending.
+
+## Bounded scope and ancestry
+
+This branch implements the first bootstrap-incarnation spawn-policy canary only.
+It does not generalize stable seats, rotation, compound message caps, two-step
+briefs, dashboards, or issue #1291 operational actions, and it does not deploy
+or run the production canary.
+
+Current `origin/epic/1268-lane-policy` was merged first as `3cb46db`. The retained
+D1A code changes were then integrated as individual commits, without claiming
+that D1A or PR #1297 merged:
+
+| Retained D1A code | D3 integration commit | Conflict disposition |
+|---|---|---|
+| `220200f` | `479091c` | Kept the epic's D0 `policy_runtime_attestation` module export while adding the frozen policy store. |
+| `8705533` | `43b43b1` | Selected the reviewed D1A frozen-schema `policy_store.rs` resolution over the stale overlapping scaffold. |
+| `c40c49d` | `3633c9f` | Applied cleanly on the resolved store. |
+
+The D1A worktree and PR #1297 were not modified, deleted, reopened, or merged.
+The merge-only D1A base/docs commit `beaf4e2` was not replayed; the D3 branch
+used the newer epic head directly.
+
+## Assembled integration matrix
+
+| Boundary / hostile case | Implemented behavior | Verification |
+|---|---|---|
+| Retry after active, committed, released, or expired lease | Reuses the one terminal decision and original child binding; creates no decision, child, lease, claim, or capacity duplicate. Terminal retries do not materialize a replacement child. | `ordinary_retries_reuse_terminal_decision_in_every_lease_state` |
+| Child launch promotion | Requires exactly one exact reserved/active child-lease binding. Missing, released, expired, already-launched, release-pending, and conflicting pairs fail closed. | `launch_promotion_requires_exactly_one_reserved_active_binding` |
+| Equal-rank policy clauses | Conflict identity includes outcome, resolved profile, capacity claims, `overridable`, lease TTL, and all other enforcement-affecting fields. | `equal_rank_conflicts_include_all_enforcement_fields` |
+| Requested exception profile | A fully specified frozen request receives that exact requested provider/model/effort/vehicle under override; an omission-caused rewrite receives only the deterministic rewrite target. | `omission_override_uses_rewrite_target_while_full_override_uses_request` |
+| Override authority | The server loads request, caller, decision, policy-version, and digest bindings and constructs the override row. Cross-request/cross-caller or caller-built authority is rejected. | `server_constructed_override_rejects_cross_caller_and_cross_request`, `frozen_schema_override_binding_and_capacity_claims_fail_closed_when_tampered` |
+| Omitted-tier fixtures | `aa6c1120` and `2260296e` remain deterministically blocked/rewritten to their explicit profiles; inherited defaults do not pass. | `omitted_models_for_aa6c1120_and_2260296e_resolve_to_explicit_profiles`, D0 omitted-tier tests |
+| Request ordering | Authenticated bootstrap caller and requested launch fields are frozen and persisted before deterministic classification. A preallocated collision-checked child ID is passed into one immediate admission transaction. | Focused policy-store suite plus HTTP integration path inspection |
+| Allow/materialize boundary | No session is created on rewrite/block. Allowed children materialize under their reserved ID without an active parent edge, so they are not routable before attestation. | Crash matrix `after-admission`, `after-session-create`, and hierarchy assertions |
+| Provider attestation and commit | Codex-fork schema-v2 provider events attest the actual model/effort and thread binding. Only then does strict `mark_child_launched` commit capacity and publish the exact hierarchy edge. | Runtime-attestation suite (7 tests), crash matrix `after-attestation` |
+| Decision, usage, lifecycle evidence | D2 envelopes are appended at admission, materialization, provider attestation, launch, rejection, release, and restart-reconciliation boundaries. Usage is an exact zero delta at the attestation boundary rather than an invented model estimate. | D2 evidence suite (9 tests), crash-matrix event assertions |
+| Launch/attestation failure | Persists release intent, stops the provisional runtime, marks and retains the audit row as `launch_rejected`/stopped, removes hierarchy/role/alias/wake/reminder ownership, releases the exact lease, and surfaces every cleanup or release failure. | Crash matrix `after-session-create`, durable cleanup implementation |
+| Restart: reserved/no session | Releases the reservation and capacity. | Crash matrix `after-admission` |
+| Restart: reserved/session pre-mark | Re-attests and promotes, or rejects/stops/detaches/releases. | Crash matrix `after-session-create`, `after-attestation` |
+| Restart: launched/live and launched/dead | Restores the exact intended hierarchy for a live committed child; releases a dead or missing child. Committed leases never TTL-expire. | Crash matrix `after-mark`; terminal retry test's committed case |
+| Restart: release-pending / post-release | Completes cleanup and release idempotently; terminal audit rows stay outside the capacity denominator. | Crash matrix `during-release`, `after-release` |
+| Restart ambiguity | Reports exact expected/visited/resolved/blocked counts and blocker text; admission remains disabled for the lane. | `ambiguous_policy_restart_state_reports_exact_blocker_and_disables_admission` |
+
+## Enabled APIs and observable state
+
+- `PolicyStore::prepare_admission` reserves capacity and the provisional child
+  atomically; `mark_child_launched`, `mark_child_release_pending`, and
+  `release_by_child` implement the durable lifecycle.
+- `PolicyStore::admission_for_child`, `resolve_child`, and
+  `reconciliation_snapshot` expose the D3 recovery view while validating all
+  persisted cross-record authority.
+- `SessionStore::promote_policy_provisional_session` publishes only the exact
+  attested parent edge; `reject_policy_provisional_session` retains a stopped
+  audit row while removing active ownership.
+- The existing spawn endpoint now returns a policy-governed child only after
+  allow, provider attestation, lease commit, and hierarchy publication.
+- The existing policy status response adds `admission_enabled`, the exact
+  `admission_blocker`, and `restart_reconciliation` counts.
+- Existing D0 attestation contracts and D2 evidence/explain/status APIs remain
+  the source of runtime proof and inspection; no parallel public contract was
+  introduced.
+
+## R3 matched characteristics
+
+R3 applies because this package changes persisted authority and lifecycle
+state, concurrent capacity admission, restart recovery and ambiguity handling,
+and public spawn behavior. Review must cover at least these scopes:
+
+1. persisted schema/authority/transaction invariants and hostile retry races;
+2. public spawn sequencing, provider attestation, cleanup/release, D2 evidence,
+   and restart convergence.
+
+At least two and at most five Codex rounds are required. Even if round 1 is
+clean, round 2 must use a differently scoped steer on the same review head. A
+repeated or structural P0/P1 at or after round 3 returns this package to design
+and parks it.
+
+## Review ledger
+
+| Round | Requested head | Reviewed head | Scope / steer | Findings and disposition | Resulting head | Wait | Reviewer usage |
+|---|---|---|---|---|---|---|---|
+| 1 | pending | pending | Persisted authority, transactionality, retry/concurrency, reconciliation ambiguity | pending | pending | pending | pending |
+| 2 | pending | pending | Public spawn order, non-routable provisional runtime, attestation/evidence, cleanup/release, crash convergence | pending | pending | pending | pending |
+
+## Verification ledger
+
+| Gate | Result |
+|---|---|
+| Policy-store hostile suite | 19 passed |
+| Restart crash/ambiguity matrix | 2 passed |
+| Provider runtime attestation | 7 passed |
+| D2 policy evidence | 9 passed |
+| D0 policy contracts | 16 passed |
+| `cargo fmt --check` | pending exact review head |
+| `git diff --check` | clean during implementation; pending exact review head |
+| `cargo test -p sm-server` | pending, to run once at exact review head |
+
+Canonical owner/reviewer token usage and numeric budget variance are recorded
+after the review rounds from `message_ledger`; they are not inferred from local
+test output.


### PR DESCRIPTION
Refs #1268

Risk: R3 — persisted authority/lifecycle state, concurrent capacity admission, restart recovery and ambiguity, and public spawn behavior.

This is the bounded first bootstrap-only canary. It integrates the retained D1A code commits into D3 with explicit conflicts; it does not claim D1A or PR #1297 merged. No stable-seat generalization, rotation, compound caps, two-step briefs, dashboard, #1291 actions, deployment, or production canary.

Implemented:
- terminal retry reuse, strict launch promotion, complete equal-rank comparison
- authoritative exact-request overrides with requested-vs-rewrite profile semantics
- freeze → reserve preallocated child → materialize non-routable → provider attest → commit/publish
- D2 decision/usage/lifecycle evidence at provider boundaries
- durable rejected-audit cleanup and release with no swallowed release errors
- pre-enable reconciliation with exact counts/blockers for reserved, launched, release-pending, terminal, and ambiguous states

Integration matrix and review ledger template: specs/1268_d3_integration_return.md

Exact review head: 62551b8bf10ea282fd4593d1001919989ea48240

Verification:
- policy-store hostile suite: 19 passed
- restart crash/ambiguity matrix: 2 passed
- runtime attestation: 7 passed
- D2 evidence: 9 passed
- D0 contracts: 16 passed
- cargo fmt --check and git diff --check: clean
- cargo test -p sm-server: 516 passed, 1 unrelated queue-authority socket liveness test failed under suite concurrency; the exact failing test passed immediately in isolated rerun (1/1)

R3 minimum: two Codex rounds. Round 1 targets persisted authority, transactions, retry/concurrency, and restart ambiguity. Round 2 must review the same head with a different scope: public spawn sequencing, provisional non-routing, attestation/evidence, cleanup/release, and crash convergence.