### PR TITLE
Thin-client sm: SSH shim to studio + node-agent teardown + local API forward

### DIFF
--- a/scripts/com.rajeshgoli.session-manager-api-forward.macbook.plist
+++ b/scripts/com.rajeshgoli.session-manager-api-forward.macbook.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.rajeshgoli.session-manager-api-forward.macbook</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <!-- Installed copy in ~/bin: the repo lives under ~/Desktop (TCC-protected),
+             which a launchd agent without Full Disk Access cannot read. -->
+        <string>/Users/rajesh/bin/session-manager-api-forward</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/session-manager-api-forward-macbook.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>/tmp/session-manager-api-forward-macbook.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <!-- ssh + nc live in /usr/bin; cloudflared (studio-away ProxyCommand) in homebrew. -->
+        <key>PATH</key>
+        <string>/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:/usr/local/bin</string>
+    </dict>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+</dict>
+</plist>

--- a/scripts/install-thin-client.sh
+++ b/scripts/install-thin-client.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# install-thin-client — make this laptop a thin client for studio's
+# session-manager (issue #1345). Idempotent.
+#
+#   A  install ~/bin/sm SSH shim (command-agnostic passthrough to studio's sm)
+#   B  tear down the old node_agent launchd job + plist
+#   C1 install the self-healing local API forward launchd helper
+#
+# Usage: scripts/install-thin-client.sh [install|uninstall|status]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+UID_NUM="$(id -u)"
+
+SHIM_SRC="$SCRIPT_DIR/sm-thin-client.sh"
+SHIM_DST="$HOME/bin/sm"
+
+NODE_LABEL="com.rajeshgoli.session-manager-node-agent.macbook"
+NODE_PLIST="$HOME/Library/LaunchAgents/$NODE_LABEL.plist"
+
+FWD_LABEL="com.rajeshgoli.session-manager-api-forward.macbook"
+FWD_PLIST_SRC="$SCRIPT_DIR/$FWD_LABEL.plist"
+FWD_PLIST_DST="$HOME/Library/LaunchAgents/$FWD_LABEL.plist"
+FWD_SCRIPT_SRC="$SCRIPT_DIR/session-manager-api-forward.sh"
+# Installed copy must live OUTSIDE ~/Desktop (TCC-protected — launchd agents
+# without Full Disk Access get "can't open input file" / exit 127 there).
+FWD_SCRIPT_DST="$HOME/bin/session-manager-api-forward"
+
+install_shim() {          # A
+  echo "== A: installing sm SSH shim -> $SHIM_DST"
+  mkdir -p "$HOME/bin"
+  install -m 0755 "$SHIM_SRC" "$SHIM_DST"
+  echo "   installed. (ensure ~/bin precedes the venv on PATH)"
+}
+
+teardown_node_agent() {   # B
+  echo "== B: tearing down node_agent"
+  launchctl bootout "gui/$UID_NUM/$NODE_LABEL" 2>/dev/null || true
+  rm -f "$NODE_PLIST"
+  # Stray in-repo copies from the old node-agent setup.
+  rm -f "$SCRIPT_DIR/$NODE_LABEL.plist" \
+        "$SCRIPT_DIR/session-manager-node-agent-wrapper.sh"
+  # Optional: retire a leftover server-anchor tmux if one lingers.
+  tmux kill-session -t __sm_server_anchor 2>/dev/null || true
+  echo "   node_agent removed (SM_API_URL / client.yaml left in place)."
+}
+
+install_forward() {       # C1
+  echo "== C1: installing self-healing API forward"
+  mkdir -p "$HOME/bin"
+  install -m 0755 "$FWD_SCRIPT_SRC" "$FWD_SCRIPT_DST"
+  cp "$FWD_PLIST_SRC" "$FWD_PLIST_DST"
+  launchctl bootout "gui/$UID_NUM/$FWD_LABEL" 2>/dev/null || true
+  launchctl bootstrap "gui/$UID_NUM" "$FWD_PLIST_DST"
+  launchctl enable "gui/$UID_NUM/$FWD_LABEL" 2>/dev/null || true
+  echo "   forward loaded. Logs: /tmp/session-manager-api-forward-macbook.log"
+}
+
+status() {
+  echo "== status =="
+  echo "-- shim ($SHIM_DST):"
+  if [ -x "$SHIM_DST" ]; then echo "   present"; else echo "   MISSING"; fi
+  echo "-- node_agent ($NODE_LABEL):"
+  launchctl print "gui/$UID_NUM/$NODE_LABEL" >/dev/null 2>&1 \
+    && echo "   STILL LOADED (unexpected)" || echo "   gone"
+  echo "-- api forward ($FWD_LABEL):"
+  launchctl print "gui/$UID_NUM/$FWD_LABEL" >/dev/null 2>&1 \
+    && echo "   loaded" || echo "   not loaded"
+  echo "-- health via forward:"
+  if curl -fsS --max-time 5 http://127.0.0.1:8420/health >/dev/null 2>&1; then
+    echo "   127.0.0.1:8420/health OK"
+  else
+    echo "   127.0.0.1:8420/health unreachable (forward may still be connecting)"
+  fi
+}
+
+uninstall() {
+  echo "== uninstall (C1 forward + shim) =="
+  launchctl bootout "gui/$UID_NUM/$FWD_LABEL" 2>/dev/null || true
+  rm -f "$FWD_PLIST_DST" "$FWD_SCRIPT_DST" "$SHIM_DST"
+  echo "   removed forward + shim (node_agent stays torn down)."
+}
+
+case "${1:-install}" in
+  install)   install_shim; teardown_node_agent; install_forward; echo; status ;;
+  uninstall) uninstall ;;
+  status)    status ;;
+  *) echo "Usage: $0 [install|uninstall|status]" >&2; exit 1 ;;
+esac

