### PR TITLE
feat: configure per-seat context monitor thresholds

### DIFF
--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -383,8 +383,22 @@ struct ContextMonitorArgs {
 
 #[derive(Subcommand)]
 enum ContextMonitorCommand {
-    Enable { target: Option<String> },
-    Disable { target: Option<String> },
+    Enable {
+        target: Option<String>,
+        /// Warning percentage for this seat (for example, 40).
+        #[arg(long, value_name = "PERCENT")]
+        threshold: Option<f64>,
+        /// Critical percentage for this seat. Defaults to the current global
+        /// critical threshold unless an existing seat override is present.
+        #[arg(long, value_name = "PERCENT")]
+        critical_threshold: Option<f64>,
+        /// Clear seat-specific thresholds and use the server defaults.
+        #[arg(long, conflicts_with_all = ["threshold", "critical_threshold"])]
+        use_default_thresholds: bool,
+    },
+    Disable {
+        target: Option<String>,
+    },
     Status,
 }
 
@@ -3856,11 +3870,16 @@ fn run_context(client: &ApiClient, args: ContextArgs) -> Result<()> {
         Some(value) => value.to_owned(),
         None => "none".to_owned(),
     };
-    let monitor = if payload["context_monitor_enabled"]
+    let monitor = if payload["context_monitor_enforced"]
         .as_bool()
         .unwrap_or(false)
     {
         "enabled"
+    } else if payload["context_monitor_enabled"]
+        .as_bool()
+        .unwrap_or(false)
+    {
+        "enabled but NOT enforced (invalid thresholds)"
     } else {
         "disabled"
     };
@@ -3879,7 +3898,10 @@ fn run_context(client: &ApiClient, args: ContextArgs) -> Result<()> {
         "Lifecycle: {}",
         payload["lifecycle_status"].as_str().unwrap_or("unknown")
     );
-    println!("State: {state} (warning {warning}, critical {critical})");
+    println!(
+        "State: {state} (warning {warning}, critical {critical}; {})",
+        payload["threshold_source"].as_str().unwrap_or("unknown")
+    );
     println!("Monitor: {monitor}, alerts -> {notify_text}");
     println!("Compaction: {compaction}");
     println!(
@@ -4007,16 +4029,27 @@ fn run_context_monitor(client: &ApiClient, args: ContextMonitorArgs) -> Result<(
                 println!("No sessions currently registered for context monitoring.");
                 return Ok(());
             }
-            println!("{:<12} {:<24} Notify Target", "Session", "Name");
-            println!("{}", "-".repeat(52));
+            println!(
+                "{:<12} {:<24} {:<14} Thresholds",
+                "Session", "Name", "Notify Target"
+            );
+            println!("{}", "-".repeat(78));
             for entry in monitored {
                 let session_id = entry["session_id"].as_str().unwrap_or("unknown");
                 let name = entry["friendly_name"].as_str().unwrap_or("");
                 let notify = entry["notify_session_id"].as_str().unwrap_or("(none)");
-                println!("{session_id:<12} {name:<24} {notify}");
+                println!(
+                    "{session_id:<12} {name:<24} {notify:<14} {}",
+                    format_context_monitor_thresholds(&entry)
+                );
             }
         }
-        ContextMonitorCommand::Enable { target } => {
+        ContextMonitorCommand::Enable {
+            target,
+            threshold,
+            critical_threshold,
+            use_default_thresholds,
+        } => {
             let requester = current_session_id()?;
             let target = target.unwrap_or_else(|| requester.clone());
             let response = client.post_json(
@@ -4024,14 +4057,23 @@ fn run_context_monitor(client: &ApiClient, args: ContextMonitorArgs) -> Result<(
                 json!({
                     "enabled": true,
                     "requester_session_id": requester,
-                    "notify_session_id": requester
+                    "notify_session_id": requester,
+                    "warning_percentage": threshold,
+                    "critical_percentage": critical_threshold,
+                    "use_default_thresholds": use_default_thresholds
                 }),
             )?;
             ensure_context_monitor_enabled(&response)?;
             if target == requester {
-                println!("Context monitoring enabled - notifications -> self ({requester})");
+                println!(
+                    "Context monitoring enabled - notifications -> self ({requester}); thresholds {}",
+                    format_context_monitor_thresholds(&response)
+                );
             } else {
-                println!("Context monitoring enabled for {target} - notifications -> {requester}");
+                println!(
+                    "Context monitoring enabled for {target} - notifications -> {requester}; thresholds {}",
+                    format_context_monitor_thresholds(&response)
+                );
             }
         }
         ContextMonitorCommand::Disable { target } => {
@@ -4059,6 +4101,16 @@ fn ensure_context_monitor_enabled(response: &Value) -> Result<()> {
         "Context monitoring was not enrolled: server returned enabled={:?}. Run `sm context-monitor status` to verify coverage.",
         response["enabled"]
     );
+}
+
+fn format_context_monitor_thresholds(payload: &Value) -> String {
+    if payload["enforced"].as_bool() != Some(true) {
+        return "INVALID / NOT ENFORCED".to_owned();
+    }
+    let warning = format_context_percentage(payload.get("warning_percentage"));
+    let critical = format_context_percentage(payload.get("critical_percentage"));
+    let source = payload["threshold_source"].as_str().unwrap_or("unknown");
+    format!("{warning} warning / {critical} critical ({source})")
 }
 
 fn lookup_identifier(client: &ApiClient, identifier: &str) -> Result<Option<String>> {
@@ -7123,6 +7175,35 @@ mod tests {
         assert_eq!(format_context_percentage(Some(&json!(43.5))), "43.5%");
         assert_eq!(format_context_percentage(Some(&Value::Null)), "unknown");
         assert_eq!(format_context_percentage(None), "unknown");
+    }
+
+    #[test]
+    fn context_monitor_threshold_formatter_is_truthful_for_default_custom_and_invalid_rows() {
+        assert_eq!(
+            format_context_monitor_thresholds(&json!({
+                "enforced": true,
+                "warning_percentage": 65.0,
+                "critical_percentage": 75.0,
+                "threshold_source": "default"
+            })),
+            "65% warning / 75% critical (default)"
+        );
+        assert_eq!(
+            format_context_monitor_thresholds(&json!({
+                "enforced": true,
+                "warning_percentage": 40.0,
+                "critical_percentage": 60.0,
+                "threshold_source": "custom"
+            })),
+            "40% warning / 60% critical (custom)"
+        );
+        assert_eq!(
+            format_context_monitor_thresholds(&json!({
+                "enforced": false,
+                "threshold_source": "invalid"
+            })),
+            "INVALID / NOT ENFORCED"
+        );
     }
 
     #[test]

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -8342,6 +8342,10 @@ async fn set_context_monitor(
                 "Context monitoring cannot enroll provider {provider:?}: no measured context gauge is available; use `sm context` on each heartbeat until provider support is added"
             ),
         }),
+        ContextMonitorOutcome::InvalidThresholdConfig(detail) => Err(ApiError::Status {
+            status: StatusCode::UNPROCESSABLE_ENTITY,
+            detail,
+        }),
         ContextMonitorOutcome::MissingNotifyTarget => Err(ApiError::Status {
             status: StatusCode::UNPROCESSABLE_ENTITY,
             detail: "notify_session_id required when enabling".to_owned(),
@@ -13898,7 +13902,7 @@ mod tests {
     };
     use axum::{
         body::{to_bytes, Body},
-        http::Method,
+        http::{header::CONTENT_TYPE, Method},
     };
     use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
     use p256::{
@@ -15523,6 +15527,109 @@ mod tests {
         config.rust_core.fixture_writes_enabled = true;
         config.rust_core.runtime_enabled = false;
         (config, queue_path)
+    }
+
+    #[tokio::test]
+    async fn context_monitor_http_persists_effective_thresholds_and_rejects_invalid_values() {
+        let state_file = PathBuf::from(write_session_state("threshold-agent", "running"));
+        let mut fixture: Value = serde_json::from_slice(&fs::read(&state_file).unwrap()).unwrap();
+        fixture["sessions"][0]["provider"] = json!("claude");
+        fs::write(&state_file, serde_json::to_vec(&fixture).unwrap()).unwrap();
+        let mut config = AppConfig::default();
+        config.paths.state_file = state_file.display().to_string();
+        config.sm_send.db_path = state_file
+            .with_file_name("context-monitor-threshold-queue.db")
+            .display()
+            .to_string();
+        config.rust_core.fixture_writes_enabled = true;
+        config.rust_core.runtime_enabled = false;
+        let app = router(AppState::new(config));
+
+        let mut custom = local_request(
+            Method::POST,
+            "/sessions/threshold-agent/context-monitor",
+            Body::from(
+                serde_json::to_vec(&json!({
+                    "enabled": true,
+                    "requester_session_id": "threshold-agent",
+                    "notify_session_id": "threshold-agent",
+                    "warning_percentage": 40.0,
+                    "critical_percentage": 60.0
+                }))
+                .unwrap(),
+            ),
+        );
+        custom
+            .headers_mut()
+            .insert(CONTENT_TYPE, "application/json".parse().unwrap());
+        let (status, body) = response_json(app.clone().oneshot(custom).await.unwrap()).await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(body["warning_percentage"], json!(40.0));
+        assert_eq!(body["critical_percentage"], json!(60.0));
+        assert_eq!(body["threshold_source"], json!("custom"));
+        assert_eq!(body["enforced"], json!(true));
+
+        let (status, body) = response_json(
+            app.clone()
+                .oneshot(local_request(
+                    Method::GET,
+                    "/sessions/context-monitor",
+                    Body::empty(),
+                ))
+                .await
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert_eq!(body["monitored"][0]["warning_percentage"], json!(40.0));
+        assert_eq!(body["monitored"][0]["critical_percentage"], json!(60.0));
+        assert_eq!(body["monitored"][0]["threshold_source"], json!("custom"));
+        assert_eq!(body["monitored"][0]["enforced"], json!(true));
+
+        let persisted_before_invalid = fs::read(&state_file).unwrap();
+        let mut invalid = local_request(
+            Method::POST,
+            "/sessions/threshold-agent/context-monitor",
+            Body::from(
+                serde_json::to_vec(&json!({
+                    "enabled": true,
+                    "requester_session_id": "threshold-agent",
+                    "notify_session_id": "threshold-agent",
+                    "warning_percentage": 80.0,
+                    "critical_percentage": 40.0
+                }))
+                .unwrap(),
+            ),
+        );
+        invalid
+            .headers_mut()
+            .insert(CONTENT_TYPE, "application/json".parse().unwrap());
+        let (status, body) = response_json(app.clone().oneshot(invalid).await.unwrap()).await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "{body}");
+        assert!(body["detail"]
+            .as_str()
+            .is_some_and(|detail| detail.contains("strictly lower")));
+        assert_eq!(fs::read(&state_file).unwrap(), persisted_before_invalid);
+
+        let mut malformed = local_request(
+            Method::POST,
+            "/sessions/threshold-agent/context-monitor",
+            Body::from(
+                serde_json::to_vec(&json!({
+                    "enabled": true,
+                    "requester_session_id": "threshold-agent",
+                    "notify_session_id": "threshold-agent",
+                    "warning_percentage": "forty"
+                }))
+                .unwrap(),
+            ),
+        );
+        malformed
+            .headers_mut()
+            .insert(CONTENT_TYPE, "application/json".parse().unwrap());
+        let response = app.oneshot(malformed).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        assert_eq!(fs::read(&state_file).unwrap(), persisted_before_invalid);
     }
 
     #[tokio::test]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -5834,10 +5834,10 @@ impl SessionStore {
                 reset_context_oneshot_flags(session);
             }
         }
-        self.write_raw_json_value(&state)?;
         if thresholds_changed {
             self.cancel_context_monitor_alerts(session_id)?;
         }
+        self.write_raw_json_value(&state)?;
         Ok(ContextMonitorOutcome::Updated(ContextMonitorResult {
             status: "ok".to_owned(),
             enabled: effective_enabled,

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1953,10 +1953,28 @@ impl SessionStore {
             })
             .map(|session| {
                 let friendly_name = session.cached_display_name();
+                let thresholds = resolve_context_monitor_thresholds(
+                    session.context_monitor_warning_percentage,
+                    session.context_monitor_critical_percentage,
+                    &self.context_monitor,
+                );
                 ContextMonitorStatus {
                     session_id: session.id,
                     friendly_name,
                     notify_session_id: session.context_monitor_notify,
+                    warning_percentage: thresholds
+                        .as_ref()
+                        .ok()
+                        .map(|value| value.warning_percentage),
+                    critical_percentage: thresholds
+                        .as_ref()
+                        .ok()
+                        .map(|value| value.critical_percentage),
+                    threshold_source: thresholds
+                        .as_ref()
+                        .map(|value| value.source.as_str().to_owned())
+                        .unwrap_or_else(|_| "invalid".to_owned()),
+                    enforced: thresholds.is_ok(),
                 }
             })
             .collect())
@@ -5718,15 +5736,67 @@ impl SessionStore {
                 ));
             }
         }
+        if !request.enabled
+            && (request.warning_percentage.is_some()
+                || request.critical_percentage.is_some()
+                || request.use_default_thresholds)
+        {
+            return Ok(ContextMonitorOutcome::InvalidThresholdConfig(
+                "threshold options require enabled=true".to_owned(),
+            ));
+        }
+        if request.use_default_thresholds
+            && (request.warning_percentage.is_some() || request.critical_percentage.is_some())
+        {
+            return Ok(ContextMonitorOutcome::InvalidThresholdConfig(
+                "use_default_thresholds conflicts with custom thresholds".to_owned(),
+            ));
+        }
         let Some(session) = session_object_mut(sessions, session_id) else {
             return Ok(ContextMonitorOutcome::NotFound);
         };
         let effective_enabled = request.enabled;
+        let current_warning = session
+            .get("context_monitor_warning_percentage")
+            .and_then(Value::as_f64);
+        let current_critical = session
+            .get("context_monitor_critical_percentage")
+            .and_then(Value::as_f64);
+        let (next_warning, next_critical) = if request.use_default_thresholds {
+            (None, None)
+        } else {
+            (
+                request.warning_percentage.or(current_warning),
+                request.critical_percentage.or(current_critical),
+            )
+        };
+        let thresholds = if request.enabled {
+            match resolve_context_monitor_thresholds(
+                next_warning,
+                next_critical,
+                &self.context_monitor,
+            ) {
+                Ok(thresholds) => Some(thresholds),
+                Err(detail) => return Ok(ContextMonitorOutcome::InvalidThresholdConfig(detail)),
+            }
+        } else {
+            None
+        };
+        let thresholds_changed =
+            current_warning != next_warning || current_critical != next_critical;
         session.insert(
             "context_monitor_enabled".to_owned(),
             Value::Bool(effective_enabled),
         );
         if effective_enabled {
+            session.insert(
+                "context_monitor_warning_percentage".to_owned(),
+                next_warning.map_or(Value::Null, |value| json!(value)),
+            );
+            session.insert(
+                "context_monitor_critical_percentage".to_owned(),
+                next_critical.map_or(Value::Null, |value| json!(value)),
+            );
             let notify_session_id = notify_session_id.unwrap();
             session.insert(
                 "context_monitor_notify".to_owned(),
@@ -5765,9 +5835,19 @@ impl SessionStore {
             }
         }
         self.write_raw_json_value(&state)?;
+        if thresholds_changed {
+            self.cancel_context_monitor_alerts(session_id)?;
+        }
         Ok(ContextMonitorOutcome::Updated(ContextMonitorResult {
             status: "ok".to_owned(),
             enabled: effective_enabled,
+            warning_percentage: thresholds.as_ref().map(|value| value.warning_percentage),
+            critical_percentage: thresholds.as_ref().map(|value| value.critical_percentage),
+            threshold_source: thresholds
+                .as_ref()
+                .map(|value| value.source.as_str().to_owned())
+                .unwrap_or_else(|| "disabled".to_owned()),
+            enforced: effective_enabled && thresholds.is_some(),
         }))
     }
 
@@ -6094,13 +6174,23 @@ impl SessionStore {
         tokens_used: i64,
     ) -> Option<ContextAlert> {
         let notify_target = json_text(session.get("context_monitor_notify"))?;
+        let thresholds = resolve_context_monitor_thresholds(
+            session
+                .get("context_monitor_warning_percentage")
+                .and_then(Value::as_f64),
+            session
+                .get("context_monitor_critical_percentage")
+                .and_then(Value::as_f64),
+            &self.context_monitor,
+        )
+        .ok()?;
         let is_self_alert = notify_target == session_id;
         let label = raw_session_label(session, session_id);
         let rounded = format_percentage(used_percentage);
         let native_codex_compaction = json_text(session.get("provider"))
             .is_some_and(|provider| provider_uses_native_context_compaction(&provider));
 
-        if used_percentage >= self.context_monitor.critical_percentage {
+        if used_percentage >= thresholds.critical_percentage {
             if flag_is_set(session, "context_critical_sent") {
                 return None;
             }
@@ -6129,7 +6219,7 @@ impl SessionStore {
             });
         }
 
-        if used_percentage >= self.context_monitor.warning_percentage {
+        if used_percentage >= thresholds.warning_percentage {
             if flag_is_set(session, "context_warning_sent") {
                 return None;
             }
@@ -8539,6 +8629,8 @@ impl SessionStore {
             context_monitor_enabled: false,
             context_monitor_notify: None,
             context_monitor_notify_source: default_context_monitor_notify_source(),
+            context_monitor_warning_percentage: None,
+            context_monitor_critical_percentage: None,
             context_warning_sent: false,
             context_critical_sent: false,
             aliases: Vec::new(),
@@ -9197,6 +9289,17 @@ pub struct ContextMonitorRequest {
     pub requester_session_id: String,
     #[serde(default)]
     pub notify_session_id: Option<String>,
+    /// Per-seat warning threshold percentage. Absent values preserve an
+    /// existing override or resolve to the configured global default.
+    #[serde(default)]
+    pub warning_percentage: Option<f64>,
+    /// Per-seat critical threshold percentage. Absent values preserve an
+    /// existing override or resolve to the configured global default.
+    #[serde(default)]
+    pub critical_percentage: Option<f64>,
+    /// Clear both seat overrides and return to the configured global defaults.
+    #[serde(default)]
+    pub use_default_thresholds: bool,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -9515,6 +9618,10 @@ pub struct ContextMonitorStatus {
     pub session_id: String,
     pub friendly_name: Option<String>,
     pub notify_session_id: Option<String>,
+    pub warning_percentage: Option<f64>,
+    pub critical_percentage: Option<f64>,
+    pub threshold_source: String,
+    pub enforced: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -9527,9 +9634,11 @@ pub struct ContextSnapshotResponse {
     pub sampled_at: Option<String>,
     pub lifecycle_status: String,
     pub state: String,
-    pub warning_percentage: f64,
-    pub critical_percentage: f64,
+    pub warning_percentage: Option<f64>,
+    pub critical_percentage: Option<f64>,
+    pub threshold_source: String,
     pub context_monitor_enabled: bool,
+    pub context_monitor_enforced: bool,
     pub notify_session_id: Option<String>,
     pub compaction_active: bool,
     pub last_handoff_path: Option<String>,
@@ -9543,12 +9652,20 @@ impl ContextSnapshotResponse {
         let friendly_name = session.cached_display_name();
         let provider = non_empty_or(session.provider, "claude");
         let unsupported_provider = !provider_has_measured_context_gauge(&provider);
+        let thresholds = resolve_context_monitor_thresholds(
+            session.context_monitor_warning_percentage,
+            session.context_monitor_critical_percentage,
+            config,
+        );
         let state = if compaction_active {
             "compacting"
+        } else if thresholds.is_err() {
+            "thresholds_unavailable"
         } else if let Some(used_percentage) = used_percentage {
-            if used_percentage >= config.critical_percentage {
+            let thresholds = thresholds.as_ref().expect("checked above");
+            if used_percentage >= thresholds.critical_percentage {
                 "critical"
-            } else if used_percentage >= config.warning_percentage {
+            } else if used_percentage >= thresholds.warning_percentage {
                 "warning"
             } else {
                 "normal"
@@ -9567,9 +9684,22 @@ impl ContextSnapshotResponse {
             sampled_at: session.context_sampled_at,
             lifecycle_status,
             state,
-            warning_percentage: config.warning_percentage,
-            critical_percentage: config.critical_percentage,
+            warning_percentage: thresholds
+                .as_ref()
+                .ok()
+                .map(|value| value.warning_percentage),
+            critical_percentage: thresholds
+                .as_ref()
+                .ok()
+                .map(|value| value.critical_percentage),
+            threshold_source: thresholds
+                .as_ref()
+                .map(|value| value.source.as_str().to_owned())
+                .unwrap_or_else(|_| "invalid".to_owned()),
             context_monitor_enabled: session.context_monitor_enabled && !unsupported_provider,
+            context_monitor_enforced: session.context_monitor_enabled
+                && !unsupported_provider
+                && thresholds.is_ok(),
             notify_session_id: if unsupported_provider {
                 None
             } else {
@@ -9585,11 +9715,16 @@ impl ContextSnapshotResponse {
 pub struct ContextMonitorResult {
     pub status: String,
     pub enabled: bool,
+    pub warning_percentage: Option<f64>,
+    pub critical_percentage: Option<f64>,
+    pub threshold_source: String,
+    pub enforced: bool,
 }
 
 #[derive(Debug, Clone)]
 pub enum ContextMonitorOutcome {
     Updated(ContextMonitorResult),
+    InvalidThresholdConfig(String),
     NotFound,
     NotRunning,
     UnsupportedProvider(String),
@@ -15056,6 +15191,14 @@ pub struct SessionRecord {
     pub context_monitor_notify: Option<String>,
     #[serde(default = "default_context_monitor_notify_source")]
     pub context_monitor_notify_source: String,
+    /// Optional per-seat warning override. When absent, the configured global
+    /// context-monitor warning threshold remains effective.
+    #[serde(default)]
+    pub context_monitor_warning_percentage: Option<f64>,
+    /// Optional per-seat critical override. When absent, the configured global
+    /// context-monitor critical threshold remains effective.
+    #[serde(default)]
+    pub context_monitor_critical_percentage: Option<f64>,
     /// One-shot latches for the current accumulation cycle. Persisted rather
     /// than held in memory (as the Python server did) so a server restart does
     /// not re-fire a warning the agent has already been told about; the cycle
@@ -15721,6 +15864,70 @@ fn provider_has_measured_context_gauge(provider: &str) -> bool {
 
 fn provider_uses_native_context_compaction(provider: &str) -> bool {
     matches!(provider.trim(), "codex" | "codex-fork" | "codex-app")
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ContextMonitorThresholdSource {
+    Default,
+    Custom,
+}
+
+impl ContextMonitorThresholdSource {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Default => "default",
+            Self::Custom => "custom",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct EffectiveContextMonitorThresholds {
+    warning_percentage: f64,
+    critical_percentage: f64,
+    source: ContextMonitorThresholdSource,
+}
+
+/// Resolve the values that will actually govern a seat. A missing seat override
+/// is deliberately normal: it means the existing server-level default remains
+/// authoritative. Invalid persisted or global values fail closed so status and
+/// alerting never claim an unenforceable policy is active.
+fn resolve_context_monitor_thresholds(
+    warning_override: Option<f64>,
+    critical_override: Option<f64>,
+    config: &ContextMonitorConfig,
+) -> Result<EffectiveContextMonitorThresholds, String> {
+    let warning_percentage = warning_override.unwrap_or(config.warning_percentage);
+    let critical_percentage = critical_override.unwrap_or(config.critical_percentage);
+    for (name, value) in [
+        ("warning_percentage", warning_percentage),
+        ("critical_percentage", critical_percentage),
+    ] {
+        if !value.is_finite() || !(0.0..=100.0).contains(&value) {
+            return Err(format!(
+                "{name} must be a finite percentage in the range (0, 100]"
+            ));
+        }
+        if value == 0.0 {
+            return Err(format!(
+                "{name} must be a finite percentage in the range (0, 100]"
+            ));
+        }
+    }
+    if warning_percentage >= critical_percentage {
+        return Err(
+            "warning_percentage must be strictly lower than critical_percentage".to_owned(),
+        );
+    }
+    Ok(EffectiveContextMonitorThresholds {
+        warning_percentage,
+        critical_percentage,
+        source: if warning_override.is_some() || critical_override.is_some() {
+            ContextMonitorThresholdSource::Custom
+        } else {
+            ContextMonitorThresholdSource::Default
+        },
+    })
 }
 
 fn session_supports_reparent_consent(session: &SessionRecord) -> bool {
@@ -16751,6 +16958,8 @@ mod tests {
             context_monitor_enabled: false,
             context_monitor_notify: None,
             context_monitor_notify_source: default_context_monitor_notify_source(),
+            context_monitor_warning_percentage: None,
+            context_monitor_critical_percentage: None,
             context_warning_sent: false,
             context_critical_sent: false,
             aliases: Vec::new(),
@@ -20024,6 +20233,41 @@ mod tests {
             .collect()
     }
 
+    fn queued_context_monitor_messages(store: &SessionStore) -> Vec<PendingMessage> {
+        store
+            .queue_store
+            .as_ref()
+            .unwrap()
+            .pending_messages_for_target_by_category("parent01", "context_monitor", 10)
+            .unwrap()
+    }
+
+    fn store_with_queued_monitored_child(
+        label: &str,
+        enabled: bool,
+        notify: Option<&str>,
+    ) -> (SessionStore, PathBuf) {
+        let legacy_store = store_with_monitored_child(label, enabled, notify);
+        let queue_path = unique_temp_path(&format!("{label}-queue"));
+        let store =
+            SessionStore::new_with_queue(legacy_store.state_file.clone(), queue_path.clone());
+        (store, queue_path)
+    }
+
+    fn context_monitor_request(
+        warning_percentage: Option<f64>,
+        critical_percentage: Option<f64>,
+    ) -> ContextMonitorRequest {
+        ContextMonitorRequest {
+            enabled: true,
+            requester_session_id: "parent01".to_owned(),
+            notify_session_id: Some("parent01".to_owned()),
+            warning_percentage,
+            critical_percentage,
+            use_default_thresholds: false,
+        }
+    }
+
     #[test]
     fn context_usage_update_persists_tokens_and_warns_once_per_cycle() {
         let store = store_with_monitored_child("ctxwarn", true, Some("parent01"));
@@ -20068,11 +20312,147 @@ mod tests {
         assert_eq!(snapshot.used_percentage, Some(43.0));
         assert_eq!(snapshot.total_input_tokens, Some(86_214));
         assert_eq!(snapshot.state, "normal");
-        assert_eq!(snapshot.warning_percentage, 50.0);
-        assert_eq!(snapshot.critical_percentage, 65.0);
+        assert_eq!(snapshot.warning_percentage, Some(50.0));
+        assert_eq!(snapshot.critical_percentage, Some(65.0));
+        assert_eq!(snapshot.threshold_source, "default");
         assert!(snapshot.context_monitor_enabled);
+        assert!(snapshot.context_monitor_enforced);
         assert_eq!(snapshot.notify_session_id.as_deref(), Some("parent01"));
         assert!(!snapshot.compaction_active);
+    }
+
+    #[test]
+    fn seat_threshold_override_persists_across_restart_and_controls_alerting() {
+        let (store, queue_path) =
+            store_with_queued_monitored_child("ctxseatthreshold", true, Some("parent01"));
+        assert!(matches!(
+            store
+                .set_context_monitor("child001", context_monitor_request(Some(40.0), Some(60.0)),)
+                .unwrap(),
+            ContextMonitorOutcome::Updated(ContextMonitorResult {
+                enabled: true,
+                warning_percentage: Some(40.0),
+                critical_percentage: Some(60.0),
+                ..
+            })
+        ));
+
+        store
+            .apply_context_usage_event(&usage_event("child001", 39.9, 79_800), None)
+            .unwrap();
+        assert!(queued_context_monitor_messages(&store).is_empty());
+        store
+            .apply_context_usage_event(&usage_event("child001", 40.0, 80_000), None)
+            .unwrap();
+        assert_eq!(queued_context_monitor_messages(&store).len(), 1);
+
+        let restarted = SessionStore::new_with_queue(store.state_file.clone(), queue_path);
+        let status = restarted.list_context_monitors().unwrap();
+        assert_eq!(status.len(), 1);
+        assert_eq!(status[0].warning_percentage, Some(40.0));
+        assert_eq!(status[0].critical_percentage, Some(60.0));
+        assert_eq!(status[0].threshold_source, "custom");
+        assert!(status[0].enforced);
+        let snapshot = restarted.get_context_snapshot("child001").unwrap().unwrap();
+        assert_eq!(snapshot.warning_percentage, Some(40.0));
+        assert_eq!(snapshot.critical_percentage, Some(60.0));
+        assert_eq!(snapshot.threshold_source, "custom");
+        assert!(snapshot.context_monitor_enforced);
+
+        // The warning latch survives the restart while the critical threshold
+        // remains independently available for the same cycle.
+        restarted
+            .apply_context_usage_event(&usage_event("child001", 55.0, 110_000), None)
+            .unwrap();
+        restarted
+            .apply_context_usage_event(&usage_event("child001", 60.0, 120_000), None)
+            .unwrap();
+        assert_eq!(queued_context_monitor_messages(&restarted).len(), 2);
+    }
+
+    #[test]
+    fn invalid_or_inverted_threshold_requests_leave_durable_state_unchanged() {
+        let store = store_with_monitored_child("ctxinvalidthreshold", true, Some("parent01"));
+        let before = store.load_raw_json_value().unwrap();
+        for (warning, critical) in [
+            (Some(0.0), None),
+            (Some(70.0), Some(70.0)),
+            (Some(80.0), Some(40.0)),
+        ] {
+            assert!(matches!(
+                store
+                    .set_context_monitor("child001", context_monitor_request(warning, critical),)
+                    .unwrap(),
+                ContextMonitorOutcome::InvalidThresholdConfig(_)
+            ));
+            assert_eq!(store.load_raw_json_value().unwrap(), before);
+        }
+    }
+
+    #[test]
+    fn threshold_reconfiguration_cancels_stale_alerts_and_waits_for_a_fresh_sample() {
+        let (store, _) =
+            store_with_queued_monitored_child("ctxthresholdstale", true, Some("parent01"));
+        store
+            .apply_context_usage_event(
+                &usage_event_at("child001", 70.0, 140_000, "2026-08-17T10:00:00Z"),
+                None,
+            )
+            .unwrap();
+        assert_eq!(queued_context_monitor_messages(&store).len(), 1);
+
+        store
+            .set_context_monitor("child001", context_monitor_request(Some(40.0), Some(60.0)))
+            .unwrap();
+        // Reconfiguration cancels a pending alert that was generated under the
+        // previous policy. Cached telemetry must not manufacture a replacement.
+        assert!(queued_context_monitor_messages(&store).is_empty());
+        assert_eq!(
+            store
+                .apply_context_usage_event(
+                    &usage_event_at("child001", 70.0, 140_000, "2026-08-17T09:59:59Z"),
+                    None,
+                )
+                .unwrap(),
+            ContextUsageOutcome::StaleSample
+        );
+        assert!(queued_context_monitor_messages(&store).is_empty());
+
+        store
+            .apply_context_usage_event(
+                &usage_event_at("child001", 40.0, 80_000, "2026-08-17T10:00:01Z"),
+                None,
+            )
+            .unwrap();
+        assert_eq!(queued_context_monitor_messages(&store).len(), 1);
+    }
+
+    #[test]
+    fn invalid_persisted_threshold_is_visible_as_unenforced_and_never_alerts() {
+        let store = store_with_monitored_child("ctxpersistedinvalid", true, Some("parent01"));
+        let mut state = store.load_raw_json_value().unwrap();
+        session_object_mut(ensure_sessions_array_mut(&mut state).unwrap(), "child001")
+            .unwrap()
+            .insert(
+                "context_monitor_warning_percentage".to_owned(),
+                json!(100.0),
+            );
+        store.write_raw_json_value(&state).unwrap();
+
+        let status = store.list_context_monitors().unwrap();
+        assert_eq!(status[0].threshold_source, "invalid");
+        assert!(!status[0].enforced);
+        assert_eq!(status[0].warning_percentage, None);
+        assert_eq!(status[0].critical_percentage, None);
+        let snapshot = store.get_context_snapshot("child001").unwrap().unwrap();
+        assert_eq!(snapshot.state, "thresholds_unavailable");
+        assert_eq!(snapshot.threshold_source, "invalid");
+        assert!(!snapshot.context_monitor_enforced);
+
+        store
+            .apply_context_usage_event(&usage_event("child001", 99.0, 198_000), None)
+            .unwrap();
+        assert!(context_monitor_messages(&store).is_empty());
     }
 
     #[test]
@@ -20189,6 +20569,9 @@ mod tests {
                     enabled: true,
                     requester_session_id: "parent01".to_owned(),
                     notify_session_id: Some("parent01".to_owned()),
+                    warning_percentage: None,
+                    critical_percentage: None,
+                    use_default_thresholds: false,
                 },
             )
             .unwrap();
@@ -20540,6 +20923,9 @@ mod tests {
             enabled: true,
             requester_session_id: "parent01".to_owned(),
             notify_session_id: Some("parent01".to_owned()),
+            warning_percentage: None,
+            critical_percentage: None,
+            use_default_thresholds: false,
         };
         assert!(matches!(
             store
@@ -20612,6 +20998,9 @@ mod tests {
                     enabled: true,
                     requester_session_id: "child001".to_owned(),
                     notify_session_id: Some("child001".to_owned()),
+                    warning_percentage: None,
+                    critical_percentage: None,
+                    use_default_thresholds: false,
                 },
             )
             .unwrap();
@@ -20705,6 +21094,9 @@ mod tests {
                     enabled: true,
                     requester_session_id: "child001".to_owned(),
                     notify_session_id: Some("child001".to_owned()),
+                    warning_percentage: None,
+                    critical_percentage: None,
+                    use_default_thresholds: false,
                 },
             )
             .unwrap();
@@ -20770,6 +21162,9 @@ mod tests {
                     enabled: true,
                     requester_session_id: "child001".to_owned(),
                     notify_session_id: Some("child001".to_owned()),
+                    warning_percentage: None,
+                    critical_percentage: None,
+                    use_default_thresholds: false,
                 },
             )
             .unwrap();
@@ -20795,6 +21190,9 @@ mod tests {
                         enabled: false,
                         requester_session_id: "child001".to_owned(),
                         notify_session_id: None,
+                        warning_percentage: None,
+                        critical_percentage: None,
+                        use_default_thresholds: false,
                     },
                 )
                 .unwrap(),
@@ -20826,6 +21224,9 @@ mod tests {
                             enabled: true,
                             requester_session_id: "parent01".to_owned(),
                             notify_session_id: Some("parent01".to_owned()),
+                            warning_percentage: None,
+                            critical_percentage: None,
+                            use_default_thresholds: false,
                         },
                     )
                     .unwrap(),
@@ -20845,6 +21246,9 @@ mod tests {
                         enabled: true,
                         requester_session_id: "parent01".to_owned(),
                         notify_session_id: Some("parent01".to_owned()),
+                        warning_percentage: None,
+                        critical_percentage: None,
+                        use_default_thresholds: false,
                     },
                 )
                 .unwrap(),
@@ -20860,6 +21264,9 @@ mod tests {
                         enabled: true,
                         requester_session_id: "parent01".to_owned(),
                         notify_session_id: Some("parent01".to_owned()),
+                        warning_percentage: None,
+                        critical_percentage: None,
+                        use_default_thresholds: false,
                     },
                 )
                 .unwrap(),


### PR DESCRIPTION
Fixes #1313

## Scope

- Add durable warning/critical context-monitor overrides per eligible seat, with reset-to-default support and fail-closed validation.
- Show effective thresholds, source, and enforcement state in the API and CLI status output.
- Preserve #1308 measured-provider enrollment: Claude and Codex-fork enroll; generic Codex and Codex-app fail closed; native Codex compaction remains notification-only.
- Cancel queued context alerts when a threshold policy changes; preserve #1308 cancellation on disable.

## Validation

- `cargo fmt --check`
- `cargo check -p sm-server`
- focused context-monitor contract tests: 4 passed
- focused threshold tests: 5 passed
- `cargo test -p sm-server --bin sm`: 79 passed
- `cargo test -p sm-server --lib`: 505 passed; one pre-existing isolated failure tracked in #1305 (`scheduled_reminders` schema absent in that test fixture).

## Review ledger — binding maximum: 3 total Codex rounds

- R1 — pending, exact head `e41ee34d4a9125f9b3da728ce409a940b70ee9a`; broad integration review.
- R2 — reserved only for a materially changed exact head, if needed.
- R3 — final permitted round. Any P0/P1/P2 on R3 stops this PR: preserve a design return and split only genuinely independent bounded slices. No round 4 and no cosmetic/unchanged resubmission.

## Deployment

Do not restart independently. After review-clean merge, coordinate one serialized signed restart and live proof with #1304 owner: verify Codex-fork enrollment plus custom threshold/status behavior.