### PR TITLE
test: isolate Rust server durable paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,10 @@ running server. See `specs/1134_rust_restart_procedure.md`.
 ### Testing
 
 ```bash
+# Rust server tests — the supported launcher also cleans isolated state. Direct
+# cargo test has a fail-safe isolation root, but must not be used for normal work.
+./scripts/test-rust-isolated.sh
+
 # Manual testing - spawn a child agent
 sm spawn --name test-agent "echo hello and exit"
 

--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -2134,12 +2134,24 @@ mod tests {
             TEST_ISOLATION_INSTANCE.fetch_add(1, Ordering::Relaxed)
         ));
         let safe_state_file = env::temp_dir().join("sm-safe-fixture-sessions.json");
+        let safe_codex_index = env::temp_dir().join("sm-safe-fixture-codex-index.jsonl");
+        let safe_transcript_root = env::temp_dir().join("sm-safe-fixture-transcripts");
         let mut config = AppConfig::default();
         config.paths.state_file = safe_state_file.display().to_string();
+        config.codex.session_index_path = Some(safe_codex_index.display().to_string());
+        config.claude.transcript_root = Some(safe_transcript_root.display().to_string());
         config.isolate_test_paths(&root).unwrap();
         assert_eq!(
             config.paths.state_file,
             safe_state_file.display().to_string()
+        );
+        assert_eq!(
+            config.codex.session_index_path.as_deref(),
+            Some(safe_codex_index.to_str().unwrap())
+        );
+        assert_eq!(
+            config.claude.transcript_root.as_deref(),
+            Some(safe_transcript_root.to_str().unwrap())
         );
 
         let mut unsafe_config = AppConfig::default();

--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -2,12 +2,19 @@ use std::{
     collections::BTreeMap,
     env, fs,
     path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
 };
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_yaml::{Mapping as YamlMapping, Value as YamlValue};
 use sha2::{Digest, Sha256};
+
+/// Required by the Rust test launcher. When present, every default-shaped
+/// durable path is redirected below this root before an `AppState` starts.
+pub const TEST_ISOLATION_ROOT_ENV: &str = "SM_TEST_ISOLATION_ROOT";
+
+static TEST_ISOLATION_INSTANCE: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone)]
 pub struct AppConfig {
@@ -131,6 +138,172 @@ impl AppConfig {
         }
         PathBuf::from(&self.queue_runner.state_dir)
     }
+
+    /// Redirect production-shaped durable paths below `root`. Explicit fixture
+    /// paths outside the production state directory are retained, while every
+    /// default AppState receives a unique state-file sibling and therefore a
+    /// unique reparent lock and queue database.
+    pub fn isolate_test_paths(&mut self, root: &Path) -> Result<()> {
+        if !root.is_absolute() {
+            anyhow::bail!("test isolation root must be absolute: {}", root.display());
+        }
+        fs::create_dir_all(root)
+            .with_context(|| format!("failed to create test isolation root {}", root.display()))?;
+        let instance = root.join(format!(
+            "appstate-{}-{}",
+            std::process::id(),
+            TEST_ISOLATION_INSTANCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&instance).with_context(|| {
+            format!(
+                "failed to create isolated AppState root {}",
+                instance.display()
+            )
+        })?;
+
+        self.paths.state_file =
+            isolate_default_data_path(&self.paths.state_file, &default_state_file(), &instance)?;
+        self.sm_send.db_path = isolate_default_data_path(
+            &self.sm_send.db_path,
+            &default_message_queue_db_path(),
+            &instance,
+        )?;
+        self.mobile_analytics.message_queue_db = isolate_default_data_path(
+            &self.mobile_analytics.message_queue_db,
+            &default_message_queue_db_path(),
+            &instance,
+        )?;
+        self.tool_logging.db_path = isolate_default_data_path(
+            &self.tool_logging.db_path,
+            &default_tool_usage_db_path(),
+            &instance,
+        )?;
+        self.usage.db_path =
+            isolate_default_data_path(&self.usage.db_path, &default_usage_db_path(), &instance)?;
+        self.codex_events.db_path = isolate_default_data_path(
+            &self.codex_events.db_path,
+            &default_codex_events_db_path(),
+            &instance,
+        )?;
+        self.codex_requests.db_path = isolate_default_data_path(
+            &self.codex_requests.db_path,
+            &default_codex_requests_db_path(),
+            &instance,
+        )?;
+        self.codex_observability.db_path = isolate_default_data_path(
+            &self.codex_observability.db_path,
+            &default_codex_observability_db_path(),
+            &instance,
+        )?;
+        self.queue_runner.state_dir = isolate_default_data_path(
+            &self.queue_runner.state_dir,
+            &default_queue_runner_state_dir(),
+            &instance,
+        )?;
+        self.mobile_terminal.device_enrollment_db_path = isolate_default_data_path(
+            &self.mobile_terminal.device_enrollment_db_path,
+            &default_mobile_terminal_device_enrollment_db_path(),
+            &instance,
+        )?;
+
+        // Default production indexes can make a test AppState scan live agent
+        // artifacts during startup. Fixtures that explicitly point elsewhere
+        // remain available, but home-relative defaults are never consulted.
+        if let Some(path) = self.codex.session_index_path.as_deref() {
+            if path == "~/.codex/session_index.jsonl" {
+                self.codex.session_index_path = None;
+            } else if path_is_under_home(path) {
+                anyhow::bail!("test isolation refuses production Codex index path {path}");
+            }
+        }
+        if let Some(path) = self.claude.transcript_root.as_deref() {
+            if path_is_under_home(path) {
+                anyhow::bail!("test isolation refuses production Claude transcript root {path}");
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Return the configured test-isolation root, creating it before any durable
+/// store can be opened. The supported launcher supplies a cleanable root. As
+/// a fail-safe, a Cargo test binary that bypasses that launcher gets its own
+/// temporary root instead of falling through to production defaults.
+pub fn test_isolation_root_from_environment() -> Result<Option<PathBuf>> {
+    let root = if let Some(root) = env::var_os(TEST_ISOLATION_ROOT_ENV) {
+        PathBuf::from(root)
+    } else if running_rust_test_binary() {
+        env::temp_dir().join(format!("sm-rust-test-{}", std::process::id()))
+    } else {
+        return Ok(None);
+    };
+    if !root.is_absolute() {
+        anyhow::bail!("{TEST_ISOLATION_ROOT_ENV} must be an absolute path");
+    }
+    fs::create_dir_all(&root)
+        .with_context(|| format!("failed to create test isolation root {}", root.display()))?;
+    Ok(Some(root))
+}
+
+fn running_rust_test_binary() -> bool {
+    let Ok(executable) = env::current_exe() else {
+        return false;
+    };
+    let in_cargo_deps = executable
+        .parent()
+        .and_then(Path::file_name)
+        .is_some_and(|name| name == "deps");
+    let has_cargo_hash = executable
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .and_then(|name| name.rsplit_once('-'))
+        .is_some_and(|(_, hash)| {
+            hash.len() >= 8 && hash.chars().all(|character| character.is_ascii_hexdigit())
+        });
+    in_cargo_deps && has_cargo_hash
+}
+
+fn production_data_root() -> Option<PathBuf> {
+    env::var_os("HOME").map(|home| Path::new(&home).join(".local/share/claude-sessions"))
+}
+
+fn expand_home_for_path_match(path: &str) -> PathBuf {
+    if path == "~" {
+        return env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(path));
+    }
+    path.strip_prefix("~/")
+        .and_then(|rest| env::var_os("HOME").map(|home| Path::new(&home).join(rest)))
+        .unwrap_or_else(|| PathBuf::from(path))
+}
+
+fn isolate_default_data_path(path: &str, default: &str, root: &Path) -> Result<String> {
+    let expanded = expand_home_for_path_match(path);
+    let Some(production_root) = production_data_root() else {
+        return Ok(path.to_owned());
+    };
+    if path == default {
+        let default_expanded = expand_home_for_path_match(default);
+        let relative = default_expanded
+            .strip_prefix(&production_root)
+            .with_context(|| {
+                format!(
+                    "default test path {default} is not under {}",
+                    production_root.display()
+                )
+            })?;
+        return Ok(root.join(relative).to_string_lossy().into_owned());
+    }
+    if expanded.starts_with(&production_root) {
+        anyhow::bail!("test isolation refuses explicit production path {path}");
+    };
+    Ok(path.to_owned())
+}
+
+fn path_is_under_home(path: &str) -> bool {
+    let expanded = expand_home_for_path_match(path);
+    env::var_os("HOME").is_some_and(|home| expanded.starts_with(PathBuf::from(home)))
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1910,6 +2083,106 @@ fn derive_session_cookie_secret(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_isolation_rehomes_all_default_durable_paths() {
+        let root = env::temp_dir().join(format!(
+            "sm-config-test-isolation-{}-{}",
+            std::process::id(),
+            TEST_ISOLATION_INSTANCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        let mut config = AppConfig::default();
+        config.isolate_test_paths(&root).unwrap();
+
+        let durable_paths = [
+            &config.paths.state_file,
+            &config.sm_send.db_path,
+            &config.mobile_analytics.message_queue_db,
+            &config.tool_logging.db_path,
+            &config.usage.db_path,
+            &config.codex_events.db_path,
+            &config.codex_requests.db_path,
+            &config.codex_observability.db_path,
+            &config.queue_runner.state_dir,
+            &config.mobile_terminal.device_enrollment_db_path,
+        ];
+        for path in durable_paths {
+            assert!(
+                Path::new(path).starts_with(&root),
+                "expected {path} below {}",
+                root.display()
+            );
+        }
+        assert!(Path::new(&config.paths.state_file)
+            .with_extension("reparent-apply.lock")
+            .starts_with(&root));
+        assert_eq!(config.codex.session_index_path, None);
+
+        let first_state_file = config.paths.state_file.clone();
+        let mut second_config = AppConfig::default();
+        second_config.isolate_test_paths(&root).unwrap();
+        assert_ne!(first_state_file, second_config.paths.state_file);
+
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn test_isolation_retains_safe_fixtures_and_rejects_production_paths() {
+        let root = env::temp_dir().join(format!(
+            "sm-config-test-isolation-explicit-{}-{}",
+            std::process::id(),
+            TEST_ISOLATION_INSTANCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        let safe_state_file = env::temp_dir().join("sm-safe-fixture-sessions.json");
+        let mut config = AppConfig::default();
+        config.paths.state_file = safe_state_file.display().to_string();
+        config.isolate_test_paths(&root).unwrap();
+        assert_eq!(
+            config.paths.state_file,
+            safe_state_file.display().to_string()
+        );
+
+        let mut unsafe_config = AppConfig::default();
+        unsafe_config.paths.state_file = production_data_root()
+            .unwrap()
+            .join("explicit-test-sessions.json")
+            .display()
+            .to_string();
+        let error = unsafe_config.isolate_test_paths(&root).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("refuses explicit production path"));
+
+        let mut unsafe_queue_config = AppConfig::default();
+        unsafe_queue_config.sm_send.db_path = production_data_root()
+            .unwrap()
+            .join("message_queue.db")
+            .display()
+            .to_string();
+        let error = unsafe_queue_config.isolate_test_paths(&root).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("refuses explicit production path"));
+
+        let mut unsafe_index_config = AppConfig::default();
+        unsafe_index_config.codex.session_index_path =
+            Some("~/.codex/sessions/index.jsonl".to_owned());
+        let error = unsafe_index_config.isolate_test_paths(&root).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("refuses production Codex index path"));
+
+        let mut unsafe_transcript_config = AppConfig::default();
+        unsafe_transcript_config.claude.transcript_root = Some("~/.claude/projects".to_owned());
+        let error = unsafe_transcript_config
+            .isolate_test_paths(&root)
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("refuses production Claude transcript root"));
+
+        let _ = fs::remove_dir_all(&root);
+    }
 
     #[test]
     fn local_env_overlay_maps_mobile_auth_and_external_access() {

--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -1,6 +1,9 @@
 use std::{
     collections::BTreeMap,
-    env, fs,
+    env,
+    ffi::OsString,
+    fs,
+    io::ErrorKind,
     path::{Path, PathBuf},
     sync::atomic::{AtomicU64, Ordering},
 };
@@ -161,6 +164,7 @@ impl AppConfig {
             )
         })?;
 
+        let custom_state_file = self.paths.state_file != default_state_file();
         self.paths.state_file =
             isolate_default_data_path(&self.paths.state_file, &default_state_file(), &instance)?;
         self.sm_send.db_path = isolate_default_data_path(
@@ -178,8 +182,14 @@ impl AppConfig {
             &default_tool_usage_db_path(),
             &instance,
         )?;
-        self.usage.db_path =
-            isolate_default_data_path(&self.usage.db_path, &default_usage_db_path(), &instance)?;
+        self.usage.db_path = if custom_state_file && self.usage.db_path == default_usage_db_path() {
+            Path::new(&self.paths.state_file)
+                .with_extension("usage.db")
+                .to_string_lossy()
+                .into_owned()
+        } else {
+            isolate_default_data_path(&self.usage.db_path, &default_usage_db_path(), &instance)?
+        };
         self.codex_events.db_path = isolate_default_data_path(
             &self.codex_events.db_path,
             &default_codex_events_db_path(),
@@ -205,6 +215,20 @@ impl AppConfig {
             &default_mobile_terminal_device_enrollment_db_path(),
             &instance,
         )?;
+        self.bug_reports.db_path = isolate_path_from_protected_root(
+            &self.bug_reports.db_path,
+            &default_bug_reports_db_path(),
+            &instance,
+            Path::new("bug_reports.db"),
+            &expand_home_for_path_match(&default_bug_reports_db_path()),
+        )?;
+        self.app_artifacts.root_dir = isolate_path_from_protected_root(
+            &self.app_artifacts.root_dir,
+            &default_app_artifacts_dir(),
+            &instance,
+            Path::new("apps"),
+            &expand_home_for_path_match(&default_app_artifacts_dir()),
+        )?;
 
         // Default production indexes can make a test AppState scan live agent
         // artifacts during startup. Fixtures that explicitly point elsewhere
@@ -212,12 +236,12 @@ impl AppConfig {
         if let Some(path) = self.codex.session_index_path.as_deref() {
             if path == "~/.codex/session_index.jsonl" {
                 self.codex.session_index_path = None;
-            } else if path_is_under_home(path) {
+            } else if path_is_under_home(path)? {
                 anyhow::bail!("test isolation refuses production Codex index path {path}");
             }
         }
         if let Some(path) = self.claude.transcript_root.as_deref() {
-            if path_is_under_home(path) {
+            if path_is_under_home(path)? {
                 anyhow::bail!("test isolation refuses production Claude transcript root {path}");
             }
         }
@@ -279,31 +303,105 @@ fn expand_home_for_path_match(path: &str) -> PathBuf {
 }
 
 fn isolate_default_data_path(path: &str, default: &str, root: &Path) -> Result<String> {
-    let expanded = expand_home_for_path_match(path);
     let Some(production_root) = production_data_root() else {
         return Ok(path.to_owned());
     };
+    let canonical_production_root = canonicalize_path_for_containment(&production_root)?;
+    let canonical_default =
+        canonicalize_path_for_containment(&expand_home_for_path_match(default))?;
+    let relative = canonical_default
+        .strip_prefix(&canonical_production_root)
+        .with_context(|| {
+            format!(
+                "default test path {default} is not under {}",
+                canonical_production_root.display()
+            )
+        })?;
+    isolate_path_from_protected_root(path, default, root, relative, &canonical_production_root)
+}
+
+fn isolate_path_from_protected_root(
+    path: &str,
+    default: &str,
+    root: &Path,
+    replacement: &Path,
+    protected_root: &Path,
+) -> Result<String> {
     if path == default {
-        let default_expanded = expand_home_for_path_match(default);
-        let relative = default_expanded
-            .strip_prefix(&production_root)
-            .with_context(|| {
-                format!(
-                    "default test path {default} is not under {}",
-                    production_root.display()
-                )
-            })?;
-        return Ok(root.join(relative).to_string_lossy().into_owned());
+        return Ok(root.join(replacement).to_string_lossy().into_owned());
     }
-    if expanded.starts_with(&production_root) {
+    if path_resolves_under_root(path, protected_root)? {
         anyhow::bail!("test isolation refuses explicit production path {path}");
-    };
+    }
     Ok(path.to_owned())
 }
 
-fn path_is_under_home(path: &str) -> bool {
-    let expanded = expand_home_for_path_match(path);
-    env::var_os("HOME").is_some_and(|home| expanded.starts_with(PathBuf::from(home)))
+fn path_is_under_home(path: &str) -> Result<bool> {
+    let Some(home) = env::var_os("HOME") else {
+        return Ok(false);
+    };
+    path_resolves_under_root(path, Path::new(&home))
+}
+
+fn path_resolves_under_root(path: &str, root: &Path) -> Result<bool> {
+    let candidate = canonicalize_path_for_containment(&expand_home_for_path_match(path))?;
+    let root = canonicalize_path_for_containment(root)?;
+    Ok(candidate.starts_with(root))
+}
+
+/// Canonicalize the longest existing prefix, then append unresolved trailing
+/// components. This catches `..` and symlink aliases even when a prospective
+/// store file has not been created yet. Any unreadable or dangling prefix is
+/// rejected rather than accepted as a fixture.
+fn canonicalize_path_for_containment(path: &Path) -> Result<PathBuf> {
+    let mut existing = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        env::current_dir()
+            .context("failed to determine current directory for test path isolation")?
+            .join(path)
+    };
+    let mut unresolved = Vec::<OsString>::new();
+    loop {
+        match fs::symlink_metadata(&existing) {
+            Ok(_) => break,
+            Err(error)
+                if matches!(error.kind(), ErrorKind::NotFound | ErrorKind::NotADirectory) =>
+            {
+                let component = existing.file_name().map(OsString::from).with_context(|| {
+                    format!(
+                        "test isolation could not find an existing ancestor for {}",
+                        path.display()
+                    )
+                })?;
+                unresolved.push(component);
+                if !existing.pop() {
+                    anyhow::bail!(
+                        "test isolation could not find an existing ancestor for {}",
+                        path.display()
+                    );
+                }
+            }
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "test isolation could not inspect explicit path {}",
+                        path.display()
+                    )
+                });
+            }
+        }
+    }
+    let mut canonical = fs::canonicalize(&existing).with_context(|| {
+        format!(
+            "test isolation could not canonicalize explicit path prefix {}",
+            existing.display()
+        )
+    })?;
+    for component in unresolved.iter().rev() {
+        canonical.push(component);
+    }
+    Ok(canonical)
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -2105,6 +2203,8 @@ mod tests {
             &config.codex_observability.db_path,
             &config.queue_runner.state_dir,
             &config.mobile_terminal.device_enrollment_db_path,
+            &config.bug_reports.db_path,
+            &config.app_artifacts.root_dir,
         ];
         for path in durable_paths {
             assert!(
@@ -2176,6 +2276,66 @@ mod tests {
             .to_string()
             .contains("refuses explicit production path"));
 
+        let production_root = production_data_root().unwrap();
+        let mut dot_alias_config = AppConfig::default();
+        dot_alias_config.paths.state_file = production_root
+            .parent()
+            .unwrap()
+            .join("claude-sessions")
+            .join("..")
+            .join("claude-sessions/alias-sessions.json")
+            .display()
+            .to_string();
+        let error = dot_alias_config.isolate_test_paths(&root).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("refuses explicit production path"));
+
+        let symlink_root = root.join("production-alias");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&production_root, &symlink_root).unwrap();
+        let mut symlink_alias_config = AppConfig::default();
+        symlink_alias_config.paths.state_file = symlink_root
+            .join("alias-sessions.json")
+            .display()
+            .to_string();
+        let error = symlink_alias_config.isolate_test_paths(&root).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("refuses explicit production path"));
+
+        let mut unsafe_bug_report_config = AppConfig::default();
+        let default_bug_report_path = PathBuf::from(default_bug_reports_db_path());
+        unsafe_bug_report_config.bug_reports.db_path = default_bug_report_path
+            .parent()
+            .unwrap()
+            .join(".")
+            .join(default_bug_report_path.file_name().unwrap())
+            .display()
+            .to_string();
+        let error = unsafe_bug_report_config
+            .isolate_test_paths(&root)
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("refuses explicit production path"));
+
+        let mut unsafe_app_artifact_config = AppConfig::default();
+        let default_app_artifact_root = PathBuf::from(default_app_artifacts_dir());
+        unsafe_app_artifact_config.app_artifacts.root_dir = default_app_artifact_root
+            .parent()
+            .unwrap()
+            .join(".")
+            .join(default_app_artifact_root.file_name().unwrap())
+            .display()
+            .to_string();
+        let error = unsafe_app_artifact_config
+            .isolate_test_paths(&root)
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("refuses explicit production path"));
+
         let mut unsafe_index_config = AppConfig::default();
         unsafe_index_config.codex.session_index_path =
             Some("~/.codex/sessions/index.jsonl".to_owned());
@@ -2194,6 +2354,26 @@ mod tests {
             .contains("refuses production Claude transcript root"));
 
         let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn test_isolation_preserves_custom_state_file_usage_db_lifecycle() {
+        let root = env::temp_dir().join(format!(
+            "sm-config-test-isolation-custom-state-{}-{}",
+            std::process::id(),
+            TEST_ISOLATION_INSTANCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        let state_file = env::temp_dir().join("sm-isolated-custom-state.json");
+        let mut config = AppConfig::default();
+        config.paths.state_file = state_file.display().to_string();
+        config.isolate_test_paths(&root).unwrap();
+
+        assert_eq!(config.paths.state_file, state_file.display().to_string());
+        assert_eq!(
+            config.usage.db_path,
+            state_file.with_extension("usage.db").display().to_string()
+        );
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]

--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -5,19 +5,24 @@ use std::{
     fs,
     io::ErrorKind,
     path::{Path, PathBuf},
-    sync::atomic::{AtomicU64, Ordering},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        OnceLock,
+    },
 };
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_yaml::{Mapping as YamlMapping, Value as YamlValue};
 use sha2::{Digest, Sha256};
+use time::OffsetDateTime;
 
 /// Required by the Rust test launcher. When present, every default-shaped
 /// durable path is redirected below this root before an `AppState` starts.
 pub const TEST_ISOLATION_ROOT_ENV: &str = "SM_TEST_ISOLATION_ROOT";
 
 static TEST_ISOLATION_INSTANCE: AtomicU64 = AtomicU64::new(0);
+static DIRECT_TEST_ISOLATION_ROOT: OnceLock<PathBuf> = OnceLock::new();
 
 #[derive(Debug, Clone)]
 pub struct AppConfig {
@@ -257,7 +262,7 @@ pub fn test_isolation_root_from_environment() -> Result<Option<PathBuf>> {
     let root = if let Some(root) = env::var_os(TEST_ISOLATION_ROOT_ENV) {
         PathBuf::from(root)
     } else if running_rust_test_binary() {
-        env::temp_dir().join(format!("sm-rust-test-{}", std::process::id()))
+        direct_test_isolation_root()?
     } else {
         return Ok(None);
     };
@@ -336,11 +341,37 @@ fn isolate_path_from_protected_root(
     Ok(path.to_owned())
 }
 
-fn path_is_under_home(path: &str) -> Result<bool> {
+pub(crate) fn path_is_under_home(path: &str) -> Result<bool> {
     let Some(home) = env::var_os("HOME") else {
         return Ok(false);
     };
     path_resolves_under_root(path, Path::new(&home))
+}
+
+fn direct_test_isolation_root() -> Result<PathBuf> {
+    if let Some(root) = DIRECT_TEST_ISOLATION_ROOT.get() {
+        return Ok(root.clone());
+    }
+    for _ in 0..128 {
+        let candidate = env::temp_dir().join(format!(
+            "sm-rust-test-{}-{}-{}",
+            std::process::id(),
+            OffsetDateTime::now_utc().unix_timestamp_nanos(),
+            TEST_ISOLATION_INSTANCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        match fs::create_dir(&candidate) {
+            Ok(()) => {
+                let _ = DIRECT_TEST_ISOLATION_ROOT.set(candidate.clone());
+                return Ok(DIRECT_TEST_ISOLATION_ROOT
+                    .get()
+                    .expect("direct test isolation root was set")
+                    .clone());
+            }
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error).context("failed to create direct test isolation root"),
+        }
+    }
+    anyhow::bail!("failed to create a unique direct test isolation root")
 }
 
 fn path_resolves_under_root(path: &str, root: &Path) -> Result<bool> {
@@ -2354,6 +2385,25 @@ mod tests {
             .contains("refuses production Claude transcript root"));
 
         let _ = fs::remove_dir_all(&root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn containment_canonicalizes_a_transcript_root_symlinked_into_home() {
+        let root = env::temp_dir().join(format!(
+            "sm-config-transcript-symlink-{}-{}",
+            std::process::id(),
+            TEST_ISOLATION_INSTANCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        let home = root.join("home");
+        let live_projects = home.join(".claude/projects");
+        let alias = root.join("outside-home-alias");
+        fs::create_dir_all(&live_projects).unwrap();
+        std::os::unix::fs::symlink(&live_projects, &alias).unwrap();
+
+        assert!(path_resolves_under_root(alias.to_str().unwrap(), &home).unwrap());
+
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -13884,6 +13884,28 @@ mod tests {
 
     const DIRECT_HARNESS_PROBE_ENV: &str = "SM_DIRECT_HARNESS_ISOLATION_PROBE";
 
+    struct ProbeChild {
+        child: Child,
+        release_path: PathBuf,
+    }
+
+    impl ProbeChild {
+        fn release_and_wait(&mut self) {
+            fs::write(&self.release_path, []).unwrap();
+            assert!(self.child.wait().unwrap().success());
+        }
+    }
+
+    impl Drop for ProbeChild {
+        fn drop(&mut self) {
+            let _ = fs::write(&self.release_path, []);
+            if self.child.try_wait().ok().flatten().is_none() {
+                let _ = self.child.kill();
+            }
+            let _ = self.child.wait();
+        }
+    }
+
     #[test]
     fn direct_test_harness_without_wrapper_cannot_open_production_state_paths() {
         if let Some(probe_path) = env::var_os(DIRECT_HARNESS_PROBE_ENV) {
@@ -13901,6 +13923,8 @@ mod tests {
                 config.codex_observability.db_path.clone(),
                 config.queue_runner.state_dir.clone(),
                 config.mobile_terminal.device_enrollment_db_path.clone(),
+                config.bug_reports.db_path.clone(),
+                config.app_artifacts.root_dir.clone(),
                 StdPath::new(&config.paths.state_file)
                     .with_extension("reparent-apply.lock")
                     .display()
@@ -13930,23 +13954,26 @@ mod tests {
         fs::create_dir_all(&probe_root).unwrap();
         let probe_path = probe_root.join("probe");
         let executable = env::current_exe().unwrap();
-        let mut child = Command::new(executable)
-            .args([
-                "--exact",
-                "http::tests::direct_test_harness_without_wrapper_cannot_open_production_state_paths",
-                "--nocapture",
-            ])
-            .env_remove(TEST_ISOLATION_ROOT_ENV)
-            .env(DIRECT_HARNESS_PROBE_ENV, &probe_path)
-            .spawn()
-            .unwrap();
+        let mut probe_child = ProbeChild {
+            child: Command::new(executable)
+                .args([
+                    "--exact",
+                    "http::tests::direct_test_harness_without_wrapper_cannot_open_production_state_paths",
+                    "--nocapture",
+                ])
+                .env_remove(TEST_ISOLATION_ROOT_ENV)
+                .env(DIRECT_HARNESS_PROBE_ENV, &probe_path)
+                .spawn()
+                .unwrap(),
+            release_path: probe_path.with_extension("release"),
+        };
 
         for _ in 0..500 {
             if probe_path.exists() {
                 break;
             }
             assert!(
-                child.try_wait().unwrap().is_none(),
+                probe_child.child.try_wait().unwrap().is_none(),
                 "isolation probe exited early"
             );
             std::thread::sleep(Duration::from_millis(10));
@@ -13972,26 +13999,34 @@ mod tests {
             effective_paths.join("\n")
         );
 
-        let lsof = Command::new("/usr/sbin/lsof")
+        match Command::new("lsof")
             .args(["-p", &child_pid.to_string()])
             .output()
-            .expect("lsof is required for the direct-harness isolation proof");
-        assert!(
-            lsof.status.success(),
-            "lsof could not inspect test child {child_pid}"
-        );
-        let open_files = String::from_utf8_lossy(&lsof.stdout);
-        assert!(
-            !open_files.contains(production_root.to_string_lossy().as_ref()),
-            "unwrapped test child opened production state path:\n{open_files}"
-        );
-        println!(
-            "direct-harness lsof proof: child pid {child_pid} has no open path below {}",
-            production_root.display()
-        );
+        {
+            Ok(lsof) => {
+                assert!(
+                    lsof.status.success(),
+                    "lsof could not inspect test child {child_pid}"
+                );
+                let open_files = String::from_utf8_lossy(&lsof.stdout);
+                assert!(
+                    !open_files.contains(production_root.to_string_lossy().as_ref()),
+                    "unwrapped test child opened production state path:\n{open_files}"
+                );
+                println!(
+                    "direct-harness lsof proof: child pid {child_pid} has no open path below {}",
+                    production_root.display()
+                );
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                println!(
+                    "direct-harness lsof unavailable; effective-path assertions remain the portable proof"
+                );
+            }
+            Err(error) => panic!("failed to invoke lsof for test child {child_pid}: {error}"),
+        }
 
-        fs::write(probe_path.with_extension("release"), []).unwrap();
-        assert!(child.wait().unwrap().success());
+        probe_child.release_and_wait();
         fs::remove_dir_all(probe_root).unwrap();
     }
 
@@ -14006,23 +14041,26 @@ mod tests {
         fs::create_dir_all(&wrapper_root).unwrap();
         let probe_path = probe_root.join("probe");
         let executable = env::current_exe().unwrap();
-        let mut child = Command::new(executable)
-            .args([
-                "--exact",
-                "http::tests::direct_test_harness_without_wrapper_cannot_open_production_state_paths",
-                "--nocapture",
-            ])
-            .env(TEST_ISOLATION_ROOT_ENV, &wrapper_root)
-            .env(DIRECT_HARNESS_PROBE_ENV, &probe_path)
-            .spawn()
-            .unwrap();
+        let mut probe_child = ProbeChild {
+            child: Command::new(executable)
+                .args([
+                    "--exact",
+                    "http::tests::direct_test_harness_without_wrapper_cannot_open_production_state_paths",
+                    "--nocapture",
+                ])
+                .env(TEST_ISOLATION_ROOT_ENV, &wrapper_root)
+                .env(DIRECT_HARNESS_PROBE_ENV, &probe_path)
+                .spawn()
+                .unwrap(),
+            release_path: probe_path.with_extension("release"),
+        };
 
         for _ in 0..500 {
             if probe_path.exists() {
                 break;
             }
             assert!(
-                child.try_wait().unwrap().is_none(),
+                probe_child.child.try_wait().unwrap().is_none(),
                 "wrapper probe exited early"
             );
             std::thread::sleep(Duration::from_millis(10));
@@ -14041,8 +14079,7 @@ mod tests {
             state_file.display()
         );
 
-        fs::write(probe_path.with_extension("release"), []).unwrap();
-        assert!(child.wait().unwrap().success());
+        probe_child.release_and_wait();
         fs::remove_dir_all(probe_root).unwrap();
     }
 
@@ -14062,6 +14099,39 @@ mod tests {
         assert!(error
             .to_string()
             .contains("refuses explicit production path"));
+    }
+
+    #[test]
+    fn test_isolation_rehomes_handler_writable_stores() {
+        let root = test_isolation_root_from_environment().unwrap().unwrap();
+        let state = AppState::try_new(AppConfig::default()).unwrap();
+        let bug_report_path = StdPath::new(&state.config().bug_reports.db_path);
+        let artifact_root = StdPath::new(&state.config().app_artifacts.root_dir);
+        assert!(bug_report_path.starts_with(&root));
+        assert!(artifact_root.starts_with(&root));
+
+        let reports = BugReportStore::new(
+            bug_report_path.to_path_buf(),
+            state.config().bug_reports.max_reports,
+        );
+        let report = reports
+            .create_report(CreateBugReport {
+                report_text: "isolated handler store proof".to_owned(),
+                reported_by: None,
+                selected_session_id: None,
+                route: None,
+                app_version: None,
+                artifact_hash: None,
+                include_debug_state: false,
+                client_state: None,
+                server_state: None,
+            })
+            .unwrap();
+        assert!(reports.report_exists(&report.id).unwrap());
+
+        let artifact =
+            store_artifact(artifact_root, "isolation-proof", b"apk", None, None, None).unwrap();
+        assert!(hashed_path(artifact_root, "isolation-proof", &artifact.artifact_hash).exists());
     }
 
     #[test]

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -13996,6 +13996,57 @@ mod tests {
     }
 
     #[test]
+    fn wrapper_supplied_absolute_root_is_honored_by_default_appstate() {
+        let probe_root = env::temp_dir().join(format!(
+            "sm-wrapper-harness-isolation-{}-{}",
+            process::id(),
+            OffsetDateTime::now_utc().unix_timestamp_nanos()
+        ));
+        let wrapper_root = probe_root.join("wrapper-root");
+        fs::create_dir_all(&wrapper_root).unwrap();
+        let probe_path = probe_root.join("probe");
+        let executable = env::current_exe().unwrap();
+        let mut child = Command::new(executable)
+            .args([
+                "--exact",
+                "http::tests::direct_test_harness_without_wrapper_cannot_open_production_state_paths",
+                "--nocapture",
+            ])
+            .env(TEST_ISOLATION_ROOT_ENV, &wrapper_root)
+            .env(DIRECT_HARNESS_PROBE_ENV, &probe_path)
+            .spawn()
+            .unwrap();
+
+        for _ in 0..500 {
+            if probe_path.exists() {
+                break;
+            }
+            assert!(
+                child.try_wait().unwrap().is_none(),
+                "wrapper probe exited early"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        let probe = fs::read_to_string(&probe_path).unwrap();
+        let mut lines = probe.lines();
+        let child_pid = lines.next().unwrap().parse::<u32>().unwrap();
+        let state_file = StdPath::new(lines.next().unwrap());
+        assert!(
+            state_file.starts_with(&wrapper_root),
+            "wrapper root was ignored: {}",
+            state_file.display()
+        );
+        println!(
+            "wrapper-harness child pid {child_pid} state path {}",
+            state_file.display()
+        );
+
+        fs::write(probe_path.with_extension("release"), []).unwrap();
+        assert!(child.wait().unwrap().success());
+        fs::remove_dir_all(probe_root).unwrap();
+    }
+
+    #[test]
     fn test_harness_rejects_explicit_production_state_before_appstate_startup() {
         let production_state_file = env::var_os("HOME")
             .map(PathBuf::from)

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -13956,16 +13956,21 @@ mod tests {
         let probe = fs::read_to_string(&probe_path).unwrap();
         let mut lines = probe.lines();
         let child_pid = lines.next().unwrap().parse::<u32>().unwrap();
+        let effective_paths: Vec<_> = lines.collect();
         let production_root = env::var_os("HOME")
             .map(PathBuf::from)
             .unwrap()
             .join(".local/share/claude-sessions");
-        for path in lines {
+        for path in &effective_paths {
             assert!(
                 !StdPath::new(path).starts_with(&production_root),
                 "child resolved production durable path {path}"
             );
         }
+        println!(
+            "direct-harness child pid {child_pid} effective durable paths:\n{}",
+            effective_paths.join("\n")
+        );
 
         let lsof = Command::new("/usr/sbin/lsof")
             .args(["-p", &child_pid.to_string()])
@@ -13979,6 +13984,10 @@ mod tests {
         assert!(
             !open_files.contains(production_root.to_string_lossy().as_ref()),
             "unwrapped test child opened production state path:\n{open_files}"
+        );
+        println!(
+            "direct-harness lsof proof: child pid {child_pid} has no open path below {}",
+            production_root.display()
         );
 
         fs::write(probe_path.with_extension("release"), []).unwrap();

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -13906,12 +13906,68 @@ mod tests {
         }
     }
 
+    struct DirectHarnessProbe {
+        pid: u32,
+        isolation_root: PathBuf,
+        effective_paths: Vec<String>,
+    }
+
+    fn spawn_direct_harness_probe(
+        probe_path: &StdPath,
+        isolation_root: Option<&StdPath>,
+    ) -> ProbeChild {
+        let executable = env::current_exe().unwrap();
+        let mut command = Command::new(executable);
+        command
+            .args([
+                "--exact",
+                "http::tests::test_isolation_direct_harness_without_wrapper_cannot_open_production_state_paths",
+                "--nocapture",
+            ])
+            .env(DIRECT_HARNESS_PROBE_ENV, probe_path);
+        if let Some(isolation_root) = isolation_root {
+            command.env(TEST_ISOLATION_ROOT_ENV, isolation_root);
+        } else {
+            command.env_remove(TEST_ISOLATION_ROOT_ENV);
+        }
+        ProbeChild {
+            child: command.spawn().unwrap(),
+            release_path: probe_path.with_extension("release"),
+        }
+    }
+
+    fn wait_for_direct_harness_probe(
+        probe_child: &mut ProbeChild,
+        probe_path: &StdPath,
+    ) -> DirectHarnessProbe {
+        for _ in 0..500 {
+            if probe_path.exists() {
+                break;
+            }
+            assert!(
+                probe_child.child.try_wait().unwrap().is_none(),
+                "isolation probe exited early"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(probe_path.exists(), "isolation probe did not become ready");
+
+        let probe = fs::read_to_string(probe_path).unwrap();
+        let mut lines = probe.lines();
+        DirectHarnessProbe {
+            pid: lines.next().unwrap().parse::<u32>().unwrap(),
+            isolation_root: PathBuf::from(lines.next().unwrap()),
+            effective_paths: lines.map(str::to_owned).collect(),
+        }
+    }
+
     #[test]
-    fn direct_test_harness_without_wrapper_cannot_open_production_state_paths() {
+    fn test_isolation_direct_harness_without_wrapper_cannot_open_production_state_paths() {
         if let Some(probe_path) = env::var_os(DIRECT_HARNESS_PROBE_ENV) {
             let probe_path = PathBuf::from(probe_path);
             let state = AppState::try_new(AppConfig::default()).unwrap();
             let config = state.config();
+            let isolation_root = test_isolation_root_from_environment().unwrap().unwrap();
             let paths = [
                 config.paths.state_file.clone(),
                 config.sm_send.db_path.clone(),
@@ -13932,7 +13988,12 @@ mod tests {
             ];
             fs::write(
                 &probe_path,
-                format!("{}\n{}", process::id(), paths.join("\n")),
+                format!(
+                    "{}\n{}\n{}",
+                    process::id(),
+                    isolation_root.display(),
+                    paths.join("\n")
+                ),
             )
             .unwrap();
 
@@ -13952,61 +14013,47 @@ mod tests {
             OffsetDateTime::now_utc().unix_timestamp_nanos()
         ));
         fs::create_dir_all(&probe_root).unwrap();
-        let probe_path = probe_root.join("probe");
-        let executable = env::current_exe().unwrap();
-        let mut probe_child = ProbeChild {
-            child: Command::new(executable)
-                .args([
-                    "--exact",
-                    "http::tests::direct_test_harness_without_wrapper_cannot_open_production_state_paths",
-                    "--nocapture",
-                ])
-                .env_remove(TEST_ISOLATION_ROOT_ENV)
-                .env(DIRECT_HARNESS_PROBE_ENV, &probe_path)
-                .spawn()
-                .unwrap(),
-            release_path: probe_path.with_extension("release"),
-        };
-
-        for _ in 0..500 {
-            if probe_path.exists() {
-                break;
-            }
-            assert!(
-                probe_child.child.try_wait().unwrap().is_none(),
-                "isolation probe exited early"
-            );
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        assert!(probe_path.exists(), "isolation probe did not become ready");
-
-        let probe = fs::read_to_string(&probe_path).unwrap();
-        let mut lines = probe.lines();
-        let child_pid = lines.next().unwrap().parse::<u32>().unwrap();
-        let effective_paths: Vec<_> = lines.collect();
+        let first_probe_path = probe_root.join("first-probe");
+        let second_probe_path = probe_root.join("second-probe");
+        let mut first_probe_child = spawn_direct_harness_probe(&first_probe_path, None);
+        let mut second_probe_child = spawn_direct_harness_probe(&second_probe_path, None);
+        let first_probe = wait_for_direct_harness_probe(&mut first_probe_child, &first_probe_path);
+        let second_probe =
+            wait_for_direct_harness_probe(&mut second_probe_child, &second_probe_path);
+        assert_ne!(
+            first_probe.isolation_root, second_probe.isolation_root,
+            "separate direct test binaries must not reuse a fallback isolation root"
+        );
         let production_root = env::var_os("HOME")
             .map(PathBuf::from)
             .unwrap()
             .join(".local/share/claude-sessions");
-        for path in &effective_paths {
+        for path in first_probe
+            .effective_paths
+            .iter()
+            .chain(second_probe.effective_paths.iter())
+        {
             assert!(
                 !StdPath::new(path).starts_with(&production_root),
                 "child resolved production durable path {path}"
             );
         }
         println!(
-            "direct-harness child pid {child_pid} effective durable paths:\n{}",
-            effective_paths.join("\n")
+            "direct-harness child pid {} fallback root {} effective durable paths:\n{}",
+            first_probe.pid,
+            first_probe.isolation_root.display(),
+            first_probe.effective_paths.join("\n")
         );
 
         match Command::new("lsof")
-            .args(["-p", &child_pid.to_string()])
+            .args(["-p", &first_probe.pid.to_string()])
             .output()
         {
             Ok(lsof) => {
                 assert!(
                     lsof.status.success(),
-                    "lsof could not inspect test child {child_pid}"
+                    "lsof could not inspect test child {}",
+                    first_probe.pid
                 );
                 let open_files = String::from_utf8_lossy(&lsof.stdout);
                 assert!(
@@ -14014,7 +14061,8 @@ mod tests {
                     "unwrapped test child opened production state path:\n{open_files}"
                 );
                 println!(
-                    "direct-harness lsof proof: child pid {child_pid} has no open path below {}",
+                    "direct-harness lsof proof: child pid {} has no open path below {}",
+                    first_probe.pid,
                     production_root.display()
                 );
             }
@@ -14023,10 +14071,14 @@ mod tests {
                     "direct-harness lsof unavailable; effective-path assertions remain the portable proof"
                 );
             }
-            Err(error) => panic!("failed to invoke lsof for test child {child_pid}: {error}"),
+            Err(error) => panic!(
+                "failed to invoke lsof for test child {}: {error}",
+                first_probe.pid
+            ),
         }
 
-        probe_child.release_and_wait();
+        first_probe_child.release_and_wait();
+        second_probe_child.release_and_wait();
         fs::remove_dir_all(probe_root).unwrap();
     }
 
@@ -14040,42 +14092,17 @@ mod tests {
         let wrapper_root = probe_root.join("wrapper-root");
         fs::create_dir_all(&wrapper_root).unwrap();
         let probe_path = probe_root.join("probe");
-        let executable = env::current_exe().unwrap();
-        let mut probe_child = ProbeChild {
-            child: Command::new(executable)
-                .args([
-                    "--exact",
-                    "http::tests::direct_test_harness_without_wrapper_cannot_open_production_state_paths",
-                    "--nocapture",
-                ])
-                .env(TEST_ISOLATION_ROOT_ENV, &wrapper_root)
-                .env(DIRECT_HARNESS_PROBE_ENV, &probe_path)
-                .spawn()
-                .unwrap(),
-            release_path: probe_path.with_extension("release"),
-        };
-
-        for _ in 0..500 {
-            if probe_path.exists() {
-                break;
-            }
-            assert!(
-                probe_child.child.try_wait().unwrap().is_none(),
-                "wrapper probe exited early"
-            );
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        let probe = fs::read_to_string(&probe_path).unwrap();
-        let mut lines = probe.lines();
-        let child_pid = lines.next().unwrap().parse::<u32>().unwrap();
-        let state_file = StdPath::new(lines.next().unwrap());
+        let mut probe_child = spawn_direct_harness_probe(&probe_path, Some(&wrapper_root));
+        let probe = wait_for_direct_harness_probe(&mut probe_child, &probe_path);
+        let state_file = StdPath::new(probe.effective_paths.first().unwrap());
         assert!(
             state_file.starts_with(&wrapper_root),
             "wrapper root was ignored: {}",
             state_file.display()
         );
         println!(
-            "wrapper-harness child pid {child_pid} state path {}",
+            "wrapper-harness child pid {} state path {}",
+            probe.pid,
             state_file.display()
         );
 

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -92,7 +92,12 @@ use crate::codex_events::{list_codex_events_from_path, CodexEventsResponse};
 use crate::codex_requests::{list_codex_pending_requests_from_path, CodexPendingRequestsResponse};
 #[cfg(test)]
 use crate::config::MobileTerminalDeviceKeyConfig;
-use crate::config::{trimmed, AppConfig, MobileTerminalUserConfig, PublicNodeConfig, UsageConfig};
+#[cfg(test)]
+use crate::config::TEST_ISOLATION_ROOT_ENV;
+use crate::config::{
+    test_isolation_root_from_environment, trimmed, AppConfig, MobileTerminalUserConfig,
+    PublicNodeConfig, UsageConfig,
+};
 use crate::email::{
     extract_reply_message_body, extract_routed_session_id, extract_subject_from_raw_email,
     extract_text_from_raw_email, normalize_explicit_session_id, EmailBridge,
@@ -407,7 +412,10 @@ impl AppState {
         Self::try_new(config).expect("session manager startup recovery failed")
     }
 
-    pub fn try_new(config: AppConfig) -> anyhow::Result<Self> {
+    pub fn try_new(mut config: AppConfig) -> anyhow::Result<Self> {
+        if let Some(root) = test_isolation_root_from_environment()? {
+            config.isolate_test_paths(&root)?;
+        }
         let state_file = expand_home(&config.paths.state_file);
         let queue_db_path = expand_home(&config.sm_send.db_path);
         let mut session_store = SessionStore::new_with_queue(state_file, queue_db_path)
@@ -13871,8 +13879,130 @@ mod tests {
     };
     use rusqlite::Connection;
     use serde::Serialize;
-    use std::{env, process};
+    use std::{env, fs, process};
     use tower::ServiceExt;
+
+    const DIRECT_HARNESS_PROBE_ENV: &str = "SM_DIRECT_HARNESS_ISOLATION_PROBE";
+
+    #[test]
+    fn direct_test_harness_without_wrapper_cannot_open_production_state_paths() {
+        if let Some(probe_path) = env::var_os(DIRECT_HARNESS_PROBE_ENV) {
+            let probe_path = PathBuf::from(probe_path);
+            let state = AppState::try_new(AppConfig::default()).unwrap();
+            let config = state.config();
+            let paths = [
+                config.paths.state_file.clone(),
+                config.sm_send.db_path.clone(),
+                config.mobile_analytics.message_queue_db.clone(),
+                config.tool_logging.db_path.clone(),
+                config.usage.db_path.clone(),
+                config.codex_events.db_path.clone(),
+                config.codex_requests.db_path.clone(),
+                config.codex_observability.db_path.clone(),
+                config.queue_runner.state_dir.clone(),
+                config.mobile_terminal.device_enrollment_db_path.clone(),
+                StdPath::new(&config.paths.state_file)
+                    .with_extension("reparent-apply.lock")
+                    .display()
+                    .to_string(),
+            ];
+            fs::write(
+                &probe_path,
+                format!("{}\n{}", process::id(), paths.join("\n")),
+            )
+            .unwrap();
+
+            let release_path = probe_path.with_extension("release");
+            for _ in 0..500 {
+                if release_path.exists() {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            panic!("direct harness isolation probe was not released");
+        }
+
+        let probe_root = env::temp_dir().join(format!(
+            "sm-direct-harness-isolation-{}-{}",
+            process::id(),
+            OffsetDateTime::now_utc().unix_timestamp_nanos()
+        ));
+        fs::create_dir_all(&probe_root).unwrap();
+        let probe_path = probe_root.join("probe");
+        let executable = env::current_exe().unwrap();
+        let mut child = Command::new(executable)
+            .args([
+                "--exact",
+                "http::tests::direct_test_harness_without_wrapper_cannot_open_production_state_paths",
+                "--nocapture",
+            ])
+            .env_remove(TEST_ISOLATION_ROOT_ENV)
+            .env(DIRECT_HARNESS_PROBE_ENV, &probe_path)
+            .spawn()
+            .unwrap();
+
+        for _ in 0..500 {
+            if probe_path.exists() {
+                break;
+            }
+            assert!(
+                child.try_wait().unwrap().is_none(),
+                "isolation probe exited early"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(probe_path.exists(), "isolation probe did not become ready");
+
+        let probe = fs::read_to_string(&probe_path).unwrap();
+        let mut lines = probe.lines();
+        let child_pid = lines.next().unwrap().parse::<u32>().unwrap();
+        let production_root = env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap()
+            .join(".local/share/claude-sessions");
+        for path in lines {
+            assert!(
+                !StdPath::new(path).starts_with(&production_root),
+                "child resolved production durable path {path}"
+            );
+        }
+
+        let lsof = Command::new("/usr/sbin/lsof")
+            .args(["-p", &child_pid.to_string()])
+            .output()
+            .expect("lsof is required for the direct-harness isolation proof");
+        assert!(
+            lsof.status.success(),
+            "lsof could not inspect test child {child_pid}"
+        );
+        let open_files = String::from_utf8_lossy(&lsof.stdout);
+        assert!(
+            !open_files.contains(production_root.to_string_lossy().as_ref()),
+            "unwrapped test child opened production state path:\n{open_files}"
+        );
+
+        fs::write(probe_path.with_extension("release"), []).unwrap();
+        assert!(child.wait().unwrap().success());
+        fs::remove_dir_all(probe_root).unwrap();
+    }
+
+    #[test]
+    fn test_harness_rejects_explicit_production_state_before_appstate_startup() {
+        let production_state_file = env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap()
+            .join(".local/share/claude-sessions/explicit-test-state.json");
+        let mut config = AppConfig::default();
+        config.paths.state_file = production_state_file.display().to_string();
+
+        let error = match AppState::try_new(config) {
+            Ok(_) => panic!("test harness accepted an explicit production state file"),
+            Err(error) => error,
+        };
+        assert!(error
+            .to_string()
+            .contains("refuses explicit production path"));
+    }
 
     #[test]
     fn codex_model_validation_errors_have_actionable_http_statuses() {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -32,7 +32,7 @@ use crate::queue::{
 };
 use crate::{
     btw::BtwStore,
-    config::{CodexReviewConfig, ContextMonitorConfig},
+    config::{test_isolation_root_from_environment, CodexReviewConfig, ContextMonitorConfig},
     runtime::{ConditionalClearOutcome, TmuxRuntime, TmuxSessionSpec},
     seat_sessions::{SeatSessionIdentity, SeatSessionStore},
     usage_burn::UsageBurnStore,
@@ -177,6 +177,8 @@ impl Drop for SessionClearGuard {
 
 impl SessionStore {
     pub fn new(state_file: PathBuf) -> Self {
+        let test_isolation_root =
+            test_isolation_root_from_environment().expect("invalid Rust test isolation root");
         let legacy_state_file = if state_file == expand_home(DEFAULT_SESSION_STATE_FILE) {
             Some(PathBuf::from(LEGACY_TMP_SESSION_STATE_FILE))
         } else {
@@ -186,8 +188,14 @@ impl SessionStore {
         Self {
             state_file,
             legacy_state_file,
-            codex_sessions_root: expand_home("~/.codex/sessions"),
-            claude_projects_roots: claude_projects_roots(None),
+            codex_sessions_root: test_isolation_root
+                .as_ref()
+                .map(|root| root.join("codex-sessions"))
+                .unwrap_or_else(|| expand_home("~/.codex/sessions")),
+            claude_projects_roots: test_isolation_root
+                .as_ref()
+                .map(|root| vec![root.join("claude-projects")])
+                .unwrap_or_else(|| claude_projects_roots(None)),
             write_lock: Arc::new(Mutex::new(())),
             reparent_apply_lock: Arc::new(Mutex::new(())),
             queue_store: None,
@@ -507,15 +515,43 @@ impl SessionStore {
             .filter(|value| !value.is_empty())
         {
             let session_index_path = expand_home(session_index_path);
-            if let Some(parent) = session_index_path.parent() {
-                self.codex_sessions_root = parent.join("sessions");
+            let test_root =
+                test_isolation_root_from_environment().expect("invalid Rust test isolation root");
+            // Test launchers may retain explicit fixture indexes outside HOME,
+            // but must never resolve the developer's live Codex index.
+            let is_live_home_path = env::var_os("HOME")
+                .is_some_and(|home| session_index_path.starts_with(PathBuf::from(home)));
+            if !test_root.is_some() || !is_live_home_path {
+                if let Some(parent) = session_index_path.parent() {
+                    self.codex_sessions_root = parent.join("sessions");
+                }
             }
         }
         self
     }
 
     pub fn with_claude_transcript_root(mut self, transcript_root: Option<&str>) -> Self {
-        self.claude_projects_roots = claude_projects_roots(transcript_root);
+        if let Some(root) =
+            test_isolation_root_from_environment().expect("invalid Rust test isolation root")
+        {
+            // `claude_projects_roots(None)` normally includes CLAUDE_CONFIG_DIR,
+            // XDG_CONFIG_HOME, and HOME. A test process must not scan any of
+            // those external roots, even after AppState applies its config. A
+            // deliberately supplied fixture root outside HOME remains usable.
+            let configured_root = transcript_root
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(expand_home);
+            let configured_under_home = configured_root.as_ref().is_some_and(|path| {
+                env::var_os("HOME").is_some_and(|home| path.starts_with(PathBuf::from(home)))
+            });
+            self.claude_projects_roots = match configured_root {
+                Some(path) if !configured_under_home => vec![path],
+                _ => vec![root.join("claude-projects")],
+            };
+        } else {
+            self.claude_projects_roots = claude_projects_roots(transcript_root);
+        }
         self
     }
 
@@ -1396,12 +1432,20 @@ impl SessionStore {
 
     #[cfg(test)]
     fn new_with_legacy_fallback(state_file: PathBuf, legacy_state_file: PathBuf) -> Self {
+        let test_isolation_root =
+            test_isolation_root_from_environment().expect("invalid Rust test isolation root");
         let seat_session_store = SeatSessionStore::for_state_file(&state_file);
         Self {
             state_file,
             legacy_state_file: Some(legacy_state_file),
-            codex_sessions_root: expand_home("~/.codex/sessions"),
-            claude_projects_roots: claude_projects_roots(None),
+            codex_sessions_root: test_isolation_root
+                .as_ref()
+                .map(|root| root.join("codex-sessions"))
+                .unwrap_or_else(|| expand_home("~/.codex/sessions")),
+            claude_projects_roots: test_isolation_root
+                .as_ref()
+                .map(|root| vec![root.join("claude-projects")])
+                .unwrap_or_else(|| claude_projects_roots(None)),
             write_lock: Arc::new(Mutex::new(())),
             reparent_apply_lock: Arc::new(Mutex::new(())),
             queue_store: None,

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -32,7 +32,10 @@ use crate::queue::{
 };
 use crate::{
     btw::BtwStore,
-    config::{test_isolation_root_from_environment, CodexReviewConfig, ContextMonitorConfig},
+    config::{
+        path_is_under_home, test_isolation_root_from_environment, CodexReviewConfig,
+        ContextMonitorConfig,
+    },
     runtime::{ConditionalClearOutcome, TmuxRuntime, TmuxSessionSpec},
     seat_sessions::{SeatSessionIdentity, SeatSessionStore},
     usage_burn::UsageBurnStore,
@@ -519,8 +522,8 @@ impl SessionStore {
                 test_isolation_root_from_environment().expect("invalid Rust test isolation root");
             // Test launchers may retain explicit fixture indexes outside HOME,
             // but must never resolve the developer's live Codex index.
-            let is_live_home_path = env::var_os("HOME")
-                .is_some_and(|home| session_index_path.starts_with(PathBuf::from(home)));
+            let is_live_home_path =
+                path_is_under_home(session_index_path.to_string_lossy().as_ref()).unwrap_or(true);
             if !test_root.is_some() || !is_live_home_path {
                 if let Some(parent) = session_index_path.parent() {
                     self.codex_sessions_root = parent.join("sessions");
@@ -543,7 +546,7 @@ impl SessionStore {
                 .filter(|value| !value.is_empty())
                 .map(expand_home);
             let configured_under_home = configured_root.as_ref().is_some_and(|path| {
-                env::var_os("HOME").is_some_and(|home| path.starts_with(PathBuf::from(home)))
+                path_is_under_home(path.to_string_lossy().as_ref()).unwrap_or(true)
             });
             self.claude_projects_roots = match configured_root {
                 Some(path) if !configured_under_home => vec![path],

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -15417,6 +15417,21 @@ mod tests {
     }
 
     #[test]
+    fn test_isolation_prevents_default_home_scans_from_being_restored() {
+        let root = test_isolation_root_from_environment().unwrap().unwrap();
+        let state_file = root.join("external-scan-fixture.json");
+        let store = SessionStore::new(state_file)
+            .with_codex_session_index_path(Some("~/.codex/session_index.jsonl"))
+            .with_claude_transcript_root(None);
+
+        assert!(store.codex_sessions_root.starts_with(&root));
+        assert!(store
+            .claude_projects_roots
+            .iter()
+            .all(|path| path.starts_with(&root)));
+    }
+
+    #[test]
     fn generated_session_ids_match_python_short_hex_contract() {
         let session_id = generate_session_id();
 

--- a/scripts/test-rust-isolated.sh
+++ b/scripts/test-rust-isolated.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Every Rust test must run through this launcher. AppState uses this root before
+# opening durable stores, so default config can never resolve the live session
+# registry, queue, usage databases, or reparent-apply lock.
+test_root="$(mktemp -d "${TMPDIR:-/tmp}/sm-rust-test.XXXXXX")"
+cleanup() {
+  rm -rf -- "$test_root"
+}
+trap cleanup EXIT
+
+SM_TEST_ISOLATION_ROOT="$test_root" cargo test -p sm-server "$@"


### PR DESCRIPTION
Fixes #1316

## What changed

- Automatically isolate Cargo test executables before `AppState` expands or opens default durable paths.
- Rehome default state, queue, usage, Codex, tool, queue-runner, and mobile-device paths under a unique test instance; reject explicit production-shaped paths.
- Suppress default HOME Codex/Claude scans while preserving explicit safe fixtures.
- Add the supported cleanup launcher and hostile direct-cargo/no-wrapper, wrapper-root, rejection, uniqueness, fixture, and scan-restoration coverage.

## Why

Raw Rust tests previously resolved `~/.local/share/claude-sessions`, contended the live reparent lock, and could affect production availability.

## Validation

- Focused #1316 corpus: 5 scoped tests passed; accepted one-time hostile no-wrapper subprocess proof passed separately.
- Full `sm-server` suite launched only via `./scripts/test-rust-isolated.sh --quiet` (477 tests), with no production descriptor observed from the active test binary.
- `cargo fmt --all -- --check`, `git diff --check`, production lock-holder checks, and bounded `/health` + `/sessions` probes passed.

No restart, deploy, or production mutation is included.