### PR TITLE
Fix Claude handoff readiness on current composer UI

### DIFF
--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -658,17 +658,19 @@ impl TmuxRuntime {
         self.clear_session_inner(tmux_session, clear_command, prompt, wake_completed, None)
     }
 
-    pub(crate) fn clear_claude_session_if<P, C, S>(
+    pub(crate) fn clear_claude_session_if<P, C, A, S>(
         &self,
         tmux_session: &str,
         prompt: &str,
         precondition: P,
         commit_clear: C,
+        clear_completed: A,
         commit_prompt: S,
     ) -> Result<ConditionalClearOutcome>
     where
         P: FnOnce() -> Result<bool>,
         C: FnOnce(&mut dyn FnMut() -> Result<()>) -> Result<bool>,
+        A: FnMut() -> Result<bool>,
         S: FnOnce(&mut dyn FnMut() -> Result<()>) -> Result<bool>,
     {
         let _guard = self.lock_session_input(tmux_session)?;
@@ -688,14 +690,12 @@ impl TmuxRuntime {
             return Ok(ConditionalClearOutcome::PreconditionFailed);
         }
 
-        if self
-            .wait_for_claude_empty_composer(
-                tmux_session,
-                Some(&pre_clear_pane),
-                Duration::from_secs_f64(5.0),
-            )
-            .is_none()
-        {
+        if !self.wait_for_confirmed_claude_clear(
+            tmux_session,
+            &pre_clear_pane,
+            clear_completed,
+            Duration::from_secs_f64(5.0),
+        )? {
             bail!("Claude handoff timed out waiting for /clear to finish");
         }
         let mut send_prompt = || self.send_text_then_enter(tmux_session, prompt);
@@ -703,6 +703,36 @@ impl TmuxRuntime {
             return Ok(ConditionalClearOutcome::PostClearPreconditionFailed);
         }
         Ok(ConditionalClearOutcome::Cleared)
+    }
+
+    fn wait_for_confirmed_claude_clear<A>(
+        &self,
+        tmux_session: &str,
+        pre_clear_pane: &str,
+        mut clear_completed: A,
+        timeout: Duration,
+    ) -> Result<bool>
+    where
+        A: FnMut() -> Result<bool>,
+    {
+        let deadline = Instant::now() + timeout;
+        loop {
+            if clear_completed()?
+                && self
+                    .wait_for_claude_empty_composer(
+                        tmux_session,
+                        Some(pre_clear_pane),
+                        Duration::ZERO,
+                    )
+                    .is_some()
+            {
+                return Ok(true);
+            }
+            if Instant::now() >= deadline {
+                return Ok(false);
+            }
+            thread::sleep(Duration::from_millis(100));
+        }
     }
 
     pub fn clear_codex_session_confirming_prompt(
@@ -3005,6 +3035,7 @@ esac
                     checks.set(checks.get() + 1);
                     Ok(false)
                 },
+                || unreachable!("clear completion must not be checked"),
                 |_send_prompt| unreachable!("prompt submission must not be reached"),
             )
             .unwrap();
@@ -3035,6 +3066,7 @@ esac
                     send_clear()?;
                     Ok(true)
                 },
+                || Ok(true),
                 |send_prompt| {
                     send_prompt()?;
                     Ok(true)
@@ -3069,6 +3101,7 @@ esac
                     send_clear()?;
                     Ok(true)
                 },
+                || Ok(true),
                 |_send_prompt| Ok(false),
             )
             .unwrap();
@@ -3101,6 +3134,7 @@ esac
                     send_clear()?;
                     Ok(true)
                 },
