### PR TITLE
Verify Codex-fork restore liveness through settle

### DIFF
--- a/crates/sm-server/src/runtime.rs
+++ b/crates/sm-server/src/runtime.rs
@@ -101,6 +101,14 @@ pub(crate) enum RestoreTmuxTeardownOutcome {
     Inconclusive { reason: String },
 }
 
+/// Restore-only tmux liveness proof with transport ambiguity preserved.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum RestoreTmuxLivenessOutcome {
+    Live,
+    Absent,
+    Inconclusive { reason: String },
+}
+
 #[derive(Clone)]
 pub struct TmuxSessionSpec {
     pub session_id: String,
@@ -884,6 +892,38 @@ impl TmuxRuntime {
             Err(error) => RestoreTmuxTeardownOutcome::Inconclusive {
                 reason: error.to_string(),
             },
+        }
+    }
+
+    /// Probe only the exact restore target without collapsing transport errors
+    /// into absence. Generic `session_exists` behavior remains unchanged.
+    pub(crate) fn probe_session_for_restore(
+        &self,
+        tmux_session: &str,
+    ) -> RestoreTmuxLivenessOutcome {
+        let exact_target = format!("={tmux_session}");
+        let output = match self
+            .tmux_command(["has-session", "-t", exact_target.as_str()])
+            .stderr(Stdio::piped())
+            .output()
+        {
+            Ok(output) => output,
+            Err(error) => {
+                return RestoreTmuxLivenessOutcome::Inconclusive {
+                    reason: format!("failed to run tmux has-session: {error}"),
+                };
+            }
+        };
+        if output.status.success() {
+            return RestoreTmuxLivenessOutcome::Live;
+        }
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("can't find session") {
+            RestoreTmuxLivenessOutcome::Absent
+        } else {
+            RestoreTmuxLivenessOutcome::Inconclusive {
+                reason: format!("tmux has-session failed: {}", stderr.trim()),
+            }
         }
     }
 
@@ -2978,6 +3018,54 @@ esac
 
     #[cfg(unix)]
     #[test]
