### PR TITLE
Require persistent signing for Rust restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,12 @@ one safe order, and registers launchd against an installed copy at
 default binary is cargo's output, so registering that way lets any later
 `cargo build` replace the executable launchd is running, which is how the service
 was taken down twice on 2026-07-27. See `specs/1134_rust_restart_procedure.md`.
+The durable non-secret default lives in `config/rust-server-signing.env` and
+must be the exact persistent certificate fingerprint from `security
+find-identity -v -p codesigning`; the script refuses ad-hoc signing or an
+implicit keychain default. During an intentional certificate rotation, supply a
+validated replacement with `SM_SIGN_IDENTITY=<40-hex-fingerprint>` and update
+that tracked config before treating it as the new default.
 
 If a deployment is already registered against `target/release/sm-server`, migrate
 it once with:

--- a/README.md
+++ b/README.md
@@ -212,8 +212,9 @@ The durable non-secret default lives in `config/rust-server-signing.env` and
 must be the exact persistent certificate fingerprint from `security
 find-identity -v -p codesigning`; the script refuses ad-hoc signing or an
 implicit keychain default. During an intentional certificate rotation, supply a
-validated replacement with `SM_SIGN_IDENTITY=<40-hex-fingerprint>` and update
-that tracked config before treating it as the new default.
+validated replacement with both `SM_SIGN_IDENTITY=<40-hex-fingerprint>` and
+the exact `SM_SIGN_DESIGNATED_REQUIREMENT` captured from disposable signing
+proof, then update that tracked config before treating it as the new default.
 
 If a deployment is already registered against `target/release/sm-server`, migrate
 it once with:

--- a/config/rust-server-signing.env
+++ b/config/rust-server-signing.env
@@ -1,0 +1,7 @@
+# Non-secret production signing contract for scripts/restart-rust-server.sh.
+# This must be the exact persistent codesigning certificate fingerprint from:
+#   security find-identity -v -p codesigning
+# A planned certificate rotation may temporarily set SM_SIGN_IDENTITY explicitly
+# for the restart, but the replacement fingerprint must be committed here before
+# that becomes the durable deployment default.
+SM_SIGN_IDENTITY=36FC54A873D584A34FCFEEA7D1F519B19A39DE72

--- a/config/rust-server-signing.env
+++ b/config/rust-server-signing.env
@@ -2,6 +2,8 @@
 # This must be the exact persistent codesigning certificate fingerprint from:
 #   security find-identity -v -p codesigning
 # A planned certificate rotation may temporarily set SM_SIGN_IDENTITY explicitly
-# for the restart, but the replacement fingerprint must be committed here before
-# that becomes the durable deployment default.
+# and also set the exact SM_SIGN_DESIGNATED_REQUIREMENT observed on disposable
+# binaries. Commit both replacement values here before they become the durable
+# deployment default.
 SM_SIGN_IDENTITY=36FC54A873D584A34FCFEEA7D1F519B19A39DE72
+SM_SIGN_DESIGNATED_REQUIREMENT=designated => identifier "com.rajeshgoli.sm-server" and certificate root = H"36fc54a873d584a34fcfeea7d1f519b19a39de72"

--- a/scripts/restart-rust-server.sh
+++ b/scripts/restart-rust-server.sh
@@ -88,6 +88,7 @@ SM_SIGN_IDENTIFIER="${SM_SIGN_IDENTIFIER:-com.rajeshgoli.sm-server}"
 # for a planned certificate rotation. This is the SHA-1 fingerprint reported by
 # `security find-identity -v -p codesigning`, not a keychain display name.
 SM_SIGN_IDENTITY="${SM_SIGN_IDENTITY:-}"
+SM_SIGN_DESIGNATED_REQUIREMENT="${SM_SIGN_DESIGNATED_REQUIREMENT:-}"
 SM_SIGNING_CONFIG="${SM_SIGNING_CONFIG:-$REPO_ROOT/config/rust-server-signing.env}"
 SM_QUEUE_AUTHORITY_SOCKET="${SM_QUEUE_AUTHORITY_SOCKET:-$HOME/.local/share/claude-sessions/queue-runner/authority.sock}"
 SM_QUEUE_AUTHORITY_VERIFIER="${SM_QUEUE_AUTHORITY_VERIFIER:-$REPO_ROOT/scripts/verify_queue_authority.py}"
@@ -131,17 +132,18 @@ Options:
 Environment overrides: SM_LABEL, SM_BINARY, SM_TARGET_DIR, SM_CARGO_OUTPUT,
 SM_CUTOVER, SM_CONFIG, SM_LOCAL_ENV, SM_LOG_DIR, SM_PLIST, SM_HOST, SM_PORT,
 SM_PYTHON_LABELS (extra labels), SM_SIGN_IDENTIFIER, SM_HEALTH_TIMEOUT,
-SM_SIGN_IDENTITY, SM_SIGNING_CONFIG, SM_QUEUE_AUTHORITY_SOCKET,
-SM_QUEUE_AUTHORITY_VERIFIER, SM_PID_SETTLE_SECONDS, SM_UNLOAD_TIMEOUT,
-SM_ALLOW_SESSION_DROP, SM_LOCK.
+SM_SIGN_IDENTITY, SM_SIGN_DESIGNATED_REQUIREMENT, SM_SIGNING_CONFIG,
+SM_QUEUE_AUTHORITY_SOCKET, SM_QUEUE_AUTHORITY_VERIFIER, SM_PID_SETTLE_SECONDS,
+SM_UNLOAD_TIMEOUT, SM_ALLOW_SESSION_DROP, SM_LOCK.
 
 The default identity is the sole `SM_SIGN_IDENTITY=...` line in the tracked,
