### PR TITLE
Continue idle queue completion wake delivery

### DIFF
--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -10541,7 +10541,10 @@ fn deliver_runtime_text_to_session_with_ready_fence_raw(
         let node = json_text(session.get("node")).unwrap_or_else(default_node);
         ensure_runtime_local_node(&node)?;
         let status = effective_raw_session_status(session);
-        if raw_session_is_stopped(session) || claude_handoff_is_pending_raw(session) {
+        if raw_session_is_stopped(session)
+            || (require_ready_fence && claude_handoff_is_pending_raw(session))
+            || (!require_ready_fence && claude_handoff_is_reserved_raw(session))
+        {
             return Ok((status, false));
         }
         let tmux_session = json_text(session.get("tmux_session"))
@@ -10610,7 +10613,7 @@ fn deliver_urgent_runtime_text_to_session_raw(
         let node = json_text(session.get("node")).unwrap_or_else(default_node);
         ensure_runtime_local_node(&node)?;
         let status = effective_raw_session_status(session);
-        if raw_session_is_stopped(session) || claude_handoff_is_pending_raw(session) {
+        if raw_session_is_stopped(session) || claude_handoff_is_reserved_raw(session) {
             return Ok((status, false));
         }
         let tmux_session = json_text(session.get("tmux_session"))
@@ -10675,7 +10678,7 @@ fn deliver_runtime_native_rename_to_session_raw(
     if raw_session_is_stopped(session) {
         return Ok((status, false));
     }
-    if claude_handoff_is_pending_raw(session) {
+    if claude_handoff_is_reserved_raw(session) {
         return Ok((status, false));
     }
     let Some(friendly_name) = extract_provider_native_rename_name(text) else {
@@ -11100,6 +11103,11 @@ fn claude_handoff_is_pending_raw(session: &Map<String, Value>) -> bool {
     json_text(session.get("provider")).as_deref() == Some("claude")
         && json_text(session.get("pending_handoff_path")).is_some()
         && json_text(session.get("pending_handoff_recorded_at")).is_some()
+}
+
+fn claude_handoff_is_reserved_raw(session: &Map<String, Value>) -> bool {
+    json_text(session.get("provider")).as_deref() == Some("claude")
+        && json_text(session.get("claude_handoff_in_progress_at")).is_some()
 }
 
 fn claude_handoff_reservation_replaced_raw(
@@ -17904,6 +17912,37 @@ mod tests {
             1
         );
         assert!(pane.input_lines().is_empty());
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
+    fn direct_delivery_allows_retryable_unreserved_claude_handoff() {
+        let pane = queue_completion_test_pane(true);
+        let (_store, _queue, state_file, queue_db) = queue_completion_test_store(&pane, "idle");
+        let mut state: Value =
+            serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+        let session = state["sessions"][0].as_object_mut().unwrap();
+        session.insert(
+            "pending_handoff_path".to_owned(),
+            Value::String("/tmp/retryable-handoff.md".to_owned()),
+        );
+        session.insert(
+            "pending_handoff_recorded_at".to_owned(),
+            Value::String("2026-06-01T00:02:00Z".to_owned()),
+        );
+
+        let (status, delivered) = deliver_runtime_text_to_session_raw(
+            &mut state,
+            "queue-target",
+            "[sm queue] handoff retry drain",
+            &pane.runtime,
+        )
+        .unwrap();
+
+        assert_eq!(status, "idle");
+        assert!(delivered);
+        assert_eq!(pane.input_lines(), vec!["[sm queue] handoff retry drain"]);
         let _ = fs::remove_file(state_file);
         let _ = fs::remove_file(queue_db);
     }

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -10479,14 +10479,20 @@ fn runtime_session_accepts_background_delivery_raw(
     session_id: &str,
     runtime: &TmuxRuntime,
 ) -> Result<bool> {
-    let Some(status) = runtime_session_status_raw(state, session_id)? else {
+    let Some(_status) = runtime_session_status_raw(state, session_id)? else {
         return Ok(false);
     };
-    if normalized_status(&status) != "idle" {
-        return Ok(false);
-    }
     let session = raw_session_object(state, session_id)
         .ok_or_else(|| anyhow::anyhow!("session {session_id} disappeared"))?;
+    // A Claude Stop hook is the durable lifecycle signal, but it is dispatched
+    // through a detached curl and can be stale or lost.  Delivery must not wait
+    // for that projection once the provider itself proves that its live composer
+    // is empty.  The provider-specific readiness check below is the
+    // authoritative, immediate safety fence; stopped and reserved-handoff
+    // sessions still cannot receive background input.
+    if raw_session_is_stopped(session) {
+        return Ok(false);
+    }
     if claude_handoff_is_reserved_raw(session) {
         return Ok(false);
     }
@@ -15786,7 +15792,11 @@ mod tests {
     use crate::config::AppConfig;
     use crate::usage_identity::{AccountIdentity, Provider, UsageIdentityStore};
     use rusqlite::Connection;
-    use std::sync::{Arc, Barrier};
+    use std::{
+        process::Command,
+        sync::{Arc, Barrier},
+        time::Duration,
+    };
 
     #[test]
     fn accepted_spawn_brief_is_private_immutable_and_records_launch_intent() {
@@ -17639,6 +17649,217 @@ mod tests {
             Some("running")
         );
         assert!(!session.contains_key("stopped_at"));
+    }
+
+    struct QueueCompletionTestPane {
+        socket_name: String,
+        input_path: PathBuf,
+        runtime: TmuxRuntime,
+        session_name: String,
+    }
+
+    impl Drop for QueueCompletionTestPane {
+        fn drop(&mut self) {
+            let _ = Command::new("tmux")
+                .args(["-L", &self.socket_name, "kill-server"])
+                .status();
+            let _ = fs::remove_file(&self.input_path);
+        }
+    }
+
+    impl QueueCompletionTestPane {
+        fn input_lines(&self) -> Vec<String> {
+            for _ in 0..100 {
+                if let Ok(text) = fs::read_to_string(&self.input_path) {
+                    return text.lines().map(ToOwned::to_owned).collect();
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Vec::new()
+        }
+    }
+
+    fn queue_completion_test_shell_quote(value: &str) -> String {
+        format!("'{}'", value.replace('\'', "'\\''"))
+    }
+
+    fn queue_completion_test_pane(input_ready: bool) -> QueueCompletionTestPane {
+        let (socket_name, runtime) = isolated_test_tmux_runtime();
+        let session_name = "queue-completion-target".to_owned();
+        let input_path = unique_temp_path("queue-completion-input");
+        let pane = if input_ready { ">" } else { ">\n✽ Thinking" };
+        let command = format!(
+            "printf '%s\\n' {}; while IFS= read -r line; do printf '%s\\n' \"$line\" >> {}; printf '%s\\n' {}; done",
+            queue_completion_test_shell_quote(pane),
+            queue_completion_test_shell_quote(&input_path.display().to_string()),
+            queue_completion_test_shell_quote(pane),
+        );
+        let output = Command::new("tmux")
+            .args([
+                "-L",
+                &socket_name,
+                "new-session",
+                "-d",
+                "-s",
+                &session_name,
+                "sh",
+                "-c",
+                &command,
+            ])
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "failed to create isolated queue test pane: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        QueueCompletionTestPane {
+            socket_name,
+            input_path,
+            runtime,
+            session_name,
+        }
+    }
+
+    fn queue_completion_test_store(
+        pane: &QueueCompletionTestPane,
+        status: &str,
+    ) -> (SessionStore, RetainedQueueStore, PathBuf, PathBuf) {
+        let state_file = unique_temp_path("queue-completion-state");
+        let queue_db = state_file.with_extension("message-queue.db");
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [{
+                    "id": "queue-target",
+                    "name": "queue-target",
+                    "working_dir": "/repo",
+                    "tmux_session": pane.session_name,
+                    "tmux_socket_name": pane.socket_name,
+                    "provider": "claude",
+                    "status": status,
+                    "created_at": "2026-06-01T00:00:00Z",
+                    "last_activity": "2026-06-01T00:00:00Z"
+                }]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let queue = RetainedQueueStore::new(queue_db.clone());
+        let store = SessionStore::new_with_queue(state_file.clone(), queue_db.clone())
+            .with_delivery_runtime(Some(pane.runtime.clone()));
+        (store, queue, state_file, queue_db)
+    }
+
+    fn enqueue_queue_completion(queue: &RetainedQueueStore, id: &str) {
+        queue
+            .enqueue_message_once_with_metadata(
+                id,
+                "queue-target",
+                "[sm queue] test job completed",
+                "sequential",
+                QueueMessageMetadata {
+                    message_category: Some("queue-completion".to_owned()),
+                    ..QueueMessageMetadata::default()
+                },
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn completion_reconciler_delivers_to_a_provider_ready_stale_running_target() {
+        let pane = queue_completion_test_pane(true);
+        let (store, queue, state_file, queue_db) = queue_completion_test_store(&pane, "running");
+        enqueue_queue_completion(&queue, "queue-completion-stale-running");
+
+        store
+            .drain_runtime_pending_message_targets_by_category("queue-completion")
+            .unwrap();
+
+        assert!(queue
+            .pending_messages_for_target_by_category("queue-target", "queue-completion", 10)
+            .unwrap()
+            .is_empty());
+        assert_eq!(pane.input_lines(), vec!["[sm queue] test job completed"]);
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
+    fn completion_reconciler_retains_idle_projection_when_provider_is_still_active() {
+        let pane = queue_completion_test_pane(false);
+        let (store, queue, state_file, queue_db) = queue_completion_test_store(&pane, "idle");
+        enqueue_queue_completion(&queue, "queue-completion-active-pane");
+
+        store
+            .drain_runtime_pending_message_targets_by_category("queue-completion")
+            .unwrap();
+
+        assert_eq!(
+            queue
+                .pending_messages_for_target_by_category("queue-target", "queue-completion", 10)
+                .unwrap()
+                .len(),
+            1
+        );
+        assert!(pane.input_lines().is_empty());
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
+    fn completion_reconciler_delivers_after_restart_from_the_durable_queue() {
+        let pane = queue_completion_test_pane(true);
+        let (store, queue, state_file, queue_db) = queue_completion_test_store(&pane, "running");
+        enqueue_queue_completion(&queue, "queue-completion-after-restart");
+        drop(store);
+        let restarted = SessionStore::new_with_queue(state_file.clone(), queue_db.clone())
+            .with_delivery_runtime(Some(pane.runtime.clone()));
+
+        restarted
+            .drain_runtime_pending_message_targets_by_category("queue-completion")
+            .unwrap();
+
+        assert!(queue
+            .pending_messages_for_target_by_category("queue-target", "queue-completion", 10)
+            .unwrap()
+            .is_empty());
+        assert_eq!(pane.input_lines(), vec!["[sm queue] test job completed"]);
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
+    fn concurrent_completion_reconcilers_deliver_one_durable_message_once() {
+        let pane = queue_completion_test_pane(true);
+        let (store, queue, state_file, queue_db) = queue_completion_test_store(&pane, "running");
+        enqueue_queue_completion(&queue, "queue-completion-concurrent");
+        let store = Arc::new(store);
+        let barrier = Arc::new(Barrier::new(3));
+        let handles = (0..2)
+            .map(|_| {
+                let store = Arc::clone(&store);
+                let barrier = Arc::clone(&barrier);
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    store
+                        .drain_runtime_pending_message_targets_by_category("queue-completion")
+                        .unwrap();
+                })
+            })
+            .collect::<Vec<_>>();
+        barrier.wait();
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        assert!(queue
+            .pending_messages_for_target_by_category("queue-target", "queue-completion", 10)
+            .unwrap()
+            .is_empty());
+        assert_eq!(pane.input_lines(), vec!["[sm queue] test job completed"]);
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
     }
 
     #[test]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -11185,16 +11185,9 @@ fn drain_pending_runtime_messages_raw(
 
         let mut should_continue = true;
         for message in messages {
-            let (next_status, delivered) = if require_ready_fence
-                && (message.message_category.as_deref() == Some("native_rename")
-                    || normalized_delivery_mode(&message.delivery_mode) == "urgent")
+            let (next_status, delivered) = if message.message_category.as_deref()
+                == Some("native_rename")
             {
-                // The completion reconciler owns only background delivery. It
-                // must not repurpose an urgent or provider-control message as
-                // an unfenced predecessor while it holds the live readiness
-                // proof for a sequential completion wake.
-                (status.clone(), false)
-            } else if message.message_category.as_deref() == Some("native_rename") {
                 deliver_runtime_native_rename_to_session_raw(
                     state,
                     session_id,
@@ -17900,6 +17893,37 @@ mod tests {
             1
         );
         assert!(pane.input_lines().is_empty());
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
+    fn completion_reconciler_drains_urgent_predecessor_before_ready_completion() {
+        let pane = queue_completion_test_pane(true);
+        let (store, queue, state_file, queue_db) = queue_completion_test_store(&pane, "running");
+        queue
+            .enqueue_message_once_with_metadata(
+                "queue-completion-urgent-predecessor",
+                "queue-target",
+                "[sm queue] urgent predecessor",
+                "urgent",
+                QueueMessageMetadata::default(),
+            )
+            .unwrap();
+        enqueue_queue_completion(&queue, "queue-completion-after-urgent-predecessor");
+
+        store
+            .drain_runtime_pending_message_targets_by_category("queue-completion")
+            .unwrap();
+
+        assert!(queue
+            .pending_messages_for_target("queue-target", 10)
+            .unwrap()
+            .is_empty());
+        let inputs = pane.input_lines();
+        assert_eq!(inputs.len(), 2);
+        assert!(inputs[0].ends_with("[sm queue] urgent predecessor"));
+        assert_eq!(inputs[1], "[sm queue] test job completed");
         let _ = fs::remove_file(state_file);
         let _ = fs::remove_file(queue_db);
     }

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -3764,7 +3764,7 @@ impl SessionStore {
                     .unwrap_or_else(default_node);
                 if is_primary_node(&node) {
                     drain_pending_runtime_messages_raw(
-                        self, &mut state, target, runtime, queue, None, None, None,
+                        self, &mut state, target, runtime, queue, None, None, None, false,
                     )?;
                 }
             }
@@ -4600,6 +4600,7 @@ impl SessionStore {
                         },
                         None,
                         Some(&message_id),
+                        false,
                     )?
                 };
                 self.write_raw_json_value(&state)?;
@@ -4852,6 +4853,7 @@ impl SessionStore {
                 None,
                 message_category,
                 None,
+                false,
             )?;
             self.write_raw_json_value(&state)?;
         }
@@ -4872,7 +4874,7 @@ impl SessionStore {
             return Ok(false);
         }
         drain_pending_runtime_messages_raw(
-            self, &mut state, session_id, runtime, queue, None, None, None,
+            self, &mut state, session_id, runtime, queue, None, None, None, true,
         )?;
         self.write_raw_json_value(&state)?;
         Ok(true)
@@ -6217,6 +6219,7 @@ impl SessionStore {
                         None,
                         None,
                         Some(&message_id),
+                        false,
                     )?;
                 }
             }
@@ -7786,6 +7789,7 @@ impl SessionStore {
                                 Some("important"),
                                 None,
                                 Some(&message_id),
+                                false,
                             )?;
                             if drain
                                 .delivered_message_ids
@@ -10493,7 +10497,7 @@ fn runtime_session_accepts_background_delivery_raw(
     if raw_session_is_stopped(session) {
         return Ok(false);
     }
-    if claude_handoff_is_reserved_raw(session) {
+    if claude_handoff_is_pending_raw(session) {
         return Ok(false);
     }
     let tmux_session = json_text(session.get("tmux_session"))
@@ -10511,6 +10515,25 @@ fn deliver_runtime_text_to_session_raw(
     text: &str,
     runtime: &TmuxRuntime,
 ) -> Result<(String, bool)> {
+    deliver_runtime_text_to_session_with_ready_fence_raw(state, session_id, text, runtime, false)
+}
+
+fn deliver_runtime_background_text_to_session_raw(
+    state: &mut Value,
+    session_id: &str,
+    text: &str,
+    runtime: &TmuxRuntime,
+) -> Result<(String, bool)> {
+    deliver_runtime_text_to_session_with_ready_fence_raw(state, session_id, text, runtime, true)
+}
+
+fn deliver_runtime_text_to_session_with_ready_fence_raw(
+    state: &mut Value,
+    session_id: &str,
+    text: &str,
+    runtime: &TmuxRuntime,
+    require_ready_fence: bool,
+) -> Result<(String, bool)> {
     let (mut status, delivered, terminal_delivery_failure) = {
         let sessions = ensure_sessions_array_mut(state)?;
         let session = session_object_mut(sessions, session_id)
@@ -10518,23 +10541,42 @@ fn deliver_runtime_text_to_session_raw(
         let node = json_text(session.get("node")).unwrap_or_else(default_node);
         ensure_runtime_local_node(&node)?;
         let status = effective_raw_session_status(session);
-        if raw_session_is_stopped(session) || claude_handoff_is_reserved_raw(session) {
+        if raw_session_is_stopped(session) || claude_handoff_is_pending_raw(session) {
             return Ok((status, false));
         }
         let tmux_session = json_text(session.get("tmux_session"))
             .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?;
+        let provider = json_text(session.get("provider")).unwrap_or_else(default_provider);
         let session_socket_name = json_text(session.get("tmux_socket_name"));
         let session_runtime = runtime.for_socket_name(session_socket_name.as_deref());
+        let _input_guard = require_ready_fence
+            .then(|| session_runtime.lock_session_input(&tmux_session))
+            .transpose()?;
+        if require_ready_fence && !session_runtime.session_input_ready(&tmux_session, &provider) {
+            return Ok((status, false));
+        }
         let (delivered, mark_stopped_on_failure) =
             match deliver_codex_fork_control_text_to_session_raw(
                 session_id, session, text, runtime,
             )? {
                 Some(true) => (true, true),
                 Some(false) if runtime.codex_fork_control_tmux_fallback_enabled() => {
-                    (session_runtime.send_input(&tmux_session, text)?, true)
+                    let delivered = if require_ready_fence {
+                        session_runtime.send_input_while_locked(&tmux_session, text)?
+                    } else {
+                        session_runtime.send_input(&tmux_session, text)?
+                    };
+                    (delivered, true)
                 }
                 Some(false) => (false, false),
-                None => (session_runtime.send_input(&tmux_session, text)?, true),
+                None => {
+                    let delivered = if require_ready_fence {
+                        session_runtime.send_input_while_locked(&tmux_session, text)?
+                    } else {
+                        session_runtime.send_input(&tmux_session, text)?
+                    };
+                    (delivered, true)
+                }
             };
         if delivered {
             mark_session_followup_activity(session, &now_rfc3339());
@@ -10568,7 +10610,7 @@ fn deliver_urgent_runtime_text_to_session_raw(
         let node = json_text(session.get("node")).unwrap_or_else(default_node);
         ensure_runtime_local_node(&node)?;
         let status = effective_raw_session_status(session);
-        if raw_session_is_stopped(session) || claude_handoff_is_reserved_raw(session) {
+        if raw_session_is_stopped(session) || claude_handoff_is_pending_raw(session) {
             return Ok((status, false));
         }
         let tmux_session = json_text(session.get("tmux_session"))
@@ -10633,7 +10675,7 @@ fn deliver_runtime_native_rename_to_session_raw(
     if raw_session_is_stopped(session) {
         return Ok((status, false));
     }
-    if claude_handoff_is_reserved_raw(session) {
+    if claude_handoff_is_pending_raw(session) {
         return Ok((status, false));
     }
     let Some(friendly_name) = extract_provider_native_rename_name(text) else {
@@ -11054,9 +11096,10 @@ fn clear_claude_handoff_error_raw(session: &mut Map<String, Value>) {
     }
 }
 
-fn claude_handoff_is_reserved_raw(session: &Map<String, Value>) -> bool {
+fn claude_handoff_is_pending_raw(session: &Map<String, Value>) -> bool {
     json_text(session.get("provider")).as_deref() == Some("claude")
-        && json_text(session.get("claude_handoff_in_progress_at")).is_some()
+        && json_text(session.get("pending_handoff_path")).is_some()
+        && json_text(session.get("pending_handoff_recorded_at")).is_some()
 }
 
 fn claude_handoff_reservation_replaced_raw(
@@ -11121,6 +11164,7 @@ fn drain_pending_runtime_messages_raw(
     delivery_mode_filter: Option<&str>,
     message_category_filter: Option<&str>,
     stop_after_message_id: Option<&str>,
+    require_ready_fence: bool,
 ) -> Result<QueueDrainResult> {
     let mut status =
         runtime_session_status_raw(state, session_id)?.unwrap_or_else(|| "stopped".to_owned());
@@ -11141,16 +11185,32 @@ fn drain_pending_runtime_messages_raw(
 
         let mut should_continue = true;
         for message in messages {
-            let (next_status, delivered) =
-                if message.message_category.as_deref() == Some("native_rename") {
-                    deliver_runtime_native_rename_to_session_raw(
-                        state,
-                        session_id,
-                        &message.text,
-                        runtime,
-                    )?
-                } else if normalized_delivery_mode(&message.delivery_mode) == "urgent" {
-                    deliver_urgent_runtime_text_to_session_raw(
+            let (next_status, delivered) = if require_ready_fence
+                && (message.message_category.as_deref() == Some("native_rename")
+                    || normalized_delivery_mode(&message.delivery_mode) == "urgent")
+            {
+                // The completion reconciler owns only background delivery. It
+                // must not repurpose an urgent or provider-control message as
+                // an unfenced predecessor while it holds the live readiness
+                // proof for a sequential completion wake.
+                (status.clone(), false)
+            } else if message.message_category.as_deref() == Some("native_rename") {
+                deliver_runtime_native_rename_to_session_raw(
+                    state,
+                    session_id,
+                    &message.text,
+                    runtime,
+                )?
+            } else if normalized_delivery_mode(&message.delivery_mode) == "urgent" {
+                deliver_urgent_runtime_text_to_session_raw(
+                    state,
+                    session_id,
+                    &message.text,
+                    runtime,
+                )?
+            } else {
+                if require_ready_fence {
+                    deliver_runtime_background_text_to_session_raw(
                         state,
                         session_id,
                         &message.text,
@@ -11158,7 +11218,8 @@ fn drain_pending_runtime_messages_raw(
                     )?
                 } else {
                     deliver_runtime_text_to_session_raw(state, session_id, &message.text, runtime)?
-                };
+                }
+            };
             status = next_status;
             if !delivered {
                 should_continue = false;
@@ -11281,6 +11342,7 @@ fn complete_runtime_message_delivery_raw(
                 Some("sequential"),
                 None,
                 None,
+                false,
             )?;
         }
     }
@@ -11451,6 +11513,7 @@ fn enqueue_stop_notification_raw(
             Some("important"),
             None,
             None,
+            false,
         )?;
     }
     Ok(())
@@ -17802,6 +17865,62 @@ mod tests {
                 .len(),
             1
         );
+        assert!(pane.input_lines().is_empty());
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
+    fn completion_reconciler_retains_ready_target_with_pending_claude_handoff() {
+        let pane = queue_completion_test_pane(true);
+        let (store, queue, state_file, queue_db) = queue_completion_test_store(&pane, "running");
+        let mut state: Value =
+            serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+        let session = state["sessions"][0].as_object_mut().unwrap();
+        session.insert(
+            "pending_handoff_path".to_owned(),
+            Value::String("/tmp/queued-handoff.md".to_owned()),
+        );
+        session.insert(
+            "pending_handoff_recorded_at".to_owned(),
+            Value::String("2026-06-01T00:02:00Z".to_owned()),
+        );
+        fs::write(&state_file, state.to_string()).unwrap();
+        enqueue_queue_completion(&queue, "queue-completion-pending-handoff");
+
+        store
+            .drain_runtime_pending_message_targets_by_category("queue-completion")
+            .unwrap();
+
+        assert_eq!(
+            queue
+                .pending_messages_for_target_by_category("queue-target", "queue-completion", 10)
+                .unwrap()
+                .len(),
+            1
+        );
+        assert!(pane.input_lines().is_empty());
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+    }
+
+    #[test]
+    fn background_delivery_rechecks_provider_ready_state_under_input_lock() {
+        let pane = queue_completion_test_pane(false);
+        let (_store, _queue, state_file, queue_db) = queue_completion_test_store(&pane, "running");
+        let mut state: Value =
+            serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+
+        let (status, delivered) = deliver_runtime_background_text_to_session_raw(
+            &mut state,
+            "queue-target",
+            "[sm queue] stale readiness proof must not inject",
+            &pane.runtime,
+        )
+        .unwrap();
+
+        assert_eq!(status, "running");
+        assert!(!delivered);
         assert!(pane.input_lines().is_empty());
         let _ = fs::remove_file(state_file);
         let _ = fs::remove_file(queue_db);

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -11185,6 +11185,9 @@ fn drain_pending_runtime_messages_raw(
 
         let mut should_continue = true;
         for message in messages {
+            let control_predecessor = require_ready_fence
+                && (message.message_category.as_deref() == Some("native_rename")
+                    || normalized_delivery_mode(&message.delivery_mode) == "urgent");
             let (next_status, delivered) = if message.message_category.as_deref()
                 == Some("native_rename")
             {
@@ -11219,6 +11222,14 @@ fn drain_pending_runtime_messages_raw(
                 break;
             }
             complete_runtime_message_delivery_raw(store, state, runtime, queue, &message)?;
+            if control_predecessor {
+                // An urgent or provider-control predecessor can have just
+                // started a turn. Wait for the next reconciliation, which
+                // will take a fresh readiness proof under the input lock,
+                // before considering a following completion wake.
+                should_continue = false;
+                break;
+            }
             let delivered_target =
                 stop_after_message_id.is_some_and(|target_id| target_id == message.id);
             delivered_message_ids.push(message.id);
@@ -17898,7 +17909,7 @@ mod tests {
     }
 
     #[test]
-    fn completion_reconciler_drains_urgent_predecessor_before_ready_completion() {
+    fn completion_reconciler_rechecks_after_urgent_predecessor_before_completion() {
         let pane = queue_completion_test_pane(true);
         let (store, queue, state_file, queue_db) = queue_completion_test_store(&pane, "running");
         queue
@@ -17916,14 +17927,32 @@ mod tests {
             .drain_runtime_pending_message_targets_by_category("queue-completion")
             .unwrap();
 
+        let inputs = pane.input_lines();
+        assert_eq!(inputs.len(), 1);
+        assert!(inputs[0].ends_with("[sm queue] urgent predecessor"));
+        assert_eq!(
+            queue
+                .pending_messages_for_target_by_category("queue-target", "queue-completion", 10)
+                .unwrap()
+                .len(),
+            1
+        );
+
+        store
+            .drain_runtime_pending_message_targets_by_category("queue-completion")
+            .unwrap();
+
         assert!(queue
             .pending_messages_for_target("queue-target", 10)
             .unwrap()
             .is_empty());
-        let inputs = pane.input_lines();
-        assert_eq!(inputs.len(), 2);
-        assert!(inputs[0].ends_with("[sm queue] urgent predecessor"));
-        assert_eq!(inputs[1], "[sm queue] test job completed");
+        assert_eq!(
+            pane.input_lines(),
+            vec![
+                inputs[0].clone(),
+                "[sm queue] test job completed".to_owned()
+            ]
+        );
         let _ = fs::remove_file(state_file);
         let _ = fs::remove_file(queue_db);
     }


### PR DESCRIPTION
Continuation of review-capped PR #1343.

This split preserves the prior durable idle-delivery fix and adds the final safety fence: after an urgent or native control predecessor, retain the completion until a later reconciliation obtains a fresh provider-ready observation under the input lock.

Validation: scripts/test-rust-isolated.sh completion reconciler, locked readiness, and concurrency coverage.