### PR TITLE
Fix queue service capacity isolation

### DIFF
--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -440,7 +440,7 @@ enum QueueCommand {
 
 #[derive(Args)]
 struct QueueRunArgs {
-    #[arg(long = "type", value_parser = ["tests", "perf", "background"], default_value = "tests")]
+    #[arg(long = "type", value_parser = ["tests", "perf", "background", "service"], default_value = "tests")]
     job_type: String,
     #[arg(long)]
     label: Option<String>,
@@ -464,7 +464,7 @@ struct QueueListArgs {
     notify: Option<String>,
     #[arg(long)]
     all: bool,
-    #[arg(long = "type", value_parser = ["tests", "perf", "background"])]
+    #[arg(long = "type", value_parser = ["tests", "perf", "background", "service"])]
     job_type: Option<String>,
     #[arg(long)]
     state: Option<String>,

--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -11,7 +11,7 @@ use std::{
     },
 };
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_yaml::{Mapping as YamlMapping, Value as YamlValue};
 use sha2::{Digest, Sha256};
@@ -137,7 +137,31 @@ impl AppConfig {
             apply_local_auth_overrides(&mut config, &env_values);
         }
 
+        config.validate_queue_runner_capacity()?;
+
         Ok(config)
+    }
+
+    fn validate_queue_runner_capacity(&self) -> Result<()> {
+        let Some(service) = self.queue_runner.types.service.as_ref() else {
+            return Ok(());
+        };
+        if self.queue_runner.max_running_jobs <= 1 {
+            bail!(
+                "queue_runner.max_running_jobs must be greater than 1 when queue_runner.types.service is configured"
+            );
+        }
+        if service.max_concurrent == 0 {
+            bail!(
+                "queue_runner.types.service.max_concurrent must be greater than zero when service is configured"
+            );
+        }
+        if (service.max_concurrent as u128) >= (self.queue_runner.max_running_jobs as u128) {
+            bail!(
+                "queue_runner.types.service.max_concurrent must be less than queue_runner.max_running_jobs so service jobs cannot consume the entire global queue capacity"
+            );
+        }
+        Ok(())
     }
 
     pub fn queue_runner_state_dir(&self) -> PathBuf {
@@ -1336,6 +1360,8 @@ pub struct QueueRunnerTypesConfig {
         deserialize_with = "deserialize_queue_runner_background_config"
     )]
     pub background: QueueRunnerTypeConfig,
+    #[serde(default, deserialize_with = "deserialize_queue_runner_service_config")]
+    pub service: Option<QueueRunnerTypeConfig>,
 }
 
 impl Default for QueueRunnerTypesConfig {
@@ -1344,6 +1370,7 @@ impl Default for QueueRunnerTypesConfig {
             tests: default_queue_runner_tests_config(),
             perf: default_queue_runner_perf_config(),
             background: default_queue_runner_background_config(),
+            service: None,
         }
     }
 }
@@ -1403,6 +1430,23 @@ where
     deserialize_queue_runner_type_config(deserializer, default_queue_runner_background_config())
 }
 
