### PR TITLE
Provide structured Claude spawn brief acknowledgement

### DIFF
--- a/crates/sm-server/src/http.rs
+++ b/crates/sm-server/src/http.rs
@@ -412,6 +412,11 @@ impl AppState {
         Self::try_new(config).expect("session manager startup recovery failed")
     }
 
+    fn runtime(&self) -> TmuxRuntime {
+        TmuxRuntime::from_app_config(&self.config)
+            .with_claude_transcript_roots(self.session_store.claude_transcript_roots())
+    }
+
     pub fn try_new(mut config: AppConfig) -> anyhow::Result<Self> {
         if let Some(root) = test_isolation_root_from_environment()? {
             config.isolate_test_paths(&root)?;
@@ -421,13 +426,12 @@ impl AppState {
         let mut session_store = SessionStore::new_with_queue(state_file, queue_db_path)
             .with_codex_session_index_path(config.codex.session_index_path.as_deref())
             .with_claude_transcript_root(config.claude.transcript_root.as_deref())
-            .with_context_monitor_config(config.context_monitor.clone())
-            .with_delivery_runtime(
-                config
-                    .rust_core
-                    .runtime_enabled
-                    .then(|| TmuxRuntime::from_app_config(&config)),
-            );
+            .with_context_monitor_config(config.context_monitor.clone());
+        if config.rust_core.runtime_enabled {
+            let runtime = TmuxRuntime::from_app_config(&config)
+                .with_claude_transcript_roots(session_store.claude_transcript_roots());
+            session_store = session_store.with_delivery_runtime(Some(runtime));
+        }
         if should_use_configured_usage_db_path(&config.usage) {
             session_store = session_store.with_usage_db_path(expand_home(&config.usage.db_path));
         }
@@ -3830,7 +3834,7 @@ async fn create_runtime_core_session(
     payload: CreateCoreSessionRequest,
     log_dir: Option<PathBuf>,
 ) -> Result<SessionRecord, ApiError> {
-    let runtime = TmuxRuntime::from_app_config(&state.config);
+    let runtime = state.runtime();
     let store = state.session_store.clone();
     tokio::task::spawn_blocking(move || {
         store.create_core_session_with_runtime(payload, log_dir, &runtime)
@@ -3858,7 +3862,7 @@ async fn start_session_review(
         &format!("/sessions/{session_id}/review"),
     )?;
     ensure_core_writes_enabled(&state)?;
-    let runtime = TmuxRuntime::from_app_config(&state.config);
+    let runtime = state.runtime();
     let wait_seconds = payload.wait;
     let watcher_session_id = payload
         .watcher_session_id
@@ -10322,6 +10326,7 @@ fn codex_fork_event_stream_path_for_session(
         provider: session.provider.clone(),
         initial_message: None,
         force_initial_prompt_stdin: false,
+        claude_session_id: None,
         model: session.model.clone(),
         reasoning_effort: session.reasoning_effort.clone(),
     };
@@ -14862,6 +14867,7 @@ mod tests {
             provider: session.provider.clone(),
             initial_message: None,
             force_initial_prompt_stdin: false,
+            claude_session_id: None,
             model: session.model.clone(),
             reasoning_effort: session.reasoning_effort.clone(),
         };
@@ -14913,6 +14919,7 @@ mod tests {
             provider: session.provider.clone(),
             initial_message: None,
             force_initial_prompt_stdin: false,
+            claude_session_id: None,
             model: session.model.clone(),
             reasoning_effort: session.reasoning_effort.clone(),
         };
@@ -14967,6 +14974,7 @@ mod tests {
             provider: session.provider.clone(),
             initial_message: None,
             force_initial_prompt_stdin: false,
+            claude_session_id: None,
             model: session.model.clone(),
             reasoning_effort: session.reasoning_effort.clone(),
         };

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -1353,6 +1353,14 @@ impl TmuxRuntime {
                 }
                 let (transcript_path, transcript_offset) =
                     self.wait_for_claude_initial_brief_transcript(spec)?;
+                self.wait_for_claude_initial_brief_composer(&spec.tmux_session)?;
+                // The input lock coordinates session-manager writers, but a
+                // human tmux client can attach while waiting for Claude to
+                // finish startup. Check again at the send boundary so an
+                // immutable brief is never pasted into an observed session.
+                if self.session_has_attached_clients(&spec.tmux_session)? {
+                    bail!("refusing to submit the initial Claude spawn brief while a tmux client is attached");
+                }
                 self.send_text_then_enter(&spec.tmux_session, prompt)?;
                 self.wait_for_claude_initial_brief_acceptance(
                     &spec.tmux_session,
@@ -1371,6 +1379,68 @@ impl TmuxRuntime {
                 .into(),
             ),
         }
+    }
+
+    /// Wait until Claude has both initialized its provider transcript and
+    /// exposed an empty composer at the live cursor. A transcript proves which
+    /// provider session will acknowledge the brief, but it can precede the
+    /// interactive UI while Claude shows startup or onboarding screens.
+    fn wait_for_claude_initial_brief_composer(&self, tmux_session: &str) -> Result<()> {
+        let deadline = Instant::now() + self.initial_brief_ready_timeout;
+        loop {
+            if !self.session_exists(tmux_session)? {
+                return Err(InitialBriefDeliveryError::SessionExited {
+                    provider: "claude".to_owned(),
+                }
+                .into());
+            }
+            if self.claude_initial_brief_composer_ready(tmux_session) {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err(InitialBriefDeliveryError::ProviderReadinessTimedOut {
+                    provider: "claude".to_owned(),
+                }
+                .into());
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    /// Claude's empty composer must be at the active cursor, not merely occur
+    /// in scrollback or resemble a typed prompt in a startup frame.
+    fn claude_initial_brief_composer_ready(&self, tmux_session: &str) -> bool {
+        let Some(pane) = self.capture_pane_text(tmux_session) else {
+            return false;
+        };
+        if !claude_composer_is_ready(&pane) {
+            return false;
+        }
+        let Some((cursor_x, cursor_y)) = self.pane_cursor_position(tmux_session) else {
+            return false;
+        };
+        claude_empty_composer_cursor(&pane, cursor_x, cursor_y)
+    }
+
+    fn pane_cursor_position(&self, tmux_session: &str) -> Option<(usize, usize)> {
+        let output = self
+            .tmux_command([
+                "display-message",
+                "-p",
+                "-t",
+                tmux_session,
+                "#{cursor_x},#{cursor_y}",
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        let cursor = String::from_utf8_lossy(&output.stdout);
+        let (x, y) = cursor.trim().split_once(',')?;
+        Some((x.parse().ok()?, y.parse().ok()?))
     }
 
     fn wait_for_initial_brief_readiness(&self, tmux_session: &str, provider: &str) -> Result<()> {
@@ -1492,6 +1562,14 @@ impl TmuxRuntime {
             );
         }
         let deadline = Instant::now() + self.initial_brief_ready_timeout;
+        let direct_candidates = claude_transcript_candidates(
+            &self.claude_projects_roots,
+            &spec.working_dir,
+            provider_session_id,
+        );
+        let project_directories =
+            claude_transcript_project_directories(&self.claude_projects_roots, &spec.working_dir);
+        let mut next_nested_scan = Instant::now();
         loop {
             if !self.session_exists(&spec.tmux_session)? {
                 return Err(InitialBriefDeliveryError::SessionExited {
@@ -1499,17 +1577,24 @@ impl TmuxRuntime {
                 }
                 .into());
             }
-            for transcript_path in claude_transcript_candidates(
-                &self.claude_projects_roots,
-                &spec.working_dir,
-                provider_session_id,
-            ) {
+            for transcript_path in &direct_candidates {
                 let Ok(metadata) = fs::metadata(&transcript_path) else {
                     continue;
                 };
                 if claude_transcript_declares_session(&transcript_path, provider_session_id) {
-                    return Ok((transcript_path, metadata.len()));
+                    return Ok((transcript_path.clone(), metadata.len()));
                 }
+            }
+            if Instant::now() >= next_nested_scan {
+                for transcript_path in claude_nested_transcript_candidates(&project_directories) {
+                    let Ok(metadata) = fs::metadata(&transcript_path) else {
+                        continue;
+                    };
+                    if claude_transcript_declares_session(&transcript_path, provider_session_id) {
+                        return Ok((transcript_path, metadata.len()));
+                    }
+                }
+                next_nested_scan = Instant::now() + Duration::from_millis(250);
             }
             if Instant::now() >= deadline {
                 return Err(InitialBriefDeliveryError::ProviderReadinessTimedOut {
@@ -1739,6 +1824,16 @@ fn claude_transcript_candidates(
     working_dir: &str,
     provider_session_id: &str,
 ) -> Vec<PathBuf> {
+    claude_transcript_project_directories(projects_roots, working_dir)
+        .iter()
+        .map(|project_dir| project_dir.join(format!("{provider_session_id}.jsonl")))
+        .collect()
+}
+
+fn claude_transcript_project_directories(
+    projects_roots: &[PathBuf],
+    working_dir: &str,
+) -> Vec<PathBuf> {
     let resolved_working_dir = PathBuf::from(working_dir)
         .canonicalize()
         .unwrap_or_else(|_| PathBuf::from(working_dir));
@@ -1747,11 +1842,31 @@ fn claude_transcript_candidates(
         .replace(std::path::MAIN_SEPARATOR, "-");
     projects_roots
         .iter()
-        .map(|root| {
-            root.join(&project_dir)
-                .join(format!("{provider_session_id}.jsonl"))
-        })
+        .map(|root| root.join(&project_dir))
         .collect()
+}
+
+/// Claude normally writes `<project>/<session-id>.jsonl`, but older and
+/// nested layouts may place the file below the project directory. The caller
+/// binds every result to the generated session ID before accepting it.
+fn claude_nested_transcript_candidates(project_directories: &[PathBuf]) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    let mut pending = project_directories.to_vec();
+    while let Some(directory) = pending.pop() {
+        let Ok(entries) = fs::read_dir(directory) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                pending.push(path);
+            } else if path.extension().and_then(|extension| extension.to_str()) == Some("jsonl") {
+                files.push(path);
+            }
+        }
+    }
+    files.sort();
+    files
 }
 
 fn claude_transcript_declares_session(path: &Path, provider_session_id: &str) -> bool {
@@ -1841,6 +1956,27 @@ fn claude_inline_placeholder(line: &str) -> bool {
     placeholder.starts_with(concat!("Try ", "\""))
         && placeholder.ends_with('"')
         && placeholder.len() > concat!("Try ", "\"").len()
+}
+
+/// Confirm that tmux's cursor is immediately after the visible composer
+/// prefix. A user-typed string, including one that resembles Claude's `Try
+/// "..."` placeholder, places the cursor farther right and is rejected.
+fn claude_empty_composer_cursor(pane: &str, cursor_x: usize, cursor_y: usize) -> bool {
+    let Some(line) = pane.lines().nth(cursor_y) else {
+        return false;
+    };
+    let leading = line.len() - line.trim_start().len();
+    let composer = &line[leading..];
+    let prefix_width = if composer.starts_with('>') {
+        1
+    } else if composer.starts_with("❯\u{a0}") {
+        2
+    } else if composer.starts_with('❯') {
+        1
+    } else {
+        return false;
+    };
+    claude_composer_line_is_ready(composer.trim()) && cursor_x == leading + prefix_width
 }
 
 fn claude_composer_footer_divider(line: &str) -> bool {
@@ -2428,6 +2564,15 @@ esac
             "❯ deploy --production",
         );
         assert!(!claude_composer_is_ready(&typed));
+    }
+
+    #[test]
+    fn claude_empty_composer_cursor_rejects_typed_or_stale_prompt_rows() {
+        let pane = "Earlier output\n❯\n────────────────────\nFable 5\n";
+
+        assert!(claude_empty_composer_cursor(pane, 1, 1));
+        assert!(!claude_empty_composer_cursor(pane, 2, 1));
+        assert!(!claude_empty_composer_cursor(pane, 1, 0));
     }
 
     #[test]

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -3,7 +3,7 @@ use std::os::unix::{fs::PermissionsExt, process::CommandExt};
 use std::{
     collections::HashMap,
     env, fs,
-    io::{Read, Seek, SeekFrom},
+    io::{BufRead, BufReader, Read, Seek, SeekFrom},
     path::{Path, PathBuf},
     process::{Command, Stdio},
     sync::{mpsc, Arc, Condvar, Mutex, OnceLock, Weak},
@@ -74,6 +74,7 @@ pub struct TmuxRuntime {
     send_keys_settle_per_ki_ms: f64,
     send_keys_settle_per_extra_line_ms: f64,
     send_keys_max_chunk_chars: usize,
+    claude_projects_roots: Vec<PathBuf>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -97,6 +98,9 @@ pub struct TmuxSessionSpec {
     /// Bypass argv prompt mode to deliver an already-verified spawn brief via
     /// tmux stdin, avoiding both command-line size limits and path races.
     pub force_initial_prompt_stdin: bool,
+    /// A caller-generated Claude provider session UUID for a verified spawn
+    /// brief.  It correlates the initial PTY submission with one transcript.
+    pub claude_session_id: Option<String>,
     pub model: Option<String>,
     pub reasoning_effort: Option<String>,
 }
@@ -105,12 +109,6 @@ pub struct TmuxSessionSpec {
 pub struct CodexForkRuntimeArtifacts {
     pub event_stream_path: PathBuf,
     pub control_socket_path: PathBuf,
-}
-
-#[derive(Debug, Clone)]
-struct ClaudeInitialBriefReadyPane {
-    pane: String,
-    composer_y: usize,
 }
 
 #[derive(Debug)]
@@ -251,6 +249,7 @@ impl TmuxRuntime {
                 .send_keys_max_chunk_chars
                 .unwrap_or(DEFAULT_SEND_KEYS_MAX_CHUNK_CHARS)
                 .max(1),
+            claude_projects_roots: Vec::new(),
         }
     }
 
@@ -283,6 +282,11 @@ impl TmuxRuntime {
         runtime.codex_fork_control_tmux_fallback_enabled =
             config.codex_fork.control_tmux_fallback_enabled;
         runtime
+    }
+
+    pub fn with_claude_transcript_roots(mut self, roots: Vec<PathBuf>) -> Self {
+        self.claude_projects_roots = roots;
+        self
     }
 
     pub fn socket_name(&self) -> Option<&str> {
@@ -1197,6 +1201,17 @@ impl TmuxRuntime {
             "codex-fork" => self.codex_fork_command_parts(spec)?,
             provider => bail!("Rust runtime does not support provider {provider}"),
         };
+        if spec.provider == "claude" {
+            if let Some(provider_session_id) = spec
+                .claude_session_id
+                .as_deref()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+            {
+                parts.push("--session-id".to_owned());
+                parts.push(shell_quote(provider_session_id));
+            }
+        }
         let model = spec
             .model
             .as_deref()
@@ -1308,11 +1323,10 @@ impl TmuxRuntime {
     /// brief twice.
     fn deliver_verified_initial_brief(&self, spec: &TmuxSessionSpec, prompt: &str) -> Result<()> {
         let _guard = self.lock_session_input(&spec.tmux_session)?;
-        let claude_ready_pane =
-            self.wait_for_initial_brief_readiness(&spec.tmux_session, &spec.provider)?;
 
         match spec.provider.as_str() {
             "codex-fork" => {
+                self.wait_for_initial_brief_readiness(&spec.tmux_session, &spec.provider)?;
                 let artifacts = self
                     .codex_fork_runtime_artifacts(spec)?
                     .expect("codex-fork must have runtime artifacts");
@@ -1334,12 +1348,21 @@ impl TmuxRuntime {
                 )
             }
             "claude" => {
-                let ready_pane = claude_ready_pane.expect("Claude readiness returns its pane");
                 if self.session_has_attached_clients(&spec.tmux_session)? {
                     bail!("refusing to submit the initial Claude spawn brief while a tmux client is attached");
                 }
+                let (transcript_path, transcript_offset) =
+                    self.wait_for_claude_initial_brief_transcript(spec)?;
                 self.send_text_then_enter(&spec.tmux_session, prompt)?;
-                self.wait_for_claude_initial_brief_acceptance(&spec.tmux_session, &ready_pane)
+                self.wait_for_claude_initial_brief_acceptance(
+                    &spec.tmux_session,
+                    &transcript_path,
+                    transcript_offset,
+                    spec.claude_session_id
+                        .as_deref()
+                        .expect("verified Claude spawn briefs have a provider session ID"),
+                    prompt,
+                )
             }
             _ => Err(
                 InitialBriefDeliveryError::ProviderAcknowledgementUnavailable {
@@ -1350,11 +1373,7 @@ impl TmuxRuntime {
         }
     }
 
-    fn wait_for_initial_brief_readiness(
-        &self,
-        tmux_session: &str,
-        provider: &str,
-    ) -> Result<Option<ClaudeInitialBriefReadyPane>> {
+    fn wait_for_initial_brief_readiness(&self, tmux_session: &str, provider: &str) -> Result<()> {
         let deadline = Instant::now() + self.initial_brief_ready_timeout;
         let mut directory_trust_accepted = false;
         loop {
@@ -1373,12 +1392,8 @@ impl TmuxRuntime {
                     directory_trust_accepted = true;
                 }
             }
-            if provider == "claude" {
-                if let Some(pane) = self.claude_initial_brief_composer_pane(tmux_session) {
-                    return Ok(Some(pane));
-                }
-            } else if self.session_input_ready(tmux_session, provider) {
-                return Ok(None);
+            if self.session_input_ready(tmux_session, provider) {
+                return Ok(());
             }
             if Instant::now() >= deadline {
                 return Err(InitialBriefDeliveryError::ProviderReadinessTimedOut {
@@ -1388,49 +1403,6 @@ impl TmuxRuntime {
             }
             thread::sleep(Duration::from_millis(50));
         }
-    }
-
-    /// Return a Claude pane only when its composer is empty and still owned by
-    /// the provider.  Claude 2.1.226 renders the empty field as an inline
-    /// `Try "..."` suggestion, so pane text alone cannot distinguish it from
-    /// typed input.  The cursor must still be immediately after the composer
-    /// prefix on that exact row before an immutable brief may be submitted.
-    fn claude_initial_brief_composer_pane(
-        &self,
-        tmux_session: &str,
-    ) -> Option<ClaudeInitialBriefReadyPane> {
-        let pane = self.capture_pane_text(tmux_session)?;
-        if !claude_composer_is_ready(&pane) {
-            return None;
-        }
-        let (cursor_x, cursor_y) = self.pane_cursor_position(tmux_session)?;
-        claude_empty_composer_cursor(&pane, cursor_x, cursor_y).then_some(
-            ClaudeInitialBriefReadyPane {
-                pane,
-                composer_y: cursor_y,
-            },
-        )
-    }
-
-    fn pane_cursor_position(&self, tmux_session: &str) -> Option<(usize, usize)> {
-        let output = self
-            .tmux_command([
-                "display-message",
-                "-p",
-                "-t",
-                tmux_session,
-                "#{cursor_x},#{cursor_y}",
-            ])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .output()
-            .ok()?;
-        if !output.status.success() {
-            return None;
-        }
-        let cursor = String::from_utf8_lossy(&output.stdout);
-        let (x, y) = cursor.trim().split_once(',')?;
-        Some((x.parse().ok()?, y.parse().ok()?))
     }
 
     fn wait_for_codex_fork_initial_brief_acceptance(
@@ -1468,17 +1440,19 @@ impl TmuxRuntime {
     fn wait_for_claude_initial_brief_acceptance(
         &self,
         tmux_session: &str,
-        ready_pane: &ClaudeInitialBriefReadyPane,
+        transcript_path: &Path,
+        transcript_offset: u64,
+        provider_session_id: &str,
+        prompt: &str,
     ) -> Result<()> {
         let deadline = Instant::now() + self.initial_brief_ack_timeout;
         loop {
-            if self.capture_pane_text(tmux_session).is_some_and(|pane| {
-                claude_initial_brief_submission_observed(
-                    &ready_pane.pane,
-                    ready_pane.composer_y,
-                    &pane,
-                )
-            }) {
+            if claude_transcript_has_matching_user_turn(
+                transcript_path,
+                transcript_offset,
+                provider_session_id,
+                prompt,
+            ) {
                 return Ok(());
             }
             if !self.session_exists(tmux_session)? {
@@ -1489,6 +1463,56 @@ impl TmuxRuntime {
             }
             if Instant::now() >= deadline {
                 return Err(InitialBriefDeliveryError::ProviderAcceptanceTimedOut {
+                    provider: "claude".to_owned(),
+                }
+                .into());
+            }
+            thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    /// Wait for the uniquely named JSONL transcript Claude creates for the
+    /// caller-provided provider session UUID.  This is a provider-owned
+    /// startup signal, not a terminal-rendering heuristic.
+    fn wait_for_claude_initial_brief_transcript(
+        &self,
+        spec: &TmuxSessionSpec,
+    ) -> Result<(PathBuf, u64)> {
+        let provider_session_id = spec.claude_session_id.as_deref().ok_or_else(|| {
+            InitialBriefDeliveryError::ProviderAcknowledgementUnavailable {
+                provider: "claude".to_owned(),
+            }
+        })?;
+        if self.claude_projects_roots.is_empty() {
+            return Err(
+                InitialBriefDeliveryError::ProviderAcknowledgementUnavailable {
+                    provider: "claude".to_owned(),
+                }
+                .into(),
+            );
+        }
+        let deadline = Instant::now() + self.initial_brief_ready_timeout;
+        loop {
+            if !self.session_exists(&spec.tmux_session)? {
+                return Err(InitialBriefDeliveryError::SessionExited {
+                    provider: "claude".to_owned(),
+                }
+                .into());
+            }
+            for transcript_path in claude_transcript_candidates(
+                &self.claude_projects_roots,
+                &spec.working_dir,
+                provider_session_id,
+            ) {
+                let Ok(metadata) = fs::metadata(&transcript_path) else {
+                    continue;
+                };
+                if claude_transcript_declares_session(&transcript_path, provider_session_id) {
+                    return Ok((transcript_path, metadata.len()));
+                }
+            }
+            if Instant::now() >= deadline {
+                return Err(InitialBriefDeliveryError::ProviderReadinessTimedOut {
                     provider: "claude".to_owned(),
                 }
                 .into());
@@ -1710,6 +1734,68 @@ fn pane_last_line(text: &str) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
+fn claude_transcript_candidates(
+    projects_roots: &[PathBuf],
+    working_dir: &str,
+    provider_session_id: &str,
+) -> Vec<PathBuf> {
+    let resolved_working_dir = PathBuf::from(working_dir)
+        .canonicalize()
+        .unwrap_or_else(|_| PathBuf::from(working_dir));
+    let project_dir = resolved_working_dir
+        .to_string_lossy()
+        .replace(std::path::MAIN_SEPARATOR, "-");
+    projects_roots
+        .iter()
+        .map(|root| {
+            root.join(&project_dir)
+                .join(format!("{provider_session_id}.jsonl"))
+        })
+        .collect()
+}
+
+fn claude_transcript_declares_session(path: &Path, provider_session_id: &str) -> bool {
+    let Ok(file) = fs::File::open(path) else {
+        return false;
+    };
+    BufReader::new(file)
+        .lines()
+        .map_while(Result::ok)
+        .filter_map(|line| serde_json::from_str::<Value>(&line).ok())
+        .any(|entry| entry.get("sessionId").and_then(Value::as_str) == Some(provider_session_id))
+}
+
+/// A transcript is acknowledgement only if it appends an exact user turn for
+/// this generated provider session after the startup boundary.  Incomplete and
+/// malformed JSONL records fail closed and are reconsidered on the next poll.
+fn claude_transcript_has_matching_user_turn(
+    path: &Path,
+    offset: u64,
+    provider_session_id: &str,
+    prompt: &str,
+) -> bool {
+    let Ok(mut file) = fs::File::open(path) else {
+        return false;
+    };
+    if file.seek(SeekFrom::Start(offset)).is_err() {
+        return false;
+    }
+    BufReader::new(file)
+        .lines()
+        .map_while(Result::ok)
+        .filter_map(|line| serde_json::from_str::<Value>(&line).ok())
+        .any(|entry| {
+            entry.get("type").and_then(Value::as_str) == Some("user")
+                && entry.get("sessionId").and_then(Value::as_str) == Some(provider_session_id)
+                && entry
+                    .get("message")
+                    .and_then(Value::as_object)
+                    .and_then(|message| message.get("content"))
+                    .and_then(Value::as_str)
+                    == Some(prompt)
+        })
+}
+
 /// Claude renders a status/footer block below its live composer. Looking only
 /// at the final pane line therefore treats every normal idle Claude session as
 /// busy. Claude 2.1.226 also displays a dim inline `Try "..."` suggestion in a
@@ -1755,79 +1841,6 @@ fn claude_inline_placeholder(line: &str) -> bool {
     placeholder.starts_with(concat!("Try ", "\""))
         && placeholder.ends_with('"')
         && placeholder.len() > concat!("Try ", "\"").len()
-}
-
-/// Confirm that tmux's cursor is immediately after the visible composer
-/// prefix.  A user-typed string, including one that resembles Claude's `Try
-/// "..."` placeholder, places the cursor farther right and is rejected.
-fn claude_empty_composer_cursor(pane: &str, cursor_x: usize, cursor_y: usize) -> bool {
-    let Some(line) = pane.lines().nth(cursor_y) else {
-        return false;
-    };
-    let leading = line.len() - line.trim_start().len();
-    let composer = &line[leading..];
-    let prefix_width = if composer.starts_with(">") {
-        1
-    } else if composer.starts_with("❯\u{a0}") {
-        2
-    } else if composer.starts_with('❯') {
-        1
-    } else {
-        return false;
-    };
-    claude_composer_line_is_ready(composer.trim()) && cursor_x == leading + prefix_width
-}
-
-fn claude_initial_brief_submission_observed(
-    ready_pane: &str,
-    composer_y: usize,
-    pane: &str,
-) -> bool {
-    if pane == ready_pane {
-        return false;
-    }
-    let Some(mut previous_markers) = claude_main_thread_activity_markers(ready_pane, composer_y)
-    else {
-        return false;
-    };
-    let Some(current_markers) = claude_main_thread_activity_markers(pane, composer_y) else {
-        return false;
-    };
-    current_markers.into_iter().any(|marker| {
-        match previous_markers
-            .iter()
-            .position(|previous| *previous == marker)
-        {
-            Some(index) => {
-                previous_markers.remove(index);
-                false
-            }
-            None => true,
-        }
-    })
-}
-
-/// Return a multiset of provider activity rows.  A ready pane can retain old
-/// completed-turn chrome above its new composer, so acknowledgement must
-/// observe an activity row that did not already exist before Enter.
-fn claude_main_thread_activity_markers(pane: &str, composer_y: usize) -> Option<Vec<&str>> {
-    let lines = pane.lines().collect::<Vec<_>>();
-    let composer = lines.get(composer_y)?.trim_start();
-    if !(composer.starts_with('❯') || composer.starts_with('>')) {
-        return None;
-    }
-    // The cursor-confirmed row is the actual boundary of the live input.
-    // Everything at or below it may be multiline prompt text, including
-    // quotes and rows that resemble activity. Provider turn rows render
-    // above the stationary composer. If that layout changes, fail closed.
-    Some(
-        lines
-            .iter()
-            .take(composer_y)
-            .map(|line| line.trim_start())
-            .filter(|line| claude_line_indicates_main_thread_activity(line))
-            .collect(),
-    )
 }
 
 fn claude_composer_footer_divider(line: &str) -> bool {
@@ -2176,6 +2189,17 @@ mod tests {
     use super::*;
     use std::os::unix::fs::PermissionsExt;
 
+    fn tempfile_path(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "sm-runtime-{label}-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ))
+    }
+
     #[test]
     fn verified_spawn_stdin_prompt_preserves_outer_whitespace() {
         let prompt = "  # Exact brief\n\n  indented detail  \n";
@@ -2188,6 +2212,7 @@ mod tests {
             provider: "claude".to_owned(),
             initial_message: Some(prompt.to_owned()),
             force_initial_prompt_stdin: true,
+            claude_session_id: None,
             model: None,
             reasoning_effort: None,
         };
@@ -2387,7 +2412,7 @@ esac
     }
 
     #[test]
-    fn claude_placeholder_readiness_requires_the_empty_composer_cursor() {
+    fn claude_placeholder_readiness_accepts_only_the_observed_empty_composer() {
         let pane = concat!(
             "○ low · /effort\n",
             "────────────────────\n",
@@ -2398,9 +2423,6 @@ esac
         );
 
         assert!(claude_composer_is_ready(pane));
-        assert!(claude_empty_composer_cursor(pane, 2, 2));
-        assert!(!claude_empty_composer_cursor(pane, 27, 2));
-
         let typed = pane.replace(
             "❯\u{a0}Try \"how does this work?\"",
             "❯ deploy --production",
@@ -2409,101 +2431,82 @@ esac
     }
 
     #[test]
-    fn claude_initial_brief_acceptance_requires_a_provider_turn_transition() {
-        let ready = "Idle header\n❯\n────────────────────\nFable 5\n";
-        assert!(!claude_initial_brief_submission_observed(
-            ready,
-            1,
-            "Idle header\n❯\n────────────────────\nFable 5\nupdated idle footer\n",
+    fn claude_initial_brief_acceptance_requires_a_new_matching_user_turn() {
+        let temp_dir = tempfile_path("claude-transcript-ack");
+        fs::create_dir_all(&temp_dir).unwrap();
+        let transcript = temp_dir.join("provider-session.jsonl");
+        let provider_session_id = "11111111-1111-4111-8111-111111111111";
+        let startup = serde_json::json!({"type":"mode", "sessionId": provider_session_id});
+        let startup = format!("{startup}\n");
+        fs::write(&transcript, &startup).unwrap();
+        let offset = startup.len() as u64;
+
+        assert!(claude_transcript_declares_session(
+            &transcript,
+            provider_session_id
         ));
-        assert!(!claude_initial_brief_submission_observed(
-            ready,
-            1,
-            "Idle header\n❯\n────────────────────\nFable 5\n",
+        assert!(!claude_transcript_has_matching_user_turn(
+            &transcript,
+            offset,
+            provider_session_id,
+            "exact immutable brief"
         ));
-        assert!(claude_initial_brief_submission_observed(
-            ready,
-            1,
-            "✽ Thinking through the task…\n❯\n────────────────────\nFable 5\n",
+
+        let malformed = "{not-json}\n";
+        let wrong_session = serde_json::json!({
+            "type":"user", "sessionId":"22222222-2222-4222-8222-222222222222",
+            "message":{"content":"exact immutable brief"}
+        });
+        let wrong_prompt = serde_json::json!({
+            "type":"user", "sessionId":provider_session_id,
+            "message":{"content":"different brief"}
+        });
+        fs::write(
+            &transcript,
+            format!("{startup}{malformed}{wrong_session}\n{wrong_prompt}\n"),
+        )
+        .unwrap();
+        assert!(!claude_transcript_has_matching_user_turn(
+            &transcript,
+            offset,
+            provider_session_id,
+            "exact immutable brief"
+        ));
+
+        let accepted = serde_json::json!({
+            "type":"user", "sessionId":provider_session_id,
+            "message":{"content":"exact immutable brief"}
+        });
+        fs::write(
+            &transcript,
+            format!("{startup}{malformed}{wrong_session}\n{wrong_prompt}\n{accepted}\n"),
+        )
+        .unwrap();
+        assert!(claude_transcript_has_matching_user_turn(
+            &transcript,
+            offset,
+            provider_session_id,
+            "exact immutable brief"
         ));
     }
 
     #[test]
-    fn claude_initial_brief_acceptance_rejects_stale_activity_from_the_ready_pane() {
-        let ready = concat!(
-            "⏺ Completed startup housekeeping\n",
-            "❯\n",
-            "────────────────────\n",
-            "Fable 5\n",
+    fn claude_initial_brief_transcript_candidate_uses_the_provider_uuid() {
+        let root = tempfile_path("claude-transcript-root");
+        let working_dir = tempfile_path("claude-transcript-working-dir");
+        fs::create_dir_all(&working_dir).unwrap();
+        let provider_session_id = "11111111-1111-4111-8111-111111111111";
+        let candidates = claude_transcript_candidates(
+            std::slice::from_ref(&root),
+            working_dir.to_str().unwrap(),
+            provider_session_id,
         );
 
-        assert!(!claude_initial_brief_submission_observed(
-            ready,
-            1,
-            concat!(
-                "⏺ Completed startup housekeeping\n",
-                "❯ pasted-but-not-submitted\n",
-                "────────────────────\n",
-                "Fable 5\n",
-            ),
-        ));
-        assert!(claude_initial_brief_submission_observed(
-            ready,
-            1,
-            concat!(
-                "✽ Thinking through the initial brief…\n",
-                "❯\n",
-                "────────────────────\n",
-                "Fable 5\n",
-            ),
-        ));
-    }
-
-    #[test]
-    fn claude_initial_brief_acceptance_rejects_marker_shaped_multiline_input() {
-        let ready = concat!(
-            "⏺ Completed startup housekeeping\n",
-            "❯\n",
-            "────────────────────\n",
-            "Fable 5\n",
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(
+            candidates[0].file_name().and_then(|name| name.to_str()),
+            Some("11111111-1111-4111-8111-111111111111.jsonl")
         );
-
-        // A failed Enter leaves every continuation row in Claude's composer.
-        // The second row deliberately resembles a provider activity marker.
-        assert!(!claude_initial_brief_submission_observed(
-            ready,
-            1,
-            concat!(
-                "⏺ Completed startup housekeeping\n",
-                "❯ first line of immutable brief\n",
-                "✽ marker-shaped continuation, still unsubmitted\n",
-                "────────────────────\n",
-                "Fable 5\n",
-            ),
-        ));
-    }
-
-    #[test]
-    fn claude_initial_brief_acceptance_anchors_input_at_the_ready_cursor_row() {
-        let ready = concat!(
-            "⏺ Completed startup housekeeping\n",
-            "❯\n",
-            "────────────────────\n",
-            "Fable 5\n",
-        );
-
-        assert!(!claude_initial_brief_submission_observed(
-            ready,
-            1,
-            concat!(
-                "⏺ Completed startup housekeeping\n",
-                "❯ first line of immutable brief\n",
-                "✽ marker-shaped continuation, still unsubmitted\n",
-                "> quoted continuation, still unsubmitted\n",
-                "────────────────────\n",
-                "Fable 5\n",
-            ),
-        ));
     }
 
     #[test]
@@ -2612,6 +2615,7 @@ esac
             provider: "claude".to_owned(),
             initial_message: None,
             force_initial_prompt_stdin: false,
+            claude_session_id: None,
             model: None,
             reasoning_effort: None,
         };
@@ -2683,6 +2687,7 @@ esac
             provider: "claude".to_owned(),
             initial_message: None,
             force_initial_prompt_stdin: false,
+            claude_session_id: None,
             model: None,
             reasoning_effort: None,
         };
@@ -2723,6 +2728,7 @@ esac
             provider: "claude".to_owned(),
             initial_message: None,
             force_initial_prompt_stdin: false,
+            claude_session_id: None,
             model: None,
             reasoning_effort: None,
         };
@@ -2758,6 +2764,7 @@ esac
             provider: "claude".to_owned(),
             initial_message: None,
             force_initial_prompt_stdin: false,
+            claude_session_id: None,
             model: None,
             reasoning_effort: Some("high".to_owned()),
         };

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -564,6 +564,10 @@ impl SessionStore {
         self
     }
 
+    pub(crate) fn claude_transcript_roots(&self) -> Vec<PathBuf> {
+        self.claude_projects_roots.clone()
+    }
+
     fn append_seat_session(
         &self,
         seat_id: &str,
@@ -873,6 +877,21 @@ impl SessionStore {
         if !matches!(launch.status.as_str(), "prepared" | "launching") {
             return Ok(());
         }
+        if launch.provider == "claude" && launch.force_initial_prompt_stdin {
+            // A restart cannot determine whether tmux delivered the immutable
+            // first brief before the process died. Replaying it risks
+            // duplicate work, so retain the artifact and require an explicit
+            // recovery decision instead.
+            mark_runtime_launch_failed(
+                &mut state,
+                launch_id,
+                &launch.session_id,
+                launch.operation_kind == "create",
+                "refusing to recover an unacknowledged Claude spawn brief because it may already have been submitted",
+            )?;
+            self.write_raw_json_value(&state)?;
+            return Ok(());
+        }
         let terminal_session = snapshot_from_raw_value(&state)?
             .sessions
             .iter()
@@ -952,6 +971,9 @@ impl SessionStore {
             provider: launch.provider.clone(),
             initial_message: launch.initial_message.clone(),
             force_initial_prompt_stdin: launch.force_initial_prompt_stdin,
+            claude_session_id: (launch.provider == "claude" && launch.force_initial_prompt_stdin)
+                .then(|| launch.provider_resume_id.clone())
+                .flatten(),
             model: launch.model.clone(),
             reasoning_effort: launch.reasoning_effort.clone(),
         };
@@ -1328,6 +1350,7 @@ impl SessionStore {
             provider: session.provider.clone(),
             initial_message: None,
             force_initial_prompt_stdin: false,
+            claude_session_id: None,
             model: session.model.clone(),
             reasoning_effort: session.reasoning_effort.clone(),
         };
@@ -4208,6 +4231,12 @@ impl SessionStore {
         let session_credential = generate_session_credential();
         let credential_sha256 = sha256_text(&session_credential);
         record.session_credential_sha256 = Some(credential_sha256.clone());
+        if record.provider == "claude" && request.spawn_brief.is_some() {
+            // Claude owns this UUID and records it in its JSONL transcript.
+            // Persist it before launching so the initial brief can be bound to
+            // one provider session rather than a rendered terminal frame.
+            record.provider_resume_id = Some(generate_claude_provider_session_id());
+        }
         if record.provider == "codex"
             && codex_cli_working_dir.as_deref() != Some(record.working_dir.as_str())
         {
@@ -4230,6 +4259,9 @@ impl SessionStore {
             provider: record.provider.clone(),
             initial_message: runtime_initial_message.clone(),
             force_initial_prompt_stdin,
+            claude_session_id: (record.provider == "claude" && request.spawn_brief.is_some())
+                .then(|| record.provider_resume_id.clone())
+                .flatten(),
             model: request.model.clone(),
             reasoning_effort: request.reasoning_effort.clone(),
         };
@@ -4263,7 +4295,7 @@ impl SessionStore {
             working_dir: spec.working_dir.clone(),
             log_file: spec.log_file.display().to_string(),
             provider: record.provider.clone(),
-            provider_resume_id: None,
+            provider_resume_id: record.provider_resume_id.clone(),
             credential_rotation_id: None,
             restore_authorized: false,
             initial_message: runtime_initial_message,
@@ -5549,6 +5581,7 @@ impl SessionStore {
             provider: record.provider.clone(),
             initial_message: None,
             force_initial_prompt_stdin: false,
+            claude_session_id: None,
             model: record.model.clone(),
             reasoning_effort: record.reasoning_effort.clone(),
         };
@@ -11248,6 +11281,7 @@ fn codex_fork_spec_for_session_raw(
         provider: "codex-fork".to_owned(),
         initial_message: None,
         force_initial_prompt_stdin: false,
+        claude_session_id: None,
         model: json_text(session.get("model")),
         reasoning_effort: json_text(session.get("reasoning_effort")),
     })
@@ -11289,6 +11323,7 @@ pub fn submit_codex_fork_btw(
         provider: "codex-fork".to_owned(),
         initial_message: None,
         force_initial_prompt_stdin: false,
+        claude_session_id: None,
         model: session.model.clone(),
         reasoning_effort: session.reasoning_effort.clone(),
     };
@@ -13013,6 +13048,7 @@ fn codex_fork_event_stream_path(session: &SessionRecord, runtime: &TmuxRuntime) 
         provider: session.provider.clone(),
         initial_message: None,
         force_initial_prompt_stdin: false,
+        claude_session_id: None,
         model: session.model.clone(),
         reasoning_effort: session.reasoning_effort.clone(),
     };
@@ -13355,6 +13391,20 @@ fn generate_session_id() -> String {
         id.push(hex_char(byte & 0x0f));
     }
     id
+}
+
+fn generate_claude_provider_session_id() -> String {
+    let mut bytes = [0u8; 16];
+    OsRng.fill_bytes(&mut bytes);
+    // RFC 4122 variant and version-4 layout, required by Claude's
+    // `--session-id` validation.
+    bytes[6] = (bytes[6] & 0x0f) | 0x40;
+    bytes[8] = (bytes[8] & 0x3f) | 0x80;
+    format!(
+        "{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}{:02x}{:02x}{:02x}{:02x}",
+        bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+        bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]
+    )
 }
 
 fn generate_unique_session_id(sessions: &[Value]) -> Result<String> {
@@ -17261,6 +17311,32 @@ mod tests {
     }
 
     #[test]
+    fn recovery_never_replays_an_unacknowledged_claude_spawn_brief() {
+        let state_file = unique_temp_path("claude-spawn-brief-recovery");
+        let mut state = terminal_rotation_fixture("relaunching", Some("launching"));
+        state["session_credential_rotations"] = json!([]);
+        let launch = &mut state["session_runtime_launches"][0];
+        launch["operation_kind"] = json!("create");
+        launch["credential_rotation_id"] = Value::Null;
+        launch["provider"] = json!("claude");
+        launch["force_initial_prompt_stdin"] = json!(true);
+        launch["initial_message"] = json!("immutable brief");
+        launch["provider_resume_id"] = json!("11111111-1111-4111-8111-111111111111");
+        fs::write(&state_file, state.to_string()).unwrap();
+
+        let store = SessionStore::new(state_file.clone());
+        store.recover_session_runtime_launches().unwrap();
+
+        let recovered = store.load_raw_json_value().unwrap();
+        assert_eq!(recovered["session_runtime_launches"][0]["status"], "failed");
+        assert_eq!(
+            recovered["session_runtime_launches"][0]["failure_reason"],
+            "refusing to recover an unacknowledged Claude spawn brief because it may already have been submitted"
+        );
+        let _ = fs::remove_file(state_file);
+    }
+
+    #[test]
     fn credential_rotation_worker_recovers_a_relaunching_runtime_transaction() {
         let state_file = unique_temp_path("credential-rotation-relaunch-recovery");
         fs::write(
@@ -19489,6 +19565,7 @@ mod tests {
             provider: record.provider.clone(),
             initial_message: None,
             force_initial_prompt_stdin: false,
+            claude_session_id: None,
             model: None,
             reasoning_effort: None,
         };
@@ -22990,6 +23067,7 @@ mod tests {
                 provider: "codex-fork".to_owned(),
                 initial_message: None,
                 force_initial_prompt_stdin: false,
+                claude_session_id: None,
                 model: None,
                 reasoning_effort: None,
             })

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -15567,8 +15567,13 @@ async fn runtime_core_claude_spawn_brief_never_retries_an_unobserved_submission(
             .as_nanos()
     );
     let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
-    let app =
-        runtime_app_with_structured_claude_provider(&state_file, &log_dir, &tmux_socket, false);
+    let app = runtime_app_with_structured_claude_provider(
+        &state_file,
+        &log_dir,
+        &tmux_socket,
+        false,
+        false,
+    );
 
     let (status, payload) = post_json(
         app,
@@ -15599,7 +15604,7 @@ async fn runtime_core_claude_spawn_brief_never_retries_an_unobserved_submission(
 }
 
 #[tokio::test]
-async fn runtime_core_claude_spawn_brief_accepts_matching_transcript_user_turn() {
+async fn runtime_core_claude_spawn_brief_accepts_matching_nested_transcript_user_turn() {
     if !tmux_available() {
         return;
     }
@@ -15616,8 +15621,13 @@ async fn runtime_core_claude_spawn_brief_accepts_matching_transcript_user_turn()
             .as_nanos()
     );
     let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
-    let app =
-        runtime_app_with_structured_claude_provider(&state_file, &log_dir, &tmux_socket, true);
+    let app = runtime_app_with_structured_claude_provider(
+        &state_file,
+        &log_dir,
+        &tmux_socket,
+        true,
+        true,
+    );
 
     let (status, payload) = post_json(
         app,
@@ -20591,10 +20601,22 @@ fn runtime_app_with_structured_claude_provider(
     log_dir: &PathBuf,
     tmux_socket: &str,
     acknowledge: bool,
+    nested_transcript: bool,
 ) -> axum::Router {
     fs::create_dir_all(log_dir).unwrap();
     let transcript_root = state_file.with_extension("claude-projects");
     let provider = log_dir.join("fake-structured-claude");
+    let transcript_layout = if nested_transcript {
+        format!(
+            r#"transcript='{}'/"$project_dir"/"$session_id"/chat.jsonl"#,
+            transcript_root.display()
+        )
+    } else {
+        format!(
+            r#"transcript='{}'/"$project_dir"/"$session_id".jsonl"#,
+            transcript_root.display()
+        )
+    };
     let acknowledgement = acknowledge.then_some(
         r#"  printf '{"type":"user","sessionId":"%s","message":{"content":"%s"}}\n' "$session_id" "$line" >> "$transcript"
 "#,
@@ -20611,17 +20633,16 @@ for argument in "$@"; do
   previous="$argument"
 done
 project_dir=$(pwd -P | sed 's#/#-#g')
-transcript='{}'/"$project_dir"/"$session_id".jsonl
+{transcript_layout}
 mkdir -p "$(dirname "$transcript")"
 printf '{{"type":"mode","sessionId":"%s"}}\n' "$session_id" > "$transcript"
-printf 'renderer layout deliberately irrelevant\n❯ '
+printf 'renderer layout deliberately irrelevant\n❯'
 while IFS= read -r line; do
   printf 'received:%s\n' "$line"
 {}
-  printf 'renderer changed again\n❯ '
+  printf 'renderer changed again\n❯'
 done
 "#,
-            transcript_root.display(),
             acknowledgement
         ),
     )

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -15567,12 +15567,8 @@ async fn runtime_core_claude_spawn_brief_never_retries_an_unobserved_submission(
             .as_nanos()
     );
     let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
-    let app = runtime_app_with_command(
-        &state_file,
-        &log_dir,
-        &tmux_socket,
-        r#"/bin/sh -lc 'printf ">"; while IFS= read -r line; do printf "\nreceived:%s\n>" "$line"; done' runtime-sh"#,
-    );
+    let app =
+        runtime_app_with_structured_claude_provider(&state_file, &log_dir, &tmux_socket, false);
 
     let (status, payload) = post_json(
         app,
@@ -15603,7 +15599,7 @@ async fn runtime_core_claude_spawn_brief_never_retries_an_unobserved_submission(
 }
 
 #[tokio::test]
-async fn runtime_core_claude_spawn_brief_accepts_provider_turn_transition() {
+async fn runtime_core_claude_spawn_brief_accepts_matching_transcript_user_turn() {
     if !tmux_available() {
         return;
     }
@@ -15620,12 +15616,8 @@ async fn runtime_core_claude_spawn_brief_accepts_provider_turn_transition() {
             .as_nanos()
     );
     let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
-    let app = runtime_app_with_command(
-        &state_file,
-        &log_dir,
-        &tmux_socket,
-        r#"/bin/sh -lc 'printf "Header\n>"; while IFS= read -r line; do printf "\nreceived:%s\n\033[2J\033[H✽ Thinking through the initial brief\n>" "$line"; done' runtime-sh"#,
-    );
+    let app =
+        runtime_app_with_structured_claude_provider(&state_file, &log_dir, &tmux_socket, true);
 
     let (status, payload) = post_json(
         app,
@@ -15644,6 +15636,17 @@ async fn runtime_core_claude_spawn_brief_accepts_provider_turn_transition() {
     let state: Value = serde_json::from_str(&fs::read_to_string(&state_file).unwrap()).unwrap();
     let launch = &state["session_runtime_launches"][0];
     assert_eq!(launch["status"], "applied");
+    let provider_session_id = launch["provider_resume_id"].as_str().unwrap();
+    assert_eq!(provider_session_id.len(), 36);
+    assert_eq!(provider_session_id.as_bytes()[14], b'4');
+    assert!(matches!(
+        provider_session_id.as_bytes()[19],
+        b'8' | b'9' | b'a' | b'b'
+    ));
+    assert_eq!(
+        state["sessions"][0]["provider_resume_id"],
+        provider_session_id
+    );
     let logs = fs::read_to_string(launch["log_file"].as_str().unwrap()).unwrap_or_default();
     assert_eq!(logs.matches("received:CLAUDE_ACCEPTED_SENTINEL").count(), 1);
 }
@@ -20581,6 +20584,85 @@ fn runtime_app(state_file: &PathBuf, log_dir: &PathBuf, tmux_socket: &str) -> ax
         tmux_socket,
         r#"/bin/sh -lc 'while IFS= read -r line; do printf "argv:%s\nids:%s:%s:%s\nruntime:%s\n" "$*" "$SESSION_MANAGER_ID" "$CLAUDE_SESSION_MANAGER_ID" "$ENABLE_TOOL_SEARCH" "$line"; done' runtime-sh"#,
     )
+}
+
+fn runtime_app_with_structured_claude_provider(
+    state_file: &PathBuf,
+    log_dir: &PathBuf,
+    tmux_socket: &str,
+    acknowledge: bool,
+) -> axum::Router {
+    fs::create_dir_all(log_dir).unwrap();
+    let transcript_root = state_file.with_extension("claude-projects");
+    let provider = log_dir.join("fake-structured-claude");
+    let acknowledgement = acknowledge.then_some(
+        r#"  printf '{"type":"user","sessionId":"%s","message":{"content":"%s"}}\n' "$session_id" "$line" >> "$transcript"
+"#,
+    )
+    .unwrap_or_default();
+    fs::write(
+        &provider,
+        format!(
+            r#"#!/bin/sh
+session_id=''
+previous=''
+for argument in "$@"; do
+  if [ "$previous" = "--session-id" ]; then session_id="$argument"; fi
+  previous="$argument"
+done
+project_dir=$(pwd -P | sed 's#/#-#g')
+transcript='{}'/"$project_dir"/"$session_id".jsonl
+mkdir -p "$(dirname "$transcript")"
+printf '{{"type":"mode","sessionId":"%s"}}\n' "$session_id" > "$transcript"
+printf 'renderer layout deliberately irrelevant\n❯ '
+while IFS= read -r line; do
+  printf 'received:%s\n' "$line"
+{}
+  printf 'renderer changed again\n❯ '
+done
+"#,
+            transcript_root.display(),
+            acknowledgement
+        ),
+    )
+    .unwrap();
+    #[cfg(unix)]
+    {
+        let mut permissions = fs::metadata(&provider).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&provider, permissions).unwrap();
+    }
+
+    router(AppState::new(AppConfig {
+        paths: PathsConfig {
+            state_file: state_file.display().to_string(),
+        },
+        sm_send: SmSendConfig {
+            db_path: queue_db_path_for_state_file(state_file)
+                .display()
+                .to_string(),
+        },
+        claude: ProviderLaunchConfig {
+            command: provider.display().to_string(),
+            args: Vec::new(),
+            default_model: None,
+            session_index_path: None,
+            transcript_root: Some(transcript_root.display().to_string()),
+        },
+        rust_core: RustCoreConfig {
+            runtime_enabled: true,
+            log_dir: Some(log_dir.display().to_string()),
+            tmux_socket_name: Some(tmux_socket.to_owned()),
+            runtime_prompt_mode: Some("stdin".to_owned()),
+            runtime_initial_brief_ready_timeout_ms: Some(2_000),
+            runtime_initial_brief_ack_timeout_ms: Some(300),
+            send_keys_settle_ms: Some(10.0),
+            send_keys_settle_max_ms: Some(50.0),
+            send_keys_max_chunk_chars: Some(128),
+            ..RustCoreConfig::default()
+        },
+        ..AppConfig::default()
+    }))
 }
 
 fn runtime_app_with_codex_fork_initial_brief_provider(


### PR DESCRIPTION
Fixes #1289

Replace Claude initial spawn-brief renderer/cursor acknowledgement with a correlated provider transcript user-turn record. Each verified Claude spawn receives a UUID session ID, waits for that exact transcript to initialize, and accepts only an appended matching user turn. Startup recovery fails closed rather than replaying an ambiguous brief.

Validation:
- cargo fmt --check
- cargo check -p sm-server
- cargo test -p sm-server --lib recovery_never_replays_an_unacknowledged_claude_spawn_brief -- --nocapture
- cargo test -p sm-server --lib claude_initial_brief -- --nocapture
- cargo test -p sm-server --test read_only_http runtime_core_claude_spawn_brief -- --nocapture

Note: the complete lib suite retains two pre-existing unrelated failures tracked in #1355 (scheduled_reminders fixture schema) and #1259 (seat_sessions initialization race).