### PR TITLE
Authenticate retirement provenance

### DIFF
--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -5168,9 +5168,29 @@ mod tests {
             stream
                 .set_read_timeout(Some(std::time::Duration::from_secs(2)))
                 .unwrap();
-            let mut buffer = [0_u8; 8192];
-            let bytes_read = stream.read(&mut buffer).unwrap();
-            let request = String::from_utf8_lossy(&buffer[..bytes_read]).to_string();
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+            let mut request = String::new();
+            let mut content_length = 0_usize;
+            loop {
+                let mut line = String::new();
+                reader.read_line(&mut line).unwrap();
+                if line.is_empty() {
+                    panic!("test request ended before its headers");
+                }
+                if let Some((name, value)) = line.trim_end_matches(['\r', '\n']).split_once(':') {
+                    if name.eq_ignore_ascii_case("content-length") {
+                        content_length = value.trim().parse().unwrap();
+                    }
+                }
+                let end_of_headers = line == "\r\n";
+                request.push_str(&line);
+                if end_of_headers {
+                    break;
+                }
+            }
+            let mut body_bytes = vec![0_u8; content_length];
+            reader.read_exact(&mut body_bytes).unwrap();
+            request.push_str(&String::from_utf8_lossy(&body_bytes));
             let reason = if status == 200 { "OK" } else { "Error" };
             let response = format!(
                 "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",

--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -917,13 +917,20 @@ fn run() -> Result<()> {
             }
         }
         Command::Retire(args) => {
-            let requester_session_id = current_session_id()?;
-            let credential = current_session_credential(&requester_session_id)?;
-            let payload = client.post_json_with_session_credential(
-                &format!("/sessions/{}/retire", args.session_id),
-                retire_request_payload(Some(requester_session_id)),
-                &credential,
-            )?;
+            let requester_session_id = optional_current_session_id();
+            let payload = if let Some(requester_session_id) = requester_session_id {
+                let credential = current_session_credential(&requester_session_id)?;
+                client.post_json_with_session_credential(
+                    &format!("/sessions/{}/retire", args.session_id),
+                    retire_request_payload(Some(requester_session_id)),
+                    &credential,
+                )?
+            } else {
+                client.post_json(
+                    &format!("/sessions/{}/retire", args.session_id),
+                    retire_request_payload(None),
+                )?
+            };
             println!("{}", retire_response_status(&payload, &args.session_id)?);
         }
         Command::Reparent(args) => run_reparent(&client, args)?,

--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -917,10 +917,12 @@ fn run() -> Result<()> {
             }
         }
         Command::Retire(args) => {
-            let requester_session_id = optional_current_session_id();
-            let payload = client.post_json(
+            let requester_session_id = current_session_id()?;
+            let credential = current_session_credential(&requester_session_id)?;
+            let payload = client.post_json_with_session_credential(
                 &format!("/sessions/{}/retire", args.session_id),
-                retire_request_payload(requester_session_id),
+                retire_request_payload(Some(requester_session_id)),
+                &credential,
             )?;
             println!("{}", retire_response_status(&payload, &args.session_id)?);
         }

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -513,6 +513,15 @@ impl AppState {
             .drain_runtime_pending_message_targets_by_category("queue-completion")
     }
 
+    /// Keeps terminal-fenced runtime launches from publishing after startup.
+    /// The durable fence remains eligible for every later reconciliation
+    /// because tmux client completion is not synchronized with an absence
+    /// check made during recovery.
+    pub fn reconcile_terminal_runtime_launch_teardowns(&self) -> anyhow::Result<()> {
+        self.session_store
+            .reconcile_terminal_runtime_launch_teardowns()
+    }
+
     pub fn with_github_review_poster(mut self, poster: Arc<dyn GitHubReviewPoster>) -> Self {
         self.github_review_poster = poster;
         self

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -8178,28 +8178,38 @@ async fn retire_session(
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty());
-    let Some(requester_session_id) = requester_session_id else {
-        return Err(ApiError::Status {
-            status: StatusCode::UNPROCESSABLE_ENTITY,
-            detail: "requester_session_id is required to retire a child session".to_owned(),
-        });
+    // A managed requester may retire only an authenticated direct child.
+    // Retained `sm watch` is intentionally outside every managed session, so
+    // it has no session credential or requester id. Admit that distinct
+    // server-owned lifecycle path only after the normal operator/local
+    // authentication check; a remote anonymous request cannot become
+    // server-owned merely by omitting the requester field.
+    let session_credential = if requester_session_id.is_some() {
+        Some(reparent_session_credential(&headers)?)
+    } else {
+        request_actor_email_from_parts(&state.config, &headers, Some(peer_addr)).ok_or_else(
+            || ApiError::Status {
+                status: StatusCode::UNAUTHORIZED,
+                detail: "Operator authentication is required".to_owned(),
+            },
+        )?;
+        None
     };
-    let session_credential = reparent_session_credential(&headers)?;
     let outcome = if state.config.rust_core.runtime_enabled {
         let runtime = TmuxRuntime::from_app_config(&state.config);
         state
             .session_store
             .retire_core_session_with_runtime_authorized(
                 &session_id,
-                Some(requester_session_id),
-                Some(&session_credential),
+                requester_session_id,
+                session_credential.as_deref(),
                 &runtime,
             )?
     } else {
         state.session_store.retire_core_session_authorized(
             &session_id,
-            Some(requester_session_id),
-            Some(&session_credential),
+            requester_session_id,
+            session_credential.as_deref(),
         )?
     };
     match outcome {

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -8168,42 +8168,61 @@ async fn retire_session(
         &format!("/sessions/{session_id}/retire"),
     )?;
     ensure_core_writes_enabled(&state)?;
+    if state.session_store.get_session(&session_id)?.is_none() {
+        return Ok(Json(json!({
+            "error": format!("Session {session_id} not found")
+        })));
+    }
     let requester_session_id = payload
         .requester_session_id
         .as_deref()
         .map(str::trim)
         .filter(|value| !value.is_empty());
-    let may_retire = state
-        .session_store
-        .get_session(&session_id)?
-        .is_some_and(|session| {
-            requester_session_id.is_none_or(|requester| {
-                requester.is_empty() || session.parent_session_id.as_deref() == Some(requester)
-            }) && (!state.config.rust_core.runtime_enabled || is_primary_node(&session.node))
+    let Some(requester_session_id) = requester_session_id else {
+        return Err(ApiError::Status {
+            status: StatusCode::UNPROCESSABLE_ENTITY,
+            detail: "requester_session_id is required to retire a child session".to_owned(),
         });
-    if may_retire {
-        teardown_btw_requests_for_session(&state, &session_id)?;
-    }
+    };
+    let session_credential = reparent_session_credential(&headers)?;
     let outcome = if state.config.rust_core.runtime_enabled {
         let runtime = TmuxRuntime::from_app_config(&state.config);
-        state.session_store.retire_core_session_with_runtime(
-            &session_id,
-            requester_session_id,
-            &runtime,
-        )?
-    } else {
         state
             .session_store
-            .retire_core_session(&session_id, requester_session_id)?
+            .retire_core_session_with_runtime_authorized(
+                &session_id,
+                Some(requester_session_id),
+                Some(&session_credential),
+                &runtime,
+            )?
+    } else {
+        state.session_store.retire_core_session_authorized(
+            &session_id,
+            Some(requester_session_id),
+            Some(&session_credential),
+        )?
     };
     match outcome {
-        CoreRetireOutcome::Retired(result) => Ok(Json(serde_json::to_value(result)?)),
+        CoreRetireOutcome::Retired(result) => {
+            if let Err(error) = teardown_btw_requests_for_session(&state, &session_id) {
+                eprintln!("retired session {session_id} but BTW teardown failed: {error:#}");
+            }
+            Ok(Json(serde_json::to_value(result)?))
+        }
         CoreRetireOutcome::NotFound => Ok(Json(json!({
             "error": format!("Session {session_id} not found")
         }))),
         CoreRetireOutcome::NotChild => Ok(Json(json!({
             "error": format!("Cannot retire session {session_id} - not your child session")
         }))),
+        CoreRetireOutcome::RootProtected => Ok(Json(json!({
+            "error": format!("Cannot retire session {session_id} - root sessions require server-owned lifecycle authority")
+        }))),
+        CoreRetireOutcome::Forbidden => Err(ApiError::Status {
+            status: StatusCode::FORBIDDEN,
+            detail: "session credential is missing, stale, or does not match the claimed requester"
+                .to_owned(),
+        }),
         CoreRetireOutcome::UnsupportedNode(node) => Err(ApiError::Status {
             status: StatusCode::BAD_REQUEST,
             detail: format!("Rust runtime does not support remote node {node}"),

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -7357,6 +7357,16 @@ fn recover_btw_requests(state: Arc<AppState>) {
     let Ok(requests) = store.list_recoverable() else {
         return;
     };
+    // Runtime retirement recovery runs before the router starts. A process may
+    // have exited after persisting an attributed retire intent but before the
+    // HTTP request reached its BTW cleanup below. Reconcile those now-terminal
+    // request participants synchronously before starting any BTW workers.
+    if let Err(error) = teardown_btw_requests_for_terminal_sessions(&state, &requests) {
+        eprintln!("BTW terminal-session recovery failed: {error:#}");
+    }
+    let Ok(requests) = store.list_recoverable() else {
+        return;
+    };
     for request in requests {
         let worker_state = state.clone();
         let worker_store = store.clone();
@@ -7430,6 +7440,30 @@ fn recover_btw_requests(state: Arc<AppState>) {
             let _ = deliver_btw_response(&worker_state, &worker_store, &request.request_id);
         });
     }
+}
+
+fn teardown_btw_requests_for_terminal_sessions(
+    state: &AppState,
+    requests: &[BtwRequestRecord],
+) -> anyhow::Result<()> {
+    let mut terminal_session_ids = BTreeSet::new();
+    for request in requests {
+        for session_id in
+            std::iter::once(&request.target_session_id).chain(request.requester_session_id.as_ref())
+        {
+            if state
+                .session_store
+                .get_session(session_id)?
+                .is_some_and(|session| session.is_stopped())
+            {
+                terminal_session_ids.insert(session_id.as_str());
+            }
+        }
+    }
+    for session_id in terminal_session_ids {
+        teardown_btw_requests_for_session(state, session_id)?;
+    }
+    Ok(())
 }
 
 fn run_btw_request(state: &AppState, request_id: &str) -> anyhow::Result<()> {

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -8249,9 +8249,17 @@ async fn retire_session(
     };
     match outcome {
         CoreRetireOutcome::Retired(result) => {
-            if let Err(error) = teardown_btw_requests_for_session(&state, &session_id) {
-                eprintln!("retired session {session_id} but BTW teardown failed: {error:#}");
-            }
+            // Retirement is durable before this cleanup. Surface a failed
+            // teardown so the caller retries the idempotent retirement rather
+            // than receiving a false success with live BTW work left behind.
+            teardown_btw_requests_for_session(&state, &session_id).map_err(|error| {
+                ApiError::Status {
+                    status: StatusCode::SERVICE_UNAVAILABLE,
+                    detail: format!(
+                        "session {session_id} was retired but BTW teardown requires retry: {error:#}"
+                    ),
+                }
+            })?;
             Ok(Json(serde_json::to_value(result)?))
         }
         CoreRetireOutcome::NotFound => Ok(Json(json!({

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -7363,6 +7363,7 @@ fn recover_btw_requests(state: Arc<AppState>) {
     // request participants synchronously before starting any BTW workers.
     if let Err(error) = teardown_btw_requests_for_terminal_sessions(&state, &requests) {
         eprintln!("BTW terminal-session recovery failed: {error:#}");
+        return;
     }
     let Ok(requests) = store.list_recoverable() else {
         return;

--- a/crates/sm-server/src/main.rs
+++ b/crates/sm-server/src/main.rs
@@ -22,6 +22,7 @@ use tokio::net::TcpListener;
 /// How often the Studio SSH reconcile loop repairs toward the desired state.
 const STUDIO_SSH_RECONCILE_INTERVAL: Duration = Duration::from_secs(30);
 const QUEUE_COMPLETION_RETRY_INTERVAL: Duration = Duration::from_secs(5);
+const TERMINAL_RUNTIME_TEARDOWN_RETRY_INTERVAL: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Parser)]
 #[command(version, about = "Rust Session Manager server scaffold")]
@@ -136,6 +137,14 @@ async fn main() -> Result<()> {
                 eprintln!("queue completion delivery retry failed: {error:#}");
             }
             thread::sleep(QUEUE_COMPLETION_RETRY_INTERVAL);
+        });
+        let terminal_runtime_state = state.clone();
+        thread::spawn(move || loop {
+            if let Err(error) = terminal_runtime_state.reconcile_terminal_runtime_launch_teardowns()
+            {
+                eprintln!("terminal runtime teardown retry failed: {error:#}");
+            }
+            thread::sleep(TERMINAL_RUNTIME_TEARDOWN_RETRY_INTERVAL);
         });
     }
     // Capture the artifact boundary before serving. The background scan may run

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -800,6 +800,16 @@ impl TmuxRuntime {
         Ok(true)
     }
 
+    /// Tear down a runtime without allowing an unresponsive tmux client to
+    /// block recovery of other independent sessions.
+    pub fn kill_session_with_timeout(&self, tmux_session: &str, timeout: Duration) -> Result<bool> {
+        if !self.session_exists_with_timeout(tmux_session, timeout)? {
+            return Ok(false);
+        }
+        self.run_tmux_with_timeout(["kill-session", "-t", tmux_session], timeout)?;
+        Ok(true)
+    }
+
     pub fn set_status_bar(&self, tmux_session: &str, friendly_name: &str) -> Result<bool> {
         if !self.session_exists(tmux_session)? {
             return Ok(false);
@@ -823,6 +833,12 @@ impl TmuxRuntime {
             .output()
             .with_context(|| "failed to run tmux has-session")?;
         Ok(output.status.success())
+    }
+
+    fn session_exists_with_timeout(&self, tmux_session: &str, timeout: Duration) -> Result<bool> {
+        Ok(self
+            .run_tmux_status_with_timeout(["has-session", "-t", tmux_session], timeout)?
+            .success())
     }
 
     fn create_session_with_bootstrap(&self, spec: &TmuxSessionSpec, command: &str) -> Result<()> {
@@ -1179,6 +1195,45 @@ impl TmuxRuntime {
             bail!("tmux command failed: {}", stderr.trim());
         }
         Ok(())
+    }
+
+    fn run_tmux_with_timeout<'a>(
+        &self,
+        args: impl IntoIterator<Item = &'a str>,
+        timeout: Duration,
+    ) -> Result<()> {
+        if !self.run_tmux_status_with_timeout(args, timeout)?.success() {
+            bail!("tmux command failed");
+        }
+        Ok(())
+    }
+
+    fn run_tmux_status_with_timeout<'a>(
+        &self,
+        args: impl IntoIterator<Item = &'a str>,
+        timeout: Duration,
+    ) -> Result<std::process::ExitStatus> {
+        let mut child = self
+            .tmux_command(args)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .with_context(|| "failed to run tmux")?;
+        let deadline = Instant::now() + timeout;
+        loop {
+            if let Some(status) = child
+                .try_wait()
+                .with_context(|| "failed to wait for tmux")?
+            {
+                return Ok(status);
+            }
+            if Instant::now() >= deadline {
+                let _ = child.kill();
+                let _ = child.wait();
+                bail!("tmux command timed out after {}ms", timeout.as_millis());
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
     }
 
     fn tmux_command<'a>(&self, args: impl IntoIterator<Item = &'a str>) -> Command {
@@ -2341,6 +2396,31 @@ printf '%s' '{"models":[{"slug":"gpt-5.6-luna","visibility":"list"}]}'
         assert_eq!(output, ">\n");
         let log = fs::read_to_string(log_path).unwrap();
         assert!(log.contains("capture-pane -p -S -1 -t sm-test"));
+    }
+
+    #[test]
+    fn bounded_kill_session_does_not_wait_on_an_unresponsive_tmux_client() {
+        let (tmux_binary, _log_path, _temp_dir) = fake_tmux_binary();
+        fs::write(
+            &tmux_binary,
+            r#"#!/bin/sh
+while :; do :; done
+"#,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&tmux_binary).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&tmux_binary, permissions).unwrap();
+        let mut runtime = TmuxRuntime::from_config(&RustCoreConfig::default());
+        runtime.tmux_binary = tmux_binary.display().to_string();
+        let started = Instant::now();
+
+        let error = runtime
+            .kill_session_with_timeout("sm-test", Duration::from_millis(25))
+            .unwrap_err();
+
+        assert!(error.to_string().contains("timed out"));
+        assert!(started.elapsed() < Duration::from_millis(250));
     }
 
     #[test]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -880,16 +880,28 @@ impl SessionStore {
         // writes terminal evidence, so this startup pass owns the remaining
         // crash window and tears down any such late runtime before ordinary
         // launch recovery considers other work.
-        // Restoration holds this same mutation lock from its terminal-marker
-        // check through tmux creation and the durable running transition. Do
-        // not release it between terminal revalidation and kill: otherwise a
-        // stale terminal snapshot could tear down a just-restored runtime.
-        let _guard = self.write_guard()?;
-        let state = self.load_raw_json_value()?;
-        for launch in terminal_runtime_teardown_records(&state)? {
-            runtime
-                .for_socket_name(launch.tmux_socket_name.as_deref())
-                .kill_session(&launch.tmux_session)?;
+        let terminal_launches = {
+            let _guard = self.write_guard()?;
+            let state = self.load_raw_json_value()?;
+            terminal_runtime_teardown_records(&state)?
+        };
+        for candidate in terminal_launches {
+            // Restore and terminal teardown share this per-session gate. The
+            // state lock is held only for revalidation, while the potentially
+            // slow tmux commands run outside the global mutation lock.
+            let _lifecycle_guard = self.lock_terminal_runtime_fence(&candidate.session_id)?;
+            let launch = {
+                let _guard = self.write_guard()?;
+                let state = self.load_raw_json_value()?;
+                terminal_runtime_teardown_records(&state)?
+                    .into_iter()
+                    .find(|launch| launch.id == candidate.id)
+            };
+            if let Some(launch) = launch {
+                runtime
+                    .for_socket_name(launch.tmux_socket_name.as_deref())
+                    .kill_session(&launch.tmux_session)?;
+            }
         }
         Ok(())
     }
@@ -5331,6 +5343,10 @@ impl SessionStore {
         self.lock_codex_cli_binding_working_dir(&record.working_dir)
     }
 
+    fn lock_terminal_runtime_fence(&self, session_id: &str) -> Result<SessionClearGuard> {
+        self.lock_named_clear_operation(&format!("terminal-runtime-fence:{session_id}"))
+    }
+
     fn lock_codex_cli_binding_working_dir(&self, working_dir: &str) -> Result<SessionClearGuard> {
         let sessions_root = resolve_path_lossy(self.codex_sessions_root.clone());
         let working_dir = resolve_path_lossy(expand_home(working_dir));
@@ -5408,6 +5424,7 @@ impl SessionStore {
         session_id: &str,
         runtime: &TmuxRuntime,
     ) -> Result<Option<CoreRestoreOutcome>> {
+        let _lifecycle_guard = self.lock_terminal_runtime_fence(session_id)?;
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
         ensure_session_not_reparent_fenced(&state, session_id)?;

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -865,7 +865,19 @@ impl SessionStore {
             .collect::<Vec<_>>();
         drop(_guard);
         for session_id in pending_ids {
-            self.retire_core_session_with_runtime_authorized(&session_id, None, None, runtime)?;
+            // This recovery runs before the HTTP server binds. Keep one
+            // unresponsive tmux socket from preventing startup or starving
+            // other durable retirement intents; the pending disposition stays
+            // in state and the periodic reconciler retries it.
+            if let Err(error) = self.retire_core_session_with_runtime_authorized_with_timeout(
+                &session_id,
+                None,
+                None,
+                runtime,
+                Some(TERMINAL_RUNTIME_TEARDOWN_COMMAND_TIMEOUT),
+            ) {
+                eprintln!("pending runtime retirement recovery for {session_id} failed: {error:#}");
+            }
         }
         Ok(())
     }
@@ -875,6 +887,10 @@ impl SessionStore {
     /// observation, so absence alone is not evidence that the launcher can no
     /// longer create the target runtime.
     pub fn reconcile_terminal_runtime_launch_teardowns(&self) -> Result<()> {
+        // Retire intents that could not finish at startup remain durable and
+        // are retried with the same bounded, per-session behavior as terminal
+        // launch teardown below.
+        self.recover_pending_runtime_retires()?;
         let Some(runtime) = self.delivery_runtime.as_ref() else {
             return Ok(());
         };
@@ -7584,6 +7600,23 @@ impl SessionStore {
         session_credential: Option<&str>,
         runtime: &TmuxRuntime,
     ) -> Result<CoreRetireOutcome> {
+        self.retire_core_session_with_runtime_authorized_with_timeout(
+            session_id,
+            requester_session_id,
+            session_credential,
+            runtime,
+            None,
+        )
+    }
+
+    fn retire_core_session_with_runtime_authorized_with_timeout(
+        &self,
+        session_id: &str,
+        requester_session_id: Option<&str>,
+        session_credential: Option<&str>,
+        runtime: &TmuxRuntime,
+        tmux_timeout: Option<Duration>,
+    ) -> Result<CoreRetireOutcome> {
         let authority = retire_authority(requester_session_id, session_credential);
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
@@ -7671,7 +7704,10 @@ impl SessionStore {
         }
 
         let session_runtime = runtime.for_socket_name(session_socket_name.as_deref());
-        let tmux_was_killed = session_runtime.kill_session(&tmux_session)?;
+        let tmux_was_killed = match tmux_timeout {
+            Some(timeout) => session_runtime.kill_session_with_timeout(&tmux_session, timeout)?,
+            None => session_runtime.kill_session(&tmux_session)?,
+        };
         let sessions = ensure_sessions_array_mut(&mut state)?;
         let session = session_object_mut(sessions, session_id)
             .ok_or_else(|| anyhow::anyhow!("session {session_id} disappeared during retire"))?;
@@ -16838,6 +16874,73 @@ mod tests {
         );
         assert_eq!(session["terminal_provenance"]["source"], "api_retire");
         assert_eq!(session["terminal_provenance"]["tmux_disposition"], "killed");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pending_retire_recovery_bounds_stalled_tmux_and_continues_later_intents() {
+        let _guard = TEST_ENV_LOCK.lock().unwrap();
+        let root = unique_temp_path("pending-retire-timeout");
+        fs::create_dir_all(&root).unwrap();
+        let tmux = root.join("tmux");
+        let invoked = root.join("runtime-invoked");
+        fs::write(
+            &tmux,
+            "#!/bin/sh\nif [ \"$3\" = \"claude-blocked\" ]; then while :; do :; done; fi\nprintf '%s\\n' \"$*\" >> \"$SM_1314_FAKE_TMUX_SENTINEL\"\nexit 0\n",
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&tmux).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&tmux, permissions).unwrap();
+        let old_path = env::var_os("PATH").unwrap_or_default();
+        let _path = EnvVarRestore::set(
+            "PATH",
+            format!("{}:{}", root.display(), old_path.to_string_lossy()),
+        );
+        let _sentinel = EnvVarRestore::set("SM_1314_FAKE_TMUX_SENTINEL", &invoked);
+
+        let pending = |id: &str| {
+            let mut child = reparent_test_session(id, Some("parent01"), "child-secret");
+            child["status"] = json!("stopped");
+            child["completion_status"] = json!("retired");
+            child["node"] = json!("primary");
+            child["terminal_provenance"] = json!({
+                "cause": "explicit_retire",
+                "observed_at": "2026-08-18T04:00:00Z",
+                "actor_session_id": "parent01",
+                "authority": "authenticated_parent",
+                "source": "api_retire",
+                "tmux_disposition": "retire_requested"
+            });
+            child
+        };
+        let state_file = root.join("state.json");
+        fs::write(
+            &state_file,
+            json!({ "sessions": [pending("blocked"), pending("healthy")] }).to_string(),
+        )
+        .unwrap();
+        let store = SessionStore::new(state_file.clone()).with_delivery_runtime(Some(
+            TmuxRuntime::from_config(&crate::config::RustCoreConfig::default()),
+        ));
+        let started = Instant::now();
+
+        store.recover_pending_runtime_retires().unwrap();
+
+        assert!(started.elapsed() < Duration::from_secs(2));
+        let recovered = store.load_raw_json_value().unwrap();
+        assert_eq!(
+            recovered["sessions"][0]["terminal_provenance"]["tmux_disposition"],
+            "retire_requested"
+        );
+        assert_eq!(
+            recovered["sessions"][1]["terminal_provenance"]["tmux_disposition"],
+            "killed"
+        );
+        let invocation = fs::read_to_string(&invoked).unwrap();
+        assert!(invocation.contains("has-session -t claude-healthy"));
+        assert!(invocation.contains("kill-session -t claude-healthy"));
         let _ = fs::remove_dir_all(root);
     }
 

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -16628,6 +16628,73 @@ mod tests {
         let _ = fs::remove_dir_all(root);
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn recovery_resumes_pending_retire_intent_without_erasing_authenticated_provenance() {
+        // The intent is written before tmux is touched.  Model a process exit
+        // at that boundary and make recovery complete the original operation,
+        // rather than treating the marker as terminal or replacing its actor.
+        let _guard = TEST_ENV_LOCK.lock().unwrap();
+        let root = unique_temp_path("pending-retire-recovery");
+        fs::create_dir_all(&root).unwrap();
+        let tmux = root.join("tmux");
+        let invoked = root.join("runtime-invoked");
+        fs::write(
+            &tmux,
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$SM_1314_FAKE_TMUX_SENTINEL\"\nexit 0\n",
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&tmux).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&tmux, permissions).unwrap();
+        let old_path = env::var_os("PATH").unwrap_or_default();
+        let _path = EnvVarRestore::set(
+            "PATH",
+            format!("{}:{}", root.display(), old_path.to_string_lossy()),
+        );
+        let _sentinel = EnvVarRestore::set("SM_1314_FAKE_TMUX_SENTINEL", &invoked);
+
+        let state_file = root.join("state.json");
+        let mut child = reparent_test_session("child01", Some("parent01"), "child-secret");
+        child["status"] = json!("stopped");
+        child["completion_status"] = json!("retired");
+        child["node"] = json!("primary");
+        child["terminal_provenance"] = json!({
+            "cause": "explicit_retire",
+            "observed_at": "2026-08-18T04:00:00Z",
+            "actor_session_id": "parent01",
+            "authority": "authenticated_parent",
+            "source": "api_retire",
+            "tmux_disposition": "retire_requested"
+        });
+        fs::write(&state_file, json!({ "sessions": [child] }).to_string()).unwrap();
+
+        let store = SessionStore::new(state_file.clone()).with_delivery_runtime(Some(
+            TmuxRuntime::from_config(&crate::config::RustCoreConfig::default()),
+        ));
+        store.recover_session_runtime_launches().unwrap();
+
+        let invocation = fs::read_to_string(&invoked).unwrap();
+        assert!(invocation.contains("has-session -t claude-child01"));
+        assert!(invocation.contains("kill-session -t claude-child01"));
+        let recovered = store.load_raw_json_value().unwrap();
+        let session = &recovered["sessions"][0];
+        assert_eq!(session["status"], "stopped");
+        assert_eq!(session["completion_status"], "retired");
+        assert_eq!(session["terminal_provenance"]["cause"], "explicit_retire");
+        assert_eq!(
+            session["terminal_provenance"]["actor_session_id"],
+            "parent01"
+        );
+        assert_eq!(
+            session["terminal_provenance"]["authority"],
+            "authenticated_parent"
+        );
+        assert_eq!(session["terminal_provenance"]["source"], "api_retire");
+        assert_eq!(session["terminal_provenance"]["tmux_disposition"], "killed");
+        let _ = fs::remove_dir_all(root);
+    }
+
     #[test]
     fn credential_rotation_authorized_restore_with_terminal_marker_continues_recovery() {
         for (completion_status, launch_status) in [

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -880,27 +880,18 @@ impl SessionStore {
         // writes terminal evidence, so this startup pass owns the remaining
         // crash window and tears down any such late runtime before ordinary
         // launch recovery considers other work.
-        for launch in self.pending_terminal_runtime_teardowns()? {
+        // Restoration holds this same mutation lock from its terminal-marker
+        // check through tmux creation and the durable running transition. Do
+        // not release it between terminal revalidation and kill: otherwise a
+        // stale terminal snapshot could tear down a just-restored runtime.
+        let _guard = self.write_guard()?;
+        let state = self.load_raw_json_value()?;
+        for launch in terminal_runtime_teardown_records(&state)? {
             runtime
                 .for_socket_name(launch.tmux_socket_name.as_deref())
                 .kill_session(&launch.tmux_session)?;
         }
         Ok(())
-    }
-
-    fn pending_terminal_runtime_teardowns(&self) -> Result<Vec<SessionRuntimeLaunchRecord>> {
-        let _guard = self.write_guard()?;
-        let state = self.load_raw_json_value()?;
-        let terminal_session_ids = terminal_session_ids_from_state(&state)?;
-        Ok(session_runtime_launch_records(&state)?
-            .into_iter()
-            .filter(|launch| {
-                (launch.terminal_teardown_pending
-                    || (launch.status == "failed"
-                        && launch.failure_reason.as_deref() == Some("target_terminal")))
-                    && terminal_session_ids.contains(&launch.session_id)
-            })
-            .collect())
     }
 
     fn recover_session_runtime_launch(&self, launch_id: &str) -> Result<()> {
@@ -13591,6 +13582,19 @@ fn terminal_session_ids_from_state(state: &Value) -> Result<BTreeSet<String>> {
         .collect())
 }
 
+fn terminal_runtime_teardown_records(state: &Value) -> Result<Vec<SessionRuntimeLaunchRecord>> {
+    let terminal_session_ids = terminal_session_ids_from_state(state)?;
+    Ok(session_runtime_launch_records(state)?
+        .into_iter()
+        .filter(|launch| {
+            (launch.terminal_teardown_pending
+                || (launch.status == "failed"
+                    && launch.failure_reason.as_deref() == Some("target_terminal")))
+                && terminal_session_ids.contains(&launch.session_id)
+        })
+        .collect())
+}
+
 fn store_session_runtime_launch_records(
     state: &mut Value,
     records: &[SessionRuntimeLaunchRecord],
@@ -16816,7 +16820,8 @@ mod tests {
         fs::write(&state_file, state.to_string()).unwrap();
 
         let store = SessionStore::new(state_file.clone());
-        let pending = store.pending_terminal_runtime_teardowns().unwrap();
+        let pending =
+            terminal_runtime_teardown_records(&store.load_raw_json_value().unwrap()).unwrap();
 
         assert_eq!(pending.len(), 1);
         assert_eq!(pending[0].id, "launch01");

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -828,6 +828,7 @@ impl SessionStore {
 
     pub fn recover_session_runtime_launches(&self) -> Result<()> {
         self.recover_pending_runtime_retires()?;
+        self.recover_terminal_runtime_launch_teardowns()?;
         loop {
             let launch_id = {
                 let _guard = self.write_guard()?;
@@ -862,6 +863,43 @@ impl SessionStore {
         drop(_guard);
         for session_id in pending_ids {
             self.retire_core_session_with_runtime_authorized(&session_id, None, None, runtime)?;
+        }
+        Ok(())
+    }
+
+    fn recover_terminal_runtime_launch_teardowns(&self) -> Result<()> {
+        let Some(runtime) = self.delivery_runtime.as_ref() else {
+            return Ok(());
+        };
+        // A create worker can bring tmux up after a concurrent retirement's
+        // first absence check. Retirement fences its launch record before it
+        // writes terminal evidence, so this startup pass owns the remaining
+        // crash window and tears down any such late runtime before ordinary
+        // launch recovery considers other work.
+        let terminal_launches = {
+            let _guard = self.write_guard()?;
+            let state = self.load_raw_json_value()?;
+            let terminal_session_ids = snapshot_from_raw_value(&state)?
+                .sessions
+                .into_iter()
+                .filter(|session| {
+                    completion_status_is_retired(session.completion_status.as_deref())
+                })
+                .map(|session| session.id)
+                .collect::<BTreeSet<_>>();
+            session_runtime_launch_records(&state)?
+                .into_iter()
+                .filter(|launch| {
+                    launch.status == "failed"
+                        && launch.failure_reason.as_deref() == Some("target_terminal")
+                        && terminal_session_ids.contains(&launch.session_id)
+                })
+                .collect::<Vec<_>>()
+        };
+        for launch in terminal_launches {
+            runtime
+                .for_socket_name(launch.tmux_socket_name.as_deref())
+                .kill_session(&launch.tmux_session)?;
         }
         Ok(())
     }
@@ -7562,6 +7600,7 @@ impl SessionStore {
         // attributed retirement rather than inferring a disappearance.
         if !pending_retire_intent {
             finalize_active_credential_rotations_for_terminal_session(&mut state, session_id)?;
+            fence_terminal_runtime_launches(&mut state, session_id)?;
             let now = now_rfc3339();
             let sessions = ensure_sessions_array_mut(&mut state)?;
             let session = session_object_mut(sessions, session_id)
@@ -13637,6 +13676,31 @@ fn finalize_active_credential_rotations_for_terminal_session(
     Ok(())
 }
 
+/// A terminal lifecycle transition must durably cancel every in-flight runtime
+/// launch for the seat before it releases the state lock. The corresponding
+/// launcher observes the terminal marker before publishing `running`; if it
+/// crashes after creating tmux, startup uses this fence to remove that late
+/// runtime instead of treating the failed launch as inert.
+fn fence_terminal_runtime_launches(state: &mut Value, session_id: &str) -> Result<()> {
+    let mut launches = session_runtime_launch_records(state)?;
+    let mut changed = false;
+    let now = now_rfc3339();
+    for launch in &mut launches {
+        if launch.session_id == session_id
+            && matches!(launch.status.as_str(), "prepared" | "launching")
+        {
+            launch.status = "failed".to_owned();
+            launch.updated_at = now.clone();
+            launch.failure_reason = Some("target_terminal".to_owned());
+            changed = true;
+        }
+    }
+    if changed {
+        store_session_runtime_launch_records(state, &launches)?;
+    }
+    Ok(())
+}
+
 /// Reconcile a missing local tmux runtime to durable terminal state without
 /// interpreting pane output.  This is only called while the caller holds the
 /// session mutation lock.
@@ -16692,6 +16756,72 @@ mod tests {
         );
         assert_eq!(session["terminal_provenance"]["source"], "api_retire");
         assert_eq!(session["terminal_provenance"]["tmux_disposition"], "killed");
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[test]
+    fn terminal_retirement_fences_a_provisional_runtime_launch() {
+        let mut state = terminal_rotation_fixture("failed", Some("launching"));
+        state["session_runtime_launches"][0]["operation_kind"] = json!("create");
+        state["session_runtime_launches"][0]["credential_rotation_id"] = Value::Null;
+
+        fence_terminal_runtime_launches(&mut state, "rotate01").unwrap();
+
+        assert_eq!(state["session_runtime_launches"][0]["status"], "failed");
+        assert_eq!(
+            state["session_runtime_launches"][0]["failure_reason"],
+            "target_terminal"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn startup_tears_down_a_late_runtime_fenced_by_terminal_retirement() {
+        let _guard = TEST_ENV_LOCK.lock().unwrap();
+        let root = unique_temp_path("terminal-launch-teardown");
+        fs::create_dir_all(&root).unwrap();
+        let tmux = root.join("tmux");
+        let invoked = root.join("runtime-invoked");
+        fs::write(
+            &tmux,
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$SM_1314_FAKE_TMUX_SENTINEL\"\nexit 0\n",
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&tmux).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&tmux, permissions).unwrap();
+        let old_path = env::var_os("PATH").unwrap_or_default();
+        let _path = EnvVarRestore::set(
+            "PATH",
+            format!("{}:{}", root.display(), old_path.to_string_lossy()),
+        );
+        let _sentinel = EnvVarRestore::set("SM_1314_FAKE_TMUX_SENTINEL", &invoked);
+
+        let state_file = root.join("state.json");
+        let mut state = terminal_rotation_fixture("failed", Some("failed"));
+        state["sessions"][0]["status"] = json!("stopped");
+        state["sessions"][0]["completion_status"] = json!("retired");
+        state["sessions"][0]["terminal_provenance"] = json!({
+            "cause": "explicit_retire",
+            "observed_at": "2026-08-18T04:00:00Z",
+            "actor_session_id": "parent01",
+            "authority": "authenticated_parent",
+            "source": "api_retire",
+            "tmux_disposition": "already_absent"
+        });
+        state["session_runtime_launches"][0]["operation_kind"] = json!("create");
+        state["session_runtime_launches"][0]["credential_rotation_id"] = Value::Null;
+        state["session_runtime_launches"][0]["failure_reason"] = json!("target_terminal");
+        fs::write(&state_file, state.to_string()).unwrap();
+
+        let store = SessionStore::new(state_file).with_delivery_runtime(Some(
+            TmuxRuntime::from_config(&crate::config::RustCoreConfig::default()),
+        ));
+        store.recover_session_runtime_launches().unwrap();
+
+        let invocation = fs::read_to_string(&invoked).unwrap();
+        assert!(invocation.contains("has-session -t claude-rotate01"));
+        assert!(invocation.contains("kill-session -t claude-rotate01"));
         let _ = fs::remove_dir_all(root);
     }
 

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -7417,6 +7417,13 @@ impl SessionStore {
                     return Ok(CoreRetireOutcome::NotChild);
                 }
             }
+            if raw_session_is_stopped(session) {
+                return Ok(CoreRetireOutcome::Retired(CoreRetireResult {
+                    ok: true,
+                    session_id: session_id.to_owned(),
+                    status: "retired".to_owned(),
+                }));
+            }
             raw_session_display_name(session, session_id)
         };
         // A terminal write and its rotation finalization share this one atomic
@@ -7500,6 +7507,13 @@ impl SessionStore {
                 {
                     return Ok(CoreRetireOutcome::NotChild);
                 }
+            }
+            if raw_session_is_stopped(session) {
+                return Ok(CoreRetireOutcome::Retired(CoreRetireResult {
+                    ok: true,
+                    session_id: session_id.to_owned(),
+                    status: "retired".to_owned(),
+                }));
             }
             let node = json_text(session.get("node")).unwrap_or_else(default_node);
             let tmux_session = json_text(session.get("tmux_session"))
@@ -13585,6 +13599,13 @@ fn mark_session_runtime_missing_terminal(state: &mut Value, session_id: &str) ->
         let now = now_rfc3339();
         session.insert("status".to_owned(), Value::String("stopped".to_owned()));
         session.insert("stopped_at".to_owned(), Value::String(now.clone()));
+        session.insert(
+            "terminal_provenance".to_owned(),
+            serde_json::to_value(TerminalProvenance::tmux_disappearance(
+                &now,
+                "runtime_liveness_check",
+            ))?,
+        );
         session.insert("last_activity".to_owned(), Value::String(now));
     }
     Ok(())
@@ -13682,8 +13703,19 @@ fn mark_runtime_launch_failed(
         finalize_active_credential_rotations_for_terminal_session(state, session_id)?;
         let sessions = ensure_sessions_array_mut(state)?;
         if let Some(session) = session_object_mut(sessions, session_id) {
-            session.insert("status".to_owned(), Value::String("stopped".to_owned()));
-            session.insert("stopped_at".to_owned(), Value::String(now_rfc3339()));
+            if !raw_session_is_stopped(session) {
+                let now = now_rfc3339();
+                session.insert("status".to_owned(), Value::String("stopped".to_owned()));
+                session.insert("stopped_at".to_owned(), Value::String(now.clone()));
+                session.insert(
+                    "terminal_provenance".to_owned(),
+                    serde_json::to_value(TerminalProvenance::startup_reconciliation(
+                        &now,
+                        "runtime_launch_failed",
+                    ))?,
+                );
+                session.insert("last_activity".to_owned(), Value::String(now));
+            }
         }
     }
     Ok(())
@@ -15098,6 +15130,17 @@ impl TerminalProvenance {
             tmux_disposition: Some("absent".to_owned()),
         }
     }
+
+    fn startup_reconciliation(observed_at: &str, source: &str) -> Self {
+        Self {
+            cause: TerminalCause::StartupReconciliation,
+            observed_at: observed_at.to_owned(),
+            actor_session_id: None,
+            authority: "server_observed".to_owned(),
+            source: source.to_owned(),
+            tmux_disposition: None,
+        }
+    }
 }
 
 fn root_seat_id(record: &SessionRecord, records: &BTreeMap<&str, &SessionRecord>) -> String {
@@ -15849,6 +15892,16 @@ mod tests {
             "stopped_at".to_owned(),
             Value::String("2026-06-01T00:02:00Z".to_owned()),
         );
+        retired.insert(
+            "terminal_provenance".to_owned(),
+            json!({
+                "cause": "tmux_disappearance",
+                "observed_at": "2026-06-01T00:02:00Z",
+                "authority": "runtime_observed",
+                "source": "runtime_delivery_failed",
+                "tmux_disposition": "absent"
+            }),
+        );
         let mut state = json!({
             "sessions": [retired],
             "session_runtime_launches": [{
@@ -15881,7 +15934,81 @@ mod tests {
 
         assert_eq!(state["sessions"].as_array().unwrap().len(), 1);
         assert_eq!(state["sessions"][0]["completion_status"], "retired");
+        assert_eq!(
+            state["sessions"][0]["terminal_provenance"]["cause"],
+            "tmux_disappearance"
+        );
+        assert_eq!(
+            state["sessions"][0]["terminal_provenance"]["observed_at"],
+            "2026-06-01T00:02:00Z"
+        );
         assert_eq!(state["session_runtime_launches"][0]["status"], "failed");
+    }
+
+    #[test]
+    fn runtime_missing_terminal_records_observed_tmux_provenance() {
+        let mut state = json!({
+            "sessions": [reparent_test_session("missing01", None, "secret")]
+        });
+
+        mark_session_runtime_missing_terminal(&mut state, "missing01").unwrap();
+
+        assert_eq!(state["sessions"][0]["status"], "stopped");
+        assert_eq!(
+            state["sessions"][0]["terminal_provenance"]["cause"],
+            "tmux_disappearance"
+        );
+        assert_eq!(
+            state["sessions"][0]["terminal_provenance"]["authority"],
+            "runtime_observed"
+        );
+        assert_eq!(
+            state["sessions"][0]["terminal_provenance"]["source"],
+            "runtime_liveness_check"
+        );
+    }
+
+    #[test]
+    fn failed_runtime_launch_records_startup_provenance() {
+        let mut state = json!({
+            "sessions": [reparent_test_session("launch01", None, "secret")],
+            "session_runtime_launches": [{
+                "id": "launch01",
+                "operation_kind": "restore",
+                "session_id": "launch01",
+                "tmux_session": "claude-launch01",
+                "working_dir": "/repo",
+                "log_file": "/tmp/launch01.log",
+                "provider": "claude",
+                "credential_sha256": sha256_text("secret"),
+                "status": "launching",
+                "created_at": "2026-06-01T00:00:00Z",
+                "updated_at": "2026-06-01T00:00:00Z"
+            }]
+        });
+
+        mark_runtime_launch_failed(
+            &mut state,
+            "launch01",
+            "launch01",
+            false,
+            "runtime exited during recovery",
+        )
+        .unwrap();
+
+        assert_eq!(state["sessions"][0]["status"], "stopped");
+        assert_eq!(
+            state["sessions"][0]["terminal_provenance"]["cause"],
+            "startup_reconciliation"
+        );
+        assert_eq!(
+            state["sessions"][0]["terminal_provenance"]["authority"],
+            "server_observed"
+        );
+        assert_eq!(
+            state["sessions"][0]["terminal_provenance"]["source"],
+            "runtime_launch_failed"
+        );
     }
 
     static TEST_ENV_LOCK: Mutex<()> = Mutex::new(());

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -57,6 +57,7 @@ const CODEX_FORK_EVENT_MONITOR_POLL: Duration = Duration::from_millis(250);
 const CODEX_FORK_CONTROL_TIMEOUT: Duration = Duration::from_secs(3);
 const CODEX_FORK_CONTROL_RECOVERY_TIMEOUT: Duration = Duration::from_secs(1);
 const CODEX_FORK_CONTROL_RECOVERY_POLL: Duration = Duration::from_millis(50);
+const TERMINAL_RUNTIME_TEARDOWN_COMMAND_TIMEOUT: Duration = Duration::from_secs(1);
 const SEAT_SESSION_RETRY_ATTEMPTS: usize = 20;
 const SEAT_SESSION_RETRY_DELAY: Duration = Duration::from_millis(100);
 const REPARENT_REQUEST_TTL_HOURS: i64 = 24;
@@ -904,9 +905,18 @@ impl SessionStore {
             // restore until this teardown attempt is complete.
             let _lifecycle_guard = self.lock_terminal_runtime_fence(&launch.session_id)?;
             if self.terminal_runtime_fence_epoch(&launch.session_id)? == epoch {
-                runtime
+                if let Err(error) = runtime
                     .for_socket_name(launch.tmux_socket_name.as_deref())
-                    .kill_session(&launch.tmux_session)?;
+                    .kill_session_with_timeout(
+                        &launch.tmux_session,
+                        TERMINAL_RUNTIME_TEARDOWN_COMMAND_TIMEOUT,
+                    )
+                {
+                    eprintln!(
+                        "terminal runtime teardown retry for {} failed: {error:#}",
+                        launch.id
+                    );
+                }
             }
         }
         Ok(())

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -7525,10 +7525,11 @@ impl SessionStore {
         if !is_primary_node(&node) {
             return Ok(CoreRetireOutcome::UnsupportedNode(node));
         }
-        let session_runtime = runtime.for_socket_name(session_socket_name.as_deref());
-        let tmux_was_killed = session_runtime.kill_session(&tmux_session)?;
         // A terminal write and its rotation finalization share this one atomic
-        // state replacement, so recovery cannot later relaunch the seat.
+        // state replacement, so recovery cannot later relaunch the seat. It
+        // must reach durable storage before the external kill: if this process
+        // exits after tmux accepts the kill, startup recovery retains the
+        // attributed retirement rather than inferring a disappearance.
         finalize_active_credential_rotations_for_terminal_session(&mut state, session_id)?;
         let now = now_rfc3339();
         let sessions = ensure_sessions_array_mut(&mut state)?;
@@ -7542,15 +7543,33 @@ impl SessionStore {
                 &now,
                 requester_session_id,
                 authority,
-                Some(if tmux_was_killed {
-                    "killed"
-                } else {
-                    "already_absent"
-                }),
+                Some("retire_requested"),
             ),
         );
         session.insert("stopped_at".to_owned(), Value::String(now.clone()));
         session.insert("last_activity".to_owned(), Value::String(now));
+        self.write_raw_json_value(&state)?;
+
+        let session_runtime = runtime.for_socket_name(session_socket_name.as_deref());
+        let tmux_was_killed = session_runtime.kill_session(&tmux_session)?;
+        let sessions = ensure_sessions_array_mut(&mut state)?;
+        let session = session_object_mut(sessions, session_id)
+            .ok_or_else(|| anyhow::anyhow!("session {session_id} disappeared during retire"))?;
+        let terminal_provenance = session
+            .get_mut("terminal_provenance")
+            .and_then(Value::as_object_mut)
+            .ok_or_else(|| anyhow::anyhow!("session {session_id} lost retirement provenance"))?;
+        terminal_provenance.insert(
+            "tmux_disposition".to_owned(),
+            Value::String(
+                if tmux_was_killed {
+                    "killed"
+                } else {
+                    "already_absent"
+                }
+                .to_owned(),
+            ),
+        );
         complete_stop_notify_after_stop_raw(
             self,
             &mut state,

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -16714,6 +16714,7 @@ mod tests {
             completion_message: None,
             completed_at: None,
             stopped_at: None,
+            terminal_provenance: None,
             is_em: false,
             role: None,
             status: status.to_owned(),

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -60,9 +60,6 @@ const CODEX_FORK_CONTROL_RECOVERY_POLL: Duration = Duration::from_millis(50);
 const SEAT_SESSION_RETRY_ATTEMPTS: usize = 20;
 const SEAT_SESSION_RETRY_DELAY: Duration = Duration::from_millis(100);
 const REPARENT_REQUEST_TTL_HOURS: i64 = 24;
-const TERMINAL_RUNTIME_TEARDOWN_STABILITY_CHECKS: usize = 5;
-const TERMINAL_RUNTIME_TEARDOWN_STABILITY_DELAY: Duration = Duration::from_millis(100);
-const TERMINAL_RUNTIME_TEARDOWN_STABLE_ABSENCES: usize = 3;
 static STATE_WRITE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone)]
@@ -831,7 +828,7 @@ impl SessionStore {
 
     pub fn recover_session_runtime_launches(&self) -> Result<()> {
         self.recover_pending_runtime_retires()?;
-        self.recover_terminal_runtime_launch_teardowns()?;
+        self.reconcile_terminal_runtime_launch_teardowns()?;
         loop {
             let launch_id = {
                 let _guard = self.write_guard()?;
@@ -870,7 +867,11 @@ impl SessionStore {
         Ok(())
     }
 
-    fn recover_terminal_runtime_launch_teardowns(&self) -> Result<()> {
+    /// Revisit terminal-fenced launches for the lifetime of the server. A
+    /// crashed tmux `new-session` client may publish after an earlier absence
+    /// observation, so absence alone is not evidence that the launcher can no
+    /// longer create the target runtime.
+    pub fn reconcile_terminal_runtime_launch_teardowns(&self) -> Result<()> {
         let Some(runtime) = self.delivery_runtime.as_ref() else {
             return Ok(());
         };
@@ -879,58 +880,10 @@ impl SessionStore {
         // writes terminal evidence, so this startup pass owns the remaining
         // crash window and tears down any such late runtime before ordinary
         // launch recovery considers other work.
-        let mut stable_absences = BTreeMap::<String, usize>::new();
-        for attempt in 0..TERMINAL_RUNTIME_TEARDOWN_STABILITY_CHECKS {
-            let terminal_launches = self.pending_terminal_runtime_teardowns()?;
-            if terminal_launches.is_empty() {
-                return Ok(());
-            }
-            for launch in terminal_launches {
-                let was_running = runtime
-                    .for_socket_name(launch.tmux_socket_name.as_deref())
-                    .kill_session(&launch.tmux_session)?;
-                let stable_absence = stable_absences.entry(launch.id).or_default();
-                *stable_absence = if was_running { 0 } else { *stable_absence + 1 };
-            }
-            if attempt + 1 < TERMINAL_RUNTIME_TEARDOWN_STABILITY_CHECKS {
-                thread::sleep(TERMINAL_RUNTIME_TEARDOWN_STABILITY_DELAY);
-            }
-        }
-        let _guard = self.write_guard()?;
-        let mut state = self.load_raw_json_value()?;
-        let terminal_session_ids = terminal_session_ids_from_state(&state)?;
-        let mut launches = session_runtime_launch_records(&state)?;
-        let unsettled_launches = launches
-            .iter()
-            .filter(|launch| {
-                launch.terminal_teardown_pending
-                    && terminal_session_ids.contains(&launch.session_id)
-                    && stable_absences.get(&launch.id).copied().unwrap_or_default()
-                        < TERMINAL_RUNTIME_TEARDOWN_STABLE_ABSENCES
-            })
-            .map(|launch| launch.id.as_str())
-            .collect::<Vec<_>>();
-        if !unsettled_launches.is_empty() {
-            anyhow::bail!(
-                "terminal runtime teardown did not reach stable absence for launch(es) {}",
-                unsettled_launches.join(", ")
-            );
-        }
-        let mut changed = false;
-        for launch in &mut launches {
-            if launch.terminal_teardown_pending
-                && terminal_session_ids.contains(&launch.session_id)
-                && stable_absences.get(&launch.id).copied().unwrap_or_default()
-                    >= TERMINAL_RUNTIME_TEARDOWN_STABLE_ABSENCES
-            {
-                launch.terminal_teardown_pending = false;
-                launch.updated_at = now_rfc3339();
-                changed = true;
-            }
-        }
-        if changed {
-            store_session_runtime_launch_records(&mut state, &launches)?;
-            self.write_raw_json_value(&state)?;
+        for launch in self.pending_terminal_runtime_teardowns()? {
+            runtime
+                .for_socket_name(launch.tmux_socket_name.as_deref())
+                .kill_session(&launch.tmux_session)?;
         }
         Ok(())
     }
@@ -942,7 +895,9 @@ impl SessionStore {
         Ok(session_runtime_launch_records(&state)?
             .into_iter()
             .filter(|launch| {
-                launch.terminal_teardown_pending
+                (launch.terminal_teardown_pending
+                    || (launch.status == "failed"
+                        && launch.failure_reason.as_deref() == Some("target_terminal")))
                     && terminal_session_ids.contains(&launch.session_id)
             })
             .collect())
@@ -16845,6 +16800,29 @@ mod tests {
         );
     }
 
+    #[test]
+    fn legacy_terminal_fenced_launch_remains_eligible_for_teardown() {
+        let state_file = unique_temp_path("legacy-terminal-launch-teardown");
+        let mut state = terminal_rotation_fixture("failed", Some("failed"));
+        state["sessions"][0]["status"] = json!("stopped");
+        state["sessions"][0]["completion_status"] = json!("retired");
+        state["session_runtime_launches"][0]["operation_kind"] = json!("create");
+        state["session_runtime_launches"][0]["credential_rotation_id"] = Value::Null;
+        state["session_runtime_launches"][0]["failure_reason"] = json!("target_terminal");
+        state["session_runtime_launches"][0]
+            .as_object_mut()
+            .unwrap()
+            .remove("terminal_teardown_pending");
+        fs::write(&state_file, state.to_string()).unwrap();
+
+        let store = SessionStore::new(state_file.clone());
+        let pending = store.pending_terminal_runtime_teardowns().unwrap();
+
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].id, "launch01");
+        let _ = fs::remove_file(state_file);
+    }
+
     #[cfg(unix)]
     #[test]
     fn startup_tears_down_a_late_runtime_fenced_by_terminal_retirement() {
@@ -16855,7 +16833,7 @@ mod tests {
         let invoked = root.join("runtime-invoked");
         fs::write(
             &tmux,
-            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$SM_1314_FAKE_TMUX_SENTINEL\"\ncase \"$1\" in\nhas-session)\n  count=0\n  if test -f \"$SM_1314_FAKE_TMUX_CHECKS\"; then count=$(cat \"$SM_1314_FAKE_TMUX_CHECKS\"); fi\n  count=$((count + 1))\n  printf '%s' \"$count\" > \"$SM_1314_FAKE_TMUX_CHECKS\"\n  if test \"$count\" -eq 2; then : > \"$SM_1314_FAKE_TMUX_SESSION\"; fi\n  test -f \"$SM_1314_FAKE_TMUX_SESSION\"\n  ;;\nkill-session) rm -f \"$SM_1314_FAKE_TMUX_SESSION\" ;;\n*) exit 0 ;;\nesac\n",
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$SM_1314_FAKE_TMUX_SENTINEL\"\ncase \"$1\" in\nhas-session)\n  count=0\n  if test -f \"$SM_1314_FAKE_TMUX_CHECKS\"; then count=$(cat \"$SM_1314_FAKE_TMUX_CHECKS\"); fi\n  count=$((count + 1))\n  printf '%s' \"$count\" > \"$SM_1314_FAKE_TMUX_CHECKS\"\n  if test \"$count\" -eq 7; then : > \"$SM_1314_FAKE_TMUX_SESSION\"; fi\n  test -f \"$SM_1314_FAKE_TMUX_SESSION\"\n  ;;\nkill-session) rm -f \"$SM_1314_FAKE_TMUX_SESSION\" ;;\n*) exit 0 ;;\nesac\n",
         )
         .unwrap();
         let mut permissions = fs::metadata(&tmux).unwrap().permissions();
@@ -16892,7 +16870,12 @@ mod tests {
         let store = SessionStore::new(state_file).with_delivery_runtime(Some(
             TmuxRuntime::from_config(&crate::config::RustCoreConfig::default()),
         ));
-        store.recover_session_runtime_launches().unwrap();
+        // A late tmux child does not have a bounded completion time. The
+        // seventh reconciliation models a launch well after the old fixed
+        // observation window; the durable fence remains eligible afterward.
+        for _ in 0..8 {
+            store.recover_session_runtime_launches().unwrap();
+        }
 
         let invocation = fs::read_to_string(&invoked).unwrap();
         assert!(invocation.contains("has-session -t claude-rotate01"));
@@ -16902,12 +16885,12 @@ mod tests {
                 .unwrap()
                 .parse::<usize>()
                 .unwrap()
-                >= TERMINAL_RUNTIME_TEARDOWN_STABILITY_CHECKS
+                >= 8
         );
         let recovered = store.load_raw_json_value().unwrap();
         assert_eq!(
             recovered["session_runtime_launches"][0]["terminal_teardown_pending"],
-            false
+            true
         );
         let _ = fs::remove_dir_all(root);
     }

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -827,6 +827,7 @@ impl SessionStore {
     }
 
     pub fn recover_session_runtime_launches(&self) -> Result<()> {
+        self.recover_pending_runtime_retires()?;
         loop {
             let launch_id = {
                 let _guard = self.write_guard()?;
@@ -841,6 +842,28 @@ impl SessionStore {
             };
             self.recover_session_runtime_launch(&launch_id)?;
         }
+    }
+
+    fn recover_pending_runtime_retires(&self) -> Result<()> {
+        let Some(runtime) = self.delivery_runtime.as_ref() else {
+            return Ok(());
+        };
+        let _guard = self.write_guard()?;
+        let state = self.load_raw_json_value()?;
+        let pending_ids = state
+            .get("sessions")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_object)
+            .filter(|session| raw_session_retire_intent_pending(session))
+            .filter_map(|session| json_text(session.get("id")))
+            .collect::<Vec<_>>();
+        drop(_guard);
+        for session_id in pending_ids {
+            self.retire_core_session_with_runtime_authorized(&session_id, None, None, runtime)?;
+        }
+        Ok(())
     }
 
     fn recover_session_runtime_launch(&self, launch_id: &str) -> Result<()> {
@@ -7493,7 +7516,7 @@ impl SessionStore {
                 return Ok(CoreRetireOutcome::Forbidden);
             }
         }
-        let (node, tmux_session, session_socket_name, recipient_name) = {
+        let (node, tmux_session, session_socket_name, recipient_name, pending_retire_intent) = {
             let sessions = ensure_sessions_array_mut(&mut state)?;
             let Some(session) = session_object_mut(sessions, session_id) else {
                 return Ok(CoreRetireOutcome::NotFound);
@@ -7508,7 +7531,8 @@ impl SessionStore {
                     return Ok(CoreRetireOutcome::NotChild);
                 }
             }
-            if raw_session_has_terminal_evidence(session) {
+            let pending_retire_intent = raw_session_retire_intent_pending(session);
+            if raw_session_has_terminal_evidence(session) && !pending_retire_intent {
                 return Ok(CoreRetireOutcome::Retired(CoreRetireResult {
                     ok: true,
                     session_id: session_id.to_owned(),
@@ -7520,7 +7544,13 @@ impl SessionStore {
                 .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?;
             let session_socket_name = json_text(session.get("tmux_socket_name"));
             let recipient_name = raw_session_display_name(session, session_id);
-            (node, tmux_session, session_socket_name, recipient_name)
+            (
+                node,
+                tmux_session,
+                session_socket_name,
+                recipient_name,
+                pending_retire_intent,
+            )
         };
         if !is_primary_node(&node) {
             return Ok(CoreRetireOutcome::UnsupportedNode(node));
@@ -7530,25 +7560,27 @@ impl SessionStore {
         // must reach durable storage before the external kill: if this process
         // exits after tmux accepts the kill, startup recovery retains the
         // attributed retirement rather than inferring a disappearance.
-        finalize_active_credential_rotations_for_terminal_session(&mut state, session_id)?;
-        let now = now_rfc3339();
-        let sessions = ensure_sessions_array_mut(&mut state)?;
-        let session = session_object_mut(sessions, session_id)
-            .ok_or_else(|| anyhow::anyhow!("session {session_id} disappeared during retire"))?;
-        session.insert("status".to_owned(), Value::String("stopped".to_owned()));
-        mark_session_retired(
-            session,
-            &now,
-            TerminalProvenance::explicit_retire(
+        if !pending_retire_intent {
+            finalize_active_credential_rotations_for_terminal_session(&mut state, session_id)?;
+            let now = now_rfc3339();
+            let sessions = ensure_sessions_array_mut(&mut state)?;
+            let session = session_object_mut(sessions, session_id)
+                .ok_or_else(|| anyhow::anyhow!("session {session_id} disappeared during retire"))?;
+            session.insert("status".to_owned(), Value::String("stopped".to_owned()));
+            mark_session_retired(
+                session,
                 &now,
-                requester_session_id,
-                authority,
-                Some("retire_requested"),
-            ),
-        );
-        session.insert("stopped_at".to_owned(), Value::String(now.clone()));
-        session.insert("last_activity".to_owned(), Value::String(now));
-        self.write_raw_json_value(&state)?;
+                TerminalProvenance::explicit_retire(
+                    &now,
+                    requester_session_id,
+                    authority,
+                    Some("retire_requested"),
+                ),
+            );
+            session.insert("stopped_at".to_owned(), Value::String(now.clone()));
+            session.insert("last_activity".to_owned(), Value::String(now));
+            self.write_raw_json_value(&state)?;
+        }
 
         let session_runtime = runtime.for_socket_name(session_socket_name.as_deref());
         let tmux_was_killed = session_runtime.kill_session(&tmux_session)?;
@@ -15531,6 +15563,17 @@ fn raw_session_has_terminal_evidence(session: &Map<String, Value>) -> bool {
         || session
             .get("terminal_provenance")
             .is_some_and(|provenance| !provenance.is_null())
+}
+
+fn raw_session_retire_intent_pending(session: &Map<String, Value>) -> bool {
+    json_text(
+        session
+            .get("terminal_provenance")
+            .and_then(Value::as_object)
+            .and_then(|provenance| provenance.get("tmux_disposition")),
+    )
+    .as_deref()
+        == Some("retire_requested")
 }
 
 fn effective_raw_session_status(session: &Map<String, Value>) -> String {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -60,6 +60,9 @@ const CODEX_FORK_CONTROL_RECOVERY_POLL: Duration = Duration::from_millis(50);
 const SEAT_SESSION_RETRY_ATTEMPTS: usize = 20;
 const SEAT_SESSION_RETRY_DELAY: Duration = Duration::from_millis(100);
 const REPARENT_REQUEST_TTL_HOURS: i64 = 24;
+const TERMINAL_RUNTIME_TEARDOWN_STABILITY_CHECKS: usize = 5;
+const TERMINAL_RUNTIME_TEARDOWN_STABILITY_DELAY: Duration = Duration::from_millis(100);
+const TERMINAL_RUNTIME_TEARDOWN_STABLE_ABSENCES: usize = 3;
 static STATE_WRITE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone)]
@@ -876,32 +879,73 @@ impl SessionStore {
         // writes terminal evidence, so this startup pass owns the remaining
         // crash window and tears down any such late runtime before ordinary
         // launch recovery considers other work.
-        let terminal_launches = {
-            let _guard = self.write_guard()?;
-            let state = self.load_raw_json_value()?;
-            let terminal_session_ids = snapshot_from_raw_value(&state)?
-                .sessions
-                .into_iter()
-                .filter(|session| {
-                    completion_status_is_retired(session.completion_status.as_deref())
-                })
-                .map(|session| session.id)
-                .collect::<BTreeSet<_>>();
-            session_runtime_launch_records(&state)?
-                .into_iter()
-                .filter(|launch| {
-                    launch.status == "failed"
-                        && launch.failure_reason.as_deref() == Some("target_terminal")
-                        && terminal_session_ids.contains(&launch.session_id)
-                })
-                .collect::<Vec<_>>()
-        };
-        for launch in terminal_launches {
-            runtime
-                .for_socket_name(launch.tmux_socket_name.as_deref())
-                .kill_session(&launch.tmux_session)?;
+        let mut stable_absences = BTreeMap::<String, usize>::new();
+        for attempt in 0..TERMINAL_RUNTIME_TEARDOWN_STABILITY_CHECKS {
+            let terminal_launches = self.pending_terminal_runtime_teardowns()?;
+            if terminal_launches.is_empty() {
+                return Ok(());
+            }
+            for launch in terminal_launches {
+                let was_running = runtime
+                    .for_socket_name(launch.tmux_socket_name.as_deref())
+                    .kill_session(&launch.tmux_session)?;
+                let stable_absence = stable_absences.entry(launch.id).or_default();
+                *stable_absence = if was_running { 0 } else { *stable_absence + 1 };
+            }
+            if attempt + 1 < TERMINAL_RUNTIME_TEARDOWN_STABILITY_CHECKS {
+                thread::sleep(TERMINAL_RUNTIME_TEARDOWN_STABILITY_DELAY);
+            }
+        }
+        let _guard = self.write_guard()?;
+        let mut state = self.load_raw_json_value()?;
+        let terminal_session_ids = terminal_session_ids_from_state(&state)?;
+        let mut launches = session_runtime_launch_records(&state)?;
+        let unsettled_launches = launches
+            .iter()
+            .filter(|launch| {
+                launch.terminal_teardown_pending
+                    && terminal_session_ids.contains(&launch.session_id)
+                    && stable_absences.get(&launch.id).copied().unwrap_or_default()
+                        < TERMINAL_RUNTIME_TEARDOWN_STABLE_ABSENCES
+            })
+            .map(|launch| launch.id.as_str())
+            .collect::<Vec<_>>();
+        if !unsettled_launches.is_empty() {
+            anyhow::bail!(
+                "terminal runtime teardown did not reach stable absence for launch(es) {}",
+                unsettled_launches.join(", ")
+            );
+        }
+        let mut changed = false;
+        for launch in &mut launches {
+            if launch.terminal_teardown_pending
+                && terminal_session_ids.contains(&launch.session_id)
+                && stable_absences.get(&launch.id).copied().unwrap_or_default()
+                    >= TERMINAL_RUNTIME_TEARDOWN_STABLE_ABSENCES
+            {
+                launch.terminal_teardown_pending = false;
+                launch.updated_at = now_rfc3339();
+                changed = true;
+            }
+        }
+        if changed {
+            store_session_runtime_launch_records(&mut state, &launches)?;
+            self.write_raw_json_value(&state)?;
         }
         Ok(())
+    }
+
+    fn pending_terminal_runtime_teardowns(&self) -> Result<Vec<SessionRuntimeLaunchRecord>> {
+        let _guard = self.write_guard()?;
+        let state = self.load_raw_json_value()?;
+        let terminal_session_ids = terminal_session_ids_from_state(&state)?;
+        Ok(session_runtime_launch_records(&state)?
+            .into_iter()
+            .filter(|launch| {
+                launch.terminal_teardown_pending
+                    && terminal_session_ids.contains(&launch.session_id)
+            })
+            .collect())
     }
 
     fn recover_session_runtime_launch(&self, launch_id: &str) -> Result<()> {
@@ -1412,6 +1456,7 @@ impl SessionStore {
             created_at: now.clone(),
             updated_at: now.clone(),
             failure_reason: None,
+            terminal_teardown_pending: false,
         });
         rotations[rotation_index].status = "relaunching".to_owned();
         rotations[rotation_index].idle_proof_at = Some(now.clone());
@@ -4335,6 +4380,7 @@ impl SessionStore {
             created_at: launch_time.clone(),
             updated_at: launch_time,
             failure_reason: None,
+            terminal_teardown_pending: false,
         });
         record.status = "stopped".to_owned();
         record.stopped_at = Some(now_rfc3339());
@@ -5530,6 +5576,7 @@ impl SessionStore {
             created_at: launch_time.clone(),
             updated_at: launch_time,
             failure_reason: None,
+            terminal_teardown_pending: false,
         });
         {
             let sessions = ensure_sessions_array_mut(&mut state)?;
@@ -13580,6 +13627,15 @@ fn session_runtime_launch_records(state: &Value) -> Result<Vec<SessionRuntimeLau
         .unwrap_or_else(|| Ok(Vec::new()))
 }
 
+fn terminal_session_ids_from_state(state: &Value) -> Result<BTreeSet<String>> {
+    Ok(snapshot_from_raw_value(state)?
+        .sessions
+        .into_iter()
+        .filter(|session| completion_status_is_retired(session.completion_status.as_deref()))
+        .map(|session| session.id)
+        .collect())
+}
+
 fn store_session_runtime_launch_records(
     state: &mut Value,
     records: &[SessionRuntimeLaunchRecord],
@@ -13667,6 +13723,7 @@ fn finalize_active_credential_rotations_for_terminal_session(
             launch.status = "failed".to_owned();
             launch.updated_at = now.clone();
             launch.failure_reason = Some("target_terminal".to_owned());
+            launch.terminal_teardown_pending = true;
             launches_changed = true;
         }
     }
@@ -13692,6 +13749,7 @@ fn fence_terminal_runtime_launches(state: &mut Value, session_id: &str) -> Resul
             launch.status = "failed".to_owned();
             launch.updated_at = now.clone();
             launch.failure_reason = Some("target_terminal".to_owned());
+            launch.terminal_teardown_pending = true;
             changed = true;
         }
     }
@@ -14937,6 +14995,11 @@ pub struct SessionRuntimeLaunchRecord {
     pub updated_at: String,
     #[serde(default)]
     pub failure_reason: Option<String>,
+    /// A terminal transition fenced this launch while its tmux creation may
+    /// still complete. Recovery clears the flag only after observing the
+    /// target absent across a stable sequence of teardown checks.
+    #[serde(default)]
+    pub terminal_teardown_pending: bool,
 }
 
 impl SessionRuntimeLaunchRecord {
@@ -16593,6 +16656,10 @@ mod tests {
             state["session_runtime_launches"][0]["failure_reason"],
             "target_terminal"
         );
+        assert_eq!(
+            state["session_runtime_launches"][0]["terminal_teardown_pending"],
+            true
+        );
 
         let state_file = unique_temp_path("credential-rotation-terminal-recovery");
         fs::write(&state_file, state.to_string()).unwrap();
@@ -16772,6 +16839,10 @@ mod tests {
             state["session_runtime_launches"][0]["failure_reason"],
             "target_terminal"
         );
+        assert_eq!(
+            state["session_runtime_launches"][0]["terminal_teardown_pending"],
+            true
+        );
     }
 
     #[cfg(unix)]
@@ -16784,7 +16855,7 @@ mod tests {
         let invoked = root.join("runtime-invoked");
         fs::write(
             &tmux,
-            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$SM_1314_FAKE_TMUX_SENTINEL\"\nexit 0\n",
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$SM_1314_FAKE_TMUX_SENTINEL\"\ncase \"$1\" in\nhas-session)\n  count=0\n  if test -f \"$SM_1314_FAKE_TMUX_CHECKS\"; then count=$(cat \"$SM_1314_FAKE_TMUX_CHECKS\"); fi\n  count=$((count + 1))\n  printf '%s' \"$count\" > \"$SM_1314_FAKE_TMUX_CHECKS\"\n  if test \"$count\" -eq 2; then : > \"$SM_1314_FAKE_TMUX_SESSION\"; fi\n  test -f \"$SM_1314_FAKE_TMUX_SESSION\"\n  ;;\nkill-session) rm -f \"$SM_1314_FAKE_TMUX_SESSION\" ;;\n*) exit 0 ;;\nesac\n",
         )
         .unwrap();
         let mut permissions = fs::metadata(&tmux).unwrap().permissions();
@@ -16796,6 +16867,9 @@ mod tests {
             format!("{}:{}", root.display(), old_path.to_string_lossy()),
         );
         let _sentinel = EnvVarRestore::set("SM_1314_FAKE_TMUX_SENTINEL", &invoked);
+        let fake_session = root.join("late-runtime-present");
+        let _fake_session = EnvVarRestore::set("SM_1314_FAKE_TMUX_SESSION", &fake_session);
+        let _fake_checks = EnvVarRestore::set("SM_1314_FAKE_TMUX_CHECKS", root.join("checks"));
 
         let state_file = root.join("state.json");
         let mut state = terminal_rotation_fixture("failed", Some("failed"));
@@ -16811,7 +16885,8 @@ mod tests {
         });
         state["session_runtime_launches"][0]["operation_kind"] = json!("create");
         state["session_runtime_launches"][0]["credential_rotation_id"] = Value::Null;
-        state["session_runtime_launches"][0]["failure_reason"] = json!("target_terminal");
+        state["session_runtime_launches"][0]["status"] = json!("launching");
+        fence_terminal_runtime_launches(&mut state, "rotate01").unwrap();
         fs::write(&state_file, state.to_string()).unwrap();
 
         let store = SessionStore::new(state_file).with_delivery_runtime(Some(
@@ -16822,6 +16897,18 @@ mod tests {
         let invocation = fs::read_to_string(&invoked).unwrap();
         assert!(invocation.contains("has-session -t claude-rotate01"));
         assert!(invocation.contains("kill-session -t claude-rotate01"));
+        assert!(
+            fs::read_to_string(root.join("checks"))
+                .unwrap()
+                .parse::<usize>()
+                .unwrap()
+                >= TERMINAL_RUNTIME_TEARDOWN_STABILITY_CHECKS
+        );
+        let recovered = store.load_raw_json_value().unwrap();
+        assert_eq!(
+            recovered["session_runtime_launches"][0]["terminal_teardown_pending"],
+            false
+        );
         let _ = fs::remove_dir_all(root);
     }
 

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -885,23 +885,34 @@ impl SessionStore {
             let state = self.load_raw_json_value()?;
             terminal_runtime_teardown_records(&state)?
         };
-        for candidate in terminal_launches {
-            // Restore and terminal teardown share this per-session gate. The
-            // state lock is held only for revalidation, while the potentially
-            // slow tmux commands run outside the global mutation lock.
-            let _lifecycle_guard = self.lock_terminal_runtime_fence(&candidate.session_id)?;
-            let launch = {
-                let _guard = self.write_guard()?;
-                let state = self.load_raw_json_value()?;
-                terminal_runtime_teardown_records(&state)?
-                    .into_iter()
-                    .find(|launch| launch.id == candidate.id)
-            };
-            if let Some(launch) = launch {
-                runtime
-                    .for_socket_name(launch.tmux_socket_name.as_deref())
-                    .kill_session(&launch.tmux_session)?;
-            }
+        let candidate_ids = terminal_launches
+            .iter()
+            .map(|launch| launch.id.as_str())
+            .collect::<BTreeSet<_>>();
+        // Restore and terminal teardown share a per-session gate. Acquire the
+        // deduplicated gates in sorted order, then revalidate every candidate
+        // in one short state-lock pass. This keeps tmux work outside the
+        // global lock without turning the once-per-second reconciliation into
+        // a full state-file scan per terminal fence.
+        let _lifecycle_guards = terminal_launches
+            .iter()
+            .map(|launch| launch.session_id.as_str())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .map(|session_id| self.lock_terminal_runtime_fence(session_id))
+            .collect::<Result<Vec<_>>>()?;
+        let launches = {
+            let _guard = self.write_guard()?;
+            let state = self.load_raw_json_value()?;
+            terminal_runtime_teardown_records(&state)?
+                .into_iter()
+                .filter(|launch| candidate_ids.contains(launch.id.as_str()))
+                .collect::<Vec<_>>()
+        };
+        for launch in launches {
+            runtime
+                .for_socket_name(launch.tmux_socket_name.as_deref())
+                .kill_session(&launch.tmux_session)?;
         }
         Ok(())
     }

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1061,6 +1061,7 @@ impl SessionStore {
             session.insert("completion_status".to_owned(), Value::Null);
             session.insert("completion_message".to_owned(), Value::Null);
             session.insert("completed_at".to_owned(), Value::Null);
+            session.insert("terminal_provenance".to_owned(), Value::Null);
             session.insert("agent_task_completed_at".to_owned(), Value::Null);
         }
         if let Some(provider_resume_id) = recovered_provider_resume_id.as_deref() {
@@ -5335,6 +5336,7 @@ impl SessionStore {
         session.insert("completion_status".to_owned(), Value::Null);
         session.insert("completion_message".to_owned(), Value::Null);
         session.insert("completed_at".to_owned(), Value::Null);
+        session.insert("terminal_provenance".to_owned(), Value::Null);
         session.insert("agent_task_completed_at".to_owned(), Value::Null);
         session.insert("last_activity".to_owned(), Value::String(now));
         if let Some(log_file) = json_text(session.get("log_file")) {
@@ -5542,6 +5544,7 @@ impl SessionStore {
         session.insert("completion_status".to_owned(), Value::Null);
         session.insert("completion_message".to_owned(), Value::Null);
         session.insert("completed_at".to_owned(), Value::Null);
+        session.insert("terminal_provenance".to_owned(), Value::Null);
         session.insert("agent_task_completed_at".to_owned(), Value::Null);
         session.insert("last_activity".to_owned(), Value::String(now));
         if let Some(socket_name) = session_runtime.socket_name() {
@@ -5644,6 +5647,7 @@ impl SessionStore {
         session.insert("completion_status".to_owned(), Value::Null);
         session.insert("completion_message".to_owned(), Value::Null);
         session.insert("completed_at".to_owned(), Value::Null);
+        session.insert("terminal_provenance".to_owned(), Value::Null);
         session.insert("agent_task_completed_at".to_owned(), Value::Null);
         session.insert("error_message".to_owned(), Value::Null);
         session.insert("last_activity".to_owned(), Value::String(now));
@@ -7370,18 +7374,45 @@ impl SessionStore {
         session_id: &str,
         requester_session_id: Option<&str>,
     ) -> Result<CoreRetireOutcome> {
+        self.retire_core_session_authorized(session_id, requester_session_id, None)
+    }
+
+    pub fn retire_core_session_authorized(
+        &self,
+        session_id: &str,
+        requester_session_id: Option<&str>,
+        session_credential: Option<&str>,
+    ) -> Result<CoreRetireOutcome> {
+        let authority = retire_authority(requester_session_id, session_credential);
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
         ensure_session_not_reparent_fenced(&state, session_id)?;
+        let sessions = snapshot_from_raw_value(&state)?.into_sessions();
+        if requester_session_id.is_some() && session_credential.is_none() {
+            return Ok(CoreRetireOutcome::Forbidden);
+        }
+        if let Some((requester_session_id, session_credential)) =
+            requester_session_id.zip(session_credential)
+        {
+            if !active_session_credential_matches(
+                &sessions,
+                requester_session_id,
+                session_credential,
+            ) {
+                return Ok(CoreRetireOutcome::Forbidden);
+            }
+        }
         let recipient_name = {
             let sessions = ensure_sessions_array_mut(&mut state)?;
             let Some(session) = session_object_mut(sessions, session_id) else {
                 return Ok(CoreRetireOutcome::NotFound);
             };
             if let Some(requester_session_id) = requester_session_id {
-                if !requester_session_id.is_empty()
-                    && json_text(session.get("parent_session_id")).as_deref()
-                        != Some(requester_session_id)
+                if json_text(session.get("parent_session_id")).is_none() {
+                    return Ok(CoreRetireOutcome::RootProtected);
+                }
+                if json_text(session.get("parent_session_id")).as_deref()
+                    != Some(requester_session_id)
                 {
                     return Ok(CoreRetireOutcome::NotChild);
                 }
@@ -7396,7 +7427,11 @@ impl SessionStore {
             .ok_or_else(|| anyhow::anyhow!("session {session_id} disappeared during retire"))?;
         let now = now_rfc3339();
         session.insert("status".to_owned(), Value::String("stopped".to_owned()));
-        mark_session_retired(session, &now);
+        mark_session_retired(
+            session,
+            &now,
+            TerminalProvenance::explicit_retire(&now, requester_session_id, authority, None),
+        );
         session.insert("stopped_at".to_owned(), Value::String(now.clone()));
         session.insert("last_activity".to_owned(), Value::String(now));
         if let Some(log_file) = json_text(session.get("log_file")) {
@@ -7417,18 +7452,51 @@ impl SessionStore {
         requester_session_id: Option<&str>,
         runtime: &TmuxRuntime,
     ) -> Result<CoreRetireOutcome> {
+        self.retire_core_session_with_runtime_authorized(
+            session_id,
+            requester_session_id,
+            None,
+            runtime,
+        )
+    }
+
+    pub fn retire_core_session_with_runtime_authorized(
+        &self,
+        session_id: &str,
+        requester_session_id: Option<&str>,
+        session_credential: Option<&str>,
+        runtime: &TmuxRuntime,
+    ) -> Result<CoreRetireOutcome> {
+        let authority = retire_authority(requester_session_id, session_credential);
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
         ensure_session_not_reparent_fenced(&state, session_id)?;
+        let sessions_snapshot = snapshot_from_raw_value(&state)?.into_sessions();
+        if requester_session_id.is_some() && session_credential.is_none() {
+            return Ok(CoreRetireOutcome::Forbidden);
+        }
+        if let Some((requester_session_id, session_credential)) =
+            requester_session_id.zip(session_credential)
+        {
+            if !active_session_credential_matches(
+                &sessions_snapshot,
+                requester_session_id,
+                session_credential,
+            ) {
+                return Ok(CoreRetireOutcome::Forbidden);
+            }
+        }
         let (node, tmux_session, session_socket_name, recipient_name) = {
             let sessions = ensure_sessions_array_mut(&mut state)?;
             let Some(session) = session_object_mut(sessions, session_id) else {
                 return Ok(CoreRetireOutcome::NotFound);
             };
             if let Some(requester_session_id) = requester_session_id {
-                if !requester_session_id.is_empty()
-                    && json_text(session.get("parent_session_id")).as_deref()
-                        != Some(requester_session_id)
+                if json_text(session.get("parent_session_id")).is_none() {
+                    return Ok(CoreRetireOutcome::RootProtected);
+                }
+                if json_text(session.get("parent_session_id")).as_deref()
+                    != Some(requester_session_id)
                 {
                     return Ok(CoreRetireOutcome::NotChild);
                 }
@@ -7444,7 +7512,7 @@ impl SessionStore {
             return Ok(CoreRetireOutcome::UnsupportedNode(node));
         }
         let session_runtime = runtime.for_socket_name(session_socket_name.as_deref());
-        let _ = session_runtime.kill_session(&tmux_session)?;
+        let tmux_was_killed = session_runtime.kill_session(&tmux_session)?;
         // A terminal write and its rotation finalization share this one atomic
         // state replacement, so recovery cannot later relaunch the seat.
         finalize_active_credential_rotations_for_terminal_session(&mut state, session_id)?;
@@ -7453,7 +7521,20 @@ impl SessionStore {
         let session = session_object_mut(sessions, session_id)
             .ok_or_else(|| anyhow::anyhow!("session {session_id} disappeared during retire"))?;
         session.insert("status".to_owned(), Value::String("stopped".to_owned()));
-        mark_session_retired(session, &now);
+        mark_session_retired(
+            session,
+            &now,
+            TerminalProvenance::explicit_retire(
+                &now,
+                requester_session_id,
+                authority,
+                Some(if tmux_was_killed {
+                    "killed"
+                } else {
+                    "already_absent"
+                }),
+            ),
+        );
         session.insert("stopped_at".to_owned(), Value::String(now.clone()));
         session.insert("last_activity".to_owned(), Value::String(now));
         complete_stop_notify_after_stop_raw(
@@ -8146,10 +8227,18 @@ impl SessionStore {
             let now = now_rfc3339();
             session.insert("last_activity".to_owned(), Value::String(now.clone()));
             if next_status == "stopped" {
-                session.insert("stopped_at".to_owned(), Value::String(now));
+                session.insert("stopped_at".to_owned(), Value::String(now.clone()));
                 terminal_provider_event = true;
+                session.insert(
+                    "terminal_provenance".to_owned(),
+                    serde_json::to_value(TerminalProvenance::provider_natural_exit(
+                        &now,
+                        "codex_fork_lifecycle_event",
+                    ))?,
+                );
             } else {
                 session.insert("stopped_at".to_owned(), Value::Null);
+                session.insert("terminal_provenance".to_owned(), Value::Null);
             }
             changed = true;
         }
@@ -8360,6 +8449,7 @@ impl SessionStore {
             completion_message: None,
             completed_at: None,
             stopped_at: None,
+            terminal_provenance: None,
             is_em: false,
             role: None,
             status: "running".to_owned(),
@@ -9291,6 +9381,8 @@ pub enum CoreRetireOutcome {
     Retired(CoreRetireResult),
     NotFound,
     NotChild,
+    RootProtected,
+    Forbidden,
     UnsupportedNode(String),
 }
 
@@ -10356,7 +10448,14 @@ fn deliver_runtime_text_to_session_raw(
         status = "stopped".to_owned();
         session.insert("status".to_owned(), Value::String(status.clone()));
         session.insert("stopped_at".to_owned(), Value::String(now.clone()));
-        session.insert("last_activity".to_owned(), Value::String(now));
+        session.insert("last_activity".to_owned(), Value::String(now.clone()));
+        session.insert(
+            "terminal_provenance".to_owned(),
+            serde_json::to_value(TerminalProvenance::tmux_disappearance(
+                &now,
+                "runtime_delivery_failed",
+            ))?,
+        );
     }
     Ok((status, delivered))
 }
@@ -10419,7 +10518,14 @@ fn deliver_urgent_runtime_text_to_session_raw(
         status = "stopped".to_owned();
         session.insert("status".to_owned(), Value::String(status.clone()));
         session.insert("stopped_at".to_owned(), Value::String(now.clone()));
-        session.insert("last_activity".to_owned(), Value::String(now));
+        session.insert("last_activity".to_owned(), Value::String(now.clone()));
+        session.insert(
+            "terminal_provenance".to_owned(),
+            serde_json::to_value(TerminalProvenance::tmux_disappearance(
+                &now,
+                "runtime_urgent_delivery_failed",
+            ))?,
+        );
     }
     Ok((status, delivered))
 }
@@ -11698,6 +11804,7 @@ fn reset_session_after_clear(session: &mut Map<String, Value>, now: &str) {
     session.insert("completion_status".to_owned(), Value::Null);
     session.insert("completion_message".to_owned(), Value::Null);
     session.insert("completed_at".to_owned(), Value::Null);
+    session.insert("terminal_provenance".to_owned(), Value::Null);
     session.insert("last_activity".to_owned(), Value::String(now.to_owned()));
     mark_review_dispatch_completed(session, now);
 }
@@ -11707,7 +11814,11 @@ fn mark_session_followup_activity(session: &mut Map<String, Value>, now: &str) {
     session.insert("last_activity".to_owned(), Value::String(now.to_owned()));
 }
 
-fn mark_session_retired(session: &mut Map<String, Value>, now: &str) {
+fn mark_session_retired(
+    session: &mut Map<String, Value>,
+    now: &str,
+    mut provenance: TerminalProvenance,
+) {
     session.insert(
         "completion_status".to_owned(),
         Value::String("retired".to_owned()),
@@ -11717,6 +11828,13 @@ fn mark_session_retired(session: &mut Map<String, Value>, now: &str) {
         Value::String("Retired via sm retire".to_owned()),
     );
     session.insert("completed_at".to_owned(), Value::String(now.to_owned()));
+    // Use the same terminal timestamp for the provenance record. A new clock
+    // sample would make ordering with `stopped_at` needlessly ambiguous.
+    provenance.observed_at = now.to_owned();
+    session.insert(
+        "terminal_provenance".to_owned(),
+        serde_json::to_value(provenance).expect("terminal provenance serializes"),
+    );
 }
 
 fn clear_authorization_error(
@@ -12864,6 +12982,29 @@ fn session_credential_matches(
         return false;
     };
     constant_time_text_eq(expected, &sha256_text(credential))
+}
+
+fn active_session_credential_matches(
+    sessions: &[SessionRecord],
+    session_id: &str,
+    credential: &str,
+) -> bool {
+    sessions
+        .iter()
+        .find(|session| session.id == session_id)
+        .is_some_and(|session| !session.is_stopped())
+        && session_credential_matches(sessions, session_id, credential)
+}
+
+fn retire_authority(
+    requester_session_id: Option<&str>,
+    session_credential: Option<&str>,
+) -> &'static str {
+    if requester_session_id.is_some() && session_credential.is_some() {
+        "authenticated_parent"
+    } else {
+        "server_owned"
+    }
 }
 
 fn credential_rotation_has_fresh_idle_proof(
@@ -14828,6 +14969,11 @@ pub struct SessionRecord {
     pub completed_at: Option<String>,
     #[serde(default)]
     pub stopped_at: Option<String>,
+    /// Durable evidence for the terminal transition. Older records have no
+    /// provenance and must remain explicitly unknown rather than being inferred
+    /// from a later server restart or a missing tmux session.
+    #[serde(default)]
+    pub terminal_provenance: Option<TerminalProvenance>,
     #[serde(default)]
     pub is_em: bool,
     #[serde(default)]
@@ -14880,6 +15026,78 @@ pub struct SessionRecord {
     pub aliases: Vec<String>,
     #[serde(skip)]
     pub pending_adoption_proposals: Vec<AdoptionProposalResponse>,
+}
+
+/// The observed mechanism that made a seat terminal. This is deliberately not
+/// an operational-role label: a successor being live is not evidence that its
+/// predecessor was intentionally retired.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TerminalCause {
+    ExplicitRetire,
+    ProviderNaturalExit,
+    TmuxDisappearance,
+    StartupReconciliation,
+    RestartInducedTeardown,
+}
+
+/// Persisted attribution for a terminal session transition.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]
+pub struct TerminalProvenance {
+    pub cause: TerminalCause,
+    pub observed_at: String,
+    #[serde(default)]
+    pub actor_session_id: Option<String>,
+    /// The authority that was verified before the terminal mutation.  The
+    /// actor field is meaningful only for an authenticated parent authority.
+    pub authority: String,
+    pub source: String,
+    #[serde(default)]
+    pub tmux_disposition: Option<String>,
+}
+
+impl TerminalProvenance {
+    fn explicit_retire(
+        observed_at: &str,
+        actor_session_id: Option<&str>,
+        authority: &str,
+        tmux_disposition: Option<&str>,
+    ) -> Self {
+        Self {
+            cause: TerminalCause::ExplicitRetire,
+            observed_at: observed_at.to_owned(),
+            actor_session_id: actor_session_id.map(ToOwned::to_owned),
+            authority: authority.to_owned(),
+            source: if authority == "authenticated_parent" {
+                "api_retire".to_owned()
+            } else {
+                "server_owned_retire".to_owned()
+            },
+            tmux_disposition: tmux_disposition.map(ToOwned::to_owned),
+        }
+    }
+
+    fn provider_natural_exit(observed_at: &str, source: &str) -> Self {
+        Self {
+            cause: TerminalCause::ProviderNaturalExit,
+            observed_at: observed_at.to_owned(),
+            actor_session_id: None,
+            authority: "provider_observed".to_owned(),
+            source: source.to_owned(),
+            tmux_disposition: None,
+        }
+    }
+
+    fn tmux_disappearance(observed_at: &str, source: &str) -> Self {
+        Self {
+            cause: TerminalCause::TmuxDisappearance,
+            observed_at: observed_at.to_owned(),
+            actor_session_id: None,
+            authority: "runtime_observed".to_owned(),
+            source: source.to_owned(),
+            tmux_disposition: Some("absent".to_owned()),
+        }
+    }
 }
 
 fn root_seat_id(record: &SessionRecord, records: &BTreeMap<&str, &SessionRecord>) -> String {
@@ -15005,6 +15223,7 @@ pub struct SessionResponse {
     last_activity: String,
     completed_at: Option<String>,
     stopped_at: Option<String>,
+    terminal_provenance: Option<TerminalProvenance>,
     tmux_session: String,
     tmux_socket_name: Option<String>,
     node: String,
@@ -15057,6 +15276,7 @@ impl From<SessionRecord> for SessionResponse {
             last_activity: session.last_activity,
             completed_at: session.completed_at,
             stopped_at: session.stopped_at,
+            terminal_provenance: session.terminal_provenance,
             tmux_session: session.tmux_session,
             tmux_socket_name: session.tmux_socket_name,
             node: non_empty_or(session.node, "primary"),
@@ -20796,11 +21016,19 @@ mod tests {
             true
         );
         assert!(matches!(
-            store.retire_core_session("child001", Some("oldpar01")),
+            store.retire_core_session_authorized(
+                "child001",
+                Some("oldpar01"),
+                Some(old_credential),
+            ),
             Ok(CoreRetireOutcome::NotChild)
         ));
         assert!(matches!(
-            store.retire_core_session("child001", Some("newpar01")),
+            store.retire_core_session_authorized(
+                "child001",
+                Some("newpar01"),
+                Some(new_credential),
+            ),
             Ok(CoreRetireOutcome::Retired(_))
         ));
 

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -13703,11 +13703,14 @@ fn mark_runtime_launch_failed(
         finalize_active_credential_rotations_for_terminal_session(state, session_id)?;
         let sessions = ensure_sessions_array_mut(state)?;
         if let Some(session) = session_object_mut(sessions, session_id) {
-            if raw_session_is_stopped(session) {
-                // A terminal completion marker may arrive before the runtime
-                // failure writer normalizes `status`. Keep the original
-                // terminal evidence intact while retaining the canonical
-                // stopped projection expected by recovery readers.
+            if raw_session_has_terminal_evidence(session) {
+                // A terminal completion marker or existing provenance may
+                // arrive before the runtime failure writer normalizes
+                // `status`. Keep that original terminal evidence intact
+                // while retaining the canonical stopped projection expected
+                // by recovery readers. A stopped status alone is
+                // transitional during credential rotation and is not
+                // terminal evidence.
                 session.insert("status".to_owned(), Value::String("stopped".to_owned()));
             } else {
                 let now = now_rfc3339();
@@ -15504,6 +15507,13 @@ fn raw_session_is_stopped(session: &Map<String, Value>) -> bool {
         || completion_status_is_retired(json_text(session.get("completion_status")).as_deref())
 }
 
+fn raw_session_has_terminal_evidence(session: &Map<String, Value>) -> bool {
+    completion_status_is_retired(json_text(session.get("completion_status")).as_deref())
+        || session
+            .get("terminal_provenance")
+            .is_some_and(|provenance| !provenance.is_null())
+}
+
 fn effective_raw_session_status(session: &Map<String, Value>) -> String {
     if raw_session_is_stopped(session) {
         "stopped".to_owned()
@@ -16562,6 +16572,14 @@ mod tests {
             assert_eq!(
                 recovered["session_runtime_launches"][0]["failure_reason"],
                 "runtime launch recovery is disabled"
+            );
+            assert_eq!(
+                recovered["sessions"][0]["terminal_provenance"]["cause"],
+                "startup_reconciliation"
+            );
+            assert_eq!(
+                recovered["sessions"][0]["terminal_provenance"]["source"],
+                "runtime_launch_failed"
             );
             let _ = fs::remove_file(state_file);
         }

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -7417,7 +7417,7 @@ impl SessionStore {
                     return Ok(CoreRetireOutcome::NotChild);
                 }
             }
-            if raw_session_is_stopped(session) {
+            if raw_session_has_terminal_evidence(session) {
                 return Ok(CoreRetireOutcome::Retired(CoreRetireResult {
                     ok: true,
                     session_id: session_id.to_owned(),
@@ -7508,7 +7508,7 @@ impl SessionStore {
                     return Ok(CoreRetireOutcome::NotChild);
                 }
             }
-            if raw_session_is_stopped(session) {
+            if raw_session_has_terminal_evidence(session) {
                 return Ok(CoreRetireOutcome::Retired(CoreRetireResult {
                     ok: true,
                     session_id: session_id.to_owned(),
@@ -15959,6 +15959,66 @@ mod tests {
             "2026-06-01T00:02:00Z"
         );
         assert_eq!(state["session_runtime_launches"][0]["status"], "failed");
+    }
+
+    #[test]
+    fn authenticated_retire_marks_a_provisional_stopped_child_terminal() {
+        let state_file = unique_temp_path("retire-provisional-stopped-child");
+        let mut child = reparent_test_session("child001", Some("parent01"), "child-secret");
+        // Runtime creation persists this projection before releasing its state
+        // lock for provider startup. It is not terminal evidence yet.
+        child["status"] = json!("stopped");
+        child["stopped_at"] = json!("2026-06-01T00:01:00Z");
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [
+                    reparent_test_session("parent01", None, "parent-secret"),
+                    child
+                ],
+                "session_runtime_launches": [{
+                    "id": "launch01",
+                    "operation_kind": "create",
+                    "session_id": "child001",
+                    "tmux_session": "claude-child001",
+                    "working_dir": "/repo",
+                    "log_file": "/tmp/child001.log",
+                    "provider": "claude",
+                    "credential_sha256": sha256_text("child-secret"),
+                    "status": "launching",
+                    "created_at": "2026-06-01T00:00:00Z",
+                    "updated_at": "2026-06-01T00:00:00Z"
+                }]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let store = SessionStore::new(state_file.clone());
+
+        assert!(matches!(
+            store.retire_core_session_authorized(
+                "child001",
+                Some("parent01"),
+                Some("parent-secret"),
+            ),
+            Ok(CoreRetireOutcome::Retired(_))
+        ));
+
+        let state = store.load_raw_json_value().unwrap();
+        assert_eq!(state["sessions"][1]["completion_status"], "retired");
+        assert_eq!(
+            state["sessions"][1]["terminal_provenance"]["cause"],
+            "explicit_retire"
+        );
+        assert_eq!(
+            state["sessions"][1]["terminal_provenance"]["actor_session_id"],
+            "parent01"
+        );
+        assert_eq!(
+            state["sessions"][1]["terminal_provenance"]["authority"],
+            "authenticated_parent"
+        );
+        let _ = fs::remove_file(state_file);
     }
 
     #[test]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -13703,7 +13703,13 @@ fn mark_runtime_launch_failed(
         finalize_active_credential_rotations_for_terminal_session(state, session_id)?;
         let sessions = ensure_sessions_array_mut(state)?;
         if let Some(session) = session_object_mut(sessions, session_id) {
-            if !raw_session_is_stopped(session) {
+            if raw_session_is_stopped(session) {
+                // A terminal completion marker may arrive before the runtime
+                // failure writer normalizes `status`. Keep the original
+                // terminal evidence intact while retaining the canonical
+                // stopped projection expected by recovery readers.
+                session.insert("status".to_owned(), Value::String("stopped".to_owned()));
+            } else {
                 let now = now_rfc3339();
                 session.insert("status".to_owned(), Value::String("stopped".to_owned()));
                 session.insert("stopped_at".to_owned(), Value::String(now.clone()));

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -88,6 +88,7 @@ pub struct SessionStore {
     credential_rotation_workers: Arc<Mutex<BTreeSet<String>>>,
     seat_session_appends: Arc<Mutex<BTreeSet<(String, String, String)>>>,
     clear_operation_locks: Arc<Mutex<BTreeMap<String, Weak<SessionClearLock>>>>,
+    terminal_runtime_fence_epochs: Arc<Mutex<BTreeMap<String, u64>>>,
     seat_session_store: SeatSessionStore,
     usage_identity_store: Option<UsageIdentityStore>,
     usage_burn_store: Option<UsageBurnStore>,
@@ -209,6 +210,7 @@ impl SessionStore {
             credential_rotation_workers: Arc::new(Mutex::new(BTreeSet::new())),
             seat_session_appends: Arc::new(Mutex::new(BTreeSet::new())),
             clear_operation_locks: Arc::new(Mutex::new(BTreeMap::new())),
+            terminal_runtime_fence_epochs: Arc::new(Mutex::new(BTreeMap::new())),
             seat_session_store,
             usage_identity_store: None,
             usage_burn_store: None,
@@ -883,36 +885,29 @@ impl SessionStore {
         let terminal_launches = {
             let _guard = self.write_guard()?;
             let state = self.load_raw_json_value()?;
-            terminal_runtime_teardown_records(&state)?
-        };
-        let candidate_ids = terminal_launches
-            .iter()
-            .map(|launch| launch.id.as_str())
-            .collect::<BTreeSet<_>>();
-        // Restore and terminal teardown share a per-session gate. Acquire the
-        // deduplicated gates in sorted order, then revalidate every candidate
-        // in one short state-lock pass. This keeps tmux work outside the
-        // global lock without turning the once-per-second reconciliation into
-        // a full state-file scan per terminal fence.
-        let _lifecycle_guards = terminal_launches
-            .iter()
-            .map(|launch| launch.session_id.as_str())
-            .collect::<BTreeSet<_>>()
-            .into_iter()
-            .map(|session_id| self.lock_terminal_runtime_fence(session_id))
-            .collect::<Result<Vec<_>>>()?;
-        let launches = {
-            let _guard = self.write_guard()?;
-            let state = self.load_raw_json_value()?;
+            let mut epochs = self
+                .terminal_runtime_fence_epochs
+                .lock()
+                .map_err(|_| anyhow::anyhow!("terminal runtime fence epoch registry poisoned"))?;
             terminal_runtime_teardown_records(&state)?
                 .into_iter()
-                .filter(|launch| candidate_ids.contains(launch.id.as_str()))
+                .map(|launch| {
+                    let epoch = *epochs.entry(launch.session_id.clone()).or_default();
+                    (launch, epoch)
+                })
                 .collect::<Vec<_>>()
         };
-        for launch in launches {
-            runtime
-                .for_socket_name(launch.tmux_socket_name.as_deref())
-                .kill_session(&launch.tmux_session)?;
+        for (launch, epoch) in terminal_launches {
+            // Restore increments its epoch while holding this same gate and
+            // the state lock. A changed epoch proves this candidate's terminal
+            // snapshot is stale; otherwise the held gate excludes a future
+            // restore until this teardown attempt is complete.
+            let _lifecycle_guard = self.lock_terminal_runtime_fence(&launch.session_id)?;
+            if self.terminal_runtime_fence_epoch(&launch.session_id)? == epoch {
+                runtime
+                    .for_socket_name(launch.tmux_socket_name.as_deref())
+                    .kill_session(&launch.tmux_session)?;
+            }
         }
         Ok(())
     }
@@ -1590,6 +1585,7 @@ impl SessionStore {
             credential_rotation_workers: Arc::new(Mutex::new(BTreeSet::new())),
             seat_session_appends: Arc::new(Mutex::new(BTreeSet::new())),
             clear_operation_locks: Arc::new(Mutex::new(BTreeMap::new())),
+            terminal_runtime_fence_epochs: Arc::new(Mutex::new(BTreeMap::new())),
             seat_session_store,
             usage_identity_store: None,
             usage_burn_store: None,
@@ -5358,6 +5354,27 @@ impl SessionStore {
         self.lock_named_clear_operation(&format!("terminal-runtime-fence:{session_id}"))
     }
 
+    fn terminal_runtime_fence_epoch(&self, session_id: &str) -> Result<u64> {
+        let mut epochs = self
+            .terminal_runtime_fence_epochs
+            .lock()
+            .map_err(|_| anyhow::anyhow!("terminal runtime fence epoch registry poisoned"))?;
+        Ok(*epochs.entry(session_id.to_owned()).or_default())
+    }
+
+    /// Call while holding the state mutation lock. The paired reconciler takes
+    /// that lock before sampling the epoch, so this is ordered with the
+    /// durable restore transition as well as its per-session lifecycle gate.
+    fn advance_terminal_runtime_fence_epoch(&self, session_id: &str) -> Result<()> {
+        let mut epochs = self
+            .terminal_runtime_fence_epochs
+            .lock()
+            .map_err(|_| anyhow::anyhow!("terminal runtime fence epoch registry poisoned"))?;
+        let epoch = epochs.entry(session_id.to_owned()).or_default();
+        *epoch = epoch.wrapping_add(1);
+        Ok(())
+    }
+
     fn lock_codex_cli_binding_working_dir(&self, working_dir: &str) -> Result<SessionClearGuard> {
         let sessions_root = resolve_path_lossy(self.codex_sessions_root.clone());
         let working_dir = resolve_path_lossy(expand_home(working_dir));
@@ -5521,6 +5538,7 @@ impl SessionStore {
             reasoning_effort: record.reasoning_effort.clone(),
         };
         let codex_fork_artifacts = session_runtime.codex_fork_runtime_artifacts(&spec)?;
+        self.advance_terminal_runtime_fence_epoch(session_id)?;
         let mut launch_records = session_runtime_launch_records(&state)?;
         let launch_id = generate_unique_runtime_launch_id(&launch_records)?;
         let launch_time = now_rfc3339();

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -91,6 +91,22 @@ async fn post_json_with_headers_and_peer(
     json_request_with_headers_and_peer(app, "POST", uri, payload, headers, peer_addr).await
 }
 
+async fn post_retire(
+    app: axum::Router,
+    session_id: &str,
+    requester_session_id: &str,
+    session_credential: &str,
+) -> (StatusCode, Value) {
+    post_json_with_headers_and_peer(
+        app,
+        &format!("/sessions/{session_id}/retire"),
+        json!({ "requester_session_id": requester_session_id }),
+        &[("X-SM-Session-Credential", session_credential)],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await
+}
+
 async fn put_json(app: axum::Router, uri: &str, payload: Value) -> (StatusCode, Value) {
     json_request_with_headers_and_peer(
         app,
@@ -176,6 +192,18 @@ fn session_credential_hash(credential: &str) -> String {
         .iter()
         .map(|byte| format!("{byte:02x}"))
         .collect()
+}
+
+fn set_fixture_session_credential(state_file: &PathBuf, session_id: &str, credential: &str) {
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(state_file).unwrap()).unwrap();
+    let session = state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == session_id)
+        .unwrap_or_else(|| panic!("fixture session {session_id} not found"));
+    session["session_credential_sha256"] = json!(session_credential_hash(credential));
+    fs::write(state_file, serde_json::to_vec_pretty(&state).unwrap()).unwrap();
 }
 
 fn queue_job_completion_notified_at(queue_state_dir: &PathBuf, job_id: &str) -> Option<String> {
@@ -10995,6 +11023,37 @@ rust_core:
 async fn fixture_core_lifecycle_creates_sends_outputs_and_retires() {
     let state_file = unique_temp_path();
     let log_dir = unique_temp_path();
+    fs::write(
+        &state_file,
+        json!({
+            "sessions": [
+                {
+                    "id": "fixture-owner",
+                    "name": "fixture-owner",
+                    "working_dir": "/repo",
+                    "tmux_session": "fixture-owner",
+                    "provider": "claude",
+                    "status": "running",
+                    "session_credential_sha256": session_credential_hash("fixture-owner-credential"),
+                    "created_at": "2026-08-18T04:00:00Z",
+                    "last_activity": "2026-08-18T04:00:00Z"
+                },
+                {
+                    "id": "otherparent",
+                    "name": "otherparent",
+                    "working_dir": "/repo",
+                    "tmux_session": "otherparent",
+                    "provider": "claude",
+                    "status": "running",
+                    "session_credential_sha256": session_credential_hash("otherparent-credential"),
+                    "created_at": "2026-08-18T04:00:00Z",
+                    "last_activity": "2026-08-18T04:00:00Z"
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
     let app = router(AppState::new(AppConfig {
         paths: PathsConfig {
             state_file: state_file.display().to_string(),
@@ -11013,6 +11072,7 @@ async fn fixture_core_lifecycle_creates_sends_outputs_and_retires() {
         json!({
             "id": "rustcore",
             "name": "rust-core",
+            "parent_session_id": "fixture-owner",
             "working_dir": "/repo",
             "provider": "claude",
             "initial_message": "initial fixture prompt"
@@ -11023,6 +11083,7 @@ async fn fixture_core_lifecycle_creates_sends_outputs_and_retires() {
     assert_eq!(payload["id"], "rustcore");
     assert_eq!(payload["status"], "running");
     assert_eq!(payload["friendly_name"], "rust-core");
+    set_fixture_session_credential(&state_file, "rustcore", "rustcore-credential");
 
     let (status, payload) = post_json(
         app.clone(),
@@ -11107,10 +11168,11 @@ async fn fixture_core_lifecycle_creates_sends_outputs_and_retires() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["agent_status_text"], "writing Rust status");
 
-    let (status, payload) = post_json(
+    let (status, payload) = post_retire(
         app.clone(),
-        "/sessions/rustchild/retire",
-        json!({ "requester_session_id": "otherparent" }),
+        "rustchild",
+        "otherparent",
+        "otherparent-credential",
     )
     .await;
     assert_eq!(status, StatusCode::OK);
@@ -11123,22 +11185,19 @@ async fn fixture_core_lifecycle_creates_sends_outputs_and_retires() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "running");
 
-    let (status, payload) = post_json(
-        app.clone(),
-        "/sessions/rustcore/retire",
-        json!({ "requester_session_id": "rustcore" }),
-    )
-    .await;
+    let (status, payload) =
+        post_retire(app.clone(), "rustcore", "rustcore", "rustcore-credential").await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(
         payload["error"],
         "Cannot retire session rustcore - not your child session"
     );
 
-    let (status, payload) = post_json(
+    let (status, payload) = post_retire(
         app.clone(),
-        "/sessions/rustgrandchild/retire",
-        json!({ "requester_session_id": "rustcore" }),
+        "rustgrandchild",
+        "rustcore",
+        "rustcore-credential",
     )
     .await;
     assert_eq!(status, StatusCode::OK);
@@ -11151,12 +11210,8 @@ async fn fixture_core_lifecycle_creates_sends_outputs_and_retires() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "running");
 
-    let (status, payload) = post_json(
-        app.clone(),
-        "/sessions/rustchild/retire",
-        json!({ "requester_session_id": "rustcore" }),
-    )
-    .await;
+    let (status, payload) =
+        post_retire(app.clone(), "rustchild", "rustcore", "rustcore-credential").await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "retired");
     assert_eq!(payload["session_id"], "rustchild");
@@ -11169,14 +11224,187 @@ async fn fixture_core_lifecycle_creates_sends_outputs_and_retires() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["error"], "Session missingcore not found");
 
-    let (status, payload) = post_json(app.clone(), "/sessions/rustcore/retire", json!({})).await;
+    let (status, payload) = post_retire(
+        app.clone(),
+        "rustcore",
+        "fixture-owner",
+        "fixture-owner-credential",
+    )
+    .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "retired");
 
     let (status, payload) = get_json(app, "/sessions?include_stopped=true").await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(payload["sessions"][0]["id"], "rustcore");
-    assert_eq!(payload["sessions"][0]["status"], "stopped");
+    let rustcore = payload["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "rustcore")
+        .unwrap();
+    assert_eq!(rustcore["status"], "stopped");
+    assert_eq!(rustcore["terminal_provenance"]["cause"], "explicit_retire");
+    assert_eq!(
+        rustcore["terminal_provenance"]["actor_session_id"],
+        "fixture-owner"
+    );
+    assert_eq!(
+        rustcore["terminal_provenance"]["authority"],
+        "authenticated_parent"
+    );
+}
+
+#[tokio::test]
+async fn runtime_restart_preserves_real_tmux_child_until_an_attributed_parent_retire() {
+    if !tmux_available() {
+        return;
+    }
+    let state_file = unique_temp_path();
+    let log_dir = unique_temp_path();
+    let working_dir = unique_temp_path();
+    fs::create_dir_all(&working_dir).unwrap();
+    let tmux_socket = format!(
+        "sm-rust-restart-provenance-{}-{}",
+        std::process::id(),
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
+    let tmux_session = "restart-provenance-child";
+    assert!(Command::new("tmux")
+        .args([
+            "-L",
+            &tmux_socket,
+            "new-session",
+            "-d",
+            "-s",
+            tmux_session,
+            "sleep 120",
+        ])
+        .status()
+        .unwrap()
+        .success());
+    fs::write(
+        &state_file,
+        json!({
+            "sessions": [
+                {
+                    "id": "restartparent",
+                    "name": "restart-parent",
+                    "working_dir": working_dir,
+                    "tmux_session": "restart-provenance-parent",
+                    "tmux_socket_name": tmux_socket,
+                    "node": "primary",
+                    "provider": "claude",
+                    "status": "running",
+                    "session_credential_sha256": session_credential_hash("restart-parent-credential"),
+                    "created_at": "2026-08-18T04:00:00Z",
+                    "last_activity": "2026-08-18T04:00:00Z"
+                },
+                {
+                    "id": "restartchild",
+                    "name": "restart-child",
+                    "parent_session_id": "restartparent",
+                    "working_dir": working_dir,
+                    "tmux_session": tmux_session,
+                    "tmux_socket_name": tmux_socket,
+                    "node": "primary",
+                    "provider": "claude",
+                    "status": "idle",
+                    "created_at": "2026-08-18T04:00:00Z",
+                    "last_activity": "2026-08-18T04:00:00Z"
+                }
+            ]
+        })
+        .to_string(),
+    )
+    .unwrap();
+    let mut config = config_with_state_file(&state_file);
+    config.rust_core.runtime_enabled = true;
+    config.rust_core.log_dir = Some(log_dir.display().to_string());
+    config.rust_core.tmux_socket_name = Some(tmux_socket.clone());
+
+    // AppState construction is the server-owned state recovery performed on a
+    // fresh process. It must observe this already-live tmux child, not tear it
+    // down merely because a server instance was replaced.
+    let _first_server = AppState::new(config.clone());
+    let app_after_restart = router(AppState::new(config));
+    assert!(tmux_session_exists(&tmux_socket, tmux_session));
+
+    let (status, payload) = post_json(
+        app_after_restart.clone(),
+        "/sessions/restartchild/retire",
+        json!({}),
+    )
+    .await;
+    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    assert_eq!(
+        payload["detail"],
+        "requester_session_id is required to retire a child session"
+    );
+    assert!(tmux_session_exists(&tmux_socket, tmux_session));
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app_after_restart.clone(),
+        "/sessions/restartchild/retire",
+        json!({ "requester_session_id": "restartparent" }),
+        &[("X-SM-Session-Credential", "incorrect-credential")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert_eq!(
+        payload["detail"],
+        "session credential is missing, stale, or does not match the claimed requester"
+    );
+    assert!(tmux_session_exists(&tmux_socket, tmux_session));
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app_after_restart.clone(),
+        "/sessions/restartparent/retire",
+        json!({ "requester_session_id": "restartparent" }),
+        &[("X-SM-Session-Credential", "restart-parent-credential")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        payload["error"],
+        "Cannot retire session restartparent - root sessions require server-owned lifecycle authority"
+    );
+    assert!(tmux_session_exists(&tmux_socket, tmux_session));
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app_after_restart.clone(),
+        "/sessions/restartchild/retire",
+        json!({ "requester_session_id": "restartparent" }),
+        &[("X-SM-Session-Credential", "restart-parent-credential")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "retired");
+    assert!(!tmux_session_exists(&tmux_socket, tmux_session));
+
+    let (status, payload) = get_json(app_after_restart, "/sessions/restartchild").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["terminal_provenance"]["cause"], "explicit_retire");
+    let persisted: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let provenance = persisted["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "restartchild")
+        .unwrap()
+        .get("terminal_provenance")
+        .unwrap();
+    assert_eq!(provenance["cause"], "explicit_retire");
+    assert_eq!(provenance["actor_session_id"], "restartparent");
+    assert_eq!(provenance["authority"], "authenticated_parent");
+    assert_eq!(provenance["source"], "api_retire");
+    assert_eq!(provenance["tmux_disposition"], "killed");
 }
 
 #[tokio::test]
@@ -11195,6 +11423,20 @@ async fn fixture_core_input_batch_reports_per_recipient_results() {
         ..AppConfig::default()
     }));
 
+    let (status, _payload) = post_json(
+        app.clone(),
+        "/sessions",
+        json!({
+            "id": "batch-owner",
+            "name": "batch-owner",
+            "working_dir": "/repo",
+            "provider": "claude"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    set_fixture_session_credential(&state_file, "batch-owner", "batch-owner-credential");
+
     for (id, name) in [
         ("batchfixturea", "batch-fixture-a"),
         ("batchfixtureb", "batch-fixture-b"),
@@ -11206,6 +11448,7 @@ async fn fixture_core_input_batch_reports_per_recipient_results() {
             json!({
                 "id": id,
                 "name": name,
+                "parent_session_id": "batch-owner",
                 "working_dir": "/repo",
                 "provider": "claude"
             }),
@@ -11214,8 +11457,13 @@ async fn fixture_core_input_batch_reports_per_recipient_results() {
         assert_eq!(status, StatusCode::OK);
         assert_eq!(payload["id"], id);
     }
-    let (status, payload) =
-        post_json(app.clone(), "/sessions/batchstopped/retire", json!({})).await;
+    let (status, payload) = post_retire(
+        app.clone(),
+        "batchstopped",
+        "batch-owner",
+        "batch-owner-credential",
+    )
+    .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "retired");
 
@@ -11294,6 +11542,7 @@ async fn fixture_core_session_graph_endpoints_round_trip_state() {
     )
     .await;
     assert_eq!(status, StatusCode::OK);
+    set_fixture_session_credential(&state_file, "graphparent", "graphparent-credential");
 
     let (status, _payload) = post_json(
         app.clone(),
@@ -11535,7 +11784,13 @@ async fn fixture_core_session_graph_endpoints_round_trip_state() {
         .unwrap();
     assert_eq!(graph_child["pending_handoff_path"], "/tmp/handoff.md");
 
-    let (status, payload) = post_json(app.clone(), "/sessions/graphchild/retire", json!({})).await;
+    let (status, payload) = post_retire(
+        app.clone(),
+        "graphchild",
+        "graphparent",
+        "graphparent-credential",
+    )
+    .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "retired");
 
@@ -11945,6 +12200,7 @@ async fn fixture_notify_on_stop_preserves_authorization_and_state_contract() {
 async fn fixture_retire_honors_delayed_stop_notify_without_runtime() {
     let state_file = write_completion_fixture();
     let queue_db_path = queue_db_path_for_state_file(&state_file);
+    set_fixture_session_credential(&state_file, "em001", "em001-credential");
     let mut config = config_with_state_file_and_queue(&state_file);
     config.rust_core.fixture_writes_enabled = true;
     let app = router(AppState::new(config));
@@ -11962,7 +12218,7 @@ async fn fixture_retire_honors_delayed_stop_notify_without_runtime() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "ok");
 
-    let (status, payload) = post_json(app.clone(), "/sessions/child001/retire", json!({})).await;
+    let (status, payload) = post_retire(app.clone(), "child001", "em001", "em001-credential").await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "retired");
 
@@ -15818,6 +16074,14 @@ async fn runtime_core_marks_missing_tmux_stopped_on_send_and_retire() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "stopped");
     assert!(payload["stopped_at"].as_str().is_some());
+    assert_eq!(
+        payload["terminal_provenance"]["cause"],
+        "tmux_disappearance"
+    );
+    assert_eq!(
+        payload["terminal_provenance"]["authority"],
+        "runtime_observed"
+    );
 
     let (status, payload) = post_json(
         app.clone(),

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -810,6 +810,45 @@ async fn session_teardown_fails_requested_what_and_marks_response_undeliverable(
     assert!(store.list_recoverable().unwrap().is_empty());
 }
 
+#[test]
+fn startup_btw_recovery_tears_down_a_pending_retirement_participant() {
+    let state_file = write_session_fixture();
+    let queue_db = queue_db_path_for_state_file(&state_file);
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let retired = state["sessions"]
+        .as_array_mut()
+        .unwrap()
+        .iter_mut()
+        .find(|session| session["id"] == "oldstate")
+        .unwrap();
+    // This is the durable record left after an authenticated runtime retirement
+    // wrote its intent but the process exited before HTTP BTW teardown.
+    retired["status"] = json!("stopped");
+    retired["completion_status"] = json!("retired");
+    retired["terminal_provenance"] = json!({
+        "cause": "explicit_retire",
+        "observed_at": "2026-08-18T04:00:00Z",
+        "actor_session_id": "run12345",
+        "authority": "authenticated_parent",
+        "source": "api_retire",
+        "tmux_disposition": "retire_requested"
+    });
+    fs::write(&state_file, state.to_string()).unwrap();
+    let store = BtwStore::new(queue_db).unwrap();
+    let request = store
+        .create(Some("run12345"), "oldstate", "claude", "poll", "summary")
+        .unwrap();
+
+    let _app = router(AppState::new(config_with_state_file_and_queue(&state_file)));
+
+    let recovered = store.get(&request.request_id).unwrap().unwrap();
+    assert_eq!(recovered.status, "failed");
+    assert_eq!(
+        recovered.error.as_deref(),
+        Some("session oldstate was torn down")
+    );
+}
+
 #[tokio::test]
 async fn legacy_kill_route_preserves_deployed_client_response() {
     let state_file = write_session_fixture();

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -11445,6 +11445,28 @@ async fn runtime_restart_preserves_real_tmux_child_until_an_attributed_parent_re
     assert_eq!(payload["status"], "retired");
     assert!(!tmux_session_exists(&tmux_socket, tmux_session));
 
+    let persisted_after_first_retire: Value =
+        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let first_provenance = persisted_after_first_retire["sessions"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|session| session["id"] == "restartchild")
+        .unwrap()["terminal_provenance"]
+        .clone();
+
+    let (status, payload) = post_json_with_headers_and_peer(
+        app_after_restart.clone(),
+        "/sessions/restartchild/retire",
+        json!({ "requester_session_id": "restartparent" }),
+        &[("X-SM-Session-Credential", "restart-parent-credential")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "retired");
+    assert!(!tmux_session_exists(&tmux_socket, tmux_session));
+
     let (status, payload) = get_json(app_after_restart, "/sessions/restartchild").await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["terminal_provenance"]["cause"], "explicit_retire");
@@ -11462,6 +11484,7 @@ async fn runtime_restart_preserves_real_tmux_child_until_an_attributed_parent_re
     assert_eq!(provenance["authority"], "authenticated_parent");
     assert_eq!(provenance["source"], "api_retire");
     assert_eq!(provenance["tmux_disposition"], "killed");
+    assert_eq!(provenance, &first_provenance);
 }
 
 #[tokio::test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -11390,17 +11390,16 @@ async fn runtime_restart_preserves_real_tmux_child_until_an_attributed_parent_re
     let app_after_restart = router(AppState::new(config));
     assert!(tmux_session_exists(&tmux_socket, tmux_session));
 
-    let (status, payload) = post_json(
+    let (status, payload) = post_json_with_headers_and_peer(
         app_after_restart.clone(),
         "/sessions/restartchild/retire",
         json!({}),
+        &[],
+        Some(SocketAddr::from(([203, 0, 113, 10], 49152))),
     )
     .await;
-    assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
-    assert_eq!(
-        payload["detail"],
-        "requester_session_id is required to retire a child session"
-    );
+    assert_eq!(status, StatusCode::UNAUTHORIZED);
+    assert_eq!(payload["detail"], "Operator authentication is required");
     assert!(tmux_session_exists(&tmux_socket, tmux_session));
 
     let (status, payload) = post_json_with_headers_and_peer(
@@ -11467,7 +11466,7 @@ async fn runtime_restart_preserves_real_tmux_child_until_an_attributed_parent_re
     assert_eq!(payload["status"], "retired");
     assert!(!tmux_session_exists(&tmux_socket, tmux_session));
 
-    let (status, payload) = get_json(app_after_restart, "/sessions/restartchild").await;
+    let (status, payload) = get_json(app_after_restart.clone(), "/sessions/restartchild").await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["terminal_provenance"]["cause"], "explicit_retire");
     let persisted: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
@@ -11485,6 +11484,30 @@ async fn runtime_restart_preserves_real_tmux_child_until_an_attributed_parent_re
     assert_eq!(provenance["source"], "api_retire");
     assert_eq!(provenance["tmux_disposition"], "killed");
     assert_eq!(provenance, &first_provenance);
+
+    // The retained watch dashboard is deliberately launched outside a managed
+    // session. Its loopback operator request has no requester credential but
+    // is still allowed to exercise server-owned lifecycle authority.
+    let (status, payload) = post_json_with_headers_and_peer(
+        app_after_restart.clone(),
+        "/sessions/restartparent/retire",
+        json!({}),
+        &[("Host", "localhost")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "retired");
+
+    let (status, payload) = get_json(app_after_restart, "/sessions/restartparent").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["terminal_provenance"]["cause"], "explicit_retire");
+    assert!(payload["terminal_provenance"]["actor_session_id"].is_null());
+    assert_eq!(payload["terminal_provenance"]["authority"], "server_owned");
+    assert_eq!(
+        payload["terminal_provenance"]["source"],
+        "server_owned_retire"
+    );
 }
 
 #[tokio::test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -206,6 +206,54 @@ fn set_fixture_session_credential(state_file: &PathBuf, session_id: &str, creden
     fs::write(state_file, serde_json::to_vec_pretty(&state).unwrap()).unwrap();
 }
 
+const RETIRE_FIXTURE_CREDENTIAL: &str = "fixture-retire-owner-credential";
+
+fn prepare_fixture_retire_authority(
+    state_file: &PathBuf,
+    session_id: &str,
+    owner_session_id: &str,
+) {
+    let mut state: Value = serde_json::from_str(&fs::read_to_string(state_file).unwrap()).unwrap();
+    let sessions = state["sessions"].as_array_mut().unwrap();
+    {
+        let session = sessions
+            .iter_mut()
+            .find(|session| session["id"] == session_id)
+            .unwrap_or_else(|| panic!("fixture session {session_id} not found"));
+        session["parent_session_id"] = json!(owner_session_id);
+    }
+    let owner = if let Some(owner) = sessions
+        .iter_mut()
+        .find(|session| session["id"] == owner_session_id)
+    {
+        owner
+    } else {
+        sessions.push(json!({
+            "id": owner_session_id,
+            "name": owner_session_id,
+            "working_dir": "/repo",
+            "tmux_session": owner_session_id,
+            "provider": "claude",
+            "status": "running",
+            "created_at": "2026-08-18T04:00:00Z",
+            "last_activity": "2026-08-18T04:00:00Z"
+        }));
+        sessions.last_mut().unwrap()
+    };
+    owner["session_credential_sha256"] = json!(session_credential_hash(RETIRE_FIXTURE_CREDENTIAL));
+    fs::write(state_file, serde_json::to_vec_pretty(&state).unwrap()).unwrap();
+}
+
+async fn post_fixture_retire(
+    app: axum::Router,
+    state_file: &PathBuf,
+    session_id: &str,
+    owner_session_id: &str,
+) -> (StatusCode, Value) {
+    prepare_fixture_retire_authority(state_file, session_id, owner_session_id);
+    post_retire(app, session_id, owner_session_id, RETIRE_FIXTURE_CREDENTIAL).await
+}
+
 fn queue_job_completion_notified_at(queue_state_dir: &PathBuf, job_id: &str) -> Option<String> {
     for attempt in 0..50 {
         let conn = Connection::open(queue_state_dir.join("queue_runner.db")).unwrap();
@@ -752,7 +800,8 @@ async fn session_teardown_fails_requested_what_and_marks_response_undeliverable(
         .create(Some("run12345"), "oldstate", "claude", "session", "summary")
         .unwrap();
 
-    let (status, payload) = post_json(app, "/sessions/run12345/retire", json!({})).await;
+    let (status, payload) =
+        post_fixture_retire(app, &state_file, "run12345", "fixture-retire-owner").await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "retired");
     let request = store.get(&request.request_id).unwrap().unwrap();
@@ -768,7 +817,15 @@ async fn legacy_kill_route_preserves_deployed_client_response() {
     config.rust_core.fixture_writes_enabled = true;
     let app = router(AppState::new(config));
 
-    let (status, payload) = post_json(app, "/sessions/run12345/kill", json!({})).await;
+    prepare_fixture_retire_authority(&state_file, "run12345", "fixture-retire-owner");
+    let (status, payload) = post_json_with_headers_and_peer(
+        app,
+        "/sessions/run12345/kill",
+        json!({ "requester_session_id": "fixture-retire-owner" }),
+        &[("X-SM-Session-Credential", RETIRE_FIXTURE_CREDENTIAL)],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "killed");
 }
@@ -13561,7 +13618,13 @@ async fn runtime_core_lifecycle_uses_tmux_backend_when_enabled() {
     )
     .await;
 
-    let (status, payload) = post_json(app.clone(), "/sessions/runtimecore/retire", json!({})).await;
+    let (status, payload) = post_fixture_retire(
+        app.clone(),
+        &state_file,
+        "runtimecore",
+        "fixture-retire-owner",
+    )
+    .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "retired");
 
@@ -14350,8 +14413,13 @@ async fn runtime_core_retire_delivers_stop_notify_side_effects() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "ok");
 
-    let (status, payload) =
-        post_json(app.clone(), "/sessions/runtimestopchild/retire", json!({})).await;
+    let (status, payload) = post_fixture_retire(
+        app.clone(),
+        &state_file,
+        "runtimestopchild",
+        "runtimestopem",
+    )
+    .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "retired");
     wait_for_output_contains(
@@ -14458,8 +14526,13 @@ async fn runtime_core_retire_delivers_stop_notify_side_effects() {
     )
     .unwrap();
 
-    let (status, payload) =
-        post_json(app.clone(), "/sessions/runtimeghostchild/retire", json!({})).await;
+    let (status, payload) = post_fixture_retire(
+        app.clone(),
+        &state_file,
+        "runtimeghostchild",
+        "fixture-retire-owner",
+    )
+    .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "retired");
     let stale_sender_notification_count: i64 = queue_conn
@@ -15439,7 +15512,7 @@ async fn runtime_core_spawn_endpoint_uses_tmux_and_parent_fields() {
     );
 
     let (status, payload) =
-        post_json(app.clone(), "/sessions/runtimechild/retire", json!({})).await;
+        post_fixture_retire(app.clone(), &state_file, "runtimechild", "runtimeparent").await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "retired");
     assert!(!tmux_session_exists(&tmux_socket, &tmux_session));
@@ -15451,8 +15524,13 @@ async fn runtime_core_spawn_endpoint_uses_tmux_and_parent_fields() {
     )
     .await;
 
-    let (status, payload) =
-        post_json(app.clone(), "/sessions/runtimeparent/retire", json!({})).await;
+    let (status, payload) = post_fixture_retire(
+        app.clone(),
+        &state_file,
+        "runtimeparent",
+        "fixture-retire-owner",
+    )
+    .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "retired");
     assert!(!tmux_session_exists(&tmux_socket, &parent_tmux_session));
@@ -15768,8 +15846,13 @@ async fn runtime_core_spawn_wait_detects_naturally_exited_tmux_child() {
     .await;
     assert!(!tmux_session_exists(&tmux_socket, child_tmux_session));
 
-    let (status, payload) =
-        post_json(app.clone(), "/sessions/naturalparent/retire", json!({})).await;
+    let (status, payload) = post_fixture_retire(
+        app.clone(),
+        &state_file,
+        "naturalparent",
+        "fixture-retire-owner",
+    )
+    .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "retired");
     assert!(!tmux_session_exists(&tmux_socket, &parent_tmux_session));
@@ -15846,8 +15929,13 @@ async fn runtime_core_spawn_wait_uses_runtime_output_as_activity() {
         .contains("Idle for"));
     assert!(!tmux_session_exists(&tmux_socket, child_tmux_session));
 
-    let (status, payload) =
-        post_json(app.clone(), "/sessions/activeparent/retire", json!({})).await;
+    let (status, payload) = post_fixture_retire(
+        app.clone(),
+        &state_file,
+        "activeparent",
+        "fixture-retire-owner",
+    )
+    .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "retired");
     assert!(!tmux_session_exists(&tmux_socket, &parent_tmux_session));
@@ -15913,7 +16001,13 @@ async fn runtime_core_send_and_retire_use_persisted_tmux_socket() {
     )
     .await;
 
-    let (status, payload) = post_json(app_b, "/sessions/runtimepersisted/retire", json!({})).await;
+    let (status, payload) = post_fixture_retire(
+        app_b,
+        &state_file,
+        "runtimepersisted",
+        "fixture-retire-owner",
+    )
+    .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "retired");
     assert!(!tmux_session_exists(&socket_a, &tmux_session));
@@ -15961,7 +16055,13 @@ async fn runtime_core_expands_bare_home_working_dir_for_tmux() {
         Some(home_path.as_path())
     );
 
-    let (status, payload) = post_json(app.clone(), "/sessions/runtimehome/retire", json!({})).await;
+    let (status, payload) = post_fixture_retire(
+        app.clone(),
+        &state_file,
+        "runtimehome",
+        "fixture-retire-owner",
+    )
+    .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "retired");
 
@@ -16099,10 +16199,11 @@ async fn runtime_core_marks_missing_tmux_stopped_on_send_and_retire() {
     let tmux_session = payload["tmux_session"].as_str().unwrap().to_owned();
     assert!(tmux_kill_session(&tmux_socket, &tmux_session));
 
-    let (status, payload) = post_json(
+    let (status, payload) = post_fixture_retire(
         app.clone(),
-        "/sessions/runtimemissingretire/retire",
-        json!({}),
+        &state_file,
+        "runtimemissingretire",
+        "fixture-retire-owner",
     )
     .await;
     assert_eq!(status, StatusCode::OK);
@@ -16239,8 +16340,13 @@ async fn runtime_core_restores_codex_session() {
     let tmux_session = payload["tmux_session"].as_str().unwrap().to_owned();
     wait_for_output_contains(app.clone(), "runtimecodex", "stock codex initial prompt").await;
 
-    let (status, payload) =
-        post_json(app.clone(), "/sessions/runtimecodex/retire", json!({})).await;
+    let (status, payload) = post_fixture_retire(
+        app.clone(),
+        &state_file,
+        "runtimecodex",
+        "fixture-retire-owner",
+    )
+    .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "retired");
     assert!(!tmux_session_exists(&tmux_socket, &tmux_session));
@@ -17390,7 +17496,13 @@ while true; do sleep 1; done
     }
 
     let tmux_session = payload["tmux_session"].as_str().unwrap().to_owned();
-    let (status, payload) = post_json(app.clone(), "/sessions/runtimefork/retire", json!({})).await;
+    let (status, payload) = post_fixture_retire(
+        app.clone(),
+        &state_file,
+        "runtimefork",
+        "fixture-retire-owner",
+    )
+    .await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["status"], "retired");
     assert!(!tmux_session_exists(&tmux_socket, &tmux_session));
@@ -17823,8 +17935,13 @@ async fn runtime_core_rejects_remote_node_send_and_retire_without_mutating_state
         json!({ "detail": "Rust runtime does not support remote node macbook" })
     );
 
-    let (status, payload) =
-        post_json(app.clone(), "/sessions/remoteruntime/retire", json!({})).await;
+    let (status, payload) = post_fixture_retire(
+        app.clone(),
+        &state_file,
+        "remoteruntime",
+        "fixture-retire-owner",
+    )
+    .await;
     assert_eq!(status, StatusCode::BAD_REQUEST);
     assert_eq!(
         payload,


### PR DESCRIPTION
Fixes #1314

## Risk classification

R3 — persists terminal lifecycle provenance; authenticates retirement authority; changes public CLI/API behavior; and verifies restart-adjacent tmux disposition.

## Scope

- Require a non-empty authenticated requester credential for API/CLI retirement.
- Protect root seats; permit only an authenticated parent to retire a child.
- Persist explicit-retire actor, authority, source, time, and tmux disposition; record observed provider/tmux terminal causes without inferring restart causation.
- Preserve current-main credential-rotation terminal fencing and final test-isolation harness.

## Verification

- cargo fmt --check
- git diff --check
- ./scripts/test-rust-isolated.sh --test read_only_http --quiet: #1314 paths pass; the sole remaining deterministic failure is pre-existing on 3b852e05 and tracked as #1331.
- ./scripts/test-rust-isolated.sh --no-fail-fast --quiet: #1331 remains the deterministic main-baseline failure; three live-catalog timeout tests pass individually on exact main and are parallel-run flakes.

## R3 review ledger

- Round 1 requested for exact head d5b257da17b6799d60aa8841234d40b90792e99b. Scope: authorization boundary, root/child semantics, durable terminal provenance, rotation-finalization ordering, and runtime tmux disposition.
- Round 2 pending only if round 1 leaves this exact immutable head unchanged; scope: hostile API/CLI/fixture paths, restart preservation, and provenance coverage.