+                || Ok(true),
                 |send_prompt| {
                     send_prompt()?;
                     Ok(true)
@@ -3112,6 +3146,41 @@ esac
         let log = fs::read_to_string(log_path).unwrap();
         assert!(log.contains("send-keys -t sm-test -l -- /clear"));
         assert!(log.contains("send-keys -t sm-test -l -- handoff prompt"));
+    }
+
+    #[test]
+    fn conditional_claude_clear_requires_provider_clear_confirmation() {
+        let (tmux_binary, log_path, _temp_dir) = fake_tmux_binary_with_fresh_clear();
+        let mut runtime = TmuxRuntime::from_config(&RustCoreConfig {
+            send_keys_settle_ms: Some(0.0),
+            send_keys_settle_max_ms: Some(0.0),
+            ..RustCoreConfig::default()
+        });
+        runtime.tmux_binary = tmux_binary.display().to_string();
+
+        let error = runtime
+            .clear_claude_session_if(
+                "sm-test",
+                "handoff prompt",
+                || Ok(true),
+                |send_clear| {
+                    send_clear()?;
+                    Ok(true)
+                },
+                || Ok(false),
+                |send_prompt| {
+                    send_prompt()?;
+                    Ok(true)
+                },
+            )
+            .unwrap_err();
+
+        assert!(error
+            .to_string()
+            .contains("timed out waiting for /clear to finish"));
+        let log = fs::read_to_string(log_path).unwrap();
+        assert!(log.contains("send-keys -t sm-test -l -- /clear"));
+        assert!(!log.contains("handoff prompt"));
     }
 
     #[test]
@@ -3130,6 +3199,7 @@ esac
                 "handoff prompt",
                 || Ok(true),
                 |_send_clear| unreachable!("typed input must not be cleared"),
+                || unreachable!("clear completion must not be checked"),
                 |_send_prompt| unreachable!("handoff prompt must not be submitted"),
             )
             .unwrap();
