### PR TITLE
Close Codex-fork restore with hostile outcome matrix

### DIFF
--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -17371,6 +17371,7 @@ esac
         let tmux_log = root.join("tmux.log");
         let old_credential_sha256 = sha256_text("old-runtime-secret");
         let state_file = root.join("sessions.json");
+        let provider_launch_state_file = root.join("provider-launch-state.json");
         fs::write(
             &tmux,
             format!(
@@ -17383,13 +17384,19 @@ case "$1" in
     exit 1
     ;;
   has-session) exit 1 ;;
-  new-session) echo "provider launch rejected by fixture" >&2; exit 1 ;;
+  new-session)
+    cp '{}' '{}' || {{ echo "could not capture provider-launch state" >&2; exit 97; }}
+    echo "provider launch rejected by fixture" >&2
+    exit 1
+    ;;
   *) exit 0 ;;
 esac
 "#,
                 tmux_log.display(),
                 old_credential_sha256,
-                state_file.display()
+                state_file.display(),
+                state_file.display(),
+                provider_launch_state_file.display()
             ),
         )
         .unwrap();
@@ -17427,6 +17434,20 @@ esac
         assert!(error
             .to_string()
             .contains("provider launch rejected by fixture"));
+
+        let provider_launch_state: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(&provider_launch_state_file).unwrap())
+                .unwrap();
+        let provider_launch_session = &provider_launch_state["sessions"][0];
+        let provider_launch = &provider_launch_state["session_runtime_launches"][0];
+        assert_ne!(
+            provider_launch_session["session_credential_sha256"],
+            old_credential_sha256
+        );
+        assert_eq!(
+            provider_launch_session["session_credential_sha256"],
+            provider_launch["credential_sha256"]
+        );
 
         let state = store.load_raw_json_value().unwrap();
         let session = &state["sessions"][0];

--- a/crates/sm-server/src/sessions.rs
+++ b/crates/sm-server/src/sessions.rs
@@ -17363,6 +17363,89 @@ esac
     }
 
     #[cfg(unix)]