--- a/scripts/install-thin-client.sh
+++ b/scripts/install-thin-client.sh
@@ -38,9 +38,6 @@ teardown_node_agent() {   # B
   echo "== B: tearing down node_agent"
   launchctl bootout "gui/$UID_NUM/$NODE_LABEL" 2>/dev/null || true
   rm -f "$NODE_PLIST"
-  # Stray in-repo copies from the old node-agent setup.
-  rm -f "$SCRIPT_DIR/$NODE_LABEL.plist" \
-        "$SCRIPT_DIR/session-manager-node-agent-wrapper.sh"
   # Optional: retire a leftover server-anchor tmux if one lingers.
   tmux kill-session -t __sm_server_anchor 2>/dev/null || true
   echo "   node_agent removed (SM_API_URL / client.yaml left in place)."
@@ -48,12 +45,12 @@ teardown_node_agent() {   # B
 
 install_forward() {       # C1
   echo "== C1: installing self-healing API forward"
-  mkdir -p "$HOME/bin"
+  mkdir -p "$HOME/bin" "$HOME/Library/LaunchAgents"
   install -m 0755 "$FWD_SCRIPT_SRC" "$FWD_SCRIPT_DST"
   cp "$FWD_PLIST_SRC" "$FWD_PLIST_DST"
   launchctl bootout "gui/$UID_NUM/$FWD_LABEL" 2>/dev/null || true
-  launchctl bootstrap "gui/$UID_NUM" "$FWD_PLIST_DST"
   launchctl enable "gui/$UID_NUM/$FWD_LABEL" 2>/dev/null || true
+  launchctl bootstrap "gui/$UID_NUM" "$FWD_PLIST_DST"
   echo "   forward loaded. Logs: /tmp/session-manager-api-forward-macbook.log"
 }
 

--- a/scripts/session-manager-api-forward.sh
+++ b/scripts/session-manager-api-forward.sh
@@ -1,0 +1,60 @@
+#!/bin/zsh
+# session-manager-api-forward — self-healing local API forward (issue #1345, C1).
+#
+# Keeps a laptop-local 127.0.0.1:8420 -> studio 127.0.0.1:8420 tunnel alive so
+# HTTP clients (DeskBar, `curl 127.0.0.1:8420/health`, SM_API_URL) reach studio's
+# session-manager without any laptop-side server. studio's bind stays
+# localhost-only; nothing is exposed on the network.
+#
+# Home -> `studio`; away -> `studio-away` (cloudflared access ssh), so the -L
+# forward works in both locations. Reuses the shim's bounded-backoff reconnect on
+# sleep/wake. Runs under launchd (KeepAlive), so it never permanently gives up.
+
+emulate -L zsh
+set -o pipefail
+
+LOCAL_PORT=8420
+REMOTE_PORT=8420
+
+pick_host() {
+  if nc -z -G 2 studio.local 22 >/dev/null 2>&1; then
+    print -r -- studio
+  else
+    print -r -- studio-away
+  fi
+}
+
+attempt=0
+backoff=1
+backoff_cap=30
+
+trap 'exit 0' INT TERM
+
+while :; do
+  host=$(pick_host)
+  start=$SECONDS
+
+  # BatchMode + accept-new so an unattended daemon never hangs on a prompt.
+  ssh -N \
+    -o BatchMode=yes \
+    -o StrictHostKeyChecking=accept-new \
+    -o ExitOnForwardFailure=yes \
+    -o ServerAliveInterval=5 \
+    -o ServerAliveCountMax=3 \
+    -L "127.0.0.1:${LOCAL_PORT}:127.0.0.1:${REMOTE_PORT}" \
+    "$host"
+  rc=$?
+
+  # If the forward held for a while, reset the backoff budget so a sleep/wake
+  # drop reconnects promptly instead of inheriting a long backoff.
+  if (( SECONDS - start >= 30 )); then
+    attempt=0
+    backoff=1
+  fi
+
+  attempt=$(( attempt + 1 ))
+  print -u2 -- "api-forward: ssh exited ($rc) via ${host}; reconnecting in ${backoff}s (attempt ${attempt})..."
+  sleep $backoff
+  backoff=$(( backoff * 2 ))
+  (( backoff > backoff_cap )) && backoff=$backoff_cap
+done

--- a/scripts/session-manager-api-forward.sh
+++ b/scripts/session-manager-api-forward.sh
@@ -37,6 +37,9 @@ while :; do
   # BatchMode + accept-new so an unattended daemon never hangs on a prompt.
   ssh -N \
     -o BatchMode=yes \
+    -o ConnectTimeout=10 \
+    -o ControlMaster=no \
+    -o ControlPath=none \
     -o StrictHostKeyChecking=accept-new \
     -o ExitOnForwardFailure=yes \
     -o ServerAliveInterval=5 \

--- a/scripts/sm-thin-client.sh
+++ b/scripts/sm-thin-client.sh
@@ -41,6 +41,14 @@ for a in "$@"; do
   remote_cmd+=" ${(q)a}"
 done
 
+# Re-running a mutation after an SSH 255 is unsafe: the remote command may have
+# committed and only its response was lost. Only commands whose whole purpose is
+# to maintain an interactive view/session are safe to reopen automatically.
+reconnect_safe=0
+case "${1:-}" in
+  watch|attach) reconnect_safe=1 ;;
+esac
+
 # Allocate a tty only when we have one locally, so interactive commands
 # (attach/watch) get a pty while piped output (sm all | grep) stays clean.
 ssh_tty=(-T)
@@ -69,6 +77,7 @@ while :; do
     -o ControlMaster=auto \
     -o ControlPath="$HOME/.ssh/cm-%r@%n:%p" \
     -o ControlPersist=120 \
+    -o ConnectTimeout=10 \
     -o ServerAliveInterval=5 \
     -o ServerAliveCountMax=3 \
     "$host" "$remote_cmd"
@@ -77,6 +86,12 @@ while :; do
   # Non-255 => remote sm exited on its own terms. Propagate and stop.
   if [[ $rc -ne 255 ]]; then
     exit $rc
+  fi
+
+  if (( ! reconnect_safe )); then
+    command_name=${1:-<none>}
+    print -u2 -- "sm: connection lost while running '${command_name}'; outcome is unknown, refusing to retry."
+    exit 255
   fi
 
   # Transport drop. If the connection had been stable (~30s+), a fresh sleep on a

--- a/scripts/sm-thin-client.sh
+++ b/scripts/sm-thin-client.sh
@@ -1,0 +1,89 @@
+#!/bin/zsh
+# sm — thin-client SSH shim to studio's session-manager (issue #1345).
+#
+# The laptop hosts no session-manager infra. This shim is command-agnostic: it
+# forwards WHATEVER arguments you pass straight to studio's real `sm` CLI over
+# ssh. It makes no assumptions about subcommands (studio's Rust CLI differs from
+# the old Python one).
+#
+# Host selection is per-run: if studio.local:22 is reachable we're home and use
+# `studio`; otherwise we're away and use `studio-away` (cloudflared access ssh).
+#
+# On sleep/wake the ssh transport drops (exit 255). We reconnect with bounded
+# exponential backoff, re-probing home<->away each attempt. Any non-255 exit is
+# the remote `sm` itself exiting (e.g. you pressed `q`) and is propagated as-is.
+#
+# Installed to ~/bin/sm (first on PATH), overriding any venv `sm`.
+
+emulate -L zsh
+set -o pipefail
+
+# Full path to studio's sm, invoked directly to sidestep login-shell PATH issues.
+STUDIO_SM='/Users/rajesh/projects/session-manager/venv/bin/sm'
+
+# --- host selection -------------------------------------------------------
+pick_host() {
+  if nc -z -G 2 studio.local 22 >/dev/null 2>&1; then
+    print -r -- studio
+  else
+    print -r -- studio-away
+  fi
+}
+
+# --- build the remote command (single remote-shell layer) -----------------
+# ssh joins our argv with spaces and hands the result to studio's login shell,
+# which re-splits it. Quote each arg once with zsh ${(q)} so it survives that
+# single re-parse intact.
+remote_cmd="$STUDIO_SM"
+for a in "$@"; do
+  remote_cmd+=" ${(q)a}"
+done
+
+# Allocate a tty only when we have one locally, so interactive commands
+# (attach/watch) get a pty while piped output (sm all | grep) stays clean.
+ssh_tty=(-T)
+[[ -t 0 && -t 1 ]] && ssh_tty=(-t)
+
+# --- reconnect loop -------------------------------------------------------
+attempt=0
+max_attempts=8
+backoff=1
+backoff_cap=30
+
+# Ctrl-C: when ssh holds the pty the signal goes to the remote; this trap is the
+# fallback for when we're sleeping between retries.
+trap 'exit 130' INT
+
+while :; do
+  host=$(pick_host)
+  start=$SECONDS
+
+  ssh "${ssh_tty[@]}" \
+    -o ServerAliveInterval=5 \
+    -o ServerAliveCountMax=3 \
+    "$host" "$remote_cmd"
+  rc=$?
+
+  # Non-255 => remote sm exited on its own terms. Propagate and stop.
+  if [[ $rc -ne 255 ]]; then
+    exit $rc
+  fi
+
+  # Transport drop. If the connection had been stable (~30s+), a fresh sleep on a
+  # long-lived watch/attach earns a fresh retry budget.
+  if (( SECONDS - start >= 30 )); then
+    attempt=0
+    backoff=1
+  fi
+
+  attempt=$(( attempt + 1 ))
+  if (( attempt > max_attempts )); then
+    print -u2 -- "sm: lost connection to studio after ${max_attempts} attempts; giving up."
+    exit 255
+  fi
+
+  print -u2 -- "sm: connection dropped (attempt ${attempt}/${max_attempts}); reconnecting in ${backoff}s..."
+  sleep $backoff
+  backoff=$(( backoff * 2 ))
+  (( backoff > backoff_cap )) && backoff=$backoff_cap
+done

--- a/scripts/sm-thin-client.sh
+++ b/scripts/sm-thin-client.sh
@@ -44,8 +44,34 @@ done
 # Re-running a mutation after an SSH 255 is unsafe: the remote command may have
 # committed and only its response was lost. Only commands whose whole purpose is
 # to maintain an interactive view/session are safe to reopen automatically.
+command_name=''
+arg_index=1
+while (( arg_index <= $# )); do
+  arg=${argv[arg_index]}
+  case "$arg" in
+    --api-url)
+      arg_index=$(( arg_index + 2 ))
+      ;;
+    --api-url=*)
+      arg_index=$(( arg_index + 1 ))
+      ;;
+    --)
+      arg_index=$(( arg_index + 1 ))
+      (( arg_index <= $# )) && command_name=${argv[arg_index]}
+      break
+      ;;
+    -*)
+      break
+      ;;
+    *)
+      command_name=$arg
+      break
+      ;;
+  esac
+done
+
 reconnect_safe=0
