### PR TITLE
Fix reparent watch read-path contention

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -513,6 +513,13 @@ impl AppState {
             .drain_runtime_pending_message_targets_by_category("queue-completion")
     }
 
+    /// Advance time/topology-derived reparent state and retry the durable
+    /// notification outbox away from HTTP request workers.
+    pub fn reconcile_reparent_background(&self) -> anyhow::Result<()> {
+        self.session_store.reconcile_reparent_requests()?;
+        self.session_store.reconcile_reparent_notifications()
+    }
+
     pub fn with_github_review_poster(mut self, poster: Arc<dyn GitHubReviewPoster>) -> Self {
         self.github_review_poster = poster;
         self
@@ -3171,7 +3178,9 @@ async fn list_reparent_requests(
     request: Request,
 ) -> Result<Json<Value>, ApiError> {
     ensure_session_read_allowed(&state, &request)?;
-    reconcile_reparent_notifications_best_effort(&state);
+    // Watch polls are a pure snapshot projection. Reconciliation may wait on
+    // the cross-process apply lock, write the queue, and invoke tmux; the
+    // dedicated background worker owns that work.
     let requests = if let Some(session_id) = header_text(request.headers(), "x-sm-session-id") {
         let credential = reparent_session_credential(request.headers())?;
         state
@@ -3278,7 +3287,8 @@ async fn get_reparent_request(
     request: Request,
 ) -> Result<Json<Value>, ApiError> {
     ensure_session_read_allowed(&state, &request)?;
-    reconcile_reparent_notifications_best_effort(&state);
+    // Keep detail polling in the same non-blocking snapshot class as the
+    // collection endpoint above.
     let record = state
         .session_store
         .get_reparent_request(&request_id)?

--- a/crates/sm-server/src/main.rs
+++ b/crates/sm-server/src/main.rs
@@ -22,6 +22,7 @@ use tokio::net::TcpListener;
 /// How often the Studio SSH reconcile loop repairs toward the desired state.
 const STUDIO_SSH_RECONCILE_INTERVAL: Duration = Duration::from_secs(30);
 const QUEUE_COMPLETION_RETRY_INTERVAL: Duration = Duration::from_secs(5);
+const REPARENT_RECONCILE_INTERVAL: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Parser)]
 #[command(version, about = "Rust Session Manager server scaffold")]
@@ -129,6 +130,17 @@ async fn main() -> Result<()> {
     }
 
     let state = AppState::try_new(config).context("failed to initialize server state")?;
+    // Reparent lifecycle and notification delivery can take the cross-process
+    // apply lock, access the retained queue, and talk to tmux.  Keep all of
+    // that work on one dedicated worker: watch polling is a snapshot read and
+    // must never wait behind it.
+    let reparent_state = state.clone();
+    thread::spawn(move || loop {
+        thread::sleep(REPARENT_RECONCILE_INTERVAL);
+        if let Err(error) = reparent_state.reconcile_reparent_background() {
+            eprintln!("reparent background reconciliation failed: {error:#}");
+        }
+    });
     if state.config().rust_core.runtime_enabled {
         let queue_delivery_state = state.clone();
         thread::spawn(move || loop {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -2699,28 +2699,30 @@ impl SessionStore {
     }
 
     pub fn get_reparent_request(&self, request_id: &str) -> Result<Option<ReparentRequestRecord>> {
-        let _guard = self.write_guard()?;
-        let mut state = self.load_raw_json_value()?;
+        // Poll routes call this method.  The registry is atomically replaced,
+        // so a direct snapshot read sees either the old or new complete state
+        // without waiting for a writer.  Lifecycle transitions belong to the
+        // reparent worker, not to a GET request.
+        let state = self.load_raw_json_value()?;
         let sessions = snapshot_from_raw_value(&state)?.into_sessions();
         let mut records = reparent_request_records(&state)?;
-        if refresh_reparent_requests(&mut records, &sessions, &state, OffsetDateTime::now_utc()) {
-            store_reparent_request_records(&mut state, &records)?;
-            self.write_raw_json_value(&state)?;
-        }
+        // This projection is intentionally not persisted.  It keeps the
+        // response truthful at an expiry boundary while the lifecycle worker
+        // performs the durable transition and outbox derivation separately.
+        refresh_reparent_requests(&mut records, &sessions, &state, OffsetDateTime::now_utc());
         Ok(records
             .into_iter()
             .find(|record| record.id == request_id.trim()))
     }
 
     pub fn list_reparent_requests(&self) -> Result<Vec<ReparentRequestRecord>> {
-        let _guard = self.write_guard()?;
-        let mut state = self.load_raw_json_value()?;
+        // Keep collection reads in the same lock-free snapshot class as
+        // `list_sessions`.  In particular, do not refresh expiry/staleness
+        // here: doing so turns a watch poll into a durable mutation.
+        let state = self.load_raw_json_value()?;
         let sessions = snapshot_from_raw_value(&state)?.into_sessions();
         let mut records = reparent_request_records(&state)?;
-        if refresh_reparent_requests(&mut records, &sessions, &state, OffsetDateTime::now_utc()) {
-            store_reparent_request_records(&mut state, &records)?;
-            self.write_raw_json_value(&state)?;
-        }
+        refresh_reparent_requests(&mut records, &sessions, &state, OffsetDateTime::now_utc());
         records.sort_by(|left, right| {
             (&left.created_at, &left.id).cmp(&(&right.created_at, &right.id))
         });
@@ -2733,17 +2735,13 @@ impl SessionStore {
         session_credential: &str,
     ) -> Result<Option<Vec<ReparentRequestRecord>>> {
         let session_id = session_id.trim();
-        let _guard = self.write_guard()?;
-        let mut state = self.load_raw_json_value()?;
+        let state = self.load_raw_json_value()?;
         let sessions = snapshot_from_raw_value(&state)?.into_sessions();
         if !session_credential_matches(&sessions, session_id, session_credential) {
             return Ok(None);
         }
         let mut records = reparent_request_records(&state)?;
-        if refresh_reparent_requests(&mut records, &sessions, &state, OffsetDateTime::now_utc()) {
-            store_reparent_request_records(&mut state, &records)?;
-            self.write_raw_json_value(&state)?;
-        }
+        refresh_reparent_requests(&mut records, &sessions, &state, OffsetDateTime::now_utc());
         records.retain(|record| record.involves_session(session_id));
         records.sort_by(|left, right| {
             (&left.created_at, &left.id).cmp(&(&right.created_at, &right.id))
@@ -2857,34 +2855,7 @@ impl SessionStore {
                 OffsetDateTime::now_utc(),
             );
             let mut changed = refreshed;
-            for record in &mut records {
-                let desired = desired_reparent_notifications(record);
-                let desired_keys = desired
-                    .iter()
-                    .map(|desired| desired.intent.key.as_str())
-                    .collect::<BTreeSet<_>>();
-                // A prior process may have recorded a not-yet-enqueued
-                // terminal intent before a winning driver committed the
-                // request.  Keep delivered audit history, but remove any
-                // unsent losing projection before choosing outbox work.
-                let previous_len = record.notification_intents.len();
-                record.notification_intents.retain(|intent| {
-                    intent.enqueued_at.is_some()
-                        || !intent.event.starts_with("terminal:")
-                        || desired_keys.contains(intent.key.as_str())
-                });
-                changed |= record.notification_intents.len() != previous_len;
-                for desired in desired {
-                    if record
-                        .notification_intents
-                        .iter()
-                        .all(|intent| intent.key != desired.intent.key)
-                    {
-                        record.notification_intents.push(desired.intent);
-                        changed = true;
-                    }
-                }
-            }
+            changed |= reconcile_reparent_notification_intents(&mut records);
             if changed {
                 store_reparent_request_records(&mut state, &records)?;
                 self.write_raw_json_value(&state)?;
@@ -2901,14 +2872,12 @@ impl SessionStore {
                         })
                 })
                 .collect::<Vec<_>>();
-            let recipients = records
+            // Runtime delivery is only meaningful for items this pass actually
+            // enqueued.  Historical delivered intents must never turn an idle
+            // retry into one full-state write and tmux call per old recipient.
+            let recipients = pending
                 .iter()
-                .flat_map(|record| {
-                    record
-                        .notification_intents
-                        .iter()
-                        .map(|intent| intent.recipient_session_id.clone())
-                })
+                .map(|desired| desired.intent.recipient_session_id.clone())
                 .collect::<BTreeSet<_>>();
             (pending, recipients)
         };
@@ -2968,6 +2937,10 @@ impl SessionStore {
                 self.write_raw_json_value(&state)?;
             }
         }
+        // Queue projection is complete. Runtime delivery is deliberately
+        // outside the cross-process apply lock so a hung tmux cannot block
+        // state transitions or make another process wait on this lock.
+        drop(_cross_process_guard);
         if let Some(runtime) = self.delivery_runtime.as_ref() {
             let mut first_error = None;
             for recipient in recipients {
@@ -3171,7 +3144,7 @@ impl SessionStore {
         }
         let sessions = snapshot_from_raw_value(&state)?.into_sessions();
         let mut records = reparent_request_records(&state)?;
-        let _ =
+        let refreshed =
             refresh_reparent_requests(&mut records, &sessions, &state, OffsetDateTime::now_utc());
         let Some(index) = records
             .iter()
@@ -3186,8 +3159,12 @@ impl SessionStore {
             })
             .map(|(index, _)| index)
         else {
-            store_reparent_request_records(&mut state, &records)?;
-            self.write_raw_json_value(&state)?;
+            // The lifecycle worker may inspect an idle registry frequently.
+            // An idle pass must not rewrite the complete sessions file.
+            if refreshed || state.get("reparent_requests").is_none() {
+                store_reparent_request_records(&mut state, &records)?;
+                self.write_raw_json_value(&state)?;
+            }
             return Ok(None);
         };
         if let Some(reason) = reparent_stale_reason(&records[index], &sessions, &state) {
@@ -4864,6 +4841,9 @@ impl SessionStore {
         runtime: &TmuxRuntime,
         message_category: Option<&str>,
     ) -> Result<()> {
+        if message_category == Some("reparent") {
+            return self.drain_reparent_runtime_messages(session_id, runtime);
+        }
         let _guard = self.write_guard()?;
         let mut state = self.load_raw_json_value()?;
         if let Some(queue) = &self.queue_store {
@@ -4881,6 +4861,62 @@ impl SessionStore {
             self.write_raw_json_value(&state)?;
         }
         Ok(())
+    }
+
+    /// Deliver reparent outbox messages without holding the sessions write
+    /// guard.  tmux can block indefinitely; holding the guard here used to
+    /// make unrelated readers queue behind a notification retry.
+    fn drain_reparent_runtime_messages(
+        &self,
+        session_id: &str,
+        runtime: &TmuxRuntime,
+    ) -> Result<()> {
+        let Some(queue) = self.queue_store.as_ref() else {
+            return Ok(());
+        };
+        loop {
+            let Some(message) = queue
+                .pending_messages_for_target_by_category(session_id, "reparent", 1)?
+                .into_iter()
+                .next()
+            else {
+                return Ok(());
+            };
+            let target = {
+                let _guard = self.write_guard()?;
+                let state = self.load_raw_json_value()?;
+                reparent_runtime_delivery_target(&state, session_id)?
+            };
+            let Some(target) = target else {
+                return Ok(());
+            };
+
+            // This is the only potentially blocking operation in this path.
+            // No state or apply lock is held while it runs.
+            let delivered = runtime
+                .for_socket_name(target.tmux_socket_name.as_deref())
+                .send_input(&target.tmux_session, &message.text)?;
+            if !delivered {
+                return Ok(());
+            }
+
+            let _guard = self.write_guard()?;
+            let mut state = self.load_raw_json_value()?;
+            if !reparent_runtime_delivery_target(&state, session_id)?
+                .is_some_and(|current| current == target)
+            {
+                // The session changed while tmux was handling the message.
+                // Leave the queue row pending for a fresh, validated attempt.
+                return Ok(());
+            }
+            queue.mark_delivered_and_apply_side_effects(&message)?;
+            let sessions = ensure_sessions_array_mut(&mut state)?;
+            let session = session_object_mut(sessions, session_id).ok_or_else(|| {
+                anyhow::anyhow!("session {session_id} disappeared during delivery")
+            })?;
+            mark_session_followup_activity(session, &now_rfc3339());
+            self.write_raw_json_value(&state)?;
+        }
     }
 
     fn drain_runtime_pending_messages_for_writable_session(
@@ -10675,6 +10711,32 @@ fn deliver_runtime_text_to_session_raw(
     deliver_runtime_text_to_session_with_ready_fence_raw(state, session_id, text, runtime, false)
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct ReparentRuntimeDeliveryTarget {
+    tmux_session: String,
+    tmux_socket_name: Option<String>,
+}
+
+fn reparent_runtime_delivery_target(
+    state: &Value,
+    session_id: &str,
+) -> Result<Option<ReparentRuntimeDeliveryTarget>> {
+    let Some(session) = raw_session_object(state, session_id) else {
+        return Ok(None);
+    };
+    let node = json_text(session.get("node")).unwrap_or_else(default_node);
+    ensure_runtime_local_node(&node)?;
+    if raw_session_is_stopped(session) || claude_handoff_is_reserved_raw(session) {
+        return Ok(None);
+    }
+    let tmux_session = json_text(session.get("tmux_session"))
+        .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?;
+    Ok(Some(ReparentRuntimeDeliveryTarget {
+        tmux_session,
+        tmux_socket_name: json_text(session.get("tmux_socket_name")),
+    }))
+}
+
 fn deliver_runtime_background_text_to_session_raw(
     state: &mut Value,
     session_id: &str,
@@ -13345,6 +13407,13 @@ fn store_reparent_request_records(
     state: &mut Value,
     records: &[ReparentRequestRecord],
 ) -> Result<()> {
+    // Notification intents are part of the durable reparent state machine,
+    // not an observation made later by a polling GET.  Every request-state
+    // write therefore carries its exact, idempotency-keyed outbox projection.
+    // This also lets a later worker retry an enqueue after a process crash
+    // without requiring another client request to repair the record.
+    let mut records = records.to_vec();
+    reconcile_reparent_notification_intents(&mut records);
     let object = state
         .as_object_mut()
         .ok_or_else(|| anyhow::anyhow!("session state root must be an object"))?;
@@ -13353,6 +13422,37 @@ fn store_reparent_request_records(
         serde_json::to_value(records)?,
     );
     Ok(())
+}
+
+fn reconcile_reparent_notification_intents(records: &mut [ReparentRequestRecord]) -> bool {
+    let mut changed = false;
+    for record in records {
+        let desired = desired_reparent_notifications(record);
+        let desired_keys = desired
+            .iter()
+            .map(|desired| desired.intent.key.as_str())
+            .collect::<BTreeSet<_>>();
+        // Preserve enqueued audit history, but discard an unqueued terminal
+        // projection if a later durable outcome superseded it.
+        let previous_len = record.notification_intents.len();
+        record.notification_intents.retain(|intent| {
+            intent.enqueued_at.is_some()
+                || !intent.event.starts_with("terminal:")
+                || desired_keys.contains(intent.key.as_str())
+        });
+        changed |= record.notification_intents.len() != previous_len;
+        for desired in desired {
+            if record
+                .notification_intents
+                .iter()
+                .all(|intent| intent.key != desired.intent.key)
+            {
+                record.notification_intents.push(desired.intent);
+                changed = true;
+            }
+        }
+    }
+    changed
 }
 
 fn reparent_apply_lease(state: &Value) -> Result<Option<ReparentApplyLease>> {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -2843,7 +2843,7 @@ impl SessionStore {
         // projection with apply/recovery, then enqueue only intents that are
         // still desired by the durable record while this lock is held.
         let _cross_process_guard = self.reparent_apply_file_lock()?;
-        let (pending, recipients) = {
+        let pending = {
             let _guard = self.write_guard()?;
             let mut state = self.load_raw_json_value()?;
             let sessions = snapshot_from_raw_value(&state)?.into_sessions();
@@ -2872,14 +2872,7 @@ impl SessionStore {
                         })
                 })
                 .collect::<Vec<_>>();
-            // Runtime delivery is only meaningful for items this pass actually
-            // enqueued.  Historical delivered intents must never turn an idle
-            // retry into one full-state write and tmux call per old recipient.
-            let recipients = pending
-                .iter()
-                .map(|desired| desired.intent.recipient_session_id.clone())
-                .collect::<BTreeSet<_>>();
-            (pending, recipients)
+            pending
         };
         for desired in pending {
             let desired = {
@@ -2942,6 +2935,15 @@ impl SessionStore {
         // state transitions or make another process wait on this lock.
         drop(_cross_process_guard);
         if let Some(runtime) = self.delivery_runtime.as_ref() {
+            // Retry every recipient with an outstanding reparent queue row,
+            // not merely recipients selected for a fresh enqueue above.  A
+            // failed runtime delivery leaves its durable queue row pending and
+            // must be retried by the next background reconciliation.
+            let recipients = self
+                .queue_store
+                .as_ref()
+                .context("reparent notifications require the retained queue store")?
+                .pending_target_session_ids_by_category("reparent")?;
             let mut first_error = None;
             for recipient in recipients {
                 if let Err(error) = self.drain_runtime_pending_messages_for_session_category(
@@ -4885,35 +4887,77 @@ impl SessionStore {
             let target = {
                 let _guard = self.write_guard()?;
                 let state = self.load_raw_json_value()?;
-                reparent_runtime_delivery_target(&state, session_id)?
+                reparent_runtime_delivery_target(&state, session_id, runtime)?
             };
             let Some(target) = target else {
                 return Ok(());
             };
 
             // This is the only potentially blocking operation in this path.
-            // No state or apply lock is held while it runs.
-            let delivered = runtime
-                .for_socket_name(target.tmux_socket_name.as_deref())
-                .send_input(&target.tmux_session, &message.text)?;
-            if !delivered {
-                return Ok(());
-            }
+            // No state or apply lock is held while it runs.  codex-fork
+            // recipients retain their managed control-channel policy, with
+            // tmux used only when the configured fallback permits it.
+            let mut control_result = None;
+            let delivered = match &target.delivery_route {
+                ReparentRuntimeDeliveryRoute::Tmux => runtime
+                    .for_socket_name(target.tmux_socket_name.as_deref())
+                    .send_input(&target.tmux_session, &message.text)?,
+                ReparentRuntimeDeliveryRoute::CodexForkControl { control_socket } => {
+                    match control_socket
+                        .as_ref()
+                        .map_err(|error| anyhow::anyhow!(error.clone()))
+                        .and_then(|control_socket| {
+                            codex_fork_submit_message(control_socket, &message.text)
+                        }) {
+                        Ok(()) => {
+                            control_result = Some(Ok(()));
+                            true
+                        }
+                        Err(error) => {
+                            control_result = Some(Err(error.to_string()));
+                            if runtime.codex_fork_control_tmux_fallback_enabled() {
+                                runtime
+                                    .for_socket_name(target.tmux_socket_name.as_deref())
+                                    .send_input(&target.tmux_session, &message.text)?
+                            } else {
+                                false
+                            }
+                        }
+                    }
+                }
+            };
 
             let _guard = self.write_guard()?;
             let mut state = self.load_raw_json_value()?;
-            if !reparent_runtime_delivery_target(&state, session_id)?
+            if !reparent_runtime_delivery_target(&state, session_id, runtime)?
                 .is_some_and(|current| current == target)
             {
                 // The session changed while tmux was handling the message.
                 // Leave the queue row pending for a fresh, validated attempt.
                 return Ok(());
             }
-            queue.mark_delivered_and_apply_side_effects(&message)?;
             let sessions = ensure_sessions_array_mut(&mut state)?;
             let session = session_object_mut(sessions, session_id).ok_or_else(|| {
                 anyhow::anyhow!("session {session_id} disappeared during delivery")
             })?;
+            let control_state_changed = control_result.is_some();
+            if let Some(control_result) = control_result {
+                match control_result {
+                    Ok(()) => {
+                        clear_codex_fork_control_degraded_raw(session);
+                    }
+                    Err(error) => {
+                        mark_codex_fork_control_degraded_raw(session, &error);
+                    }
+                }
+            }
+            if !delivered {
+                if control_state_changed {
+                    self.write_raw_json_value(&state)?;
+                }
+                return Ok(());
+            }
+            queue.mark_delivered_and_apply_side_effects(&message)?;
             mark_session_followup_activity(session, &now_rfc3339());
             self.write_raw_json_value(&state)?;
         }
@@ -10715,11 +10759,21 @@ fn deliver_runtime_text_to_session_raw(
 struct ReparentRuntimeDeliveryTarget {
     tmux_session: String,
     tmux_socket_name: Option<String>,
+    delivery_route: ReparentRuntimeDeliveryRoute,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ReparentRuntimeDeliveryRoute {
+    Tmux,
+    CodexForkControl {
+        control_socket: std::result::Result<PathBuf, String>,
+    },
 }
 
 fn reparent_runtime_delivery_target(
     state: &Value,
     session_id: &str,
+    runtime: &TmuxRuntime,
 ) -> Result<Option<ReparentRuntimeDeliveryTarget>> {
     let Some(session) = raw_session_object(state, session_id) else {
         return Ok(None);
@@ -10731,9 +10785,21 @@ fn reparent_runtime_delivery_target(
     }
     let tmux_session = json_text(session.get("tmux_session"))
         .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?;
+    let provider = json_text(session.get("provider")).unwrap_or_else(default_provider);
+    let delivery_route = if provider.eq_ignore_ascii_case("codex-fork") {
+        ReparentRuntimeDeliveryRoute::CodexForkControl {
+            control_socket: codex_fork_control_socket_path_for_session_raw(
+                session_id, session, runtime,
+            )
+            .map_err(|error| error.to_string()),
+        }
+    } else {
+        ReparentRuntimeDeliveryRoute::Tmux
+    };
     Ok(Some(ReparentRuntimeDeliveryTarget {
         tmux_session,
         tmux_socket_name: json_text(session.get("tmux_socket_name")),
+        delivery_route,
     }))
 }
 
@@ -22591,6 +22657,146 @@ mod tests {
 
         let _ = fs::remove_file(state_file);
         let _ = fs::remove_file(queue_db);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn reparent_notifications_retry_pending_codex_fork_control_delivery_without_tmux_fallback() {
+        use std::os::unix::net::UnixListener;
+
+        let root = env::temp_dir().join(format!("sm-rp-{}", generate_session_id()));
+        fs::create_dir_all(&root).unwrap();
+        let state_file = root.join("sessions.json");
+        let queue_db = root.join("messages.db");
+        let new_parent_id = generate_session_id();
+        let log_file = env::temp_dir().join(format!("sm-rp-{new_parent_id}.log"));
+        let mut new_parent = reparent_test_session(&new_parent_id, None, "new-secret");
+        new_parent["provider"] = json!("codex-fork");
+        new_parent["log_file"] = json!(log_file.display().to_string());
+        new_parent["error_message"] = json!("codex_fork_control_degraded: prior outage");
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [
+                    reparent_test_session("oldpar01", None, "old-secret"),
+                    new_parent,
+                    reparent_test_session("child001", Some("oldpar01"), "child-secret")
+                ]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let queue = RetainedQueueStore::new(queue_db.clone());
+        queue.ensure_schema().unwrap();
+        let mut config = crate::config::AppConfig::default();
+        config.codex_fork.control_tmux_fallback_enabled = false;
+        let runtime = TmuxRuntime::from_app_config(&config);
+        let control_socket = runtime
+            .codex_fork_runtime_artifacts(&TmuxSessionSpec {
+                session_id: new_parent_id.clone(),
+                session_credential: None,
+                tmux_session: format!("claude-{new_parent_id}"),
+                working_dir: "/repo".to_owned(),
+                log_file: log_file.clone(),
+                provider: "codex-fork".to_owned(),
+                initial_message: None,
+                force_initial_prompt_stdin: false,
+                model: None,
+                reasoning_effort: None,
+            })
+            .unwrap()
+            .unwrap()
+            .control_socket_path;
+        let store = SessionStore::new_with_queue(state_file.clone(), queue_db.clone())
+            .with_delivery_runtime(Some(runtime));
+        let request = match store
+            .create_reparent_request(
+                "child001",
+                CreateReparentRequest {
+                    requester_session_id: "oldpar01".to_owned(),
+                    target_parent_session_id: new_parent_id.clone(),
+                },
+                "old-secret",
+            )
+            .unwrap()
+        {
+            ReparentMutationOutcome::Created(record) => record,
+            other => panic!("unexpected create outcome: {other:?}"),
+        };
+
+        // The managed control socket is unavailable. Because terminal-session
+        // fallback is disabled, the durable notice remains pending.
+        store.reconcile_reparent_notifications().unwrap();
+        assert_eq!(
+            queue
+                .pending_messages_for_target_by_category(&new_parent_id, "reparent", 10)
+                .unwrap()
+                .len(),
+            1
+        );
+
+        let listener = UnixListener::bind(&control_socket).unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let server = thread::spawn(move || {
+            let mut requests = Vec::new();
+            let deadline = Instant::now() + Duration::from_secs(3);
+            while requests.len() < 2 && Instant::now() < deadline {
+                match listener.accept() {
+                    Ok((mut stream, _)) => {
+                        let mut raw_request = String::new();
+                        BufReader::new(stream.try_clone().unwrap())
+                            .read_line(&mut raw_request)
+                            .unwrap();
+                        let request: Value = serde_json::from_str(&raw_request).unwrap();
+                        let response = if requests.is_empty() {
+                            json!({
+                                "ok": true,
+                                "epoch": "epoch-1",
+                                "result": { "epoch": "epoch-1" }
+                            })
+                        } else {
+                            json!({ "ok": true, "epoch": "epoch-1", "result": {} })
+                        };
+                        writeln!(stream, "{}", serde_json::to_string(&response).unwrap()).unwrap();
+                        requests.push(request);
+                    }
+                    Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(10));
+                    }
+                    Err(error) => panic!("control listener failed: {error}"),
+                }
+            }
+            requests
+        });
+
+        // The request already has an enqueued intent, so this second pass is a
+        // retry of the retained row rather than a fresh notification.
+        store.reconcile_reparent_notifications().unwrap();
+        let requests = server.join().unwrap();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0]["command"], "get_epoch");
+        assert_eq!(requests[1]["command"], "submit_message");
+        assert!(requests[1]["message"]
+            .as_str()
+            .unwrap()
+            .contains(&format!("sm reparent approve {}", request.id)));
+        assert!(queue
+            .pending_messages_for_target_by_category(&new_parent_id, "reparent", 10)
+            .unwrap()
+            .is_empty());
+        let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+        assert!(state["sessions"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|session| session["id"] == new_parent_id)
+            .unwrap()["error_message"]
+            .is_null());
+
+        let _ = fs::remove_file(control_socket);
+        let _ = fs::remove_file(state_file);
+        let _ = fs::remove_file(queue_db);
+        let _ = fs::remove_dir(root);
     }
 
     #[test]

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -9,6 +9,7 @@ use base64::{
 };
 use futures_util::{future::join, StreamExt as _};
 use hmac::{Hmac, Mac};
+use nix::fcntl::{Flock, FlockArg};
 use rusqlite::{Connection, OptionalExtension};
 use serde_json::{json, Value};
 use sha1::{Digest, Sha1};
@@ -18327,6 +18328,140 @@ async fn reparent_request_read_marks_changed_topology_stale() {
         .as_str()
         .unwrap()
         .contains("parent changed"));
+}
+
+#[tokio::test]
+async fn reparent_request_polls_are_snapshot_only_while_apply_lock_is_held() {
+    let state_file = write_reparent_fixture();
+    let mut config = config_with_state_file(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let app = router(AppState::new(config));
+
+    let (status, created) = post_json_with_headers_and_peer(
+        app.clone(),
+        "/sessions/child/reparent-requests",
+        json!({
+            "requester_session_id": "oldparent",
+            "target_parent_session_id": "newparent"
+        }),
+        &[("x-sm-session-credential", "old-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let request_id = created["id"].as_str().unwrap().to_owned();
+
+    let before = fs::read(&state_file).unwrap();
+    let before_modified = fs::metadata(&state_file).unwrap().modified().unwrap();
+    let lock_file = fs::OpenOptions::new()
+        .create(true)
+        .read(true)
+        .write(true)
+        .open(state_file.with_extension("reparent-apply.lock"))
+        .unwrap();
+    let _apply_lock = Flock::lock(lock_file, FlockArg::LockExclusive).unwrap();
+
+    let polls = (0..32).map(|_| get_json(app.clone(), "/reparent-requests"));
+    let detail_uri = format!("/reparent-requests/{request_id}");
+    let detail = get_json(app.clone(), &detail_uri);
+    let (collections, (detail_status, detail)) =
+        tokio::time::timeout(Duration::from_millis(250), async {
+            (futures_util::future::join_all(polls).await, detail.await)
+        })
+        .await
+        .expect("reparent polls waited on the apply lock");
+    for (status, payload) in collections {
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(payload["requests"].as_array().unwrap().len(), 1);
+    }
+    assert_eq!(detail_status, StatusCode::OK);
+    assert_eq!(detail["id"], request_id);
+    assert_eq!(fs::read(&state_file).unwrap(), before);
+    assert_eq!(
+        fs::metadata(&state_file).unwrap().modified().unwrap(),
+        before_modified
+    );
+}
+
+#[tokio::test]
+async fn idle_reparent_background_pass_does_not_rewrite_state() {
+    let state_file = write_reparent_fixture();
+    let queue_db = queue_db_path_for_state_file(&state_file);
+    let mut config = config_with_state_file_and_queue(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let state = AppState::new(config);
+    let app = router(state.clone());
+
+    let (status, _) = post_json_with_headers_and_peer(
+        app,
+        "/sessions/child/reparent-requests",
+        json!({
+            "requester_session_id": "oldparent",
+            "target_parent_session_id": "newparent"
+        }),
+        &[("x-sm-session-credential", "old-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(queued_message_texts(&queue_db, "newparent").len(), 1);
+
+    let before = fs::read(&state_file).unwrap();
+    let before_modified = fs::metadata(&state_file).unwrap().modified().unwrap();
+    state.reconcile_reparent_background().unwrap();
+    assert_eq!(fs::read(&state_file).unwrap(), before);
+    assert_eq!(
+        fs::metadata(&state_file).unwrap().modified().unwrap(),
+        before_modified
+    );
+}
+
+#[tokio::test]
+async fn reparent_background_transition_persists_and_enqueues_terminal_intents() {
+    let state_file = write_reparent_fixture();
+    let queue_db = queue_db_path_for_state_file(&state_file);
+    let mut config = config_with_state_file_and_queue(&state_file);
+    config.rust_core.fixture_writes_enabled = true;
+    let state = AppState::new(config);
+    let app = router(state.clone());
+
+    let (status, created) = post_json_with_headers_and_peer(
+        app,
+        "/sessions/child/reparent-requests",
+        json!({
+            "requester_session_id": "oldparent",
+            "target_parent_session_id": "newparent"
+        }),
+        &[("x-sm-session-credential", "old-token")],
+        Some(SocketAddr::from(([127, 0, 0, 1], 49152))),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let request_id = created["id"].as_str().unwrap();
+
+    let mut raw_state: Value =
+        serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    raw_state["reparent_requests"][0]["expires_at"] = json!("2020-01-01T00:00:00Z");
+    fs::write(&state_file, serde_json::to_vec_pretty(&raw_state).unwrap()).unwrap();
+
+    state.reconcile_reparent_background().unwrap();
+
+    let raw_state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
+    let record = &raw_state["reparent_requests"][0];
+    assert_eq!(record["id"], request_id);
+    assert_eq!(record["status"], "expired");
+    let terminal_intents = record["notification_intents"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|intent| intent["event"] == "terminal:expired")
+        .collect::<Vec<_>>();
+    assert_eq!(terminal_intents.len(), 2);
+    assert!(terminal_intents
+        .iter()
+        .all(|intent| intent["enqueued_at"].as_str().is_some()));
+    assert_eq!(queued_message_texts(&queue_db, "newparent").len(), 2);
+    assert_eq!(queued_message_texts(&queue_db, "oldparent").len(), 1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #1315

## What changed

- Makes reparent collection and detail routes lock-free snapshot projections with no durable writes, queue operations, apply-lock acquisition, or runtime calls.
- Moves expiry/topology persistence and durable notification retry to a dedicated five-second background worker.
- Materializes idempotency-keyed notification intents whenever reparent records are stored, including terminal transitions.
- Delivers reparent runtime messages without holding the sessions write guard or cross-process apply lock; idle retries target only newly enqueued recipients.

## Why

`sm watch` polls had synchronously reconciled historical reparent notifications, which could serialize workers behind the apply lock and repeatedly rewrite the complete sessions registry. Runtime delivery could also hold the shared state lock while tmux blocked.

## Validation

- `cargo check -p sm-server`
- `cargo fmt --check`
- `git diff --check`
- Reparent focused suite, including a 32-concurrent-poll apply-lock hostile test, idle no-write test, terminal-transition outbox test, and live runtime-delivery test.
- Full isolated integration and unit suites were run. The remaining unrelated baseline failures are tracked in #1349 and #1350.