### PR TITLE
sm watch: restore terminal state on exit (no more mouse-escape dump)

### DIFF
--- a/scripts/sm-thin-client.sh
+++ b/scripts/sm-thin-client.sh
@@ -75,6 +75,23 @@ case "$command_name" in
   watch|attach) reconnect_safe=1 ;;
 esac
 
+# Mouse reporting is enabled on the laptop terminal by bytes received over the
+# SSH channel. If that channel drops, a remote cleanup handler cannot send the
+# matching disable sequence back. Sanitize locally after every interactive SSH
+# attempt and again from shell exit/signal traps. Repeated writes are harmless.
+sanitize_terminal() {
+  (( reconnect_safe )) || return 0
+
+  local reset_sequence=$'\e[?1000l\e[?1002l\e[?1003l\e[?1005l\e[?1006l\e[?1015l\e[?25h'
+  if [[ -t 1 ]]; then
+    print -rn -- "$reset_sequence"
+  elif [[ -t 2 ]]; then
+    print -rn -u2 -- "$reset_sequence"
+  elif [[ -w /dev/tty ]]; then
+    print -rn -- "$reset_sequence" >/dev/tty 2>/dev/null || true
+  fi
+}
+
 # Allocate a tty only when we have one locally, so interactive commands
 # (attach/watch) get a pty while piped output (sm all | grep) stays clean.
 ssh_tty=(-T)
@@ -86,9 +103,13 @@ max_attempts=8
 backoff=1
 backoff_cap=30
 
-# Ctrl-C: when ssh holds the pty the signal goes to the remote; this trap is the
-# fallback for when we're sleeping between retries.
-trap 'exit 130' INT
+# When ssh holds the pty, signals normally reach the remote. These traps cover
+# local delivery while the shim is between retries. EXIT also covers ordinary
+# watch/attach termination.
+trap 'sanitize_terminal' EXIT
+trap 'sanitize_terminal; exit 129' HUP
+trap 'sanitize_terminal; exit 130' INT
+trap 'sanitize_terminal; exit 143' TERM
 
 while :; do
   host=$(pick_host)
@@ -108,6 +129,10 @@ while :; do
     -o ServerAliveCountMax=3 \
     "$host" "$remote_cmd"
   rc=$?
+
+  # In particular, run this before handling rc=255: once ssh has returned, the
+  # remote process can no longer repair terminal modes on this machine.
+  sanitize_terminal
 
   # Non-255 => remote sm exited on its own terms. Propagate and stop.
   if [[ $rc -ne 255 ]]; then

--- a/scripts/test-sm-thin-client.sh
+++ b/scripts/test-sm-thin-client.sh
@@ -73,4 +73,51 @@ run_shim '' all >/dev/null 2>&1
 test "$(cat "$TMP/ssh.count")" -eq 1
 grep -Fq 'ConnectTimeout=10' "$TMP/ssh.log"
 
+# Run watch under a real pseudo-terminal. A transport drop must emit the local
+# mouse-disable sequence even though the remote channel is already gone.
+PYTHON_BIN="$(command -v python3)"
+export SHIM TMP
+"$PYTHON_BIN" <<'PY'
+import errno
+import os
+import pty
+import subprocess
+
+master, slave = pty.openpty()
+env = os.environ.copy()
+env.update(
+    {
+        "HOME": f"{env['TMP']}/home",
+        "PATH": f"{env['TMP']}/bin:/usr/bin:/bin",
+        "MOCK_SSH_COUNT": f"{env['TMP']}/pty-ssh.count",
+        "MOCK_SSH_LOG": f"{env['TMP']}/pty-ssh.log",
+        "MOCK_SSH_RESULTS": "1:255",
+    }
+)
+proc = subprocess.Popen(
+    [env["SHIM"], "watch"],
+    stdin=slave,
+    stdout=slave,
+    stderr=slave,
+    env=env,
+    close_fds=True,
+)
+os.close(slave)
+output = bytearray()
+while True:
+    try:
+        chunk = os.read(master, 4096)
+    except OSError as exc:
+        if exc.errno == errno.EIO:
+            break
+        raise
+    if not chunk:
+        break
+    output.extend(chunk)
+os.close(master)
+assert proc.wait(timeout=10) == 0
+reset = b"\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1005l\x1b[?1006l\x1b[?1015l\x1b[?25h"
+assert reset in output, output
+PY
+
 echo "sm thin-client tests passed"