-case "${1:-}" in
+case "$command_name" in
   watch|attach) reconnect_safe=1 ;;
 esac
 
@@ -89,7 +115,7 @@ while :; do
   fi
 
   if (( ! reconnect_safe )); then
-    command_name=${1:-<none>}
+    [[ -n "$command_name" ]] || command_name='<none>'
     print -u2 -- "sm: connection lost while running '${command_name}'; outcome is unknown, refusing to retry."
     exit 255
   fi

--- a/scripts/sm-thin-client.sh
+++ b/scripts/sm-thin-client.sh
@@ -31,10 +31,12 @@ pick_host() {
 }
 
 # --- build the remote command (single remote-shell layer) -----------------
-# ssh joins our argv with spaces and hands the result to studio's login shell,
-# which re-splits it. Quote each arg once with zsh ${(q)} so it survives that
-# single re-parse intact.
-remote_cmd="$STUDIO_SM"
+# ssh hands our command to a NON-login remote shell whose PATH lacks Homebrew,
+# so tools `sm` shells out to (notably `tmux` for attach) aren't found. Prepend
+# Homebrew bins — `$PATH` stays literal locally and is expanded on studio.
+# ssh joins our argv with spaces and the remote shell re-splits it, so quote
+# each arg once with zsh ${(q)} to survive that single re-parse intact.
+remote_cmd='PATH=/opt/homebrew/bin:/usr/local/bin:$PATH'" $STUDIO_SM"
 for a in "$@"; do
   remote_cmd+=" ${(q)a}"
 done