@@ -3385,8 +3455,9 @@ esac
             .unwrap()
             .as_nanos();
         let temp_dir = std::env::temp_dir().join(format!(
-            "sm-runtime-fake-tmux-{}-{unique}",
-            std::process::id()
+            "sm-runtime-fake-tmux-{}-{:?}-{unique}",
+            std::process::id(),
+            std::thread::current().id(),
         ));
         fs::create_dir_all(&temp_dir).unwrap();
         let tmux_binary = temp_dir.join("tmux");

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -678,10 +678,9 @@ impl TmuxRuntime {
         if !precondition()? {
             return Ok(ConditionalClearOutcome::PreconditionFailed);
         }
-        if !self.wait_for_prompt(tmux_session, Duration::from_secs_f64(3.0)) {
-            return Ok(ConditionalClearOutcome::IdlePromptNotReady);
-        }
-        let Some(pre_clear_pane) = self.capture_pane_text(tmux_session) else {
+        let Some(pre_clear_pane) =
+            self.wait_for_claude_empty_composer(tmux_session, None, Duration::from_secs_f64(3.0))
+        else {
             return Ok(ConditionalClearOutcome::IdlePromptNotReady);
         };
         let mut send_clear = || self.send_text_then_enter(tmux_session, "/clear");
@@ -689,7 +688,13 @@ impl TmuxRuntime {
             return Ok(ConditionalClearOutcome::PreconditionFailed);
         }
 
-        if !self.wait_for_fresh_prompt(tmux_session, &pre_clear_pane, Duration::from_secs_f64(5.0))
+        if self
+            .wait_for_claude_empty_composer(
+                tmux_session,
+                Some(&pre_clear_pane),
+                Duration::from_secs_f64(5.0),
+            )
+            .is_none()
         {
             bail!("Claude handoff timed out waiting for /clear to finish");
         }
@@ -978,21 +983,21 @@ impl TmuxRuntime {
         }
     }
 
-    fn wait_for_fresh_prompt(
+    fn wait_for_claude_empty_composer(
         &self,
         tmux_session: &str,
-        previous_pane: &str,
+        previous_pane: Option<&str>,
         timeout: Duration,
-    ) -> bool {
+    ) -> Option<String> {
         let deadline = Instant::now() + timeout;
         loop {
-            if self.capture_pane_text(tmux_session).is_some_and(|pane| {
-                pane != previous_pane && pane_last_line(&pane).as_deref() == Some(">")
-            }) {
-                return true;
+            if let Some(pane) = self.claude_empty_composer_pane(tmux_session) {
+                if previous_pane.is_none_or(|previous| pane != previous) {
+                    return Some(pane);
+                }
             }
             if Instant::now() >= deadline {
-                return false;
+                return None;
             }
             thread::sleep(Duration::from_millis(100));
         }
@@ -1410,16 +1415,20 @@ impl TmuxRuntime {
     /// Claude's empty composer must be at the active cursor, not merely occur
     /// in scrollback or resemble a typed prompt in a startup frame.
     fn claude_initial_brief_composer_ready(&self, tmux_session: &str) -> bool {
+        self.claude_empty_composer_pane(tmux_session).is_some()
+    }
+
+    fn claude_empty_composer_pane(&self, tmux_session: &str) -> Option<String> {
         let Some(pane) = self.capture_pane_text(tmux_session) else {
-            return false;
+            return None;
         };
         if !claude_composer_is_ready(&pane) {
-            return false;
+            return None;
         }
         let Some((cursor_x, cursor_y)) = self.pane_cursor_position(tmux_session) else {
-            return false;
+            return None;
         };
-        claude_empty_composer_cursor(&pane, cursor_x, cursor_y)
+        claude_empty_composer_cursor(&pane, cursor_x, cursor_y).then_some(pane)
     }
 
     fn pane_cursor_position(&self, tmux_session: &str) -> Option<(usize, usize)> {
@@ -2975,7 +2984,7 @@ esac
 
     #[test]
     fn conditional_claude_clear_revalidates_before_touching_the_pane() {
-        let (tmux_binary, log_path, _temp_dir) = fake_tmux_binary();
+        let (tmux_binary, log_path, _temp_dir) = fake_tmux_binary_with_fresh_clear();
         let mut runtime = TmuxRuntime::from_config(&RustCoreConfig {
             send_keys_settle_ms: Some(0.0),
             send_keys_settle_max_ms: Some(0.0),
@@ -3074,12 +3083,76 @@ esac
     }
 
     #[test]
-    fn fresh_prompt_wait_rejects_the_unchanged_pre_clear_prompt() {
-        let (tmux_binary, _log_path, _temp_dir) = fake_tmux_binary();
+    fn conditional_claude_clear_accepts_current_placeholder_composer() {
+        let (tmux_binary, log_path, _temp_dir) = fake_tmux_binary_with_fresh_clear();
+        let mut runtime = TmuxRuntime::from_config(&RustCoreConfig {
+            send_keys_settle_ms: Some(0.0),
+            send_keys_settle_max_ms: Some(0.0),
+            ..RustCoreConfig::default()
+        });
+        runtime.tmux_binary = tmux_binary.display().to_string();
+
+        let outcome = runtime
+            .clear_claude_session_if(
+                "sm-test",
+                "handoff prompt",
+                || Ok(true),
+                |send_clear| {
+                    send_clear()?;
+                    Ok(true)
+                },
+                |send_prompt| {
+                    send_prompt()?;
+                    Ok(true)
+                },
+            )
+            .unwrap();
+
+        assert_eq!(outcome, ConditionalClearOutcome::Cleared);
+        let log = fs::read_to_string(log_path).unwrap();
+        assert!(log.contains("send-keys -t sm-test -l -- /clear"));
+        assert!(log.contains("send-keys -t sm-test -l -- handoff prompt"));
+    }
+
+    #[test]
+    fn conditional_claude_clear_rejects_typed_placeholder_lookalike() {
+        let (tmux_binary, log_path, _temp_dir) = fake_tmux_binary_with_typed_claude_composer();
+        let mut runtime = TmuxRuntime::from_config(&RustCoreConfig {
+            send_keys_settle_ms: Some(0.0),
+            send_keys_settle_max_ms: Some(0.0),
+            ..RustCoreConfig::default()
+        });
+        runtime.tmux_binary = tmux_binary.display().to_string();
+
+        let outcome = runtime
+            .clear_claude_session_if(
+                "sm-test",
+                "handoff prompt",
+                || Ok(true),
+                |_send_clear| unreachable!("typed input must not be cleared"),
+                |_send_prompt| unreachable!("handoff prompt must not be submitted"),
+            )
+            .unwrap();
+
+        assert_eq!(outcome, ConditionalClearOutcome::IdlePromptNotReady);
+        let log = fs::read_to_string(log_path).unwrap();
+        assert!(!log.contains("send-keys -t sm-test -l -- /clear"));
+        assert!(!log.contains("handoff prompt"));
+    }
+
+    #[test]
+    fn claude_composer_wait_rejects_the_unchanged_pre_clear_pane() {
+        let (tmux_binary, _log_path, _temp_dir) = fake_tmux_binary_with_fresh_clear();
         let mut runtime = TmuxRuntime::from_config(&RustCoreConfig::default());
         runtime.tmux_binary = tmux_binary.display().to_string();
 
-        assert!(!runtime.wait_for_fresh_prompt("sm-test", "ready\n>\n", Duration::ZERO,));
+        assert!(runtime
+            .wait_for_claude_empty_composer(
+                "sm-test",
+                Some("ready\n❯\u{a0}Try \"fix typecheck errors\"\n"),
+                Duration::ZERO,
+            )
+            .is_none());
     }
 
     #[test]
@@ -3347,6 +3420,7 @@ esac
 
     fn fake_tmux_binary_with_stuck_clear() -> (PathBuf, PathBuf, PathBuf) {
         let (tmux_binary, log_path, temp_dir) = fake_tmux_binary();
+        let clear_marker = temp_dir.join("clear-sent");
         fs::write(
             &tmux_binary,
             format!(
@@ -3354,12 +3428,24 @@ esac
 printf '%s\n' "$*" >> "{}"
 case "$1" in
   has-session) exit 0 ;;
-  display-message) echo 0; exit 0 ;;
+  send-keys)
+    if [ "$*" = 'send-keys -t sm-test -l -- /clear' ]; then
+      : > "{}"
+    fi
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *'#{{cursor_x}},#{{cursor_y}}'*) echo '2,1' ;;
+      *) echo 0 ;;
+    esac
+    exit 0
+    ;;
   capture-pane)
-    if grep -q 'send-keys -t sm-test -l -- /clear' "{}"; then
+    if [ -f "{}" ]; then
       printf 'clearing\n'
     else
-      printf 'ready\n>\n'
+      printf 'ready\n❯\302\240Try "fix typecheck errors"\n'
     fi
     exit 0
     ;;
@@ -3368,7 +3454,8 @@ case "$1" in
 esac
 "#,
                 log_path.display(),
-                log_path.display(),
+                clear_marker.display(),
+                clear_marker.display(),
             ),
         )
         .unwrap();
@@ -3380,6 +3467,7 @@ esac
 
     fn fake_tmux_binary_with_fresh_clear() -> (PathBuf, PathBuf, PathBuf) {
         let (tmux_binary, log_path, temp_dir) = fake_tmux_binary();
+        let clear_marker = temp_dir.join("clear-sent");
         fs::write(
             &tmux_binary,
             format!(
@@ -3387,12 +3475,24 @@ esac
 printf '%s\n' "$*" >> "{}"
 case "$1" in
   has-session) exit 0 ;;
-  display-message) echo 0; exit 0 ;;
+  send-keys)
+    if [ "$*" = 'send-keys -t sm-test -l -- /clear' ]; then
+      : > "{}"
+    fi
+    exit 0
+    ;;
+  display-message)
+    case "$*" in
+      *'#{{cursor_x}},#{{cursor_y}}'*) echo '2,1' ;;
+      *) echo 0 ;;
+    esac
+    exit 0
+    ;;
   capture-pane)
