### PR TITLE
Fix codex-fork restore false success after rejected resume

### DIFF
--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -796,8 +796,14 @@ impl TmuxRuntime {
         if !self.session_exists(tmux_session)? {
             return Ok(false);
         }
-        self.run_tmux(["kill-session", "-t", tmux_session])?;
-        Ok(true)
+        match self.run_tmux(["kill-session", "-t", tmux_session]) {
+            Ok(()) => Ok(true),
+            // `kill_session` is intentionally idempotent. The session may
+            // exit after the existence check above but before tmux handles
+            // the kill request, which is still an already-absent outcome.
+            Err(error) if is_tmux_session_gone_error(&error) => Ok(false),
+            Err(error) => Err(error),
+        }
     }
 
     pub fn set_status_bar(&self, tmux_session: &str, friendly_name: &str) -> Result<bool> {
@@ -2576,6 +2582,32 @@ esac
     fn tmux_no_current_target_counts_as_session_gone() {
         let error = anyhow::anyhow!("tmux command failed: no current target");
         assert!(is_tmux_session_gone_error(&error));
+    }
+
+    #[test]
+    fn kill_session_treats_a_gone_race_as_already_absent() {
+        let (tmux_binary, _log_path, _temp_dir) = fake_tmux_binary();
+        fs::write(
+            &tmux_binary,
+            r#"#!/bin/sh
+if [ "$1" = "-L" ]; then
+  shift 2
+fi
+case "$1" in
+  has-session) exit 0 ;;
+  kill-session) echo "can't find session: sm-test" >&2; exit 1 ;;
+  *) exit 0 ;;
+esac
+"#,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&tmux_binary).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&tmux_binary, permissions).unwrap();
+        let mut runtime = TmuxRuntime::from_config(&RustCoreConfig::default());
+        runtime.tmux_binary = tmux_binary.display().to_string();
+
+        assert!(!runtime.kill_session("sm-test").unwrap());
     }
 
     #[test]

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -793,9 +793,11 @@ impl TmuxRuntime {
     }
 
     pub fn kill_session(&self, tmux_session: &str) -> Result<bool> {
-        if !self.session_exists(tmux_session)? {
-            return Ok(false);
-        }
+        // Do not preflight this with `has-session`: its nonzero status can
+        // mean either a genuinely absent target or that tmux could not be
+        // reached.  `kill-session` gives us the authoritative result for the
+        // operation we need to perform, and its known absent-target errors
+        // remain safely idempotent.
         match self.run_tmux(["kill-session", "-t", tmux_session]) {
             Ok(()) => Ok(true),
             // `kill_session` is intentionally idempotent. The session may
@@ -828,7 +830,14 @@ impl TmuxRuntime {
             .stderr(Stdio::piped())
             .output()
             .with_context(|| "failed to run tmux has-session")?;
-        Ok(output.status.success())
+        if output.status.success() {
+            return Ok(true);
+        }
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if is_tmux_session_gone_message(&stderr) {
+            return Ok(false);
+        }
+        bail!("tmux has-session failed: {}", stderr.trim());
     }
 
     fn create_session_with_bootstrap(&self, spec: &TmuxSessionSpec, command: &str) -> Result<()> {
@@ -1690,11 +1699,16 @@ fn duration_from_seconds(seconds: f64) -> Duration {
 }
 
 fn is_tmux_session_gone_error(error: &anyhow::Error) -> bool {
-    let message = error.to_string();
+    is_tmux_session_gone_message(&error.to_string())
+}
+
+fn is_tmux_session_gone_message(message: &str) -> bool {
     message.contains("no server running")
         || message.contains("can't find session")
         || message.contains("no current target")
         || message.contains("server exited unexpectedly")
+        || (message.contains("error connecting to ")
+            && message.contains("No such file or directory"))
 }
 
 fn shell_quote_path(path: &Path) -> String {
@@ -2611,6 +2625,32 @@ esac
     }
 
     #[test]
+    fn session_exists_rejects_tmux_transport_failures() {
+        let (tmux_binary, _log_path, _temp_dir) = fake_tmux_binary();
+        fs::write(
+            &tmux_binary,
+            r#"#!/bin/sh
+if [ "$1" = "-L" ]; then
+  shift 2
+fi
+case "$1" in
+  has-session) echo "permission denied while contacting tmux server" >&2; exit 1 ;;
+  *) exit 0 ;;
+esac
+"#,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&tmux_binary).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&tmux_binary, permissions).unwrap();
+        let mut runtime = TmuxRuntime::from_config(&RustCoreConfig::default());
+        runtime.tmux_binary = tmux_binary.display().to_string();
+
+        let error = runtime.session_exists("sm-test").unwrap_err();
+        assert!(error.to_string().contains("permission denied"));
+    }
+
+    #[test]
     fn set_status_bar_updates_tmux_status_left() {
         let (tmux_binary, log_path, _temp_dir) = fake_tmux_binary();
         let mut runtime = TmuxRuntime::from_config(&RustCoreConfig::default());
@@ -3207,7 +3247,12 @@ if [ "$1" = "-L" ]; then
   shift 2
 fi
 case "$1" in
-  has-session) exit {} ;;
+  has-session)
+    if [ {} -ne 0 ]; then
+      echo "can't find session: sm-test" >&2
+    fi
+    exit {}
+    ;;
   display-message) echo 0; exit 0 ;;
   capture-pane) printf 'ready\n>\n'; exit 0 ;;
   show-options) exit 0 ;;
@@ -3215,6 +3260,7 @@ case "$1" in
 esac
 "#,
                 log_path.display(),
