### PR TITLE
Add restore-only checked tmux teardown

### DIFF
--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -863,9 +863,12 @@ impl TmuxRuntime {
         &self,
         tmux_session: &str,
     ) -> RestoreTmuxTeardownOutcome {
-        match self.run_tmux(["kill-session", "-t", tmux_session]) {
+        // tmux otherwise accepts a unique prefix or pattern. A destructive
+        // restore teardown must act only on the exact durable target.
+        let exact_target = format!("={tmux_session}");
+        match self.run_tmux(["kill-session", "-t", exact_target.as_str()]) {
             Ok(()) => RestoreTmuxTeardownOutcome::Killed,
-            Err(error) if is_tmux_session_gone_error(&error) => {
+            Err(error) if is_tmux_restore_target_absent_error(&error) => {
                 RestoreTmuxTeardownOutcome::AlreadyAbsent
             }
             Err(error) => RestoreTmuxTeardownOutcome::Inconclusive {
@@ -1874,6 +1877,16 @@ fn is_tmux_session_gone_error(error: &anyhow::Error) -> bool {
         || message.contains("server exited unexpectedly")
 }
 
+/// Return true only when tmux authoritatively rejected the requested target.
+///
+/// Connection-level failures are deliberately excluded. In particular, both
+/// a cold default socket and an unlinked socket owned by a live server may say
+/// `no server running`, so that message cannot authorize replacement work.
+fn is_tmux_restore_target_absent_error(error: &anyhow::Error) -> bool {
+    let message = error.to_string();
+    message.contains("can't find session")
+}
+
 fn shell_quote_path(path: &Path) -> String {
     shell_quote(&path.display().to_string())
 }
@@ -2414,6 +2427,7 @@ mod tests {
     struct RealTmuxServerGuard {
         runtime: TmuxRuntime,
         server_pid: String,
+        temp_root: Option<PathBuf>,
     }
 
     #[cfg(unix)]
@@ -2425,6 +2439,9 @@ mod tests {
                 .args(["-USR1", self.server_pid.as_str()])
                 .status();
             let _ = self.runtime.run_tmux(["kill-server"]);
+            if let Some(temp_root) = self.temp_root.as_ref() {
+                let _ = fs::remove_dir_all(temp_root);
+            }
         }
     }
 
@@ -2829,19 +2846,14 @@ esac
             RestoreTmuxTeardownOutcome::Killed
         );
         let log = fs::read_to_string(log_path).unwrap();
-        assert!(log.contains("kill-session -t sm-test"));
+        assert!(log.contains("kill-session -t =sm-test"));
         assert!(!log.contains("has-session"));
     }
 
     #[cfg(unix)]
     #[test]
     fn restore_teardown_treats_only_authoritative_absence_as_idempotent() {
-        for message in [
-            "can't find session: sm-test",
-            "no current target",
-            "no server running on /tmp/tmux-501/session-manager",
-            "server exited unexpectedly",
-        ] {
+        for message in ["can't find session: sm-test"] {
             let (tmux_binary, _log_path, _temp_dir) = fake_tmux_binary();
             fs::write(
                 &tmux_binary,
@@ -2869,10 +2881,13 @@ esac
     #[test]
     fn restore_teardown_keeps_transport_failures_inconclusive() {
         for message in [
+            "no current target",
+            "no server running on /tmp/tmux-501/default",
             "error connecting to /tmp/tmux-501/session-manager (No such file or directory)",
             "error connecting to /tmp/tmux-501/session-manager (Connection refused)",
             "permission denied while contacting tmux server",
             "lost server connection",
+            "server exited unexpectedly",
         ] {
             let (tmux_binary, _log_path, _temp_dir) = fake_tmux_binary();
             fs::write(
@@ -2949,6 +2964,7 @@ esac
         let _server_guard = RealTmuxServerGuard {
             runtime: runtime.clone(),
             server_pid: server_pid.clone(),
+            temp_root: None,
         };
         let socket_path = runtime
             .tmux_command([
@@ -2988,6 +3004,157 @@ esac
             .status()
             .unwrap();
         assert!(recovered.success());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn real_tmux_default_socket_is_inconclusive_both_cold_and_unlinked_live() {
+        if !Command::new("tmux")
+            .arg("-V")
+            .output()
+            .is_ok_and(|output| output.status.success())
+        {
+            return;
+        }
+
+        // Keep this path short enough for tmux's AF_UNIX socket limit on macOS.
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let temp_root = PathBuf::from(format!("/tmp/sm-rtd-{}-{unique}", std::process::id()));
+        fs::create_dir_all(&temp_root).unwrap();
+        let canonical_temp_root = fs::canonicalize(&temp_root).unwrap();
+        let tmux_wrapper = temp_root.join("tmux-isolated");
+        fs::write(
+            &tmux_wrapper,
+            format!(
+                "#!/bin/sh\nunset TMUX\nexport TMUX_TMPDIR={}\nexec tmux \"$@\"\n",
+                shell_quote_path(&temp_root)
+            ),
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&tmux_wrapper).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&tmux_wrapper, permissions).unwrap();
+
+        let session_name = format!("sm-restore-default-{}", std::process::id());
+        let mut runtime = TmuxRuntime::from_config(&RustCoreConfig::default());
+        runtime.tmux_binary = tmux_wrapper.display().to_string();
+
+        let cold_outcome = runtime.teardown_session_for_restore(&session_name);
+        assert!(
+            matches!(
+                cold_outcome,
+                RestoreTmuxTeardownOutcome::Inconclusive { .. }
+            ),
+            "cold default socket outcome: {cold_outcome:?}"
+        );
+
+        let created = runtime
+            .tmux_command(["new-session", "-d", "-s", session_name.as_str(), "sleep 30"])
+            .output()
+            .unwrap();
+        assert!(
+            created.status.success(),
+            "failed to create isolated default-socket fixture: {}",
+            String::from_utf8_lossy(&created.stderr)
+        );
+        let server_pid = runtime
+            .tmux_command([
+                "display-message",
+                "-p",
+                "-t",
+                session_name.as_str(),
+                "#{pid}",
+            ])
+            .output()
+            .unwrap();
+        let server_pid = String::from_utf8(server_pid.stdout)
+            .unwrap()
+            .trim()
+            .to_owned();
+        let _server_guard = RealTmuxServerGuard {
+            runtime: runtime.clone(),
+            server_pid: server_pid.clone(),
+            temp_root: Some(temp_root.clone()),
+        };
+        let socket_path = runtime
+            .tmux_command([
+                "display-message",
+                "-p",
+                "-t",
+                session_name.as_str(),
+                "#{socket_path}",
+            ])
+            .output()
+            .unwrap();
+        let socket_path = PathBuf::from(String::from_utf8(socket_path.stdout).unwrap().trim());
+        assert!(socket_path.starts_with(&canonical_temp_root));
+        fs::remove_file(&socket_path).unwrap();
+
+        let outcome = runtime.teardown_session_for_restore(&session_name);
+        let server_still_live = Command::new("kill")
+            .args(["-0", server_pid.as_str()])
+            .status()
+            .is_ok_and(|status| status.success());
+        assert!(matches!(
+            outcome,
+            RestoreTmuxTeardownOutcome::Inconclusive { .. }
+        ));
+        assert!(server_still_live);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn real_tmux_restore_teardown_never_kills_a_prefix_match() {
+        if !Command::new("tmux")
+            .arg("-V")
+            .output()
+            .is_ok_and(|output| output.status.success())
+        {
+            return;
+        }
+
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let socket_name = format!("sm-restore-prefix-{}-{unique}", std::process::id());
+        let requested_name = format!("sm-prefix-{}", std::process::id());
+        let live_name = format!("{requested_name}-other");
+        let runtime = TmuxRuntime::from_config(&RustCoreConfig {
+            tmux_socket_name: Some(socket_name),
+            ..RustCoreConfig::default()
+        });
+        let created = runtime
+            .tmux_command(["new-session", "-d", "-s", live_name.as_str(), "sleep 30"])
+            .output()
+            .unwrap();
+        assert!(created.status.success());
+        let server_pid = runtime
+            .tmux_command(["display-message", "-p", "-t", live_name.as_str(), "#{pid}"])
+            .output()
+            .unwrap();
+        let server_pid = String::from_utf8(server_pid.stdout)
+            .unwrap()
+            .trim()
+            .to_owned();
+        let _server_guard = RealTmuxServerGuard {
+            runtime: runtime.clone(),
+            server_pid,
+            temp_root: None,
+        };
+
+        assert_eq!(
+            runtime.teardown_session_for_restore(&requested_name),
+            RestoreTmuxTeardownOutcome::AlreadyAbsent
+        );
+        assert!(runtime
+            .tmux_command(["has-session", "-t", format!("={live_name}").as_str()])
+            .status()
+            .unwrap()
+            .success());
     }
 
     #[test]

--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -86,6 +86,19 @@ pub(crate) enum ConditionalClearOutcome {
     SessionMissing,
 }
 
+/// Result of the conservative tmux teardown used by Codex-fork restore.
+///
+/// This is intentionally separate from `kill_session`: generic runtime callers
+/// retain their existing behavior, while restore can distinguish authoritative
+/// absence from a transport failure that leaves runtime liveness unknown.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)] // Introduced as the isolated prerequisite consumed by #1362.
+pub(crate) enum RestoreTmuxTeardownOutcome {
+    Killed,
+    AlreadyAbsent,
+    Inconclusive { reason: String },
+}
+
 #[derive(Clone)]
 pub struct TmuxSessionSpec {
     pub session_id: String,
@@ -837,6 +850,28 @@ impl TmuxRuntime {
         }
         self.run_tmux(["kill-session", "-t", tmux_session])?;
         Ok(true)
+    }
+
+    /// Tear down a restore target without a racy existence preflight.
+    ///
+    /// Only tmux's explicit absent-target responses establish absence. A
+    /// missing socket is inconclusive: it is emitted for both a cold named
+    /// server and a live server whose socket pathname was accidentally
+    /// removed.
+    #[allow(dead_code)] // Introduced as the isolated prerequisite consumed by #1362.
+    pub(crate) fn teardown_session_for_restore(
+        &self,
+        tmux_session: &str,
+    ) -> RestoreTmuxTeardownOutcome {
+        match self.run_tmux(["kill-session", "-t", tmux_session]) {
+            Ok(()) => RestoreTmuxTeardownOutcome::Killed,
+            Err(error) if is_tmux_session_gone_error(&error) => {
+                RestoreTmuxTeardownOutcome::AlreadyAbsent
+            }
+            Err(error) => RestoreTmuxTeardownOutcome::Inconclusive {
+                reason: error.to_string(),
+            },
+        }
     }
 
     pub fn set_status_bar(&self, tmux_session: &str, friendly_name: &str) -> Result<bool> {
@@ -2375,6 +2410,24 @@ mod tests {
         ))
     }
 
+    #[cfg(unix)]
+    struct RealTmuxServerGuard {
+        runtime: TmuxRuntime,
+        server_pid: String,
+    }
+
+    #[cfg(unix)]
+    impl Drop for RealTmuxServerGuard {
+        fn drop(&mut self) {
+            // SIGUSR1 recreates an accidentally unlinked server socket, which
+            // makes the ordinary tmux cleanup command reachable again.
+            let _ = Command::new("kill")
+                .args(["-USR1", self.server_pid.as_str()])
+                .status();
+            let _ = self.runtime.run_tmux(["kill-server"]);
+        }
+    }
+
     #[test]
     fn verified_spawn_stdin_prompt_preserves_outer_whitespace() {
         let prompt = "  # Exact brief\n\n  indented detail  \n";
@@ -2763,6 +2816,178 @@ esac
     fn tmux_no_current_target_counts_as_session_gone() {
         let error = anyhow::anyhow!("tmux command failed: no current target");
         assert!(is_tmux_session_gone_error(&error));
+    }
+
+    #[test]
+    fn restore_teardown_kills_without_an_existence_preflight() {
+        let (tmux_binary, log_path, _temp_dir) = fake_tmux_binary();
+        let mut runtime = TmuxRuntime::from_config(&RustCoreConfig::default());
+        runtime.tmux_binary = tmux_binary.display().to_string();
+
+        assert_eq!(
+            runtime.teardown_session_for_restore("sm-test"),
+            RestoreTmuxTeardownOutcome::Killed
+        );
+        let log = fs::read_to_string(log_path).unwrap();
+        assert!(log.contains("kill-session -t sm-test"));
+        assert!(!log.contains("has-session"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restore_teardown_treats_only_authoritative_absence_as_idempotent() {
+        for message in [
+            "can't find session: sm-test",
+            "no current target",
+            "no server running on /tmp/tmux-501/session-manager",
+            "server exited unexpectedly",
+        ] {
+            let (tmux_binary, _log_path, _temp_dir) = fake_tmux_binary();
+            fs::write(
+                &tmux_binary,
+                format!(
+                    "#!/bin/sh\necho '{}' >&2\nexit 1\n",
+                    message.replace('\'', "'\\''")
+                ),
+            )
+            .unwrap();
+            let mut permissions = fs::metadata(&tmux_binary).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&tmux_binary, permissions).unwrap();
+            let mut runtime = TmuxRuntime::from_config(&RustCoreConfig::default());
+            runtime.tmux_binary = tmux_binary.display().to_string();
+
+            assert_eq!(
+                runtime.teardown_session_for_restore("sm-test"),
+                RestoreTmuxTeardownOutcome::AlreadyAbsent,
+                "message: {message}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restore_teardown_keeps_transport_failures_inconclusive() {
+        for message in [
+            "error connecting to /tmp/tmux-501/session-manager (No such file or directory)",
+            "error connecting to /tmp/tmux-501/session-manager (Connection refused)",
+            "permission denied while contacting tmux server",
+            "lost server connection",
+        ] {
+            let (tmux_binary, _log_path, _temp_dir) = fake_tmux_binary();
+            fs::write(
+                &tmux_binary,
+                format!(
+                    "#!/bin/sh\necho '{}' >&2\nexit 1\n",
+                    message.replace('\'', "'\\''")
+                ),
+            )
+            .unwrap();
+            let mut permissions = fs::metadata(&tmux_binary).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&tmux_binary, permissions).unwrap();
+            let mut runtime = TmuxRuntime::from_config(&RustCoreConfig::default());
+            runtime.tmux_binary = tmux_binary.display().to_string();
+
+            assert!(matches!(
+                runtime.teardown_session_for_restore("sm-test"),
+                RestoreTmuxTeardownOutcome::Inconclusive { reason }
+                    if reason.contains(message)
+            ));
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn real_tmux_missing_socket_is_inconclusive_both_cold_and_live() {
+        if !Command::new("tmux")
+            .arg("-V")
+            .output()
+            .is_ok_and(|output| output.status.success())
+        {
+            return;
+        }
+
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let socket_name = format!("sm-restore-teardown-{}-{unique}", std::process::id());
+        let session_name = format!("sm-restore-{}", std::process::id());
+        let runtime = TmuxRuntime::from_config(&RustCoreConfig {
+            tmux_socket_name: Some(socket_name.clone()),
+            ..RustCoreConfig::default()
+        });
+
+        assert!(matches!(
+            runtime.teardown_session_for_restore(&session_name),
+            RestoreTmuxTeardownOutcome::Inconclusive { reason }
+                if reason.contains("No such file or directory")
+        ));
+
+        let created = runtime
+            .tmux_command(["new-session", "-d", "-s", session_name.as_str(), "sleep 30"])
+            .output()
+            .unwrap();
+        assert!(
+            created.status.success(),
+            "failed to create real tmux fixture: {}",
+            String::from_utf8_lossy(&created.stderr)
+        );
+        let server_pid = runtime
+            .tmux_command([
+                "display-message",
+                "-p",
+                "-t",
+                session_name.as_str(),
+                "#{pid}",
+            ])
+            .output()
+            .unwrap();
+        let server_pid = String::from_utf8(server_pid.stdout).unwrap();
+        let server_pid = server_pid.trim().to_owned();
+        let _server_guard = RealTmuxServerGuard {
+            runtime: runtime.clone(),
+            server_pid: server_pid.clone(),
+        };
+        let socket_path = runtime
+            .tmux_command([
+                "display-message",
+                "-p",
+                "-t",
+                session_name.as_str(),
+                "#{socket_path}",
+            ])
+            .output()
+            .unwrap();
+        let socket_path = PathBuf::from(String::from_utf8(socket_path.stdout).unwrap().trim());
+        assert!(socket_path.ends_with(&socket_name));
+        fs::remove_file(&socket_path).unwrap();
+
+        let outcome = runtime.teardown_session_for_restore(&session_name);
+        let server_still_live = Command::new("kill")
+            .args(["-0", server_pid.as_str()])
+            .status()
+            .is_ok_and(|status| status.success());
+        assert!(matches!(
+            outcome,
+            RestoreTmuxTeardownOutcome::Inconclusive { reason }
+                if reason.contains("No such file or directory")
+        ));
+        assert!(
+            server_still_live,
+            "tmux server exited after its socket was unlinked"
+        );
+
+        Command::new("kill")
+            .args(["-USR1", server_pid.as_str()])
+            .status()
+            .unwrap();
+        let recovered = runtime
+            .tmux_command(["has-session", "-t", session_name.as_str()])
+            .status()
+            .unwrap();
+        assert!(recovered.success());
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1361

Parent: #1324

## Invariant

Codex-fork restore teardown can distinguish killed, authoritative absence, and inconclusive transport failure without changing shared `session_exists` or `kill_session` behavior.

## Surface ledger

- Added `RestoreTmuxTeardownOutcome` and `teardown_session_for_restore` only.
- No existing production caller changes in this prerequisite slice.
- Shared `session_exists`, `kill_session`, create, stop, send, recredential, and recovery behavior is byte-for-byte unchanged.
- The temporary dead-code annotation is removed when #1362 consumes the prerequisite.

## Evidence carried from #1356/#1358

- Direct `kill-session` removes the observation/teardown race.
- Only explicit `can't find session` output is accepted as authoritative absence.
- Default/named missing socket, `no current target`, permission, connection-refused, lost-connection, and unexpected-server-exit output is inconclusive.
- Destructive restore targets use tmux exact-match syntax `=<session>`; a real tmux prefix-collision test proves a live prefix match survives.
- Real tmux tests prove both named and default cold sockets remain inconclusive and an unlinked live server remains live and recoverable with `SIGUSR1`.

## Out of scope

No restore state projection, credential mutation, structured acceptance, settle window, restart recovery, neutral-server-anchor implementation, or generic lifecycle changes.

## Validation

- `./scripts/test-rust-isolated.sh restore_teardown -- --nocapture`: 4 passed.
- `./scripts/test-rust-isolated.sh real_tmux_default_socket_is_inconclusive_both_cold_and_unlinked_live -- --nocapture`: passed.
- `./scripts/test-rust-isolated.sh real_tmux_missing_socket_is_inconclusive_both_cold_and_live -- --nocapture`: passed in the full run.
- Full supported isolated Rust suite: 524 passed; the deterministic pre-existing `http::tests::reminder_http_rejects_killed_target_with_status_drift` fixture failure remains (`scheduled_reminders` table missing), tracked by #1305/#1350/#1352/#1355.
- `cargo fmt --check` and `git diff --check` pass.

## Review protocol

Tier: **R3** — ambiguity semantics authorize destructive recovery behavior.

- Round 1 reviewed `e848fcb` and found two P1s: default-socket ambiguity and non-exact tmux targeting.
- Consolidated correction: `62796ca`, including sibling transport classification and real-tmux hostile coverage.
- Round 2 is the final external review allowed by the stricter #1324 vehicle protocol. Any reachable P0/P1 closes this vehicle rather than starting a third review loop.
