### PR TITLE
Fix codex-fork restore false success after rejected resume

### DIFF
--- a/specs/1324_codex_fork_restore_acceptance.md
+++ b/specs/1324_codex_fork_restore_acceptance.md
@@ -1,0 +1,63 @@
+# #1324 Codex-fork restore acceptance
+
+## Measured evidence
+
+On 2026-08-18, historical root `d0d5f272` was restored with the durable
+Codex resume identity `01a0028b-c5d3-75c1-8df6-4b40b2eb2d48` after its account
+changed. The provider emitted structured `session_start`, then `session_end`
+about 140 ms later, and the tmux/provider runtime was absent. The API still
+projected it as running/idle. Terminal output is not evidence for this change.
+
+The current durable state retains the historical record as stopped and its
+successor is `9ffe4f64`. The short-lived event rows had already been pruned
+from the bounded store when this investigation began.
+
+Source trace at `origin/main` `414a704380b136cad9ec5a9b2b36e6c5a9798614`:
+`SessionManager.restore_session()` treated successful
+`tmux.create_session_with_command()` as the success boundary, then immediately
+cleared stopped metadata and set `status=running` before the codex-fork event
+monitor could observe provider acceptance or exit.
+
+An isolated fake provider command confirmed that boundary against the unpatched
+base: its tmux launch returned true, it wrote structured `session_start` and
+`session_end`, and its tmux runtime was absent; `restore_session()` still
+returned success and projected `running` / `working`. No terminal capture was
+read. The patched equivalent rejects the same stream as stopped.
+
+## Decision
+
+For a codex-fork restore, persist a stopped, pending-acceptance marker before
+launch. Admit the runtime only when the raw structured stream emits
+`thread_started` for the exact durable resume id and tmux remains live through
+the acceptance window. A `session_end`, provider error, missing/mismatched
+identity, tmux disappearance, or timeout rejects the launch, tears down its
+artifacts, and leaves the durable row stopped with an actionable reason. The
+resume id is never rebound during this provisional phase.
+
+On process restart, an unfinished acceptance marker is recovered as stopped,
+not healed to idle/running, even if an ambiguous runtime artifact remains.
+
+## Test contract
+
+The isolated fake provider command writes structured JSONL and exits without
+terminal text. Coverage includes account-bound rejection, immediate
+`session_start`/`session_end`, missing thread start with tmux loss, mismatched
+thread identity, valid live acceptance, restart recovery, and stopped
+activity/attach projection. Remote restore coverage supplies the same matching
+acceptance event through its bridge queue.
+
+## Boundaries
+
+This is distinct from #1322's recredential admission/wait behavior and only
+cross-links their shared stale-runtime truthfulness family. No provider retry
+or fresh thread creation is introduced. No production restore, restart,
+deployment, or live probe is authorized by this work item.
+
+Rust tests are not run: #1317 is currently draft and #1316 is its open issue;
+the required final reviewed head and maintainer integration authorization have
+not been supplied. Python isolated tests and static checks are allowed.
+
+## Classification
+
+Single ticket: the bounded Python restore admission, recovery, projection, and
+remote-bridge test surface can be completed in one agent context.

--- a/src/models.py
+++ b/src/models.py
@@ -309,6 +309,11 @@ class Session:
     error_message: Optional[str] = None
     transcript_path: Optional[str] = None  # Claude's transcript file path
     provider_resume_id: Optional[str] = None  # Provider-native conversation/thread/session id for restore
+    # A codex-fork restore is durable but not live until the provider confirms it
+    # resumed the exact stored identity.  Keeping this marker lets startup reject
+    # a server crash in the middle of that acceptance handshake conservatively.
+    restore_launch_pending: bool = False
+    restore_pending_resume_id: Optional[str] = None
     model: Optional[str] = None  # Explicit provider model passed at launch; replayed on restore
     forked_from_session_id: Optional[str] = None  # SM session id this session was forked from
     forked_from_provider_resume_id: Optional[str] = None  # Source provider resume id captured before fork
@@ -411,6 +416,8 @@ class Session:
             "error_message": self.error_message,
             "transcript_path": self.transcript_path,
             "provider_resume_id": self.provider_resume_id,
+            "restore_launch_pending": self.restore_launch_pending,
+            "restore_pending_resume_id": self.restore_pending_resume_id,
             "model": self.model,
             "forked_from_session_id": self.forked_from_session_id,
             "forked_from_provider_resume_id": self.forked_from_provider_resume_id,
@@ -514,6 +521,8 @@ class Session:
             error_message=data.get("error_message"),
             transcript_path=data.get("transcript_path"),
             provider_resume_id=data.get("provider_resume_id"),
+            restore_launch_pending=bool(data.get("restore_launch_pending", False)),
+            restore_pending_resume_id=data.get("restore_pending_resume_id"),
             model=data.get("model"),
             forked_from_session_id=data.get("forked_from_session_id"),
             forked_from_provider_resume_id=data.get("forked_from_provider_resume_id"),

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -7708,6 +7708,20 @@ done
                 try:
                     remote_event_queue = await self._register_codex_fork_remote_bridge(session)
                     remote_bridge_registered = True