@@ -58,7 +60,15 @@ while :; do
   host=$(pick_host)
   start=$SECONDS
 
+  # ControlMaster: the first call opens a shared master that persists briefly,
+  # so back-to-back `sm` calls (and follow-ups after `watch`) reuse it instead of
+  # paying a fresh TCP+auth handshake each time. Per-host socket (%n) keeps
+  # home/away separate. On sleep the master dies with the channel (exit 255) and
+  # the loop below reopens it.
   ssh "${ssh_tty[@]}" \
+    -o ControlMaster=auto \
+    -o ControlPath="$HOME/.ssh/cm-%r@%n:%p" \
+    -o ControlPersist=120 \
     -o ServerAliveInterval=5 \
     -o ServerAliveCountMax=3 \
     "$host" "$remote_cmd"

--- a/scripts/test-sm-thin-client.sh
+++ b/scripts/test-sm-thin-client.sh
@@ -63,6 +63,12 @@ test "$(cat "$TMP/ssh.count")" -eq 2
 run_shim '1:255' attach abc123 >/dev/null 2>&1
 test "$(cat "$TMP/ssh.count")" -eq 2
 
+run_shim '1:255' --api-url http://127.0.0.1:8420 watch >/dev/null 2>&1
+test "$(cat "$TMP/ssh.count")" -eq 2
+
+run_shim '1:255' --api-url=http://127.0.0.1:8420 attach abc123 >/dev/null 2>&1
+test "$(cat "$TMP/ssh.count")" -eq 2
+
 run_shim '' all >/dev/null 2>&1
 test "$(cat "$TMP/ssh.count")" -eq 1
 grep -Fq 'ConnectTimeout=10' "$TMP/ssh.log"

