### PR TITLE
Fix Codex-fork restore tmux teardown semantics

### DIFF
--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -285,6 +285,12 @@ impl TmuxRuntime {
         runtime
     }
 
+    #[cfg(test)]
+    pub(crate) fn with_tmux_binary_for_test(mut self, tmux_binary: impl Into<String>) -> Self {
+        self.tmux_binary = tmux_binary.into();
+        self
+    }
+
     pub fn socket_name(&self) -> Option<&str> {
         self.socket_name.as_deref()
     }
@@ -793,11 +799,18 @@ impl TmuxRuntime {
     }
 
     pub fn kill_session(&self, tmux_session: &str) -> Result<bool> {
-        if !self.session_exists(tmux_session)? {
-            return Ok(false);
+        // Do not preflight this with `has-session`: its nonzero status can
+        // mean either a genuinely absent target or that tmux could not be
+        // reached. `kill-session` gives us the authoritative result for the
+        // operation we need to perform, and its known absent-target errors
+        // remain safely idempotent.
+        match self.run_tmux(["kill-session", "-t", tmux_session]) {
+            Ok(()) => Ok(true),
+            // The session can exit after an earlier observation but before
+            // tmux handles the kill request. That is still already absent.
+            Err(error) if is_tmux_session_gone_error(&error) => Ok(false),
+            Err(error) => Err(error),
         }
-        self.run_tmux(["kill-session", "-t", tmux_session])?;
-        Ok(true)
     }
 
     pub fn set_status_bar(&self, tmux_session: &str, friendly_name: &str) -> Result<bool> {
@@ -822,7 +835,14 @@ impl TmuxRuntime {
             .stderr(Stdio::piped())
             .output()
             .with_context(|| "failed to run tmux has-session")?;
-        Ok(output.status.success())
+        if output.status.success() {
+            return Ok(true);
+        }
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if is_tmux_session_gone_message(&stderr) {
+            return Ok(false);
+        }
+        bail!("tmux has-session failed: {}", stderr.trim());
     }
 
     fn create_session_with_bootstrap(&self, spec: &TmuxSessionSpec, command: &str) -> Result<()> {
@@ -1684,11 +1704,16 @@ fn duration_from_seconds(seconds: f64) -> Duration {
 }
 
 fn is_tmux_session_gone_error(error: &anyhow::Error) -> bool {
-    let message = error.to_string();
+    is_tmux_session_gone_message(&error.to_string())
+}
+
+fn is_tmux_session_gone_message(message: &str) -> bool {
     message.contains("no server running")
         || message.contains("can't find session")
         || message.contains("no current target")
         || message.contains("server exited unexpectedly")
+        || (message.contains("error connecting to ")
+            && message.contains("No such file or directory"))
 }
 
 fn shell_quote_path(path: &Path) -> String {
@@ -2579,6 +2604,94 @@ esac
     }
 
     #[test]
+    fn kill_session_treats_an_absent_target_as_idempotent() {
+        let (tmux_binary, _log_path, _temp_dir) = fake_tmux_binary();
+        fs::write(
+            &tmux_binary,
+            r#"#!/bin/sh
+if [ "$1" = "-L" ]; then
+  shift 2
+fi
+case "$1" in
+  kill-session) echo "can't find session: sm-test" >&2; exit 1 ;;
+  *) exit 0 ;;
+esac
+"#,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&tmux_binary).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&tmux_binary, permissions).unwrap();
+        let mut runtime = TmuxRuntime::from_config(&RustCoreConfig::default());
+        runtime.tmux_binary = tmux_binary.display().to_string();
+
+        assert!(!runtime.kill_session("sm-test").unwrap());
+    }
+
+    #[test]
+    fn kill_session_treats_a_disappearance_race_as_already_absent() {
+        let (tmux_binary, _log_path, _temp_dir) = fake_tmux_binary();
+        fs::write(
+            &tmux_binary,
+            r#"#!/bin/sh
+if [ "$1" = "-L" ]; then
+  shift 2
+fi
+case "$1" in
+  has-session) exit 0 ;;
+  kill-session) echo "can't find session: sm-test" >&2; exit 1 ;;
+  *) exit 0 ;;
+esac
+"#,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&tmux_binary).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&tmux_binary, permissions).unwrap();
+        let mut runtime = TmuxRuntime::from_config(&RustCoreConfig::default());
+        runtime.tmux_binary = tmux_binary.display().to_string();
+
+        // A previous observer saw the runtime. `kill_session` intentionally
+        // does not repeat that racy observation before asking tmux to kill.
+        assert!(runtime.session_exists("sm-test").unwrap());
+        assert!(!runtime.kill_session("sm-test").unwrap());
+    }
+
+    #[test]
+    fn session_exists_rejects_permission_socket_and_transport_failures() {
+        for failure in [
+            "permission denied while contacting tmux server",
+            "error connecting to /tmp/tmux-501/default: Connection refused",
+            "lost server connection",
+        ] {
+            let (tmux_binary, _log_path, _temp_dir) = fake_tmux_binary();
+            fs::write(
+                &tmux_binary,
+                format!(
+                    r#"#!/bin/sh
+if [ "$1" = "-L" ]; then
+  shift 2
+fi
+case "$1" in
+  has-session) echo "{failure}" >&2; exit 1 ;;
+  *) exit 0 ;;
+esac
+"#
+                ),
+            )
+            .unwrap();
+            let mut permissions = fs::metadata(&tmux_binary).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&tmux_binary, permissions).unwrap();
+            let mut runtime = TmuxRuntime::from_config(&RustCoreConfig::default());
+            runtime.tmux_binary = tmux_binary.display().to_string();
+
+            let error = runtime.session_exists("sm-test").unwrap_err();
+            assert!(error.to_string().contains(failure));
+        }
+    }
+
+    #[test]
     fn set_status_bar_updates_tmux_status_left() {
         let (tmux_binary, log_path, _temp_dir) = fake_tmux_binary();
         let mut runtime = TmuxRuntime::from_config(&RustCoreConfig::default());
@@ -3175,7 +3288,12 @@ if [ "$1" = "-L" ]; then
   shift 2
 fi
 case "$1" in
-  has-session) exit {} ;;
+  has-session)
+    if [ {} -ne 0 ]; then
+      echo "can't find session: sm-test" >&2
+    fi
+    exit {}
+    ;;
   display-message) echo 0; exit 0 ;;
   capture-pane) printf 'ready\n>\n'; exit 0 ;;
   show-options) exit 0 ;;