+                if has_session { 0 } else { 1 },
                 if has_session { 0 } else { 1 }
             ),
         )

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -5730,6 +5730,7 @@ impl SessionStore {
                 CODEX_FORK_THREAD_STARTED_TIMEOUT,
                 session_runtime.startup_settle_duration(),
                 || session_runtime.session_exists(&record.tmux_session),
+                || session_runtime.accept_codex_directory_trust_prompt(&record.tmux_session),
             ) {
                 if let Err(teardown_error) = session_runtime.kill_session(&record.tmux_session) {
                     mark_runtime_launch_teardown_failed(
@@ -8968,21 +8969,24 @@ fn wait_for_codex_fork_provider_resume_id_after_offset(
 /// did not immediately disappear. Unlike a fresh launch, a restore must never
 /// accept a newly-created root thread in place of the identity it was asked to
 /// resume.
-fn wait_for_codex_fork_restore_acceptance<F>(
+fn wait_for_codex_fork_restore_acceptance<F, H>(
     event_stream_path: &Path,
     initial_offset: u64,
     expected_provider_resume_id: &str,
     timeout: Duration,
     liveness_window: Duration,
     mut runtime_is_live: F,
+    mut handle_startup_prompt: H,
 ) -> Result<()>
 where
     F: FnMut() -> Result<bool>,
+    H: FnMut() -> Result<bool>,
 {
     let started = Instant::now();
     let mut accepted_at = None;
     let mut offset = initial_offset;
     let mut buffer = String::new();
+    let mut directory_trust_accepted = false;
     loop {
         if !runtime_is_live()? {
             anyhow::bail!(
@@ -9012,6 +9016,9 @@ where
                     accepted_at.get_or_insert_with(Instant::now);
                 }
             }
+        }
+        if !directory_trust_accepted {
+            directory_trust_accepted = handle_startup_prompt()?;
         }
         if let Some(accepted_at) = accepted_at {
             if accepted_at.elapsed() >= liveness_window {
@@ -20195,9 +20202,44 @@ mod tests {
             Duration::from_millis(50),
             Duration::ZERO,
             || Ok(true),
+            || Ok(false),
         )
         .unwrap();
 
+        let _ = fs::remove_file(event_stream_path);
+    }
+
+    #[test]
+    fn codex_fork_restore_acceptance_accepts_directory_trust_before_thread_start() {
+        let event_stream_path = unique_temp_path("codex-restore-trust-events");
+        fs::write(&event_stream_path, "").unwrap();
+        let writer_path = event_stream_path.clone();
+        let writer = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(125));
+            fs::write(
+                writer_path,
+                "{\"event_type\":\"thread_started\",\"payload\":{\"thread\":{\"id\":\"durable-root\"}}}\n",
+            )
+            .unwrap();
+        });
+        let mut prompt_checks = 0;
+
+        wait_for_codex_fork_restore_acceptance(
+            &event_stream_path,
+            0,
+            "durable-root",
+            Duration::from_secs(1),
+            Duration::ZERO,
+            || Ok(true),
+            || {
+                prompt_checks += 1;
+                Ok(true)
+            },
+        )
+        .unwrap();
+
+        assert_eq!(prompt_checks, 1);
+        writer.join().unwrap();
         let _ = fs::remove_file(event_stream_path);
     }
 
@@ -20219,6 +20261,7 @@ mod tests {
             Duration::from_millis(50),
             Duration::ZERO,
             || Ok(true),
+            || Ok(false),
         )
         .unwrap_err();
         assert!(format!("{error:#}").contains("provider ended"));
@@ -20242,6 +20285,7 @@ mod tests {
             Duration::from_millis(50),
             Duration::ZERO,
             || Ok(true),
+            || Ok(false),
         )
         .unwrap_err();
         assert!(mismatch
@@ -20257,6 +20301,7 @@ mod tests {
             Duration::ZERO,
             Duration::ZERO,
             || Ok(true),
+            || Ok(false),
         )
         .unwrap_err();
         assert!(timeout.to_string().contains("timed out waiting"));
@@ -20267,6 +20312,7 @@ mod tests {
             "durable-root",
             Duration::from_millis(50),
             Duration::ZERO,
+            || Ok(false),
             || Ok(false),
         )
         .unwrap_err();

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -873,6 +873,28 @@ impl SessionStore {
         if !matches!(launch.status.as_str(), "prepared" | "launching") {
             return Ok(());
         }
+        if launch.operation_kind == "restore" && launch.provider == "codex-fork" {
+            // A Codex-fork restore is not live until its provider has bound
+            // the exact durable root-thread identity and remained alive for
+            // its acceptance window. A server restart while that proof is in
+            // flight leaves the launch ambiguous, so never replay it: doing
+            // so can silently create or bind a different provider thread.
+            if let Some(runtime) = self.delivery_runtime.as_ref() {
+                let session_runtime = runtime.for_socket_name(launch.tmux_socket_name.as_deref());
+                if session_runtime.session_exists(&launch.tmux_session)? {
+                    session_runtime.kill_session(&launch.tmux_session)?;
+                }
+            }
+            mark_runtime_launch_failed(
+                &mut state,
+                launch_id,
+                &launch.session_id,
+                false,
+                "interrupted codex-fork restore acceptance requires an explicit manual restore",
+            )?;
+            self.write_raw_json_value(&state)?;
+            return Ok(());
+        }
         let terminal_session = snapshot_from_raw_value(&state)?
             .sessions
             .iter()
@@ -5647,6 +5669,36 @@ impl SessionStore {
             return Err(error);
         }
 
+        if let Some(artifacts) = codex_fork_artifacts.as_ref() {
+            let expected_provider_resume_id = provider_resume_id.as_deref().ok_or_else(|| {
+                anyhow::anyhow!("codex-fork restore is missing its provider resume id")
+            })?;
+            if let Err(error) = wait_for_codex_fork_restore_acceptance(
+                &artifacts.event_stream_path,
+                0,
+                expected_provider_resume_id,
+                CODEX_FORK_THREAD_STARTED_TIMEOUT,
+                session_runtime.startup_settle_duration(),
+                || session_runtime.session_exists(&record.tmux_session),
+            ) {
+                let _ = session_runtime.kill_session(&record.tmux_session);
+                mark_runtime_launch_failed(
+                    &mut state,
+                    &launch_id,
+                    &record.id,
+                    false,
+                    &error.to_string(),
+                )?;
+                self.write_raw_json_value(&state)?;
+                return Err(error).with_context(|| {
+                    format!(
+                        "codex-fork session {} did not accept durable provider resume id {expected_provider_resume_id}",
+                        record.id
+                    )
+                });
+            }
+        }
+
         let sessions = ensure_sessions_array_mut(&mut state)?;
         let Some(session) = session_object_mut(sessions, session_id) else {
             return Ok(None);
@@ -5660,6 +5712,7 @@ impl SessionStore {
         session.insert("terminal_provenance".to_owned(), Value::Null);
         session.insert("retirement_intent".to_owned(), Value::Null);
         session.insert("agent_task_completed_at".to_owned(), Value::Null);
+        session.insert("error_message".to_owned(), Value::Null);
         session.insert("last_activity".to_owned(), Value::String(now));
         if let Some(socket_name) = session_runtime.socket_name() {
             session.insert(
@@ -8845,6 +8898,69 @@ fn wait_for_codex_fork_provider_resume_id_after_offset(
     )
 }
 
+/// Prove that a Codex-fork restore resumed the exact durable root thread and
+/// did not immediately disappear. Unlike a fresh launch, a restore must never
+/// accept a newly-created root thread in place of the identity it was asked to
+/// resume.
+fn wait_for_codex_fork_restore_acceptance<F>(
+    event_stream_path: &Path,
+    initial_offset: u64,
+    expected_provider_resume_id: &str,
+    timeout: Duration,
+    liveness_window: Duration,
+    mut runtime_is_live: F,
+) -> Result<()>
+where
+    F: FnMut() -> Result<bool>,
+{
+    let started = Instant::now();
+    let mut accepted_at = None;
+    let mut offset = initial_offset;
+    let mut buffer = String::new();
+    loop {
+        if !runtime_is_live()? {
+            anyhow::bail!(
+                "codex-fork tmux runtime disappeared while waiting for restore acceptance"
+            );
+        }
+        if let Ok(chunk) = read_file_from_offset(event_stream_path, &mut offset) {
+            for line in split_complete_event_lines(&mut buffer, &chunk) {
+                let Ok(event) = serde_json::from_str::<Value>(line.trim()) else {
+                    continue;
+                };
+                let Some(event) = event.as_object() else {
+                    continue;
+                };
+                if codex_fork_event_ends_session(event) {
+                    anyhow::bail!(
+                        "codex-fork provider ended before restore acceptance in {}",
+                        event_stream_path.display()
+                    );
+                }
+                if let Some(provider_resume_id) = extract_codex_fork_thread_started(event) {
+                    if provider_resume_id != expected_provider_resume_id {
+                        anyhow::bail!(
+                            "codex-fork restore bound unexpected root thread {provider_resume_id}; expected {expected_provider_resume_id}"
+                        );
+                    }
+                    accepted_at.get_or_insert_with(Instant::now);
+                }
+            }
+        }
+        if let Some(accepted_at) = accepted_at {
+            if accepted_at.elapsed() >= liveness_window {
+                return Ok(());
+            }
+        } else if started.elapsed() >= timeout {
+            anyhow::bail!(
+                "timed out waiting for codex-fork restore to bind root thread {expected_provider_resume_id} in {}",
+                event_stream_path.display()
+            );
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
+}
+
 fn wait_for_codex_fork_provider_resume_id_after_offset_with_startup<F>(
     event_stream_path: &Path,
     initial_offset: u64,
@@ -9085,6 +9201,18 @@ fn codex_fork_status_for_event(event: &Map<String, Value>) -> Option<&'static st
         other if other.ends_with("_begin") => Some("running"),
         _ => None,
     }
+}
+
+fn codex_fork_event_ends_session(event: &Map<String, Value>) -> bool {
+    matches!(
+        normalize_codex_fork_event_type(
+            &codex_fork_event_type(event)
+                .unwrap_or_default()
+                .replace('/', "_")
+        )
+        .as_str(),
+        "session_end" | "shutdown" | "shutdown_complete"
+    )
 }
 
 fn codex_fork_event_starts_turn(event: &Map<String, Value>) -> bool {
@@ -14348,6 +14476,10 @@ fn mark_runtime_launch_failed(
         if let Some(session) = session_object_mut(sessions, session_id) {
             session.insert("status".to_owned(), Value::String("stopped".to_owned()));
             session.insert("stopped_at".to_owned(), Value::String(now_rfc3339()));
+            session.insert(
+                "error_message".to_owned(),
+                Value::String(format!("runtime launch failed: {failure_reason}")),
+            );
         }
     }
     Ok(())
@@ -17010,6 +17142,66 @@ mod tests {
         assert_eq!(
             state["session_credential_rotations"][0]["failure_reason"],
             "target_terminal"
+        );
+        let _ = fs::remove_file(state_file);
+    }
+
+    #[test]
+    fn restart_recovery_fails_ambiguous_codex_fork_restore_without_relaunching() {
+        let state_file = unique_temp_path("codex-fork-restore-recovery");
+        let (tmux_socket_name, runtime) = isolated_test_tmux_runtime();
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [{
+                    "id": "restore01",
+                    "name": "restore-codex-fork",
+                    "provider": "codex-fork",
+                    "provider_resume_id": "durable-root",
+                    "working_dir": "/tmp",
+                    "tmux_session": "codex-fork-restore01",
+                    "tmux_socket_name": tmux_socket_name,
+                    "log_file": "/tmp/codex-fork-restore01.log",
+                    "status": "stopped",
+                    "completion_status": "killed",
+                    "created_at": "2026-08-18T00:00:00Z",
+                    "last_activity": "2026-08-18T00:00:00Z"
+                }],
+                "session_runtime_launches": [{
+                    "id": "launch01",
+                    "operation_kind": "restore",
+                    "session_id": "restore01",
+                    "tmux_session": "codex-fork-restore01",
+                    "tmux_socket_name": tmux_socket_name,
+                    "working_dir": "/tmp",
+                    "log_file": "/tmp/codex-fork-restore01.log",
+                    "provider": "codex-fork",
+                    "provider_resume_id": "durable-root",
+                    "restore_authorized": true,
+                    "credential_sha256": "test-credential",
+                    "status": "launching",
+                    "created_at": "2026-08-18T00:00:00Z",
+                    "updated_at": "2026-08-18T00:00:00Z"
+                }]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let store = SessionStore::new(state_file.clone()).with_delivery_runtime(Some(runtime));
+
+        store.recover_session_runtime_launches().unwrap();
+
+        let state = store.load_raw_json_value().unwrap();
+        assert_eq!(state["sessions"][0]["status"], "stopped");
+        assert_eq!(state["sessions"][0]["provider_resume_id"], "durable-root");
+        assert!(state["sessions"][0]["error_message"]
+            .as_str()
+            .unwrap()
+            .contains("explicit manual restore"));
+        assert_eq!(state["session_runtime_launches"][0]["status"], "failed");
+        assert_eq!(
+            state["session_runtime_launches"][0]["failure_reason"],
+            "interrupted codex-fork restore acceptance requires an explicit manual restore"
         );
         let _ = fs::remove_file(state_file);
     }
@@ -19813,6 +20005,182 @@ mod tests {
     }
 
     #[test]
+    fn codex_fork_restore_acceptance_requires_exact_root_identity_and_liveness() {
+        let event_stream_path = unique_temp_path("codex-restore-acceptance-valid");
+        fs::write(
+            &event_stream_path,
+            r#"{"event_type":"thread/started","payload":{"thread":{"id":"durable-root"}}}
+"#,
+        )
+        .unwrap();
+
+        wait_for_codex_fork_restore_acceptance(
+            &event_stream_path,
+            0,
+            "durable-root",
+            Duration::from_millis(50),
+            Duration::ZERO,
+            || Ok(true),
+        )
+        .unwrap();
+
+        let _ = fs::remove_file(event_stream_path);
+    }
+
+    #[test]
+    fn codex_fork_restore_acceptance_rejects_provider_end_without_thread_start() {
+        let event_stream_path = unique_temp_path("codex-restore-acceptance-ended");
+        fs::write(
+            &event_stream_path,
+            r#"{"event_type":"session_start","payload":{}}
+{"event_type":"session_end","payload":{}}
+"#,
+        )
+        .unwrap();
+
+        let error = wait_for_codex_fork_restore_acceptance(
+            &event_stream_path,
+            0,
+            "durable-root",
+            Duration::from_millis(50),
+            Duration::ZERO,
+            || Ok(true),
+        )
+        .unwrap_err();
+        assert!(format!("{error:#}").contains("provider ended"));
+
+        let _ = fs::remove_file(event_stream_path);
+    }
+
+    #[test]
+    fn codex_fork_restore_acceptance_rejects_mismatch_timeout_and_tmux_loss() {
+        let mismatch_path = unique_temp_path("codex-restore-acceptance-mismatch");
+        fs::write(
+            &mismatch_path,
+            r#"{"event_type":"thread_started","payload":{"thread":{"id":"new-root"}}}
+"#,
+        )
+        .unwrap();
+        let mismatch = wait_for_codex_fork_restore_acceptance(
+            &mismatch_path,
+            0,
+            "durable-root",
+            Duration::from_millis(50),
+            Duration::ZERO,
+            || Ok(true),
+        )
+        .unwrap_err();
+        assert!(mismatch
+            .to_string()
+            .contains("unexpected root thread new-root"));
+
+        let timeout_path = unique_temp_path("codex-restore-acceptance-timeout");
+        fs::write(&timeout_path, "").unwrap();
+        let timeout = wait_for_codex_fork_restore_acceptance(
+            &timeout_path,
+            0,
+            "durable-root",
+            Duration::ZERO,
+            Duration::ZERO,
+            || Ok(true),
+        )
+        .unwrap_err();
+        assert!(timeout.to_string().contains("timed out waiting"));
+
+        let tmux_loss = wait_for_codex_fork_restore_acceptance(
+            &timeout_path,
+            0,
+            "durable-root",
+            Duration::from_millis(50),
+            Duration::ZERO,
+            || Ok(false),
+        )
+        .unwrap_err();
+        assert!(tmux_loss.to_string().contains("tmux runtime disappeared"));
+
+        let _ = fs::remove_file(mismatch_path);
+        let _ = fs::remove_file(timeout_path);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn codex_fork_restore_projects_running_only_after_exact_provider_acceptance() {
+        let Some(fixture) = CodexForkRestoreFixture::new("valid", "valid") else {
+            return;
+        };
+
+        let restored = fixture
+            .store()
+            .restore_core_session_with_runtime("restore01", &fixture.runtime)
+            .unwrap()
+            .unwrap();
+        let CoreRestoreOutcome::Restored(restored) = restored else {
+            panic!("restore did not report success");
+        };
+
+        assert_eq!(restored.status, "running");
+        assert_eq!(restored.provider_resume_id.as_deref(), Some("durable-root"));
+        let state = fixture.store().load_raw_json_value().unwrap();
+        assert_eq!(state["sessions"][0]["status"], "running");
+        assert_eq!(state["sessions"][0]["error_message"], Value::Null);
+        assert_eq!(state["session_runtime_launches"][0]["status"], "applied");
+        assert!(fixture
+            .runtime
+            .session_exists("codex-fork-restore01")
+            .unwrap());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn codex_fork_restore_provider_end_leaves_truthful_stopped_projection() {
+        let Some(fixture) = CodexForkRestoreFixture::new("provider-end", "provider-end") else {
+            return;
+        };
+
+        let error = fixture
+            .store()
+            .restore_core_session_with_runtime("restore01", &fixture.runtime)
+            .unwrap_err();
+        assert!(format!("{error:#}").contains("provider ended"));
+
+        let state = fixture.store().load_raw_json_value().unwrap();
+        assert_eq!(state["sessions"][0]["status"], "stopped");
+        assert_eq!(state["sessions"][0]["provider_resume_id"], "durable-root");
+        assert!(state["sessions"][0]["error_message"]
+            .as_str()
+            .unwrap()
+            .contains("provider ended"));
+        assert_eq!(state["session_runtime_launches"][0]["status"], "failed");
+        assert!(!fixture
+            .runtime
+            .session_exists("codex-fork-restore01")
+            .unwrap());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn codex_fork_restore_immediate_exit_leaves_truthful_stopped_projection() {
+        let Some(fixture) = CodexForkRestoreFixture::new("immediate-exit", "immediate-exit") else {
+            return;
+        };
+
+        assert!(fixture
+            .store()
+            .restore_core_session_with_runtime("restore01", &fixture.runtime)
+            .is_err());
+
+        let state = fixture.store().load_raw_json_value().unwrap();
+        assert_eq!(state["sessions"][0]["status"], "stopped");
+        assert_eq!(state["sessions"][0]["provider_resume_id"], "durable-root");
+        assert!(state["sessions"][0]["error_message"].is_string());
+        assert_eq!(state["session_runtime_launches"][0]["status"], "failed");
+        assert!(!fixture
+            .runtime
+            .session_exists("codex-fork-restore01")
+            .unwrap());
+    }
+
+    #[test]
     fn codex_fork_launch_binding_accepts_trust_before_root_thread_starts() {
         let event_stream_path = unique_temp_path("codex-trust-bind-events");
         fs::write(&event_stream_path, "").unwrap();
@@ -20260,6 +20628,129 @@ mod tests {
         log_file: PathBuf,
         tmux_socket: String,
         tmux_session: String,
+    }
+
+    #[cfg(unix)]
+    struct CodexForkRestoreFixture {
+        state_file: PathBuf,
+        fixture_dir: PathBuf,
+        tmux_socket: String,
+        runtime: TmuxRuntime,
+    }
+
+    #[cfg(unix)]
+    impl CodexForkRestoreFixture {
+        fn new(label: &str, outcome: &str) -> Option<Self> {
+            if !Command::new("tmux")
+                .arg("-V")
+                .output()
+                .ok()?
+                .status
+                .success()
+            {
+                return None;
+            }
+            let state_file = unique_temp_path(&format!("codex-restore-{label}"));
+            let fixture_dir = state_file.with_extension("dir");
+            fs::create_dir_all(&fixture_dir).ok()?;
+            let command_path = fixture_dir.join("fake-codex-fork");
+            let script = match outcome {
+                "valid" => {
+                    r#"#!/bin/sh
+event_stream=''
+resume_id=''
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --event-stream) event_stream="$2"; shift 2 ;;
+    resume | --resume) resume_id="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+printf '{"event_type":"thread_started","payload":{"thread":{"id":"%s"}}}\n' "$resume_id" >> "$event_stream"
+sleep 30
+"#
+                }
+                "provider-end" => {
+                    r#"#!/bin/sh
+event_stream=''
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --event-stream) event_stream="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+printf '%s\n' '{"event_type":"session_start","payload":{}}' >> "$event_stream"
+printf '%s\n' '{"event_type":"session_end","payload":{}}' >> "$event_stream"
+sleep 30
+"#
+                }
+                "immediate-exit" => "#!/bin/sh\nexit 0\n",
+                _ => return None,
+            };
+            fs::write(&command_path, script).ok()?;
+            let mut permissions = fs::metadata(&command_path).ok()?.permissions();
+            permissions.set_mode(0o700);
+            fs::set_permissions(&command_path, permissions).ok()?;
+
+            let tmux_socket = format!(
+                "sm-1324-{}-{}",
+                std::process::id(),
+                OffsetDateTime::now_utc().unix_timestamp_nanos()
+            );
+            let mut config = AppConfig::default();
+            config.rust_core.tmux_socket_name = Some(tmux_socket.clone());
+            config.rust_core.runtime_start_settle_ms = Some(20);
+            config.codex_fork.command = command_path.display().to_string();
+            config.codex_fork.args = Vec::new();
+            let runtime = TmuxRuntime::from_app_config(&config);
+            let log_file = fixture_dir.join("restore01.log");
+            fs::write(
+                &state_file,
+                json!({
+                    "sessions": [{
+                        "id": "restore01",
+                        "name": "restore-codex-fork",
+                        "provider": "codex-fork",
+                        "provider_resume_id": "durable-root",
+                        "working_dir": fixture_dir.display().to_string(),
+                        "tmux_session": "codex-fork-restore01",
+                        "tmux_socket_name": tmux_socket,
+                        "log_file": log_file.display().to_string(),
+                        "status": "stopped",
+                        "stopped_at": "2026-08-18T00:00:00Z",
+                        "completion_status": "killed",
+                        "completion_message": "previous runtime stopped",
+                        "created_at": "2026-08-18T00:00:00Z",
+                        "last_activity": "2026-08-18T00:00:00Z"
+                    }]
+                })
+                .to_string(),
+            )
+            .ok()?;
+            Some(Self {
+                state_file,
+                fixture_dir,
+                tmux_socket,
+                runtime,
+            })
+        }
+
+        fn store(&self) -> SessionStore {
+            SessionStore::new_with_legacy_fallback(self.state_file.clone(), self.state_file.clone())
+        }
+    }
+
+    #[cfg(unix)]
+    impl Drop for CodexForkRestoreFixture {
+        fn drop(&mut self) {
+            let _ = Command::new("tmux")
+                .args(["-L", &self.tmux_socket, "kill-server"])
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status();
+            let _ = fs::remove_file(&self.state_file);
+            let _ = fs::remove_dir_all(&self.fixture_dir);
+        }
     }
 
     impl CodexForkHandoffFixture {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -881,8 +881,17 @@ impl SessionStore {
             // so can silently create or bind a different provider thread.
             if let Some(runtime) = self.delivery_runtime.as_ref() {
                 let session_runtime = runtime.for_socket_name(launch.tmux_socket_name.as_deref());
-                if session_runtime.session_exists(&launch.tmux_session)? {
-                    session_runtime.kill_session(&launch.tmux_session)?;
+                if let Err(error) = session_runtime.kill_session(&launch.tmux_session) {
+                    mark_runtime_launch_teardown_failed(
+                        &mut state,
+                        launch_id,
+                        &launch.session_id,
+                        &format!(
+                            "interrupted codex-fork restore acceptance could not tear down its runtime: {error}"
+                        ),
+                    )?;
+                    self.write_raw_json_value(&state)?;
+                    return Ok(());
                 }
             }
             mark_runtime_launch_failed(
@@ -1005,10 +1014,17 @@ impl SessionStore {
             } else {
                 None
             };
+        if let Err(error) = session_runtime.kill_session(&launch.tmux_session) {
+            mark_runtime_launch_teardown_failed(
+                &mut state,
+                launch_id,
+                &launch.session_id,
+                &format!("failed to tear down prior runtime during launch recovery: {error}"),
+            )?;
+            self.write_raw_json_value(&state)?;
+            return Ok(());
+        }
         let result = (|| -> Result<()> {
-            if session_runtime.session_exists(&launch.tmux_session)? {
-                session_runtime.kill_session(&launch.tmux_session)?;
-            }
             if launch.operation_kind == "create" {
                 session_runtime.create_session(&spec)
             } else {
@@ -1055,7 +1071,20 @@ impl SessionStore {
                         recovered_provider_resume_id = Some(provider_resume_id);
                     }
                     Err(error) => {
-                        let _ = session_runtime.kill_session(&launch.tmux_session);
+                        if let Err(teardown_error) =
+                            session_runtime.kill_session(&launch.tmux_session)
+                        {
+                            mark_runtime_launch_teardown_failed(
+                                &mut state,
+                                launch_id,
+                                &launch.session_id,
+                                &format!(
+                                    "{error}; failed to tear down runtime after provider startup rejection: {teardown_error}"
+                                ),
+                            )?;
+                            self.write_raw_json_value(&state)?;
+                            return Ok(());
+                        }
                         mark_runtime_launch_failed(
                             &mut state,
                             launch_id,
@@ -1400,10 +1429,17 @@ impl SessionStore {
         store_session_credential_rotation_records(&mut state, &rotations)?;
         self.write_raw_json_value(&state)?;
 
+        if let Err(error) = session_runtime.kill_session(&session.tmux_session) {
+            mark_runtime_launch_teardown_failed(
+                &mut state,
+                &launch_id,
+                session_id,
+                &format!("failed to tear down prior runtime before credential relaunch: {error}"),
+            )?;
+            self.write_raw_json_value(&state)?;
+            return Ok(true);
+        }
         let relaunch_result = (|| -> Result<()> {
-            if session_runtime.session_exists(&session.tmux_session)? {
-                session_runtime.kill_session(&session.tmux_session)?;
-            }
             session_runtime.restore_session(
                 &spec,
                 &session.provider,
@@ -4380,9 +4416,26 @@ impl SessionStore {
                     record.provider_resume_id = Some(provider_resume_id);
                 }
                 Err(error) => {
-                    let _ = runtime.kill_session(&record.tmux_session);
+                    let teardown_error = runtime.kill_session(&record.tmux_session).err();
                     let _guard = self.write_guard()?;
                     let mut state = self.load_raw_json_value()?;
+                    if let Some(teardown_error) = teardown_error {
+                        mark_runtime_launch_teardown_failed(
+                            &mut state,
+                            &launch_id,
+                            &record.id,
+                            &format!(
+                                "{error}; failed to tear down runtime after provider startup rejection: {teardown_error}"
+                            ),
+                        )?;
+                        self.write_raw_json_value(&state)?;
+                        return Err(error).with_context(|| {
+                            format!(
+                                "codex-fork session {} did not publish a provider resume id",
+                                record.id
+                            )
+                        });
+                    }
                     let remove_provisional_session =
                         remove_failed_provisional_runtime_session(&state, &record.id);
                     mark_runtime_launch_failed(
@@ -5642,18 +5695,15 @@ impl SessionStore {
         store_session_runtime_launch_records(&mut state, &launch_records)?;
         self.write_raw_json_value(&state)?;
 
-        if session_runtime.session_exists(&record.tmux_session)? {
-            if let Err(error) = session_runtime.kill_session(&record.tmux_session) {
-                mark_runtime_launch_failed(
-                    &mut state,
-                    &launch_id,
-                    &record.id,
-                    false,
-                    &format!("failed to tear down prior runtime before restore: {error}"),
-                )?;
-                self.write_raw_json_value(&state)?;
-                return Err(error);
-            }
+        if let Err(error) = session_runtime.kill_session(&record.tmux_session) {
+            mark_runtime_launch_teardown_failed(
+                &mut state,
+                &launch_id,
+                &record.id,
+                &format!("failed to tear down prior runtime before restore: {error}"),
+            )?;
+            self.write_raw_json_value(&state)?;
+            return Err(error);
         }
         if let Err(error) =
             session_runtime.restore_session(&spec, &record.provider, provider_resume_id.as_deref())
@@ -5681,7 +5731,23 @@ impl SessionStore {
                 session_runtime.startup_settle_duration(),
                 || session_runtime.session_exists(&record.tmux_session),
             ) {
-                let _ = session_runtime.kill_session(&record.tmux_session);
+                if let Err(teardown_error) = session_runtime.kill_session(&record.tmux_session) {
+                    mark_runtime_launch_teardown_failed(
+                        &mut state,
+                        &launch_id,
+                        &record.id,
+                        &format!(
+                            "{error}; failed to tear down runtime after restore acceptance rejection: {teardown_error}"
+                        ),
+                    )?;
+                    self.write_raw_json_value(&state)?;
+                    return Err(error).with_context(|| {
+                        format!(
+                            "codex-fork session {} did not accept durable provider resume id {expected_provider_resume_id}",
+                            record.id
+                        )
+                    });
+                }
                 mark_runtime_launch_failed(
                     &mut state,
                     &launch_id,
@@ -14485,6 +14551,64 @@ fn mark_runtime_launch_failed(
     Ok(())
 }
 
+/// Record an inconclusive teardown without claiming the runtime is stopped.
+///
+/// A tmux command error is not evidence that the target process is gone. The
+/// session remains operator-visible and fenced from another restore until the
+/// runtime can be inspected or explicitly retired.
+fn mark_runtime_launch_teardown_failed(
+    state: &mut Value,
+    launch_id: &str,
+    session_id: &str,
+    failure_reason: &str,
+) -> Result<()> {
+    let mut records = session_runtime_launch_records(state)?;
+    let record = records
+        .iter_mut()
+        .find(|record| record.id == launch_id)
+        .ok_or_else(|| anyhow::anyhow!("runtime launch {launch_id} disappeared"))?;
+    record.status = "failed".to_owned();
+    record.updated_at = now_rfc3339();
+    record.failure_reason = Some(failure_reason.to_owned());
+    let credential_rotation_id = record.credential_rotation_id.clone();
+    let restore_authorized = record.is_authorized_restore_intent();
+    store_session_runtime_launch_records(state, &records)?;
+    if let Some(credential_rotation_id) = credential_rotation_id {
+        let mut rotations = session_credential_rotation_records(state)?;
+        if let Some(rotation) = rotations
+            .iter_mut()
+            .find(|rotation| rotation.id == credential_rotation_id)
+        {
+            rotation.status = "failed".to_owned();
+            rotation.updated_at = now_rfc3339();
+            rotation.failure_reason = Some(failure_reason.to_owned());
+            rotation.runtime_launch_id = Some(launch_id.to_owned());
+            store_session_credential_rotation_records(state, &rotations)?;
+        }
+    }
+    let sessions = ensure_sessions_array_mut(state)?;
+    if let Some(session) = session_object_mut(sessions, session_id) {
+        // An explicitly admitted restore already has authority to clear its
+        // prior terminal marker. Retain that intent when teardown is unknown;
+        // otherwise raw_session_is_stopped would hide the live runtime.
+        if restore_authorized {
+            session.insert("completion_status".to_owned(), Value::Null);
+            session.insert("completion_message".to_owned(), Value::Null);
+            session.insert("completed_at".to_owned(), Value::Null);
+            session.insert("terminal_provenance".to_owned(), Value::Null);
+            session.insert("retirement_intent".to_owned(), Value::Null);
+            session.insert("agent_task_completed_at".to_owned(), Value::Null);
+        }
+        session.insert("status".to_owned(), Value::String("error".to_owned()));
+        session.insert("stopped_at".to_owned(), Value::Null);
+        session.insert(
+            "error_message".to_owned(),
+            Value::String(format!("runtime teardown failed: {failure_reason}")),
+        );
+    }
+    Ok(())
+}
+
 fn reparent_topology_fingerprint(
     kind: &str,
     subject_session_id: &str,
@@ -17204,6 +17328,56 @@ mod tests {
             "interrupted codex-fork restore acceptance requires an explicit manual restore"
         );
         let _ = fs::remove_file(state_file);
+    }
+
+    #[test]
+    fn runtime_teardown_failure_keeps_an_authorized_restore_operator_visible() {
+        let mut state = json!({
+            "sessions": [{
+                "id": "restore01",
+                "name": "restore-codex-fork",
+                "provider": "codex-fork",
+                "working_dir": "/tmp",
+                "tmux_session": "codex-fork-restore01",
+                "status": "stopped",
+                "completion_status": "killed",
+                "created_at": "2026-08-18T00:00:00Z",
+                "last_activity": "2026-08-18T00:00:00Z"
+            }],
+            "session_runtime_launches": [{
+                "id": "launch01",
+                "operation_kind": "restore",
+                "session_id": "restore01",
+                "tmux_session": "codex-fork-restore01",
+                "working_dir": "/tmp",
+                "log_file": "/tmp/codex-fork-restore01.log",
+                "provider": "codex-fork",
+                "provider_resume_id": "durable-root",
+                "restore_authorized": true,
+                "credential_sha256": "test-credential",
+                "status": "launching",
+                "created_at": "2026-08-18T00:00:00Z",
+                "updated_at": "2026-08-18T00:00:00Z"
+            }]
+        });
+
+        mark_runtime_launch_teardown_failed(
+            &mut state,
+            "launch01",
+            "restore01",
+            "tmux transport failed",
+        )
+        .unwrap();
+
+        let session = state["sessions"][0].as_object().unwrap();
+        assert_eq!(session["status"], "error");
+        assert!(session["completion_status"].is_null());
+        assert!(!raw_session_is_stopped(session));
+        assert!(session["error_message"]
+            .as_str()
+            .unwrap()
+            .contains("tmux transport failed"));
+        assert_eq!(state["session_runtime_launches"][0]["status"], "failed");
     }
 
     #[test]

--- a/specs/1324_codex_fork_restore_acceptance.md
+++ b/specs/1324_codex_fork_restore_acceptance.md
@@ -18,6 +18,10 @@ window before applying the restore.
 `session_end`, `shutdown`, a mismatched root thread, a missing root-thread
 event, or missing tmux runtime fails the launch. The failure keeps the stored
 resume identity, leaves the session stopped, and records an actionable reason.
+If tmux teardown itself cannot be confirmed, the session instead remains
+operator-visible in an error state and is fenced from another restore; a
+failed tmux command is not proof that the runtime stopped. A normal
+already-gone tmux race is idempotent and still reaches the stopped projection.
 Interrupted Codex-fork restore acceptance is ambiguous after process restart,
 so recovery fails it conservatively rather than replaying the launch.
 
@@ -30,6 +34,8 @@ so recovery fails it conservatively rather than replaying the launch.
 - tmux disappearance;
 - restart recovery; and
 - stopped durable projection with an actionable error reason.
+- teardown failure preserves an operator-visible error projection, while an
+  already-gone tmux race remains a successful teardown.
 
 ## Classification
 

--- a/specs/1324_codex_fork_restore_acceptance.md
+++ b/specs/1324_codex_fork_restore_acceptance.md
@@ -1,0 +1,38 @@
+# #1324 Codex-fork restore acceptance
+
+## Problem
+
+The Rust restore lifecycle treated a successful tmux launch as a successful
+Codex-fork resume. A provider that rejected the saved, account-bound root
+thread could exit immediately while the durable session was already projected
+as running.
+
+## Approach
+
+Keep a Codex-fork restore stopped and its runtime-launch record `launching`
+until the newly created event stream publishes a root `thread_started` event
+whose ID exactly matches the durable `provider_resume_id`. After that event,
+require the tmux session to remain live through the configured runtime settle
+window before applying the restore.
+
+`session_end`, `shutdown`, a mismatched root thread, a missing root-thread
+event, or missing tmux runtime fails the launch. The failure keeps the stored
+resume identity, leaves the session stopped, and records an actionable reason.
+Interrupted Codex-fork restore acceptance is ambiguous after process restart,
+so recovery fails it conservatively rather than replaying the launch.
+
+## Coverage
+
+- exact valid root-thread acceptance and liveness window;
+- immediate provider exit;
+- `session_start` followed by `session_end` without `thread_started`;
+- mismatched and absent root-thread identities;
+- tmux disappearance;
+- restart recovery; and
+- stopped durable projection with an actionable error reason.
+
+## Classification
+
+Single ticket: the Rust restore lifecycle, durable launch state, and focused
+hostile tests are bounded work that one agent can complete without a separate
+epic.


### PR DESCRIPTION
Fixes #1324

## Summary

- keep Codex-fork restores stopped until the structured stream binds the exact durable root thread and tmux remains live through the configured settle window
- fail on provider terminal events, mismatched or missing root-thread identity, and tmux disappearance without rebinding the stored resume ID
- fail ambiguous in-progress Codex-fork restore launches conservatively during server restart recovery
- retain an actionable stopped-state failure reason for truthful status and attach projection

## Validation

- `cargo fmt --check`
- `git diff --check`
- `./scripts/test-rust-isolated.sh codex_fork_restore_` — 7 passed
- `./scripts/test-rust-isolated.sh` — 521 passed, 2 unrelated failures: a reproducible missing `scheduled_reminders` fixture table and one non-reproducible concurrent tmux delivery failure. Tracked in #1355; the concurrency test passed in isolation.

## Design

See `specs/1324_codex_fork_restore_acceptance.md`.