### PR TITLE
fix: keep reparent reconciliation off poll reads

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -513,6 +513,15 @@ impl AppState {
             .drain_runtime_pending_message_targets_by_category("queue-completion")
     }
 
+    /// Retry durable reparent notification intents away from request handlers.
+    ///
+    /// The reconciliation lock and queue writes can block, so this work must
+    /// stay off watch/poll reads. The server's single background retry driver
+    /// calls it after startup and after any transient mutation-time failure.
+    pub fn retry_reparent_notifications(&self) -> anyhow::Result<()> {
+        self.session_store.reconcile_reparent_notifications()
+    }
+
     pub fn with_github_review_poster(mut self, poster: Arc<dyn GitHubReviewPoster>) -> Self {
         self.github_review_poster = poster;
         self

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -404,6 +404,7 @@ pub struct AppState {
     mobile_terminal_revoked_keys: Arc<Mutex<BTreeSet<(String, String)>>>,
     mobile_terminal_runtime_disabled: Arc<AtomicBool>,
     studio_ssh_enabled: Arc<AtomicBool>,
+    reparent_notification_retry_pending: Arc<AtomicBool>,
     mobile_terminal_secret: [u8; 32],
 }
 
@@ -462,6 +463,7 @@ impl AppState {
                 );
             session_store = session_store.with_usage_report_store(report_store);
         }
+        let reparent_notification_retry_pending = Arc::new(AtomicBool::new(false));
         session_store
             .recover_session_runtime_launches()
             .context("session runtime launch recovery failed")?;
@@ -470,6 +472,7 @@ impl AppState {
             .context("reparent authority recovery failed")?;
         if let Err(error) = session_store.reconcile_reparent_notifications() {
             eprintln!("reparent notification recovery failed: {error:#}");
+            reparent_notification_retry_pending.store(true, Ordering::SeqCst);
         }
         if let Err(error) = session_store.recover_session_credential_rotation_workers() {
             eprintln!("session credential rotation recovery failed: {error:#}");
@@ -504,6 +507,7 @@ impl AppState {
             mobile_terminal_revoked_keys: Arc::new(Mutex::new(BTreeSet::new())),
             mobile_terminal_runtime_disabled: Arc::new(AtomicBool::new(false)),
             studio_ssh_enabled: Arc::new(AtomicBool::new(studio_ssh_enabled)),
+            reparent_notification_retry_pending,
             mobile_terminal_secret,
         })
     }
@@ -513,13 +517,32 @@ impl AppState {
             .drain_runtime_pending_message_targets_by_category("queue-completion")
     }
 
+    /// Request a background retry for a durable reparent notification intent.
+    pub fn request_reparent_notification_retry(&self) {
+        self.reparent_notification_retry_pending
+            .store(true, Ordering::SeqCst);
+    }
+
     /// Retry durable reparent notification intents away from request handlers.
     ///
     /// The reconciliation lock and queue writes can block, so this work must
     /// stay off watch/poll reads. The server's single background retry driver
-    /// calls it after startup and after any transient mutation-time failure.
-    pub fn retry_reparent_notifications(&self) -> anyhow::Result<()> {
-        self.session_store.reconcile_reparent_notifications()
+    /// calls it only when startup, a mutation, or a poll observes outstanding
+    /// notification work.
+    pub fn retry_reparent_notifications(&self) -> anyhow::Result<bool> {
+        if !self
+            .reparent_notification_retry_pending
+            .swap(false, Ordering::SeqCst)
+        {
+            return Ok(false);
+        }
+        match self.session_store.reconcile_reparent_notifications() {
+            Ok(()) => Ok(true),
+            Err(error) => {
+                self.request_reparent_notification_retry();
+                Err(error)
+            }
+        }
     }
 
     pub fn with_github_review_poster(mut self, poster: Arc<dyn GitHubReviewPoster>) -> Self {
@@ -3208,6 +3231,7 @@ async fn list_reparent_requests(
         }
         state.session_store.list_reparent_requests()?
     };
+    request_reparent_notification_retry_if_needed(&state, &requests);
     Ok(Json(json!({
         "requests": requests,
     })))
@@ -3325,6 +3349,7 @@ async fn get_reparent_request(
             detail: "Operator authentication or managed session identity is required".to_owned(),
         });
     }