--- a/scripts/test-sm-thin-client.sh
+++ b/scripts/test-sm-thin-client.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SHIM="$ROOT/scripts/sm-thin-client.sh"
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/sm-thin-client-test.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/bin" "$TMP/home/.ssh"
+
+cat >"$TMP/bin/nc" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+
+cat >"$TMP/bin/sleep" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+
+cat >"$TMP/bin/ssh" <<'EOF'
+#!/bin/sh
+count=0
+if [ -f "$MOCK_SSH_COUNT" ]; then count=$(cat "$MOCK_SSH_COUNT"); fi
+count=$((count + 1))
+printf '%s' "$count" >"$MOCK_SSH_COUNT"
+printf '%s\n' "$*" >>"$MOCK_SSH_LOG"
+case ",$MOCK_SSH_RESULTS," in
+  *,"$count":255,*) exit 255 ;;
+  *) exit 0 ;;
+esac
+EOF
+
+chmod +x "$TMP/bin/nc" "$TMP/bin/sleep" "$TMP/bin/ssh"
+
+run_shim() {
+  local results=$1
+  shift
+  : >"$TMP/ssh.log"
+  rm -f "$TMP/ssh.count"
+  HOME="$TMP/home" \
+    PATH="$TMP/bin:/usr/bin:/bin" \
+    MOCK_SSH_COUNT="$TMP/ssh.count" \
+    MOCK_SSH_LOG="$TMP/ssh.log" \
+    MOCK_SSH_RESULTS="$results" \
+    "$SHIM" "$@"
+}
+
+set +e
+# shellcheck disable=SC2016 # Literal payload must never execute locally.
+mutation_output=$(run_shim '1:255' spawn --name test-agent '$(touch /tmp/must-not-run)' 2>&1)
+mutation_rc=$?
+set -e
+test "$mutation_rc" -eq 255
+test "$(cat "$TMP/ssh.count")" -eq 1
+grep -Fq "outcome is unknown, refusing to retry" <<<"$mutation_output"
+test ! -e /tmp/must-not-run
+
+run_shim '1:255' watch >/dev/null 2>&1
+test "$(cat "$TMP/ssh.count")" -eq 2
+
+run_shim '1:255' attach abc123 >/dev/null 2>&1
+test "$(cat "$TMP/ssh.count")" -eq 2
+
+run_shim '' all >/dev/null 2>&1
+test "$(cat "$TMP/ssh.count")" -eq 1
+grep -Fq 'ConnectTimeout=10' "$TMP/ssh.log"
+
+echo "sm thin-client tests passed"