@@ -3183,6 +3301,7 @@ case "$1" in
 esac
 "#,
                 log_path.display(),
+                if has_session { 0 } else { 1 },
                 if has_session { 0 } else { 1 }
             ),
         )

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -1708,12 +1708,12 @@ fn is_tmux_session_gone_error(error: &anyhow::Error) -> bool {
 }
 
 fn is_tmux_session_gone_message(message: &str) -> bool {
+    // A missing socket is deliberately not an absent-target signal: a live
+    // tmux server can recreate an accidentally unlinked socket on SIGUSR1.
     message.contains("no server running")
         || message.contains("can't find session")
         || message.contains("no current target")
         || message.contains("server exited unexpectedly")
-        || (message.contains("error connecting to ")
-            && message.contains("No such file or directory"))
 }
 
 fn shell_quote_path(path: &Path) -> String {
@@ -2658,10 +2658,41 @@ esac
     }
 
     #[test]
+    fn kill_session_rejects_a_missing_socket_as_a_transport_failure() {
+        let (tmux_binary, _log_path, _temp_dir) = fake_tmux_binary();
+        fs::write(
+            &tmux_binary,
+            r#"#!/bin/sh
+if [ "$1" = "-L" ]; then
+  shift 2
+fi
+case "$1" in
+  kill-session)
+    echo "error connecting to /tmp/tmux-501/sm-test (No such file or directory)" >&2
+    exit 1
+    ;;
+  *) exit 0 ;;
+esac
+"#,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&tmux_binary).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&tmux_binary, permissions).unwrap();
+        let mut runtime = TmuxRuntime::from_config(&RustCoreConfig::default());
+        runtime.tmux_binary = tmux_binary.display().to_string();
+
+        let error = runtime.kill_session("sm-test").unwrap_err();
+        assert!(error.to_string().contains("error connecting to"));
+        assert!(error.to_string().contains("No such file or directory"));
+    }
+
+    #[test]
     fn session_exists_rejects_permission_socket_and_transport_failures() {
         for failure in [
             "permission denied while contacting tmux server",
             "error connecting to /tmp/tmux-501/default: Connection refused",
+            "error connecting to /tmp/tmux-501/sm-test (No such file or directory)",
             "lost server connection",
         ] {
             let (tmux_binary, _log_path, _temp_dir) = fake_tmux_binary();

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -5620,7 +5620,21 @@ impl SessionStore {
         store_session_runtime_launch_records(&mut state, &launch_records)?;
         self.write_raw_json_value(&state)?;
 
-        if session_runtime.session_exists(&record.tmux_session)? {
+        if record.provider == "codex-fork" {
+            // For a Codex-fork restore, a tmux command failure is not proof
+            // that the prior runtime is gone. Keep the seat visible and fence
+            // another restore until an operator can resolve the runtime.
+            if let Err(error) = session_runtime.kill_session(&record.tmux_session) {
+                mark_runtime_launch_teardown_failed(
+                    &mut state,
+                    &launch_id,
+                    &record.id,
+                    &format!("failed to tear down prior runtime before restore: {error}"),
+                )?;
+                self.write_raw_json_value(&state)?;
+                return Err(error);
+            }
+        } else if session_runtime.session_exists(&record.tmux_session)? {
             if let Err(error) = session_runtime.kill_session(&record.tmux_session) {
                 mark_runtime_launch_failed(
                     &mut state,
@@ -14353,6 +14367,50 @@ fn mark_runtime_launch_failed(
     Ok(())
 }
 
+/// Record an inconclusive teardown without claiming the runtime is stopped.
+///
+/// A tmux command error is not evidence that the target process is gone. The
+/// session remains operator-visible and fenced from another restore until the
+/// runtime can be inspected or explicitly retired.
+fn mark_runtime_launch_teardown_failed(
+    state: &mut Value,
+    launch_id: &str,
+    session_id: &str,
+    failure_reason: &str,
+) -> Result<()> {
+    let mut records = session_runtime_launch_records(state)?;
+    let record = records
+        .iter_mut()
+        .find(|record| record.id == launch_id)
+        .ok_or_else(|| anyhow::anyhow!("runtime launch {launch_id} disappeared"))?;
+    record.status = "failed".to_owned();
+    record.updated_at = now_rfc3339();
+    record.failure_reason = Some(failure_reason.to_owned());
+    let restore_authorized = record.is_authorized_restore_intent();
+    store_session_runtime_launch_records(state, &records)?;
+
+    let sessions = ensure_sessions_array_mut(state)?;
+    if let Some(session) = session_object_mut(sessions, session_id) {
+        // The caller admitted this restore before it cleared a terminal
+        // marker. Do not let that marker hide an unconfirmed runtime.
+        if restore_authorized {
+            session.insert("completion_status".to_owned(), Value::Null);
+            session.insert("completion_message".to_owned(), Value::Null);
+            session.insert("completed_at".to_owned(), Value::Null);
+            session.insert("terminal_provenance".to_owned(), Value::Null);
+            session.insert("retirement_intent".to_owned(), Value::Null);
+            session.insert("agent_task_completed_at".to_owned(), Value::Null);
+        }
+        session.insert("status".to_owned(), Value::String("error".to_owned()));
+        session.insert("stopped_at".to_owned(), Value::Null);
+        session.insert(
+            "error_message".to_owned(),
+            Value::String(format!("runtime teardown failed: {failure_reason}")),
+        );
+    }
+    Ok(())
+}
+
 fn reparent_topology_fingerprint(
     kind: &str,
     subject_session_id: &str,
@@ -16710,6 +16768,56 @@ mod tests {
         assert_eq!(state["session_runtime_launches"][0]["status"], "failed");
     }
 
+    #[test]
+    fn runtime_teardown_failure_keeps_an_authorized_restore_operator_visible() {
+        let mut state = json!({
+            "sessions": [{
+                "id": "restore01",
+                "name": "restore-codex-fork",
+                "provider": "codex-fork",
+                "working_dir": "/tmp",
+                "tmux_session": "codex-fork-restore01",
+                "status": "stopped",
+                "completion_status": "killed",
+                "created_at": "2026-08-18T00:00:00Z",
+                "last_activity": "2026-08-18T00:00:00Z"
+            }],
+            "session_runtime_launches": [{
+                "id": "launch01",
+                "operation_kind": "restore",
+                "session_id": "restore01",
+                "tmux_session": "codex-fork-restore01",
+                "working_dir": "/tmp",
+                "log_file": "/tmp/codex-fork-restore01.log",
+                "provider": "codex-fork",
+                "provider_resume_id": "durable-root",
+                "restore_authorized": true,
+                "credential_sha256": "test-credential",
+                "status": "launching",
+                "created_at": "2026-08-18T00:00:00Z",
+                "updated_at": "2026-08-18T00:00:00Z"
+            }]
+        });
+
+        mark_runtime_launch_teardown_failed(
+            &mut state,
+            "launch01",
+            "restore01",
+            "tmux transport failed",
+        )
+        .unwrap();
+
+        let session = state["sessions"][0].as_object().unwrap();
+        assert_eq!(session["status"], "error");
+        assert!(session["completion_status"].is_null());
+        assert!(!raw_session_is_stopped(session));
+        assert!(session["error_message"]
+            .as_str()
+            .unwrap()
+            .contains("tmux transport failed"));
+        assert_eq!(state["session_runtime_launches"][0]["status"], "failed");
+    }
+
     static TEST_ENV_LOCK: Mutex<()> = Mutex::new(());
 
     struct EnvVarRestore {
@@ -16736,6 +16844,80 @@ mod tests {
                 env::remove_var(self.key);
             }
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn codex_fork_restore_teardown_transport_failure_is_fenced_and_operator_visible() {
+        let root = unique_temp_path("codex-fork-restore-teardown-failure");
+        fs::create_dir_all(&root).unwrap();
+        let tmux = root.join("tmux");
+        fs::write(
+            &tmux,
+            r#"#!/bin/sh
+case "$1" in
+  kill-session) echo "permission denied while contacting tmux server" >&2; exit 1 ;;
+  *) exit 99 ;;
+esac
+"#,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&tmux).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&tmux, permissions).unwrap();
+
+        let state_file = root.join("sessions.json");
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [{
+                    "id": "restore01",
+                    "name": "restore-codex-fork",
+                    "provider": "codex-fork",
+                    "provider_resume_id": "durable-root",
+                    "working_dir": root,
+                    "tmux_session": "codex-fork-restore01",
+                    "log_file": root.join("restore.log"),
+                    "status": "stopped",
+                    "completion_status": "killed",
+                    "created_at": "2026-08-18T00:00:00Z",
+                    "last_activity": "2026-08-18T00:00:00Z"
+                }]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let store = SessionStore::new(state_file.clone());
+        let runtime = TmuxRuntime::from_config(&crate::config::RustCoreConfig::default())
+            .with_tmux_binary_for_test(tmux.display().to_string());
+
+        let error = store
+            .restore_core_session_with_runtime("restore01", &runtime)
+            .unwrap_err();
+        assert!(error.to_string().contains("permission denied"));
+
+        let state = store.load_raw_json_value().unwrap();
+        let session = &state["sessions"][0];
+        assert_eq!(session["status"], "error");
+        assert!(session["stopped_at"].is_null());
+        assert!(session["completion_status"].is_null());
+        assert_eq!(session["provider_resume_id"], "durable-root");
+        assert!(session["error_message"]
+            .as_str()
+            .unwrap()
+            .contains("permission denied"));
+        assert_eq!(state["session_runtime_launches"][0]["status"], "failed");
+        assert!(state["session_runtime_launches"][0]["failure_reason"]
+            .as_str()
+            .unwrap()
+            .contains("permission denied"));
+        assert!(matches!(
+            store
+                .restore_core_session_with_runtime("restore01", &runtime)
+                .unwrap(),
+            Some(CoreRestoreOutcome::NotStopped)
+        ));
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -16856,7 +16856,7 @@ mod tests {
             &tmux,
             r#"#!/bin/sh
 case "$1" in
-  kill-session) echo "permission denied while contacting tmux server" >&2; exit 1 ;;
+  kill-session) echo "error connecting to /tmp/tmux-501/codex-fork-restore01 (No such file or directory)" >&2; exit 1 ;;
   *) exit 99 ;;
 esac
 "#,
@@ -16894,7 +16894,7 @@ esac
         let error = store
             .restore_core_session_with_runtime("restore01", &runtime)
             .unwrap_err();
-        assert!(error.to_string().contains("permission denied"));
+        assert!(error.to_string().contains("No such file or directory"));
 
         let state = store.load_raw_json_value().unwrap();
         let session = &state["sessions"][0];
@@ -16905,12 +16905,12 @@ esac
         assert!(session["error_message"]
             .as_str()
             .unwrap()
-            .contains("permission denied"));
+            .contains("No such file or directory"));
         assert_eq!(state["session_runtime_launches"][0]["status"], "failed");
         assert!(state["session_runtime_launches"][0]["failure_reason"]
             .as_str()
             .unwrap()
-            .contains("permission denied"));
+            .contains("No such file or directory"));
         assert!(matches!(
             store
                 .restore_core_session_with_runtime("restore01", &runtime)
@@ -17170,6 +17170,33 @@ esac
         (socket_name, runtime)
     }
 
+    fn authoritative_absent_target_test_tmux_runtime() -> (String, TmuxRuntime, PathBuf) {
+        let root = unique_temp_path("tmux-authoritative-absent-target");
+        fs::create_dir_all(&root).unwrap();
+        let tmux = root.join("tmux");
+        fs::write(
+            &tmux,
+            r#"#!/bin/sh
+if [ "$1" = "-L" ]; then
+  shift 2
+fi
+case "$1" in
+  has-session) echo "can't find session: $3" >&2; exit 1 ;;
+  *) exit 0 ;;
+esac
+"#,
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&tmux).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&tmux, permissions).unwrap();
+        let socket_name = "sm-test-known-absent".to_owned();
+        let runtime = TmuxRuntime::from_config(&crate::config::RustCoreConfig::default())
+            .with_tmux_binary_for_test(tmux.display().to_string())
+            .for_socket_name(Some(&socket_name));
+        (socket_name, runtime, root)
+    }
+
     #[test]
     fn credential_rotation_stopped_before_admission_is_first_call_truthful_and_idempotent() {
         let state_file = unique_temp_path("credential-rotation-stopped-admission");
@@ -17204,7 +17231,7 @@ esac
         // Deliberately stale-looking log content is present but is not read by
         // admission; only the missing tmux runtime decides terminal liveness.
         state["sessions"][0]["log_file"] = json!("/tmp/stale-auth-scrollback.log");
-        let (tmux_socket_name, runtime) = isolated_test_tmux_runtime();
+        let (tmux_socket_name, runtime, root) = authoritative_absent_target_test_tmux_runtime();
         state["sessions"][0]["tmux_socket_name"] = json!(tmux_socket_name);
         fs::write(&state_file, state.to_string()).unwrap();
         let store = SessionStore::new(state_file.clone()).with_delivery_runtime(Some(runtime));
@@ -17220,6 +17247,7 @@ esac
             .unwrap()
             .is_empty());
         let _ = fs::remove_file(state_file);
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]
@@ -17241,7 +17269,7 @@ esac
     #[test]
     fn credential_rotation_send_undeliverable_finalizes_waiting_record() {
         let mut state = terminal_rotation_fixture("waiting_idle", None);
-        let (tmux_socket_name, runtime) = isolated_test_tmux_runtime();
+        let (tmux_socket_name, runtime, root) = authoritative_absent_target_test_tmux_runtime();
         state["sessions"][0]["tmux_socket_name"] = json!(tmux_socket_name);
 
         let (status, delivered) =
@@ -17255,6 +17283,7 @@ esac
             state["session_credential_rotations"][0]["failure_reason"],
             "target_terminal"
         );
+        let _ = fs::remove_dir_all(root);
     }
 
     #[test]


### PR DESCRIPTION
## Invariant

A Codex-fork restore may treat tmux as absent only when tmux authoritatively reports an absent target. Any other teardown or transport failure leaves the durable session operator-visible and fenced in `error`.

## Hunk ledger against #1356

### Retained

- `a36ac4`: idempotent `kill-session` behavior for a disappearance race.
- `a36ac4`: truthful failed-teardown projection, retained only for the Codex-fork restore boundary.
- `e462a4`: authoritative `kill-session` without a racy `has-session` preflight.
- `e462a4`: `has-session` distinguishes known absence from permission, socket, and transport failures.
- The related fake-tmux tests, extended with a direct Codex-fork restore projection test.

### P1 correction

- A missing tmux socket (`error connecting … No such file or directory`) is an inconclusive transport failure, not confirmed server absence. A live tmux server can recreate an accidentally removed socket, so this condition propagates into the existing `error`/fence projection. Regression tests cover `kill-session`, `has-session`, and the Codex-fork restore boundary.

### Deferred

- `abc03e9`: structured Codex-fork restore acceptance, exact root-ID gate, settle window, and rejection handling — Part 2.
- `e462a4`: directory-trust prompt handling and `shutdown_complete` acceptance behavior — Part 2.
- `a36ac4`: ambiguous launching Codex-fork restore restart recovery — Part 3.

### Dropped

- `a36ac4` generic create, recredential, and non-restore launch/recovery teardown changes. They are outside this contracts restore-only scope.
- The superseded #1356 working-spec edits; the #1324 delivery-contract comment is authoritative.

## Out of scope

Generic create behavior, credential/recredential relaunch, generic launch recovery, and all structured restore acceptance/restart recovery work.

## Validation

- Focused fake-tmux and restore projection tests pass.
- `cargo fmt --check` and `git diff --check` pass.
- Full isolated Rust suite: 521 passed; one unrelated existing failure remains: `http::tests::reminder_http_rejects_killed_target_with_status_drift` fails because its fixture has no `scheduled_reminders` table (tracked by #1352, #1355, #1350, and #1305).