+    request_reparent_notification_retry_if_needed(&state, std::slice::from_ref(&record));
     Ok(Json(serde_json::to_value(record)?))
 }
 
@@ -3476,6 +3501,22 @@ fn human_decide_reparent_request(
 fn reconcile_reparent_notifications_best_effort(state: &AppState) {
     if let Err(error) = state.session_store.reconcile_reparent_notifications() {
         eprintln!("reparent notification reconciliation failed: {error:#}");
+        state.request_reparent_notification_retry();
+    }
+}
+
+fn request_reparent_notification_retry_if_needed(
+    state: &AppState,
+    records: &[crate::sessions::ReparentRequestRecord],
+) {
+    if records.iter().any(|record| {
+        record
+            .notification_intents
+            .iter()
+            .any(|intent| intent.enqueued_at.is_none())
+            || (record.status != "pending" && record.notification_intents.is_empty())
+    }) {
+        state.request_reparent_notification_retry();
     }
 }
 

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -3171,7 +3171,12 @@ async fn list_reparent_requests(
     request: Request,
 ) -> Result<Json<Value>, ApiError> {
     ensure_session_read_allowed(&state, &request)?;
-    reconcile_reparent_notifications_best_effort(&state);
+    // This is a watch/poll read path. Reconciliation takes the cross-process
+    // reparent apply lock and may perform queue writes, so running it here can
+    // turn one contended outbox retry into enough blocked request workers to
+    // make unrelated reads (including /health) unavailable. Mutation and
+    // recovery paths still reconcile the durable outbox; this response reports
+    // the durable request/notification state as it exists now.
     let requests = if let Some(session_id) = header_text(request.headers(), "x-sm-session-id") {
         let credential = reparent_session_credential(request.headers())?;
         state
@@ -3278,7 +3283,9 @@ async fn get_reparent_request(
     request: Request,
 ) -> Result<Json<Value>, ApiError> {
     ensure_session_read_allowed(&state, &request)?;
-    reconcile_reparent_notifications_best_effort(&state);
+    // Keep detail reads non-blocking for the same reason as the collection
+    // poll above. A pending notification remains visible in the durable record
+    // instead of making the read path pretend the outbox was reconciled.
     let record = state
         .session_store
         .get_reparent_request(&request_id)?

--- a/crates/sm-server/src/main.rs
+++ b/crates/sm-server/src/main.rs
@@ -22,6 +22,7 @@ use tokio::net::TcpListener;
 /// How often the Studio SSH reconcile loop repairs toward the desired state.
 const STUDIO_SSH_RECONCILE_INTERVAL: Duration = Duration::from_secs(30);
 const QUEUE_COMPLETION_RETRY_INTERVAL: Duration = Duration::from_secs(5);
+const REPARENT_NOTIFICATION_RETRY_INTERVAL: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Parser)]
 #[command(version, about = "Rust Session Manager server scaffold")]
@@ -123,6 +124,17 @@ async fn main() -> Result<()> {
     }
 
     let state = AppState::try_new(config).context("failed to initialize server state")?;
+    // Reparent notification reconciliation can wait on the cross-process
+    // apply lock and queue writes. Keep its durable retry driver on one
+    // dedicated background thread so poll reads never consume request workers
+    // waiting for the outbox.
+    let reparent_notification_state = state.clone();
+    thread::spawn(move || loop {
+        thread::sleep(REPARENT_NOTIFICATION_RETRY_INTERVAL);
+        if let Err(error) = reparent_notification_state.retry_reparent_notifications() {
+            eprintln!("reparent notification retry failed: {error:#}");
+        }
+    });
     if state.config().rust_core.runtime_enabled {
         let queue_delivery_state = state.clone();
         thread::spawn(move || loop {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -2815,74 +2815,70 @@ impl SessionStore {
         // not an observation made by a losing apply driver.  Serialize the
         // projection with apply/recovery, then enqueue only intents that are
         // still desired by the durable record while this lock is held.
-        let _cross_process_guard = self.reparent_apply_file_lock()?;
-        let (pending, recipients) = {
-            let _guard = self.write_guard()?;
-            let mut state = self.load_raw_json_value()?;
-            let sessions = snapshot_from_raw_value(&state)?.into_sessions();
-            let mut records = reparent_request_records(&state)?;
-            let refreshed = refresh_reparent_requests(
-                &mut records,
-                &sessions,
-                &state,
-                OffsetDateTime::now_utc(),
-            );
-            let mut changed = refreshed;
-            for record in &mut records {
-                let desired = desired_reparent_notifications(record);
-                let desired_keys = desired
-                    .iter()
-                    .map(|desired| desired.intent.key.as_str())
-                    .collect::<BTreeSet<_>>();
-                // A prior process may have recorded a not-yet-enqueued
-                // terminal intent before a winning driver committed the
-                // request.  Keep delivered audit history, but remove any
-                // unsent losing projection before choosing outbox work.
-                let previous_len = record.notification_intents.len();
-                record.notification_intents.retain(|intent| {
-                    intent.enqueued_at.is_some()
-                        || !intent.event.starts_with("terminal:")
-                        || desired_keys.contains(intent.key.as_str())
-                });
-                changed |= record.notification_intents.len() != previous_len;
-                for desired in desired {
-                    if record
-                        .notification_intents
+        let recipients = {
+            let _cross_process_guard = self.reparent_apply_file_lock()?;
+            let (pending, recipients) = {
+                let _guard = self.write_guard()?;
+                let mut state = self.load_raw_json_value()?;
+                let sessions = snapshot_from_raw_value(&state)?.into_sessions();
+                let mut records = reparent_request_records(&state)?;
+                let refreshed = refresh_reparent_requests(
+                    &mut records,
+                    &sessions,
+                    &state,
+                    OffsetDateTime::now_utc(),
+                );
+                let mut changed = refreshed;
+                for record in &mut records {
+                    let desired = desired_reparent_notifications(record);
+                    let desired_keys = desired
                         .iter()
-                        .all(|intent| intent.key != desired.intent.key)
-                    {
-                        record.notification_intents.push(desired.intent);
-                        changed = true;
+                        .map(|desired| desired.intent.key.as_str())
+                        .collect::<BTreeSet<_>>();
+                    // A prior process may have recorded a not-yet-enqueued
+                    // terminal intent before a winning driver committed the
+                    // request.  Keep delivered audit history, but remove any
+                    // unsent losing projection before choosing outbox work.
+                    let previous_len = record.notification_intents.len();
+                    record.notification_intents.retain(|intent| {
+                        intent.enqueued_at.is_some()
+                            || !intent.event.starts_with("terminal:")
+                            || desired_keys.contains(intent.key.as_str())
+                    });
+                    changed |= record.notification_intents.len() != previous_len;
+                    for desired in desired {
+                        if record
+                            .notification_intents
+                            .iter()
+                            .all(|intent| intent.key != desired.intent.key)
+                        {
+                            record.notification_intents.push(desired.intent);
+                            changed = true;
+                        }
                     }
                 }
-            }
-            if changed {
-                store_reparent_request_records(&mut state, &records)?;
-                self.write_raw_json_value(&state)?;
-            }
-            let pending = records
-                .iter()
-                .flat_map(|record| {
-                    desired_reparent_notifications(record)
-                        .into_iter()
-                        .filter(|desired| {
-                            record.notification_intents.iter().any(|intent| {
-                                intent.key == desired.intent.key && intent.enqueued_at.is_none()
+                if changed {
+                    store_reparent_request_records(&mut state, &records)?;
+                    self.write_raw_json_value(&state)?;
+                }
+                let pending = records
+                    .iter()
+                    .flat_map(|record| {
+                        desired_reparent_notifications(record)
+                            .into_iter()
+                            .filter(|desired| {
+                                record.notification_intents.iter().any(|intent| {
+                                    intent.key == desired.intent.key && intent.enqueued_at.is_none()
+                                })
                             })
-                        })
-                })
-                .collect::<Vec<_>>();
-            let recipients = records
-                .iter()
-                .flat_map(|record| {
-                    record
-                        .notification_intents
-                        .iter()
-                        .map(|intent| intent.recipient_session_id.clone())
-                })
-                .collect::<BTreeSet<_>>();
-            (pending, recipients)
-        };
+                    })
+                    .collect::<Vec<_>>();
+                let recipients = pending
+                    .iter()
+                    .map(|desired| desired.intent.recipient_session_id.clone())
+                    .collect::<BTreeSet<_>>();
+                (pending, recipients)
+            };
         for desired in pending {
             let desired = {
                 let _guard = self.write_guard()?;
@@ -2938,7 +2934,9 @@ impl SessionStore {
                 store_reparent_request_records(&mut state, &records)?;
                 self.write_raw_json_value(&state)?;
             }
-        }
+            }
+            recipients
+        };
         if let Some(runtime) = self.delivery_runtime.as_ref() {
             let mut first_error = None;
             for recipient in recipients {

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -7,8 +7,12 @@ use base64::{
     engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
     Engine as _,
 };
-use futures_util::{future::join, StreamExt as _};
+use futures_util::{
+    future::{join, join_all},
+    StreamExt as _,
+};
 use hmac::{Hmac, Mac};
+use nix::fcntl::{Flock, FlockArg};
 use rusqlite::{Connection, OptionalExtension};
 use serde_json::{json, Value};
 use sha1::{Digest, Sha1};
@@ -17707,6 +17711,45 @@ async fn reparent_request_requires_bound_credentials_and_dual_agent_consent() {
     assert_eq!(child["parent_session_id"], "newparent");
     assert_eq!(raw_state["reparent_requests"][0]["status"], "applied");
     assert_eq!(raw_state["reparent_requests"][0]["ready_to_apply"], false);
+}
+
+#[tokio::test]
+async fn reparent_request_poll_stays_available_while_apply_lock_is_held() {
+    let state_file = write_reparent_fixture();
+    let app = router(AppState::new(config_with_state_file(&state_file)));
+    let lock_path = state_file.with_extension("reparent-apply.lock");
+    let lock_file = fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(lock_path)
+        .unwrap();
+    let _held_lock = Flock::lock(lock_file, FlockArg::LockExclusive).unwrap();
+
+    let headers = vec![
+        ("x-sm-session-id", "unrelated".to_owned()),
+        ("x-sm-session-credential", "unrelated-token".to_owned()),
+    ];
+    let polls = (0..32)
+        .map(|_| {
+            get_json_with_host_and_headers(app.clone(), "/reparent-requests", "localhost", &headers)
+        })
+        .collect::<Vec<_>>();
+    let results = tokio::time::timeout(Duration::from_millis(250), join_all(polls))
+        .await
+        .expect("reparent polls must not wait for the apply lock");
+    assert!(results
+        .iter()
+        .all(|result| result.0 == StatusCode::OK && result.1["requests"] == json!([])));
+
+    let detail = tokio::time::timeout(
+        Duration::from_millis(250),
+        get_json_with_host_and_headers(app, "/reparent-requests/missing", "localhost", &headers),
+    )
+    .await
+    .expect("reparent detail poll must not wait for the apply lock");
+
+    assert_eq!(detail.0, StatusCode::NOT_FOUND);
 }
 
 #[tokio::test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -17753,6 +17753,53 @@ async fn reparent_request_poll_stays_available_while_apply_lock_is_held() {
 }
 
 #[tokio::test]
+async fn reparent_notification_retry_recovers_after_a_transient_mutation_failure() {
+    let state_file = write_reparent_fixture();
+    let queue_db = queue_db_path_for_state_file(&state_file);
+    let mut config = config_with_state_file_and_queue(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let state = Arc::new(AppState::new(config));
+    let app = router((*state).clone());
+
+    let queue_lock = Connection::open(&queue_db).unwrap();
+    queue_lock.execute_batch("BEGIN EXCLUSIVE").unwrap();
+    let (status, created) = post_json_with_headers_and_peer(
+        app,
+        "/sessions/child/reparent-requests",
+        json!({
+            "requester_session_id": "oldparent",
+            "target_parent_session_id": "newparent"
+        }),
+        &[("x-sm-session-credential", "old-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    queue_lock.execute_batch("ROLLBACK").unwrap();
+
+    let request_id = created["id"].as_str().unwrap();
+    let persisted: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    assert!(persisted["reparent_requests"][0]["notification_intents"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|intent| intent["enqueued_at"].is_null()));
+    assert!(queued_message_texts(&queue_db, "newparent").is_empty());
+
+    state.retry_reparent_notifications().unwrap();
+
+    let messages = queued_message_texts(&queue_db, "newparent");
+    assert_eq!(messages.len(), 1);
+    assert!(messages[0].contains(request_id));
+    let retried: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    assert!(retried["reparent_requests"][0]["notification_intents"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .all(|intent| intent["enqueued_at"].is_string()));
+}
+
+#[tokio::test]
 async fn reparent_request_rejects_unauthorized_cycles_and_overlapping_edges() {
     let state_file = write_reparent_fixture();
     let mut config = config_with_state_file(&state_file);

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -17786,7 +17786,7 @@ async fn reparent_notification_retry_recovers_after_a_transient_mutation_failure
         .any(|intent| intent["enqueued_at"].is_null()));
     assert!(queued_message_texts(&queue_db, "newparent").is_empty());
 
-    state.retry_reparent_notifications().unwrap();
+    assert!(state.retry_reparent_notifications().unwrap());
 
     let messages = queued_message_texts(&queue_db, "newparent");
     assert_eq!(messages.len(), 1);
@@ -17797,6 +17797,7 @@ async fn reparent_notification_retry_recovers_after_a_transient_mutation_failure
         .unwrap()
         .iter()
         .all(|intent| intent["enqueued_at"].is_string()));
+    assert!(!state.retry_reparent_notifications().unwrap());
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Risk tier

R3 — public polling hot path and cross-process concurrency/reconciliation behavior.

## Frozen capability

Remove synchronous reparent-notification reconciliation only from `GET /reparent-requests` and `GET /reparent-requests/{id}`. Preserve eventual delivery with a bounded background retry driver. Startup, recovery, and mutation paths retain durable outbox reconciliation; polls expose pending durable notification state instead of blocking request workers.

## Exact head

`3a73257c822ffb0bebff67e313160726c84fdf00`, rebased onto deployed main `3b852e05f07d931522408f40ad73ee61ff45e42a`.

## Evidence and gates

- #1315 production sample tied request-worker starvation to synchronous `reconcile_reparent_notifications` waiting on the cross-process `sessions.reparent-apply.lock`; post-contention collection polls remained 1.284–2.276 s.
- #1314/#1316 isolation and recovery handoff is already contained in this base.
- `scripts/test-rust-isolated.sh --test read_only_http reparent_request_poll_stays_available_while_apply_lock_is_held` — pass.
- `scripts/test-rust-isolated.sh --test read_only_http reparent_notification_retry_recovers_after_a_transient_mutation_failure` — pass.
- `scripts/test-rust-isolated.sh --test read_only_http` — 281 passed.
- `git diff --check` — pass.

## R3 review record

- Round 1 — requested/reviewed exact head `2614ace9e34457d66eccdfcafdf82ff6a1c8695b`; scope: poll-read non-blocking behavior, durable degraded-state semantics, and lock-contention hostile test. Result: one reachable P1 (no ongoing retry after transient mutation-time failure). Disposition: accepted and repaired in `48dbab795bcc3477d0019bf55bc2584889596c79`; regression test proves durable unsent intent is retried after queue-lock release.
- Round 2 — requested/reviewed exact head `48dbab795bcc3477d0019bf55bc2584889596c79`; scope: background retry containment, eventual notification delivery, and preservation of non-blocking poll reads. Result: one reachable P1 (idle periodic retry drained historical recipients while holding the apply lock). Disposition: accepted and repaired in `3a73257c822ffb0bebff67e313160726c84fdf00`; retries are event-gated, runtime delivery uses only pending recipients after the apply lock releases, and the retry regression proves an idle retry is a no-op.
- Round 3 — requested for exact head `3a73257c822ffb0bebff67e313160726c84fdf00`; scope: atomic retry scheduling, lock boundaries, durable notification truthfulness, and poll-worker isolation.

No owner classification or approval gate is requested.