### PR TITLE
Make context monitor policy-neutral

### DIFF
--- a/crates/sm-server/src/bin/sm.rs
+++ b/crates/sm-server/src/bin/sm.rs
@@ -360,6 +360,9 @@ struct TailArgs {
 }
 
 #[derive(Args)]
+#[command(
+    after_help = "Destructive operation: after the current turn, this sends /clear to the calling Claude session and injects the handoff prompt."
+)]
 struct HandoffArgs {
     file_path: Option<String>,
 }
@@ -385,12 +388,12 @@ struct ContextMonitorArgs {
 enum ContextMonitorCommand {
     Enable {
         target: Option<String>,
-        /// Warning percentage for this seat (for example, 40).
+        /// Notification percentage for this seat. Repeat to register multiple
+        /// levels, for example: --threshold 10 --threshold 20 --threshold 30.
         #[arg(long, value_name = "PERCENT")]
-        threshold: Option<f64>,
-        /// Critical percentage for this seat. Defaults to the current global
-        /// critical threshold unless an existing seat override is present.
-        #[arg(long, value_name = "PERCENT")]
+        threshold: Vec<f64>,
+        /// Legacy second threshold. Prefer repeating --threshold instead.
+        #[arg(long, value_name = "PERCENT", conflicts_with = "threshold")]
         critical_threshold: Option<f64>,
         /// Clear seat-specific thresholds and use the server defaults.
         #[arg(long, conflicts_with_all = ["threshold", "critical_threshold"])]
@@ -980,7 +983,9 @@ fn run() -> Result<()> {
             match payload["status"].as_str() {
                 Some("executed") => println!("Handoff executed"),
                 Some("recorded") => println!("Handoff recorded"),
-                _ => println!("Handoff scheduled - will execute after current turn completes"),
+                _ => println!(
+                    "Handoff scheduled - after this turn it will /clear this session and inject the handoff prompt"
+                ),
             }
         }
         Command::TaskComplete(_) => {
@@ -3862,8 +3867,20 @@ fn run_context(client: &ApiClient, args: ContextArgs) -> Result<()> {
     let label = payload["friendly_name"].as_str().unwrap_or(session_id);
     let provider = payload["provider"].as_str().unwrap_or("-");
     let state = payload["state"].as_str().unwrap_or("unknown");
-    let warning = format_context_percentage(payload.get("warning_percentage"));
-    let critical = format_context_percentage(payload.get("critical_percentage"));
+    let levels = payload["threshold_percentages"]
+        .as_array()
+        .map(|values| {
+            values
+                .iter()
+                .map(|value| format_context_percentage(Some(value)))
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .unwrap_or_else(|| {
+            let warning = format_context_percentage(payload.get("warning_percentage"));
+            let critical = format_context_percentage(payload.get("critical_percentage"));
+            format!("{warning}, {critical}")
+        });
     let notify = payload["notify_session_id"].as_str();
     let notify_text = match notify {
         Some(value) if value == session_id => "self".to_owned(),
@@ -3899,7 +3916,7 @@ fn run_context(client: &ApiClient, args: ContextArgs) -> Result<()> {
         payload["lifecycle_status"].as_str().unwrap_or("unknown")
     );
     println!(
-        "State: {state} (warning {warning}, critical {critical}; {})",
+        "State: {state} (levels {levels}; {})",
         payload["threshold_source"].as_str().unwrap_or("unknown")
     );
     println!("Monitor: {monitor}, alerts -> {notify_text}");
@@ -4058,7 +4075,8 @@ fn run_context_monitor(client: &ApiClient, args: ContextMonitorArgs) -> Result<(
                     "enabled": true,
                     "requester_session_id": requester,
                     "notify_session_id": requester,
-                    "warning_percentage": threshold,
+                    "threshold_percentages": (!threshold.is_empty()).then_some(threshold),
+                    "warning_percentage": null,
                     "critical_percentage": critical_threshold,
                     "use_default_thresholds": use_default_thresholds
                 }),
@@ -4107,10 +4125,22 @@ fn format_context_monitor_thresholds(payload: &Value) -> String {
     if payload["enforced"].as_bool() != Some(true) {
         return "INVALID / NOT ENFORCED".to_owned();
     }
-    let warning = format_context_percentage(payload.get("warning_percentage"));
-    let critical = format_context_percentage(payload.get("critical_percentage"));
     let source = payload["threshold_source"].as_str().unwrap_or("unknown");
-    format!("{warning} warning / {critical} critical ({source})")
+    let levels = payload["threshold_percentages"]
+        .as_array()
+        .map(|values| {
+            values
+                .iter()
+                .map(|value| format_context_percentage(Some(value)))
+                .collect::<Vec<_>>()
+                .join(", ")
+        })
+        .unwrap_or_else(|| {
+            let warning = format_context_percentage(payload.get("warning_percentage"));
+            let critical = format_context_percentage(payload.get("critical_percentage"));
+            format!("{warning}, {critical}")
+        });
+    format!("{levels} ({source})")
 }
 
 fn lookup_identifier(client: &ApiClient, identifier: &str) -> Result<Option<String>> {
@@ -7186,7 +7216,7 @@ mod tests {
                 "critical_percentage": 75.0,
                 "threshold_source": "default"
             })),
-            "65% warning / 75% critical (default)"
+            "65%, 75% (default)"
         );
         assert_eq!(
             format_context_monitor_thresholds(&json!({
@@ -7195,7 +7225,7 @@ mod tests {
                 "critical_percentage": 60.0,
                 "threshold_source": "custom"
             })),
-            "40% warning / 60% critical (custom)"
+            "40%, 60% (custom)"
         );
         assert_eq!(
             format_context_monitor_thresholds(&json!({

--- a/crates/sm-server/src/config.rs
+++ b/crates/sm-server/src/config.rs
@@ -1138,6 +1138,10 @@ fn default_tool_usage_db_path() -> String {
 /// `context_window.used_percentage`.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ContextMonitorConfig {
+    /// Ordered notification milestones. When omitted, the legacy warning and
+    /// critical values below remain the two default milestones.
+    #[serde(default)]
+    pub threshold_percentages: Vec<f64>,
     #[serde(default = "default_context_warning_percentage")]
     pub warning_percentage: f64,
     #[serde(default = "default_context_critical_percentage")]
@@ -1147,6 +1151,7 @@ pub struct ContextMonitorConfig {
 impl Default for ContextMonitorConfig {
     fn default() -> Self {
         Self {
+            threshold_percentages: Vec::new(),
             warning_percentage: default_context_warning_percentage(),
             critical_percentage: default_context_critical_percentage(),
         }

--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -15608,7 +15608,7 @@ mod tests {
         assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "{body}");
         assert!(body["detail"]
             .as_str()
-            .is_some_and(|detail| detail.contains("strictly lower")));
+            .is_some_and(|detail| detail.contains("strictly increasing")));
         assert_eq!(fs::read(&state_file).unwrap(), persisted_before_invalid);
 
         let mut malformed = local_request(

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -1954,6 +1954,7 @@ impl SessionStore {
             .map(|session| {
                 let friendly_name = session.cached_display_name();
                 let thresholds = resolve_context_monitor_thresholds(
+                    session.context_monitor_threshold_percentages.clone(),
                     session.context_monitor_warning_percentage,
                     session.context_monitor_critical_percentage,
                     &self.context_monitor,
@@ -1970,6 +1971,10 @@ impl SessionStore {
                         .as_ref()
                         .ok()
                         .map(|value| value.critical_percentage),
+                    threshold_percentages: thresholds
+                        .as_ref()
+                        .ok()
+                        .map(|value| value.percentages.clone()),
                     threshold_source: thresholds
                         .as_ref()
                         .map(|value| value.source.as_str().to_owned())
@@ -5739,7 +5744,8 @@ impl SessionStore {
             }
         }
         if !request.enabled
-            && (request.warning_percentage.is_some()
+            && (request.threshold_percentages.is_some()
+                || request.warning_percentage.is_some()
                 || request.critical_percentage.is_some()
                 || request.use_default_thresholds)
         {
@@ -5748,7 +5754,9 @@ impl SessionStore {
             ));
         }
         if request.use_default_thresholds
-            && (request.warning_percentage.is_some() || request.critical_percentage.is_some())
+            && (request.threshold_percentages.is_some()
+                || request.warning_percentage.is_some()
+                || request.critical_percentage.is_some())
         {
             return Ok(ContextMonitorOutcome::InvalidThresholdConfig(
                 "use_default_thresholds conflicts with custom thresholds".to_owned(),
@@ -5764,16 +5772,24 @@ impl SessionStore {
         let current_critical = session
             .get("context_monitor_critical_percentage")
             .and_then(Value::as_f64);
-        let (next_warning, next_critical) = if request.use_default_thresholds {
-            (None, None)
+        let current_percentages =
+            json_percentages(session.get("context_monitor_threshold_percentages"));
+        let (next_percentages, next_warning, next_critical) = if request.use_default_thresholds {
+            (None, None, None)
+        } else if let Some(percentages) = request.threshold_percentages.clone() {
+            // A new arbitrary-size override supersedes the legacy two-value
+            // override instead of combining incompatible policies.
+            (Some(percentages), None, None)
         } else {
             (
+                current_percentages.clone(),
                 request.warning_percentage.or(current_warning),
                 request.critical_percentage.or(current_critical),
             )
         };
         let thresholds = if request.enabled {
             match resolve_context_monitor_thresholds(
+                next_percentages.clone(),
                 next_warning,
                 next_critical,
                 &self.context_monitor,
@@ -5784,13 +5800,20 @@ impl SessionStore {
         } else {
             None
         };
-        let thresholds_changed =
-            current_warning != next_warning || current_critical != next_critical;
+        let thresholds_changed = current_percentages != next_percentages
+            || current_warning != next_warning
+            || current_critical != next_critical;
         session.insert(
             "context_monitor_enabled".to_owned(),
             Value::Bool(effective_enabled),
         );
         if effective_enabled {
+            session.insert(
+                "context_monitor_threshold_percentages".to_owned(),
+                next_percentages.map_or(Value::Null, |values| {
+                    Value::Array(values.into_iter().map(|value| json!(value)).collect())
+                }),
+            );
             session.insert(
                 "context_monitor_warning_percentage".to_owned(),
                 next_warning.map_or(Value::Null, |value| json!(value)),
@@ -5845,6 +5868,7 @@ impl SessionStore {
             enabled: effective_enabled,
             warning_percentage: thresholds.as_ref().map(|value| value.warning_percentage),
             critical_percentage: thresholds.as_ref().map(|value| value.critical_percentage),
+            threshold_percentages: thresholds.as_ref().map(|value| value.percentages.clone()),
             threshold_source: thresholds
                 .as_ref()
                 .map(|value| value.source.as_str().to_owned())
@@ -6165,18 +6189,19 @@ impl SessionStore {
         Ok(ContextUsageOutcome::Recorded { used_percentage })
     }
 
-    /// Decide whether this usage sample trips a threshold, latching the
-    /// corresponding one-shot flag when it does. Returns the alert to queue, or
-    /// `None` when the threshold is not reached or has already fired this cycle.
+    /// Decide whether this usage sample reaches a previously unreported
+    /// notification milestone. The monitor reports measured context only; it
+    /// deliberately does not prescribe any provider or workflow policy.
     fn latch_context_alert(
         &self,
         session: &mut Map<String, Value>,
         session_id: &str,
         used_percentage: f64,
-        tokens_used: i64,
+        _tokens_used: i64,
     ) -> Option<ContextAlert> {
         let notify_target = json_text(session.get("context_monitor_notify"))?;
         let thresholds = resolve_context_monitor_thresholds(
+            json_percentages(session.get("context_monitor_threshold_percentages")),
             session
                 .get("context_monitor_warning_percentage")
                 .and_then(Value::as_f64),
@@ -6186,69 +6211,48 @@ impl SessionStore {
             &self.context_monitor,
         )
         .ok()?;
-        let is_self_alert = notify_target == session_id;
         let label = raw_session_label(session, session_id);
         let rounded = format_percentage(used_percentage);
-        let native_codex_compaction = json_text(session.get("provider"))
-            .is_some_and(|provider| provider_uses_native_context_compaction(&provider));
-
-        if used_percentage >= thresholds.critical_percentage {
-            if flag_is_set(session, "context_critical_sent") {
-                return None;
-            }
-            session.insert("context_critical_sent".to_owned(), Value::Bool(true));
-            let text = if is_self_alert && native_codex_compaction {
-                format!(
-                    "[sm context] Context at {rounded}% — critically high. \
-                     Codex will compact inline; continue the current task and do not run `sm handoff`."
-                )
-            } else if is_self_alert {
-                format!(
-                    "[sm context] Context at {rounded}% — critically high. \
-                     Write your handoff doc NOW and run `sm handoff <path>`. \
-                     Compaction is imminent."
-                )
-            } else {
-                format!(
-                    "[sm context] Child {label} ({session_id}) context at {rounded}% \
-                     — critically high. Compaction is imminent."
-                )
-            };
-            return Some(ContextAlert {
-                notify_target,
-                text,
-                delivery_mode: "urgent",
-            });
+        let mut reported = context_reported_thresholds(session, &thresholds.percentages);
+        let reached = thresholds
+            .percentages
+            .iter()
+            .any(|threshold| used_percentage >= *threshold && !reported.contains(threshold));
+        if !reached {
+            return None;
         }
 
+        // A sampled value can jump over several milestones. Report the actual
+        // current value once, then mark every crossed milestone so later
+        // renders cannot manufacture a burst of stale notifications.
+        for threshold in &thresholds.percentages {
+            if used_percentage >= *threshold && !reported.contains(threshold) {
+                reported.push(*threshold);
+            }
+        }
+        session.insert(
+            "context_reported_thresholds".to_owned(),
+            Value::Array(reported.into_iter().map(|value| json!(value)).collect()),
+        );
+        // Preserve the legacy latches as a migration projection. They are no
+        // longer used to decide notification text or delivery, but existing
+        // persisted-state consumers still expose the first and final level.
         if used_percentage >= thresholds.warning_percentage {
-            if flag_is_set(session, "context_warning_sent") {
-                return None;
-            }
             session.insert("context_warning_sent".to_owned(), Value::Bool(true));
-            let text = if is_self_alert && native_codex_compaction {
-                format!(
-                    "[sm context] Context at {rounded}% ({} tokens). \
-                     Codex will compact inline; continue the current task and do not run `sm handoff`.",
-                    format_thousands(tokens_used)
-                )
-            } else if is_self_alert {
-                format!(
-                    "[sm context] Context at {rounded}% ({} tokens). \
-                     Consider writing a handoff doc and running `sm handoff <path>`.",
-                    format_thousands(tokens_used)
-                )
-            } else {
-                format!("[sm context] Child {label} ({session_id}) context at {rounded}%.")
-            };
-            return Some(ContextAlert {
-                notify_target,
-                text,
-                delivery_mode: "sequential",
-            });
         }
-
-        None
+        if used_percentage >= thresholds.critical_percentage {
+            session.insert("context_critical_sent".to_owned(), Value::Bool(true));
+        }
+        let text = if notify_target == session_id {
+            format!("[sm context] Your context is now at {rounded}%.")
+        } else {
+            format!("[sm context] Context for {label} ({session_id}) is now at {rounded}%.")
+        };
+        Some(ContextAlert {
+            notify_target,
+            text,
+            delivery_mode: "sequential",
+        })
     }
 
     fn queue_context_monitor_message(
@@ -8633,6 +8637,7 @@ impl SessionStore {
             context_monitor_enabled: false,
             context_monitor_notify: None,
             context_monitor_notify_source: default_context_monitor_notify_source(),
+            context_monitor_threshold_percentages: None,
             context_monitor_warning_percentage: None,
             context_monitor_critical_percentage: None,
             context_warning_sent: false,
@@ -9293,6 +9298,10 @@ pub struct ContextMonitorRequest {
     pub requester_session_id: String,
     #[serde(default)]
     pub notify_session_id: Option<String>,
+    /// Ordered per-seat notification milestones. This is the policy-neutral
+    /// interface; every reached percentage emits a factual context update.
+    #[serde(default)]
+    pub threshold_percentages: Option<Vec<f64>>,
     /// Per-seat warning threshold percentage. Absent values preserve an
     /// existing override or resolve to the configured global default.
     #[serde(default)]
@@ -9624,6 +9633,7 @@ pub struct ContextMonitorStatus {
     pub notify_session_id: Option<String>,
     pub warning_percentage: Option<f64>,
     pub critical_percentage: Option<f64>,
+    pub threshold_percentages: Option<Vec<f64>>,
     pub threshold_source: String,
     pub enforced: bool,
 }
@@ -9640,6 +9650,7 @@ pub struct ContextSnapshotResponse {
     pub state: String,
     pub warning_percentage: Option<f64>,
     pub critical_percentage: Option<f64>,
+    pub threshold_percentages: Option<Vec<f64>>,
     pub threshold_source: String,
     pub context_monitor_enabled: bool,
     pub context_monitor_enforced: bool,
@@ -9657,6 +9668,7 @@ impl ContextSnapshotResponse {
         let provider = non_empty_or(session.provider, "claude");
         let unsupported_provider = !provider_has_measured_context_gauge(&provider);
         let thresholds = resolve_context_monitor_thresholds(
+            session.context_monitor_threshold_percentages.clone(),
             session.context_monitor_warning_percentage,
             session.context_monitor_critical_percentage,
             config,
@@ -9696,6 +9708,10 @@ impl ContextSnapshotResponse {
                 .as_ref()
                 .ok()
                 .map(|value| value.critical_percentage),
+            threshold_percentages: thresholds
+                .as_ref()
+                .ok()
+                .map(|value| value.percentages.clone()),
             threshold_source: thresholds
                 .as_ref()
                 .map(|value| value.source.as_str().to_owned())
@@ -9721,6 +9737,7 @@ pub struct ContextMonitorResult {
     pub enabled: bool,
     pub warning_percentage: Option<f64>,
     pub critical_percentage: Option<f64>,
+    pub threshold_percentages: Option<Vec<f64>>,
     pub threshold_source: String,
     pub enforced: bool,
 }
@@ -9997,6 +10014,10 @@ fn clear_stop_notify_raw(state: &mut Value, session_id: &str) -> Result<()> {
 fn reset_context_oneshot_flags(session: &mut Map<String, Value>) {
     session.insert("context_warning_sent".to_owned(), Value::Bool(false));
     session.insert("context_critical_sent".to_owned(), Value::Bool(false));
+    session.insert(
+        "context_reported_thresholds".to_owned(),
+        Value::Array(Vec::new()),
+    );
     session.insert("context_cycle_reset_emitted_at".to_owned(), Value::Null);
 }
 
@@ -10050,6 +10071,7 @@ fn format_percentage(value: f64) -> String {
     }
 }
 
+#[cfg(test)]
 fn format_thousands(value: i64) -> String {
     let negative = value < 0;
     let digits = value.unsigned_abs().to_string();
@@ -15272,6 +15294,10 @@ pub struct SessionRecord {
     pub context_monitor_notify: Option<String>,
     #[serde(default = "default_context_monitor_notify_source")]
     pub context_monitor_notify_source: String,
+    /// Optional ordered per-seat notification milestones. When absent, the
+    /// configured global milestone list (or the legacy pair) applies.
+    #[serde(default)]
+    pub context_monitor_threshold_percentages: Option<Vec<f64>>,
     /// Optional per-seat warning override. When absent, the configured global
     /// context-monitor warning threshold remains effective.
     #[serde(default)]
@@ -15943,10 +15969,6 @@ fn provider_has_measured_context_gauge(provider: &str) -> bool {
     matches!(provider.trim(), "claude" | "codex-fork")
 }
 
-fn provider_uses_native_context_compaction(provider: &str) -> bool {
-    matches!(provider.trim(), "codex" | "codex-fork" | "codex-app")
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ContextMonitorThresholdSource {
     Default,
@@ -15962,8 +15984,9 @@ impl ContextMonitorThresholdSource {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 struct EffectiveContextMonitorThresholds {
+    percentages: Vec<f64>,
     warning_percentage: f64,
     critical_percentage: f64,
     source: ContextMonitorThresholdSource,
@@ -15974,41 +15997,87 @@ struct EffectiveContextMonitorThresholds {
 /// authoritative. Invalid persisted or global values fail closed so status and
 /// alerting never claim an unenforceable policy is active.
 fn resolve_context_monitor_thresholds(
+    percentages_override: Option<Vec<f64>>,
     warning_override: Option<f64>,
     critical_override: Option<f64>,
     config: &ContextMonitorConfig,
 ) -> Result<EffectiveContextMonitorThresholds, String> {
-    let warning_percentage = warning_override.unwrap_or(config.warning_percentage);
-    let critical_percentage = critical_override.unwrap_or(config.critical_percentage);
-    for (name, value) in [
-        ("warning_percentage", warning_percentage),
-        ("critical_percentage", critical_percentage),
-    ] {
-        if !value.is_finite() || !(0.0..=100.0).contains(&value) {
+    let has_custom_override =
+        percentages_override.is_some() || warning_override.is_some() || critical_override.is_some();
+    let configured_percentages = if config.threshold_percentages.is_empty() {
+        vec![config.warning_percentage, config.critical_percentage]
+    } else {
+        config.threshold_percentages.clone()
+    };
+    let percentages = if let Some(percentages) = percentages_override {
+        percentages
+    } else if warning_override.is_some() || critical_override.is_some() {
+        vec![
+            warning_override.unwrap_or(configured_percentages[0]),
+            critical_override.unwrap_or(
+                *configured_percentages
+                    .last()
+                    .expect("configured thresholds exist"),
+            ),
+        ]
+    } else {
+        configured_percentages
+    };
+    for value in &percentages {
+        if !value.is_finite() || !(0.0..=100.0).contains(value) {
             return Err(format!(
-                "{name} must be a finite percentage in the range (0, 100]"
+                "context-monitor thresholds must be finite percentages in the range (0, 100]"
             ));
         }
-        if value == 0.0 {
+        if *value == 0.0 {
             return Err(format!(
-                "{name} must be a finite percentage in the range (0, 100]"
+                "context-monitor thresholds must be finite percentages in the range (0, 100]"
             ));
         }
     }
-    if warning_percentage >= critical_percentage {
+    if percentages.is_empty() || percentages.windows(2).any(|pair| pair[0] >= pair[1]) {
         return Err(
-            "warning_percentage must be strictly lower than critical_percentage".to_owned(),
+            "context-monitor thresholds must be non-empty and strictly increasing".to_owned(),
         );
     }
     Ok(EffectiveContextMonitorThresholds {
-        warning_percentage,
-        critical_percentage,
-        source: if warning_override.is_some() || critical_override.is_some() {
+        warning_percentage: percentages[0],
+        critical_percentage: *percentages.last().expect("non-empty thresholds checked"),
+        percentages,
+        source: if has_custom_override {
             ContextMonitorThresholdSource::Custom
         } else {
             ContextMonitorThresholdSource::Default
         },
     })
+}
+
+/// Read durable notification latches, translating the pre-list two-threshold
+/// representation exactly once for existing sessions.
+fn context_reported_thresholds(session: &Map<String, Value>, thresholds: &[f64]) -> Vec<f64> {
+    if let Some(values) = session
+        .get("context_reported_thresholds")
+        .and_then(Value::as_array)
+    {
+        return values.iter().filter_map(Value::as_f64).collect();
+    }
+    let mut reported = Vec::new();
+    if flag_is_set(session, "context_warning_sent") {
+        reported.push(thresholds[0]);
+    }
+    if flag_is_set(session, "context_critical_sent") {
+        let final_threshold = *thresholds.last().expect("non-empty thresholds checked");
+        if !reported.contains(&final_threshold) {
+            reported.push(final_threshold);
+        }
+    }
+    reported
+}
+
+fn json_percentages(value: Option<&Value>) -> Option<Vec<f64>> {
+    value
+        .and_then(Value::as_array)
+        .map(|values| values.iter().filter_map(Value::as_f64).collect::<Vec<_>>())
 }
 
 fn session_supports_reparent_consent(session: &SessionRecord) -> bool {
@@ -17043,6 +17112,7 @@ mod tests {
             context_monitor_enabled: false,
             context_monitor_notify: None,
             context_monitor_notify_source: default_context_monitor_notify_source(),
+            context_monitor_threshold_percentages: None,
             context_monitor_warning_percentage: None,
             context_monitor_critical_percentage: None,
             context_warning_sent: false,
@@ -20694,8 +20764,24 @@ mod tests {
             enabled: true,
             requester_session_id: "parent01".to_owned(),
             notify_session_id: Some("parent01".to_owned()),
+            threshold_percentages: None,
             warning_percentage,
             critical_percentage,
+            use_default_thresholds: false,
+        }
+    }
+
+    fn context_monitor_levels_request(
+        levels: Vec<f64>,
+        notify_session_id: &str,
+    ) -> ContextMonitorRequest {
+        ContextMonitorRequest {
+            enabled: true,
+            requester_session_id: "child001".to_owned(),
+            notify_session_id: Some(notify_session_id.to_owned()),
+            threshold_percentages: Some(levels),
+            warning_percentage: None,
+            critical_percentage: None,
             use_default_thresholds: false,
         }
     }
@@ -20728,6 +20814,57 @@ mod tests {
         assert!(session.context_warning_sent);
         assert!(!session.context_critical_sent);
         assert_eq!(context_monitor_messages(&store).len(), 1);
+    }
+
+    #[test]
+    fn context_monitor_reports_each_registered_level_without_prescribing_policy() {
+        let store = store_with_monitored_child("ctxlevels", true, Some("child001"));
+        store
+            .set_context_monitor(
+                "child001",
+                context_monitor_levels_request(vec![10.0, 20.0, 30.0], "child001"),
+            )
+            .unwrap();
+
+        store
+            .apply_context_usage_event(&usage_event("child001", 9.0, 18_000), None)
+            .unwrap();
+        assert!(context_monitor_messages(&store).is_empty());
+
+        store
+            .apply_context_usage_event(&usage_event("child001", 10.0, 20_000), None)
+            .unwrap();
+        let first = context_monitor_messages(&store);
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0]["text"], "[sm context] Your context is now at 10%.");
+        assert!(!first[0]["text"].as_str().unwrap().contains("handoff"));
+        assert!(!first[0]["text"].as_str().unwrap().contains("critical"));
+
+        // A delayed status-line sample may cross multiple levels. It produces
+        // one factual reading and latches every crossed level, so later
+        // unchanged renders do not create stale alert bursts.
+        store
+            .apply_context_usage_event(&usage_event("child001", 25.0, 50_000), None)
+            .unwrap();
+        store
+            .apply_context_usage_event(&usage_event("child001", 25.0, 50_000), None)
+            .unwrap();
+        let messages = context_monitor_messages(&store);
+        assert_eq!(messages.len(), 2);
+        assert_eq!(
+            messages[1]["text"],
+            "[sm context] Your context is now at 25%."
+        );
+
+        store
+            .apply_context_usage_event(&usage_event("child001", 30.0, 60_000), None)
+            .unwrap();
+        let messages = context_monitor_messages(&store);
+        assert_eq!(messages.len(), 3);
+        assert_eq!(
+            messages[2]["text"],
+            "[sm context] Your context is now at 30%."
+        );
     }
 
     #[test]
@@ -21001,6 +21138,7 @@ mod tests {
                     enabled: true,
                     requester_session_id: "parent01".to_owned(),
                     notify_session_id: Some("parent01".to_owned()),
+                    threshold_percentages: None,
                     warning_percentage: None,
                     critical_percentage: None,
                     use_default_thresholds: false,
@@ -21178,7 +21316,7 @@ mod tests {
     }
 
     #[test]
-    fn context_critical_fires_separately_from_the_warning() {
+    fn context_levels_notify_separately_without_priority_policy() {
         let store = store_with_monitored_child("ctxcrit", true, Some("parent01"));
         store
             .apply_context_usage_event(&usage_event("child001", 52.0, 104_000), None)
@@ -21196,7 +21334,7 @@ mod tests {
         assert_eq!(messages.len(), 2);
         assert_eq!(
             messages[1].get("delivery_mode").and_then(Value::as_str),
-            Some("urgent")
+            Some("sequential")
         );
     }
 
@@ -21355,6 +21493,7 @@ mod tests {
             enabled: true,
             requester_session_id: "parent01".to_owned(),
             notify_session_id: Some("parent01".to_owned()),
+            threshold_percentages: None,
             warning_percentage: None,
             critical_percentage: None,
             use_default_thresholds: false,
@@ -21430,6 +21569,7 @@ mod tests {
                     enabled: true,
                     requester_session_id: "child001".to_owned(),
                     notify_session_id: Some("child001".to_owned()),
+                    threshold_percentages: None,
                     warning_percentage: None,
                     critical_percentage: None,
                     use_default_thresholds: false,
@@ -21457,8 +21597,8 @@ mod tests {
             .unwrap();
         let first_alert = context_monitor_messages(&store).pop().unwrap();
         let first_text = first_alert["text"].as_str().unwrap();
-        assert!(first_text.contains("Codex will compact inline"));
-        assert!(!first_text.contains("run `sm handoff <path>`"));
+        assert_eq!(first_text, "[sm context] Your context is now at 70.0%.");
+        assert!(!first_text.contains("handoff"));
         assert_eq!(
             queue
                 .pending_messages_for_target("child001", 10)
@@ -21526,6 +21666,7 @@ mod tests {
                     enabled: true,
                     requester_session_id: "child001".to_owned(),
                     notify_session_id: Some("child001".to_owned()),
+                    threshold_percentages: None,
                     warning_percentage: None,
                     critical_percentage: None,
                     use_default_thresholds: false,
@@ -21594,6 +21735,7 @@ mod tests {
                     enabled: true,
                     requester_session_id: "child001".to_owned(),
                     notify_session_id: Some("child001".to_owned()),
+                    threshold_percentages: None,
                     warning_percentage: None,
                     critical_percentage: None,
                     use_default_thresholds: false,
@@ -21622,6 +21764,7 @@ mod tests {
                         enabled: false,
                         requester_session_id: "child001".to_owned(),
                         notify_session_id: None,
+                        threshold_percentages: None,
                         warning_percentage: None,
                         critical_percentage: None,
                         use_default_thresholds: false,
@@ -21656,6 +21799,7 @@ mod tests {
                             enabled: true,
                             requester_session_id: "parent01".to_owned(),
                             notify_session_id: Some("parent01".to_owned()),
+                            threshold_percentages: None,
                             warning_percentage: None,
                             critical_percentage: None,
                             use_default_thresholds: false,
@@ -21678,6 +21822,7 @@ mod tests {
                         enabled: true,
                         requester_session_id: "parent01".to_owned(),
                         notify_session_id: Some("parent01".to_owned()),
+                        threshold_percentages: None,
                         warning_percentage: None,
                         critical_percentage: None,
                         use_default_thresholds: false,
@@ -21696,6 +21841,7 @@ mod tests {
                         enabled: true,
                         requester_session_id: "parent01".to_owned(),
                         notify_session_id: Some("parent01".to_owned()),
+                        threshold_percentages: None,
                         warning_percentage: None,
                         critical_percentage: None,
                         use_default_thresholds: false,

--- a/src/cli/commands.py
+++ b/src/cli/commands.py
@@ -5458,7 +5458,7 @@ def cmd_clear(
 
 def cmd_handoff(client: SessionManagerClient, session_id: str, file_path: str) -> int:
     """
-    Schedule a self-directed context rotation via handoff doc.
+    Schedule a destructive self-directed context rotation via handoff doc.
 
     Agent writes handoff state to a doc, then calls sm handoff. The server
     executes /clear + prompt injection after the current turn completes (Stop hook).
@@ -5498,7 +5498,9 @@ def cmd_handoff(client: SessionManagerClient, session_id: str, file_path: str) -
         print(f"Error: {result.get('error') or result.get('detail')}", file=sys.stderr)
         return 1
 
-    print("Handoff scheduled — will execute after current turn completes")
+    print(
+        "Handoff scheduled — after this turn it will /clear this session and inject the handoff prompt"
+    )
     return 0
 
 

--- a/src/cli/main.py
+++ b/src/cli/main.py
@@ -831,7 +831,14 @@ def main():
     )
 
     # sm handoff <file_path>
-    handoff_parser = subparsers.add_parser("handoff", help="Self-directed context rotation via handoff doc")
+    handoff_parser = subparsers.add_parser(
+        "handoff",
+        help="Destructive self-directed context rotation via handoff doc",
+        description=(
+            "After the current turn, this sends /clear to the calling Claude session "
+            "and injects the handoff prompt."
+        ),
+    )
     handoff_parser.add_argument("file_path", help="Path to handoff document")
 
     # sm task-complete

--- a/src/server.py
+++ b/src/server.py
@@ -9201,17 +9201,10 @@ Provide ONLY the summary, no preamble or questions."""
                 if queue_mgr:
                     is_self_alert = (session.context_monitor_notify == session.id)
                     if is_self_alert:
-                        msg = (
-                            f"[sm context] Context at {used_pct}% — critically high. "
-                            "Write your handoff doc NOW and run `sm handoff <path>`. "
-                            "Compaction is imminent."
-                        )
+                        msg = f"[sm context] Your context is now at {used_pct}%."
                     else:
                         child_label = _effective_session_name(session)
-                        msg = (
-                            f"[sm context] Child {child_label} ({session.id}) context at {used_pct}% — critically high. "
-                            "Compaction is imminent."
-                        )
+                        msg = f"[sm context] Context for {child_label} ({session.id}) is now at {used_pct}%."
                     queue_mgr.queue_message(
                         target_session_id=session.context_monitor_notify,
                         text=msg,
@@ -9226,14 +9219,10 @@ Provide ONLY the summary, no preamble or questions."""
                 if queue_mgr:
                     is_self_alert = (session.context_monitor_notify == session.id)
                     if is_self_alert:
-                        total = data.get("total_input_tokens", 0)
-                        msg = (
-                            f"[sm context] Context at {used_pct}% ({total:,} tokens). "
-                            "Consider writing a handoff doc and running `sm handoff <path>`."
-                        )
+                        msg = f"[sm context] Your context is now at {used_pct}%."
                     else:
                         child_label = _effective_session_name(session)
-                        msg = f"[sm context] Child {child_label} ({session.id}) context at {used_pct}%."
+                        msg = f"[sm context] Context for {child_label} ({session.id}) is now at {used_pct}%."
                     queue_mgr.queue_message(
                         target_session_id=session.context_monitor_notify,
                         text=msg,

--- a/tests/unit/test_context_monitor.py
+++ b/tests/unit/test_context_monitor.py
@@ -316,7 +316,7 @@ class TestCriticalThreshold:
         queue_mgr = mock_session_manager.message_queue_manager
         assert queue_mgr.queue_message.called
         call_kwargs = queue_mgr.queue_message.call_args[1]
-        assert "critically high" in call_kwargs["text"].lower()
+        assert call_kwargs["text"] == "[sm context] Your context is now at 65%."
         assert call_kwargs["delivery_mode"] == "urgent"
 
     def test_critical_flag_set_after_firing(self, client, session):
@@ -1064,7 +1064,7 @@ class TestChildForwardedNotifications:
         _post_context(client, session.id, used_pct=70)
 
         call_kwargs = mock_session_manager.message_queue_manager.queue_message.call_args[1]
-        assert "Child" in call_kwargs["text"]
+        assert "Context for" in call_kwargs["text"]
         assert "engineer-abc" in call_kwargs["text"]
 
     def test_child_critical_falls_back_to_session_id(self, mock_session_manager):
@@ -1078,7 +1078,7 @@ class TestChildForwardedNotifications:
         _post_context(client, session.id, used_pct=70)
 
         call_kwargs = mock_session_manager.message_queue_manager.queue_message.call_args[1]
-        assert "Child" in call_kwargs["text"]
+        assert "Context for" in call_kwargs["text"]
         assert session.id in call_kwargs["text"]
 
     def test_child_critical_omits_handoff_instruction(self, mock_session_manager):
@@ -1105,7 +1105,7 @@ class TestChildForwardedNotifications:
         _post_context(client, session.id, used_pct=55)
 
         call_kwargs = mock_session_manager.message_queue_manager.queue_message.call_args[1]
-        assert "Child" in call_kwargs["text"]
+        assert "Context for" in call_kwargs["text"]
         assert session.id in call_kwargs["text"]
 
     def test_child_warning_omits_handoff_suggestion(self, mock_session_manager):
@@ -1121,22 +1121,22 @@ class TestChildForwardedNotifications:
         call_kwargs = mock_session_manager.message_queue_manager.queue_message.call_args[1]
         assert "Consider writing a handoff" not in call_kwargs["text"]
 
-    def test_self_critical_includes_handoff_instruction(self, mock_session_manager, session):
-        """Self critical alert (context_monitor_notify == session.id) includes handoff instruction."""
+    def test_self_critical_is_a_neutral_context_reading(self, mock_session_manager, session):
+        """Self alerts report context without prescribing a recovery policy."""
         # session fixture has context_monitor_notify = session.id (self-alert path)
         _post_context(TestClient(create_app(session_manager=mock_session_manager)), session.id, used_pct=70)
 
         call_kwargs = mock_session_manager.message_queue_manager.queue_message.call_args[1]
-        assert "Write your handoff doc" in call_kwargs["text"]
-        assert "Child" not in call_kwargs["text"]
+        assert call_kwargs["text"] == "[sm context] Your context is now at 70%."
+        assert "handoff" not in call_kwargs["text"].lower()
 
-    def test_self_warning_includes_handoff_suggestion(self, mock_session_manager, session):
-        """Self warning alert (context_monitor_notify == session.id) includes handoff suggestion."""
+    def test_self_warning_is_a_neutral_context_reading(self, mock_session_manager, session):
+        """Self alerts report context without prescribing a recovery policy."""
         _post_context(TestClient(create_app(session_manager=mock_session_manager)), session.id, used_pct=55)
 
         call_kwargs = mock_session_manager.message_queue_manager.queue_message.call_args[1]
-        assert "Consider writing a handoff" in call_kwargs["text"]
-        assert "Child" not in call_kwargs["text"]
+        assert call_kwargs["text"] == "[sm context] Your context is now at 55%."
+        assert "handoff" not in call_kwargs["text"].lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1213

## Summary

- Replace provider- and hierarchy-specific context-monitor instructions with factual threshold notifications.
- Support ordered per-seat notification levels through repeated `--threshold` flags.
- Preserve the legacy warning/critical API as a compatibility layer and make `sm handoff` explicitly describe its `/clear` behavior.

## Root cause

The context monitor embedded a Claude-specific handoff policy in a generic telemetry alert. That advice assumed an orchestration model and could trigger destructive context rotation.

## Validation

- `cargo check -p sm-server`
- `cargo test -p sm-server --lib -- --skip reminder_http_rejects_killed_target_with_status_drift` (514 passed; unrelated known failure tracked in #1305)
- `./venv/bin/pytest -q tests/unit/test_context_monitor.py tests/unit/test_handoff.py tests/unit/test_cli_parsing.py` (213 passed)