+    fn restore_liveness_probe_is_exact_and_tri_state() {
+        for (label, status, message, expected) in [
+            ("live", 0, "", RestoreTmuxLivenessOutcome::Live),
+            (
+                "absent",
+                1,
+                "can't find session: sm-test",
+                RestoreTmuxLivenessOutcome::Absent,
+            ),
+            (
+                "transport",
+                1,
+                "error connecting to /tmp/tmux-501/session-manager (No such file or directory)",
+                RestoreTmuxLivenessOutcome::Inconclusive {
+                    reason: "tmux has-session failed: error connecting to /tmp/tmux-501/session-manager (No such file or directory)".to_owned(),
+                },
+            ),
+        ] {
+            let (tmux_binary, log_path, _temp_dir) = fake_tmux_binary();
+            fs::write(
+                &tmux_binary,
+                format!(
+                    "#!/bin/sh\nprintf '%s\\n' \"$*\" >> '{}'\nprintf '%s\\n' '{}' >&2\nexit {status}\n",
+                    log_path.display(),
+                    message.replace('\'', "'\\''")
+                ),
+            )
+            .unwrap();
+            let mut permissions = fs::metadata(&tmux_binary).unwrap().permissions();
+            permissions.set_mode(0o755);
+            fs::set_permissions(&tmux_binary, permissions).unwrap();
+            let mut runtime = TmuxRuntime::from_config(&RustCoreConfig::default());
+            runtime.tmux_binary = tmux_binary.display().to_string();
+
+            assert_eq!(
+                runtime.probe_session_for_restore("sm-test"),
+                expected,
+                "{label}"
+            );
+            assert_eq!(
+                fs::read_to_string(log_path).unwrap(),
+                "has-session -t =sm-test\n"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn real_tmux_missing_socket_is_inconclusive_both_cold_and_live() {
         if !Command::new("tmux")
             .arg("-V")
@@ -3045,6 +3133,7 @@ esac
         fs::remove_file(&socket_path).unwrap();
 
         let outcome = runtime.teardown_session_for_restore(&session_name);
+        let liveness = runtime.probe_session_for_restore(&session_name);
         let server_still_live = Command::new("kill")
             .args(["-0", server_pid.as_str()])
             .status()
@@ -3052,6 +3141,11 @@ esac
         assert!(matches!(
             outcome,
             RestoreTmuxTeardownOutcome::Inconclusive { reason }
+                if reason.contains("No such file or directory")
+        ));
+        assert!(matches!(
+            liveness,
+            RestoreTmuxLivenessOutcome::Inconclusive { reason }
                 if reason.contains("No such file or directory")
         ));
         assert!(

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -36,7 +36,10 @@ use crate::{
         path_is_under_home, test_isolation_root_from_environment, CodexReviewConfig,
         ContextMonitorConfig,
     },
-    runtime::{ConditionalClearOutcome, RestoreTmuxTeardownOutcome, TmuxRuntime, TmuxSessionSpec},
+    runtime::{
+        ConditionalClearOutcome, RestoreTmuxLivenessOutcome, RestoreTmuxTeardownOutcome,
+        TmuxRuntime, TmuxSessionSpec,
+    },
     seat_sessions::{SeatSessionIdentity, SeatSessionStore},
     usage_burn::UsageBurnStore,
     usage_identity::{Provider as UsageProvider, UsageIdentityStore},
@@ -5789,16 +5792,23 @@ impl SessionStore {
             let expected_provider_resume_id = provider_resume_id.as_deref().ok_or_else(|| {
                 anyhow::anyhow!("codex-fork restore is missing its provider resume id")
             })?;
-            if let Err(acceptance_error) = wait_for_codex_fork_restore_root_acceptance(
+            let verification_result = wait_for_codex_fork_restore_root_acceptance(
                 &artifacts.event_stream_path,
                 0,
                 expected_provider_resume_id,
                 CODEX_FORK_THREAD_STARTED_TIMEOUT,
                 || session_runtime.session_exists(&record.tmux_session),
                 || session_runtime.accept_codex_directory_trust_prompt(&record.tmux_session),
-            ) {
+            )
+            .and_then(|()| {
+                wait_for_codex_fork_restore_liveness(
+                    session_runtime.startup_settle_duration(),
+                    || session_runtime.probe_session_for_restore(&record.tmux_session),
+                )
+            });
+            if let Err(acceptance_error) = verification_result {
                 let failure_reason = format!(
-                    "codex-fork restore rejected durable root {expected_provider_resume_id}: {acceptance_error}"
+                    "codex-fork restore verification failed for durable root {expected_provider_resume_id}: {acceptance_error}"
                 );
                 let mut returned_failure = failure_reason.clone();
                 match session_runtime.teardown_session_for_restore(&record.tmux_session) {
@@ -9167,6 +9177,34 @@ where
             );
         }
         thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn wait_for_codex_fork_restore_liveness<F>(settle_window: Duration, mut probe: F) -> Result<()>
+where
+    F: FnMut() -> RestoreTmuxLivenessOutcome,
+{
+    let deadline = Instant::now() + settle_window;
+    loop {
+        match probe() {
+            RestoreTmuxLivenessOutcome::Live => {}
+            RestoreTmuxLivenessOutcome::Absent => {
+                anyhow::bail!("codex-fork tmux runtime disappeared during restore settle window")
+            }
+            RestoreTmuxLivenessOutcome::Inconclusive { reason } => {
+                anyhow::bail!(
+                    "codex-fork tmux liveness was inconclusive during restore settle window: {reason}"
+                )
+            }
+        }
+        let now = Instant::now();
+        if now >= deadline {
+            return Ok(());
+        }
+        thread::sleep(std::cmp::min(
+            Duration::from_millis(50),
+            deadline.saturating_duration_since(now),
+        ));
     }
 }
 
@@ -17336,6 +17374,14 @@ esac
     #[cfg(unix)]
     impl CodexForkRestoreRootFixture {
         fn new(label: &str, provider_script: &str) -> Option<Self> {
+            Self::new_with_settle(label, provider_script, None)
+        }
+
+        fn new_with_settle(
+            label: &str,
+            provider_script: &str,
+            settle_ms: Option<u64>,
+        ) -> Option<Self> {
             if !Command::new("tmux")
                 .arg("-V")
                 .output()
@@ -17393,6 +17439,7 @@ esac
 
             let mut config = AppConfig::default();
             config.rust_core.tmux_socket_name = Some(tmux_socket.clone());
+            config.rust_core.runtime_start_settle_ms = settle_ms;
             config.codex_fork.command = command_path.display().to_string();
             config.codex_fork.args = Vec::new();
             let runtime = TmuxRuntime::from_app_config(&config);
@@ -17510,6 +17557,112 @@ sleep 30
             .runtime
             .session_exists("codex-fork-restore01")
             .unwrap());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn codex_fork_restore_rejects_runtime_that_exits_during_settle() {
+        let Some(fixture) = CodexForkRestoreRootFixture::new_with_settle(
+            "settle-exit",
+            r#"#!/bin/sh
+event_stream=''
+resume_id=''
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --event-stream) event_stream="$2"; shift 2 ;;
+    resume | --resume) resume_id="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+printf '{"event_type":"thread_started","payload":{"thread":{"id":"%s"}}}\n' "$resume_id" >> "$event_stream"
+sleep 1
+"#,
+            Some(3_000),
+        ) else {
+            return;
+        };
+
+        let error = fixture
+            .store()
+            .restore_core_session_with_runtime("restore01", &fixture.runtime)
+            .unwrap_err();
+        assert!(format!("{error:#}").contains("disappeared during restore settle window"));
+        let state = fixture.store().load_raw_json_value().unwrap();
+        assert_eq!(state["sessions"][0]["status"], "stopped");
+        assert_eq!(state["sessions"][0]["provider_resume_id"], "durable-root");
+        assert_eq!(state["session_runtime_launches"][0]["status"], "failed");
+        assert!(!fixture
+            .runtime
+            .session_exists("codex-fork-restore01")
+            .unwrap());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn codex_fork_restore_fences_transport_ambiguity_during_settle() {
+        let Some(fixture) = CodexForkRestoreRootFixture::new_with_settle(
+            "settle-unlinked",
+            r#"#!/bin/sh
+event_stream=''
+resume_id=''
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --event-stream) event_stream="$2"; shift 2 ;;
+    resume | --resume) resume_id="$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+printf '{"event_type":"thread_started","payload":{"thread":{"id":"%s"}}}\n' "$resume_id" >> "$event_stream"
+sleep 1
+socket_path=${TMUX%%,*}
+rm -f "$socket_path"
+sleep 30
+"#,
+            Some(3_000),
+        ) else {
+            return;
+        };
+
+        let error = fixture
+            .store()
+            .restore_core_session_with_runtime("restore01", &fixture.runtime)
+            .unwrap_err();
+        let error = format!("{error:#}");
+        assert!(error.contains("liveness was inconclusive"), "{error}");
+        assert!(
+            error.contains("failed to confirm rejected runtime teardown"),
+            "{error}"
+        );
+        let state = fixture.store().load_raw_json_value().unwrap();
+        assert_eq!(state["sessions"][0]["status"], "error");
+        assert!(state["sessions"][0]["stopped_at"].is_null());
+        assert_eq!(
+            state["sessions"][0]["session_credential_sha256"],
+            state["session_runtime_launches"][0]["credential_sha256"]
+        );
+        assert_eq!(state["session_runtime_launches"][0]["status"], "failed");
+        assert!(Command::new("kill")
+            .args(["-0", &fixture.tmux_server_pid])
+            .status()
+            .unwrap()
+            .success());
+
+        Command::new("kill")
+            .args(["-USR1", &fixture.tmux_server_pid])
+            .status()
+            .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            if fixture
+                .runtime
+                .session_exists("codex-fork-restore01")
+                .unwrap_or(false)
+            {
+                break;
+            }
+            assert!(Instant::now() < deadline);
+            thread::sleep(Duration::from_millis(20));
+        }
     }
 
     #[cfg(unix)]
@@ -21054,6 +21207,32 @@ sleep 30
         .unwrap_err();
         assert!(tmux_loss.to_string().contains("tmux runtime disappeared"));
         let _ = fs::remove_file(event_stream_path);
+    }
+
+    #[test]
+    fn codex_fork_restore_liveness_requires_live_through_the_settle_window() {
+        let mut live_probes = 0;
+        wait_for_codex_fork_restore_liveness(Duration::from_millis(60), || {
+            live_probes += 1;
+            RestoreTmuxLivenessOutcome::Live
+        })
+        .unwrap();
+        assert!(live_probes >= 2);
+
+        let absent = wait_for_codex_fork_restore_liveness(Duration::ZERO, || {
+            RestoreTmuxLivenessOutcome::Absent
+        })
+        .unwrap_err();
+        assert!(absent.to_string().contains("disappeared"));
+
+        let inconclusive = wait_for_codex_fork_restore_liveness(Duration::ZERO, || {
+            RestoreTmuxLivenessOutcome::Inconclusive {
+                reason: "lost server connection".to_owned(),
+            }
+        })
+        .unwrap_err();
+        assert!(inconclusive.to_string().contains("inconclusive"));
+        assert!(inconclusive.to_string().contains("lost server connection"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1364
Parent: #1324
Depends on merged Parts 1-3

## Invariant

After exact root acceptance, a Codex-fork restore is projected `running` only if the exact tmux target remains demonstrably live through the configured settle window. Transport ambiguity never becomes false absence or success.

## Changes

- add a restore-only exact tri-state tmux liveness probe: live, authoritative absence, or inconclusive transport
- require live proof throughout the configured post-acceptance settle window
- route confirmed disappearance through stopped rejection
- route inconclusive liveness and teardown through the fenced operator-visible error contract
- retain shared `session_exists` behavior unchanged
- stabilize real-tmux settle fixtures so root acceptance precedes the deliberate exit/socket unlink boundary under parallel test load

## Scope boundary

No generic liveness behavior, startup recovery, root-identity semantics, or non-Codex-fork restore changes.

## Validation

- `cargo fmt --check`
- `git diff --check`
- `./scripts/test-rust-isolated.sh codex_fork_restore -- --nocapture` — 13 passed
- exact probe coverage asserts `has-session -t =<session>` and preserves missing-socket ambiguity
- isolated real-tmux coverage proves exit-during-settle rejection and unlinked-live-server fencing

## Review protocol

R3 vehicle under the bounded #1324 protocol: at most two external Codex review requests. A P1 in review two closes and re-slices this vehicle; there will be no third review loop.