-non-secret $SM_SIGNING_CONFIG. An explicit SM_SIGN_IDENTITY override supports
-planned certificate rotation. Every value must be the exact uppercase 40-hex
-fingerprint from `security find-identity -v -p codesigning`. The restart refuses
-a missing, unavailable, ad-hoc, wrong-identifier, or non-certificate-anchored
-staged signature before it stops the service. It never falls back to
-`codesign --sign -`.
+non-secret $SM_SIGNING_CONFIG. Planned certificate rotation explicitly overrides
+both SM_SIGN_IDENTITY and SM_SIGN_DESIGNATED_REQUIREMENT with values proven on
+disposable binaries; this supports CA-issued identities whose leaf fingerprint
+differs from their designated requirement's certificate root. The restart
+refuses a missing, unavailable, ad-hoc, wrong-identifier, or
+non-certificate-anchored staged signature before it stops the service. It never
+falls back to `codesign --sign -`.
 
 SM_LABEL, SM_BINARY, SM_CONFIG, SM_LOCAL_ENV, SM_LOG_DIR, SM_PLIST, SM_HOST, and
 SM_PORT are forwarded to the cutover script, so both phases act on the same
@@ -219,25 +221,34 @@ step() { printf '\n==> %s\n' "$1"; }
 fail() { echo "ERROR: $1" >&2; exit 1; }
 
 load_signing_identity() {
-  local configured count invalid
+  local configured configured_requirement identity_count requirement_count invalid
   [[ -r "$SM_SIGNING_CONFIG" ]] \
     || fail "signing config is not readable: $SM_SIGNING_CONFIG; the running service was not touched"
   # This file is deployment data, not shell code. Parse only the one
   # non-secret key so editing the config can never execute commands in the
   # production restart path.
-  count="$(grep -Ec '^SM_SIGN_IDENTITY=[0-9A-F]{40}$' "$SM_SIGNING_CONFIG" || true)"
-  invalid="$(grep -Ev '^(#.*|[[:space:]]*|SM_SIGN_IDENTITY=[0-9A-F]{40})$' "$SM_SIGNING_CONFIG" || true)"
-  if [[ "$count" != "1" || -n "$invalid" ]]; then
-    fail "signing config must contain exactly one uppercase SM_SIGN_IDENTITY=40-hex-fingerprint line and only comments or blank lines; the running service was not touched"
+  identity_count="$(grep -Ec '^SM_SIGN_IDENTITY=[0-9A-F]{40}$' "$SM_SIGNING_CONFIG" || true)"
+  requirement_count="$(grep -Ec '^SM_SIGN_DESIGNATED_REQUIREMENT=.+$' "$SM_SIGNING_CONFIG" || true)"
+  invalid="$(grep -Ev '^(#.*|[[:space:]]*|SM_SIGN_IDENTITY=[0-9A-F]{40}|SM_SIGN_DESIGNATED_REQUIREMENT=.+)$' "$SM_SIGNING_CONFIG" || true)"
+  if [[ "$identity_count" != "1" || "$requirement_count" != "1" || -n "$invalid" ]]; then
+    fail "signing config must contain exactly one SM_SIGN_IDENTITY and one SM_SIGN_DESIGNATED_REQUIREMENT line and only comments or blank lines; the running service was not touched"
   fi
   configured="$(sed -n -E 's/^SM_SIGN_IDENTITY=([0-9A-F]{40})$/\1/p' "$SM_SIGNING_CONFIG")"
+  configured_requirement="$(sed -n -E 's/^SM_SIGN_DESIGNATED_REQUIREMENT=//p' "$SM_SIGNING_CONFIG")"
   if [[ -z "$SM_SIGN_IDENTITY" ]]; then
     SM_SIGN_IDENTITY="$configured"
+  fi
+  if [[ -z "$SM_SIGN_DESIGNATED_REQUIREMENT" ]]; then
+    SM_SIGN_DESIGNATED_REQUIREMENT="$configured_requirement"
   fi
   if ! [[ "$SM_SIGN_IDENTITY" =~ ^[0-9A-F]{40}$ ]]; then
     fail "SM_SIGN_IDENTITY must be the exact uppercase 40-hex fingerprint of a valid codesigning identity; no ad-hoc fallback is permitted"
   fi
-  SM_SIGN_IDENTITY_LOWER="$(printf '%s' "$SM_SIGN_IDENTITY" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$SM_SIGN_DESIGNATED_REQUIREMENT" != "designated => identifier \"$SM_SIGN_IDENTIFIER\" and certificate "* ]] \
+      || ! printf '%s\n' "$SM_SIGN_DESIGNATED_REQUIREMENT" \
+          | grep -Eq '^designated => identifier ".+" and certificate (root|leaf) = H"[0-9a-f]{40}"$'; then
+    fail "SM_SIGN_DESIGNATED_REQUIREMENT must be an exact certificate-root or certificate-leaf requirement for $SM_SIGN_IDENTIFIER; the running service was not touched"
+  fi
 }
 
 require_signing_identity() {
@@ -252,7 +263,7 @@ require_signing_identity() {
 }
 
 verify_staged_signature() {
-  local metadata requirement expected_requirement
+  local metadata requirement
   metadata="$(codesign -dvvv "$SM_STAGING" 2>&1)" \
     || fail "could not inspect the staged signature; the running service was not touched"
 
@@ -268,11 +279,10 @@ verify_staged_signature() {
 
   requirement="$(codesign -dr - "$SM_STAGING" 2>&1)" \
     || fail "could not read the staged designated requirement; the running service was not touched"
-  expected_requirement="designated => identifier \"$SM_SIGN_IDENTIFIER\" and certificate root = H\"$SM_SIGN_IDENTITY_LOWER\""
-  if ! printf '%s\n' "$requirement" | grep -Fx "$expected_requirement" >/dev/null; then
-    fail "staged designated requirement is not the stable certificate-anchored requirement for $SM_SIGN_IDENTITY; the running service was not touched"
+  if ! printf '%s\n' "$requirement" | grep -Fx "$SM_SIGN_DESIGNATED_REQUIREMENT" >/dev/null; then
+    fail "staged designated requirement is not the stable configured certificate-anchored requirement; the running service was not touched"
   fi
-  echo "signature ok: $SM_SIGN_IDENTIFIER; certificate root $SM_SIGN_IDENTITY"
+  echo "signature ok: $SM_SIGN_IDENTIFIER; $SM_SIGN_DESIGNATED_REQUIREMENT"
 }
 
 # Relative paths must resolve exactly as rust-service-cutover.sh resolves them

--- a/scripts/restart-rust-server.sh
+++ b/scripts/restart-rust-server.sh
@@ -83,6 +83,12 @@ else
   SM_BASE_URL="http://$SM_PROBE_HOST:$SM_PORT"
 fi
 SM_SIGN_IDENTIFIER="${SM_SIGN_IDENTIFIER:-com.rajeshgoli.sm-server}"
+# A persistent certificate identity is loaded from the tracked, non-secret
+# deployment config below, unless an explicit environment override is supplied
+# for a planned certificate rotation. This is the SHA-1 fingerprint reported by
+# `security find-identity -v -p codesigning`, not a keychain display name.
+SM_SIGN_IDENTITY="${SM_SIGN_IDENTITY:-}"
+SM_SIGNING_CONFIG="${SM_SIGNING_CONFIG:-$REPO_ROOT/config/rust-server-signing.env}"
 SM_QUEUE_AUTHORITY_SOCKET="${SM_QUEUE_AUTHORITY_SOCKET:-$HOME/.local/share/claude-sessions/queue-runner/authority.sock}"
 SM_QUEUE_AUTHORITY_VERIFIER="${SM_QUEUE_AUTHORITY_VERIFIER:-$REPO_ROOT/scripts/verify_queue_authority.py}"
 SM_HEALTH_TIMEOUT="${SM_HEALTH_TIMEOUT:-60}"
@@ -125,8 +131,17 @@ Options:
 Environment overrides: SM_LABEL, SM_BINARY, SM_TARGET_DIR, SM_CARGO_OUTPUT,
 SM_CUTOVER, SM_CONFIG, SM_LOCAL_ENV, SM_LOG_DIR, SM_PLIST, SM_HOST, SM_PORT,
 SM_PYTHON_LABELS (extra labels), SM_SIGN_IDENTIFIER, SM_HEALTH_TIMEOUT,
-SM_QUEUE_AUTHORITY_SOCKET, SM_QUEUE_AUTHORITY_VERIFIER, SM_PID_SETTLE_SECONDS,
-SM_UNLOAD_TIMEOUT, SM_ALLOW_SESSION_DROP, SM_LOCK.
+SM_SIGN_IDENTITY, SM_SIGNING_CONFIG, SM_QUEUE_AUTHORITY_SOCKET,
+SM_QUEUE_AUTHORITY_VERIFIER, SM_PID_SETTLE_SECONDS, SM_UNLOAD_TIMEOUT,
+SM_ALLOW_SESSION_DROP, SM_LOCK.
+
+The default identity is the sole `SM_SIGN_IDENTITY=...` line in the tracked,
+non-secret $SM_SIGNING_CONFIG. An explicit SM_SIGN_IDENTITY override supports
+planned certificate rotation. Every value must be the exact uppercase 40-hex
+fingerprint from `security find-identity -v -p codesigning`. The restart refuses
+a missing, unavailable, ad-hoc, wrong-identifier, or non-certificate-anchored
+staged signature before it stops the service. It never falls back to
+`codesign --sign -`.
 
 SM_LABEL, SM_BINARY, SM_CONFIG, SM_LOCAL_ENV, SM_LOG_DIR, SM_PLIST, SM_HOST, and
 SM_PORT are forwarded to the cutover script, so both phases act on the same
@@ -203,6 +218,63 @@ fi
 step() { printf '\n==> %s\n' "$1"; }
 fail() { echo "ERROR: $1" >&2; exit 1; }
 
+load_signing_identity() {
+  local configured count invalid
+  [[ -r "$SM_SIGNING_CONFIG" ]] \
+    || fail "signing config is not readable: $SM_SIGNING_CONFIG; the running service was not touched"
+  # This file is deployment data, not shell code. Parse only the one
+  # non-secret key so editing the config can never execute commands in the
+  # production restart path.
+  count="$(grep -Ec '^SM_SIGN_IDENTITY=[0-9A-F]{40}$' "$SM_SIGNING_CONFIG" || true)"
+  invalid="$(grep -Ev '^(#.*|[[:space:]]*|SM_SIGN_IDENTITY=[0-9A-F]{40})$' "$SM_SIGNING_CONFIG" || true)"
+  if [[ "$count" != "1" || -n "$invalid" ]]; then
+    fail "signing config must contain exactly one uppercase SM_SIGN_IDENTITY=40-hex-fingerprint line and only comments or blank lines; the running service was not touched"
+  fi
+  configured="$(sed -n -E 's/^SM_SIGN_IDENTITY=([0-9A-F]{40})$/\1/p' "$SM_SIGNING_CONFIG")"
+  if [[ -z "$SM_SIGN_IDENTITY" ]]; then
+    SM_SIGN_IDENTITY="$configured"
+  fi
+  if ! [[ "$SM_SIGN_IDENTITY" =~ ^[0-9A-F]{40}$ ]]; then
+    fail "SM_SIGN_IDENTITY must be the exact uppercase 40-hex fingerprint of a valid codesigning identity; no ad-hoc fallback is permitted"
+  fi
+  SM_SIGN_IDENTITY_LOWER="$(printf '%s' "$SM_SIGN_IDENTITY" | tr '[:upper:]' '[:lower:]')"
+}
+
+require_signing_identity() {
+  # `codesign --sign` is still the definitive usability check below, against
+  # the staged file. This early keychain check produces an actionable failure
+  # before a build/sign attempt and rejects a missing or unavailable identity
+  # while the currently registered service remains untouched.
+  if ! security find-identity -v -p codesigning 2>/dev/null \
+      | grep -Eq "^[[:space:]]*[0-9]+\\) $SM_SIGN_IDENTITY "; then
+    fail "configured signing identity $SM_SIGN_IDENTITY is not a valid usable codesigning identity; the running service was not touched"
+  fi
+}
+
+verify_staged_signature() {
+  local metadata requirement expected_requirement
+  metadata="$(codesign -dvvv "$SM_STAGING" 2>&1)" \
+    || fail "could not inspect the staged signature; the running service was not touched"
+
+  if ! printf '%s\n' "$metadata" | grep -Fx "Identifier=$SM_SIGN_IDENTIFIER" >/dev/null; then
+    fail "staged signature identifier is not $SM_SIGN_IDENTIFIER; the running service was not touched"
+  fi
+  if printf '%s\n' "$metadata" | grep -Fx 'Signature=adhoc' >/dev/null; then
+    fail "staged signature is ad-hoc; a persistent certificate identity is required and the running service was not touched"
+  fi
+  if ! printf '%s\n' "$metadata" | grep -Eq '^Authority=.+$'; then
+    fail "staged signature has no certificate authority; the running service was not touched"
+  fi
+
+  requirement="$(codesign -dr - "$SM_STAGING" 2>&1)" \
+    || fail "could not read the staged designated requirement; the running service was not touched"
+  expected_requirement="designated => identifier \"$SM_SIGN_IDENTIFIER\" and certificate root = H\"$SM_SIGN_IDENTITY_LOWER\""
+  if ! printf '%s\n' "$requirement" | grep -Fx "$expected_requirement" >/dev/null; then
+    fail "staged designated requirement is not the stable certificate-anchored requirement for $SM_SIGN_IDENTITY; the running service was not touched"
+  fi
+  echo "signature ok: $SM_SIGN_IDENTIFIER; certificate root $SM_SIGN_IDENTITY"
+}
+
 # Relative paths must resolve exactly as rust-service-cutover.sh resolves them
 # (against the repo root, not the caller's cwd). Otherwise we would stage and
 # install one file while registering another, and still pass every health check.
@@ -224,6 +296,7 @@ SM_TARGET_DIR="$(resolve_path "$SM_TARGET_DIR")"
 SM_CONFIG="$(resolve_path "$SM_CONFIG")"
 SM_PLIST="$(resolve_path "$SM_PLIST")"
 SM_CUTOVER="$(resolve_path "$SM_CUTOVER")"
+SM_SIGNING_CONFIG="$(resolve_path "$SM_SIGNING_CONFIG")"
 [[ -n "$SM_LOCAL_ENV" ]] && SM_LOCAL_ENV="$(resolve_path "$SM_LOCAL_ENV")"
 [[ -n "$SM_LOG_DIR" ]] && SM_LOG_DIR="$(resolve_path "$SM_LOG_DIR")"
 
@@ -412,6 +485,8 @@ step "Preflight: checking what the restart will require"
 # so a missing cutover would otherwise not surface until much later.
 [[ -x "$SM_CUTOVER" ]] || fail "cutover script not executable: $SM_CUTOVER - the running service was not touched"
 [[ -r "$SM_CONFIG" ]] || fail "config not readable: $SM_CONFIG - the running service was not touched"
+load_signing_identity
+require_signing_identity
 if [[ -n "$SM_LOCAL_ENV" && ! -r "$SM_LOCAL_ENV" ]]; then
   fail "local env overlay not readable: $SM_LOCAL_ENV - the running service was not touched"
 fi
@@ -529,16 +604,16 @@ mkdir -p "$(dirname "$SM_BINARY")" \
   || fail "could not create $(dirname "$SM_BINARY") - the running service was not touched"
 cp -p "$SOURCE_BINARY" "$SM_STAGING" \
   || fail "could not stage $SOURCE_BINARY - the running service was not touched"
-# A stable identifier keeps the signing identity from churning per build. Ad-hoc
-# signing otherwise derives the identifier from the Mach-O UUID (and the linker
-# derives it from cargo's deps/ filename), so it changed on every rebuild.
-codesign --force --sign - --identifier "$SM_SIGN_IDENTIFIER" "$SM_STAGING" \
-  || fail "codesign failed - the running service was not touched"
+# `SM_SIGN_IDENTITY` has already been required to name a usable keychain
+# identity. Never substitute `--sign -`: it would create a new CDHash-based TCC
+# identity every time a build changes.
+codesign --force --sign "$SM_SIGN_IDENTITY" --identifier "$SM_SIGN_IDENTIFIER" "$SM_STAGING" \
+  || fail "codesign with persistent identity $SM_SIGN_IDENTITY failed - the running service was not touched"
 
 step "Verifying signature"
 codesign --verify --strict "$SM_STAGING" \
   || fail "signature verification failed - the running service was not touched"
-echo "signature ok: $(codesign -dvvv "$SM_STAGING" 2>&1 | awk -F= '/^Identifier=/{print $2}')"
+verify_staged_signature
 
 step "Validating the configuration with the new binary"
 # Readability is not validity. A malformed config.yaml or local-env overlay would

--- a/specs/1134_rust_restart_procedure.md
+++ b/specs/1134_rust_restart_procedure.md
@@ -95,11 +95,15 @@ Phase 1 (service untouched on any failure; nothing writes the registered path)
   record /health and session count (a healthy server must yield a baseline)
   preflight: cutover executable, config readable, local-env readable,
              no lingering Python label, registered path is NOT cargo's output,
-             plist would not be rewritten
+             plist would not be rewritten, durable signing config readable,
+             configured identity usable in the keychain
   cargo build --release -p sm-server --target-dir <pinned>
   cp cargo output -> staging (beside the installed binary)
-  codesign --force --sign - --identifier com.rajeshgoli.sm-server <staging>
+  codesign --force --sign <configured persistent identity> \
+           --identifier com.rajeshgoli.sm-server <staging>
   codesign --verify --strict <staging>
+  verify staged Identifier, non-ad-hoc certificate Authority, and exact
+         configured certificate-anchored designated requirement
 Phase 2
   cutover stop-rust                     <- bootout
   confirm the job is really unloaded    <- the cutover swallows bootout failures

--- a/specs/1134_rust_restart_procedure.md
+++ b/specs/1134_rust_restart_procedure.md
@@ -356,6 +356,44 @@ Notes on specific choices:
   investigation with no restart - so the escape hatch exists, but the default is
   strict.
 
+### TCC signing revision (#1301)
+
+The old `codesign --force --sign -` command produced a new ad-hoc CDHash
+requirement for each rebuilt `sm-server`. That is not a stable macOS TCC client
+identity and caused repeated protected-folder prompts in production.
+
+The supported restart contract now reads the exact uppercase 40-hex fingerprint
+from the tracked, non-secret `config/rust-server-signing.env`; an explicit
+`SM_SIGN_IDENTITY` override is reserved for a planned certificate rotation.
+The file is parsed as data (not sourced as shell code), must contain exactly one
+identity line, and is therefore durable and discoverable to future operators.
+The production machine's measured default is
+`36FC54A873D584A34FCFEEA7D1F519B19A39DE72` (`Office Automate Local Signing`),
+with a fail-closed override/rotation path.
+
+Before `stop-rust`, the script requires that identity to be available from the
+keychain, signs the disposable staged binary with it, verifies strictly, and
+rejects ad-hoc output, a wrong identifier, absent certificate authority, or a
+designated requirement other than:
+
+```
+designated => identifier "com.rajeshgoli.sm-server" and certificate root = H"<configured fingerprint lowercase>"
+```
+
+The certificate-root requirement is expected to remain identical across changed
+binary content, while CDHash may change. `--sign -` is never an allowed
+fallback. All of these gates run before the installed binary is replaced or the
+launchd job is stopped, so the atomic install, re-registration, rollback, queue
+authority, health, PID, and session checks are unchanged.
+
+Pre-deployment proof is performed only on disposable binaries: sign two
+different-content copies with the named fingerprint, run `codesign --verify
+--strict`, then compare `codesign -dr -` output. Do not use protected-folder
+access as a signing or TCC test. After deployment, inspect `codesign -dv`,
+`codesign -dr -`, launchd's live PID/executable path, health, session count, and
+queue authority. Do not clear the existing TCC record unless Rajesh explicitly
+approves it.
+
 ## Recovery
 
 If the service is down and the script cannot fix it:

--- a/specs/1134_rust_restart_procedure.md
+++ b/specs/1134_rust_restart_procedure.md
@@ -364,12 +364,16 @@ identity and caused repeated protected-folder prompts in production.
 
 The supported restart contract now reads the exact uppercase 40-hex fingerprint
 from the tracked, non-secret `config/rust-server-signing.env`; an explicit
-`SM_SIGN_IDENTITY` override is reserved for a planned certificate rotation.
+`SM_SIGN_IDENTITY` plus `SM_SIGN_DESIGNATED_REQUIREMENT` override is reserved
+for a planned certificate rotation.
 The file is parsed as data (not sourced as shell code), must contain exactly one
 identity line, and is therefore durable and discoverable to future operators.
 The production machine's measured default is
 `36FC54A873D584A34FCFEEA7D1F519B19A39DE72` (`Office Automate Local Signing`),
-with a fail-closed override/rotation path.
+whose currently observed self-signed requirement uses the same certificate-root
+hash. A CA-issued future leaf may have a different root hash: the rotation
+procedure must prove and supply both values, not infer the requirement from the
+leaf fingerprint.
 
 Before `stop-rust`, the script requires that identity to be available from the
 keychain, signs the disposable staged binary with it, verifies strictly, and
@@ -377,14 +381,14 @@ rejects ad-hoc output, a wrong identifier, absent certificate authority, or a
 designated requirement other than:
 
 ```
-designated => identifier "com.rajeshgoli.sm-server" and certificate root = H"<configured fingerprint lowercase>"
+designated => identifier "com.rajeshgoli.sm-server" and certificate (root|leaf) = H"<observed certificate hash>"
 ```
 
-The certificate-root requirement is expected to remain identical across changed
-binary content, while CDHash may change. `--sign -` is never an allowed
-fallback. All of these gates run before the installed binary is replaced or the
-launchd job is stopped, so the atomic install, re-registration, rollback, queue
-authority, health, PID, and session checks are unchanged.
+The exact configured certificate requirement is expected to remain identical
+across changed binary content, while CDHash may change. `--sign -` is never an
+allowed fallback. All of these gates run before the installed binary is replaced
+or the launchd job is stopped, so the atomic install, re-registration, rollback,
+queue authority, health, PID, and session checks are unchanged.
 
 Pre-deployment proof is performed only on disposable binaries: sign two
 different-content copies with the named fingerprint, run `codesign --verify

--- a/tests/unit/test_restart_rust_server.py
+++ b/tests/unit/test_restart_rust_server.py
@@ -22,6 +22,10 @@ SCRIPT = REPO_ROOT / "scripts" / "restart-rust-server.sh"
 CALLS = "calls.log"
 LABEL = "com.example.test"
 SIGN_IDENTITY = "36FC54A873D584A34FCFEEA7D1F519B19A39DE72"
+SIGN_REQUIREMENT = (
+    'designated => identifier "com.rajeshgoli.sm-server" '
+    f'and certificate root = H"{SIGN_IDENTITY.lower()}"'
+)
 
 
 def _write(path: Path, body: str, executable: bool = False) -> Path:
@@ -82,6 +86,7 @@ def env(tmp_path, request):
     (state / "codesign_inspect_rc").write_text("0")
     (state / "codesign_requirement_rc").write_text("0")
     (state / "signing_identity_present").write_text("1")
+    (state / "available_signing_identity").write_text(SIGN_IDENTITY)
     (state / "signed_identifier").write_text("com.rajeshgoli.sm-server")
     (state / "signed_signature").write_text("")
     (state / "signed_authority").write_text("Office Automate Local Signing")
@@ -167,7 +172,7 @@ exit "$(cat "{state}/codesign_sign_rc")"
         f"""#!/bin/bash
 echo "security $*" >> "{log}"
 if [[ "$(cat "{state}/signing_identity_present")" == "1" ]]; then
-  echo '  1) {SIGN_IDENTITY} "Office Automate Local Signing"'
+  echo "  1) $(cat "{state}/available_signing_identity") \"Office Automate Local Signing\""
   echo '     1 valid identities found'
 else
   echo '     0 valid identities found'
@@ -286,7 +291,9 @@ exit 0
 
     config = _write(tmp_path / "config.yaml", "server:\n  port: 8420\n")
     signing_config = _write(
-        tmp_path / "rust-server-signing.env", f"SM_SIGN_IDENTITY={SIGN_IDENTITY}\n"
+        tmp_path / "rust-server-signing.env",
+        f"SM_SIGN_IDENTITY={SIGN_IDENTITY}\n"
+        f"SM_SIGN_DESIGNATED_REQUIREMENT={SIGN_REQUIREMENT}\n",
     )
     # Matches the stub's render-plist output, so there is no divergence by default.
     plist = _write(tmp_path / "service.plist", "<plist>canned</plist>\n")
@@ -433,7 +440,7 @@ def test_missing_signing_identity_blocks_before_service_mutation(env):
     result = env["run"](SM_SIGN_IDENTITY="")
 
     assert result.returncode != 0
-    assert "signing config must contain exactly one" in result.stderr
+    assert "signing config must contain exactly one SM_SIGN_IDENTITY" in result.stderr
     assert "cargo build" not in calls(env)
     assert_service_untouched(env)
 
@@ -475,7 +482,7 @@ def test_wrong_staged_certificate_authority_blocks_before_service_mutation(env):
     result = env["run"]()
 
     assert result.returncode != 0
-    assert "stable certificate-anchored requirement" in result.stderr
+    assert "stable configured certificate-anchored requirement" in result.stderr
     assert_service_untouched(env)
 
 
@@ -735,6 +742,32 @@ def test_tracked_signing_config_supplies_the_durable_default(env):
     assert f"--sign {SIGN_IDENTITY}" in calls(env)
 
 
+def test_ca_issued_rotation_accepts_distinct_leaf_and_requirement_root(env):
+    """A CA-issued leaf must not be compared to the root named by `-dr`.
+
+    The rotation supplies the leaf fingerprint used by `--sign` plus the exact
+    disposable-proof requirement. They intentionally differ, while the staged
+    requirement must still equal the configured stable certificate anchor.
+    """
+    rotated_leaf = "A" * 40
+    rotated_root = "b" * 40
+    rotated_requirement = (
+        'designated => identifier "com.rajeshgoli.sm-server" '
+        f'and certificate root = H"{rotated_root}"'
+    )
+    (env["state"] / "available_signing_identity").write_text(rotated_leaf)
+    (env["state"] / "requirement_identity").write_text(rotated_root)
+
+    result = env["run"](
+        SM_SIGN_IDENTITY=rotated_leaf,
+        SM_SIGN_DESIGNATED_REQUIREMENT=rotated_requirement,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert f"--sign {rotated_leaf}" in calls(env)
+    assert (env["state"] / "requirements.log").read_text().splitlines() == [rotated_requirement]
+
+
 def test_two_different_staged_binaries_require_the_same_certificate_requirement(env):
     """Changed bytes must not turn the TCC-facing identity back into a CDHash.
 
@@ -752,11 +785,7 @@ def test_two_different_staged_binaries_require_the_same_certificate_requirement(
     assert "MARKER=REBUILT_CHANGED" in env["installed"].read_text()
 
     requirements = (env["state"] / "requirements.log").read_text().splitlines()
-    expected = (
-        'designated => identifier "com.rajeshgoli.sm-server" '
-        f'and certificate root = H"{SIGN_IDENTITY.lower()}"'
-    )
-    assert requirements == [expected, expected]
+    assert requirements == [SIGN_REQUIREMENT, SIGN_REQUIREMENT]
 
 
 def test_restart_goes_through_the_cutover_script(env):

--- a/tests/unit/test_restart_rust_server.py
+++ b/tests/unit/test_restart_rust_server.py
@@ -21,6 +21,7 @@ SCRIPT = REPO_ROOT / "scripts" / "restart-rust-server.sh"
 
 CALLS = "calls.log"
 LABEL = "com.example.test"
+SIGN_IDENTITY = "36FC54A873D584A34FCFEEA7D1F519B19A39DE72"
 
 
 def _write(path: Path, body: str, executable: bool = False) -> Path:
@@ -78,6 +79,13 @@ def env(tmp_path, request):
     (state / "cargo_rc").write_text("0")
     (state / "codesign_sign_rc").write_text("0")
     (state / "codesign_verify_rc").write_text("0")
+    (state / "codesign_inspect_rc").write_text("0")
+    (state / "codesign_requirement_rc").write_text("0")
+    (state / "signing_identity_present").write_text("1")
+    (state / "signed_identifier").write_text("com.rajeshgoli.sm-server")
+    (state / "signed_signature").write_text("")
+    (state / "signed_authority").write_text("Office Automate Local Signing")
+    (state / "requirement_identity").write_text(SIGN_IDENTITY.lower())
     (state / "start_rc").write_text("0")
     (state / "stop_rc").write_text("0")
     (state / "stop_leaves_loaded").write_text("0")
@@ -134,10 +142,36 @@ echo "codesign $* [registered=$reg]" >> "{log}"
 for a in "$@"; do
   case "$a" in
     --verify) exit "$(cat "{state}/codesign_verify_rc")" ;;
-    -dvvv) echo "Identifier=com.rajeshgoli.sm-server" >&2; exit 0 ;;
+    -dvvv)
+      echo "Identifier=$(cat "{state}/signed_identifier")" >&2
+      signature="$(cat "{state}/signed_signature")"
+      [[ -n "$signature" ]] && echo "Signature=$signature" >&2
+      authority="$(cat "{state}/signed_authority")"
+      [[ -n "$authority" ]] && echo "Authority=$authority" >&2
+      exit "$(cat "{state}/codesign_inspect_rc")"
+      ;;
+    -dr)
+      requirement="designated => identifier \\\"$(cat "{state}/signed_identifier")\\\" and certificate root = H\\\"$(cat "{state}/requirement_identity")\\\""
+      echo "$requirement" >> "{state}/requirements.log"
+      echo "$requirement" >&2
+      exit "$(cat "{state}/codesign_requirement_rc")"
+      ;;
   esac
 done
 exit "$(cat "{state}/codesign_sign_rc")"
+""",
+        executable=True,
+    )
+    _write(
+        bin_dir / "security",
+        f"""#!/bin/bash
+echo "security $*" >> "{log}"
+if [[ "$(cat "{state}/signing_identity_present")" == "1" ]]; then
+  echo '  1) {SIGN_IDENTITY} "Office Automate Local Signing"'
+  echo '     1 valid identities found'
+else
+  echo '     0 valid identities found'
+fi
 """,
         executable=True,
     )
@@ -251,6 +285,9 @@ exit 0
     )
 
     config = _write(tmp_path / "config.yaml", "server:\n  port: 8420\n")
+    signing_config = _write(
+        tmp_path / "rust-server-signing.env", f"SM_SIGN_IDENTITY={SIGN_IDENTITY}\n"
+    )
     # Matches the stub's render-plist output, so there is no divergence by default.
     plist = _write(tmp_path / "service.plist", "<plist>canned</plist>\n")
     authority_socket_path = Path("/tmp") / f"sm-rst-{uuid.uuid4().hex}.sock"
@@ -269,6 +306,7 @@ exit 0
         "log": log,
         "installed": installed,
         "cargo_output": cargo_output,
+        "signing_config": signing_config,
         "plist": plist,
         "authority_socket": authority_socket,
         "authority_socket_path": authority_socket_path,
@@ -280,6 +318,7 @@ exit 0
             installed,
             cargo_output,
             config,
+            signing_config,
             plist,
             authority_socket_path,
             authority_verifier,
@@ -293,6 +332,7 @@ def _make_runner(
     installed,
     cargo_output,
     config,
+    signing_config,
     plist,
     authority_socket_path,
     authority_verifier,
@@ -308,6 +348,7 @@ def _make_runner(
             "SM_PLIST": str(plist),
             "SM_CUTOVER": str(cutover),
             "SM_CONFIG": str(config),
+            "SM_SIGNING_CONFIG": str(signing_config),
             "SM_PYTHON_LABELS": "com.example.legacy-python",  # extra, on top of the enforced set
             "SM_HOST": "127.0.0.1",
             "SM_PORT": "9",
@@ -315,6 +356,7 @@ def _make_runner(
             "SM_PID_SETTLE_SECONDS": "2",
             "SM_UNLOAD_TIMEOUT": "2",
             "SM_LABEL": LABEL,
+            "SM_SIGN_IDENTITY": SIGN_IDENTITY,
             "SM_LOCK": str(binary_dir_lock),
             "SM_QUEUE_AUTHORITY_SOCKET": str(authority_socket_path),
             "SM_QUEUE_AUTHORITY_VERIFIER": str(authority_verifier),
@@ -372,7 +414,7 @@ def test_sign_failure_leaves_service_untouched(env):
     result = env["run"]()
 
     assert result.returncode != 0
-    assert "codesign failed" in result.stderr
+    assert "codesign with persistent identity" in result.stderr
     assert_service_untouched(env)
 
 
@@ -383,6 +425,57 @@ def test_verify_failure_leaves_service_untouched(env):
 
     assert result.returncode != 0
     assert "signature verification failed" in result.stderr
+    assert_service_untouched(env)
+
+
+def test_missing_signing_identity_blocks_before_service_mutation(env):
+    env["signing_config"].write_text("# identity deliberately missing\n")
+    result = env["run"](SM_SIGN_IDENTITY="")
+
+    assert result.returncode != 0
+    assert "signing config must contain exactly one" in result.stderr
+    assert "cargo build" not in calls(env)
+    assert_service_untouched(env)
+
+
+def test_unusable_keychain_identity_blocks_before_service_mutation(env):
+    (env["state"] / "signing_identity_present").write_text("0")
+
+    result = env["run"]()
+
+    assert result.returncode != 0
+    assert "not a valid usable codesigning identity" in result.stderr
+    assert "cargo build" not in calls(env)
+    assert_service_untouched(env)
+
+
+def test_ad_hoc_staged_output_blocks_before_service_mutation(env):
+    (env["state"] / "signed_signature").write_text("adhoc")
+
+    result = env["run"]()
+
+    assert result.returncode != 0
+    assert "staged signature is ad-hoc" in result.stderr
+    assert_service_untouched(env)
+
+
+def test_wrong_staged_identifier_blocks_before_service_mutation(env):
+    (env["state"] / "signed_identifier").write_text("com.example.wrong")
+
+    result = env["run"]()
+
+    assert result.returncode != 0
+    assert "staged signature identifier is not" in result.stderr
+    assert_service_untouched(env)
+
+
+def test_wrong_staged_certificate_authority_blocks_before_service_mutation(env):
+    (env["state"] / "requirement_identity").write_text("0" * 40)
+
+    result = env["run"]()
+
+    assert result.returncode != 0
+    assert "stable certificate-anchored requirement" in result.stderr
     assert_service_untouched(env)
 
 
@@ -632,6 +725,38 @@ def test_signs_with_a_stable_identifier(env):
     env["run"]()
 
     assert "--identifier com.rajeshgoli.sm-server" in calls(env)
+    assert f"--sign {SIGN_IDENTITY}" in calls(env)
+
+
+def test_tracked_signing_config_supplies_the_durable_default(env):
+    result = env["run"](SM_SIGN_IDENTITY="")
+
+    assert result.returncode == 0, result.stderr
+    assert f"--sign {SIGN_IDENTITY}" in calls(env)
+
+
+def test_two_different_staged_binaries_require_the_same_certificate_requirement(env):
+    """Changed bytes must not turn the TCC-facing identity back into a CDHash.
+
+    The two runs stage different fake cargo outputs. The codesign stub records
+    the exact designated requirement requested by the real script's inspection
+    path, so this catches a regression that checks only the identifier or only
+    the first staged binary.
+    """
+    first = env["run"]()
+    assert first.returncode == 0, first.stderr
+
+    _write(env["state"] / "rebuilt-binary", _fake(env, "REBUILT_CHANGED"))
+    second = env["run"]()
+    assert second.returncode == 0, second.stderr
+    assert "MARKER=REBUILT_CHANGED" in env["installed"].read_text()
+
+    requirements = (env["state"] / "requirements.log").read_text().splitlines()
+    expected = (
+        'designated => identifier "com.rajeshgoli.sm-server" '
+        f'and certificate root = H"{SIGN_IDENTITY.lower()}"'
+    )
+    assert requirements == [expected, expected]
 
 
 def test_restart_goes_through_the_cutover_script(env):


### PR DESCRIPTION
Fixes #1301

## R3 classification

Production restart/control path, signing/TCC security boundary, atomic install and launchd recovery/concurrency behavior.

## Delivered capability

The supported Rust restart pipeline uses tracked non-secret identity and empirically captured designated-requirement configuration; it never falls back to ad-hoc signing. Before stopping the service it validates identity availability, strict signature, expected identifier, certificate authority, and exact configured requirement. CA-issued rotation must supply both signing leaf and proven requirement. Atomic install/cutover/queue-authority/health/session behavior remains unchanged.

## Disposable proof

Different-content disposable binaries signed non-interactively with `36FC54A873D584A34FCFEEA7D1F519B19A39DE72` both yielded `designated => identifier "com.rajeshgoli.sm-server" and certificate root = H"36fc54a873d584a34fcfeea7d1f519b19a39de72"`; no protected-folder access was attempted.

## Validation

`bash -n scripts/restart-rust-server.sh`; focused hostile signing tests (8 passed, then 6 passed after documentation repair).

## R3 review record

| Round | Head | Scope/findings | Resulting head | Result |
| --- | --- | --- | --- | --- |
| 1 | `85bdcf0` | Full frozen change; clean | unchanged | passed |
| 2 | `85bdcf0` | Valid P2 CA leaf/root mismatch; narrow repair | `541efc9` | repaired head required review |
| 3 | `541efc9` | Valid P2 operative procedure still showed ad-hoc signing; documentation-only repair | `b5fb45b` | repaired head required review |
| 4 | `b5fb45bc25832e8fa1689907eb47d884f866470a` | Focused procedure repair and frozen capability boundary | pending | pending |