+fn deserialize_queue_runner_service_config<'de, D>(
+    deserializer: D,
+) -> Result<Option<QueueRunnerTypeConfig>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let overrides = Option::<QueueRunnerTypeConfigOverrides>::deserialize(deserializer)?;
+    Ok(overrides.map(|overrides| QueueRunnerTypeConfig {
+        max_concurrent: overrides
+            .max_concurrent
+            .unwrap_or(default_queue_runner_service_config().max_concurrent),
+        default_timeout_seconds: overrides
+            .default_timeout_seconds
+            .unwrap_or(default_queue_runner_service_config().default_timeout_seconds),
+    }))
+}
+
 impl Default for QueueRunnerConfig {
     fn default() -> Self {
         Self {
@@ -1450,6 +1494,13 @@ fn default_queue_runner_background_config() -> QueueRunnerTypeConfig {
     QueueRunnerTypeConfig {
         max_concurrent: 2,
         default_timeout_seconds: 3600,
+    }
+}
+
+fn default_queue_runner_service_config() -> QueueRunnerTypeConfig {
+    QueueRunnerTypeConfig {
+        max_concurrent: 1,
+        default_timeout_seconds: 86400,
     }
 }
 
@@ -3152,5 +3203,38 @@ codex_fork:
             config.codex_fork.args,
             vec!["-c", "check_for_update_on_startup=false"]
         );
+    }
+
+    #[test]
+    fn queue_service_config_is_explicit_and_cannot_consume_global_capacity() {
+        let raw: RawConfig = serde_yaml::from_str(
+            r#"
+queue_runner:
+  max_running_jobs: 4
+  types:
+    service:
+      max_concurrent: 2
+"#,
+        )
+        .unwrap();
+        let config = AppConfig::from(raw);
+        let service = config.queue_runner.types.service.as_ref().unwrap();
+        assert_eq!(service.max_concurrent, 2);
+        assert_eq!(service.default_timeout_seconds, 86400);
+        assert!(config.validate_queue_runner_capacity().is_ok());
+
+        let mut invalid = config.clone();
+        invalid
+            .queue_runner
+            .types
+            .service
+            .as_mut()
+            .unwrap()
+            .max_concurrent = 4;
+        assert!(invalid
+            .validate_queue_runner_capacity()
+            .unwrap_err()
+            .to_string()
+            .contains("cannot consume the entire global queue capacity"));
     }
 }

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -5546,10 +5546,10 @@ async fn create_queue_job(
 
     let job_type = payload.job_type.trim();
     let default_timeout =
-        queue_job_default_timeout_seconds(&state.config, job_type).ok_or_else(|| {
+        queue_job_default_timeout_seconds(&state.config, job_type).map_err(|detail| {
             ApiError::Status {
                 status: StatusCode::BAD_REQUEST,
-                detail: format!("unknown queue job type: {job_type}"),
+                detail,
             }
         })?;
     let argv = payload
@@ -5684,6 +5684,12 @@ fn queue_admission_policy(config: &AppConfig) -> QueueAdmissionPolicy {
         tests_max_concurrent: config.queue_runner.types.tests.max_concurrent,
         perf_max_concurrent: config.queue_runner.types.perf.max_concurrent,
         background_max_concurrent: config.queue_runner.types.background.max_concurrent,
+        service_max_concurrent: config
+            .queue_runner
+            .types
+            .service
+            .as_ref()
+            .map_or(0, |service| service.max_concurrent),
     }
 }
 
@@ -13152,12 +13158,24 @@ fn default_queue_job_type() -> String {
     "tests".to_owned()
 }
 
-fn queue_job_default_timeout_seconds(config: &AppConfig, job_type: &str) -> Option<i64> {
+fn queue_job_default_timeout_seconds(
+    config: &AppConfig,
+    job_type: &str,
+) -> std::result::Result<i64, String> {
     match job_type {
-        "tests" => Some(config.queue_runner.types.tests.default_timeout_seconds),
-        "perf" => Some(config.queue_runner.types.perf.default_timeout_seconds),
-        "background" => Some(config.queue_runner.types.background.default_timeout_seconds),
-        _ => None,
+        "tests" => Ok(config.queue_runner.types.tests.default_timeout_seconds),
+        "perf" => Ok(config.queue_runner.types.perf.default_timeout_seconds),
+        "background" => Ok(config.queue_runner.types.background.default_timeout_seconds),
+        "service" => config
+            .queue_runner
+            .types
+            .service
+            .as_ref()
+            .map(|service| service.default_timeout_seconds)
+            .ok_or_else(|| {
+                "queue service jobs require queue_runner.types.service to be configured".to_owned()
+            }),
+        _ => Err(format!("unknown queue job type: {job_type}")),
     }
 }
 

--- a/crates/sm-server/src/main.rs
+++ b/crates/sm-server/src/main.rs
@@ -94,6 +94,12 @@ async fn main() -> Result<()> {
             tests_max_concurrent: config.queue_runner.types.tests.max_concurrent,
             perf_max_concurrent: config.queue_runner.types.perf.max_concurrent,
             background_max_concurrent: config.queue_runner.types.background.max_concurrent,
+            service_max_concurrent: config
+                .queue_runner
+                .types
+                .service
+                .as_ref()
+                .map_or(0, |service| service.max_concurrent),
         };
         thread::spawn(move || {
             match RetainedQueueStore::recover_queue_jobs_in_state_dir_with_policy(

--- a/crates/sm-server/src/queue.rs
+++ b/crates/sm-server/src/queue.rs
@@ -11,7 +11,7 @@ use std::{
     time::{Duration as StdDuration, Instant},
 };
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use rand_core::{OsRng, RngCore};
 use rusqlite::{
     params,
@@ -171,6 +171,7 @@ pub struct QueueAdmissionPolicy {
     pub tests_max_concurrent: usize,
     pub perf_max_concurrent: usize,
     pub background_max_concurrent: usize,
+    pub service_max_concurrent: usize,
 }
 
 impl Default for QueueAdmissionPolicy {
@@ -181,6 +182,7 @@ impl Default for QueueAdmissionPolicy {
             tests_max_concurrent: 2,
             perf_max_concurrent: 1,
             background_max_concurrent: 2,
+            service_max_concurrent: 0,
         }
     }
 }
@@ -2787,6 +2789,12 @@ fn admit_pending_queue_jobs_conn(
     let _admission_guard = QUEUE_ADMISSION_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
+    // Validate before clearing any existing holds: after a restart, preserved
+    // service processes may outnumber a newly lowered configuration.  In that
+    // state, admitting even one finite job would violate the configured global
+    // reserve for non-service work.
+    let running_jobs = list_queue_job_runtime_records_conn(conn)?;
+    ensure_service_capacity_reserve_before_admission(&running_jobs, admission_policy)?;
     let requeued = conn.execute(
         "UPDATE queue_jobs SET holding_reason = NULL WHERE state = 'pending' AND holding_reason IS NOT NULL",
         [],
@@ -2872,6 +2880,47 @@ fn admit_pending_queue_jobs_conn(
     Ok(summary)
 }
 
+fn ensure_service_capacity_reserve_before_admission(
+    jobs: &[QueueJobRuntimeRecord],
+    admission_policy: QueueAdmissionPolicy,
+) -> Result<()> {
+    let global_capacity = usize::try_from(admission_policy.max_running_jobs)
+        .context("queue max_running_jobs must be a non-negative integer")?;
+    let service_capacity = admission_policy.service_max_concurrent;
+    if service_capacity >= global_capacity && service_capacity != 0 {
+        bail!(
+            "queue service capacity configuration is invalid before admission: \
+             service_cap={service_capacity} global_capacity={global_capacity}; \
+             service capacity must leave at least one non-service slot"
+        );
+    }
+
+    let non_service_reserve = global_capacity.saturating_sub(service_capacity);
+    let recovered_service_ids = jobs
+        .iter()
+        .filter(|job| job.state == "running" && job.job_type == "service")
+        .map(|job| job.id.as_str())
+        .collect::<Vec<_>>();
+    let recovered_service_count = recovered_service_ids.len();
+    let preserves_service_cap = recovered_service_count <= service_capacity;
+    let preserves_global_reserve = recovered_service_count
+        .checked_add(non_service_reserve)
+        .is_some_and(|required_capacity| required_capacity <= global_capacity);
+    if preserves_service_cap && preserves_global_reserve {
+        return Ok(());
+    }
+
+    bail!(
+        "queue admission blocked: recovered live service occupancy violates configured capacity; \
+         recovered_live_service_jobs={recovered_service_count} \
+         service_cap={service_capacity} global_capacity={global_capacity} \
+         non_service_reserve={non_service_reserve} \
+         job_ids=[{}]. Recovered jobs were left unchanged and no pending job was admitted; \
+         reduce live service occupancy or raise the configuration before retrying recovery.",
+        recovered_service_ids.join(", ")
+    );
+}
+
 fn schedule_queue_admission_retry(
     state_dir: PathBuf,
     message_queue_db_path: PathBuf,
@@ -2893,7 +2942,7 @@ fn schedule_queue_admission_retry(
 
 const DEFAULT_MAX_RUNNING_QUEUE_JOBS: i64 = 2;
 const DEFAULT_PERF_COOLDOWN_SECONDS: i64 = 30;
-const QUEUE_JOB_TYPE_ORDER: [&str; 3] = ["perf", "tests", "background"];
+const QUEUE_JOB_TYPE_ORDER: [&str; 4] = ["perf", "tests", "background", "service"];
 static QUEUE_ADMISSION_LOCK: Mutex<()> = Mutex::new(());
 
 fn next_admissible_queue_job_id_conn(
@@ -3006,6 +3055,7 @@ impl QueueAdmissionPolicy {
             "tests" => self.tests_max_concurrent,
             "perf" => self.perf_max_concurrent,
             "background" => self.background_max_concurrent,
+            "service" => self.service_max_concurrent,
             _ => 1,
         }
     }
@@ -4643,6 +4693,138 @@ mod tests {
 
         job.timeout_seconds = 10;
         assert!(queue_job_timed_out_at(&job, much_later));
+    }
+
+    #[test]
+    fn service_capacity_does_not_block_finite_background_admission() {
+        let state_dir = unique_temp_path("service-capacity");
+        let create_job = |job_type: &str, label: &str| {
+            RetainedQueueStore::create_queue_job_in_state_dir(
+                &state_dir,
+                CreateQueueJob {
+                    job_type: job_type.to_owned(),
+                    label: label.to_owned(),
+                    requester_session_id: Some("requester".to_owned()),
+                    notify_session_id: "notify".to_owned(),
+                    cwd: "/tmp".to_owned(),
+                    argv: Some(vec!["true".to_owned()]),
+                    script: None,
+                    env: BTreeMap::new(),
+                    timeout_seconds: 60,
+                },
+            )
+            .unwrap()
+        };
+        let first_service = create_job("service", "first service");
+        let second_service = create_job("service", "second service");
+        let background = create_job("background", "finite background");
+        let third_service = create_job("service", "third service");
+        let conn = open_queue_jobs_connection(&state_dir.join("queue_runner.db")).unwrap();
+        for job_id in [&first_service.id, &second_service.id] {
+            conn.execute(
+                "UPDATE queue_jobs SET state = 'running', started_at = ?2 WHERE id = ?1",
+                params![job_id, now_rfc3339()],
+            )
+            .unwrap();
+        }
+        let policy = QueueAdmissionPolicy {
+            max_running_jobs: 4,
+            service_max_concurrent: 2,
+            ..QueueAdmissionPolicy::default()
+        };
+
+        let jobs = list_queue_job_runtime_records_conn(&conn).unwrap();
+        let mut summary = QueueAdmissionSummary::default();
+        assert_eq!(
+            next_admissible_queue_job_id_conn(&conn, &jobs, policy, &mut summary).unwrap(),
+            Some(background.id.clone())
+        );
+
+        conn.execute(
+            "UPDATE queue_jobs SET state = 'running', started_at = ?2 WHERE id = ?1",
+            params![background.id, now_rfc3339()],
+        )
+        .unwrap();
+        let jobs = list_queue_job_runtime_records_conn(&conn).unwrap();
+        let mut summary = QueueAdmissionSummary::default();
+        assert_eq!(
+            next_admissible_queue_job_id_conn(&conn, &jobs, policy, &mut summary).unwrap(),
+            None
+        );
+        let holding_reason: Option<String> = conn
+            .query_row(
+                "SELECT holding_reason FROM queue_jobs WHERE id = ?1",
+                params![third_service.id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(holding_reason.as_deref(), Some("concurrency_cap"));
+
+        drop(conn);
+        fs::remove_dir_all(state_dir).unwrap();
+    }
+
+    #[test]
+    fn perf_displacement_never_selects_service_jobs() {
+        let state_dir = unique_temp_path("service-perf-displacement");
+        let create_job = |job_type: &str, label: &str| {
+            RetainedQueueStore::create_queue_job_in_state_dir(
+                &state_dir,
+                CreateQueueJob {
+                    job_type: job_type.to_owned(),
+                    label: label.to_owned(),
+                    requester_session_id: Some("requester".to_owned()),
+                    notify_session_id: "notify".to_owned(),
+                    cwd: "/tmp".to_owned(),
+                    argv: Some(vec!["true".to_owned()]),
+                    script: None,
+                    env: BTreeMap::new(),
+                    timeout_seconds: 60,
+                },
+            )
+            .unwrap()
+        };
+        let service = create_job("service", "long-lived service");
+        let perf = create_job("perf", "pending perf");
+        let conn = open_queue_jobs_connection(&state_dir.join("queue_runner.db")).unwrap();
+        conn.execute(
+            "UPDATE queue_jobs SET state = 'running', started_at = ?2 WHERE id = ?1",
+            params![service.id, now_rfc3339()],
+        )
+        .unwrap();
+        let jobs = list_queue_job_runtime_records_conn(&conn).unwrap();
+
+        assert!(!displace_background_for_perf_conn(
+            &conn,
+            &jobs,
+            &state_dir.join("message_queue.db"),
+            0,
+            QueueAdmissionPolicy {
+                max_running_jobs: 4,
+                service_max_concurrent: 2,
+                ..QueueAdmissionPolicy::default()
+            },
+        )
+        .unwrap());
+        let state: String = conn
+            .query_row(
+                "SELECT state FROM queue_jobs WHERE id = ?1",
+                params![service.id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(state, "running");
+        let perf_state: String = conn
+            .query_row(
+                "SELECT state FROM queue_jobs WHERE id = ?1",
+                params![perf.id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(perf_state, "pending");
+
+        drop(conn);
+        fs::remove_dir_all(state_dir).unwrap();
     }
 
     #[test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -15,7 +15,7 @@ use sha1::{Digest, Sha1};
 use sha2::Sha256;
 use sm_server::btw::BtwStore;
 use sm_server::config::RustShadowConfig;
-use sm_server::queue::{QueueAdmissionPolicy, RetainedQueueStore};
+use sm_server::queue::{CreateQueueJob, QueueAdmissionPolicy, RetainedQueueStore};
 use sm_server::{
     config::{
         AppArtifactsConfig, AppConfig, BugReportsConfig, CodexEventsConfig, CodexForkLaunchConfig,
@@ -4385,6 +4385,41 @@ async fn queue_job_background_accepts_explicit_no_timeout() {
 }
 
 #[tokio::test]
+async fn queue_job_service_requires_explicit_capacity_configuration() {
+    let state_file = write_session_fixture();
+    let queue_state_dir = state_file.with_extension("queue-runner-service-unconfigured");
+    let message_queue_db = state_file.with_extension("queue-service-unconfigured-message-queue.db");
+    let working_dir = unique_temp_path().with_extension("queue-cwd");
+    fs::create_dir_all(&working_dir).unwrap();
+    let app = queue_runtime_test_app(
+        &state_file,
+        &queue_state_dir,
+        &message_queue_db,
+        false,
+        true,
+    );
+
+    let (status, rejected) = post_json(
+        app,
+        "/queue-jobs",
+        json!({
+            "type": "service",
+            "label": "unconfigured service",
+            "script": "printf service",
+            "cwd": working_dir.display().to_string(),
+            "notify_target": "run12345",
+            "requester_session_id": "run12345"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        rejected["detail"],
+        "queue service jobs require queue_runner.types.service to be configured"
+    );
+}
+
+#[tokio::test]
 async fn queue_job_runtime_persists_failure_and_timeout() {
     let state_file = write_session_fixture();
     let queue_state_dir = state_file.with_extension("queue-runner-terminal");
@@ -5442,6 +5477,191 @@ async fn queue_runtime_recovery_polls_live_running_job_to_completion() {
     let notifications = queued_message_texts(&message_queue_db, "run12345");
     assert_eq!(notifications.len(), 1);
     assert!(notifications[0].contains("log tail:\nrecovered-live"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn queue_runtime_recovery_at_service_capacity_preserves_non_service_reserve() {
+    let state_file = write_session_fixture();
+    let queue_state_dir = state_file.with_extension("queue-runner-recover-service-capacity");
+    let message_queue_db =
+        state_file.with_extension("queue-recover-service-capacity-message-queue.db");
+    let working_dir = unique_temp_path().with_extension("queue-cwd");
+    fs::create_dir_all(&working_dir).unwrap();
+    let mut config = AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        queue_runner: QueueRunnerConfig {
+            state_dir: queue_state_dir.display().to_string(),
+            cancel_grace_seconds: 0,
+            max_running_jobs: 4,
+            configured: true,
+            ..QueueRunnerConfig::default()
+        },
+        sm_send: SmSendConfig {
+            db_path: message_queue_db.display().to_string(),
+        },
+        ..AppConfig::default()
+    };
+    config.queue_runner.types.service = Some(QueueRunnerTypeConfig {
+        max_concurrent: 2,
+        default_timeout_seconds: 60,
+    });
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+    let first_service = create_pending_queue_job_of_type(
+        app.clone(),
+        &working_dir,
+        "service",
+        "recover service one",
+        "printf placeholder",
+        60,
+    )
+    .await;
+    let second_service = create_pending_queue_job_of_type(
+        app.clone(),
+        &working_dir,
+        "service",
+        "recover service two",
+        "printf placeholder",
+        60,
+    )
+    .await;
+    let background = create_pending_queue_job_of_type(
+        app.clone(),
+        &working_dir,
+        "background",
+        "recover finite background",
+        "printf finite-background",
+        60,
+    )
+    .await;
+    let mut first_child = Command::new("/bin/zsh")
+        .arg("-lc")
+        .arg("sleep 0.3")
+        .process_group(0)
+        .spawn()
+        .unwrap();
+    let mut second_child = Command::new("/bin/zsh")
+        .arg("-lc")
+        .arg("sleep 0.3")
+        .process_group(0)
+        .spawn()
+        .unwrap();
+    for (job_id, child) in [
+        (&first_service, &first_child),
+        (&second_service, &second_child),
+    ] {
+        let pid = i64::from(child.id());
+        mark_queue_job_running(&queue_state_dir, job_id, &test_now_rfc3339(), pid, pid);
+    }
+
+    let summary = RetainedQueueStore::recover_queue_jobs_in_state_dir_with_policy(
+        &queue_state_dir,
+        &message_queue_db,
+        0,
+        QueueAdmissionPolicy {
+            max_running_jobs: 4,
+            service_max_concurrent: 2,
+            ..QueueAdmissionPolicy::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(summary.recovered_running, 2);
+    assert_eq!(summary.polling_running, 2);
+    assert_eq!(summary.started_pending, 1);
+    let completed = wait_for_queue_job_state(app, &background, &["succeeded"]).await;
+    assert_eq!(completed["type"], "background");
+    assert_eq!(completed["exit_code"], 0);
+    let _ = first_child.wait();
+    let _ = second_child.wait();
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn queue_runtime_recovery_rejects_live_services_above_reduced_capacity() {
+    let state_dir = unique_temp_path().with_extension("queue-recover-reduced-service-capacity");
+    let message_queue_db = state_dir.with_extension("message-queue.db");
+    let create_job = |job_type: &str, label: &str| {
+        RetainedQueueStore::create_queue_job_in_state_dir(
+            &state_dir,
+            CreateQueueJob {
+                job_type: job_type.to_owned(),
+                label: label.to_owned(),
+                requester_session_id: Some("requester".to_owned()),
+                notify_session_id: "notify".to_owned(),
+                cwd: "/tmp".to_owned(),
+                argv: Some(vec!["true".to_owned()]),
+                script: None,
+                env: Default::default(),
+                timeout_seconds: 60,
+            },
+        )
+        .unwrap()
+    };
+    let services = [
+        create_job("service", "old service one"),
+        create_job("service", "old service two"),
+        create_job("service", "old service three"),
+        create_job("service", "old service four"),
+    ];
+    let background = create_job("background", "must remain pending");
+    let mut children = services
+        .iter()
+        .map(|service| {
+            let child = Command::new("/bin/zsh")
+                .arg("-lc")
+                .arg("sleep 30")
+                .spawn()
+                .unwrap();
+            let pid = i64::from(child.id());
+            mark_queue_job_running(&state_dir, &service.id, &test_now_rfc3339(), pid, pid);
+            child
+        })
+        .collect::<Vec<_>>();
+
+    let error = RetainedQueueStore::recover_queue_jobs_in_state_dir_with_policy(
+        &state_dir,
+        &message_queue_db,
+        0,
+        QueueAdmissionPolicy {
+            // Previously admitted under 8/4; now reduced to 4/3.
+            max_running_jobs: 4,
+            service_max_concurrent: 3,
+            ..QueueAdmissionPolicy::default()
+        },
+    )
+    .unwrap_err()
+    .to_string();
+    assert!(error.contains("recovered_live_service_jobs=4"));
+    assert!(error.contains("service_cap=3"));
+    assert!(error.contains("global_capacity=4"));
+    assert!(error.contains("non_service_reserve=1"));
+    for service in &services {
+        assert!(error.contains(&service.id));
+        let record = RetainedQueueStore::get_queue_job_from_path(
+            &state_dir.join("queue_runner.db"),
+            &service.id,
+        )
+        .unwrap()
+        .unwrap();
+        assert_eq!(record.state, "running");
+    }
+    let background_record = RetainedQueueStore::get_queue_job_from_path(
+        &state_dir.join("queue_runner.db"),
+        &background.id,
+    )
+    .unwrap()
+    .unwrap();
+    assert_eq!(background_record.state, "pending");
+
+    for child in &mut children {
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+    let _ = fs::remove_dir_all(&state_dir);
+    let _ = fs::remove_file(&message_queue_db);
 }
 
 #[cfg(unix)]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -5607,6 +5607,7 @@ async fn queue_runtime_recovery_rejects_live_services_above_reduced_capacity() {
         create_job("service", "old service four"),
     ];
     let background = create_job("background", "must remain pending");
+    set_queue_job_holding_reason(&state_dir, &background.id, "memory_pressure");
     let mut children = services
         .iter()
         .map(|service| {
@@ -5655,6 +5656,10 @@ async fn queue_runtime_recovery_rejects_live_services_above_reduced_capacity() {
     .unwrap()
     .unwrap();
     assert_eq!(background_record.state, "pending");
+    assert_eq!(
+        background_record.holding_reason.as_deref(),
+        Some("memory_pressure")
+    );
 
     for child in &mut children {
         let _ = child.kill();

--- a/specs/1318_service_capacity_class.md
+++ b/specs/1318_service_capacity_class.md
@@ -1,0 +1,55 @@
+# Service capacity class
+
+Issue: #1318
+
+## Measured basis
+
+At the incident timestamp, two long-lived Vite/API processes owned by
+`expectation-layer-orch` occupied the two `background` slots. Four jobs total
+were running, below the configured global cap of eight. The watchdog was held
+by the background type cap, not by global or tests/perf contention.
+
+The active services are the only current durable service callers. Historical
+24-hour `background` jobs include one-shot work, so timeout, label, and argv
+cannot safely classify a job as a service.
+
+## Contract
+
+- `service` is an explicit submitter-selected, durable queue type.
+- Existing records remain their persisted type; no migration or heuristic
+  reclassification is performed.
+- `queue_runner.types.service` is opt-in. A service submission fails loudly
+  until that configuration is present.
+- When configured, service capacity must be positive and strictly below
+  `max_running_jobs`; it can never silently consume the entire global pool.
+- Service jobs still count against the global cap, while retaining a separate
+  per-type cap from finite `background` jobs.
+- Recovery checks live persisted service rows before every admission attempt.
+  If a configuration reduction leaves more live services than the service cap
+  or consumes the configured non-service reserve, recovery fails with the
+  counts and job IDs; it leaves those rows unchanged and admits nothing.
+- Admission order places finite background work before newly queued services.
+  Perf cooldown and test ordering are unchanged. Perf displacement remains
+  limited to finite background jobs and never terminates a service.
+
+## Required proof
+
+- Hostile scheduler coverage proves two services admit finite background work
+  while a third service is held.
+- Hostile recovery coverage proves the service-capacity boundary admits finite
+  background work, while a reduction from 8/4 to 4/3 with four live services
+  fails loudly, identifies every service row, and leaves finite work pending.
+- Config coverage proves missing service configuration and global-consuming
+  service capacities fail loudly.
+- CLI/API accepts and projects `service`; unsupported values still fail.
+
+## Rollout
+
+Deployment must add the explicitly chosen service configuration without raising
+global or background caps. After deployment, hand the new `--type service`
+contract to `d0d5f272` (`expectation-layer-orch`) for future submissions only.
+Do not resubmit, alter, or otherwise mutate its current Vite/API services.
+
+## Ticket classification
+
+Single ticket.


### PR DESCRIPTION
## Summary
- Add explicit opt-in durable service queue type with its own configured capacity.
- Keep service jobs under the global cap and reserve non-service capacity.
- Fail recovery before mutating pending holds or admitting work when live recovered services violate lowered capacity.

## Spec Reference
- specs/1318_service_capacity_class.md

## Test Plan
- cargo fmt --check — pass
- Focused recovery, capacity, and perf-displacement tests — pass
- cargo test -p sm-server — 496 library, 76 CLI, and 281 integration tests passed; one unrelated reparent test fails identically on deployed main 3b852e05f07d931522408f40ad73ee61ff45e42a.

Fixes #1318