+                except asyncio.CancelledError:
+                    # CancelledError is a BaseException on supported Python
+                    # versions.  No runtime has launched yet, but the durable
+                    # admission marker must not block the next explicit restore.
+                    session.restore_launch_pending = False
+                    session.restore_pending_resume_id = None
+                    session.status = SessionStatus.STOPPED
+                    session.stopped_at = datetime.now()
+                    session.error_message = (
+                        "Codex-fork restore was cancelled before remote bridge "
+                        "registration completed"
+                    )
+                    self._save_state()
+                    raise
                 except Exception as exc:
                     self.mark_node_unreachable(session.id, True)
                     error = await self._fail_codex_fork_restore_acceptance(

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -7694,22 +7694,28 @@ done
                     session.provider = effective_provider
             remote_bridge_registered = False
             remote_event_queue: Optional[asyncio.Queue[Optional[str]]] = None
+            if session.provider == "codex-fork":
+                # Persist before the remote bridge registration await as well as
+                # before local tmux launch.  This is the restore admission lock:
+                # a concurrent caller must not register or launch another
+                # runtime while this provider identity is being verified.
+                session.restore_launch_pending = True
+                session.restore_pending_resume_id = resume_id
+                session.status = SessionStatus.STOPPED
+                session.error_message = "Codex-fork restore awaiting provider acceptance"
+                self._save_state()
             if session.provider == "codex-fork" and normalize_node_id(session.node) != PRIMARY_NODE:
                 try:
                     remote_event_queue = await self._register_codex_fork_remote_bridge(session)
                     remote_bridge_registered = True
                 except Exception as exc:
                     self.mark_node_unreachable(session.id, True)
-                    return False, session, str(exc)
-            if session.provider == "codex-fork":
-                # Persist the in-flight state before launching.  If SM restarts
-                # now, hydrate must leave this record stopped rather than turn an
-                # unobserved provider process into a false live session.
-                session.restore_launch_pending = True
-                session.restore_pending_resume_id = resume_id
-                session.status = SessionStatus.STOPPED
-                session.error_message = "Codex-fork restore awaiting provider acceptance"
-                self._save_state()
+                    error = await self._fail_codex_fork_restore_acceptance(
+                        session,
+                        f"Codex-fork remote bridge registration failed: {exc}",
+                        remote_bridge_registered=False,
+                    )
+                    return False, session, error
             if not self.tmux.create_session_with_command(
                 session.tmux_session,
                 session.working_dir,

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -5992,6 +5992,11 @@ done
                 should_remove = True
             elif session.provider != "codex-fork":
                 should_remove = True
+            elif session.restore_launch_pending:
+                # Restore admission persists stopped until the provider proves
+                # the exact resume identity; its artifacts are live evidence
+                # during that short acceptance window.
+                should_remove = False
             elif session.status == SessionStatus.STOPPED:
                 should_remove = True
             elif not self._tmux_session_exists_for_session(session):
@@ -7606,6 +7611,8 @@ done
         session = self.sessions.get(session_id)
         if not session:
             return False, None, "Session not found"
+        if session.provider == "codex-fork" and session.restore_launch_pending:
+            return False, session, "Codex-fork restore is already awaiting provider acceptance"
         try:
             tmux_runtime_missing = (
                 session.provider != "codex-app"

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -329,6 +329,12 @@ class SessionManager:
         self.codex_fork_fork_timeout_seconds = float(
             codex_fork_config.get("fork_timeout_seconds", 30.0)
         )
+        self.codex_fork_restore_acceptance_timeout_seconds = float(
+            codex_fork_config.get("restore_acceptance_timeout_seconds", 5.0)
+        )
+        self.codex_fork_restore_acceptance_window_seconds = float(
+            codex_fork_config.get("restore_acceptance_window_seconds", 0.5)
+        )
         self.codex_fork_control_tmux_fallback_enabled = _coerce_rollout_flag(
             codex_fork_config.get("control_tmux_fallback_enabled"),
             default=True,
@@ -1221,6 +1227,7 @@ class SessionManager:
         cleaned_sessions: list[dict] = []
         retired_codex_app_sessions = False
         registry_backfilled = False
+        interrupted_restore_recovered = False
         for session_data in data.get("sessions", []):
             raw_provider = session_data.get("provider")
             raw_tmux_session = session_data.get("tmux_session")
@@ -1270,6 +1277,28 @@ class SessionManager:
                     retired_codex_app_sessions = True
                 self.sessions[session.id] = session
                 logger.info(f"Restored codex app session: {session.name}")
+                continue
+
+            if session.provider == "codex-fork" and session.restore_launch_pending:
+                # A process restart can occur after tmux accepted the command but
+                # before SM observed provider acceptance.  That runtime is
+                # deliberately ambiguous: do not heal it to idle/running or bind
+                # its identity on startup.
+                session.restore_launch_pending = False
+                session.restore_pending_resume_id = None
+                session.status = SessionStatus.STOPPED
+                session.stopped_at = datetime.now()
+                session.error_message = (
+                    "Codex-fork restore acceptance was interrupted; "
+                    "the runtime was not applied. Restore again only after "
+                    "verifying the stored provider resume identity."
+                )
+                self.sessions[session.id] = session
+                interrupted_restore_recovered = True
+                logger.warning(
+                    "Preserved ambiguous codex-fork restore as stopped: %s",
+                    session.name,
+                )
                 continue
 
             if session.status == SessionStatus.STOPPED:
@@ -1392,7 +1421,7 @@ class SessionManager:
             self.adoption_proposals[proposal.id] = proposal
         registry_recovered = self._recover_missing_maintainer_registration()
         registry_changed = self._prune_agent_registrations(persist=False)
-        if retired_codex_app_sessions or registry_recovered or registry_changed:
+        if retired_codex_app_sessions or registry_recovered or registry_changed or interrupted_restore_recovered:
             self._save_state()
 
     def _rewrite_state_raw(self, sessions_data: list[dict], extra_state: Optional[dict] = None) -> bool:
@@ -3996,6 +4025,132 @@ done
             await asyncio.sleep(poll_interval)
 
         return False, None, "Timed out waiting for provider fork confirmation"
+
+    async def _wait_for_codex_fork_restore_acceptance(
+        self,
+        session: Session,
+        *,
+        expected_resume_id: str,
+        remote_events: Optional[asyncio.Queue[Optional[str]]] = None,
+    ) -> tuple[bool, str]:
+        """Prove that a codex-fork restore resumed its recorded provider identity.
+
+        Tmux command creation is only process admission.  A restore becomes live
+        only after the provider emits ``thread_started`` for the exact stored
+        resume id and does not terminally exit during the acceptance window.
+        Raw events are inspected before normal ingestion so a rejected launch
+        cannot replace the durable resume id with a newly-created thread.
+        """
+        deadline = time.monotonic() + max(
+            0.1, self.codex_fork_restore_acceptance_timeout_seconds
+        )
+        poll_interval = max(0.02, min(0.2, self.codex_fork_event_poll_interval_seconds))
+        survival_deadline: Optional[float] = None
+        stream_path = self._codex_fork_event_stream_path(session)
+        offset = 0
+        buffer = ""
+
+        while time.monotonic() < deadline:
+            lines: list[str] = []
+            if remote_events is not None:
+                try:
+                    line = await asyncio.wait_for(remote_events.get(), timeout=poll_interval)
+                except asyncio.TimeoutError:
+                    line = ""
+                if line is None:
+                    return False, "Codex-fork restore lost its remote event stream before provider acceptance"
+                if line:
+                    lines.append(line)
+            elif stream_path.exists():
+                with open(stream_path, "r", encoding="utf-8", errors="ignore") as handle:
+                    handle.seek(offset)
+                    chunk = handle.read()
+                    offset = handle.tell()
+                if chunk:
+                    buffer += chunk
+                    lines = buffer.splitlines()
+                    if buffer and not buffer.endswith("\n"):
+                        buffer = lines.pop() if lines else buffer
+                    else:
+                        buffer = ""
+
+            for line in lines:
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(event, dict):
+                    continue
+                event_type = event.get("event_type") or event.get("type")
+                normalized = self._normalize_codex_fork_event_type(event_type)
+                payload = event.get("payload") if isinstance(event.get("payload"), dict) else {}
+
+                if normalized == "session_end":
+                    return False, "Codex-fork provider ended before restore acceptance"
+                if normalized == "error":
+                    return False, "Codex-fork provider reported an error before restore acceptance"
+
+                thread_id, _ = self._extract_codex_fork_thread_started(event_type, payload)
+                if thread_id:
+                    if thread_id != expected_resume_id:
+                        return (
+                            False,
+                            "Codex-fork provider resumed a different thread "
+                            f"({thread_id} != {expected_resume_id})",
+                        )
+                    if survival_deadline is None:
+                        survival_deadline = time.monotonic() + max(
+                            0.0, self.codex_fork_restore_acceptance_window_seconds
+                        )
+
+            try:
+                tmux_exists = self._tmux_session_exists_for_session(session)
+            except Exception as exc:
+                return False, f"Codex-fork restore could not verify tmux liveness: {exc}"
+            if not tmux_exists:
+                return False, "Codex-fork tmux runtime disappeared before restore acceptance"
+
+            if survival_deadline is not None and time.monotonic() >= survival_deadline:
+                return True, ""
+
+            if remote_events is None:
+                await asyncio.sleep(poll_interval)
+
+        if survival_deadline is not None:
+            return False, "Codex-fork provider did not survive the restore acceptance window"
+        return (
+            False,
+            "Codex-fork provider did not confirm the expected resume identity before timeout",
+        )
+
+    async def _fail_codex_fork_restore_acceptance(
+        self,
+        session: Session,
+        reason: str,
+        *,
+        remote_bridge_registered: bool,
+    ) -> str:
+        """Return a rejected restore to durable stopped state without retrying it."""
+        with contextlib.suppress(Exception):
+            if self._tmux_session_exists_for_session(session):
+                self.tmux.kill_session(session.tmux_session)
+        if remote_bridge_registered:
+            with contextlib.suppress(Exception):
+                await self.codex_fork_node_agents.unregister_session(session.id)
+        self._unlink_codex_fork_runtime_artifacts(session)
+        self.codex_fork_runtime_owner.pop(session.id, None)
+        session.restore_launch_pending = False
+        session.restore_pending_resume_id = None
+        session.status = SessionStatus.STOPPED
+        session.stopped_at = datetime.now()
+        session.error_message = reason
+        self._set_codex_fork_lifecycle_state(
+            session_id=session.id,
+            state="shutdown",
+            cause_event_type="restore_acceptance_rejected",
+        )
+        self._save_state()
+        return reason
 
     async def fork_session(
         self,
@@ -7531,13 +7686,23 @@ done
                     )
                     session.provider = effective_provider
             remote_bridge_registered = False
+            remote_event_queue: Optional[asyncio.Queue[Optional[str]]] = None
             if session.provider == "codex-fork" and normalize_node_id(session.node) != PRIMARY_NODE:
                 try:
-                    await self._register_codex_fork_remote_bridge(session)
+                    remote_event_queue = await self._register_codex_fork_remote_bridge(session)
                     remote_bridge_registered = True
                 except Exception as exc:
                     self.mark_node_unreachable(session.id, True)
                     return False, session, str(exc)
+            if session.provider == "codex-fork":
+                # Persist the in-flight state before launching.  If SM restarts
+                # now, hydrate must leave this record stopped rather than turn an
+                # unobserved provider process into a false live session.
+                session.restore_launch_pending = True
+                session.restore_pending_resume_id = resume_id
+                session.status = SessionStatus.STOPPED
+                session.error_message = "Codex-fork restore awaiting provider acceptance"
+                self._save_state()
             if not self.tmux.create_session_with_command(
                 session.tmux_session,
                 session.working_dir,
@@ -7552,11 +7717,30 @@ done
                 if remote_bridge_registered:
                     with contextlib.suppress(Exception):
                         await self.codex_fork_node_agents.unregister_session(session.id)
-                if tmux_error:
+                if session.provider == "codex-fork":
+                    await self._fail_codex_fork_restore_acceptance(
+                        session,
+                        tmux_error or "Failed to restore Codex session runtime",
+                        remote_bridge_registered=False,
+                    )
+                elif tmux_error:
                     session.error_message = tmux_error
                     self._save_state()
                 return False, session, tmux_error or "Failed to restore Codex session runtime"
             session.tmux_socket_name = self._tmux_socket_name()
+            if session.provider == "codex-fork":
+                accepted, acceptance_error = await self._wait_for_codex_fork_restore_acceptance(
+                    session,
+                    expected_resume_id=resume_id,
+                    remote_events=remote_event_queue,
+                )
+                if not accepted:
+                    error = await self._fail_codex_fork_restore_acceptance(
+                        session,
+                        acceptance_error,
+                        remote_bridge_registered=remote_bridge_registered,
+                    )
+                    return False, session, error
         elif session.provider == "codex-app":
             thread_id = session.codex_thread_id or resume_id
             if not thread_id:
@@ -7586,6 +7770,8 @@ done
             return False, session, f"Restore not supported for provider={session.provider}"
 
         session.error_message = None
+        session.restore_launch_pending = False
+        session.restore_pending_resume_id = None
         session.completion_status = None
         session.completion_message = None
         session.completed_at = None

--- a/tests/unit/test_codex_fork_restore_acceptance.py
+++ b/tests/unit/test_codex_fork_restore_acceptance.py
@@ -1,0 +1,219 @@
+"""Hostile restore-admission coverage for account-bound codex-fork resumes."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from src.models import Session, SessionStatus
+from src.session_manager import SessionManager
+
+
+class FakeProviderTmux:
+    """Launch the configured fake provider, then expose its tmux liveness."""
+
+    socket_name = None
+
+    def __init__(self, *, remains_live: bool) -> None:
+        self.remains_live = remains_live
+        self.live = False
+        self.launches: list[tuple[str, list[str]]] = []
+
+    def session_exists(self, _name: str, node: str = "primary") -> bool:
+        return self.live
+
+    def create_session_with_command(self, _name: str, _cwd: str, _log_file: str, **kwargs: object) -> bool:
+        command = str(kwargs["command"])
+        args = [str(arg) for arg in kwargs["args"]]
+        self.launches.append((command, args))
+        # The fake provider writes structured JSONL and exits.  Its terminal
+        # text is intentionally unavailable to the test.
+        subprocess.run([command, *args], check=True, cwd=_cwd, env=os.environ.copy())
+        self.live = self.remains_live
+        return True
+
+    def kill_session(self, _name: str) -> bool:
+        self.live = False
+        return True
+
+
+def _fake_provider(tmp_path: Path) -> Path:
+    command = tmp_path / "fake_codex_fork.py"
+    command.write_text(
+        "#!/usr/bin/env python3\n"
+        "import os\n"
+        "import sys\n"
+        "from pathlib import Path\n"
+        "args = sys.argv[1:]\n"
+        "event_path = args[args.index('--event-stream') + 1]\n"
+        "Path(event_path).write_text(os.environ['FAKE_CODEX_FORK_EVENTS'])\n"
+    )
+    command.chmod(0o755)
+    return command
+
+
+def _manager(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, events: list[dict], *, remains_live: bool):
+    monkeypatch.setenv("FAKE_CODEX_FORK_EVENTS", "".join(json.dumps(event) + "\n" for event in events))
+    manager = SessionManager(
+        log_dir=str(tmp_path),
+        state_file=str(tmp_path / "sessions.json"),
+        config={
+            "codex_fork": {
+                "command": str(_fake_provider(tmp_path)),
+                "args": [],
+                "restore_acceptance_timeout_seconds": 0.15,
+                "restore_acceptance_window_seconds": 0.02,
+                "event_poll_interval_seconds": 0.01,
+            }
+        },
+    )
+    tmux = FakeProviderTmux(remains_live=remains_live)
+    manager.tmux = tmux
+    session = Session(
+        id="restore01",
+        name="codex-fork-restore01",
+        working_dir=str(tmp_path),
+        tmux_session="codex-fork-restore01",
+        log_file=str(tmp_path / "restore.log"),
+        provider="codex-fork",
+        status=SessionStatus.STOPPED,
+        provider_resume_id="account-bound-resume-id",
+    )
+    manager.sessions[session.id] = session
+    return manager, tmux, session
+
+
+@pytest.mark.asyncio
+async def test_restore_rejects_account_bound_resume_when_fake_provider_starts_then_ends(monkeypatch, tmp_path):
+    """The measured production shape never crosses restore's success boundary."""
+    manager, tmux, session = _manager(
+        tmp_path,
+        monkeypatch,
+        [
+            {"event_type": "session_start", "seq": 1},
+            {"event_type": "session_end", "seq": 2},
+        ],
+        remains_live=False,
+    )
+
+    success, restored, error = await manager.restore_session(session.id)
+
+    assert success is False
+    assert restored is session
+    assert error == "Codex-fork provider ended before restore acceptance"
+    assert tmux.launches  # process launch itself succeeded; provider acceptance did not
+    assert session.status == SessionStatus.STOPPED
+    assert session.provider_resume_id == "account-bound-resume-id"
+    assert session.error_message == error
+    assert manager.get_activity_state(session) == "stopped"
+    assert manager.get_attach_descriptor(session.id)["attach_supported"] is False
+
+
+@pytest.mark.asyncio
+async def test_restore_rejects_mismatched_thread_started_identity(monkeypatch, tmp_path):
+    manager, _tmux, session = _manager(
+        tmp_path,
+        monkeypatch,
+        [{"event_type": "thread_started", "payload": {"thread": {"id": "new-account-thread"}}}],
+        remains_live=True,
+    )
+
+    success, _restored, error = await manager.restore_session(session.id)
+
+    assert success is False
+    assert error == "Codex-fork provider resumed a different thread (new-account-thread != account-bound-resume-id)"
+    assert session.status == SessionStatus.STOPPED
+    assert session.provider_resume_id == "account-bound-resume-id"
+
+
+@pytest.mark.asyncio
+async def test_restore_rejects_tmux_disappearance_without_a_thread_started_event(monkeypatch, tmp_path):
+    manager, _tmux, session = _manager(
+        tmp_path,
+        monkeypatch,
+        [{"event_type": "session_start", "seq": 1}],
+        remains_live=False,
+    )
+
+    success, _restored, error = await manager.restore_session(session.id)
+
+    assert success is False
+    assert error == "Codex-fork tmux runtime disappeared before restore acceptance"
+    assert session.status == SessionStatus.STOPPED
+
+
+@pytest.mark.asyncio
+async def test_restore_rejects_live_runtime_that_never_confirms_resume_identity(monkeypatch, tmp_path):
+    manager, _tmux, session = _manager(
+        tmp_path,
+        monkeypatch,
+        [{"event_type": "session_start", "seq": 1}],
+        remains_live=True,
+    )
+
+    success, _restored, error = await manager.restore_session(session.id)
+
+    assert success is False
+    assert error == "Codex-fork provider did not confirm the expected resume identity before timeout"
+    assert session.status == SessionStatus.STOPPED
+    assert session.provider_resume_id == "account-bound-resume-id"
+
+
+@pytest.mark.asyncio
+async def test_restore_applies_only_a_live_matching_thread_started_identity(monkeypatch, tmp_path):
+    manager, _tmux, session = _manager(
+        tmp_path,
+        monkeypatch,
+        [
+            {"event_type": "session_start", "seq": 1},
+            {
+                "event_type": "thread_started",
+                "seq": 2,
+                "payload": {"thread": {"id": "account-bound-resume-id"}},
+            },
+        ],
+        remains_live=True,
+    )
+
+    success, restored, error = await manager.restore_session(session.id)
+
+    assert success is True
+    assert error is None
+    assert restored is session
+    assert session.status == SessionStatus.RUNNING
+    assert session.provider_resume_id == "account-bound-resume-id"
+    assert session.restore_launch_pending is False
+    assert manager.get_attach_descriptor(session.id)["attach_supported"] is True
+    await manager._stop_codex_fork_event_monitor(session.id)
+
+
+def test_restart_recovers_ambiguous_restore_as_stopped_and_unattachable(tmp_path):
+    state_file = tmp_path / "sessions.json"
+    session = Session(
+        id="ambig001",
+        name="codex-fork-ambig001",
+        working_dir=str(tmp_path),
+        tmux_session="codex-fork-ambig001",
+        log_file=str(tmp_path / "ambig.log"),
+        provider="codex-fork",
+        status=SessionStatus.STOPPED,
+        provider_resume_id="account-bound-resume-id",
+        restore_launch_pending=True,
+        restore_pending_resume_id="account-bound-resume-id",
+    )
+    state_file.write_text(json.dumps({"sessions": [session.to_dict()]}))
+
+    manager = SessionManager(log_dir=str(tmp_path), state_file=str(state_file), config={})
+    restored = manager.get_session(session.id)
+
+    assert restored is not None
+    assert restored.status == SessionStatus.STOPPED
+    assert restored.restore_launch_pending is False
+    assert restored.provider_resume_id == "account-bound-resume-id"
+    assert "acceptance was interrupted" in restored.error_message
+    assert manager.get_activity_state(restored) == "stopped"
+    assert manager.get_attach_descriptor(restored.id)["attach_supported"] is False

--- a/tests/unit/test_codex_fork_restore_acceptance.py
+++ b/tests/unit/test_codex_fork_restore_acceptance.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 import subprocess
@@ -161,6 +162,31 @@ async def test_restore_rejects_live_runtime_that_never_confirms_resume_identity(
     assert error == "Codex-fork provider did not confirm the expected resume identity before timeout"
     assert session.status == SessionStatus.STOPPED
     assert session.provider_resume_id == "account-bound-resume-id"
+
+
+@pytest.mark.asyncio
+async def test_restore_rejects_an_overlapping_attempt_while_acceptance_is_pending(monkeypatch, tmp_path):
+    manager, tmux, session = _manager(
+        tmp_path,
+        monkeypatch,
+        [{"event_type": "session_start", "seq": 1}],
+        remains_live=True,
+    )
+    first_restore = asyncio.create_task(manager.restore_session(session.id))
+    for _ in range(20):
+        if session.restore_launch_pending:
+            break
+        await asyncio.sleep(0.01)
+
+    second_success, second_session, second_error = await manager.restore_session(session.id)
+    first_success, _first_session, first_error = await first_restore
+
+    assert second_success is False
+    assert second_session is session
+    assert second_error == "Codex-fork restore is already awaiting provider acceptance"
+    assert len(tmux.launches) == 1
+    assert first_success is False
+    assert first_error == "Codex-fork provider did not confirm the expected resume identity before timeout"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_codex_fork_runtime_maintenance.py
+++ b/tests/unit/test_codex_fork_runtime_maintenance.py
@@ -28,8 +28,20 @@ def test_prune_codex_fork_runtime_artifacts_removes_dead_files(tmp_path):
         log_file=str(tmp_path / "dead1234.log"),
         provider_resume_id="resume-dead1234",
     )
+    pending = Session(
+        id="pending1",
+        name="codex-fork-pending1",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        status=SessionStatus.STOPPED,
+        log_file=str(tmp_path / "pending1.log"),
+        provider_resume_id="resume-pending1",
+        restore_launch_pending=True,
+        restore_pending_resume_id="resume-pending1",
+    )
     manager.sessions[live.id] = live
     manager.sessions[dead.id] = dead
+    manager.sessions[pending.id] = pending
     manager.tmux.session_exists = lambda name: name == live.tmux_session
 
     live_event = manager._codex_fork_event_stream_path(live)
@@ -37,8 +49,19 @@ def test_prune_codex_fork_runtime_artifacts_removes_dead_files(tmp_path):
     orphan_event = tmp_path / "orphan123.codex-fork.events.jsonl"
     live_socket = manager._codex_fork_control_socket_path(live)
     dead_socket = manager._codex_fork_control_socket_path(dead)
+    pending_event = manager._codex_fork_event_stream_path(pending)
+    pending_socket = manager._codex_fork_control_socket_path(pending)
     orphan_socket = tmp_path / "orphan123.codex-fork.control.sock"
-    for path in (live_event, dead_event, orphan_event, live_socket, dead_socket, orphan_socket):
+    for path in (
+        live_event,
+        dead_event,
+        orphan_event,
+        live_socket,
+        dead_socket,
+        pending_event,
+        pending_socket,
+        orphan_socket,
+    ):
         path.write_text("x")
 
     removed = sorted(manager.prune_codex_fork_runtime_artifacts())
@@ -53,6 +76,8 @@ def test_prune_codex_fork_runtime_artifacts_removes_dead_files(tmp_path):
     )
     assert live_event.exists()
     assert live_socket.exists()
+    assert pending_event.exists()
+    assert pending_socket.exists()
     assert not dead_event.exists()
     assert not dead_socket.exists()
     assert not orphan_event.exists()

--- a/tests/unit/test_remote_codex_fork_transport.py
+++ b/tests/unit/test_remote_codex_fork_transport.py
@@ -802,7 +802,14 @@ async def test_restore_remote_codex_fork_registers_bridge_before_launch_and_uses
             }
         )
     )
-    manager._register_codex_fork_remote_bridge = AsyncMock(return_value=acceptance_events)
+    async def register_bridge(candidate: Session):
+        # Remote bridge registration is the first restore await; admission must
+        # already be durable so a concurrent restore cannot pass its guard.
+        assert candidate.restore_launch_pending is True
+        assert candidate.restore_pending_resume_id == "resume-restoreremote1"
+        return acceptance_events
+
+    manager._register_codex_fork_remote_bridge = AsyncMock(side_effect=register_bridge)
     manager._start_codex_fork_event_monitor = Mock()
     manager.codex_fork_restore_acceptance_timeout_seconds = 0.1
     manager.codex_fork_restore_acceptance_window_seconds = 0.01
@@ -825,6 +832,44 @@ async def test_restore_remote_codex_fork_registers_bridge_before_launch_and_uses
     control_socket_path = args[args.index("--control-socket") + 1]
     assert event_stream_path == "/tmp/worker-sm/restoreremote1.codex-fork.events.jsonl"
     assert control_socket_path == "/tmp/worker-sm/restoreremote1.codex-fork.control.sock"
+
+
+@pytest.mark.asyncio
+async def test_restore_remote_codex_fork_bridge_failure_clears_pending_admission(tmp_path):
+    manager = _manager(tmp_path)
+    session = Session(
+        id="restorebridgefail",
+        name="codex-fork-restorebridgefail",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        node="worker",
+        status=SessionStatus.STOPPED,
+        provider_resume_id="resume-restorebridgefail",
+    )
+    manager.sessions[session.id] = session
+
+    class HealthyConnection:
+        def is_healthy(self):
+            return True
+
+    manager.codex_fork_node_agents._connections["worker"] = HealthyConnection()
+    manager.node_runner.command_available = Mock(return_value=True)
+    manager.node_runner.run = Mock(
+        return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+    )
+    manager._register_codex_fork_remote_bridge = AsyncMock(side_effect=RuntimeError("bridge unavailable"))
+    manager.tmux.session_exists = Mock(return_value=False)
+    manager.tmux.create_session_with_command = Mock(return_value=True)
+
+    success, restored, error = await manager.restore_session(session.id)
+
+    assert success is False
+    assert restored is session
+    assert error == "Codex-fork remote bridge registration failed: bridge unavailable"
+    assert session.status == SessionStatus.STOPPED
+    assert session.restore_launch_pending is False
+    assert session.restore_pending_resume_id is None
+    manager.tmux.create_session_with_command.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_remote_codex_fork_transport.py
+++ b/tests/unit/test_remote_codex_fork_transport.py
@@ -793,9 +793,21 @@ async def test_restore_remote_codex_fork_registers_bridge_before_launch_and_uses
     manager.node_runner.run = Mock(
         return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
     )
-    manager._register_codex_fork_remote_bridge = AsyncMock()
+    acceptance_events: asyncio.Queue[object] = asyncio.Queue()
+    acceptance_events.put_nowait(
+        json.dumps(
+            {
+                "event_type": "thread_started",
+                "payload": {"thread": {"id": "resume-restoreremote1"}},
+            }
+        )
+    )
+    manager._register_codex_fork_remote_bridge = AsyncMock(return_value=acceptance_events)
     manager._start_codex_fork_event_monitor = Mock()
-    manager.tmux.session_exists = Mock(return_value=False)
+    manager.codex_fork_restore_acceptance_timeout_seconds = 0.1
+    manager.codex_fork_restore_acceptance_window_seconds = 0.01
+    manager.codex_fork_event_poll_interval_seconds = 0.01
+    manager.tmux.session_exists = Mock(return_value=True)
     manager.tmux.create_session_with_command = Mock(return_value=True)
 
     success, restored, error = await manager.restore_session(session.id)

--- a/tests/unit/test_remote_codex_fork_transport.py
+++ b/tests/unit/test_remote_codex_fork_transport.py
@@ -873,6 +873,56 @@ async def test_restore_remote_codex_fork_bridge_failure_clears_pending_admission
 
 
 @pytest.mark.asyncio
+async def test_restore_remote_codex_fork_bridge_cancellation_clears_pending_admission(tmp_path):
+    manager = _manager(tmp_path)
+    session = Session(
+        id="restorebridgecancel",
+        name="codex-fork-restorebridgecancel",
+        working_dir=str(tmp_path),
+        provider="codex-fork",
+        node="worker",
+        status=SessionStatus.STOPPED,
+        provider_resume_id="resume-restorebridgecancel",
+    )
+    manager.sessions[session.id] = session
+
+    class HealthyConnection:
+        def is_healthy(self):
+            return True
+
+    bridge_entered = asyncio.Event()
+    never_finish = asyncio.Event()
+
+    async def register_bridge(_candidate: Session):
+        bridge_entered.set()
+        await never_finish.wait()
+        raise AssertionError("cancelled bridge should not resume")
+
+    manager.codex_fork_node_agents._connections["worker"] = HealthyConnection()
+    manager.node_runner.command_available = Mock(return_value=True)
+    manager.node_runner.run = Mock(
+        return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+    )
+    manager._register_codex_fork_remote_bridge = AsyncMock(side_effect=register_bridge)
+    manager.tmux.session_exists = Mock(return_value=False)
+    manager.tmux.create_session_with_command = Mock(return_value=True)
+
+    restore_task = asyncio.create_task(manager.restore_session(session.id))
+    await asyncio.wait_for(bridge_entered.wait(), timeout=0.2)
+    assert session.restore_launch_pending is True
+    restore_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await restore_task
+
+    assert session.status == SessionStatus.STOPPED
+    assert session.restore_launch_pending is False
+    assert session.restore_pending_resume_id is None
+    assert session.error_message == "Codex-fork restore was cancelled before remote bridge registration completed"
+    manager.tmux.create_session_with_command.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_remote_codex_fork_create_rejects_legacy_codex_fallback(tmp_path):
     manager = _manager(tmp_path)
 


### PR DESCRIPTION
Fixes #1324

## What changed

Codex-fork restores now remain durably stopped until a structured `thread_started` confirms the exact stored resume identity and tmux survives the startup acceptance window. Immediate `session_end`, missing/mismatched identity, tmux loss, provider error, or timeout leaves an actionable stopped record and does not rebind the resume ID. Interrupted acceptance recovers conservatively as stopped on restart. Pending restores retain their event/control artifacts, and overlapping restore requests are rejected before a second launch—including before remote bridge registration. Remote bridge cancellation clears the admission marker before re-raising.

## Root cause

Restore treated successful tmux command creation as provider acceptance and immediately projected running before the event stream could report rejection or exit.

## Validation

- Fake provider command/event-stream hostile tests: rejection, immediate exit, missing/mismatched identity, tmux loss, valid acceptance, restart recovery, pending-artifact retention, local/remote overlapping restore admission, bridge-failure/cancellation recovery, and attach/activity projection.
- `pytest -q tests/unit/test_codex_fork_restore_acceptance.py tests/unit/test_codex_fork_runtime_maintenance.py tests/integration/test_session_lifecycle.py tests/unit/test_remote_codex_fork_transport.py tests/unit/test_codex_fork_restore.py` (85 passed).
- `compileall` and `git diff --check`.
- Rust tests not run: #1317 remains draft and maintainer integration authorization has not been granted.

## Review tier

R3: persisted session shape plus restore lifecycle, restart recovery, ambiguity semantics, and production hot-path projection. Four bounded Codex rounds are recorded; the final reviewed head is clean.

## Review record

- Round 1 requested for `a2d20bccef81d0850f52bb504d441a09302e62f7`; reviewed `a2d20bccef`. Two P2 findings were valid: the maintenance pruner removed pending acceptance artifacts, and concurrent restore could overlap. Both were fixed in `34a3ed1ca1f35ef416608b55bbe1cdcd499557aa` with targeted tests.
- Round 2 requested/reviewed for `34a3ed1ca1f35ef416608b55bbe1cdcd499557aa`; one P2 was valid: remote bridge registration awaited before admission was durable. Fixed in `38b67b7169877e29b041f9f520a3d1a981fd38ed`; the marker is now set before bridge registration and bridge failure returns stopped with the marker cleared.
- Round 3 requested/reviewed for `38b67b7169877e29b041f9f520a3d1a981fd38ed`; one P2 was valid: cancellation during bridge registration bypassed `except Exception` and stranded the marker. Fixed in `207db10909e1f030c50d13128bfce008b816d1d6`; cancellation now clears durable admission and re-raises.
- Round 4 reviewed `207db10909e1f030c50d13128bfce008b816d1d6`; clean: no major issues.

No production restore, restart, deployment, or live probe was performed.