### PR DESCRIPTION
Fixes #1345.

Makes the laptop (`macbook`) a pure thin client for studio's session-manager. No always-on SM infra runs locally: the fragile `node_agent` is replaced by a stateless SSH shim plus a self-healing local API forward.

## Risk and review

**R3**: production-control scripts tear down a launchd service, install a replacement command, maintain an authenticated SSH tunnel, and define retry/ambiguity behavior.

Three-round hard cap applies. Current exact review head: `7b87b6a41868d951de802427e5a54fc2b3b45352`.

Review ledger:
- Pre-review maintainer audit on `b5839ac`: repaired blind mutation replay after SSH ambiguity, inherited forwarding multiplexing, source-checkout deletion, and launchd enable/bootstrap ordering. Result: `ca5a1b3`.
- Round 1 on `ca5a1b3`: no P0/P1; one valid P2 for global `--api-url` before `watch`/`attach`. Repaired with bounded initial-global-option parsing and split/equals-form regressions. Result: `7b87b6a`.
- Round 2: pending exact-head confirmation on `7b87b6a`.

The shim retries only explicitly resumable `watch` and `attach` sessions, including when the Rust CLI's global `--api-url` precedes the subcommand. Any other command fails closed on SSH 255 with an actionable ambiguous-outcome message.

## A — `sm` SSH shim (`scripts/sm-thin-client.sh` → `~/bin/sm`)
- Command-agnostic passthrough to studio's `sm` at full path (`/Users/rajesh/projects/session-manager/venv/bin/sm`).
- Per-run host selection: `nc -z -G 2 studio.local 22` open → `studio`, else → `studio-away`.
- Args quoted once with zsh `${(q)}` for one remote-shell layer.
- `ssh -t` when local stdin/stdout are TTYs, `-T` when piped.
- Shared SSH master reduces back-to-back call latency.
- `watch`/`attach` reconnect after transport loss with bounded exponential backoff; mutations and other commands are never blindly replayed.

## B — Tear down local infra
Installer boots out `com.rajeshgoli.session-manager-node-agent.macbook` and removes its plist. `SM_API_URL` and `~/.config/session-manager/client.yaml` remain.

## C1 — Self-healing local API forward
- Dedicated non-multiplexed `ssh -N -L 127.0.0.1:8420:127.0.0.1:8420` connection to `studio` or `studio-away`.
- Connect and server-alive timeouts plus bounded backoff inside a launchd `KeepAlive` job.
- Studio remains bound to localhost.

Helpers install to `~/bin`, outside the TCC-protected Desktop checkout.

## Verification
- `bash -n scripts/install-thin-client.sh scripts/test-sm-thin-client.sh`
- `zsh -n scripts/sm-thin-client.sh scripts/session-manager-api-forward.sh`
- `shellcheck scripts/install-thin-client.sh scripts/test-sm-thin-client.sh`
- `plutil -lint scripts/com.rajeshgoli.session-manager-api-forward.macbook.plist`
- `scripts/test-sm-thin-client.sh`
- `git diff --check`

The deterministic mock-SSH test proves mutation ambiguity causes exactly one SSH attempt, while `watch` and `attach` reconnect after one simulated transport failure, both directly and after split/equals-form global `--api-url`. It also proves a literal command-substitution payload is not executed locally.

## Applied laptop evidence from the original implementation
- local forwarded `/health` returned healthy;
- old node-agent launchd job/plist removed;
- forward launchd job ran the installed `~/bin/session-manager-api-forward` and maintained a live local port forward.

Companion ticket: rajeshgoli/deskbar#102.