-    if grep -q 'send-keys -t sm-test -l -- /clear' "{}"; then
-      printf 'cleared\n>\n'
+    if [ -f "{}" ]; then
+      printf 'cleared\n❯\302\240Try "write a function"\n'
     else
-      printf 'ready\n>\n'
+      printf 'ready\n❯\302\240Try "fix typecheck errors"\n'
     fi
     exit 0
     ;;
@@ -3401,6 +3501,38 @@ case "$1" in
 esac
 "#,
                 log_path.display(),
+                clear_marker.display(),
+                clear_marker.display(),
+            ),
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&tmux_binary).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&tmux_binary, permissions).unwrap();
+        (tmux_binary, log_path, temp_dir)
+    }
+
+    fn fake_tmux_binary_with_typed_claude_composer() -> (PathBuf, PathBuf, PathBuf) {
+        let (tmux_binary, log_path, temp_dir) = fake_tmux_binary();
+        fs::write(
+            &tmux_binary,
+            format!(
+                r#"#!/bin/sh
+printf '%s\n' "$*" >> "{}"
+case "$1" in
+  has-session) exit 0 ;;
+  display-message)
+    case "$*" in
+      *'#{{cursor_x}},#{{cursor_y}}'*) echo '27,1' ;;
+      *) echo 0 ;;
+    esac
+    exit 0
+    ;;
+  capture-pane) printf 'ready\n❯\302\240Try "fix typecheck errors"\n'; exit 0 ;;
+  show-options) exit 0 ;;
+  *) exit 0 ;;
+esac
+"#,
                 log_path.display(),
             ),
         )

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -6829,9 +6829,42 @@ impl SessionStore {
         Ok(true)
     }
 