--- a/src/cli/watch_tui.py
+++ b/src/cli/watch_tui.py
@@ -6,7 +6,9 @@ import curses
 import os
 import queue
 import re
+import signal
 import subprocess
+import sys
 import threading
 import time
 from dataclasses import dataclass, field
@@ -1319,6 +1321,43 @@ def _tmux_attach_command(tmux_session: str, tmux_socket_name: str | None = None)
     return cmd
 
 
+# Escape sequences that leave the terminal usable again. An attached child
+# (tmux with `mouse on`, or an ssh wrapper) can enable mouse reporting and fail
+# to disable it if the connection drops uncleanly, leaving the shell echoing
+# raw mouse events like `35;14;6M`. curses' endwin() does not undo these, so we
+# emit the disables ourselves on every exit path.
+_TERMINAL_RESET_SEQUENCE = (
+    "\033[?1000l"  # normal (click) mouse tracking
+    "\033[?1002l"  # button-event (drag) tracking
+    "\033[?1003l"  # any-motion tracking
+    "\033[?1005l"  # UTF-8 extended coordinates
+    "\033[?1006l"  # SGR extended coordinates
+    "\033[?1015l"  # urxvt extended coordinates
+    "\033[?25h"    # show cursor
+)
+
+
+def _sanitize_terminal() -> None:
+    """Best-effort disable of mouse reporting / restore of the cursor on the
+    controlling terminal. Safe to call multiple times and never raises."""
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            if stream is not None and stream.isatty():
+                stream.write(_TERMINAL_RESET_SEQUENCE)
+                stream.flush()
+                return
+        except Exception:
+            continue
+    try:
+        fd = os.open("/dev/tty", os.O_WRONLY)
+        try:
+            os.write(fd, _TERMINAL_RESET_SEQUENCE.encode("ascii", "ignore"))
+        finally:
+            os.close(fd)
+    except OSError:
+        pass
+
+
 def _attach_tmux(
     stdscr,
     tmux_session: str,
@@ -1331,6 +1370,9 @@ def _attach_tmux(
         command = attach_command if attach_command else _tmux_attach_command(tmux_session, tmux_socket_name)
         subprocess.run(command, check=False)
     finally:
+        # The attached session may have left mouse reporting enabled; clear it
+        # before we hand control back to curses.
+        _sanitize_terminal()
         curses.reset_prog_mode()
         curses.curs_set(0)
         stdscr.nodelay(True)
@@ -2088,7 +2130,33 @@ def run_watch_tui(
             if detail_worker:
                 detail_worker.stop()
 
-    curses.wrapper(_loop)
+    def _handle_terminal_signal(signum, _frame):
+        # An ssh drop delivers SIGHUP; SIGTERM may arrive from tooling. Neither
+        # runs the finally blocks below, so sanitize here before exiting with
+        # the default disposition.
+        _sanitize_terminal()
+        signal.signal(signum, signal.SIG_DFL)
+        os.kill(os.getpid(), signum)
+
+    previous_handlers: dict[int, object] = {}
+    for signame in ("SIGHUP", "SIGTERM"):
+        sig = getattr(signal, signame, None)
+        if sig is None:
+            continue
+        try:
+            previous_handlers[sig] = signal.signal(sig, _handle_terminal_signal)
+        except (ValueError, OSError):
+            pass
+
+    try:
+        curses.wrapper(_loop)
+    finally:
+        _sanitize_terminal()
+        for sig, handler in previous_handlers.items():
+            try:
+                signal.signal(sig, handler)
+            except (ValueError, OSError):
+                pass
     return 0
 
 

--- a/tests/unit/test_watch_tui.py
+++ b/tests/unit/test_watch_tui.py
@@ -5,10 +5,14 @@ from __future__ import annotations
 import time
 from pathlib import Path
 
+from src.cli import watch_tui
 from src.cli.watch_tui import (
     DetailFetchWorker,
     DetailSnapshot,
+    _TERMINAL_RESET_SEQUENCE,
+    _attach_tmux,
     _codex_projection_enabled,
+    _sanitize_terminal,
     _arm_retire_confirmation,
     _create_watch_session,
     _fork_watch_session,
@@ -61,6 +65,72 @@ def test_tmux_attach_command_includes_socket_when_available():
         "-t",
         "claude-test",
     ]
+
+
+class _FakeTTY:
+    def __init__(self, is_tty=True):
+        self._is_tty = is_tty
+        self.written = []
+        self.flushed = False
+
+    def isatty(self):
+        return self._is_tty
+
+    def write(self, text):
+        self.written.append(text)
+
+    def flush(self):
+        self.flushed = True
+
+
+def test_sanitize_terminal_disables_mouse_reporting(monkeypatch):
+    fake = _FakeTTY(is_tty=True)
+    monkeypatch.setattr(watch_tui.sys, "stdout", fake)
+
+    _sanitize_terminal()
+
+    out = "".join(fake.written)
+    assert out == _TERMINAL_RESET_SEQUENCE
+    assert "\033[?1006l" in out  # SGR mouse reporting off
+    assert "\033[?1003l" in out  # any-motion tracking off
+    assert "\033[?25h" in out    # cursor restored
+    assert fake.flushed
+
+
+def test_sanitize_terminal_never_raises_without_a_tty(monkeypatch):
+    monkeypatch.setattr(watch_tui.sys, "stdout", _FakeTTY(is_tty=False))
+    monkeypatch.setattr(watch_tui.sys, "stderr", _FakeTTY(is_tty=False))
+
+    def _boom(*_args, **_kwargs):
+        raise OSError("no controlling terminal")
+
+    monkeypatch.setattr(watch_tui.os, "open", _boom)
+
+    # Must be a no-op rather than propagate.
+    _sanitize_terminal()
+
+
+def test_attach_tmux_sanitizes_terminal_after_attach(monkeypatch):
+    calls = []
+
+    class _FakeStdscr:
+        def nodelay(self, _value):
+            pass
+
+        def clear(self):
+            pass
+
+    monkeypatch.setattr(watch_tui.curses, "def_prog_mode", lambda: None)
+    monkeypatch.setattr(watch_tui.curses, "endwin", lambda: None)
+    monkeypatch.setattr(watch_tui.curses, "reset_prog_mode", lambda: None)
+    monkeypatch.setattr(watch_tui.curses, "curs_set", lambda _value: None)
+    monkeypatch.setattr(watch_tui.subprocess, "run", lambda *a, **k: calls.append("run"))
+    monkeypatch.setattr(watch_tui, "_sanitize_terminal", lambda: calls.append("sanitize"))
+
+    _attach_tmux(_FakeStdscr(), "claude-test", "session-manager-test")
+
+    # The terminal must be sanitized, and only after the attach child returns.
+    assert calls == ["run", "sanitize"]
 
 
 def test_resolve_tmux_attach_target_hydrates_descriptor_socket():


### PR DESCRIPTION
## Problem

Quitting `sm watch` or losing SSH during a thin-client `ssh studio sm watch` could leave the laptop terminal echoing raw mouse events like `35;14;6M`.

The remote curses/tmux process can sanitize normal exits, but after an SSH channel is gone a remote SIGHUP handler cannot send reset bytes back to the laptop terminal. Both ends therefore need bounded cleanup.

## Fix

- Remote `sm watch` emits mouse-disable and cursor-restore sequences after attach, during normal unwind, and from SIGHUP/SIGTERM handlers.
- The local thin-client shim emits the same idempotent reset after every interactive SSH attempt and from EXIT/HUP/INT/TERM traps.
- Non-interactive commands are unchanged and receive no terminal escape output.

## Tests

- `58 passed` in `tests/unit/test_watch_tui.py`.
- `scripts/test-sm-thin-client.sh` passes, including a real pseudo-terminal SSH-255 regression proving laptop-side cleanup after transport loss.
- `zsh -n scripts/sm-thin-client.sh`, `bash -n scripts/test-sm-thin-client.sh`, and `git diff --check` pass.