+    #[test]
+    fn codex_fork_restore_request_commits_new_credential_after_authoritative_absence() {
+        let root = unique_temp_path("codex-fork-restore-request-absent");
+        fs::create_dir_all(&root).unwrap();
+        let tmux = root.join("tmux");
+        let tmux_log = root.join("tmux.log");
+        let old_credential_sha256 = sha256_text("old-runtime-secret");
+        let state_file = root.join("sessions.json");
+        fs::write(
+            &tmux,
+            format!(
+                r#"#!/bin/sh
+printf '%s\n' "$*" >> "{}"
+case "$1" in
+  kill-session)
+    grep -q '{}' '{}' || {{ echo "credential rotated before teardown" >&2; exit 98; }}
+    echo "can't find session: codex-fork-restore-absent" >&2
+    exit 1
+    ;;
+  has-session) exit 1 ;;
+  new-session) echo "provider launch rejected by fixture" >&2; exit 1 ;;
+  *) exit 0 ;;
+esac
+"#,
+                tmux_log.display(),
+                old_credential_sha256,
+                state_file.display()
+            ),
+        )
+        .unwrap();
+        let mut permissions = fs::metadata(&tmux).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&tmux, permissions).unwrap();
+        fs::write(
+            &state_file,
+            json!({
+                "sessions": [{
+                    "id": "restore-absent",
+                    "name": "restore-codex-fork",
+                    "provider": "codex-fork",
+                    "provider_resume_id": "durable-root",
+                    "session_credential_sha256": old_credential_sha256,
+                    "working_dir": root,
+                    "tmux_session": "codex-fork-restore-absent",
+                    "log_file": root.join("restore.log"),
+                    "status": "stopped",
+                    "completion_status": "killed",
+                    "created_at": "2026-08-18T00:00:00Z",
+                    "last_activity": "2026-08-18T00:00:00Z"
+                }]
+            })
+            .to_string(),
+        )
+        .unwrap();
+        let store = SessionStore::new(state_file.clone());
+        let runtime = TmuxRuntime::from_config(&crate::config::RustCoreConfig::default())
+            .with_tmux_binary_for_test(tmux.display().to_string());
+
+        let error = store
+            .restore_core_session_with_runtime("restore-absent", &runtime)
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("provider launch rejected by fixture"));
+
+        let state = store.load_raw_json_value().unwrap();
+        let session = &state["sessions"][0];
+        let launch = &state["session_runtime_launches"][0];
+        assert_eq!(session["status"], "stopped");
+        assert_eq!(session["provider_resume_id"], "durable-root");
+        assert_ne!(session["session_credential_sha256"], old_credential_sha256);
+        assert_eq!(
+            session["session_credential_sha256"],
+            launch["credential_sha256"]
+        );
+        assert_eq!(launch["status"], "failed");
+        let tmux_log = fs::read_to_string(&tmux_log).unwrap();
+        assert!(tmux_log.starts_with("kill-session -t =codex-fork-restore-absent\n"));
+        assert!(tmux_log.contains("new-session -d -s codex-fork-restore-absent"));
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
     struct CodexForkRestoreRootFixture {
         state_file: PathBuf,
         fixture_dir: PathBuf,

--- a/specs/1366_codex_fork_restore_hostile_matrix.md
+++ b/specs/1366_codex_fork_restore_hostile_matrix.md
@@ -1,0 +1,67 @@
+# #1324 Codex-fork restore hostile closure matrix
+
+This document is the closure ledger for #1324. It records the behavior that
+must remain true on current `main`; it does not define new shared lifecycle
+semantics.
+
+## Durable outcomes
+
+| Boundary | Hostile outcome | Session projection | Launch | Credential/root | Runtime and retry |
+| --- | --- | --- | --- | --- | --- |
+| Explicit request, before teardown | exact target killed | stopped if the replacement launch fails | failed | replacement credential committed only after kill; durable root unchanged | old runtime gone; explicit retry remains possible |
+| Explicit request, before teardown | authoritative target absence | replacement may launch | launching/applied or failed with provider result | replacement credential committed only after authoritative absence; root unchanged until exact acceptance | no old runtime; no prefix target is touched |
+| Explicit request, before teardown | missing socket, permission, execution, or other transport failure | error, with terminal fields cleared | failed | old credential and durable root retained | launch nothing; ordinary retry fenced |
+| Startup, pending authorized restore before credential commit | killed or authoritative absence | stopped with explicit manual-restore reason | failed | old credential/root retained | never replay provider; require explicit restore |
+| Startup, pending authorized restore after credential commit/provider launch | killed or authoritative absence | stopped with explicit manual-restore reason | failed | replacement credential/root retained | exact teardown; never replay provider; require explicit restore |
+| Startup, either credential boundary | unavailable runtime or inconclusive teardown | error, with terminal fields cleared | failed | currently persisted credential/root retained | never replay provider; ordinary retry fenced |
+| Provider acceptance | exact durable root; `shutdown_complete` before/after | continue to settle | launching | replacement credential and durable root correspond | runtime must still pass settle |
+| Provider acceptance | wrong root, missing/timeout, `session_end`, or `shutdown` | stopped after confirmed teardown; error if teardown is inconclusive | failed | replacement credential and durable root retained for the launched runtime | checked exact teardown; no false running state |
+| Post-acceptance settle | exact target live through deadline | running | applied | replacement credential and exact durable root | attach descriptor supported |
+| Post-acceptance settle | authoritative disappearance | stopped | failed | replacement credential/root retained | attach descriptor unsupported for stopped lifecycle |
+| Post-acceptance settle | transport ambiguity, including unlinked live socket | error, with terminal fields cleared | failed | replacement credential/root retained | possibly-live runtime preserved; attach target remains structurally known but transport is unavailable until recovery |
+
+## Executable evidence
+
+The supported runner is `./scripts/test-rust-isolated.sh`. The closure run must
+include the following groups from current `main`:
+
+- `runtime::tests::restore_teardown_*`: no existence preflight, authoritative
+  absence only, and transport ambiguity.
+- `runtime::tests::real_tmux_restore_teardown_never_kills_a_prefix_match`:
+  destructive targets use `=<session>`.
+- `runtime::tests::real_tmux_missing_socket_is_inconclusive_both_cold_and_live`
+  and `real_tmux_default_socket_is_inconclusive_both_cold_and_unlinked_live`:
+  a missing pathname is not absence evidence.
+- `runtime::tests::real_tmux_configured_socket_has_one_neutral_anchor_before_agents`:
+  fixture and production named servers retain a neutral server argv.
+- `sessions::tests::codex_fork_restore_request_*`: credential ordering,
+  provider-launch fencing, exact teardown, and request retry behavior.
+- `sessions::tests::codex_fork_restore_recovery_*`: both credential boundaries,
+  killed/absent/inconclusive/disabled-runtime outcomes, preserved durable
+  identity, and no provider replay.
+- `sessions::tests::codex_fork_restore_root_acceptance_*`: exact identity,
+  mismatch, timeout, trust handling, terminal events, and
+  `shutdown_complete` churn.
+- `sessions::tests::codex_fork_restore_projects_running_only_after_exact_root_acceptance`,
+  `codex_fork_restore_rejects_mismatched_root_and_tears_down_runtime`, and
+  `codex_fork_restore_rejection_fences_inconclusive_teardown_with_live_credential`:
+  isolated real-tmux acceptance and rejection projections.
+- `runtime::tests::restore_liveness_probe_is_exact_and_tri_state` and
+  `sessions::tests::codex_fork_restore_liveness_requires_live_through_the_settle_window`:
+  exact tri-state settle proof.
+- `sessions::tests::codex_fork_restore_rejects_runtime_that_exits_during_settle`
+  and `codex_fork_restore_fences_transport_ambiguity_during_settle`: isolated
+  real-tmux settle failures.
+- `read_only_http::runtime_core_lifecycle_uses_codex_fork_launch_config`:
+  successful HTTP restore, status projection, provider arguments, fresh
+  artifacts, and live attach target.
+
+## Non-regression boundary
+
+Generic `session_exists`, create, recredential, Claude/classic-Codex restore,
+and unrelated lifecycle behavior are intentionally outside #1324. Known
+full-suite fixture/concurrency debt is tracked separately and is not converted
+into restore behavior: reminder schema setup, queue-authority stale-socket
+timing (#1311), completion delivery concurrency (#1367 and #1378),
+context-monitor path lifetime (#1369), and historical materialization timing
+(#1379).


### PR DESCRIPTION
Fixes #1366
Closes #1324

## Outcome

Current `main` now has a complete bounded evidence ledger for the #1324 Codex-fork restore incident. This vehicle introduces no lifecycle behavior; it records the hostile matrix and adds the one missing explicit-request `AlreadyAbsent` transaction case.

## Changes

- add `specs/1366_codex_fork_restore_hostile_matrix.md` mapping request, crash recovery, root acceptance, settle, tmux transport, durable state, credential/root authority, retry, and attach/status outcomes
- add closure coverage proving an authoritative absent target preserves the old credential through exact teardown, commits the replacement before provider launch, retains the durable root, and never uses a prefix target
- enumerate the executable fake/real-tmux and HTTP evidence required to close #1324
- preserve generic create/recredential/session-existence and non-Codex-fork behavior unchanged

## Validation

- `cargo fmt --check`
- `git diff --check`
- `./scripts/test-rust-isolated.sh codex_fork_restore -- --nocapture` — 14 passed
- `./scripts/test-rust-isolated.sh restore_teardown -- --nocapture` — 4 passed
- `./scripts/test-rust-isolated.sh real_tmux_ -- --nocapture` — 4 passed
- `./scripts/test-rust-isolated.sh runtime_core_lifecycle_uses_codex_fork_launch_config -- --nocapture` — 1 passed
- `./scripts/test-rust-isolated.sh` — all #1324 coverage passed; 540/541 overall passed, with the sole failure independently reproduced as the unrelated pre-existing `scheduled_reminders` fixture defect tracked by #1305/#1350/#1352/#1355

## Review protocol

Final R3 evidence vehicle under the bounded #1324 protocol: at most two external Codex review requests. A P1 in review two closes and re-slices this vehicle; there will be no third review loop.