+    #[allow(clippy::too_many_arguments)]
+    fn current_claude_handoff_clear_was_observed(
+        &self,
+        session_id: &str,
+        file_path: &str,
+        recorded_at: &str,
+        reservation_at: &str,
+        tmux_session: &str,
+        socket_name: &Option<String>,
+        previous_reset_emitted_at: Option<&str>,
+    ) -> Result<bool> {
+        let _guard = self.write_guard()?;
+        let state = self.load_raw_json_value()?;
+        let Some(session) = raw_session_object(&state, session_id) else {
+            return Ok(false);
+        };
+        let reservation_matches = json_text(session.get("provider")).as_deref() == Some("claude")
+            && !raw_session_is_stopped(session)
+            && is_primary_node(&json_text(session.get("node")).unwrap_or_else(default_node))
+            && json_text(session.get("tmux_session")).as_deref() == Some(tmux_session)
+            && json_text(session.get("tmux_socket_name")).as_deref() == socket_name.as_deref()
+            && json_text(session.get("pending_handoff_path")).as_deref() == Some(file_path)
+            && json_text(session.get("pending_handoff_recorded_at")).as_deref()
+                == Some(recorded_at)
+            && json_text(session.get("claude_handoff_in_progress_at")).as_deref()
+                == Some(reservation_at);
+        if !reservation_matches {
+            return Ok(false);
+        }
+        let reset_emitted_at = json_text(session.get("context_cycle_reset_emitted_at"));
+        Ok(reset_emitted_at.is_some() && reset_emitted_at.as_deref() != previous_reset_emitted_at)
+    }
+
     fn execute_pending_claude_handoff(&self, session_id: &str) -> Result<bool> {
         let _clear_guard = self.lock_clear_operation(session_id)?;
-        let (file_path, recorded_at, reservation_at, tmux_session, socket_name) = {
+        let (file_path, recorded_at, reservation_at, tmux_session, socket_name, reset_emitted_at) = {
             let _guard = self.write_guard()?;
             let state = self.load_raw_json_value()?;
             let Some(session) = raw_session_object(&state, session_id) else {
@@ -6859,6 +6892,7 @@ impl SessionStore {
                 json_text(session.get("tmux_session"))
                     .ok_or_else(|| anyhow::anyhow!("session {session_id} missing tmux_session"))?,
                 json_text(session.get("tmux_socket_name")),
+                json_text(session.get("context_cycle_reset_emitted_at")),
             )
         };
 
@@ -6888,6 +6922,14 @@ impl SessionStore {
             let commit_tmux_session = tmux_session.clone();
             let commit_socket_name = socket_name.clone();
             let commit_clear_started = clear_started.clone();
+            let confirmation_store = self.clone();
+            let confirmation_session_id = session_id.to_owned();
+            let confirmation_file_path = file_path.clone();
+            let confirmation_recorded_at = recorded_at.clone();
+            let confirmation_reservation_at = reservation_at.clone();
+            let confirmation_tmux_session = tmux_session.clone();
+            let confirmation_socket_name = socket_name.clone();
+            let confirmation_reset_emitted_at = reset_emitted_at.clone();
             let prompt_store = self.clone();
             let prompt_session_id = session_id.to_owned();
             let prompt_file_path = file_path.clone();
@@ -6923,6 +6965,17 @@ impl SessionStore {
                             commit_clear_started.store(true, Ordering::Release);
                             send_clear()
                         },
+                    )
+                },
+                move || {
+                    confirmation_store.current_claude_handoff_clear_was_observed(
+                        &confirmation_session_id,
+                        &confirmation_file_path,
+                        &confirmation_recorded_at,
+                        &confirmation_reservation_at,
+                        &confirmation_tmux_session,
+                        &confirmation_socket_name,
+                        confirmation_reset_emitted_at.as_deref(),
                     )
                 },
                 move |send_prompt| {

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -6859,7 +6859,13 @@ impl SessionStore {
             return Ok(false);
         }
         let reset_emitted_at = json_text(session.get("context_cycle_reset_emitted_at"));
-        Ok(reset_emitted_at.is_some() && reset_emitted_at.as_deref() != previous_reset_emitted_at)
+        let reset_is_new = reset_emitted_at.as_deref() != previous_reset_emitted_at;
+        let reset_follows_reservation = reset_emitted_at
+            .as_deref()
+            .and_then(parse_timestamp)
+            .zip(parse_timestamp(reservation_at))
+            .is_some_and(|(reset, reservation)| reset > reservation);
+        Ok(reset_is_new && reset_follows_reservation)
     }
 
     fn execute_pending_claude_handoff(&self, session_id: &str) -> Result<bool> {

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -14924,7 +14924,7 @@ async fn runtime_core_claude_handoff_executes_after_stop_without_interrupting_ac
         &state_file,
         &log_dir,
         _tmux_guard.0.as_str(),
-        r#"/bin/sh -lc 'printf ">\n"; while IFS= read -r line; do if [ "$line" = "/clear" ]; then sleep 1; fi; printf "runtime:%s\n>\n" "$line"; done' runtime-sh"#,
+        r#"/bin/sh -lc 'printf ">"; while IFS= read -r line; do if [ "$line" = "/clear" ]; then sleep 1; fi; printf "\nruntime:%s\n>" "$line"; done' runtime-sh"#,
     );
 
     let (status, _payload) = post_json(
@@ -15017,6 +15017,25 @@ async fn runtime_core_claude_handoff_executes_after_stop_without_interrupting_ac
     assert_eq!(status, StatusCode::OK);
     assert_eq!(payload["delivered"], false);
 
+    let clear_output =
+        wait_for_output_contains(app.clone(), "runtimehandoff", "runtime:/clear").await;
+    assert!(!clear_output["output"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("continue from where you left off"));
+    let (status, payload) = post_json(
+        app.clone(),
+        "/hooks/context-usage",
+        json!({
+            "session_id": "runtimehandoff",
+            "event": "context_reset",
+            "sm_hook_emitted_at": "2026-08-11T20:00:01.000000Z"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "flags_reset");
+
     let handoff_output = wait_for_output_contains(
         app.clone(),
         "runtimehandoff",
@@ -15093,7 +15112,7 @@ async fn runtime_core_claude_handoff_failure_retains_pending_and_restart_recover
             .as_nanos()
     );
     let _tmux_guard = TestTmuxSocket(tmux_socket.clone());
-    let runtime_command = r#"/bin/sh -lc 'printf ">\n"; while IFS= read -r line; do printf "runtime:%s\n>\n" "$line"; done' runtime-sh"#;
+    let runtime_command = r#"/bin/sh -lc 'printf ">"; while IFS= read -r line; do printf "\nruntime:%s\n>" "$line"; done' runtime-sh"#;
     let app = runtime_app_with_command(&state_file, &log_dir, &tmux_socket, runtime_command);
 
     let (status, _) = post_json(
@@ -15230,7 +15249,28 @@ async fn runtime_core_claude_handoff_failure_retains_pending_and_restart_recover
     )
     .unwrap();
     let restarted = runtime_app_with_command(&state_file, &log_dir, &tmux_socket, runtime_command);
-    tokio::time::sleep(Duration::from_secs(4)).await;
+    let clear_output = wait_for_output_contains(
+        restarted.clone(),
+        "runtimehandoffrecovery",
+        "runtime:/clear",
+    )
+    .await;
+    assert!(!clear_output["output"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("continue from where you left off"));
+    let (status, payload) = post_json(
+        restarted.clone(),
+        "/hooks/context-usage",
+        json!({
+            "session_id": "runtimehandoffrecovery",
+            "event": "context_reset",
+            "sm_hook_emitted_at": "2026-08-11T20:00:02.000000Z"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "flags_reset");
     wait_for_output_contains(
         restarted.clone(),
         "runtimehandoffrecovery",

--- a/crates/sm-server/tests/read_only_http.rs
+++ b/crates/sm-server/tests/read_only_http.rs
@@ -15029,7 +15029,30 @@ async fn runtime_core_claude_handoff_executes_after_stop_without_interrupting_ac
         json!({
             "session_id": "runtimehandoff",
             "event": "context_reset",
-            "sm_hook_emitted_at": "2026-08-11T20:00:01.000000Z"
+            "sm_hook_emitted_at": "2020-01-01T00:00:00.000000Z"
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["status"], "flags_reset");
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    let (status, output) = get_json(app.clone(), "/sessions/runtimehandoff/output?lines=20").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(!output["output"]
+        .as_str()
+        .unwrap_or_default()
+        .contains("continue from where you left off"));
+
+    let reset_emitted_at = (time::OffsetDateTime::now_utc() + time::Duration::seconds(1))
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap();
+    let (status, payload) = post_json(
+        app.clone(),
+        "/hooks/context-usage",
+        json!({
+            "session_id": "runtimehandoff",
+            "event": "context_reset",
+            "sm_hook_emitted_at": reset_emitted_at
         }),
     )
     .await;
@@ -15259,13 +15282,16 @@ async fn runtime_core_claude_handoff_failure_retains_pending_and_restart_recover
         .as_str()
         .unwrap_or_default()
         .contains("continue from where you left off"));
+    let reset_emitted_at = (time::OffsetDateTime::now_utc() + time::Duration::seconds(1))
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap();
     let (status, payload) = post_json(
         restarted.clone(),
         "/hooks/context-usage",
         json!({
             "session_id": "runtimehandoffrecovery",
             "event": "context_reset",
-            "sm_hook_emitted_at": "2026-08-11T20:00:02.000000Z"
+            "sm_hook_emitted_at": reset_emitted_at
         }),
     )
     .await;


### PR DESCRIPTION
## Summary

- replace Claude handoff's legacy final-line `>` readiness checks with the existing cursor-confirmed empty-composer predicate
- require Claude's structured `SessionStart(source=clear)` event, emitted after the current reservation, plus a safe fresh composer before injecting the handoff prompt
- preserve fail-closed behavior for typed input, stale panes, delayed old hooks, redraw timeouts, missing clear confirmation, and transaction changes
- add current-UI, hostile runtime, and real-tmux restart-recovery coverage
- make fake-tmux paths unique per test thread to remove the parallel collision recorded in #1359

## Measured production evidence

Session `cdcc9b63` durably recorded a handoff, then failed three seconds after its Stop event because current Claude rendered `❯ Try "..."` with footer rows rather than a final bare `>`. There was no intervening provider user turn.

## Review ledger

- Round 1 reviewed `0fad507`. P1 `3818747509` was valid and repaired by requiring a durable provider clear-hook boundary before prompt injection. P2 `3818747510` is accepted residual ambiguity under the maintainer's P2 exit rule.
- Round 2 reviewed `3f5e961`. P1 `3818786556` was valid: a delayed old clear hook could differ from the baseline. Fixed at `7c07d39` by requiring the hook producer timestamp to be strictly newer than the current handoff reservation; the real-tmux test first sends an older hook and proves no prompt is injected.
- Round 3 is the final permitted review and is restricted to confirmation of the stale-hook repair. There will be no Round 4.

## Validation

- conditional Claude clear tests: 6 passed
- runtime module tests: 39 passed
- context reset tests: 1 passed
- Claude handoff state tests: 5 passed
- real-tmux Claude handoff/restart recovery tests: 2 passed, including delayed-old-hook refusal
- full isolated suite on round-1 head: 517 passed; sole failure is the pre-existing `scheduled_reminders` fixture defect tracked by #1305
- `cargo check -p sm-server`
- `cargo fmt --all -- --check`
- `git diff --check`
- supported signed pre-merge deployment of round-1 head: PID 80700 stable, health and queue authority passed, sessions 5 -> 5

Fixes #1213
Closes #1359
