### PR TITLE
Fix stopped-root reparent recovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,10 @@ running server. See `specs/1134_rust_restart_procedure.md`.
 ### Testing
 
 ```bash
+# Rust server tests — the supported launcher also cleans isolated state. Direct
+# cargo test has a fail-safe isolation root, but must not be used for normal work.
+./scripts/test-rust-isolated.sh
+
 # Manual testing - spawn a child agent
 sm spawn --name test-agent "echo hello and exit"
 

--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -2134,12 +2134,24 @@ mod tests {
             TEST_ISOLATION_INSTANCE.fetch_add(1, Ordering::Relaxed)
         ));
         let safe_state_file = env::temp_dir().join("sm-safe-fixture-sessions.json");
+        let safe_codex_index = env::temp_dir().join("sm-safe-fixture-codex-index.jsonl");
+        let safe_transcript_root = env::temp_dir().join("sm-safe-fixture-transcripts");
         let mut config = AppConfig::default();
         config.paths.state_file = safe_state_file.display().to_string();
+        config.codex.session_index_path = Some(safe_codex_index.display().to_string());
+        config.claude.transcript_root = Some(safe_transcript_root.display().to_string());
         config.isolate_test_paths(&root).unwrap();
         assert_eq!(
             config.paths.state_file,
             safe_state_file.display().to_string()
+        );
+        assert_eq!(
+            config.codex.session_index_path.as_deref(),
+            Some(safe_codex_index.to_str().unwrap())
+        );
+        assert_eq!(
+            config.claude.transcript_root.as_deref(),
+            Some(safe_transcript_root.to_str().unwrap())
         );
 
         let mut unsafe_config = AppConfig::default();

--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -2,12 +2,19 @@ use std::{
     collections::BTreeMap,
     env, fs,
     path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
 };
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_yaml::{Mapping as YamlMapping, Value as YamlValue};
 use sha2::{Digest, Sha256};
+
+/// Required by the Rust test launcher. When present, every default-shaped
+/// durable path is redirected below this root before an `AppState` starts.
+pub const TEST_ISOLATION_ROOT_ENV: &str = "SM_TEST_ISOLATION_ROOT";
+
+static TEST_ISOLATION_INSTANCE: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone)]
 pub struct AppConfig {
@@ -131,6 +138,172 @@ impl AppConfig {
         }
         PathBuf::from(&self.queue_runner.state_dir)
     }
+
+    /// Redirect production-shaped durable paths below `root`. Explicit fixture
+    /// paths outside the production state directory are retained, while every
+    /// default AppState receives a unique state-file sibling and therefore a
+    /// unique reparent lock and queue database.
+    pub fn isolate_test_paths(&mut self, root: &Path) -> Result<()> {
+        if !root.is_absolute() {
+            anyhow::bail!("test isolation root must be absolute: {}", root.display());
+        }
+        fs::create_dir_all(root)
+            .with_context(|| format!("failed to create test isolation root {}", root.display()))?;
+        let instance = root.join(format!(
+            "appstate-{}-{}",
+            std::process::id(),
+            TEST_ISOLATION_INSTANCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        fs::create_dir_all(&instance).with_context(|| {
+            format!(
+                "failed to create isolated AppState root {}",
+                instance.display()
+            )
+        })?;
+
+        self.paths.state_file =
+            isolate_default_data_path(&self.paths.state_file, &default_state_file(), &instance)?;
+        self.sm_send.db_path = isolate_default_data_path(
+            &self.sm_send.db_path,
+            &default_message_queue_db_path(),
+            &instance,
+        )?;
+        self.mobile_analytics.message_queue_db = isolate_default_data_path(
+            &self.mobile_analytics.message_queue_db,
+            &default_message_queue_db_path(),
+            &instance,
+        )?;
+        self.tool_logging.db_path = isolate_default_data_path(
+            &self.tool_logging.db_path,
+            &default_tool_usage_db_path(),
+            &instance,
+        )?;
+        self.usage.db_path =
+            isolate_default_data_path(&self.usage.db_path, &default_usage_db_path(), &instance)?;
+        self.codex_events.db_path = isolate_default_data_path(
+            &self.codex_events.db_path,
+            &default_codex_events_db_path(),
+            &instance,
+        )?;
+        self.codex_requests.db_path = isolate_default_data_path(
+            &self.codex_requests.db_path,
+            &default_codex_requests_db_path(),
+            &instance,
+        )?;
+        self.codex_observability.db_path = isolate_default_data_path(
+            &self.codex_observability.db_path,
+            &default_codex_observability_db_path(),
+            &instance,
+        )?;
+        self.queue_runner.state_dir = isolate_default_data_path(
+            &self.queue_runner.state_dir,
+            &default_queue_runner_state_dir(),
+            &instance,
+        )?;
+        self.mobile_terminal.device_enrollment_db_path = isolate_default_data_path(
+            &self.mobile_terminal.device_enrollment_db_path,
+            &default_mobile_terminal_device_enrollment_db_path(),
+            &instance,
+        )?;
+
+        // Default production indexes can make a test AppState scan live agent
+        // artifacts during startup. Fixtures that explicitly point elsewhere
+        // remain available, but home-relative defaults are never consulted.
+        if let Some(path) = self.codex.session_index_path.as_deref() {
+            if path == "~/.codex/session_index.jsonl" {
+                self.codex.session_index_path = None;
+            } else if path_is_under_home(path) {
+                anyhow::bail!("test isolation refuses production Codex index path {path}");
+            }
+        }
+        if let Some(path) = self.claude.transcript_root.as_deref() {
+            if path_is_under_home(path) {
+                anyhow::bail!("test isolation refuses production Claude transcript root {path}");
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Return the configured test-isolation root, creating it before any durable
+/// store can be opened. The supported launcher supplies a cleanable root. As
+/// a fail-safe, a Cargo test binary that bypasses that launcher gets its own
+/// temporary root instead of falling through to production defaults.
+pub fn test_isolation_root_from_environment() -> Result<Option<PathBuf>> {
+    let root = if let Some(root) = env::var_os(TEST_ISOLATION_ROOT_ENV) {
+        PathBuf::from(root)
+    } else if running_rust_test_binary() {
+        env::temp_dir().join(format!("sm-rust-test-{}", std::process::id()))
+    } else {
+        return Ok(None);
+    };
+    if !root.is_absolute() {
+        anyhow::bail!("{TEST_ISOLATION_ROOT_ENV} must be an absolute path");
+    }
+    fs::create_dir_all(&root)
+        .with_context(|| format!("failed to create test isolation root {}", root.display()))?;
+    Ok(Some(root))
+}
+
+fn running_rust_test_binary() -> bool {
+    let Ok(executable) = env::current_exe() else {
+        return false;
+    };
+    let in_cargo_deps = executable
+        .parent()
+        .and_then(Path::file_name)
+        .is_some_and(|name| name == "deps");
+    let has_cargo_hash = executable
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .and_then(|name| name.rsplit_once('-'))
+        .is_some_and(|(_, hash)| {
+            hash.len() >= 8 && hash.chars().all(|character| character.is_ascii_hexdigit())
+        });
+    in_cargo_deps && has_cargo_hash
+}
+
+fn production_data_root() -> Option<PathBuf> {
+    env::var_os("HOME").map(|home| Path::new(&home).join(".local/share/claude-sessions"))
+}
+
+fn expand_home_for_path_match(path: &str) -> PathBuf {
+    if path == "~" {
+        return env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from(path));
+    }
+    path.strip_prefix("~/")
+        .and_then(|rest| env::var_os("HOME").map(|home| Path::new(&home).join(rest)))
+        .unwrap_or_else(|| PathBuf::from(path))
+}
+
+fn isolate_default_data_path(path: &str, default: &str, root: &Path) -> Result<String> {
+    let expanded = expand_home_for_path_match(path);
+    let Some(production_root) = production_data_root() else {
+        return Ok(path.to_owned());
+    };
+    if path == default {
+        let default_expanded = expand_home_for_path_match(default);
+        let relative = default_expanded
+            .strip_prefix(&production_root)
+            .with_context(|| {
+                format!(
+                    "default test path {default} is not under {}",
+                    production_root.display()
+                )
+            })?;
+        return Ok(root.join(relative).to_string_lossy().into_owned());
+    }
+    if expanded.starts_with(&production_root) {
+        anyhow::bail!("test isolation refuses explicit production path {path}");
+    };
+    Ok(path.to_owned())
+}
+
+fn path_is_under_home(path: &str) -> bool {
+    let expanded = expand_home_for_path_match(path);
+    env::var_os("HOME").is_some_and(|home| expanded.starts_with(PathBuf::from(home)))
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -1910,6 +2083,106 @@ fn derive_session_cookie_secret(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_isolation_rehomes_all_default_durable_paths() {
+        let root = env::temp_dir().join(format!(
+            "sm-config-test-isolation-{}-{}",
+            std::process::id(),
+            TEST_ISOLATION_INSTANCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        let mut config = AppConfig::default();
+        config.isolate_test_paths(&root).unwrap();
+
+        let durable_paths = [
+            &config.paths.state_file,
+            &config.sm_send.db_path,
+            &config.mobile_analytics.message_queue_db,
+            &config.tool_logging.db_path,
+            &config.usage.db_path,
+            &config.codex_events.db_path,
+            &config.codex_requests.db_path,
+            &config.codex_observability.db_path,
+            &config.queue_runner.state_dir,
+            &config.mobile_terminal.device_enrollment_db_path,
+        ];
+        for path in durable_paths {
+            assert!(
+                Path::new(path).starts_with(&root),
+                "expected {path} below {}",
+                root.display()
+            );
+        }
+        assert!(Path::new(&config.paths.state_file)
+            .with_extension("reparent-apply.lock")
+            .starts_with(&root));
+        assert_eq!(config.codex.session_index_path, None);
+
+        let first_state_file = config.paths.state_file.clone();
+        let mut second_config = AppConfig::default();
+        second_config.isolate_test_paths(&root).unwrap();
+        assert_ne!(first_state_file, second_config.paths.state_file);
+
+        fs::remove_dir_all(&root).unwrap();
+    }
+
+    #[test]
+    fn test_isolation_retains_safe_fixtures_and_rejects_production_paths() {
+        let root = env::temp_dir().join(format!(
+            "sm-config-test-isolation-explicit-{}-{}",
+            std::process::id(),
+            TEST_ISOLATION_INSTANCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        let safe_state_file = env::temp_dir().join("sm-safe-fixture-sessions.json");
+        let mut config = AppConfig::default();
+        config.paths.state_file = safe_state_file.display().to_string();
+        config.isolate_test_paths(&root).unwrap();
+        assert_eq!(
+            config.paths.state_file,
+            safe_state_file.display().to_string()
+        );
+
+        let mut unsafe_config = AppConfig::default();
+        unsafe_config.paths.state_file = production_data_root()
+            .unwrap()
+            .join("explicit-test-sessions.json")
+            .display()
+            .to_string();
+        let error = unsafe_config.isolate_test_paths(&root).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("refuses explicit production path"));
+
+        let mut unsafe_queue_config = AppConfig::default();
+        unsafe_queue_config.sm_send.db_path = production_data_root()
+            .unwrap()
+            .join("message_queue.db")
+            .display()
+            .to_string();
+        let error = unsafe_queue_config.isolate_test_paths(&root).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("refuses explicit production path"));
+
+        let mut unsafe_index_config = AppConfig::default();
+        unsafe_index_config.codex.session_index_path =
+            Some("~/.codex/sessions/index.jsonl".to_owned());
+        let error = unsafe_index_config.isolate_test_paths(&root).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("refuses production Codex index path"));
+
+        let mut unsafe_transcript_config = AppConfig::default();
+        unsafe_transcript_config.claude.transcript_root = Some("~/.claude/projects".to_owned());
+        let error = unsafe_transcript_config
+            .isolate_test_paths(&root)
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("refuses production Claude transcript root"));
+
+        let _ = fs::remove_dir_all(&root);
+    }
 
     #[test]
     fn local_env_overlay_maps_mobile_auth_and_external_access() {

--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -1,6 +1,9 @@
 use std::{
     collections::BTreeMap,
-    env, fs,
+    env,
+    ffi::OsString,
+    fs,
+    io::ErrorKind,
     path::{Path, PathBuf},
     sync::atomic::{AtomicU64, Ordering},
 };
@@ -161,6 +164,7 @@ impl AppConfig {
             )
         })?;
 
+        let custom_state_file = self.paths.state_file != default_state_file();
         self.paths.state_file =
             isolate_default_data_path(&self.paths.state_file, &default_state_file(), &instance)?;
         self.sm_send.db_path = isolate_default_data_path(
@@ -178,8 +182,14 @@ impl AppConfig {
             &default_tool_usage_db_path(),
             &instance,
         )?;
-        self.usage.db_path =
-            isolate_default_data_path(&self.usage.db_path, &default_usage_db_path(), &instance)?;
+        self.usage.db_path = if custom_state_file && self.usage.db_path == default_usage_db_path() {
+            Path::new(&self.paths.state_file)
+                .with_extension("usage.db")
+                .to_string_lossy()
+                .into_owned()
+        } else {
+            isolate_default_data_path(&self.usage.db_path, &default_usage_db_path(), &instance)?
+        };
         self.codex_events.db_path = isolate_default_data_path(
             &self.codex_events.db_path,
             &default_codex_events_db_path(),
@@ -205,6 +215,20 @@ impl AppConfig {
             &default_mobile_terminal_device_enrollment_db_path(),
             &instance,
         )?;
+        self.bug_reports.db_path = isolate_path_from_protected_root(
+            &self.bug_reports.db_path,
+            &default_bug_reports_db_path(),
+            &instance,
+            Path::new("bug_reports.db"),
+            &expand_home_for_path_match(&default_bug_reports_db_path()),
+        )?;
+        self.app_artifacts.root_dir = isolate_path_from_protected_root(
+            &self.app_artifacts.root_dir,
+            &default_app_artifacts_dir(),
+            &instance,
+            Path::new("apps"),
+            &expand_home_for_path_match(&default_app_artifacts_dir()),
+        )?;
 
         // Default production indexes can make a test AppState scan live agent
         // artifacts during startup. Fixtures that explicitly point elsewhere
@@ -212,12 +236,12 @@ impl AppConfig {
         if let Some(path) = self.codex.session_index_path.as_deref() {
             if path == "~/.codex/session_index.jsonl" {
                 self.codex.session_index_path = None;
-            } else if path_is_under_home(path) {
+            } else if path_is_under_home(path)? {
                 anyhow::bail!("test isolation refuses production Codex index path {path}");
             }
         }
         if let Some(path) = self.claude.transcript_root.as_deref() {
-            if path_is_under_home(path) {
+            if path_is_under_home(path)? {
                 anyhow::bail!("test isolation refuses production Claude transcript root {path}");
             }
         }
@@ -279,31 +303,105 @@ fn expand_home_for_path_match(path: &str) -> PathBuf {
 }
 
 fn isolate_default_data_path(path: &str, default: &str, root: &Path) -> Result<String> {
-    let expanded = expand_home_for_path_match(path);
     let Some(production_root) = production_data_root() else {
         return Ok(path.to_owned());
     };
+    let canonical_production_root = canonicalize_path_for_containment(&production_root)?;
+    let canonical_default =
+        canonicalize_path_for_containment(&expand_home_for_path_match(default))?;
+    let relative = canonical_default
+        .strip_prefix(&canonical_production_root)
+        .with_context(|| {
+            format!(
+                "default test path {default} is not under {}",
+                canonical_production_root.display()
+            )
+        })?;
+    isolate_path_from_protected_root(path, default, root, relative, &canonical_production_root)
+}
+
+fn isolate_path_from_protected_root(
+    path: &str,
+    default: &str,
+    root: &Path,
+    replacement: &Path,
+    protected_root: &Path,
+) -> Result<String> {
     if path == default {
-        let default_expanded = expand_home_for_path_match(default);
-        let relative = default_expanded
-            .strip_prefix(&production_root)
-            .with_context(|| {
-                format!(
-                    "default test path {default} is not under {}",
-                    production_root.display()
-                )
-            })?;
-        return Ok(root.join(relative).to_string_lossy().into_owned());
+        return Ok(root.join(replacement).to_string_lossy().into_owned());
     }
-    if expanded.starts_with(&production_root) {
+    if path_resolves_under_root(path, protected_root)? {
         anyhow::bail!("test isolation refuses explicit production path {path}");
-    };
+    }
     Ok(path.to_owned())
 }
 
-fn path_is_under_home(path: &str) -> bool {
-    let expanded = expand_home_for_path_match(path);
-    env::var_os("HOME").is_some_and(|home| expanded.starts_with(PathBuf::from(home)))
+fn path_is_under_home(path: &str) -> Result<bool> {
+    let Some(home) = env::var_os("HOME") else {
+        return Ok(false);
+    };
+    path_resolves_under_root(path, Path::new(&home))
+}
+
+fn path_resolves_under_root(path: &str, root: &Path) -> Result<bool> {
+    let candidate = canonicalize_path_for_containment(&expand_home_for_path_match(path))?;
+    let root = canonicalize_path_for_containment(root)?;
+    Ok(candidate.starts_with(root))
+}
+
+/// Canonicalize the longest existing prefix, then append unresolved trailing
+/// components. This catches `..` and symlink aliases even when a prospective
+/// store file has not been created yet. Any unreadable or dangling prefix is
+/// rejected rather than accepted as a fixture.
+fn canonicalize_path_for_containment(path: &Path) -> Result<PathBuf> {
+    let mut existing = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        env::current_dir()
+            .context("failed to determine current directory for test path isolation")?
+            .join(path)
+    };
+    let mut unresolved = Vec::<OsString>::new();
+    loop {
+        match fs::symlink_metadata(&existing) {
+            Ok(_) => break,
+            Err(error)
+                if matches!(error.kind(), ErrorKind::NotFound | ErrorKind::NotADirectory) =>
+            {
+                let component = existing.file_name().map(OsString::from).with_context(|| {
+                    format!(
+                        "test isolation could not find an existing ancestor for {}",
+                        path.display()
+                    )
+                })?;
+                unresolved.push(component);
+                if !existing.pop() {
+                    anyhow::bail!(
+                        "test isolation could not find an existing ancestor for {}",
+                        path.display()
+                    );
+                }
+            }
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "test isolation could not inspect explicit path {}",
+                        path.display()
+                    )
+                });
+            }
+        }
+    }
+    let mut canonical = fs::canonicalize(&existing).with_context(|| {
+        format!(
+            "test isolation could not canonicalize explicit path prefix {}",
+            existing.display()
+        )
+    })?;
+    for component in unresolved.iter().rev() {
+        canonical.push(component);
+    }
+    Ok(canonical)
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -2105,6 +2203,8 @@ mod tests {
             &config.codex_observability.db_path,
             &config.queue_runner.state_dir,
             &config.mobile_terminal.device_enrollment_db_path,
+            &config.bug_reports.db_path,
+            &config.app_artifacts.root_dir,
         ];
         for path in durable_paths {
             assert!(
@@ -2176,6 +2276,66 @@ mod tests {
             .to_string()
             .contains("refuses explicit production path"));
 
+        let production_root = production_data_root().unwrap();
+        let mut dot_alias_config = AppConfig::default();
+        dot_alias_config.paths.state_file = production_root
+            .parent()
+            .unwrap()
+            .join("claude-sessions")
+            .join("..")
+            .join("claude-sessions/alias-sessions.json")
+            .display()
+            .to_string();
+        let error = dot_alias_config.isolate_test_paths(&root).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("refuses explicit production path"));
+
+        let symlink_root = root.join("production-alias");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&production_root, &symlink_root).unwrap();
+        let mut symlink_alias_config = AppConfig::default();
+        symlink_alias_config.paths.state_file = symlink_root
+            .join("alias-sessions.json")
+            .display()
+            .to_string();
+        let error = symlink_alias_config.isolate_test_paths(&root).unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("refuses explicit production path"));
+
+        let mut unsafe_bug_report_config = AppConfig::default();
+        let default_bug_report_path = PathBuf::from(default_bug_reports_db_path());
+        unsafe_bug_report_config.bug_reports.db_path = default_bug_report_path
+            .parent()
+            .unwrap()
+            .join(".")
+            .join(default_bug_report_path.file_name().unwrap())
+            .display()
+            .to_string();
+        let error = unsafe_bug_report_config
+            .isolate_test_paths(&root)
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("refuses explicit production path"));
+
+        let mut unsafe_app_artifact_config = AppConfig::default();
+        let default_app_artifact_root = PathBuf::from(default_app_artifacts_dir());
+        unsafe_app_artifact_config.app_artifacts.root_dir = default_app_artifact_root
+            .parent()
+            .unwrap()
+            .join(".")
+            .join(default_app_artifact_root.file_name().unwrap())
+            .display()
+            .to_string();
+        let error = unsafe_app_artifact_config
+            .isolate_test_paths(&root)
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("refuses explicit production path"));
+
         let mut unsafe_index_config = AppConfig::default();
         unsafe_index_config.codex.session_index_path =
             Some("~/.codex/sessions/index.jsonl".to_owned());
@@ -2194,6 +2354,26 @@ mod tests {
             .contains("refuses production Claude transcript root"));
 
         let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn test_isolation_preserves_custom_state_file_usage_db_lifecycle() {
+        let root = env::temp_dir().join(format!(
+            "sm-config-test-isolation-custom-state-{}-{}",
+            std::process::id(),
+            TEST_ISOLATION_INSTANCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        let state_file = env::temp_dir().join("sm-isolated-custom-state.json");
+        let mut config = AppConfig::default();
+        config.paths.state_file = state_file.display().to_string();
+        config.isolate_test_paths(&root).unwrap();
+
+        assert_eq!(config.paths.state_file, state_file.display().to_string());
+        assert_eq!(
+            config.usage.db_path,
+            state_file.with_extension("usage.db").display().to_string()
+        );
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]

--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -5,19 +5,24 @@ use std::{
     fs,
     io::ErrorKind,
     path::{Path, PathBuf},
-    sync::atomic::{AtomicU64, Ordering},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        OnceLock,
+    },
 };
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_yaml::{Mapping as YamlMapping, Value as YamlValue};
 use sha2::{Digest, Sha256};
+use time::OffsetDateTime;
 
 /// Required by the Rust test launcher. When present, every default-shaped
 /// durable path is redirected below this root before an `AppState` starts.
 pub const TEST_ISOLATION_ROOT_ENV: &str = "SM_TEST_ISOLATION_ROOT";
 
 static TEST_ISOLATION_INSTANCE: AtomicU64 = AtomicU64::new(0);
+static DIRECT_TEST_ISOLATION_ROOT: OnceLock<PathBuf> = OnceLock::new();
 
 #[derive(Debug, Clone)]
 pub struct AppConfig {
@@ -257,7 +262,7 @@ pub fn test_isolation_root_from_environment() -> Result<Option<PathBuf>> {
     let root = if let Some(root) = env::var_os(TEST_ISOLATION_ROOT_ENV) {
         PathBuf::from(root)
     } else if running_rust_test_binary() {
-        env::temp_dir().join(format!("sm-rust-test-{}", std::process::id()))
+        direct_test_isolation_root()?
     } else {
         return Ok(None);
     };
@@ -336,11 +341,37 @@ fn isolate_path_from_protected_root(
     Ok(path.to_owned())
 }
 
-fn path_is_under_home(path: &str) -> Result<bool> {
+pub(crate) fn path_is_under_home(path: &str) -> Result<bool> {
     let Some(home) = env::var_os("HOME") else {
         return Ok(false);
     };
     path_resolves_under_root(path, Path::new(&home))
+}
+
+fn direct_test_isolation_root() -> Result<PathBuf> {
+    if let Some(root) = DIRECT_TEST_ISOLATION_ROOT.get() {
+        return Ok(root.clone());
+    }
+    for _ in 0..128 {
+        let candidate = env::temp_dir().join(format!(
+            "sm-rust-test-{}-{}-{}",
+            std::process::id(),
+            OffsetDateTime::now_utc().unix_timestamp_nanos(),
+            TEST_ISOLATION_INSTANCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        match fs::create_dir(&candidate) {
+            Ok(()) => {
+                let _ = DIRECT_TEST_ISOLATION_ROOT.set(candidate.clone());
+                return Ok(DIRECT_TEST_ISOLATION_ROOT
+                    .get()
+                    .expect("direct test isolation root was set")
+                    .clone());
+            }
+            Err(error) if error.kind() == ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error).context("failed to create direct test isolation root"),
+        }
+    }
+    anyhow::bail!("failed to create a unique direct test isolation root")
 }
 
 fn path_resolves_under_root(path: &str, root: &Path) -> Result<bool> {
@@ -2354,6 +2385,25 @@ mod tests {
             .contains("refuses production Claude transcript root"));
 
         let _ = fs::remove_dir_all(&root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn containment_canonicalizes_a_transcript_root_symlinked_into_home() {
+        let root = env::temp_dir().join(format!(
+            "sm-config-transcript-symlink-{}-{}",
+            std::process::id(),
+            TEST_ISOLATION_INSTANCE.fetch_add(1, Ordering::Relaxed)
+        ));
+        let home = root.join("home");
+        let live_projects = home.join(".claude/projects");
+        let alias = root.join("outside-home-alias");
+        fs::create_dir_all(&live_projects).unwrap();
+        std::os::unix::fs::symlink(&live_projects, &alias).unwrap();
+
+        assert!(path_resolves_under_root(alias.to_str().unwrap(), &home).unwrap());
+
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -13884,6 +13884,28 @@ mod tests {
 
     const DIRECT_HARNESS_PROBE_ENV: &str = "SM_DIRECT_HARNESS_ISOLATION_PROBE";
 
+    struct ProbeChild {
+        child: Child,
+        release_path: PathBuf,
+    }
+
+    impl ProbeChild {
+        fn release_and_wait(&mut self) {
+            fs::write(&self.release_path, []).unwrap();
+            assert!(self.child.wait().unwrap().success());
+        }
+    }
+
+    impl Drop for ProbeChild {
+        fn drop(&mut self) {
+            let _ = fs::write(&self.release_path, []);
+            if self.child.try_wait().ok().flatten().is_none() {
+                let _ = self.child.kill();
+            }
+            let _ = self.child.wait();
+        }
+    }
+
     #[test]
     fn direct_test_harness_without_wrapper_cannot_open_production_state_paths() {
         if let Some(probe_path) = env::var_os(DIRECT_HARNESS_PROBE_ENV) {
@@ -13901,6 +13923,8 @@ mod tests {
                 config.codex_observability.db_path.clone(),
                 config.queue_runner.state_dir.clone(),
                 config.mobile_terminal.device_enrollment_db_path.clone(),
+                config.bug_reports.db_path.clone(),
+                config.app_artifacts.root_dir.clone(),
                 StdPath::new(&config.paths.state_file)
                     .with_extension("reparent-apply.lock")
                     .display()
@@ -13930,23 +13954,26 @@ mod tests {
         fs::create_dir_all(&probe_root).unwrap();
         let probe_path = probe_root.join("probe");
         let executable = env::current_exe().unwrap();
-        let mut child = Command::new(executable)
-            .args([
-                "--exact",
-                "http::tests::direct_test_harness_without_wrapper_cannot_open_production_state_paths",
-                "--nocapture",
-            ])
-            .env_remove(TEST_ISOLATION_ROOT_ENV)
-            .env(DIRECT_HARNESS_PROBE_ENV, &probe_path)
-            .spawn()
-            .unwrap();
+        let mut probe_child = ProbeChild {
+            child: Command::new(executable)
+                .args([
+                    "--exact",
+                    "http::tests::direct_test_harness_without_wrapper_cannot_open_production_state_paths",
+                    "--nocapture",
+                ])
+                .env_remove(TEST_ISOLATION_ROOT_ENV)
+                .env(DIRECT_HARNESS_PROBE_ENV, &probe_path)
+                .spawn()
+                .unwrap(),
+            release_path: probe_path.with_extension("release"),
+        };
 
         for _ in 0..500 {
             if probe_path.exists() {
                 break;
             }
             assert!(
-                child.try_wait().unwrap().is_none(),
+                probe_child.child.try_wait().unwrap().is_none(),
                 "isolation probe exited early"
             );
             std::thread::sleep(Duration::from_millis(10));
@@ -13972,26 +13999,34 @@ mod tests {
             effective_paths.join("\n")
         );
 
-        let lsof = Command::new("/usr/sbin/lsof")
+        match Command::new("lsof")
             .args(["-p", &child_pid.to_string()])
             .output()
-            .expect("lsof is required for the direct-harness isolation proof");
-        assert!(
-            lsof.status.success(),
-            "lsof could not inspect test child {child_pid}"
-        );
-        let open_files = String::from_utf8_lossy(&lsof.stdout);
-        assert!(
-            !open_files.contains(production_root.to_string_lossy().as_ref()),
-            "unwrapped test child opened production state path:\n{open_files}"
-        );
-        println!(
-            "direct-harness lsof proof: child pid {child_pid} has no open path below {}",
-            production_root.display()
-        );
+        {
+            Ok(lsof) => {
+                assert!(
+                    lsof.status.success(),
+                    "lsof could not inspect test child {child_pid}"
+                );
+                let open_files = String::from_utf8_lossy(&lsof.stdout);
+                assert!(
+                    !open_files.contains(production_root.to_string_lossy().as_ref()),
+                    "unwrapped test child opened production state path:\n{open_files}"
+                );
+                println!(
+                    "direct-harness lsof proof: child pid {child_pid} has no open path below {}",
+                    production_root.display()
+                );
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                println!(
+                    "direct-harness lsof unavailable; effective-path assertions remain the portable proof"
+                );
+            }
+            Err(error) => panic!("failed to invoke lsof for test child {child_pid}: {error}"),
+        }
 
-        fs::write(probe_path.with_extension("release"), []).unwrap();
-        assert!(child.wait().unwrap().success());
+        probe_child.release_and_wait();
         fs::remove_dir_all(probe_root).unwrap();
     }
 
@@ -14006,23 +14041,26 @@ mod tests {
         fs::create_dir_all(&wrapper_root).unwrap();
         let probe_path = probe_root.join("probe");
         let executable = env::current_exe().unwrap();
-        let mut child = Command::new(executable)
-            .args([
-                "--exact",
-                "http::tests::direct_test_harness_without_wrapper_cannot_open_production_state_paths",
-                "--nocapture",
-            ])
-            .env(TEST_ISOLATION_ROOT_ENV, &wrapper_root)
-            .env(DIRECT_HARNESS_PROBE_ENV, &probe_path)
-            .spawn()
-            .unwrap();
+        let mut probe_child = ProbeChild {
+            child: Command::new(executable)
+                .args([
+                    "--exact",
+                    "http::tests::direct_test_harness_without_wrapper_cannot_open_production_state_paths",
+                    "--nocapture",
+                ])
+                .env(TEST_ISOLATION_ROOT_ENV, &wrapper_root)
+                .env(DIRECT_HARNESS_PROBE_ENV, &probe_path)
+                .spawn()
+                .unwrap(),
+            release_path: probe_path.with_extension("release"),
+        };
 
         for _ in 0..500 {
             if probe_path.exists() {
                 break;
             }
             assert!(
-                child.try_wait().unwrap().is_none(),
+                probe_child.child.try_wait().unwrap().is_none(),
                 "wrapper probe exited early"
             );
             std::thread::sleep(Duration::from_millis(10));
@@ -14041,8 +14079,7 @@ mod tests {
             state_file.display()
         );
 
-        fs::write(probe_path.with_extension("release"), []).unwrap();
-        assert!(child.wait().unwrap().success());
+        probe_child.release_and_wait();
         fs::remove_dir_all(probe_root).unwrap();
     }
 
@@ -14062,6 +14099,39 @@ mod tests {
         assert!(error
             .to_string()
             .contains("refuses explicit production path"));
+    }
+
+    #[test]
+    fn test_isolation_rehomes_handler_writable_stores() {
+        let root = test_isolation_root_from_environment().unwrap().unwrap();
+        let state = AppState::try_new(AppConfig::default()).unwrap();
+        let bug_report_path = StdPath::new(&state.config().bug_reports.db_path);
+        let artifact_root = StdPath::new(&state.config().app_artifacts.root_dir);
+        assert!(bug_report_path.starts_with(&root));
+        assert!(artifact_root.starts_with(&root));
+
+        let reports = BugReportStore::new(
+            bug_report_path.to_path_buf(),
+            state.config().bug_reports.max_reports,
+        );
+        let report = reports
+            .create_report(CreateBugReport {
+                report_text: "isolated handler store proof".to_owned(),
+                reported_by: None,
+                selected_session_id: None,
+                route: None,
+                app_version: None,
+                artifact_hash: None,
+                include_debug_state: false,
+                client_state: None,
+                server_state: None,
+            })
+            .unwrap();
+        assert!(reports.report_exists(&report.id).unwrap());
+
+        let artifact =
+            store_artifact(artifact_root, "isolation-proof", b"apk", None, None, None).unwrap();
+        assert!(hashed_path(artifact_root, "isolation-proof", &artifact.artifact_hash).exists());
     }
 
     #[test]

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -13996,6 +13996,57 @@ mod tests {
     }
 
     #[test]
+    fn wrapper_supplied_absolute_root_is_honored_by_default_appstate() {
+        let probe_root = env::temp_dir().join(format!(
+            "sm-wrapper-harness-isolation-{}-{}",
+            process::id(),
+            OffsetDateTime::now_utc().unix_timestamp_nanos()
+        ));
+        let wrapper_root = probe_root.join("wrapper-root");
+        fs::create_dir_all(&wrapper_root).unwrap();
+        let probe_path = probe_root.join("probe");
+        let executable = env::current_exe().unwrap();
+        let mut child = Command::new(executable)
+            .args([
+                "--exact",
+                "http::tests::direct_test_harness_without_wrapper_cannot_open_production_state_paths",
+                "--nocapture",
+            ])
+            .env(TEST_ISOLATION_ROOT_ENV, &wrapper_root)
+            .env(DIRECT_HARNESS_PROBE_ENV, &probe_path)
+            .spawn()
+            .unwrap();
+
+        for _ in 0..500 {
+            if probe_path.exists() {
+                break;
+            }
+            assert!(
+                child.try_wait().unwrap().is_none(),
+                "wrapper probe exited early"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        let probe = fs::read_to_string(&probe_path).unwrap();
+        let mut lines = probe.lines();
+        let child_pid = lines.next().unwrap().parse::<u32>().unwrap();
+        let state_file = StdPath::new(lines.next().unwrap());
+        assert!(
+            state_file.starts_with(&wrapper_root),
+            "wrapper root was ignored: {}",
+            state_file.display()
+        );
+        println!(
+            "wrapper-harness child pid {child_pid} state path {}",
+            state_file.display()
+        );
+
+        fs::write(probe_path.with_extension("release"), []).unwrap();
+        assert!(child.wait().unwrap().success());
+        fs::remove_dir_all(probe_root).unwrap();
+    }
+
+    #[test]
     fn test_harness_rejects_explicit_production_state_before_appstate_startup() {
         let production_state_file = env::var_os("HOME")
             .map(PathBuf::from)

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -13956,16 +13956,21 @@ mod tests {
         let probe = fs::read_to_string(&probe_path).unwrap();
         let mut lines = probe.lines();
         let child_pid = lines.next().unwrap().parse::<u32>().unwrap();
+        let effective_paths: Vec<_> = lines.collect();
         let production_root = env::var_os("HOME")
             .map(PathBuf::from)
             .unwrap()
             .join(".local/share/claude-sessions");
-        for path in lines {
+        for path in &effective_paths {
             assert!(
                 !StdPath::new(path).starts_with(&production_root),
                 "child resolved production durable path {path}"
             );
         }
+        println!(
+            "direct-harness child pid {child_pid} effective durable paths:\n{}",
+            effective_paths.join("\n")
+        );
 
         let lsof = Command::new("/usr/sbin/lsof")
             .args(["-p", &child_pid.to_string()])
@@ -13979,6 +13984,10 @@ mod tests {
         assert!(
             !open_files.contains(production_root.to_string_lossy().as_ref()),
             "unwrapped test child opened production state path:\n{open_files}"
+        );
+        println!(
+            "direct-harness lsof proof: child pid {child_pid} has no open path below {}",
+            production_root.display()
         );
 
         fs::write(probe_path.with_extension("release"), []).unwrap();

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -13906,12 +13906,68 @@ mod tests {
         }
     }
 
+    struct DirectHarnessProbe {
+        pid: u32,
+        isolation_root: PathBuf,
+        effective_paths: Vec<String>,
+    }
+
+    fn spawn_direct_harness_probe(
+        probe_path: &StdPath,
+        isolation_root: Option<&StdPath>,
+    ) -> ProbeChild {
+        let executable = env::current_exe().unwrap();
+        let mut command = Command::new(executable);
+        command
+            .args([
+                "--exact",
+                "http::tests::test_isolation_direct_harness_without_wrapper_cannot_open_production_state_paths",
+                "--nocapture",
+            ])
+            .env(DIRECT_HARNESS_PROBE_ENV, probe_path);
+        if let Some(isolation_root) = isolation_root {
+            command.env(TEST_ISOLATION_ROOT_ENV, isolation_root);
+        } else {
+            command.env_remove(TEST_ISOLATION_ROOT_ENV);
+        }
+        ProbeChild {
+            child: command.spawn().unwrap(),
+            release_path: probe_path.with_extension("release"),
+        }
+    }
+
+    fn wait_for_direct_harness_probe(
+        probe_child: &mut ProbeChild,
+        probe_path: &StdPath,
+    ) -> DirectHarnessProbe {
+        for _ in 0..500 {
+            if probe_path.exists() {
+                break;
+            }
+            assert!(
+                probe_child.child.try_wait().unwrap().is_none(),
+                "isolation probe exited early"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(probe_path.exists(), "isolation probe did not become ready");
+
+        let probe = fs::read_to_string(probe_path).unwrap();
+        let mut lines = probe.lines();
+        DirectHarnessProbe {
+            pid: lines.next().unwrap().parse::<u32>().unwrap(),
+            isolation_root: PathBuf::from(lines.next().unwrap()),
+            effective_paths: lines.map(str::to_owned).collect(),
+        }
+    }
+
     #[test]
-    fn direct_test_harness_without_wrapper_cannot_open_production_state_paths() {
+    fn test_isolation_direct_harness_without_wrapper_cannot_open_production_state_paths() {
         if let Some(probe_path) = env::var_os(DIRECT_HARNESS_PROBE_ENV) {
             let probe_path = PathBuf::from(probe_path);
             let state = AppState::try_new(AppConfig::default()).unwrap();
             let config = state.config();
+            let isolation_root = test_isolation_root_from_environment().unwrap().unwrap();
             let paths = [
                 config.paths.state_file.clone(),
                 config.sm_send.db_path.clone(),
@@ -13932,7 +13988,12 @@ mod tests {
             ];
             fs::write(
                 &probe_path,
-                format!("{}\n{}", process::id(), paths.join("\n")),
+                format!(
+                    "{}\n{}\n{}",
+                    process::id(),
+                    isolation_root.display(),
+                    paths.join("\n")
+                ),
             )
             .unwrap();
 
@@ -13952,61 +14013,47 @@ mod tests {
             OffsetDateTime::now_utc().unix_timestamp_nanos()
         ));
         fs::create_dir_all(&probe_root).unwrap();
-        let probe_path = probe_root.join("probe");
-        let executable = env::current_exe().unwrap();
-        let mut probe_child = ProbeChild {
-            child: Command::new(executable)
-                .args([
-                    "--exact",
-                    "http::tests::direct_test_harness_without_wrapper_cannot_open_production_state_paths",
-                    "--nocapture",
-                ])
-                .env_remove(TEST_ISOLATION_ROOT_ENV)
-                .env(DIRECT_HARNESS_PROBE_ENV, &probe_path)
-                .spawn()
-                .unwrap(),
-            release_path: probe_path.with_extension("release"),
-        };
-
-        for _ in 0..500 {
-            if probe_path.exists() {
-                break;
-            }
-            assert!(
-                probe_child.child.try_wait().unwrap().is_none(),
-                "isolation probe exited early"
-            );
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        assert!(probe_path.exists(), "isolation probe did not become ready");
-
-        let probe = fs::read_to_string(&probe_path).unwrap();
-        let mut lines = probe.lines();
-        let child_pid = lines.next().unwrap().parse::<u32>().unwrap();
-        let effective_paths: Vec<_> = lines.collect();
+        let first_probe_path = probe_root.join("first-probe");
+        let second_probe_path = probe_root.join("second-probe");
+        let mut first_probe_child = spawn_direct_harness_probe(&first_probe_path, None);
+        let mut second_probe_child = spawn_direct_harness_probe(&second_probe_path, None);
+        let first_probe = wait_for_direct_harness_probe(&mut first_probe_child, &first_probe_path);
+        let second_probe =
+            wait_for_direct_harness_probe(&mut second_probe_child, &second_probe_path);
+        assert_ne!(
+            first_probe.isolation_root, second_probe.isolation_root,
+            "separate direct test binaries must not reuse a fallback isolation root"
+        );
         let production_root = env::var_os("HOME")
             .map(PathBuf::from)
             .unwrap()
             .join(".local/share/claude-sessions");
-        for path in &effective_paths {
+        for path in first_probe
+            .effective_paths
+            .iter()
+            .chain(second_probe.effective_paths.iter())
+        {
             assert!(
                 !StdPath::new(path).starts_with(&production_root),
                 "child resolved production durable path {path}"
             );
         }
         println!(
-            "direct-harness child pid {child_pid} effective durable paths:\n{}",
-            effective_paths.join("\n")
+            "direct-harness child pid {} fallback root {} effective durable paths:\n{}",
+            first_probe.pid,
+            first_probe.isolation_root.display(),
+            first_probe.effective_paths.join("\n")
         );
 
         match Command::new("lsof")
-            .args(["-p", &child_pid.to_string()])
+            .args(["-p", &first_probe.pid.to_string()])
             .output()
         {
             Ok(lsof) => {
                 assert!(
                     lsof.status.success(),
-                    "lsof could not inspect test child {child_pid}"
+                    "lsof could not inspect test child {}",
+                    first_probe.pid
                 );
                 let open_files = String::from_utf8_lossy(&lsof.stdout);
                 assert!(
@@ -14014,7 +14061,8 @@ mod tests {
                     "unwrapped test child opened production state path:\n{open_files}"
                 );
                 println!(
-                    "direct-harness lsof proof: child pid {child_pid} has no open path below {}",
+                    "direct-harness lsof proof: child pid {} has no open path below {}",
+                    first_probe.pid,
                     production_root.display()
                 );
             }
@@ -14023,10 +14071,14 @@ mod tests {
                     "direct-harness lsof unavailable; effective-path assertions remain the portable proof"
                 );
             }
-            Err(error) => panic!("failed to invoke lsof for test child {child_pid}: {error}"),
+            Err(error) => panic!(
+                "failed to invoke lsof for test child {}: {error}",
+                first_probe.pid
+            ),
         }
 
-        probe_child.release_and_wait();
+        first_probe_child.release_and_wait();
+        second_probe_child.release_and_wait();
         fs::remove_dir_all(probe_root).unwrap();
     }
 
@@ -14040,42 +14092,17 @@ mod tests {
         let wrapper_root = probe_root.join("wrapper-root");
         fs::create_dir_all(&wrapper_root).unwrap();
         let probe_path = probe_root.join("probe");
-        let executable = env::current_exe().unwrap();
-        let mut probe_child = ProbeChild {
-            child: Command::new(executable)
-                .args([
-                    "--exact",
-                    "http::tests::direct_test_harness_without_wrapper_cannot_open_production_state_paths",
-                    "--nocapture",
-                ])
-                .env(TEST_ISOLATION_ROOT_ENV, &wrapper_root)
-                .env(DIRECT_HARNESS_PROBE_ENV, &probe_path)
-                .spawn()
-                .unwrap(),
-            release_path: probe_path.with_extension("release"),
-        };
-
-        for _ in 0..500 {
-            if probe_path.exists() {
-                break;
-            }
-            assert!(
-                probe_child.child.try_wait().unwrap().is_none(),
-                "wrapper probe exited early"
-            );
-            std::thread::sleep(Duration::from_millis(10));
-        }
-        let probe = fs::read_to_string(&probe_path).unwrap();
-        let mut lines = probe.lines();
-        let child_pid = lines.next().unwrap().parse::<u32>().unwrap();
-        let state_file = StdPath::new(lines.next().unwrap());
+        let mut probe_child = spawn_direct_harness_probe(&probe_path, Some(&wrapper_root));
+        let probe = wait_for_direct_harness_probe(&mut probe_child, &probe_path);
+        let state_file = StdPath::new(probe.effective_paths.first().unwrap());
         assert!(
             state_file.starts_with(&wrapper_root),
             "wrapper root was ignored: {}",
             state_file.display()
         );
         println!(
-            "wrapper-harness child pid {child_pid} state path {}",
+            "wrapper-harness child pid {} state path {}",
+            probe.pid,
             state_file.display()
         );
 

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -92,7 +92,12 @@ use crate::codex_events::{list_codex_events_from_path, CodexEventsResponse};
 use crate::codex_requests::{list_codex_pending_requests_from_path, CodexPendingRequestsResponse};
 #[cfg(test)]
 use crate::config::MobileTerminalDeviceKeyConfig;
-use crate::config::{trimmed, AppConfig, MobileTerminalUserConfig, PublicNodeConfig, UsageConfig};
+#[cfg(test)]
+use crate::config::TEST_ISOLATION_ROOT_ENV;
+use crate::config::{
+    test_isolation_root_from_environment, trimmed, AppConfig, MobileTerminalUserConfig,
+    PublicNodeConfig, UsageConfig,
+};
 use crate::email::{
     extract_reply_message_body, extract_routed_session_id, extract_subject_from_raw_email,
     extract_text_from_raw_email, normalize_explicit_session_id, EmailBridge,
@@ -407,7 +412,10 @@ impl AppState {
         Self::try_new(config).expect("session manager startup recovery failed")
     }
 
-    pub fn try_new(config: AppConfig) -> anyhow::Result<Self> {
+    pub fn try_new(mut config: AppConfig) -> anyhow::Result<Self> {
+        if let Some(root) = test_isolation_root_from_environment()? {
+            config.isolate_test_paths(&root)?;
+        }
         let state_file = expand_home(&config.paths.state_file);
         let queue_db_path = expand_home(&config.sm_send.db_path);
         let mut session_store = SessionStore::new_with_queue(state_file, queue_db_path)
@@ -13871,8 +13879,130 @@ mod tests {
     };
     use rusqlite::Connection;
     use serde::Serialize;
-    use std::{env, process};
+    use std::{env, fs, process};
     use tower::ServiceExt;
+
+    const DIRECT_HARNESS_PROBE_ENV: &str = "SM_DIRECT_HARNESS_ISOLATION_PROBE";
+
+    #[test]
+    fn direct_test_harness_without_wrapper_cannot_open_production_state_paths() {
+        if let Some(probe_path) = env::var_os(DIRECT_HARNESS_PROBE_ENV) {
+            let probe_path = PathBuf::from(probe_path);
+            let state = AppState::try_new(AppConfig::default()).unwrap();
+            let config = state.config();
+            let paths = [
+                config.paths.state_file.clone(),
+                config.sm_send.db_path.clone(),
+                config.mobile_analytics.message_queue_db.clone(),
+                config.tool_logging.db_path.clone(),
+                config.usage.db_path.clone(),
+                config.codex_events.db_path.clone(),
+                config.codex_requests.db_path.clone(),
+                config.codex_observability.db_path.clone(),
+                config.queue_runner.state_dir.clone(),
+                config.mobile_terminal.device_enrollment_db_path.clone(),
+                StdPath::new(&config.paths.state_file)
+                    .with_extension("reparent-apply.lock")
+                    .display()
+                    .to_string(),
+            ];
+            fs::write(
+                &probe_path,
+                format!("{}\n{}", process::id(), paths.join("\n")),
+            )
+            .unwrap();
+
+            let release_path = probe_path.with_extension("release");
+            for _ in 0..500 {
+                if release_path.exists() {
+                    return;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            panic!("direct harness isolation probe was not released");
+        }
+
+        let probe_root = env::temp_dir().join(format!(
+            "sm-direct-harness-isolation-{}-{}",
+            process::id(),
+            OffsetDateTime::now_utc().unix_timestamp_nanos()
+        ));
+        fs::create_dir_all(&probe_root).unwrap();
+        let probe_path = probe_root.join("probe");
+        let executable = env::current_exe().unwrap();
+        let mut child = Command::new(executable)
+            .args([
+                "--exact",
+                "http::tests::direct_test_harness_without_wrapper_cannot_open_production_state_paths",
+                "--nocapture",
+            ])
+            .env_remove(TEST_ISOLATION_ROOT_ENV)
+            .env(DIRECT_HARNESS_PROBE_ENV, &probe_path)
+            .spawn()
+            .unwrap();
+
+        for _ in 0..500 {
+            if probe_path.exists() {
+                break;
+            }
+            assert!(
+                child.try_wait().unwrap().is_none(),
+                "isolation probe exited early"
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(probe_path.exists(), "isolation probe did not become ready");
+
+        let probe = fs::read_to_string(&probe_path).unwrap();
+        let mut lines = probe.lines();
+        let child_pid = lines.next().unwrap().parse::<u32>().unwrap();
+        let production_root = env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap()
+            .join(".local/share/claude-sessions");
+        for path in lines {
+            assert!(
+                !StdPath::new(path).starts_with(&production_root),
+                "child resolved production durable path {path}"
+            );
+        }
+
+        let lsof = Command::new("/usr/sbin/lsof")
+            .args(["-p", &child_pid.to_string()])
+            .output()
+            .expect("lsof is required for the direct-harness isolation proof");
+        assert!(
+            lsof.status.success(),
+            "lsof could not inspect test child {child_pid}"
+        );
+        let open_files = String::from_utf8_lossy(&lsof.stdout);
+        assert!(
+            !open_files.contains(production_root.to_string_lossy().as_ref()),
+            "unwrapped test child opened production state path:\n{open_files}"
+        );
+
+        fs::write(probe_path.with_extension("release"), []).unwrap();
+        assert!(child.wait().unwrap().success());
+        fs::remove_dir_all(probe_root).unwrap();
+    }
+
+    #[test]
+    fn test_harness_rejects_explicit_production_state_before_appstate_startup() {
+        let production_state_file = env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap()
+            .join(".local/share/claude-sessions/explicit-test-state.json");
+        let mut config = AppConfig::default();
+        config.paths.state_file = production_state_file.display().to_string();
+
+        let error = match AppState::try_new(config) {
+            Ok(_) => panic!("test harness accepted an explicit production state file"),
+            Err(error) => error,
+        };
+        assert!(error
+            .to_string()
+            .contains("refuses explicit production path"));
+    }
 
     #[test]
     fn codex_model_validation_errors_have_actionable_http_statuses() {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1959,7 +1959,7 @@ impl SessionStore {
 
         let now = OffsetDateTime::now_utc();
         let mut records = reparent_request_records(&state)?;
-        let _ = refresh_reparent_requests(&mut records, &sessions, now);
+        let _ = refresh_reparent_requests(&mut records, &sessions, &state, now);
         let affected_ids = BTreeSet::from([subject_session_id.to_owned()]);
         if let Some(conflict) = records.iter().find(|record| {
             record.is_active() && !record.affected_session_ids().is_disjoint(&affected_ids)
@@ -2260,7 +2260,7 @@ impl SessionStore {
         };
         let now = OffsetDateTime::now_utc();
         let mut records = reparent_request_records(&state)?;
-        let refreshed = refresh_reparent_requests(&mut records, &sessions, now);
+        let refreshed = refresh_reparent_requests(&mut records, &sessions, &state, now);
         let affected_ids = preview
             .edge_changes
             .iter()
@@ -2390,7 +2390,7 @@ impl SessionStore {
         }
         let mut records = reparent_request_records(&state)?;
         let now = OffsetDateTime::now_utc();
-        let refreshed = refresh_reparent_requests(&mut records, &sessions, now);
+        let refreshed = refresh_reparent_requests(&mut records, &sessions, &state, now);
         let Some(index) = records.iter().position(|record| record.id == request_id) else {
             if refreshed {
                 store_reparent_request_records(&mut state, &records)?;
@@ -2493,7 +2493,7 @@ impl SessionStore {
         let sessions = snapshot_from_raw_value(&state)?.into_sessions();
         let mut records = reparent_request_records(&state)?;
         let now = OffsetDateTime::now_utc();
-        let refreshed = refresh_reparent_requests(&mut records, &sessions, now);
+        let refreshed = refresh_reparent_requests(&mut records, &sessions, &state, now);
         let Some(index) = records.iter().position(|record| record.id == request_id) else {
             if refreshed {
                 store_reparent_request_records(&mut state, &records)?;
@@ -2572,7 +2572,7 @@ impl SessionStore {
         let mut state = self.load_raw_json_value()?;
         let sessions = snapshot_from_raw_value(&state)?.into_sessions();
         let mut records = reparent_request_records(&state)?;
-        if refresh_reparent_requests(&mut records, &sessions, OffsetDateTime::now_utc()) {
+        if refresh_reparent_requests(&mut records, &sessions, &state, OffsetDateTime::now_utc()) {
             store_reparent_request_records(&mut state, &records)?;
             self.write_raw_json_value(&state)?;
         }
@@ -2586,7 +2586,7 @@ impl SessionStore {
         let mut state = self.load_raw_json_value()?;
         let sessions = snapshot_from_raw_value(&state)?.into_sessions();
         let mut records = reparent_request_records(&state)?;
-        if refresh_reparent_requests(&mut records, &sessions, OffsetDateTime::now_utc()) {
+        if refresh_reparent_requests(&mut records, &sessions, &state, OffsetDateTime::now_utc()) {
             store_reparent_request_records(&mut state, &records)?;
             self.write_raw_json_value(&state)?;
         }
@@ -2609,7 +2609,7 @@ impl SessionStore {
             return Ok(None);
         }
         let mut records = reparent_request_records(&state)?;
-        if refresh_reparent_requests(&mut records, &sessions, OffsetDateTime::now_utc()) {
+        if refresh_reparent_requests(&mut records, &sessions, &state, OffsetDateTime::now_utc()) {
             store_reparent_request_records(&mut state, &records)?;
             self.write_raw_json_value(&state)?;
         }
@@ -2719,8 +2719,12 @@ impl SessionStore {
             let mut state = self.load_raw_json_value()?;
             let sessions = snapshot_from_raw_value(&state)?.into_sessions();
             let mut records = reparent_request_records(&state)?;
-            let refreshed =
-                refresh_reparent_requests(&mut records, &sessions, OffsetDateTime::now_utc());
+            let refreshed = refresh_reparent_requests(
+                &mut records,
+                &sessions,
+                &state,
+                OffsetDateTime::now_utc(),
+            );
             let mut changed = refreshed;
             for record in &mut records {
                 let desired = desired_reparent_notifications(record);
@@ -3036,7 +3040,8 @@ impl SessionStore {
         }
         let sessions = snapshot_from_raw_value(&state)?.into_sessions();
         let mut records = reparent_request_records(&state)?;
-        let _ = refresh_reparent_requests(&mut records, &sessions, OffsetDateTime::now_utc());
+        let _ =
+            refresh_reparent_requests(&mut records, &sessions, &state, OffsetDateTime::now_utc());
         let Some(index) = records
             .iter()
             .enumerate()
@@ -3054,7 +3059,7 @@ impl SessionStore {
             self.write_raw_json_value(&state)?;
             return Ok(None);
         };
-        if let Some(reason) = reparent_stale_reason(&records[index], &sessions) {
+        if let Some(reason) = reparent_stale_reason(&records[index], &sessions, &state) {
             records[index].status = "stale".to_owned();
             records[index].ready_to_apply = false;
             records[index].failure_reason = Some(reason);
@@ -3289,7 +3294,7 @@ impl SessionStore {
             .clone()
             .context("reparent apply plan is missing")?;
         let sessions = snapshot_from_raw_value(&state)?.into_sessions();
-        if let Some(reason) = reparent_stale_reason(record, &sessions) {
+        if let Some(reason) = reparent_stale_reason(record, &sessions, &state) {
             anyhow::bail!("reparent request became stale before quiesce: {reason}");
         }
         quiesce_json_reparent_routes(&mut state, &plan)?;
@@ -3338,7 +3343,7 @@ impl SessionStore {
             .clone()
             .context("reparent apply plan is missing")?;
         let sessions = snapshot_from_raw_value(&state)?.into_sessions();
-        if let Some(reason) = reparent_stale_reason(record, &sessions) {
+        if let Some(reason) = reparent_stale_reason(record, &sessions, &state) {
             return Ok(Some(reason));
         }
         commit_json_reparent_plan(&mut state, &plan)?;
@@ -13372,6 +13377,7 @@ fn approvals_satisfied(
 fn refresh_reparent_requests(
     records: &mut [ReparentRequestRecord],
     sessions: &[SessionRecord],
+    state: &Value,
     now: OffsetDateTime,
 ) -> bool {
     let mut changed = false;
@@ -13407,7 +13413,7 @@ fn refresh_reparent_requests(
             }
             _ => {}
         }
-        if let Some(reason) = reparent_stale_reason(record, sessions) {
+        if let Some(reason) = reparent_stale_reason(record, sessions, state) {
             if let Some(winner) = superseded_by_request_id {
                 record.status = "superseded".to_owned();
                 record.superseded_by_request_id = Some(winner.clone());
@@ -13449,6 +13455,7 @@ fn reparent_request_supersedes(
 fn reparent_stale_reason(
     record: &ReparentRequestRecord,
     sessions: &[SessionRecord],
+    state: &Value,
 ) -> Option<String> {
     let expected_fingerprint = reparent_topology_fingerprint(
         &record.kind,
@@ -13541,6 +13548,25 @@ fn reparent_stale_reason(
                     "stopped-root request lacks durable maintainer authorization binding"
                         .to_owned(),
                 );
+            }
+            match find_raw_registration(state, "maintainer") {
+                Ok(Some(maintainer)) if maintainer.session_id == target_parent_id => {}
+                Ok(Some(_)) => {
+                    return Some(
+                        "durable maintainer registration changed after request creation".to_owned(),
+                    );
+                }
+                Ok(None) => {
+                    return Some(
+                        "durable maintainer registration disappeared after request creation"
+                            .to_owned(),
+                    );
+                }
+                Err(_) => {
+                    return Some(
+                        "durable maintainer registration could not be revalidated".to_owned(),
+                    );
+                }
             }
             if sessions.iter().any(|session| {
                 session.parent_session_id.as_deref()
@@ -21158,6 +21184,63 @@ mod tests {
                 .as_deref(),
             Some("maintainer")
         );
+        let _ = fs::remove_file(state_file);
+    }
+
+    #[test]
+    fn stopped_root_recovery_stales_on_maintainer_reassignment_without_edges() {
+        let (store, state_file) = stopped_root_recovery_store("maintainer-reassignment");
+        let request = match store
+            .create_reparent_tree_request(
+                "outgoing",
+                CreateReparentTreeRequest {
+                    requester_session_id: "successor".to_owned(),
+                    target_session_id: "successor".to_owned(),
+                    dry_run: false,
+                },
+                "successor-secret",
+            )
+            .unwrap()
+        {
+            ReparentMutationOutcome::Created(record) => record,
+            other => panic!("unexpected create outcome: {other:?}"),
+        };
+        {
+            let _guard = store.write_guard().unwrap();
+            let mut state = store.load_raw_json_value().unwrap();
+            state["agent_registrations"] = json!([{
+                "role": "maintainer",
+                "session_id": "replacement-maintainer",
+                "created_at": now_rfc3339(),
+            }]);
+            store.write_raw_json_value(&state).unwrap();
+        }
+        let stale = store.get_reparent_request(&request.id).unwrap().unwrap();
+        assert_eq!(stale.status, "stale");
+        assert_eq!(
+            stale.failure_reason.as_deref(),
+            Some("durable maintainer registration changed after request creation")
+        );
+        assert_eq!(
+            store
+                .get_session("successor")
+                .unwrap()
+                .unwrap()
+                .parent_session_id
+                .as_deref(),
+            Some("maintainer")
+        );
+        for session_id in ["outgoing", "worker-a", "worker-b"] {
+            assert_eq!(
+                store
+                    .get_session(session_id)
+                    .unwrap()
+                    .unwrap()
+                    .parent_session_id
+                    .as_deref(),
+                Some("outgoing")
+            );
+        }
         let _ = fs::remove_file(state_file);
     }
 

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -32,7 +32,7 @@ use crate::queue::{
 };
 use crate::{
     btw::BtwStore,
-    config::{CodexReviewConfig, ContextMonitorConfig},
+    config::{test_isolation_root_from_environment, CodexReviewConfig, ContextMonitorConfig},
     runtime::{ConditionalClearOutcome, TmuxRuntime, TmuxSessionSpec},
     seat_sessions::{SeatSessionIdentity, SeatSessionStore},
     usage_burn::UsageBurnStore,
@@ -177,6 +177,8 @@ impl Drop for SessionClearGuard {
 
 impl SessionStore {
     pub fn new(state_file: PathBuf) -> Self {
+        let test_isolation_root =
+            test_isolation_root_from_environment().expect("invalid Rust test isolation root");
         let legacy_state_file = if state_file == expand_home(DEFAULT_SESSION_STATE_FILE) {
             Some(PathBuf::from(LEGACY_TMP_SESSION_STATE_FILE))
         } else {
@@ -186,8 +188,14 @@ impl SessionStore {
         Self {
             state_file,
             legacy_state_file,
-            codex_sessions_root: expand_home("~/.codex/sessions"),
-            claude_projects_roots: claude_projects_roots(None),
+            codex_sessions_root: test_isolation_root
+                .as_ref()
+                .map(|root| root.join("codex-sessions"))
+                .unwrap_or_else(|| expand_home("~/.codex/sessions")),
+            claude_projects_roots: test_isolation_root
+                .as_ref()
+                .map(|root| vec![root.join("claude-projects")])
+                .unwrap_or_else(|| claude_projects_roots(None)),
             write_lock: Arc::new(Mutex::new(())),
             reparent_apply_lock: Arc::new(Mutex::new(())),
             queue_store: None,
@@ -507,15 +515,43 @@ impl SessionStore {
             .filter(|value| !value.is_empty())
         {
             let session_index_path = expand_home(session_index_path);
-            if let Some(parent) = session_index_path.parent() {
-                self.codex_sessions_root = parent.join("sessions");
+            let test_root =
+                test_isolation_root_from_environment().expect("invalid Rust test isolation root");
+            // Test launchers may retain explicit fixture indexes outside HOME,
+            // but must never resolve the developer's live Codex index.
+            let is_live_home_path = env::var_os("HOME")
+                .is_some_and(|home| session_index_path.starts_with(PathBuf::from(home)));
+            if !test_root.is_some() || !is_live_home_path {
+                if let Some(parent) = session_index_path.parent() {
+                    self.codex_sessions_root = parent.join("sessions");
+                }
             }
         }
         self
     }
 
     pub fn with_claude_transcript_root(mut self, transcript_root: Option<&str>) -> Self {
-        self.claude_projects_roots = claude_projects_roots(transcript_root);
+        if let Some(root) =
+            test_isolation_root_from_environment().expect("invalid Rust test isolation root")
+        {
+            // `claude_projects_roots(None)` normally includes CLAUDE_CONFIG_DIR,
+            // XDG_CONFIG_HOME, and HOME. A test process must not scan any of
+            // those external roots, even after AppState applies its config. A
+            // deliberately supplied fixture root outside HOME remains usable.
+            let configured_root = transcript_root
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(expand_home);
+            let configured_under_home = configured_root.as_ref().is_some_and(|path| {
+                env::var_os("HOME").is_some_and(|home| path.starts_with(PathBuf::from(home)))
+            });
+            self.claude_projects_roots = match configured_root {
+                Some(path) if !configured_under_home => vec![path],
+                _ => vec![root.join("claude-projects")],
+            };
+        } else {
+            self.claude_projects_roots = claude_projects_roots(transcript_root);
+        }
         self
     }
 
@@ -1396,12 +1432,20 @@ impl SessionStore {
 
     #[cfg(test)]
     fn new_with_legacy_fallback(state_file: PathBuf, legacy_state_file: PathBuf) -> Self {
+        let test_isolation_root =
+            test_isolation_root_from_environment().expect("invalid Rust test isolation root");
         let seat_session_store = SeatSessionStore::for_state_file(&state_file);
         Self {
             state_file,
             legacy_state_file: Some(legacy_state_file),
-            codex_sessions_root: expand_home("~/.codex/sessions"),
-            claude_projects_roots: claude_projects_roots(None),
+            codex_sessions_root: test_isolation_root
+                .as_ref()
+                .map(|root| root.join("codex-sessions"))
+                .unwrap_or_else(|| expand_home("~/.codex/sessions")),
+            claude_projects_roots: test_isolation_root
+                .as_ref()
+                .map(|root| vec![root.join("claude-projects")])
+                .unwrap_or_else(|| claude_projects_roots(None)),
             write_lock: Arc::new(Mutex::new(())),
             reparent_apply_lock: Arc::new(Mutex::new(())),
             queue_store: None,

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1989,7 +1989,9 @@ impl SessionStore {
             subject_session_id,
             target_parent_session_id,
             expected_parent_session_id.as_deref(),
+            None,
             &[],
+            false,
             false,
         );
         let approvals = vec![ReparentApprovalRecord {
@@ -2010,8 +2012,12 @@ impl SessionStore {
             target_parent_session_id: target_parent_session_id.to_owned(),
             expected_parent_session_id,
             expected_parent_is_live,
+            expected_target_parent_session_id: None,
+            expected_target_parent_is_live: false,
+            stopped_root_authorized_maintainer_session_id: None,
             detach_non_live_parent: false,
             peer_root_succession: false,
+            stopped_root_recovery: false,
             frozen_live_child_ids: Vec::new(),
             initiator_session_id: requester_session_id.to_owned(),
             required_agent_approvals,
@@ -2081,13 +2087,14 @@ impl SessionStore {
             ));
         };
         let mut blockers = Vec::new();
-        if !source.is_live_for_registry() {
+        let stopped_root_recovery = stopped_root_recovery_source_eligible(source);
+        if !source.is_live_for_registry() && !stopped_root_recovery {
             blockers.push(format!("source session {source_session_id} is stopped"));
         }
         if !target.is_live_for_registry() {
             blockers.push(format!("target session {target_session_id} is stopped"));
         }
-        if !session_supports_reparent_consent(source) {
+        if !stopped_root_recovery && !session_supports_reparent_consent(source) {
             blockers.push(format!(
                 "source session {source_session_id} cannot participate in credential-bound consent"
             ));
@@ -2098,14 +2105,16 @@ impl SessionStore {
             ));
         }
         let target_is_direct_child = target.parent_session_id.as_deref() == Some(source_session_id);
-        let peer_root_succession =
-            source.parent_session_id.is_none() && target.parent_session_id.is_none();
-        if !target_is_direct_child && !peer_root_succession {
+        let peer_root_succession = !stopped_root_recovery
+            && source.parent_session_id.is_none()
+            && target.parent_session_id.is_none();
+        if !stopped_root_recovery && !target_is_direct_child && !peer_root_succession {
             blockers.push(format!(
                 "target session {target_session_id} must be a live direct child of {source_session_id}, or both source and target must be roots for peer-root succession"
             ));
         }
         let expected_parent_session_id = source.parent_session_id.clone();
+        let expected_target_parent_session_id = target.parent_session_id.clone();
         let expected_parent_is_live = expected_parent_session_id.as_deref().is_some_and(|id| {
             sessions
                 .iter()
@@ -2124,10 +2133,69 @@ impl SessionStore {
                 ));
             }
         }
-        let initiator_allowed = requester_session_id == source_session_id
-            || requester_session_id == target_session_id
-            || (expected_parent_is_live
-                && expected_parent_session_id.as_deref() == Some(requester_session_id));
+        let expected_target_parent = expected_target_parent_session_id
+            .as_deref()
+            .and_then(|id| sessions.iter().find(|session| session.id == id));
+        let expected_target_parent_is_live =
+            expected_target_parent.is_some_and(SessionRecord::is_live_for_registry);
+        let stopped_root_authorized_maintainer_session_id = if stopped_root_recovery {
+            match expected_target_parent {
+                Some(target_parent) => {
+                    if !target_parent.is_live_for_registry()
+                        || !session_supports_reparent_consent(target_parent)
+                    {
+                        blockers.push(format!(
+                            "current target parent session {} cannot participate in credential-bound consent",
+                            target_parent.id
+                        ));
+                    }
+                    let maintainer = find_raw_registration(&state, "maintainer")?;
+                    match maintainer {
+                        Some(maintainer) if maintainer.session_id == target_parent.id => {
+                            Some(maintainer.session_id)
+                        }
+                        Some(_) => {
+                            blockers.push(
+                                "current target parent is not the durable maintainer".to_owned(),
+                            );
+                            None
+                        }
+                        None => {
+                            blockers.push(
+                                "stopped-root recovery requires a durable maintainer registration"
+                                    .to_owned(),
+                            );
+                            None
+                        }
+                    }
+                }
+                None => {
+                    blockers.push(
+                        "stopped-root recovery requires a live current target parent".to_owned(),
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        if stopped_root_recovery
+            && sessions
+                .iter()
+                .any(|session| session.parent_session_id.as_deref() == Some(target_session_id))
+        {
+            blockers.push(format!(
+                "stopped-root recovery requires target session {target_session_id} to have no existing children"
+            ));
+        }
+        let initiator_allowed = if stopped_root_recovery {
+            requester_session_id == target_session_id
+        } else {
+            requester_session_id == source_session_id
+                || requester_session_id == target_session_id
+                || (expected_parent_is_live
+                    && expected_parent_session_id.as_deref() == Some(requester_session_id))
+        };
         if !initiator_allowed {
             return Ok(ReparentMutationOutcome::Forbidden(
                 "only the source, target, or live source parent may request tree promotion"
@@ -2150,18 +2218,27 @@ impl SessionStore {
             target_session_id,
             expected_parent_session_id.as_deref(),
             target_parent_session_id,
+            expected_target_parent_session_id.as_deref(),
             &frozen_live_child_ids,
             peer_root_succession,
+            stopped_root_recovery,
         );
         if reparent_plan_would_create_cycle(&sessions, &edge_changes) {
             blockers.push("tree promotion would create a session hierarchy cycle".to_owned());
         }
         let (json_routing_changes, queue_routing_changes) =
             self.build_reparent_routing_changes(&state, &edge_changes)?;
-        let mut required_agent_approvals =
-            BTreeSet::from([source_session_id.to_owned(), target_session_id.to_owned()]);
+        let mut required_agent_approvals = BTreeSet::from([target_session_id.to_owned()]);
+        if !stopped_root_recovery {
+            required_agent_approvals.insert(source_session_id.to_owned());
+        }
         if expected_parent_is_live {
             if let Some(parent) = expected_parent_session_id.as_ref() {
+                required_agent_approvals.insert(parent.clone());
+            }
+        }
+        if stopped_root_recovery {
+            if let Some(parent) = expected_target_parent_session_id.as_ref() {
                 required_agent_approvals.insert(parent.clone());
             }
         }
@@ -2172,6 +2249,7 @@ impl SessionStore {
             source_session_id: source_session_id.to_owned(),
             target_session_id: target_session_id.to_owned(),
             peer_root_succession,
+            stopped_root_recovery,
             frozen_live_child_ids: frozen_live_child_ids.clone(),
             edge_changes,
             json_routing_changes,
@@ -2188,36 +2266,17 @@ impl SessionStore {
             .iter()
             .map(|change| change.session_id.clone())
             .chain(expected_parent_session_id.iter().cloned())
+            .chain(expected_target_parent_session_id.iter().cloned())
             .collect::<BTreeSet<_>>();
         let active_conflict = records.iter().find(|record| {
             record.is_active() && !record.affected_session_ids().is_disjoint(&affected_ids)
         });
-        if request.dry_run {
-            let mut preview = preview;
-            if let Some(conflict) = active_conflict {
-                let overlapping_session = if affected_ids.contains(&conflict.subject_session_id) {
-                    conflict.subject_session_id.clone()
-                } else {
-                    conflict
-                        .affected_session_ids()
-                        .intersection(&affected_ids)
-                        .next()
-                        .cloned()
-                        .unwrap_or_else(|| "unknown".to_owned())
-                };
-                preview.blockers.push(format!(
-                    "request {} already controls session {} in the tree promotion",
-                    conflict.id, overlapping_session
-                ));
-            }
+        if let Some(blocker) = blockers.first() {
             if refreshed {
                 store_reparent_request_records(&mut state, &records)?;
                 self.write_raw_json_value(&state)?;
             }
-            return Ok(ReparentMutationOutcome::Preview(preview));
-        }
-        if let Some(blocker) = blockers.into_iter().next() {
-            return Ok(ReparentMutationOutcome::BadRequest(blocker));
+            return Ok(ReparentMutationOutcome::BadRequest(blocker.clone()));
         }
         if let Some(conflict) = active_conflict {
             let overlapping_session = if affected_ids.contains(&conflict.subject_session_id) {
@@ -2237,6 +2296,13 @@ impl SessionStore {
                 conflict.id, overlapping_session
             )));
         }
+        if request.dry_run {
+            if refreshed {
+                store_reparent_request_records(&mut state, &records)?;
+                self.write_raw_json_value(&state)?;
+            }
+            return Ok(ReparentMutationOutcome::Preview(preview));
+        }
         let created_at = now.format(&Rfc3339)?;
         let expires_at =
             (now + TimeDuration::hours(REPARENT_REQUEST_TTL_HOURS)).format(&Rfc3339)?;
@@ -2253,7 +2319,11 @@ impl SessionStore {
             target_parent_session_id: target_session_id.to_owned(),
             expected_parent_session_id,
             expected_parent_is_live,
+            expected_target_parent_session_id,
+            expected_target_parent_is_live,
+            stopped_root_authorized_maintainer_session_id,
             detach_non_live_parent: true,
+            stopped_root_recovery,
             frozen_live_child_ids,
             initiator_session_id: requester_session_id.to_owned(),
             required_agent_approvals: required_agent_approvals.clone(),
@@ -2276,8 +2346,10 @@ impl SessionStore {
                 source_session_id,
                 target_session_id,
                 source.parent_session_id.as_deref(),
+                target.parent_session_id.as_deref(),
                 &preview.frozen_live_child_ids,
                 peer_root_succession,
+                stopped_root_recovery,
             ),
             peer_root_succession,
             apply_stage: None,
@@ -3021,8 +3093,10 @@ impl SessionStore {
                 &record.target_parent_session_id,
                 record.expected_parent_session_id.as_deref(),
                 tree_target_parent_session_id(record),
+                record.expected_target_parent_session_id.as_deref(),
                 &record.frozen_live_child_ids,
                 record.peer_root_succession,
+                record.stopped_root_recovery,
             )
         } else {
             vec![ReparentEdgeChange {
@@ -13245,8 +13319,10 @@ fn reparent_topology_fingerprint(
     subject_session_id: &str,
     target_parent_session_id: &str,
     expected_parent_session_id: Option<&str>,
+    expected_target_parent_session_id: Option<&str>,
     frozen_live_child_ids: &[String],
     peer_root_succession: bool,
+    stopped_root_recovery: bool,
 ) -> String {
     let mut children = frozen_live_child_ids.to_vec();
     children.sort();
@@ -13261,6 +13337,14 @@ fn reparent_topology_fingerprint(
     // persisted fingerprints remain valid across this schema extension.
     if peer_root_succession {
         canonical["tree_mode"] = Value::String("peer_root_succession".to_owned());
+    }
+    if stopped_root_recovery {
+        canonical["tree_mode"] = Value::String("stopped_root_recovery".to_owned());
+        canonical["expected_target_parent_session_id"] = Value::String(
+            expected_target_parent_session_id
+                .unwrap_or_default()
+                .to_owned(),
+        );
     }
     let digest = Sha256::digest(serde_json::to_vec(&canonical).unwrap_or_default());
     digest.iter().map(|byte| format!("{byte:02x}")).collect()
@@ -13371,8 +13455,10 @@ fn reparent_stale_reason(
         &record.subject_session_id,
         &record.target_parent_session_id,
         record.expected_parent_session_id.as_deref(),
+        record.expected_target_parent_session_id.as_deref(),
         &record.frozen_live_child_ids,
         record.peer_root_succession,
+        record.stopped_root_recovery,
     );
     if record.topology_fingerprint != expected_fingerprint {
         return Some("stored topology fingerprint does not match the request plan".to_owned());
@@ -13383,7 +13469,13 @@ fn reparent_stale_reason(
     else {
         return Some("subject session no longer exists".to_owned());
     };
-    if !subject.is_live_for_registry() {
+    if record.stopped_root_recovery {
+        if !stopped_root_recovery_source_eligible(subject) {
+            return Some(
+                "stopped-root predecessor terminal state changed after request creation".to_owned(),
+            );
+        }
+    } else if !subject.is_live_for_registry() {
         return Some("subject session is no longer live".to_owned());
     }
     if subject.parent_session_id != record.expected_parent_session_id {
@@ -13412,7 +13504,53 @@ fn reparent_stale_reason(
         return Some("target parent session is no longer live".to_owned());
     }
     if record.kind == "tree" {
-        if record.peer_root_succession {
+        if record.stopped_root_recovery {
+            if target.parent_session_id != record.expected_target_parent_session_id {
+                return Some(
+                    "stopped-root successor parent changed after request creation".to_owned(),
+                );
+            }
+            if !record.expected_target_parent_is_live {
+                return Some(
+                    "stopped-root successor did not have a live parent at request creation"
+                        .to_owned(),
+                );
+            }
+            let Some(target_parent_id) = record.expected_target_parent_session_id.as_deref() else {
+                return Some(
+                    "stopped-root successor parent is missing from request plan".to_owned(),
+                );
+            };
+            let Some(target_parent) = sessions
+                .iter()
+                .find(|session| session.id == target_parent_id)
+            else {
+                return Some("stopped-root successor parent no longer exists".to_owned());
+            };
+            if !target_parent.is_live_for_registry()
+                || !session_supports_reparent_consent(target_parent)
+            {
+                return Some("stopped-root successor parent can no longer consent".to_owned());
+            }
+            if record
+                .stopped_root_authorized_maintainer_session_id
+                .as_deref()
+                != Some(target_parent_id)
+            {
+                return Some(
+                    "stopped-root request lacks durable maintainer authorization binding"
+                        .to_owned(),
+                );
+            }
+            if sessions.iter().any(|session| {
+                session.parent_session_id.as_deref()
+                    == Some(record.target_parent_session_id.as_str())
+            }) {
+                return Some(
+                    "stopped-root successor gained children after request creation".to_owned(),
+                );
+            }
+        } else if record.peer_root_succession {
             if target.parent_session_id.is_some() {
                 return Some("peer-root successor is no longer a root".to_owned());
             }
@@ -13436,8 +13574,10 @@ fn reparent_stale_reason(
             &record.target_parent_session_id,
             record.expected_parent_session_id.as_deref(),
             tree_target_parent_session_id(record),
+            record.expected_target_parent_session_id.as_deref(),
             &record.frozen_live_child_ids,
             record.peer_root_succession,
+            record.stopped_root_recovery,
         );
         if reparent_plan_would_create_cycle(sessions, &changes) {
             return Some("current tree plan would create a hierarchy cycle".to_owned());
@@ -13457,11 +13597,19 @@ fn tree_reparent_edge_changes(
     target_session_id: &str,
     expected_source_parent_session_id: Option<&str>,
     target_parent_session_id: Option<&str>,
+    expected_target_parent_session_id: Option<&str>,
     frozen_live_child_ids: &[String],
     peer_root_succession: bool,
+    stopped_root_recovery: bool,
 ) -> Vec<ReparentEdgeChange> {
     let mut changes = Vec::new();
-    if !peer_root_succession {
+    if stopped_root_recovery {
+        changes.push(ReparentEdgeChange {
+            session_id: target_session_id.to_owned(),
+            expected_parent_session_id: expected_target_parent_session_id.map(ToOwned::to_owned),
+            new_parent_session_id: None,
+        });
+    } else if !peer_root_succession {
         changes.push(ReparentEdgeChange {
             session_id: target_session_id.to_owned(),
             expected_parent_session_id: Some(source_session_id.to_owned()),
@@ -13484,6 +13632,13 @@ fn tree_reparent_edge_changes(
             }),
     );
     changes
+}
+
+/// The predecessor-side eligibility rule is deliberately shared by planning
+/// and commit freshness checks: a recovery can never silently widen to a live
+/// source or to a stopped non-root.
+fn stopped_root_recovery_source_eligible(source: &SessionRecord) -> bool {
+    source.is_stopped() && source.parent_session_id.is_none()
 }
 
 fn tree_target_parent_session_id(record: &ReparentRequestRecord) -> Option<&str> {
@@ -13860,6 +14015,7 @@ pub struct ReparentTreePreview {
     pub source_session_id: String,
     pub target_session_id: String,
     pub peer_root_succession: bool,
+    pub stopped_root_recovery: bool,
     pub frozen_live_child_ids: Vec<String>,
     pub edge_changes: Vec<ReparentEdgeChange>,
     pub json_routing_changes: Vec<ReparentRoutingChange>,
@@ -14076,8 +14232,10 @@ fn reparent_edge_summary(record: &ReparentRequestRecord) -> String {
                     &record.target_parent_session_id,
                     record.expected_parent_session_id.as_deref(),
                     tree_target_parent_session_id(record),
+                    record.expected_target_parent_session_id.as_deref(),
                     &record.frozen_live_child_ids,
                     record.peer_root_succession,
+                    record.stopped_root_recovery,
                 )
             } else {
                 vec![ReparentEdgeChange {
@@ -14137,11 +14295,21 @@ pub struct ReparentRequestRecord {
     #[serde(default)]
     pub expected_parent_is_live: bool,
     #[serde(default)]
+    pub expected_target_parent_session_id: Option<String>,
+    #[serde(default)]
+    pub expected_target_parent_is_live: bool,
+    #[serde(default)]
+    pub stopped_root_authorized_maintainer_session_id: Option<String>,
+    #[serde(default)]
     pub detach_non_live_parent: bool,
     /// A root-to-root succession does not move the successor upward; it moves
     /// the outgoing root and its frozen children underneath that peer root.
     #[serde(default)]
     pub peer_root_succession: bool,
+    /// A stopped root may only be recovered beneath an authorized live
+    /// successor whose durable maintainer parent approves its detachment.
+    #[serde(default)]
+    pub stopped_root_recovery: bool,
     #[serde(default)]
     pub frozen_live_child_ids: Vec<String>,
     pub initiator_session_id: String,
@@ -14261,6 +14429,9 @@ impl ReparentRequestRecord {
         affected.insert(self.subject_session_id.clone());
         affected.insert(self.target_parent_session_id.clone());
         if let Some(parent_id) = self.expected_parent_session_id.as_ref() {
+            affected.insert(parent_id.clone());
+        }
+        if let Some(parent_id) = self.expected_target_parent_session_id.as_ref() {
             affected.insert(parent_id.clone());
         }
         if let Some(plan) = self.apply_plan.as_ref() {
@@ -20802,6 +20973,345 @@ mod tests {
     }
 
     #[test]
+    fn stopped_root_recovery_has_exact_preview_apply_parity_and_post_state() {
+        let (store, state_file) = stopped_root_recovery_store("exact-parity");
+        let preview = match store
+            .create_reparent_tree_request(
+                "outgoing",
+                CreateReparentTreeRequest {
+                    requester_session_id: "successor".to_owned(),
+                    target_session_id: "successor".to_owned(),
+                    dry_run: true,
+                },
+                "successor-secret",
+            )
+            .unwrap()
+        {
+            ReparentMutationOutcome::Preview(preview) => preview,
+            other => panic!("unexpected preview outcome: {other:?}"),
+        };
+        assert!(preview.stopped_root_recovery);
+        assert!(preview.blockers.is_empty());
+        assert_eq!(
+            preview.edge_changes,
+            vec![
+                ReparentEdgeChange {
+                    session_id: "successor".to_owned(),
+                    expected_parent_session_id: Some("maintainer".to_owned()),
+                    new_parent_session_id: None,
+                },
+                ReparentEdgeChange {
+                    session_id: "outgoing".to_owned(),
+                    expected_parent_session_id: None,
+                    new_parent_session_id: Some("successor".to_owned()),
+                },
+                ReparentEdgeChange {
+                    session_id: "worker-a".to_owned(),
+                    expected_parent_session_id: Some("outgoing".to_owned()),
+                    new_parent_session_id: Some("successor".to_owned()),
+                },
+                ReparentEdgeChange {
+                    session_id: "worker-b".to_owned(),
+                    expected_parent_session_id: Some("outgoing".to_owned()),
+                    new_parent_session_id: Some("successor".to_owned()),
+                },
+            ]
+        );
+
+        let request = match store
+            .create_reparent_tree_request(
+                "outgoing",
+                CreateReparentTreeRequest {
+                    requester_session_id: "successor".to_owned(),
+                    target_session_id: "successor".to_owned(),
+                    dry_run: false,
+                },
+                "successor-secret",
+            )
+            .unwrap()
+        {
+            ReparentMutationOutcome::Created(record) => record,
+            other => panic!("unexpected create outcome: {other:?}"),
+        };
+        assert!(request.stopped_root_recovery);
+        assert_eq!(
+            request.expected_target_parent_session_id.as_deref(),
+            Some("maintainer")
+        );
+        assert_eq!(
+            request.required_agent_approvals,
+            vec!["maintainer", "successor"]
+        );
+        assert!(!request.ready_to_apply);
+        let applied = store
+            .decide_reparent_request(
+                &request.id,
+                DecideReparentRequest {
+                    requester_session_id: "maintainer".to_owned(),
+                },
+                ReparentDecision::Approved,
+                "maintainer-secret",
+            )
+            .unwrap();
+        let ReparentMutationOutcome::Updated(applied) = applied else {
+            panic!("unexpected approval outcome");
+        };
+        assert_eq!(applied.status, "applied");
+        assert_eq!(
+            applied.apply_plan.unwrap().edge_changes,
+            preview.edge_changes
+        );
+        assert_eq!(
+            store
+                .get_session("successor")
+                .unwrap()
+                .unwrap()
+                .parent_session_id,
+            None
+        );
+        for session_id in ["outgoing", "worker-a", "worker-b"] {
+            assert_eq!(
+                store
+                    .get_session(session_id)
+                    .unwrap()
+                    .unwrap()
+                    .parent_session_id
+                    .as_deref(),
+                Some("successor")
+            );
+        }
+        assert_eq!(
+            store
+                .get_session("stopped-worker")
+                .unwrap()
+                .unwrap()
+                .parent_session_id
+                .as_deref(),
+            Some("outgoing")
+        );
+        let _ = fs::remove_file(state_file);
+    }
+
+    #[test]
+    fn stopped_root_recovery_fails_closed_for_changed_children_and_pending_conflict() {
+        let (store, state_file) = stopped_root_recovery_store("stale-and-conflict");
+        let request = match store
+            .create_reparent_tree_request(
+                "outgoing",
+                CreateReparentTreeRequest {
+                    requester_session_id: "successor".to_owned(),
+                    target_session_id: "successor".to_owned(),
+                    dry_run: false,
+                },
+                "successor-secret",
+            )
+            .unwrap()
+        {
+            ReparentMutationOutcome::Created(record) => record,
+            other => panic!("unexpected create outcome: {other:?}"),
+        };
+        assert!(matches!(
+            store
+                .create_reparent_tree_request(
+                    "outgoing",
+                    CreateReparentTreeRequest {
+                        requester_session_id: "successor".to_owned(),
+                        target_session_id: "successor".to_owned(),
+                        dry_run: false,
+                    },
+                    "successor-secret",
+                )
+                .unwrap(),
+            ReparentMutationOutcome::Conflict(_)
+        ));
+        {
+            let _guard = store.write_guard().unwrap();
+            let mut state = store.load_raw_json_value().unwrap();
+            ensure_sessions_array_mut(&mut state)
+                .unwrap()
+                .push(reparent_test_session(
+                    "late-worker",
+                    Some("outgoing"),
+                    "late-secret",
+                ));
+            store.write_raw_json_value(&state).unwrap();
+        }
+        let stale = store.get_reparent_request(&request.id).unwrap().unwrap();
+        assert_eq!(stale.status, "stale");
+        for session_id in ["outgoing", "worker-a", "worker-b", "late-worker"] {
+            assert_eq!(
+                store
+                    .get_session(session_id)
+                    .unwrap()
+                    .unwrap()
+                    .parent_session_id
+                    .as_deref(),
+                Some("outgoing")
+            );
+        }
+        assert_eq!(
+            store
+                .get_session("successor")
+                .unwrap()
+                .unwrap()
+                .parent_session_id
+                .as_deref(),
+            Some("maintainer")
+        );
+        let _ = fs::remove_file(state_file);
+    }
+
+    #[test]
+    fn stopped_root_recovery_rejects_live_source_terminal_target_or_target_children() {
+        let (store, state_file) = stopped_root_recovery_store("hostile-eligibility");
+        {
+            let _guard = store.write_guard().unwrap();
+            let mut state = store.load_raw_json_value().unwrap();
+            session_object_mut(ensure_sessions_array_mut(&mut state).unwrap(), "outgoing")
+                .unwrap()
+                .insert("status".to_owned(), Value::String("idle".to_owned()));
+            store.write_raw_json_value(&state).unwrap();
+        }
+        assert!(matches!(
+            store
+                .create_reparent_tree_request(
+                    "outgoing",
+                    CreateReparentTreeRequest {
+                        requester_session_id: "successor".to_owned(),
+                        target_session_id: "successor".to_owned(),
+                        dry_run: true,
+                    },
+                    "successor-secret",
+                )
+                .unwrap(),
+            ReparentMutationOutcome::BadRequest(_)
+        ));
+        {
+            let _guard = store.write_guard().unwrap();
+            let mut state = store.load_raw_json_value().unwrap();
+            session_object_mut(ensure_sessions_array_mut(&mut state).unwrap(), "outgoing")
+                .unwrap()
+                .insert("status".to_owned(), Value::String("stopped".to_owned()));
+            session_object_mut(ensure_sessions_array_mut(&mut state).unwrap(), "successor")
+                .unwrap()
+                .insert("status".to_owned(), Value::String("stopped".to_owned()));
+            store.write_raw_json_value(&state).unwrap();
+        }
+        assert!(matches!(
+            store
+                .create_reparent_tree_request(
+                    "outgoing",
+                    CreateReparentTreeRequest {
+                        requester_session_id: "successor".to_owned(),
+                        target_session_id: "successor".to_owned(),
+                        dry_run: false,
+                    },
+                    "successor-secret",
+                )
+                .unwrap(),
+            ReparentMutationOutcome::BadRequest(_)
+        ));
+        {
+            let _guard = store.write_guard().unwrap();
+            let mut state = store.load_raw_json_value().unwrap();
+            let sessions = ensure_sessions_array_mut(&mut state).unwrap();
+            session_object_mut(sessions, "successor")
+                .unwrap()
+                .insert("status".to_owned(), Value::String("idle".to_owned()));
+            sessions.push(reparent_test_session(
+                "successor-child",
+                Some("successor"),
+                "successor-child-secret",
+            ));
+            store.write_raw_json_value(&state).unwrap();
+        }
+        assert!(matches!(
+            store
+                .create_reparent_tree_request(
+                    "outgoing",
+                    CreateReparentTreeRequest {
+                        requester_session_id: "successor".to_owned(),
+                        target_session_id: "successor".to_owned(),
+                        dry_run: false,
+                    },
+                    "successor-secret",
+                )
+                .unwrap(),
+            ReparentMutationOutcome::BadRequest(_)
+        ));
+        let _ = fs::remove_file(state_file);
+    }
+
+    #[test]
+    fn stopped_root_recovery_restarts_idempotently_from_a_persisted_stage() {
+        let (store, state_file) = stopped_root_recovery_store("restart");
+        let request = match store
+            .create_reparent_tree_request(
+                "outgoing",
+                CreateReparentTreeRequest {
+                    requester_session_id: "successor".to_owned(),
+                    target_session_id: "successor".to_owned(),
+                    dry_run: false,
+                },
+                "successor-secret",
+            )
+            .unwrap()
+        {
+            ReparentMutationOutcome::Created(record) => record,
+            other => panic!("unexpected create outcome: {other:?}"),
+        };
+        {
+            let _guard = store.write_guard().unwrap();
+            let mut state = store.load_raw_json_value().unwrap();
+            let mut records = reparent_request_records(&state).unwrap();
+            let record = records
+                .iter_mut()
+                .find(|record| record.id == request.id)
+                .unwrap();
+            record.approvals.push(ReparentApprovalRecord {
+                actor_kind: "agent".to_owned(),
+                actor_id: "maintainer".to_owned(),
+                decision: "approved".to_owned(),
+                decided_at: now_rfc3339(),
+            });
+            record.ready_to_apply = true;
+            store_reparent_request_records(&mut state, &records).unwrap();
+            store.write_raw_json_value(&state).unwrap();
+        }
+        assert_eq!(
+            store.acquire_reparent_apply_lease().unwrap().as_deref(),
+            Some(request.id.as_str())
+        );
+        store.quiesce_reparent_json_routing(&request.id).unwrap();
+        drop(store);
+
+        let recovered = SessionStore::new(state_file.clone())
+            .reconcile_reparent_requests()
+            .unwrap()
+            .unwrap();
+        assert_eq!(recovered.status, "applied");
+        let final_store = SessionStore::new(state_file.clone());
+        assert_eq!(
+            final_store
+                .get_session("outgoing")
+                .unwrap()
+                .unwrap()
+                .parent_session_id
+                .as_deref(),
+            Some("successor")
+        );
+        assert_eq!(
+            final_store
+                .get_session("successor")
+                .unwrap()
+                .unwrap()
+                .parent_session_id,
+            None
+        );
+        let _ = fs::remove_file(state_file);
+    }
+
+    #[test]
     fn peer_root_succession_recovers_from_a_persisted_apply_stage_after_restart() {
         let state_file = unique_temp_path("peer-root-restart");
         fs::write(
@@ -21400,6 +21910,36 @@ mod tests {
             "parent_session_id": parent,
             "session_credential_sha256": sha256_text(credential)
         })
+    }
+
+    fn stopped_root_recovery_store(label: &str) -> (SessionStore, PathBuf) {
+        let state_file = unique_temp_path(label);
+        let mut outgoing = reparent_test_session("outgoing", None, "outgoing-secret");
+        outgoing["status"] = Value::String("stopped".to_owned());
+        let mut stopped_worker =
+            reparent_test_session("stopped-worker", Some("outgoing"), "stopped-secret");
+        stopped_worker["status"] = Value::String("stopped".to_owned());
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [
+                    reparent_test_session("maintainer", None, "maintainer-secret"),
+                    outgoing,
+                    reparent_test_session("successor", Some("maintainer"), "successor-secret"),
+                    reparent_test_session("worker-a", Some("outgoing"), "worker-a-secret"),
+                    reparent_test_session("worker-b", Some("outgoing"), "worker-b-secret"),
+                    stopped_worker
+                ],
+                "agent_registrations": [{
+                    "role": "maintainer",
+                    "session_id": "maintainer",
+                    "created_at": "2026-08-18T00:00:00Z"
+                }]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        (SessionStore::new(state_file.clone()), state_file)
     }
 
     fn unique_temp_path(label: &str) -> PathBuf {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -20355,13 +20355,12 @@ mod tests {
             )
             .unwrap();
 
-        let ReparentMutationOutcome::Preview(preview) = outcome else {
-            panic!("unexpected tree preview outcome: {outcome:?}");
-        };
-        assert!(preview.blockers.iter().any(|blocker| {
-            blocker.contains("target session target01")
-                && blocker.contains("cannot participate in credential-bound consent")
-        }));
+        assert!(matches!(
+            outcome,
+            ReparentMutationOutcome::BadRequest(message)
+                if message.contains("target session target01")
+                    && message.contains("cannot participate in credential-bound consent")
+        ));
         let _ = fs::remove_file(state_file);
     }
 
@@ -21226,7 +21225,15 @@ mod tests {
         }
         let stale = store.get_reparent_request(&request.id).unwrap().unwrap();
         assert_eq!(stale.status, "stale");
-        for session_id in ["outgoing", "worker-a", "worker-b", "late-worker"] {
+        assert_eq!(
+            store
+                .get_session("outgoing")
+                .unwrap()
+                .unwrap()
+                .parent_session_id,
+            None
+        );
+        for session_id in ["worker-a", "worker-b", "late-worker"] {
             assert_eq!(
                 store
                     .get_session(session_id)
@@ -21292,7 +21299,15 @@ mod tests {
                 .as_deref(),
             Some("maintainer")
         );
-        for session_id in ["outgoing", "worker-a", "worker-b"] {
+        assert_eq!(
+            store
+                .get_session("outgoing")
+                .unwrap()
+                .unwrap()
+                .parent_session_id,
+            None
+        );
+        for session_id in ["worker-a", "worker-b"] {
             assert_eq!(
                 store
                     .get_session(session_id)

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -32,7 +32,10 @@ use crate::queue::{
 };
 use crate::{
     btw::BtwStore,
-    config::{test_isolation_root_from_environment, CodexReviewConfig, ContextMonitorConfig},
+    config::{
+        path_is_under_home, test_isolation_root_from_environment, CodexReviewConfig,
+        ContextMonitorConfig,
+    },
     runtime::{ConditionalClearOutcome, TmuxRuntime, TmuxSessionSpec},
     seat_sessions::{SeatSessionIdentity, SeatSessionStore},
     usage_burn::UsageBurnStore,
@@ -519,8 +522,8 @@ impl SessionStore {
                 test_isolation_root_from_environment().expect("invalid Rust test isolation root");
             // Test launchers may retain explicit fixture indexes outside HOME,
             // but must never resolve the developer's live Codex index.
-            let is_live_home_path = env::var_os("HOME")
-                .is_some_and(|home| session_index_path.starts_with(PathBuf::from(home)));
+            let is_live_home_path =
+                path_is_under_home(session_index_path.to_string_lossy().as_ref()).unwrap_or(true);
             if !test_root.is_some() || !is_live_home_path {
                 if let Some(parent) = session_index_path.parent() {
                     self.codex_sessions_root = parent.join("sessions");
@@ -543,7 +546,7 @@ impl SessionStore {
                 .filter(|value| !value.is_empty())
                 .map(expand_home);
             let configured_under_home = configured_root.as_ref().is_some_and(|path| {
-                env::var_os("HOME").is_some_and(|home| path.starts_with(PathBuf::from(home)))
+                path_is_under_home(path.to_string_lossy().as_ref()).unwrap_or(true)
             });
             self.claude_projects_roots = match configured_root {
                 Some(path) if !configured_under_home => vec![path],

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -15417,6 +15417,21 @@ mod tests {
     }
 
     #[test]
+    fn test_isolation_prevents_default_home_scans_from_being_restored() {
+        let root = test_isolation_root_from_environment().unwrap().unwrap();
+        let state_file = root.join("external-scan-fixture.json");
+        let store = SessionStore::new(state_file)
+            .with_codex_session_index_path(Some("~/.codex/session_index.jsonl"))
+            .with_claude_transcript_root(None);
+
+        assert!(store.codex_sessions_root.starts_with(&root));
+        assert!(store
+            .claude_projects_roots
+            .iter()
+            .all(|path| path.starts_with(&root)));
+    }
+
+    #[test]
     fn generated_session_ids_match_python_short_hex_contract() {
         let session_id = generate_session_id();
 

--- a/scripts/test-rust-isolated.sh
+++ b/scripts/test-rust-isolated.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Every Rust test must run through this launcher. AppState uses this root before
+# opening durable stores, so default config can never resolve the live session
+# registry, queue, usage databases, or reparent-apply lock.
+test_root="$(mktemp -d "${TMPDIR:-/tmp}/sm-rust-test.XXXXXX")"
+cleanup() {
+  rm -rf -- "$test_root"
+}
+trap cleanup EXIT
+
+SM_TEST_ISOLATION_ROOT="$test_root" cargo test -p sm-server "$@"

--- a/specs/1325_stopped_root_reparent_recovery.md
+++ b/specs/1325_stopped_root_reparent_recovery.md
@@ -1,0 +1,56 @@
+# 1325 - Stopped-root reparent recovery
+
+Issue: #1325 (regression in #1285)
+
+## Measured incident
+
+`9ffe4f64` dry-ran `sm reparent-tree d0d5f272 --to 9ffe4f64` at
+`2026-08-18T16:23:09.823Z`. It exited 0 while projecting a target-to-root
+edge, source-to-target edge, and exactly five live source children. It also
+reported that the source was stopped and target did not meet the old direct
+child/peer-root topology. The matching apply failed at
+`2026-08-18T16:23:22.247Z` with HTTP 400 `source session d0d5f272 is stopped`.
+No edge changed.
+
+Durable state showed stopped root `d0d5f272`; five live children
+`77de8fd5`, `37b926be`, `a2242bc3`, `07664488`, and `f4e86f39`; stopped child
+`711debab`; and live successor `9ffe4f64` under maintainer `031de889`.
+
+## Contract
+
+The persisted `stopped_root_recovery` mode applies only to a durably stopped
+root, a live consent-capable successor, and a live consent-capable current
+successor parent that is the durable `maintainer` registration. The target must
+have no children. Its credential starts the request; its current maintainer
+parent gives the second ordinary credential-bound approval. There is no new
+synchronous human gate: the durable maintainer registration and its recorded
+approval are the recovery authority.
+
+The immutable plan binds both old parents and exactly the frozen live source
+children:
+
+1. successor: current maintainer parent to root;
+2. stopped source: root to successor;
+3. every frozen live child: source to successor.
+
+Stopped historical children do not move. A changed parent, source terminal
+state, target liveness, target child set, frozen source-child set, missing
+maintainer binding, pending overlap, or fingerprint mismatch fails closed
+before authority commit. Preview returns the same rejection class as apply;
+it never emits a successful actionable plan with blockers.
+
+The existing durable apply plan and stage machine retain all-or-nothing routing
+quiesce/rollback, restart recovery, and idempotent terminal-state recovery.
+
+## Verification gate
+
+Hostile isolated coverage is added for exact preview/apply parity and
+post-state, stopped-child exclusion, changed child set/zero partial edges,
+overlapping pending request, live source, terminal target, target children,
+and restart continuation. Rust tests are deliberately not executed until PR
+#1317 has final reviewed isolation acceptance and the maintainer provides the
+integration handoff.
+
+## Classification
+
+Single ticket.

--- a/specs/1325_stopped_root_reparent_recovery.md
+++ b/specs/1325_stopped_root_reparent_recovery.md
@@ -26,6 +26,10 @@ parent gives the second ordinary credential-bound approval. There is no new
 synchronous human gate: the durable maintainer registration and its recorded
 approval are the recovery authority.
 
+Freshness re-reads that durable `maintainer` registration before every pending
+decision, lease acquisition, quiesce, and authority commit. A removed or
+reassigned maintainer registration makes the request stale with no edge change.
+
 The immutable plan binds both old parents and exactly the frozen live source
 children:
 


### PR DESCRIPTION
Fixes #1325

## Summary

- adds an authorized stopped-root recovery mode that binds the successor’s current maintainer parent and exact frozen live-child set
- makes dry-run reject blockers exactly as apply does, instead of returning an actionable HTTP-success preview
- preserves an immutable, parent-bound plan through atomic/retryable apply and restart recovery
- adds isolated hostile coverage for parity, conflict, stale topology, terminal/live eligibility, and restart recovery

## Root cause

Preview returned a plan while separately reporting blockers; apply rejected the stopped source; commit freshness independently required the source live. Existing non-peer planning also assumed the target was already a child of source.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p sm-server --tests` (compile only)
- `git diff --check`

Rust tests were not executed: PR #1317 isolation acceptance and explicit maintainer integration handoff remain required.